### PR TITLE
fix(forms): Min/MaxValidator change parseInt to parseFloat

### DIFF
--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -130,7 +130,7 @@ export class MinValidator implements Validator,
 
   registerOnValidatorChange(fn: () => void): void { this._onChange = fn; }
 
-  private _createValidator(): void { this._validator = Validators.min(parseInt(this.min, 10)); }
+  private _createValidator(): void { this._validator = Validators.min(parseFloat(this.min)); }
 }
 
 
@@ -169,7 +169,7 @@ export class MaxValidator implements Validator,
 
   registerOnValidatorChange(fn: () => void): void { this._onChange = fn; }
 
-  private _createValidator(): void { this._validator = Validators.max(parseInt(this.max, 10)); }
+  private _createValidator(): void { this._validator = Validators.max(parseFloat(this.max)); }
 }
 
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

`MinValidator` and `MaxValidator` use `parseInt` to convert the attribute string to an integer, this does not allow floating point `min` or `max`. This is probably due to a reuse of code from `MinLengthValidator` and `MaxLengthValidator`.

**What is the new behavior?**

The following is now possible:
``` HTML
<input [min]="0.55" [max]="1.25">
```
`parseInt` is replaced by `parseFloat`.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x ] No
```

**Other information**:

Closes #17080

