### PR TITLE
refactor(compiler): change `bundle` to `flatModuleIndex` in the code

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -266,7 +266,7 @@ compilePackage() {
     $NGC -p ${1}/tsconfig-build.json
     echo "======           Create ${1}/../${package_name}.d.ts re-export file for Closure"
     echo "$(cat ${LICENSE_BANNER}) ${N} export * from './${package_name}/index'" > ${2}/../${package_name}.d.ts
-    echo "{\"__symbolic\":\"module\",\"version\":3,\"metadata\":{},\"exports\":[{\"from\":\"./${package_name}/index\"}],\"bundleRedirect\":true}" > ${2}/../${package_name}.metadata.json
+    echo "{\"__symbolic\":\"module\",\"version\":3,\"metadata\":{},\"exports\":[{\"from\":\"./${package_name}/index\"}],\"flatModuleIndexRedirect\":true}" > ${2}/../${package_name}.metadata.json
   fi
 
   for DIR in ${1}/* ; do

--- a/packages/compiler-cli/src/compiler_host.ts
+++ b/packages/compiler-cli/src/compiler_host.ts
@@ -31,9 +31,9 @@ export class CompilerHost implements AotCompilerHost {
   protected basePath: string;
   private genDir: string;
   private resolverCache = new Map<string, ModuleMetadata[]>();
-  private bundleIndexCache = new Map<string, boolean>();
-  private bundleIndexNames = new Set<string>();
-  private bundleRedirectNames = new Set<string>();
+  private flatModuleIndexCache = new Map<string, boolean>();
+  private flatModuleIndexNames = new Set<string>();
+  private flatModuleIndexRedirectNames = new Set<string>();
   private moduleFileNames = new Map<string, string|null>();
   protected resolveModuleNameHost: CompilerHostContext;
 
@@ -281,8 +281,8 @@ export class CompilerHost implements AotCompilerHost {
       // Check for a bundle index.
       if (this.hasBundleIndex(filePath)) {
         const normalFilePath = path.normalize(filePath);
-        return this.bundleIndexNames.has(normalFilePath) ||
-            this.bundleRedirectNames.has(normalFilePath);
+        return this.flatModuleIndexNames.has(normalFilePath) ||
+            this.flatModuleIndexRedirectNames.has(normalFilePath);
       }
     }
     return true;
@@ -313,7 +313,7 @@ export class CompilerHost implements AotCompilerHost {
 
   private hasBundleIndex(filePath: string): boolean {
     const checkBundleIndex = (directory: string): boolean => {
-      let result = this.bundleIndexCache.get(directory);
+      let result = this.flatModuleIndexCache.get(directory);
       if (result == null) {
         if (path.basename(directory) == 'node_module') {
           // Don't look outside the node_modules this package is installed in.
@@ -333,14 +333,14 @@ export class CompilerHost implements AotCompilerHost {
                   const metadataFile = typings.replace(DTS, '.metadata.json');
                   if (this.context.fileExists(metadataFile)) {
                     const metadata = JSON.parse(this.context.readFile(metadataFile));
-                    if (metadata.bundleRedirect) {
-                      this.bundleRedirectNames.add(typings);
+                    if (metadata.flatModuleIndexRedirect) {
+                      this.flatModuleIndexRedirectNames.add(typings);
                       // Note: don't set result = true,
                       // as this would mark this folder
                       // as having a bundleIndex too early without
                       // filling the bundleIndexNames.
                     } else if (metadata.importAs) {
-                      this.bundleIndexNames.add(typings);
+                      this.flatModuleIndexNames.add(typings);
                       result = true;
                     }
                   }
@@ -360,7 +360,7 @@ export class CompilerHost implements AotCompilerHost {
             result = false;
           }
         }
-        this.bundleIndexCache.set(directory, result);
+        this.flatModuleIndexCache.set(directory, result);
       }
       return result;
     };


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Refactoring (no functional changes, no api changes)
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**

Uses the accepted `flatModule` name instead of `bundle`.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```