### PR TITLE
docs(aio): correct statement in router guide

### DIFF
--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -944,8 +944,7 @@ When the application launches, the initial URL in the browser bar is something l
 
 
 
-That doesn't match any of the configured routes which means that the application won't display any component when it's launched.
-The user must click one of the links to trigger a navigation and display a component.
+However, the router will match this url to the wildcard route, displaying the `PageNotFoundComponent`.
 
 It would be nicer if the application had a **default route** that displayed the list of heroes immediately,
 just as it will when the user clicks the "Heroes" link or pastes `localhost:3000/heroes` into the address bar.


### PR DESCRIPTION
The router guide incorrectly states the following:
1) That the example url "doesn't match any of the configured routes"
2) "the application won't display any component when it's launched" 

The change clarifies that:
1) The router matches the example url to the wildcard route
2) The PageNotFoundComponent is displayed as a result

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Other... Please describe: docs
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

