### PR TITLE
fix(core): allow undefined value for renderer setElement(…)

### DIFF
--- a/packages/core/src/render/api.ts
+++ b/packages/core/src/render/api.ts
@@ -73,7 +73,7 @@ export abstract class Renderer {
 
   abstract setElementProperty(renderElement: any, propertyName: string, propertyValue: any): void;
 
-  abstract setElementAttribute(renderElement: any, attributeName: string, attributeValue: string):
+  abstract setElementAttribute(renderElement: any, attributeName: string, attributeValue?: string):
       void;
 
   /**
@@ -84,7 +84,7 @@ export abstract class Renderer {
 
   abstract setElementClass(renderElement: any, className: string, isAdd: boolean): void;
 
-  abstract setElementStyle(renderElement: any, styleName: string, styleValue: string): void;
+  abstract setElementStyle(renderElement: any, styleName: string, styleValue?: string): void;
 
   abstract invokeElementMethod(renderElement: any, methodName: string, args?: any[]): void;
 

--- a/packages/core/src/view/refs.ts
+++ b/packages/core/src/view/refs.ts
@@ -433,7 +433,7 @@ class RendererAdapter implements RendererV1 {
     this.delegate.setProperty(renderElement, propertyName, propertyValue);
   }
 
-  setElementAttribute(renderElement: Element, namespaceAndName: string, attributeValue: string):
+  setElementAttribute(renderElement: Element, namespaceAndName: string, attributeValue?: string):
       void {
     const [ns, name] = splitNamespace(namespaceAndName);
     if (attributeValue != null) {
@@ -453,7 +453,7 @@ class RendererAdapter implements RendererV1 {
     }
   }
 
-  setElementStyle(renderElement: HTMLElement, styleName: string, styleValue: string): void {
+  setElementStyle(renderElement: HTMLElement, styleName: string, styleValue?: string): void {
     if (styleValue != null) {
       this.delegate.setStyle(renderElement, styleName, styleValue);
     } else {

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -692,10 +692,10 @@ export declare abstract class Renderer {
     abstract projectNodes(parentElement: any, nodes: any[]): void;
     abstract selectRootElement(selectorOrNode: string | any, debugInfo?: RenderDebugInfo): any;
     abstract setBindingDebugInfo(renderElement: any, propertyName: string, propertyValue: string): void;
-    abstract setElementAttribute(renderElement: any, attributeName: string, attributeValue: string): void;
+    abstract setElementAttribute(renderElement: any, attributeName: string, attributeValue?: string): void;
     abstract setElementClass(renderElement: any, className: string, isAdd: boolean): void;
     abstract setElementProperty(renderElement: any, propertyName: string, propertyValue: any): void;
-    abstract setElementStyle(renderElement: any, styleName: string, styleValue: string): void;
+    abstract setElementStyle(renderElement: any, styleName: string, styleValue?: string): void;
     abstract setText(renderNode: any, text: string): void;
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Renderer (V1) issue #13686, which has been closed but not fixed.


**What is the new behavior?**
Using Renderer’s setElementAttribute or setElementStyle with a null or undefined value removes the
corresponding attribute or style. The argument type now allows this when using strictNullChecks.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:

