### PR TITLE
build(aio): fix up API doc-gen templates

### DIFF
--- a/aio/tools/transforms/templates/api/includes/class-overview.html
+++ b/aio/tools/transforms/templates/api/includes/class-overview.html
@@ -1,11 +1,11 @@
 {% macro renderMember(member) %}{% if not member.internal -%}
-<a class="code-anchor" href="#{$ member.name $}">{$ member.name $}</a> {$ params.paramList(member.parameters) | indent(4, false) | trim() $}{$ params.returnType(member.returnType) $}
+<a class="code-anchor" href="#{$ member.name $}">{$ member.name $}</a>{$ params.paramList(member.parameters) | indent(4, false) | trim() $}{$ params.returnType(member.returnType) $}
 {%- endif %}{% endmacro -%}
 
 <section class="class-overview">
   <h2>Overview</h2>
   <code-example language="ts" hideCopy="true">
-  {$ doc.docType $} {$ doc.name $} {$ doc.heritage $} {
+  {$ doc.docType $} {$ doc.name $}{$ doc.heritage $} {
   {%- if doc.statics.length %}{% for member in doc.statics %}
     static {$ renderMember(member) $}{% endfor %}{% endif %}
   {%- if doc.constructorDoc %}

--- a/aio/tools/transforms/templates/api/includes/interface-overview.html
+++ b/aio/tools/transforms/templates/api/includes/interface-overview.html
@@ -1,10 +1,10 @@
 <section class="interface-overview">
   <h2>Interface Overview</h2>
   <code-example language="ts" hideCopy="true">
-  interface {$ doc.name $} {$ doc.heritage $} { {% if doc.newMember %}
-    <a class="code-anchor" href="#{$ doc.newMember.name $}">{$ doc.newMember.name | indent(6, false) | trim $}</a> {$ params.paramList(doc.newMember.parameters) | indent(8, false) | trim $}{$ params.returnType(doc.newMember.returnType) $}{% endif %}{% if doc.callMember %}
-    <a class="code-anchor" href="#{$ doc.callMember.name $}">{$ doc.callMember.name | indent(6, false) | trim $}</a> {$ params.paramList(doc.callMember.parameters) | indent(8, false) | trim $}{$ params.returnType(doc.callMember.returnType) $}{% endif %}{% if doc.members.length %}{% for member in doc.members %}{% if not member.internal %}
-    <a class="code-anchor" href="#{$ member.name $}">{$ member.name | indent(6, false) | trim $}</a> {$ params.paramList(member.parameters) | indent(8, false) | trim $}{$ params.returnType(member.returnType) $}{% endif %}{% endfor %}{% endif %}
+  interface {$ doc.name $}{$ doc.heritage $} { {% if doc.newMember %}
+    <a class="code-anchor" href="#{$ doc.newMember.name $}">{$ doc.newMember.name | indent(6, false) | trim $}</a>{$ params.paramList(doc.newMember.parameters) | indent(8, false) | trim $}{$ params.returnType(doc.newMember.returnType) $}{% endif %}{% if doc.callMember %}
+    <a class="code-anchor" href="#{$ doc.callMember.name $}">{$ doc.callMember.name | indent(6, false) | trim $}</a>{$ params.paramList(doc.callMember.parameters) | indent(8, false) | trim $}{$ params.returnType(doc.callMember.returnType) $}{% endif %}{% if doc.members.length %}{% for member in doc.members %}{% if not member.internal %}
+    <a class="code-anchor" href="#{$ member.name $}">{$ member.name | indent(6, false) | trim $}</a>{$ params.paramList(member.parameters) | indent(8, false) | trim $}{$ params.returnType(member.returnType) $}{% endif %}{% endfor %}{% endif %}
   }
   </code-example>
 </section>

--- a/aio/tools/transforms/templates/api/includes/members.html
+++ b/aio/tools/transforms/templates/api/includes/members.html
@@ -1,19 +1,29 @@
-{% if doc.members.length %}
+{% if doc.members.length or doc.newMember or doc.callMember %}
 <section class="member-members">
   <h2>Members</h2>
+  {% if doc.newMember %}
+    <div class="new-member">
+      <a id="{$ doc.newMember.name $}"></a>
+      <code-example hideCopy="true">{$ doc.newMember.name $}{$ params.paramList(doc.newMember.parameters) | trim $}{$ params.returnType(doc.newMember.returnType) $}</code-example>
+      {% if not doc.newMember.notYetDocumented %}{$ doc.newMember.description | marked $}{% endif %}
+    </div>
+    {% if doc.members.length or doc.callMember %}<hr>{% endif %}
+  {% endif %}
+  {% if doc.callMember %}
+    <div class="call-member">
+      <a id="{$ doc.callMember.name $}"></a>
+      <code-example hideCopy="true">{$ doc.callMember.name $}{$ params.paramList(doc.callMember.parameters) | trim $}{$ params.returnType(doc.callMember.returnType) $}</code-example>
+      {% if not doc.callMember.notYetDocumented %}{$ doc.callMember.description | marked $}{% endif %}
+    </div>
+    {% if doc.members.length %}<hr>{% endif %}
+  {% endif %}
   {% for member in doc.members %}{% if not member.internal %}
     <div class="instance-member">
       <a id="{$ member.name $}"></a>
       <code-example hideCopy="true">{$ member.name $}{$ params.paramList(member.parameters) | trim $}{$ params.returnType(member.returnType) $}</code-example>
-      {%- if not member.notYetDocumented %}
-      {$ member.description | marked $}
-      {% endif %}
+      {% if not member.notYetDocumented %}{$ member.description | marked $}{% endif %}
     </div>
-
-    {% if not loop.last %}
-    <hr>
-    {% endif %}
-
+    {% if not loop.last %}<hr>{% endif %}
   {% endif %}{% endfor %}
 </section>
 {% endif %}

--- a/aio/tools/transforms/templates/api/interface.template.html
+++ b/aio/tools/transforms/templates/api/interface.template.html
@@ -4,6 +4,5 @@
 {% block details %}
   {% include "includes/interface-overview.html" %}
   {% include "includes/description.html" %}
-  <!-- TODO include callMember and newMember -->
   {% include "includes/members.html" %}
 {% endblock %}

--- a/aio/tools/transforms/templates/api/lib/paramList.html
+++ b/aio/tools/transforms/templates/api/lib/paramList.html
@@ -8,5 +8,5 @@
 
 
 {% macro returnType(returnType) -%}
-  {%- if returnType %} : {$ returnType | escape $}{% endif -%}
+  {%- if returnType %}: {$ returnType | escape $}{% endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
* Remove whitespace before type specifiers
* Generate `new` and `call` member info for interfaces
