### PR TITLE
fix(router): make remove trailing slash consistent with URL params

### DIFF
--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -168,9 +168,16 @@ export class Location {
   }
 
   /**
-   * If url has a trailing slash, remove it, otherwise return url as is.
+   * If url has a trailing slash, remove it, otherwise return url as is. This
+   * method looks for the first occurence of either #, ?, or the end of the
+   * line as `/` characters after any of these should not be replaced.
    */
-  public static stripTrailingSlash(url: string): string { return url.replace(/\/$/, ''); }
+  public static stripTrailingSlash(url: string): string {
+    const match = url.match(/#|\?|$/);
+    const pathEndIdx = match && match.index || url.length;
+    const droppedSlashIdx = pathEndIdx - (url[pathEndIdx - 1] === '/' ? 1 : 0);
+    return url.slice(0, droppedSlashIdx) + url.slice(pathEndIdx);
+  }
 }
 
 function _stripBaseHref(baseHref: string, url: string): string {

--- a/packages/common/test/location/location_spec.ts
+++ b/packages/common/test/location/location_spec.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Location} from '../../src/location/location';
+
+export function main() {
+  const baseUrl = '/base';
+
+  describe('Location Class', () => {
+    describe('stripTrailingSlash', () => {
+      it('should strip single character slash', () => {
+        const input = '/';
+        expect(Location.stripTrailingSlash(input)).toBe('');
+      });
+
+      it('should normalize strip a trailing slash', () => {
+        const input = baseUrl + '/';
+        expect(Location.stripTrailingSlash(input)).toBe(baseUrl);
+      });
+
+      it('should ignore query params when stripping a slash', () => {
+        const input = baseUrl + '/?param=1';
+        expect(Location.stripTrailingSlash(input)).toBe(baseUrl + '?param=1');
+      });
+
+      it('should not remove slashes inside query params', () => {
+        const input = baseUrl + '?test/?=3';
+        expect(Location.stripTrailingSlash(input)).toBe(input);
+      });
+
+      it('should not remove slashes after a pound sign', () => {
+        const input = baseUrl + '#test/?=3';
+        expect(Location.stripTrailingSlash(input)).toBe(input);
+      });
+    });
+  });
+}


### PR DESCRIPTION
closes #16069

supersedes #17045 (which fails lint)

_note: the original PR was approved to be merged in master_
