### PR TITLE
fix(aio): close API filter selects when clicking outside (and improve a11y)

### DIFF
--- a/aio/src/app/embedded/api/api-list.component.html
+++ b/aio/src/app/embedded/api/api-list.component.html
@@ -1,22 +1,24 @@
 <div class="l-flex-wrap info-banner api-filter">
 
-  <div class="form-select-menu" (click)="onTypeSelectClick($event)">
-    <button class="form-select-button has-symbol" (click)="toggleTypeMenu()">
+  <div class="form-select-menu" (click)="onTypeSelectClick($event)" (keydown.esc)="typeMenuVisible(false)">
+    <button class="form-select-button has-symbol" (click)="typeMenuVisible(true)">
       <strong>Type:</strong><span class="symbol {{type.name}}"></span>{{type.title}}
     </button>
     <ul class="form-select-dropdown" *ngIf="showTypeMenu">
-      <li *ngFor="let t of types" (click)="setType(t)" [class.selected]="t === type">
+      <li *ngFor="let t of types" [class.selected]="t === type" role="button" tabindex="0"
+         (click)="setType(t)" (keydown.enter)="setType(t)" (keydown.space)="setType(t); $event.preventDefault()">
         <span class="symbol {{t.name}}"></span>{{t.title}}
       </li>
     </ul>
   </div>
 
-  <div class="form-select-menu" (click)="onStatusSelectClick($event)">
-    <button class="form-select-button" (click)="toggleStatusMenu()">
+  <div class="form-select-menu" (click)="onStatusSelectClick($event)" (keydown.esc)="statusMenuVisible(false)">
+    <button class="form-select-button" (click)="statusMenuVisible(true)">
       <strong>Status:</strong>{{status.title}}
     </button>
     <ul class="form-select-dropdown" *ngIf="showStatusMenu">
-      <li *ngFor="let s of statuses" (click)="setStatus(s)" [class.selected]="s === status">
+      <li *ngFor="let s of statuses" [class.selected]="s === status" role="button" tabindex="0"
+         (click)="setStatus(s)" (keydown.enter)="setStatus(s)" (keydown.space)="setStatus(s); $event.preventDefault()">
         {{s.title}}
       </li>
     </ul>

--- a/aio/src/app/embedded/api/api-list.component.html
+++ b/aio/src/app/embedded/api/api-list.component.html
@@ -1,6 +1,6 @@
 <div class="l-flex-wrap info-banner api-filter">
 
-  <div class="form-select-menu">
+  <div class="form-select-menu" (click)="onTypeSelectClick($event)">
     <button class="form-select-button has-symbol" (click)="toggleTypeMenu()">
       <strong>Type:</strong><span class="symbol {{type.name}}"></span>{{type.title}}
     </button>
@@ -11,7 +11,7 @@
     </ul>
   </div>
 
-  <div class="form-select-menu">
+  <div class="form-select-menu" (click)="onStatusSelectClick($event)">
     <button class="form-select-button" (click)="toggleStatusMenu()">
       <strong>Status:</strong>{{status.title}}
     </button>

