### PR TITLE
fix(common): use correct ICU plural rules for all locales

### DIFF
--- a/packages/common/src/localization.ts
+++ b/packages/common/src/localization.ts
@@ -172,42 +172,6 @@ export function getPluralCase(locale: string, nLike: number | string): Plural {
     case 'xog':
       if (n === 1) return Plural.One;
       return Plural.Other;
-    case 'agq':
-    case 'bas':
-    case 'cu':
-    case 'dav':
-    case 'dje':
-    case 'dua':
-    case 'dyo':
-    case 'ebu':
-    case 'ewo':
-    case 'guz':
-    case 'kam':
-    case 'khq':
-    case 'ki':
-    case 'kln':
-    case 'kok':
-    case 'ksf':
-    case 'lrc':
-    case 'lu':
-    case 'luo':
-    case 'luy':
-    case 'mer':
-    case 'mfe':
-    case 'mgh':
-    case 'mua':
-    case 'mzn':
-    case 'nmg':
-    case 'nus':
-    case 'qu':
-    case 'rn':
-    case 'rw':
-    case 'sbp':
-    case 'twq':
-    case 'vai':
-    case 'yav':
-    case 'yue':
-    case 'zgh':
     case 'ak':
     case 'ln':
     case 'mg':
@@ -428,6 +392,9 @@ export function getPluralCase(locale: string, nLike: number | string): Plural {
       if (n === Math.floor(n) && n >= 0 && n <= 1 || n === Math.floor(n) && n >= 11 && n <= 99)
         return Plural.One;
       return Plural.Other;
+    // When there is no specification, the default is always "other"
+    // Spec: http://cldr.unicode.org/index/cldr-spec/plural-rules
+    // > other (required—general plural form — also used if the language only has a single form)
     default:
       return Plural.Other;
   }

--- a/packages/common/test/localization_spec.ts
+++ b/packages/common/test/localization_spec.ts
@@ -119,6 +119,16 @@ export function main() {
         expect(l10n.getPluralCategory(24)).toEqual('few');
         expect(l10n.getPluralCategory(25)).toEqual('other');
       });
+
+      it('should return the default value for a locale with no rule', () => {
+        const l10n = new NgLocaleLocalization('zgh');
+
+        expect(l10n.getPluralCategory(0)).toEqual('other');
+        expect(l10n.getPluralCategory(1)).toEqual('other');
+        expect(l10n.getPluralCategory(3)).toEqual('other');
+        expect(l10n.getPluralCategory(5)).toEqual('other');
+        expect(l10n.getPluralCategory(10)).toEqual('other');
+      });
     });
 
     describe('getPluralCategory', () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
```
[x] Bugfix
```

**What is the current behavior?**
Some locales with empty plural rules were using the wrong plural rule instead of the default one because of a bug in the extraction script.


**What is the new behavior?**
The extraction script has been fixed and the localization file updated accordingly. All the locales that were miscategorized have been removed so that they now use the default rule.
I've also updated the script based on the changes that have been done to the localization script (even if the code is supposed to be generated, some people have changed the content without updating the script).


**Does this PR introduce a breaking change?**
```
[x] No
```