### PR TITLE
fix(aio): add missing WeakMap polyfill

### DIFF
--- a/aio/src/ie-polyfills.js
+++ b/aio/src/ie-polyfills.js
@@ -11,6 +11,7 @@ import 'core-js/es6/date';
 import 'core-js/es6/array';
 import 'core-js/es6/regexp';
 import 'core-js/es6/map';
+import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

IE9 & IE10 will throw `'WeakMap' is undefined` error.

**What is the new behavior?**

IE9 & IE10 won't throw that error.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

The `WeakMap` feature in ES2015 is used by the **View Engine** at [angular/packages/core/src/view/util.ts](https://github.com/angular/angular/blob/39b92f7e546b8bdecc0e08c915d36717358c122b/packages/core/src/view/util.ts#L237):

```typescript
const DEFINITION_CACHE = new WeakMap<any, Definition<any>>();
```

Since IE9 & IE10 does not provide that by default, it should be consider part of IE polyfills.