--- a/aio/src/app/embedded/api/api-list.component.ts
+++ b/aio/src/app/embedded/api/api-list.component.ts
@@ -102,12 +102,12 @@ export class ApiListComponent implements OnInit, OnDestroy {
 
   onStatusSelectClick(evt) {
     evt.stopPropagation();
-    this.showTypeMenu = false;
+    this.typeMenuVisible(false);
   }
 
   onTypeSelectClick(evt) {
     evt.stopPropagation();
-    this.showStatusMenu = false;
+    this.statusMenuVisible(false);
   }
 
   // Todo: may need to debounce as the original did
@@ -117,23 +117,23 @@ export class ApiListComponent implements OnInit, OnDestroy {
   }
 
   setStatus(status: MenuItem) {
-    this.toggleStatusMenu();
     this.status = status;
+    this.statusMenuVisible(false);
     this.setSearchCriteria({status: status.name});
   }
 
   setType(type: MenuItem) {
-    this.toggleTypeMenu();
     this.type = type;
+    this.typeMenuVisible(false);
     this.setSearchCriteria({type: type.name});
   }
 
-  toggleStatusMenu() {
-    this.showStatusMenu = !this.showStatusMenu;
+  statusMenuVisible(isVisible) {
+    this.showStatusMenu = isVisible;
   }
 
-  toggleTypeMenu() {
-    this.showTypeMenu = !this.showTypeMenu;
+  typeMenuVisible(isVisible) {
+    this.showTypeMenu = isVisible;
   }
 
   //////// Private //////////

--- a/aio/src/app/embedded/api/api-list.component.ts
+++ b/aio/src/app/embedded/api/api-list.component.ts
@@ -6,11 +6,15 @@
 * Can add/remove API entity links based on filter settings.
 */
 
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, Inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { DOCUMENT } from '@angular/platform-browser';
 
 import { Observable } from 'rxjs/Observable';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { Subject } from 'rxjs/Subject';
 import { combineLatest } from 'rxjs/observable/combineLatest';
+import { fromEvent } from 'rxjs/observable/fromEvent';
+import 'rxjs/add/operator/takeUntil';
 
 import { LocationService } from 'app/shared/location.service';
 import { ApiItem, ApiSection, ApiService } from './api.service';
@@ -30,13 +34,14 @@ class SearchCriteria {
   selector: 'aio-api-list',
   templateUrl: './api-list.component.html'
 })
-export class ApiListComponent implements OnInit {
+export class ApiListComponent implements OnInit, OnDestroy {
 
   filteredSections: Observable<ApiSection[]>;
 
   showStatusMenu = false;
   showTypeMenu = false;
 
+  private onDestroy = new Subject();
   private criteriaSubject = new ReplaySubject<SearchCriteria>(1);
   private searchCriteria = new SearchCriteria();
 
@@ -69,9 +74,16 @@ export class ApiListComponent implements OnInit {
 
   constructor(
     private apiService: ApiService,
+    @Inject(DOCUMENT) private doc: Document,
     private locationService: LocationService) { }
 
   ngOnInit() {
+    fromEvent(this.doc, 'click')
+        .takeUntil(this.onDestroy)
+        .subscribe(() => {
+          this.showStatusMenu = false;
+          this.showTypeMenu = false;
+        })
 
     this.filteredSections = combineLatest(
       this.apiService.sections,
@@ -82,6 +94,20 @@ export class ApiListComponent implements OnInit {
     );
 
     this.initializeSearchCriteria();
+  }
+
+  ngOnDestroy() {
+    this.onDestroy.next();
+  }
+
+  onStatusSelectClick(evt) {
+    evt.stopPropagation();
+    this.showTypeMenu = false;
+  }
+
+  onTypeSelectClick(evt) {
+    evt.stopPropagation();
+    this.showStatusMenu = false;
   }
 
   // Todo: may need to debounce as the original did

--- a/aio/src/app/search/search-results/search-results.component.ts
+++ b/aio/src/app/search/search-results/search-results.component.ts
@@ -1,5 +1,4 @@
-import { Component, EventEmitter, HostListener, OnDestroy, OnInit, Output } from '@angular/core';
-import { Observable } from 'rxjs/Observable';
+import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
 import { SearchResult, SearchResults, SearchService } from '../search.service';

--- a/aio/src/styles/2-modules/_api-list.scss
+++ b/aio/src/styles/2-modules/_api-list.scss
@@ -31,7 +31,7 @@ aio-api-list {
 aio-api-list > div {
     display: flex;
     margin: 32px auto;
-    
+
     @media (max-width: 600px) {
         flex-direction: column;
         margin: 16px auto;
@@ -148,6 +148,11 @@ $form-select-width: 200px;
     .symbol {
       margin-right: 8px;
     }
+  }
+
+  &:focus {
+    border: 1px solid $blue-400;
+    box-shadow: 0 2px 2px rgba($blue-400, 0.24), 0 0 2px rgba($blue-400, 0.12);
   }
 }
 


### PR DESCRIPTION
There weren't any tests for this functionality before, but adding some is probably a good idea (if we decide to go with this approach).

An alternative approach is to bring in material's `MdSelect` (with its dependencies).