### PR TITLE
aio: title and search index fixes

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -107,6 +107,7 @@
     "ts-node": "~2.0.0",
     "tslint": "~4.5.0",
     "typescript": "2.2.0",
+    "unist-util-filter": "^0.2.1",
     "unist-util-source": "^1.0.1",
     "unist-util-visit": "^1.1.1",
     "vrsource-tslint-rules": "^4.0.1",

--- a/aio/tools/transforms/angular-base-package/index.js
+++ b/aio/tools/transforms/angular-base-package/index.js
@@ -55,6 +55,7 @@ module.exports = new Package('angular-base', [
 
     generateKeywordsProcessor.ignoreWordsFile = path.resolve(__dirname, 'ignore.words');
     generateKeywordsProcessor.docTypesToIgnore = ['example-region'];
+    generateKeywordsProcessor.propertiesToIgnore = ['renderedContent'];
   })
 
   // Where do we write the output files?

--- a/aio/tools/transforms/angular-base-package/post-processors/add-image-dimensions.spec.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/add-image-dimensions.spec.js
@@ -32,7 +32,7 @@ describe('addImageDimensions post-processor', () => {
     processor.$process(docs);
     expect(getImageDimensionsSpy).toHaveBeenCalledWith('base/path', 'a/b.jpg');
     expect(getImageDimensionsSpy).toHaveBeenCalledWith('base/path', 'c/d.png');
-    expect(docs).toEqual([{
+    expect(docs).toEqual([jasmine.objectContaining({
       docType: 'a',
       renderedContent: `
         <p>xxx</p>
@@ -41,7 +41,7 @@ describe('addImageDimensions post-processor', () => {
         <img src="c/d.png" width="30" height="40">
         <p>zzz</p>
       `
-    }]);
+    })]);
   });
 
   it('should log a warning for images with no src attribute', () => {
@@ -51,10 +51,10 @@ describe('addImageDimensions post-processor', () => {
     }];
     processor.$process(docs);
     expect(getImageDimensionsSpy).not.toHaveBeenCalled();
-    expect(docs).toEqual([{
+    expect(docs).toEqual([jasmine.objectContaining({
       docType: 'a',
       renderedContent: '<img attr="value">'
-    }]);
+    })]);
     expect(log.warn).toHaveBeenCalled();
   });
 
@@ -70,10 +70,10 @@ describe('addImageDimensions post-processor', () => {
     }];
     processor.$process(docs);
     expect(getImageDimensionsSpy).toHaveBeenCalled();
-    expect(docs).toEqual([{
+    expect(docs).toEqual([jasmine.objectContaining({
       docType: 'a',
       renderedContent: '<img src="missing">'
-    }]);
+    })]);
     expect(log.warn).toHaveBeenCalled();
   });
 
@@ -88,14 +88,14 @@ describe('addImageDimensions post-processor', () => {
     }];
     processor.$process(docs);
     expect(getImageDimensionsSpy).not.toHaveBeenCalled();
-    expect(docs).toEqual([{
+    expect(docs).toEqual([jasmine.objectContaining({
       docType: 'a',
       renderedContent: `
         <img src="a/b.jpg" width="10">
         <img src="c/d.jpg" height="10">
         <img src="e/f.jpg" width="10" height="10">
       `
-    }]);
+    })]);
   });
 
   function mockGetImageDimensions() {

--- a/aio/tools/transforms/angular-base-package/post-processors/h1-checker.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/h1-checker.js
@@ -1,6 +1,8 @@
 const visit = require('unist-util-visit');
 const is = require('hast-util-is-element');
 const source = require('unist-util-source');
+const toString = require('hast-util-to-string');
+const filter = require('unist-util-filter');
 
 module.exports = function h1CheckerPostProcessor() {
   return (ast, file) => {
@@ -8,11 +10,23 @@ module.exports = function h1CheckerPostProcessor() {
     visit(ast, node => {
       if (is(node, 'h1')) {
         h1s.push(node);
+        file.title = getText(node);
       }
     });
+
     if (h1s.length > 1) {
       const h1Src = h1s.map(node => source(node, file)).join(', ');
       file.fail(`More than one h1 found [${h1Src}]`);
     }
   };
 };
+
+function getText(h1) {
+  // Remove the aria-hidden anchor from the h1 node
+  const cleaned = filter(h1, node => !(
+    is(node, 'a') && node.properties &&
+    (node.properties.ariaHidden === 'true' || node.properties['aria-hidden'] === 'true')
+  ));
+
+  return toString(cleaned);
+}

--- a/aio/tools/transforms/angular-base-package/post-processors/h1-checker.spec.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/h1-checker.spec.js
@@ -46,4 +46,27 @@ describe('h1Checker postprocessor', () => {
     };
     expect(() => processor.$process([doc])).not.toThrow();
   });
+
+  it('should attach the h1 text to the vFile', () => {
+    const doc = {
+      docType: 'a',
+      renderedContent: '<h1>Heading 1</h1>'
+    };
+    processor.$process([doc]);
+    expect(doc.vFile.title).toEqual('Heading 1');
+  });
+
+  it('should clean aria-hidden anchors from h1 text added to the vFile', () => {
+    const doc = {
+      docType: 'a',
+      renderedContent:
+        '<h1 class="no-toc" id="what-is-angular">' +
+          '<a title="Link to this heading" class="header-link" aria-hidden="true" href="docs#what-is-angular">' +
+            '<i class="material-icons">link</i>' +
+          '</a>What is Angular?' +
+        '</h1>'
+    };
+    processor.$process([doc]);
+    expect(doc.vFile.title).toEqual('What is Angular?');
+  });
 });

