### PR TITLE
fix(router): opening links in new window

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -209,9 +209,9 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   ngOnChanges(changes: {}): any { this.updateTargetUrlAndHref(); }
   ngOnDestroy(): any { this.subscription.unsubscribe(); }
 
-  @HostListener('click', ['$event.button', '$event.ctrlKey', '$event.metaKey'])
-  onClick(button: number, ctrlKey: boolean, metaKey: boolean): boolean {
-    if (button !== 0 || ctrlKey || metaKey) {
+  @HostListener('click', ['$event.button', '$event.ctrlKey', '$event.metaKey', '$event.shiftKey'])
+  onClick(button: number, ctrlKey: boolean, metaKey: boolean, shiftKey: boolean): boolean {
+    if (button !== 0 || ctrlKey || metaKey || shiftKey) {
       return true;
     }
 

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -337,7 +337,7 @@ export declare class RouterLinkWithHref implements OnChanges, OnDestroy {
     constructor(router: Router, route: ActivatedRoute, locationStrategy: LocationStrategy);
     ngOnChanges(changes: {}): any;
     ngOnDestroy(): any;
-    onClick(button: number, ctrlKey: boolean, metaKey: boolean): boolean;
+    onClick(button: number, ctrlKey: boolean, metaKey: boolean, shiftKey: boolean): boolean;
 }
 
 /** @stable */


### PR DESCRIPTION
Shift-clicks on router-links should not prevent browser default action.

A follow on to:
https://github.com/angular/angular/commit/1ac9dda93d01e5e61a3af32a9c596e6f26d50b00

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Shift-clicking on a router-link has no special effect.  It opens the link in the current tab.

**What is the new behavior?**

Shift-clicking is passed on to the browser to handle.  Most (all?) browsers will open the link in a new window.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

This is a follow-on to https://github.com/angular/angular/commit/1ac9dda93d01e5e61a3af32a9c596e6f26d50b00
which added this functionality for the ctrl and meta keys.