### PR TITLE
fix(platform-browser): replace the placeholder url on sanitization

### DIFF
--- a/aio/content/examples/security/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/security/e2e/src/app.e2e-spec.ts
@@ -17,7 +17,7 @@ describe('Security E2E Tests', () => {
 
   it('escapes untrusted URLs', () => {
     let untrustedUrl = element(By.className('e2e-dangerous-url'));
-    expect(untrustedUrl.getAttribute('href')).toMatch(/^unsafe:javascript/);
+    expect(untrustedUrl.getAttribute('href')).toMatch(/^about:invalid#unsafe&url=javascript/);
   });
 
   it('binds trusted URLs', () => {

--- a/packages/core/src/sanitization/url_sanitizer.ts
+++ b/packages/core/src/sanitization/url_sanitizer.ts
@@ -51,7 +51,7 @@ export function _sanitizeUrl(url: string): string {
     console.warn(`WARNING: sanitizing unsafe URL value ${url} (see http://g.co/ng/security#xss)`);
   }
 
-  return 'unsafe:' + url;
+  return 'about:invalid#unsafe&url=' + encodeURI(url);
 }
 
 export function sanitizeSrcset(srcset: string): string {

--- a/packages/core/test/linker/security_integration_spec.ts
+++ b/packages/core/test/linker/security_integration_spec.ts
@@ -146,7 +146,7 @@ function declareTests({useJit}: {useJit: boolean}) {
         ci.ctxProp = 'javascript:alert(1)';
         fixture.detectChanges();
         value = isAttribute ? getDOM().getAttribute(e, 'href') : getDOM().getProperty(e, 'href');
-        expect(value).toEqual('unsafe:javascript:alert(1)');
+        expect(value).toEqual('about:invalid#unsafe&url=javascript:alert(1)');
       }
 
       it('should escape unsafe properties', () => {

--- a/packages/core/test/sanitization/html_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/html_sanitizer_spec.ts
@@ -44,7 +44,7 @@ import {_sanitizeHtml} from '../../src/sanitization/html_sanitizer';
           .toEqual('<a xlink:href="something">t</a>');
       expect(_sanitizeHtml(defaultDoc, '<a xlink:evil="something">t</a>')).toEqual('<a>t</a>');
       expect(_sanitizeHtml(defaultDoc, '<a xlink:href="javascript:foo()">t</a>'))
-          .toEqual('<a xlink:href="unsafe:javascript:foo()">t</a>');
+          .toEqual('<a xlink:href="about:javascript:foo()">t</a>');
     });
 
     it('supports HTML5 elements', () => {
@@ -54,7 +54,7 @@ import {_sanitizeHtml} from '../../src/sanitization/html_sanitizer';
 
     it('sanitizes srcset attributes', () => {
       expect(_sanitizeHtml(defaultDoc, '<img srcset="/foo.png 400px, javascript:evil() 23px">'))
-          .toEqual('<img srcset="/foo.png 400px, unsafe:javascript:evil() 23px">');
+          .toEqual('<img srcset="/foo.png 400px, about:javascript:evil() 23px">');
     });
 
     it('supports sanitizing plain text',
@@ -163,7 +163,7 @@ import {_sanitizeHtml} from '../../src/sanitization/html_sanitizer';
       it('should prevent mXSS attacks', function() {
         // In Chrome Canary 62, the ideographic space character is kept as a stringified HTML entity
         expect(_sanitizeHtml(defaultDoc, '<a href="&#x3000;javascript:alert(1)">CLICKME</a>'))
-            .toMatch(/<a href="unsafe:(&#12288;)?javascript:alert\(1\)">CLICKME<\/a>/);
+            .toMatch(/<a href="about:(&#12288;)?javascript:alert\(1\)">CLICKME<\/a>/);
       });
     }
   });

--- a/packages/core/test/sanitization/url_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/url_sanitizer_spec.ts
@@ -24,7 +24,7 @@ import {_sanitizeUrl, sanitizeSrcset} from '../../src/sanitization/url_sanitizer
     afterEach(() => { console.warn = originalLog; });
 
     t.it('reports unsafe URLs', () => {
-      t.expect(_sanitizeUrl('javascript:evil()')).toBe('unsafe:javascript:evil()');
+      t.expect(_sanitizeUrl('javascript:evil()')).toBe('about:javascript:evil()');
       t.expect(logMsgs.join('\n')).toMatch(/sanitizing unsafe URL value/);
     });
 
@@ -73,7 +73,7 @@ import {_sanitizeUrl, sanitizeSrcset} from '../../src/sanitization/url_sanitizer
         'data:application/x-msdownload;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
       ];
       for (const url of invalidUrls) {
-        t.it(`valid ${url}`, () => t.expect(_sanitizeUrl(url)).toMatch(/^unsafe:/));
+        t.it(`valid ${url}`, () => t.expect(_sanitizeUrl(url)).toMatch(/^about:/));
       }
     });
 
@@ -110,7 +110,9 @@ import {_sanitizeUrl, sanitizeSrcset} from '../../src/sanitization/url_sanitizer
         'http://angular.io/images/test.png, ht:tp://angular.io/images/test.png',
       ];
       for (const srcset of invalidSrcsets) {
-        t.it(`valid ${srcset}`, () => t.expect(sanitizeSrcset(srcset)).toMatch(/unsafe:/));
+        t.it(
+            `valid ${srcset}`,
+            () => t.expect(sanitizeSrcset(srcset)).toMatch(/about:invalid#unsafe&url=/));
       }
     });
 


### PR DESCRIPTION
cc @mprobst 

The previous unsafe:foo scheme is not great, because it's not specified and
it doesn't encode the actual URL. I don't think this is a security issue right
now, but it's a risk, things might go wrong if some browser quirks appear. Using 
about:invalid#unsafe&url=foo is more explicit, and uses a scheme that is
expected to fail (but still not standardized, I think?). The urlencoding also makes
sure that no weird characters go into the DOM.

I don't think the previous behavior was ever documented? 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features) 
- [] Docs have been added / updated (for bug fixes / features)

Not documented AFAIK. I don't think users are supposed to rely on that.

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

On sanitization, URLs deemed unsafe ("javascript:foo(1 & 2)" for example) are appended to "unsafe:" (example becomes "unsafe:javascript:foo(1 & 2)").

**What is the new behavior?**

On sanitization, unsafe URLs are urlencoded, and appended to "about:invalid#unsafe&url=" (example becomes "about:invalid#unsafe&url=javascript:foo(1%20%26%202)").

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```
Errr... good question ? I don't think this is really breaking (undocumented behavior), but it might break some tests relying on the full /^unsafe:/ regexp. Trivial to fix, but maybe this PR should wait for a breaking change window.