--- a/aio/tools/transforms/angular-base-package/processors/convertToJson.js
+++ b/aio/tools/transforms/angular-base-package/processors/convertToJson.js
@@ -12,17 +12,13 @@ module.exports = function convertToJsonProcessor(log, createDocMessage) {
 
           let title = doc.title;
 
-          // We do allow an empty `title` but resort to `name` if it is not even defined
+          // We do allow an empty `title` but if it is `undefined` we resort to `vFile.title` and then `name`
           if (title === undefined) {
-            title = doc.name;
+            title = (doc.vFile && doc.vFile.title);
           }
 
-          // If there is no title then try to extract it from the first h1 in the renderedContent
           if (title === undefined) {
-            const match = /<h1[^>]*>(.+?)<\/h1>/.exec(contents);
-            if (match) {
-              title = match[1];
-            }
+            title = doc.name;
           }
 
           // If there is still no title then log a warning

--- a/aio/tools/transforms/angular-base-package/processors/convertToJson.spec.js
+++ b/aio/tools/transforms/angular-base-package/processors/convertToJson.spec.js
@@ -50,8 +50,12 @@ describe('convertToJson processor', () => {
     expect(log.warn).not.toHaveBeenCalled();
   });
 
-  it('should get the title from the first `h1` if no title nor name is specified', () => {
-    const docs = [{ docType: 'test-doc', renderedContent: '<div><h1 class="title">Some title</h1><article><h1>Article 1</h1></article></div>' }];
+  it('should get the title from the title extracted from the h1 in the rendered content if no title property is specified', () => {
+    const docs = [{
+      docType: 'test-doc',
+      vFile: { title: 'Some title' },
+      renderedContent: '<div><h1 class="title">Some title</h1><article><h1>Article 1</h1></article></div>'
+    }];
     processor.$process(docs);
     expect(JSON.parse(docs[0].renderedContent).contents).toEqual('<div><h1 class="title">Some title</h1><article><h1>Article 1</h1></article></div>');
     expect(JSON.parse(docs[0].renderedContent).title).toEqual('Some title');

--- a/aio/tools/transforms/angular-base-package/processors/generateKeywords.js
+++ b/aio/tools/transforms/angular-base-package/processors/generateKeywords.js
@@ -22,8 +22,8 @@ module.exports = function generateKeywordsProcessor(log, readFilesProcessor) {
       propertiesToIgnore: {},
       outputFolder: {presence: true}
     },
-    $runAfter: ['paths-computed'],
-    $runBefore: ['rendering-docs'],
+    $runAfter: ['postProcessHtml'],
+    $runBefore: ['writing-files'],
     $process: function(docs) {
 
       // Keywords to ignore
@@ -103,9 +103,10 @@ module.exports = function generateKeywordsProcessor(log, readFilesProcessor) {
           }
         });
 
+        doc.searchTitle = doc.searchTitle || doc.title || doc.vFile && doc.vFile.title || doc.name;
 
         doc.searchTerms = {
-          titleWords: extractTitleWords(doc.title || doc.name),
+          titleWords: extractTitleWords(doc.searchTitle),
           keywords: words.sort().join(' '),
           members: members.sort().join(' ')
         };
@@ -115,16 +116,16 @@ module.exports = function generateKeywordsProcessor(log, readFilesProcessor) {
       var searchData =
           filteredDocs.filter(function(page) { return page.searchTerms; }).map(function(page) {
             return Object.assign(
-                {path: page.path, title: page.searchTitle || page.name || page.title, type: page.docType}, page.searchTerms);
+                {path: page.path, title: page.searchTitle, type: page.docType}, page.searchTerms);
           });
 
       docs.push({
         docType: 'json-doc',
         id: 'search-data-json',
-        template: 'json-doc.template.json',
         path: this.outputFolder + '/search-data.json',
         outputPath: this.outputFolder + '/search-data.json',
-        data: searchData
+        data: searchData,
+        renderedContent: JSON.stringify(searchData)
       });
     }
   };

--- a/aio/tools/transforms/post-process-package/processors/post-process-html.js
+++ b/aio/tools/transforms/post-process-package/processors/post-process-html.js
@@ -39,6 +39,7 @@ module.exports = function postProcessHtml(log, createDocMessage) {
             vFile.messages.forEach(m => {
               log.warn(createDocMessage(m.message, doc));
             });
+            doc.vFile = vFile;
           } catch(e) {
             throw new Error(createDocMessage(e.message, doc));
           }

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -2705,6 +2705,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+flatmap@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/flatmap/-/flatmap-0.0.3.tgz#1f18a4d938152d495965f9c958d923ab2dd669b4"
+
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
@@ -7256,9 +7260,20 @@ unist-builder@^1.0.1:
   dependencies:
     object-assign "^4.1.0"
 
+unist-util-filter@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/unist-util-filter/-/unist-util-filter-0.2.1.tgz#e2f7876828903a6a9308e362051f86b14f35b545"
+  dependencies:
+    flatmap "0.0.3"
+    unist-util-is "^1.0.0"
+
 unist-util-generated@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.0.tgz#8c95657ff12b32eaffe0731fbb37da6995fae01b"
+
+unist-util-is@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-1.0.0.tgz#4c7b3c5c0f6aa963640056fe4af7b5fcfdbb8ef0"
 
 unist-util-is@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Now that titles are extracted from the `h1` in the `renderedContent`, the consumers of the
title had to be moved to after the `postProcessHtml` processor.

Closes #17048