### PR TITLE
fix(aio): use the current version in the version picker

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -484,7 +484,6 @@
   ],
 
   "docVersions": [
-    { "title": "v4.0.0", "url": null },
-    { "title": "v2",     "url": "https://v2.angular.io" }
+    { "title": "v2", "url": "https://v2.angular.io" }
   ]
 }

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -210,14 +210,14 @@ describe('AppComponent', () => {
 
     it('should pick first (current) version by default', () => {
       const versionSelector = sidenav.querySelector('select');
-      expect(versionSelector.value).toEqual(TestHttp.docVersions[0].title);
+      expect(versionSelector.value).toEqual(component.versionInfo.raw);
       expect(versionSelector.selectedIndex).toEqual(0);
     });
 
     // Older docs versions have an href
     it('should navigate when change to a version with an href', () => {
       component.onDocVersionChange(1);
-      expect(locationService.go).toHaveBeenCalledWith(TestHttp.docVersions[1].url);
+      expect(locationService.go).toHaveBeenCalledWith(TestHttp.docVersions[0].url);
     });
 
     // The current docs version should not have an href
@@ -612,7 +612,6 @@ class TestHttp {
   static versionFull = '4.0.0-local+sha.73808dd';
 
   static docVersions: NavigationNode[] = [
-    { title: 'v4.0.0' },
     { title: 'v2', url: 'https://v2.angular.io' }
   ];
 

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -13,6 +13,8 @@ import { SearchBoxComponent } from 'app/search/search-box/search-box.component';
 import { SearchService } from 'app/search/search.service';
 import { SwUpdateNotificationsService } from 'app/sw-updates/sw-update-notifications.service';
 
+import { combineLatest } from 'rxjs/observable/combineLatest';
+
 const sideNavView = 'SideNav';
 
 @Component({
@@ -139,13 +141,20 @@ export class AppComponent implements OnInit {
       this.sideNavToggle(this.isSideBySide ? openSideNav : false);
     });
 
+    // Compute the version picker list from the current version and the versions in the navigation map
+    combineLatest(
+      this.navigationService.versionInfo.map(versionInfo => ({ title: versionInfo.raw, url: null })),
+      this.navigationService.navigationViews.map(views => views['docVersions']),
+      (currentVersion, otherVersions) => [currentVersion, ...otherVersions])
+      .subscribe(versions => {
+        this.docVersions = versions;
+        this.currentDocVersion = this.docVersions[0];
+      });
+
     this.navigationService.navigationViews.subscribe(views => {
-      this.docVersions  = views['docVersions']  || [];
       this.footerNodes  = views['Footer']  || [];
       this.sideNavNodes = views['SideNav'] || [];
       this.topMenuNodes = views['TopBar']  || [];
-
-      this.currentDocVersion = this.docVersions[0];
     });
 
     this.navigationService.versionInfo.subscribe( vi => this.versionInfo = vi );


### PR DESCRIPTION
Previously we hardcoded the current version into the navigation items.
Now only previous versions are included there. The current version is
computed from the currentVersion info.

Closes #16909
