### PR TITLE
feat(http):  MockConnection- add ability to trigger xhr response errors

### DIFF
--- a/packages/http/test/backends/mock_backend_spec.ts
+++ b/packages/http/test/backends/mock_backend_spec.ts
@@ -71,6 +71,18 @@ export function main() {
          connection.mockError(new Error('nope'));
        }));
 
+    it('should allow responding a xhr response error',
+       inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+         const fakeErrorWithStatusResponse: Response =
+             new Response(new ResponseOptions({body: 'error', status: 401}));
+         const connection: MockConnection = backend.createConnection(sampleRequest1);
+         connection.response.subscribe(null !, (error: Response) => {
+           expect(error.status).toBe(401);
+           async.done();
+         });
+         connection.mockXHRError(fakeErrorWithStatusResponse);
+       }));
+
     it('should not throw when there are no unresolved requests',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          const connection: MockConnection = backend.createConnection(sampleRequest1);

--- a/packages/http/testing/src/mock_backend.ts
+++ b/packages/http/testing/src/mock_backend.ts
@@ -103,6 +103,27 @@ export class MockConnection implements Connection {
     this.readyState = ReadyState.Done;
     this.response.error(err);
   }
+
+  /**
+   * Emits the provided response object as an error to the {@link Response} {@link EventEmitter}
+   * returned
+   * from {@link Http}.
+   *
+   * ### Example
+   *
+   * ```
+   * var connection;
+   * backend.connections.subscribe(c => connection = c);
+   * http.request('data.json').subscribe(null, (err)=> console.error(err.status));
+   * connection.mockXHRError(new Response(new ResponseOptions({ body: 'error', status: 401 })));
+   * ```
+   *
+   */
+
+  mockXHRError(err: Response) {
+    this.readyState = ReadyState.Done;
+    this.response.error(err);
+  }
 }
 
 /**


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**
- [ x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ x ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
`mockError` in `MockConnection` only accepts `Error` type object.
That means that you can't emulate an xhr error response with an error status like 401.


**What is the new behavior?**
I've added a `mockXHRError` method that accepts a `Response` type and passes it to `response.error()`


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

