### PR TITLE
build(aio): less verbose boilerplate generator

### DIFF
--- a/aio/tools/examples/add-example-boilerplate.js
+++ b/aio/tools/examples/add-example-boilerplate.js
@@ -38,7 +38,6 @@ function add() {
   installNodeModules();
 
   nodeModulesPaths.map((linkPath) => {
-    console.log("symlinking " + linkPath + ' -> ' + realPath)
     fs.ensureSymlinkSync(realPath, linkPath);
   });
 


### PR DESCRIPTION
There is a log that says "Copying example files". I opted to leave it.