### PR TITLE
fix(aio): place progress bar at the top

### DIFF
--- a/aio/src/styles/2-modules/_progress-bar.scss
+++ b/aio/src/styles/2-modules/_progress-bar.scss
@@ -2,11 +2,7 @@
   height: 2px;
   overflow: hidden;
   position: fixed;
-  top: 64px;
+  top: 0;
   width: 100vw;
-  z-index: 5;
-
-  @media (max-width: 600px) {
-      top: 56px;
-  }
+  z-index: 11;
 }


### PR DESCRIPTION
Previously, the progress bar would be placed right under the static top bar. Now that the top bar i not tatic any more, it makes more sense to place the progress bar at the top of the page.

Fixes #17103.
