### PR TITLE
docs(aio): Add info about how to create translation source files via Angular CLI

### DIFF
--- a/aio/content/guide/i18n.md
+++ b/aio/content/guide/i18n.md
@@ -312,6 +312,12 @@ Windows users may have to quote the command like this: `"./node_modules/.bin/ng-
 
 </div>
 
+In case you are using the Angular CLI you can enter the follwing shorthand instead:
+
+<code-example language="sh" class="code-shell">
+  ng xi18n
+
+</code-example>
 
 
 By default, the tool generates a translation file named **`messages.xlf`** in the
@@ -371,7 +377,14 @@ to make the command easier to remember and run:
   }
 </code-example>
 
+or in case you are using Angular CLI:
 
+<code-example format='.' language='sh'>
+  "scripts": {
+    "i18n": "ng xi18n",
+    ...
+  }
+</code-example>
 
 Now you can issue command variations such as these:
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Docs
```

**What is the current behavior?** (You can also link to an open issue here)

The [Internationalization (I18N) recipe](https://angular.io/docs/ts/latest/cookbook/i18n.html) is missing info about how to create translation source files via Angular CLI.

**What is the new behavior?**

Added the information

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

This is extermely important. Because using the way which is described right now doesn’t work when using Sass imports.

I found upon a few closed Github issues which offered dirty workarounds and nearly tried to used on of them:

- https://github.com/angular/angular/issues/11747
- https://github.com/mgechev/angular-seed/issues/1488
- https://github.com/mgechev/angular-seed/issues/1772

But it’s all good when using the Angular CLI ❤️ 

**Question**: Should I replace the old way with the angular CLI way instead?

