### PR TITLE
fix(tsc-wrapped): support as and class expressions

### DIFF
--- a/tools/@angular/tsc-wrapped/src/evaluator.ts
+++ b/tools/@angular/tsc-wrapped/src/evaluator.ts
@@ -644,6 +644,11 @@ export class Evaluator {
             return result;
           }, this.evaluateNode(templateExpression.head));
         }
+      case ts.SyntaxKind.AsExpression:
+        const asExpression = <ts.AsExpression>node;
+        return this.evaluateNode(asExpression.expression);
+      case ts.SyntaxKind.ClassExpression:
+        return {__symbolic: 'class'};
     }
     return recordEntry(errorSymbol('Expression form not supported', node), node);
   }

--- a/tools/@angular/tsc-wrapped/test/collector.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/collector.spec.ts
@@ -727,6 +727,21 @@ describe('Collector', () => {
     });
   });
 
+  it('should treat exported class expressions as a class', () => {
+    const source = ts.createSourceFile(
+        '', `
+    export const InjectionToken: {new<T>(desc: string): InjectionToken<T>;} = class extends OpaqueToken {
+      constructor(desc: string) {
+        super(desc);
+      }
+
+      toString(): string { return \`InjectionToken ${this._desc}\`; }
+    } as any;`,
+        ts.ScriptTarget.Latest, true);
+    const metadata = collector.getMetadata(source);
+    expect(metadata.metadata).toEqual({InjectionToken: {__symbolic: 'class'}});
+  });
+
   describe('in strict mode', () => {
     it('should throw if an error symbol is collecting a reference to a non-exported symbol', () => {
       const source = program.getSourceFile('/local-symbol-ref.ts');


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

Using an `as` or `class` expression would report an error.

**What is the new behavior?**

Now collects expression that use `as` by ignoring the type and collects class expressions.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
