### PR TITLE
docs(aio): remove links to top of documents

### DIFF
--- a/aio/content/guide/ajs-quick-reference.md
+++ b/aio/content/guide/ajs-quick-reference.md
@@ -150,11 +150,6 @@ The following table lists some of the key AngularJS template features with their
 </table>
 
 
-
-[Back to top](guide/ajs-quick-reference#top)
-
-
-
 ## Template directives
 AngularJS provides more than seventy built-in directives for templates.
 Many of them aren't needed in Angular because of its more capable and expressive binding system.
@@ -721,10 +716,6 @@ The following are some of the key AngularJS built-in directives and their equiva
 </table>
 
 
-
-[Back to top](guide/ajs-quick-reference#top)
-
-
 {@a filters-pipes}
 
 
@@ -992,9 +983,6 @@ For more information on pipes, see [Pipes](guide/pipes).
 
 
 
-[Back to top](guide/ajs-quick-reference#top)
-
-
 {@a controllers-components}
 
 
@@ -1215,11 +1203,6 @@ The Angular code is shown using TypeScript.
 
 </table>
 
-
-
-[Back to top](guide/ajs-quick-reference#top)
-
-
 {@a style-sheets}
 
 
@@ -1297,6 +1280,3 @@ also encapsulate a style sheet within a specific component.
 
 </table>
 
-
-
-[Back to top](guide/ajs-quick-reference#top)

--- a/aio/content/guide/set-document-title.md
+++ b/aio/content/guide/set-document-title.md
@@ -83,4 +83,3 @@ you'll have to provide a different `Title` service that understands
 the concept of a "document title" for that specific platform.
 Ideally, the application itself neither knows nor cares about the runtime environment.
 
-[Back to top](guide/set-document-title#top)

--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -37,7 +37,6 @@ You can extend the HTML vocabulary of your templates with components and directi
 In the following sections, you'll learn how to get and set DOM (Document Object Model) values dynamically through data binding.
 
 Begin with the first form of data binding&mdash;interpolation&mdash;to see how much richer template HTML can be.
-  <a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -81,7 +80,7 @@ Though this is not exactly true. Interpolation is a special syntax that Angular 
 
 But first, let's take a closer look at template expressions and statements.
 
-<a href="#top-of-page">back to top</a>
+
 
 <hr/>
 
@@ -147,7 +146,6 @@ the global namespace. They can't refer to `window` or `document`. They
 can't call `console.log` or `Math.max`. They are restricted to referencing
 members of the expression context.
 
-<a href="#top-of-page">back to top</a>
 
 {@a no-side-effects}
 
@@ -204,7 +202,7 @@ Dependent values should not change during a single turn of the event loop.
 If an idempotent expression returns a string or a number, it returns the same string or number
 when called twice in a row. If the expression returns an object (including an `array`),
 it returns the same object *reference* when called twice in a row.
-<a href="#top-of-page">back to top</a>
+
 
 <hr/>
 
@@ -276,7 +274,6 @@ A method call or simple property assignment should be the norm.
 Now that you have a feel for template expressions and statements,
 you're ready to learn about the varieties of data binding syntax beyond interpolation.
 
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -585,7 +582,6 @@ The following table summarizes:
 </table>
 
 With this broad view in mind, you're ready to look at binding types in detail.
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -773,7 +769,6 @@ content harmlessly.
   <img src='generated/images/guide/template-syntax/evil-title.png' alt="evil title made safe">
 </figure>
 
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -847,7 +842,6 @@ is to set ARIA attributes, as in this example:
 <code-example path="template-syntax/src/app/app.component.html" region="attrib-binding-aria" title="src/app/app.component.html" linenums="false">
 </code-example>
 
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -885,7 +879,6 @@ the [NgClass directive](guide/template-syntax#ngClass) is usually preferred when
 
 </div>
 
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -920,8 +913,6 @@ Note that a _style property_ name can be written in either
 [camelCase](guide/glossary#camelcase), such as `fontSize`.
 
 </div>
-
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -1053,7 +1044,6 @@ Deleting the hero updates the model, perhaps triggering other changes
 including queries and saves to a remote server.
 These changes percolate through the system and are ultimately displayed in this and other views.
 
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -1118,7 +1108,6 @@ However, no native HTML element follows the `x` value and `xChange` event patter
 
 Fortunately, the Angular [_NgModel_](guide/template-syntax#ngModel) directive is a bridge that enables two-way binding to form elements.
 
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -1162,7 +1151,7 @@ This section is an introduction to the most commonly used attribute directives:
 * [`NgClass`](guide/template-syntax#ngClass) - add and remove a set of CSS classes
 * [`NgStyle`](guide/template-syntax#ngStyle) - add and remove a set of HTML styles
 * [`NgModel`](guide/template-syntax#ngModel) - two-way data binding to an HTML form element
-<a href="#top-of-page">back to top</a>
+
 
 <hr/>
 
@@ -1203,8 +1192,6 @@ It's up to you to call `setCurrentClassess()`, both initially and when the depen
 
 </div>
 
-<a href="#top-of-page">back to top</a>
-
 <hr/>
 
 {@a ngStyle}
@@ -1241,7 +1228,6 @@ It's up to you to call `setCurrentStyles()`, both initially and when the depende
 
 </div>
 
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -1334,8 +1320,6 @@ Here are all variations in action, including the uppercase version:
 <figure>
   <img src='generated/images/guide/template-syntax/ng-model-anim.gif' alt="NgModel variations">
 </figure>
-
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -1431,7 +1415,6 @@ described below.
 
 </div>
 
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -1553,7 +1536,6 @@ Here is an illustration of the _trackBy_ effect.
   <img src="generated/images/guide/template-syntax/ng-for-track-by-anim.gif" alt="trackBy">
 </figure>
 
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -1600,8 +1582,6 @@ For example, you could replace the `<confused-hero>` switch case with the follow
 
 <code-example path="template-syntax/src/app/app.component.html" region="NgSwitch-div" title="src/app/app.component.html" linenums="false">
 </code-example>
-
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -1673,7 +1653,6 @@ This example declares the `fax` variable as `ref-fax` instead of `#fax`.
 <code-example path="template-syntax/src/app/app.component.html" region="ref-fax" title="src/app/app.component.html" linenums="false">
 </code-example>
 
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -1810,7 +1789,6 @@ the directive property name on the *left* and the public alias on the *right*:
 
 </div>
 
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -1861,7 +1839,6 @@ The generated output would look something like this
     "rate": 325 }
 </code-example>
 
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 
@@ -1935,7 +1912,6 @@ The display is blank, but the app keeps rolling without errors.
 
 It works perfectly with long property paths such as `a?.b?.c?.d`.
 
-<a href="#top-of-page">back to top</a>
 
 <hr/>
 

--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -18,7 +18,7 @@ The sample application and all tests in this guide are available as live example
 * <live-example name="setup" plnkr="quickstart-specs" embedded-style>The QuickStart seed's AppComponent spec</live-example>.
 * <live-example embedded-style>The sample application to be tested</live-example>.
 * <live-example plnkr="app-specs" embedded-style>All specs that test the sample application</live-example>.
-* <live-example plnkr="bag-specs" embedded-style>A grab bag of additional specs</live-example>.<a href="#top" class='to-top'>Back to top</a>
+* <live-example plnkr="bag-specs" embedded-style>A grab bag of additional specs</live-example>.
 
 <hr/>
 
@@ -199,7 +199,6 @@ A comprehensive review of the Angular testing utilities appears [later in this g
 
 But first you should write a dummy test to verify that your test environment is set up properly
 and to lock in a few basic testing skills.
-<a href="#top" class='to-top'>Back to top</a>
 
 <hr/>
 
@@ -365,7 +364,6 @@ Debug specs in the browser in the same way that you debug an application.
 
 You can also try this test as a <live-example plnkr="1st-specs" title="First spec" embedded-style></live-example> in plunker.
 All of the tests in this guide are available as [live examples](guide/testing#live-examples "Live examples of these tests").
-<a href="#top" class='to-top'>Back to top</a>
 
 <hr/>
 
@@ -631,7 +629,7 @@ There is no harm in calling `detectChanges()` more often than is strictly necess
 
 </div>
 
-<a href="#top" class='to-top'>Back to top</a>
+
 
 <hr/>
 
@@ -800,7 +798,7 @@ The tests in this guide only call `compileComponents` when necessary.
 
 </div>
 
-<a href="#top" class='to-top'>Back to top</a>
+
 
 <hr/>
 
@@ -966,7 +964,6 @@ In a spec with multiple expectations, it can help clarify what went wrong and wh
 The remaining tests confirm the logic of the component when the service returns different values.
 The second test validates the effect of changing the user name.
 The third test checks that the component displays the proper message when there is no logged-in user.
-<a href="#top" class='to-top'>Back to top</a>
 
 <hr/>
 
@@ -1202,7 +1199,7 @@ and `fakeAsync`, is a viable and occasionally necessary technique.
 For example, you can't call `async` or `fakeAsync` when testing
 code that involves the `intervalTimer`, as is common when
 testing async `Observable` methods.
-<a href="#top" class='to-top'>Back to top</a>
+
 
 <hr/>
 
@@ -1482,7 +1479,7 @@ The tests themselves are almost identical to the stand-alone version:
 
 Only the selected event test differs. It confirms that the selected `DashboardHeroComponent` hero
 really does find its way up through the event binding to the host component.
-<a href="#top" class='to-top'>Back to top</a>
+
 
 <hr/>
 
@@ -1782,7 +1779,6 @@ Inspect and download _all_ of the guide's application test code with this <live-
 
 </div>
 
-<a href="#top" class='to-top'>Back to top</a>
 
 <hr/>
 
@@ -1848,7 +1844,7 @@ Here are a few more `HeroDetailComponent` tests to drive the point home.
 
 </code-example>
 
-<a href="#top" class='to-top'>Back to top</a>
+
 
 <hr/>
 
@@ -1944,8 +1940,6 @@ especially when the feature module is small and mostly self-contained, as featur
 </div>
 
 
-
-<a href="#top" class='to-top'>Back to top</a>
 
 <hr/>
 
@@ -2104,7 +2098,6 @@ The `TestBed` offers similar `overrideDirective`, `overrideModule`, and `overrid
 for digging into and replacing parts of these other classes.
 
 Explore the options and combinations on your own.
-<a href="#top" class='to-top'>Back to top</a>
 
 <hr/>
 
@@ -2272,8 +2265,6 @@ tests with the `RouterTestingModule`.
 
 </div>
 
-<a href="#top" class='to-top'>Back to top</a>
-
 <hr/>
 
 
@@ -2327,7 +2318,6 @@ such as misspelled or misused components and directives.
 
 </div>
 
-<a href="#top" class='to-top'>Back to top</a>
 
 <hr/>
 
@@ -2427,7 +2417,7 @@ The test for the default color uses the injector of the second `<h2>` to get its
 and its `defaultColor`.
 
 * `DebugElement.properties` affords access to the artificial custom property that is set by the directive.
-<a href="#top" class='to-top'>Back to top</a>
+
 
 <hr/>
 
@@ -2655,7 +2645,6 @@ may require meticulous preparation with the Angular testing utilities.
 On the other hand, isolated unit tests can't confirm that the `ButtonComp` is
 properly bound to its template or even data bound at all.
 Use Angular tests for that.
-<a href="#top" class='to-top'>Back to top</a>
 
 <hr/>
 
@@ -3642,8 +3631,6 @@ The Angular `By` class has three static methods for common predicates:
 
 </code-example>
 
-<a href="#top" class='to-top'>Back to top</a>
-
 <div class='l' class='hr'>
 
 </div>
@@ -3792,7 +3779,6 @@ The sample tests are written to run in Jasmine and karma.
 The two "fast path" setups added the appropriate Jasmine and karma npm packages to the
 `devDependencies` section of the `package.json`.
 They're installed when you run `npm install`.
-<a href="#top" class='to-top'>Back to top</a>
 
 <div class='l' class='hr'>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Removes links back to top of documents
```

**What is the current behavior?** (You can also link to an open issue here)

Some docs have links to top.

**What is the new behavior?**

Remove all these links from within the page to the top.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

