### PR TITLE
fix/feat/refactor(upgrade): make upgraded components more consistent between dynamic and static

### DIFF
--- a/packages/upgrade/src/common/angular1.ts
+++ b/packages/upgrade/src/common/angular1.ts
@@ -33,6 +33,7 @@ export interface ICompileService {
 }
 export interface ILinkFn {
   (scope: IScope, cloneAttachFn?: ICloneAttachFunction, options?: ILinkFnOptions): IAugmentedJQuery;
+  $$slots?: {[slotName: string]: ILinkFn};
 }
 export interface ILinkFnOptions {
   parentBoundTranscludeFn?: Function;
@@ -75,9 +76,10 @@ export interface IDirective {
   templateUrl?: string|Function;
   templateNamespace?: string;
   terminal?: boolean;
-  transclude?: boolean|'element'|{[key: string]: string};
+  transclude?: DirectiveTranscludeProperty;
 }
 export type DirectiveRequireProperty = SingleOrListOrMap<string>;
+export type DirectiveTranscludeProperty = boolean | 'element' | {[key: string]: string};
 export interface IDirectiveCompileFn {
   (templateElement: IAugmentedJQuery, templateAttributes: IAttributes,
    transclude: ITranscludeFunction): IDirectivePrePost;
@@ -97,7 +99,7 @@ export interface IComponent {
   require?: DirectiveRequireProperty;
   template?: string|Function;
   templateUrl?: string|Function;
-  transclude?: boolean;
+  transclude?: DirectiveTranscludeProperty;
 }
 export interface IAttributes { $observe(attr: string, fn: (v: string) => void): void; }
 export interface ITranscludeFunction {

--- a/packages/upgrade/src/common/upgrade_helper.ts
+++ b/packages/upgrade/src/common/upgrade_helper.ts
@@ -90,12 +90,6 @@ export class UpgradeHelper {
     if (directive.terminal) this.notSupported('terminal');
     if (directive.compile) this.notSupported('compile');
 
-    const link = directive.link;
-    // QUESTION: why not support link.post?
-    if (typeof link == 'object') {
-      if (link.post) this.notSupported('link.post');
-    }
-
     return directive;
   }
 

--- a/packages/upgrade/src/common/upgrade_helper.ts
+++ b/packages/upgrade/src/common/upgrade_helper.ts
@@ -1,0 +1,238 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ElementRef, Injector, SimpleChanges} from '@angular/core';
+
+import * as angular from './angular1';
+import {$COMPILE, $CONTROLLER, $HTTP_BACKEND, $INJECTOR, $TEMPLATE_CACHE} from './constants';
+import {controllerKey, directiveNormalize, isFunction} from './util';
+
+
+// Constants
+export const REQUIRE_PREFIX_RE = /^(\^\^?)?(\?)?(\^\^?)?/;
+
+// Interfaces
+export interface IBindingDestination {
+  [key: string]: any;
+  $onChanges?: (changes: SimpleChanges) => void;
+}
+
+export interface IControllerInstance extends IBindingDestination {
+  $doCheck?: () => void;
+  $onDestroy?: () => void;
+  $onInit?: () => void;
+  $postLink?: () => void;
+}
+
+// Classes
+export class UpgradeHelper {
+  public readonly $injector: angular.IInjectorService;
+  public readonly element: Element;
+  public readonly $element: angular.IAugmentedJQuery;
+  public readonly directive: angular.IDirective;
+
+  private readonly $compile: angular.ICompileService;
+  private readonly $controller: angular.IControllerService;
+  private readonly $templateCache: angular.ITemplateCacheService;
+
+  constructor(private injector: Injector, private name: string, elementRef: ElementRef) {
+    this.$injector = injector.get($INJECTOR);
+    this.$compile = this.$injector.get($COMPILE);
+    this.$controller = this.$injector.get($CONTROLLER);
+    this.$templateCache = this.$injector.get($TEMPLATE_CACHE);
+
+    this.element = elementRef.nativeElement;
+    this.$element = angular.element(this.element);
+
+    this.directive = this.getDirective();
+  }
+
+  buildController(controllerType: angular.IController, $scope: angular.IScope) {
+    // TODO: Document that we do not pre-assign bindings on the controller instance.
+    // Quoted properties below so that this code can be optimized with Closure Compiler.
+    const locals = {'$scope': $scope, '$element': this.$element};
+    const controller = this.$controller(controllerType, locals, null, this.directive.controllerAs);
+
+    this.$element.data !(controllerKey(this.directive.name !), controller);
+
+    return controller;
+  }
+
+  compileTemplate(): angular.ILinkFn {
+    if (this.directive.template !== undefined) {
+      return this.compileHtml(this.getOrCall<string>(this.directive.template));
+    } else if (this.directive.templateUrl) {
+      const url = this.getOrCall<string>(this.directive.templateUrl);
+      const html = this.$templateCache.get(url) as string;
+      if (html !== undefined) {
+        return this.compileHtml(html);
+      } else {
+        throw new Error('loading directive templates asynchronously is not supported');
+      }
+    } else {
+      throw new Error(`Directive '${this.name}' is not a component, it is missing template.`);
+    }
+  }
+
+  getDirective(): angular.IDirective {
+    const directives: angular.IDirective[] = this.$injector.get(this.name + 'Directive');
+    if (directives.length > 1) {
+      throw new Error(`Only support single directive definition for: ${this.name}`);
+    }
+
+    const directive = directives[0];
+    if (directive.replace) this.notSupported('replace');
+    if (directive.terminal) this.notSupported('terminal');
+    if (directive.compile) this.notSupported('compile');
+
+    const link = directive.link;
+    // QUESTION: why not support link.post?
+    if (typeof link == 'object') {
+      if (link.post) this.notSupported('link.post');
+    }
+
+    return directive;
+  }
+
+  prepareTransclusion(): angular.ILinkFn|undefined {
+    const transclude = this.directive.transclude;
+    const contentChildNodes = this.extractChildNodes();
+    let $template = contentChildNodes;
+    let attachChildrenFn: angular.ILinkFn|undefined = (scope, cloneAttach) =>
+        cloneAttach !($template, scope);
+
+    if (transclude) {
+      const slots = Object.create(null);
+
+      if (typeof transclude === 'object') {
+        $template = [];
+
+        const slotMap = Object.create(null);
+        const filledSlots = Object.create(null);
+
+        // Parse the element selectors.
+        Object.keys(transclude).forEach(slotName => {
+          let selector = transclude[slotName];
+          const optional = selector.charAt(0) === '?';
+          selector = optional ? selector.substring(1) : selector;
+
+          slotMap[selector] = slotName;
+          slots[slotName] = null;            // `null`: Defined but not yet filled.
+          filledSlots[slotName] = optional;  // Consider optional slots as filled.
+        });
+
+        // Add the matching elements into their slot.
+        contentChildNodes.forEach(node => {
+          const slotName = slotMap[directiveNormalize(node.nodeName.toLowerCase())];
+          if (slotName) {
+            filledSlots[slotName] = true;
+            slots[slotName] = slots[slotName] || [];
+            slots[slotName].push(node);
+          } else {
+            $template.push(node);
+          }
+        });
+
+        // Check for required slots that were not filled.
+        Object.keys(filledSlots).forEach(slotName => {
+          if (!filledSlots[slotName]) {
+            throw new Error(`Required transclusion slot '${slotName}' on directive: ${this.name}`);
+          }
+        });
+
+        Object.keys(slots).filter(slotName => slots[slotName]).forEach(slotName => {
+          const nodes = slots[slotName];
+          slots[slotName] = (scope: angular.IScope, cloneAttach: angular.ICloneAttachFunction) =>
+              cloneAttach !(nodes, scope);
+        });
+      }
+
+      // Attach `$$slots` to default slot transclude fn.
+      attachChildrenFn.$$slots = slots;
+
+      // AngularJS v1.6+ ignores empty or whitespace-only transcluded text nodes. But Angular
+      // removes all text content after the first interpolation and updates it later, after
+      // evaluating the expressions. This would result in AngularJS failing to recognize text
+      // nodes that start with an interpolation as transcluded content and use the fallback
+      // content instead.
+      // To avoid this issue, we add a
+      // [zero-width non-joiner character](https://en.wikipedia.org/wiki/Zero-width_non-joiner)
+      // to empty text nodes (which can only be a result of Angular removing their initial content).
+      // NOTE: Transcluded text content that starts with whitespace followed by an interpolation
+      //       will still fail to be detected by AngularJS v1.6+
+      $template.forEach(node => {
+        if (node.nodeType === Node.TEXT_NODE && !node.nodeValue) {
+          node.nodeValue = '\u200C';
+        }
+      });
+    }
+
+    return attachChildrenFn;
+  }
+
+  resolveRequire(require: angular.DirectiveRequireProperty):
+      angular.SingleOrListOrMap<IControllerInstance>|null {
+    if (!require) {
+      return null;
+    } else if (Array.isArray(require)) {
+      return require.map(req => this.resolveRequire(req));
+    } else if (typeof require === 'object') {
+      const value: {[key: string]: IControllerInstance} = {};
+      Object.keys(require).forEach(key => value[key] = this.resolveRequire(require[key]) !);
+      return value;
+    } else if (typeof require === 'string') {
+      const match = require.match(REQUIRE_PREFIX_RE) !;
+      const inheritType = match[1] || match[3];
+
+      const name = require.substring(match[0].length);
+      const isOptional = !!match[2];
+      const searchParents = !!inheritType;
+      const startOnParent = inheritType === '^^';
+
+      const ctrlKey = controllerKey(name);
+      const elem = startOnParent ? this.$element.parent !() : this.$element;
+      const value = searchParents ? elem.inheritedData !(ctrlKey) : elem.data !(ctrlKey);
+
+      if (!value && !isOptional) {
+        throw new Error(
+            `Unable to find required '${require}' in upgraded directive '${this.name}'.`);
+      }
+
+      return value;
+    } else {
+      throw new Error(
+          `Unrecognized 'require' syntax on upgraded directive '${this.name}': ${require}`);
+    }
+  }
+
+  private compileHtml(html: string): angular.ILinkFn {
+    this.element.innerHTML = html;
+    return this.$compile(this.element.childNodes);
+  }
+
+  private extractChildNodes(): Node[] {
+    const childNodes: Node[] = [];
+    let childNode: Node|null;
+
+    while (childNode = this.element.firstChild) {
+      this.element.removeChild(childNode);
+      childNodes.push(childNode);
+    }
+
+    return childNodes;
+  }
+
+  private getOrCall<T>(property: T|Function): T {
+    return isFunction(property) ? property() : property;
+  }
+
+  private notSupported(feature: string) {
+    throw new Error(
+        `Upgraded directive '${this.name}' contains unsupported feature: '${feature}'.`);
+  }
+}

--- a/packages/upgrade/src/common/util.ts
+++ b/packages/upgrade/src/common/util.ts
@@ -9,6 +9,9 @@
 import {Type} from '@angular/core';
 import * as angular from './angular1';
 
+const DIRECTIVE_PREFIX_REGEXP = /^(?:x|data)[:\-_]/i;
+const DIRECTIVE_SPECIAL_CHARS_REGEXP = /[:\-_]+(.)/g;
+
 export function onError(e: any) {
   // TODO: (misko): We seem to not have a stack trace here!
   if (console.error) {
@@ -22,6 +25,11 @@ export function onError(e: any) {
 
 export function controllerKey(name: string): string {
   return '$' + name + 'Controller';
+}
+
+export function directiveNormalize(name: string): string {
+  return name.replace(DIRECTIVE_PREFIX_REGEXP, '')
+      .replace(DIRECTIVE_SPECIAL_CHARS_REGEXP, (_, letter) => letter.toUpperCase());
 }
 
 export function getAttributesAsArray(node: Node): [string, string][] {

--- a/packages/upgrade/src/common/util.ts
+++ b/packages/upgrade/src/common/util.ts
@@ -50,6 +50,10 @@ export function getComponentName(component: Type<any>): string {
   return (component as any).overriddenName || component.name || component.toString().split('\n')[0];
 }
 
+export function isFunction(value: any): value is Function {
+  return typeof value === 'function';
+}
+
 export class Deferred<R> {
   promise: Promise<R>;
   resolve: (value?: R|PromiseLike<R>) => void;

--- a/packages/upgrade/src/dynamic/upgrade_adapter.ts
+++ b/packages/upgrade/src/dynamic/upgrade_adapter.ts
@@ -546,8 +546,8 @@ export class UpgradeAdapter {
       (ng1Injector: angular.IInjectorService, rootScope: angular.IRootScopeService) => {
         UpgradeNg1ComponentAdapterBuilder.resolve(this.ng1ComponentsToBeUpgraded, ng1Injector)
             .then(() => {
-              // At this point we have ng1 injector and we have lifted ng1 components into ng2, we
-              // now can bootstrap ng2.
+              // At this point we have ng1 injector and we have prepared
+              // ng1 components to be upgraded, we now can bootstrap ng2.
               const DynamicNgUpgradeModule =
                   NgModule({
                     providers: [

--- a/packages/upgrade/src/dynamic/upgrade_ng1_adapter.ts
+++ b/packages/upgrade/src/dynamic/upgrade_ng1_adapter.ts
@@ -6,26 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, DoCheck, ElementRef, EventEmitter, Inject, OnChanges, OnInit, SimpleChange, SimpleChanges, Type} from '@angular/core';
+import {Directive, DoCheck, ElementRef, EventEmitter, Inject, Injector, OnChanges, OnInit, SimpleChange, SimpleChanges, Type} from '@angular/core';
 
 import * as angular from '../common/angular1';
-import {$COMPILE, $CONTROLLER, $HTTP_BACKEND, $SCOPE, $TEMPLATE_CACHE} from '../common/constants';
-import {controllerKey, strictEquals} from '../common/util';
-
-
-interface IBindingDestination {
-  [key: string]: any;
-  $onChanges?: (changes: SimpleChanges) => void;
-}
-
-interface IControllerInstance extends IBindingDestination {
-  $doCheck?: () => void;
-  $onDestroy?: () => void;
-  $onInit?: () => void;
-  $postLink?: () => void;
-}
-
-type LifecycleHook = '$doCheck' | '$onChanges' | '$onDestroy' | '$onInit' | '$postLink';
+import {$SCOPE} from '../common/constants';
+import {IBindingDestination, IControllerInstance, UpgradeHelper} from '../common/upgrade_helper';
+import {isFunction, strictEquals} from '../common/util';
 
 
 const CAMEL_CASE = /([A-Z])/g;
@@ -44,51 +30,31 @@ export class UpgradeNg1ComponentAdapterBuilder {
   propertyOutputs: string[] = [];
   checkProperties: string[] = [];
   propertyMap: {[name: string]: string} = {};
-  linkFn: angular.ILinkFn|null = null;
   directive: angular.IDirective|null = null;
-  $controller: angular.IControllerService|null = null;
+  template: string;
 
   constructor(public name: string) {
-    const selector = name.replace(
-        CAMEL_CASE, (all: any /** TODO #9100 */, next: string) => '-' + next.toLowerCase());
+    const selector =
+        name.replace(CAMEL_CASE, (all: string, next: string) => '-' + next.toLowerCase());
     const self = this;
-    this.type = Directive({
-                  selector: selector,
-                  inputs: this.inputsRename,
-                  outputs: this.outputsRename
-                }).Class({
-      constructor: [
-        new Inject($SCOPE), ElementRef,
-        function(scope: angular.IScope, elementRef: ElementRef) {
-          return new UpgradeNg1ComponentAdapter(
-              self.linkFn !, scope, self.directive !, elementRef, self.$controller !, self.inputs,
-              self.outputs, self.propertyOutputs, self.checkProperties, self.propertyMap);
-        }
-      ],
-      ngOnInit: function() { /* needs to be here for ng2 to properly detect it */ },
-      ngOnChanges: function() { /* needs to be here for ng2 to properly detect it */ },
-      ngDoCheck: function() { /* needs to be here for ng2 to properly detect it */ },
-      ngOnDestroy: function() { /* needs to be here for ng2 to properly detect it */ },
-    });
-  }
 
-  extractDirective(injector: angular.IInjectorService): angular.IDirective {
-    const directives: angular.IDirective[] = injector.get(this.name + 'Directive');
-    if (directives.length > 1) {
-      throw new Error('Only support single directive definition for: ' + this.name);
-    }
-    const directive = directives[0];
-    if (directive.replace) this.notSupported('replace');
-    if (directive.terminal) this.notSupported('terminal');
-    const link = directive.link;
-    if (typeof link == 'object') {
-      if ((<angular.IDirectivePrePost>link).post) this.notSupported('link.post');
-    }
-    return directive;
-  }
-
-  private notSupported(feature: string) {
-    throw new Error(`Upgraded directive '${this.name}' does not support '${feature}'.`);
+    this.type =
+        Directive({selector: selector, inputs: this.inputsRename, outputs: this.outputsRename})
+            .Class({
+              constructor: [
+                new Inject($SCOPE), Injector, ElementRef,
+                function(scope: angular.IScope, injector: Injector, elementRef: ElementRef) {
+                  const helper = new UpgradeHelper(injector, name, elementRef, this.directive);
+                  return new UpgradeNg1ComponentAdapter(
+                      helper, scope, self.template, self.inputs, self.outputs, self.propertyOutputs,
+                      self.checkProperties, self.propertyMap);
+                }
+              ],
+              ngOnInit: function() { /* needs to be here for ng2 to properly detect it */ },
+              ngOnChanges: function() { /* needs to be here for ng2 to properly detect it */ },
+              ngDoCheck: function() { /* needs to be here for ng2 to properly detect it */ },
+              ngOnDestroy: function() { /* needs to be here for ng2 to properly detect it */ },
+            });
   }
 
   extractBindings() {
@@ -148,66 +114,22 @@ export class UpgradeNg1ComponentAdapterBuilder {
     }
   }
 
-  compileTemplate(
-      compile: angular.ICompileService, templateCache: angular.ITemplateCacheService,
-      httpBackend: angular.IHttpBackendService): Promise<angular.ILinkFn>|null {
-    if (this.directive !.template !== undefined) {
-      this.linkFn = compileHtml(
-          isFunction(this.directive !.template) ? (this.directive !.template as Function)() :
-                                                  this.directive !.template);
-    } else if (this.directive !.templateUrl) {
-      const url = isFunction(this.directive !.templateUrl) ?
-          (this.directive !.templateUrl as Function)() :
-          this.directive !.templateUrl;
-      const html = templateCache.get(url);
-      if (html !== undefined) {
-        this.linkFn = compileHtml(html);
-      } else {
-        return new Promise((resolve, err) => {
-          httpBackend(
-              'GET', url, null,
-              (status: any /** TODO #9100 */, response: any /** TODO #9100 */) => {
-                if (status == 200) {
-                  resolve(this.linkFn = compileHtml(templateCache.put(url, response)));
-                } else {
-                  err(`GET ${url} returned ${status}: ${response}`);
-                }
-              });
-        });
-      }
-    } else {
-      throw new Error(`Directive '${this.name}' is not a component, it is missing template.`);
-    }
-    return null;
-    function compileHtml(html: any /** TODO #9100 */): angular.ILinkFn {
-      const div = document.createElement('div');
-      div.innerHTML = html;
-      return compile(div.childNodes);
-    }
-  }
-
   /**
    * Upgrade ng1 components into Angular.
    */
   static resolve(
       exportedComponents: {[name: string]: UpgradeNg1ComponentAdapterBuilder},
-      injector: angular.IInjectorService): Promise<angular.ILinkFn[]> {
-    const promises: Promise<angular.ILinkFn>[] = [];
-    const compile: angular.ICompileService = injector.get($COMPILE);
-    const templateCache: angular.ITemplateCacheService = injector.get($TEMPLATE_CACHE);
-    const httpBackend: angular.IHttpBackendService = injector.get($HTTP_BACKEND);
-    const $controller: angular.IControllerService = injector.get($CONTROLLER);
-    for (const name in exportedComponents) {
-      if ((<any>exportedComponents).hasOwnProperty(name)) {
-        const exportedComponent = exportedComponents[name];
-        exportedComponent.directive = exportedComponent.extractDirective(injector);
-        exportedComponent.$controller = $controller;
-        exportedComponent.extractBindings();
-        const promise: Promise<angular.ILinkFn> =
-            exportedComponent.compileTemplate(compile, templateCache, httpBackend) !;
-        if (promise) promises.push(promise);
-      }
-    }
+      $injector: angular.IInjectorService): Promise<string[]> {
+    const promises = Object.keys(exportedComponents).map(name => {
+      const exportedComponent = exportedComponents[name];
+      exportedComponent.directive = UpgradeHelper.getDirective($injector, name);
+      exportedComponent.extractBindings();
+
+      return Promise
+          .resolve(UpgradeHelper.getTemplate($injector, exportedComponent.directive, true))
+          .then(template => exportedComponent.template = template);
+    });
+
     return Promise.all(promises);
   }
 }
@@ -216,28 +138,31 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
   private controllerInstance: IControllerInstance|null = null;
   destinationObj: IBindingDestination|null = null;
   checkLastValues: any[] = [];
-  componentScope: angular.IScope;
+  private directive: angular.IDirective;
   element: Element;
   $element: any = null;
+  componentScope: angular.IScope;
 
   constructor(
-      private linkFn: angular.ILinkFn, scope: angular.IScope, private directive: angular.IDirective,
-      elementRef: ElementRef, private $controller: angular.IControllerService,
+      private helper: UpgradeHelper, scope: angular.IScope, private template: string,
       private inputs: string[], private outputs: string[], private propOuts: string[],
       private checkProperties: string[], private propertyMap: {[key: string]: string}) {
-    this.element = elementRef.nativeElement;
-    this.componentScope = scope.$new(!!directive.scope);
-    this.$element = angular.element(this.element);
-    const controllerType = directive.controller;
-    if (directive.bindToController && controllerType) {
-      this.controllerInstance = this.buildController(controllerType);
+    this.directive = helper.directive;
+    this.element = helper.element;
+    this.$element = helper.$element;
+    this.componentScope = scope.$new(!!this.directive.scope);
+
+    const controllerType = this.directive.controller;
+
+    if (this.directive.bindToController && controllerType) {
+      this.controllerInstance = this.helper.buildController(controllerType, this.componentScope);
       this.destinationObj = this.controllerInstance;
     } else {
       this.destinationObj = this.componentScope;
     }
 
     for (let i = 0; i < inputs.length; i++) {
-      (this as any /** TODO #9100 */)[inputs[i]] = null;
+      (this as any)[inputs[i]] = null;
     }
     for (let j = 0; j < outputs.length; j++) {
       const emitter = (this as any)[outputs[j]] = new EventEmitter<any>();
@@ -250,39 +175,43 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
   }
 
   ngOnInit() {
-    if (!this.directive.bindToController && this.directive.controller) {
-      this.controllerInstance = this.buildController(this.directive.controller);
+    // Collect contents, insert and compile template
+    const attachChildNodes: angular.ILinkFn|undefined = this.helper.prepareTransclusion();
+    const linkFn = this.helper.compileTemplate(this.template);
+
+    // Instantiate controller (if not already done so)
+    const controllerType = this.directive.controller;
+    const bindToController = this.directive.bindToController;
+    if (controllerType && !bindToController) {
+      this.controllerInstance = this.helper.buildController(controllerType, this.componentScope);
     }
 
+    // Require other controllers
+    const requiredControllers =
+        this.helper.resolveAndBindRequiredControllers(this.controllerInstance);
+
+    // Hook: $onInit
     if (this.controllerInstance && isFunction(this.controllerInstance.$onInit)) {
       this.controllerInstance.$onInit();
     }
 
-    let link = this.directive.link;
-    if (typeof link == 'object') link = (<angular.IDirectivePrePost>link).pre;
-    if (link) {
-      const attrs: angular.IAttributes = NOT_SUPPORTED;
-      const transcludeFn: angular.ITranscludeFunction = NOT_SUPPORTED;
-      const linkController = this.resolveRequired(this.$element, this.directive.require !);
-      (<angular.IDirectiveLinkFn>this.directive.link)(
-          this.componentScope, this.$element, attrs, linkController, transcludeFn);
+    // Linking
+    const link = this.directive.link;
+    const preLink = (typeof link == 'object') && (link as angular.IDirectivePrePost).pre;
+    const postLink = (typeof link == 'object') ? (link as angular.IDirectivePrePost).post : link;
+    const attrs: angular.IAttributes = NOT_SUPPORTED;
+    const transcludeFn: angular.ITranscludeFunction = NOT_SUPPORTED;
+    if (preLink) {
+      preLink(this.componentScope, this.$element, attrs, requiredControllers, transcludeFn);
     }
 
-    const childNodes: Node[] = [];
-    let childNode: any /** TODO #9100 */;
-    while (childNode = this.element.firstChild) {
-      this.element.removeChild(childNode);
-      childNodes.push(childNode);
-    }
-    this.linkFn(this.componentScope, (clonedElement, scope) => {
-      for (let i = 0, ii = clonedElement !.length; i < ii; i++) {
-        this.element.appendChild(clonedElement ![i]);
-      }
-    }, {
-      parentBoundTranscludeFn: (scope: any /** TODO #9100 */,
-                                cloneAttach: any /** TODO #9100 */) => { cloneAttach(childNodes); }
-    });
+    linkFn(this.componentScope, null !, {parentBoundTranscludeFn: attachChildNodes});
 
+    if (postLink) {
+      postLink(this.componentScope, this.$element, attrs, requiredControllers, transcludeFn);
+    }
+
+    // Hook: $postLink
     if (this.controllerInstance && isFunction(this.controllerInstance.$postLink)) {
       this.controllerInstance.$postLink();
     }
@@ -329,56 +258,4 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
   setComponentProperty(name: string, value: any) {
     this.destinationObj ![this.propertyMap[name]] = value;
   }
-
-  private buildController(controllerType: any /** TODO #9100 */) {
-    const locals = {$scope: this.componentScope, $element: this.$element};
-    const controller: any =
-        this.$controller(controllerType, locals, null, this.directive.controllerAs);
-    this.$element.data(controllerKey(this.directive.name !), controller);
-    return controller;
-  }
-
-  private resolveRequired(
-      $element: angular.IAugmentedJQuery, require: angular.DirectiveRequireProperty): any {
-    if (!require) {
-      return undefined;
-    } else if (typeof require == 'string') {
-      let name: string = <string>require;
-      let isOptional = false;
-      let startParent = false;
-      let searchParents = false;
-      if (name.charAt(0) == '?') {
-        isOptional = true;
-        name = name.substr(1);
-      }
-      if (name.charAt(0) == '^') {
-        searchParents = true;
-        name = name.substr(1);
-      }
-      if (name.charAt(0) == '^') {
-        startParent = true;
-        name = name.substr(1);
-      }
-
-      const key = controllerKey(name);
-      if (startParent) $element = $element.parent !();
-      const dep = searchParents ? $element.inheritedData !(key) : $element.data !(key);
-      if (!dep && !isOptional) {
-        throw new Error(`Can not locate '${require}' in '${this.directive.name}'.`);
-      }
-      return dep;
-    } else if (require instanceof Array) {
-      const deps: any[] = [];
-      for (let i = 0; i < require.length; i++) {
-        deps.push(this.resolveRequired($element, require[i]));
-      }
-      return deps;
-    }
-    throw new Error(
-        `Directive '${this.directive.name}' require syntax unrecognized: ${this.directive.require}`);
-  }
-}
-
-function isFunction(value: any): value is Function {
-  return typeof value === 'function';
 }

--- a/packages/upgrade/src/static/upgrade_component.ts
+++ b/packages/upgrade/src/static/upgrade_component.ts
@@ -8,10 +8,10 @@
 
 import {DoCheck, ElementRef, EventEmitter, Injector, OnChanges, OnDestroy, OnInit, SimpleChanges, ɵlooseIdentical as looseIdentical} from '@angular/core';
 import * as angular from '../common/angular1';
-import {$COMPILE, $CONTROLLER, $HTTP_BACKEND, $INJECTOR, $SCOPE, $TEMPLATE_CACHE} from '../common/constants';
-import {controllerKey, directiveNormalize} from '../common/util';
+import {$SCOPE} from '../common/constants';
+import {IBindingDestination, IControllerInstance, REQUIRE_PREFIX_RE, UpgradeHelper} from '../common/upgrade_helper';
+import {isFunction} from '../common/util';
 
-const REQUIRE_PREFIX_RE = /^(\^\^?)?(\?)?(\^\^?)?/;
 const NOT_SUPPORTED: any = 'NOT_SUPPORTED';
 const INITIAL_VALUE = {
   __UNINITIALIZED__: true
@@ -25,20 +25,6 @@ class Bindings {
 
   propertyToOutputMap: {[propName: string]: string} = {};
 }
-
-interface IBindingDestination {
-  [key: string]: any;
-  $onChanges?: (changes: SimpleChanges) => void;
-}
-
-interface IControllerInstance extends IBindingDestination {
-  $doCheck?: () => void;
-  $onDestroy?: () => void;
-  $onInit?: () => void;
-  $postLink?: () => void;
-}
-
-type LifecycleHook = '$doCheck' | '$onChanges' | '$onDestroy' | '$onInit' | '$postLink';
 
 /**
  * @whatItDoes
@@ -81,11 +67,9 @@ type LifecycleHook = '$doCheck' | '$onChanges' | '$onDestroy' | '$onInit' | '$po
  * @experimental
  */
 export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
+  private helper: UpgradeHelper;
+
   private $injector: angular.IInjectorService;
-  private $compile: angular.ICompileService;
-  private $templateCache: angular.ITemplateCacheService;
-  private $httpBackend: angular.IHttpBackendService;
-  private $controller: angular.IControllerService;
 
   private element: Element;
   private $element: angular.IAugmentedJQuery;
@@ -120,16 +104,14 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
    * already implements them and so does not wire up calls to them at runtime.
    */
   constructor(private name: string, private elementRef: ElementRef, private injector: Injector) {
-    this.$injector = injector.get($INJECTOR);
-    this.$compile = this.$injector.get($COMPILE);
-    this.$templateCache = this.$injector.get($TEMPLATE_CACHE);
-    this.$httpBackend = this.$injector.get($HTTP_BACKEND);
-    this.$controller = this.$injector.get($CONTROLLER);
+    this.helper = new UpgradeHelper(injector, name, elementRef);
 
-    this.element = elementRef.nativeElement;
-    this.$element = angular.element(this.element);
+    this.$injector = this.helper.$injector;
 
-    this.directive = this.getDirective(name);
+    this.element = this.helper.element;
+    this.$element = this.helper.$element;
+
+    this.directive = this.helper.directive;
     this.bindings = this.initializeBindings(this.directive);
 
     // We ask for the AngularJS scope from the Angular injector, since
@@ -144,16 +126,14 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
 
   ngOnInit() {
     // Collect contents, insert and compile template
-    const attachChildNodes: angular.ILinkFn|undefined =
-        this.prepareTransclusion(this.directive.transclude);
-    const linkFn = this.compileTemplate(this.directive);
+    const attachChildNodes: angular.ILinkFn|undefined = this.helper.prepareTransclusion();
+    const linkFn = this.helper.compileTemplate();
 
     // Instantiate controller
     const controllerType = this.directive.controller;
     const bindToController = this.directive.bindToController;
     if (controllerType) {
-      this.controllerInstance = this.buildController(
-          controllerType, this.$componentScope, this.$element, this.directive.controllerAs !);
+      this.controllerInstance = this.helper.buildController(controllerType, this.$componentScope);
     } else if (bindToController) {
       throw new Error(
           `Upgraded directive '${this.directive.name}' specifies 'bindToController' but no controller.`);
@@ -165,8 +145,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
 
     // Require other controllers
     const directiveRequire = this.getDirectiveRequire(this.directive);
-    const requiredControllers =
-        this.resolveRequire(this.directive.name !, this.$element, directiveRequire);
+    const requiredControllers = this.helper.resolveRequire(directiveRequire);
 
     if (this.directive.bindToController && isMap(directiveRequire)) {
       const requiredControllersMap = requiredControllers as{[key: string]: IControllerInstance};
@@ -253,23 +232,6 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     this.$componentScope.$destroy();
   }
 
-  private getDirective(name: string): angular.IDirective {
-    const directives: angular.IDirective[] = this.$injector.get(name + 'Directive');
-    if (directives.length > 1) {
-      throw new Error('Only support single directive definition for: ' + this.name);
-    }
-    const directive = directives[0];
-    if (directive.replace) this.notSupported('replace');
-    if (directive.terminal) this.notSupported('terminal');
-    if (directive.compile) this.notSupported('compile');
-    const link = directive.link;
-    // QUESTION: why not support link.post?
-    if (typeof link == 'object') {
-      if ((<angular.IDirectivePrePost>link).post) this.notSupported('link.post');
-    }
-    return directive;
-  }
-
   private getDirectiveRequire(directive: angular.IDirective): angular.DirectiveRequireProperty {
     const require = directive.require || (directive.controller && directive.name) !;
 
@@ -332,158 +294,6 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     return bindings;
   }
 
-  private prepareTransclusion(transclude: angular.DirectiveTranscludeProperty = false):
-      angular.ILinkFn|undefined {
-    const contentChildNodes = this.extractChildNodes(this.element);
-    let $template = contentChildNodes;
-    let attachChildrenFn: angular.ILinkFn|undefined = (scope, cloneAttach) =>
-        cloneAttach !($template, scope);
-
-    if (transclude) {
-      const slots = Object.create(null);
-
-      if (typeof transclude === 'object') {
-        $template = [];
-
-        const slotMap = Object.create(null);
-        const filledSlots = Object.create(null);
-
-        // Parse the element selectors.
-        Object.keys(transclude).forEach(slotName => {
-          let selector = transclude[slotName];
-          const optional = selector.charAt(0) === '?';
-          selector = optional ? selector.substring(1) : selector;
-
-          slotMap[selector] = slotName;
-          slots[slotName] = null;            // `null`: Defined but not yet filled.
-          filledSlots[slotName] = optional;  // Consider optional slots as filled.
-        });
-
-        // Add the matching elements into their slot.
-        contentChildNodes.forEach(node => {
-          const slotName = slotMap[directiveNormalize(node.nodeName.toLowerCase())];
-          if (slotName) {
-            filledSlots[slotName] = true;
-            slots[slotName] = slots[slotName] || [];
-            slots[slotName].push(node);
-          } else {
-            $template.push(node);
-          }
-        });
-
-        // Check for required slots that were not filled.
-        Object.keys(filledSlots).forEach(slotName => {
-          if (!filledSlots[slotName]) {
-            throw new Error(`Required transclusion slot '${slotName}' on directive: ${this.name}`);
-          }
-        });
-
-        Object.keys(slots).filter(slotName => slots[slotName]).forEach(slotName => {
-          const nodes = slots[slotName];
-          slots[slotName] = (scope: angular.IScope, cloneAttach: angular.ICloneAttachFunction) =>
-              cloneAttach !(nodes, scope);
-        });
-      }
-
-      // Attach `$$slots` to default slot transclude fn.
-      attachChildrenFn.$$slots = slots;
-    }
-
-    return attachChildrenFn;
-  }
-
-  private extractChildNodes(element: Element): Node[] {
-    const childNodes: Node[] = [];
-    let childNode: Node|null;
-
-    while (childNode = element.firstChild) {
-      element.removeChild(childNode);
-      childNodes.push(childNode);
-    }
-
-    return childNodes;
-  }
-
-  private compileTemplate(directive: angular.IDirective): angular.ILinkFn {
-    if (this.directive.template !== undefined) {
-      return this.compileHtml(getOrCall(this.directive.template));
-    } else if (this.directive.templateUrl) {
-      const url = getOrCall(this.directive.templateUrl);
-      const html = this.$templateCache.get(url) as string;
-      if (html !== undefined) {
-        return this.compileHtml(html);
-      } else {
-        throw new Error('loading directive templates asynchronously is not supported');
-        // return new Promise((resolve, reject) => {
-        //   this.$httpBackend('GET', url, null, (status: number, response: string) => {
-        //     if (status == 200) {
-        //       resolve(this.compileHtml(this.$templateCache.put(url, response)));
-        //     } else {
-        //       reject(`GET component template from '${url}' returned '${status}: ${response}'`);
-        //     }
-        //   });
-        // });
-      }
-    } else {
-      throw new Error(`Directive '${this.name}' is not a component, it is missing template.`);
-    }
-  }
-
-  private buildController(
-      controllerType: angular.IController, $scope: angular.IScope,
-      $element: angular.IAugmentedJQuery, controllerAs: string) {
-    // TODO: Document that we do not pre-assign bindings on the controller instance
-    // Quoted properties below so that this code can be optimized with Closure Compiler.
-    const locals = {'$scope': $scope, '$element': $element};
-    const controller = this.$controller(controllerType, locals, null, controllerAs);
-    $element.data !(controllerKey(this.directive.name !), controller);
-    return controller;
-  }
-
-  private resolveRequire(
-      directiveName: string, $element: angular.IAugmentedJQuery,
-      require: angular.DirectiveRequireProperty):
-      angular.SingleOrListOrMap<IControllerInstance>|null {
-    if (!require) {
-      return null;
-    } else if (Array.isArray(require)) {
-      return require.map(req => this.resolveRequire(directiveName, $element, req));
-    } else if (typeof require === 'object') {
-      const value: {[key: string]: IControllerInstance} = {};
-
-      Object.keys(require).forEach(
-          key => value[key] = this.resolveRequire(directiveName, $element, require[key]) !);
-
-      return value;
-    } else if (typeof require === 'string') {
-      const match = require.match(REQUIRE_PREFIX_RE) !;
-      const inheritType = match[1] || match[3];
-
-      const name = require.substring(match[0].length);
-      const isOptional = !!match[2];
-      const searchParents = !!inheritType;
-      const startOnParent = inheritType === '^^';
-
-      const ctrlKey = controllerKey(name);
-
-      if (startOnParent) {
-        $element = $element.parent !();
-      }
-
-      const value = searchParents ? $element.inheritedData !(ctrlKey) : $element.data !(ctrlKey);
-
-      if (!value && !isOptional) {
-        throw new Error(
-            `Unable to find required '${require}' in upgraded directive '${directiveName}'.`);
-      }
-
-      return value;
-    } else {
-      throw new Error(
-          `Unrecognized require syntax on upgraded directive '${directiveName}': ${require}`);
-    }
-  }
-
   private initializeOutputs() {
     // Initialize the outputs for `=` and `&` bindings
     this.bindings.twoWayBoundProperties.concat(this.bindings.expressionBoundProperties)
@@ -512,24 +322,6 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
       this.bindingDestination.$onChanges(changes);
     }
   }
-
-  private notSupported(feature: string) {
-    throw new Error(
-        `Upgraded directive '${this.name}' contains unsupported feature: '${feature}'.`);
-  }
-
-  private compileHtml(html: string): angular.ILinkFn {
-    this.element.innerHTML = html;
-    return this.$compile(this.element.childNodes);
-  }
-}
-
-function getOrCall<T>(property: Function | T): T {
-  return isFunction(property) ? property() : property;
-}
-
-function isFunction(value: any): value is Function {
-  return typeof value === 'function';
 }
 
 // NOTE: Only works for `typeof T !== 'object'`.

--- a/packages/upgrade/test/common/test_helpers.ts
+++ b/packages/upgrade/test/common/test_helpers.ts
@@ -20,9 +20,10 @@ export function html(html: string): Element {
   return div;
 }
 
-export function multiTrim(text: string | null | undefined): string {
+export function multiTrim(text: string | null | undefined, allSpace = false): string {
   if (typeof text == 'string') {
-    return text.replace(/\n/g, '').replace(/\s\s+/g, ' ').trim();
+    const repl = allSpace ? '' : ' ';
+    return text.replace(/\n/g, '').replace(/\s+/g, repl).trim();
   }
   throw new Error('Argument can not be undefined.');
 }

--- a/packages/upgrade/test/dynamic/upgrade_spec.ts
+++ b/packages/upgrade/test/dynamic/upgrade_spec.ts
@@ -1974,6 +1974,633 @@ export function main() {
            }));
       });
 
+      describe('linking', () => {
+        it('should run the pre-linking after instantiating the controller', async(() => {
+             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+             const log: string[] = [];
+
+             // Define `ng1Directive`
+             const ng1Directive: angular.IDirective = {
+               template: '',
+               link: {pre: () => log.push('ng1-pre')},
+               controller: class {constructor() { log.push('ng1-ctrl'); }}
+             };
+
+             // Define `Ng2Component`
+             @Component({selector: 'ng2', template: '<ng1></ng1>'})
+             class Ng2Component {
+             }
+
+             // Define `ng1Module`
+             const ng1Module = angular.module('ng1', [])
+                                   .directive('ng1', () => ng1Directive)
+                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+
+             // Define `Ng2Module`
+             @NgModule({
+               imports: [BrowserModule],
+               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component]
+             })
+             class Ng2Module {
+             }
+
+             // Bootstrap
+             const element = html(`<ng2></ng2>`);
+
+             adapter.bootstrap(element, ['ng1']).ready(() => {
+               expect(log).toEqual(['ng1-ctrl', 'ng1-pre']);
+             });
+           }));
+
+        it('should run the pre-linking function before linking', async(() => {
+             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+             const log: string[] = [];
+
+             // Define `ng1Directive`
+             const ng1DirectiveA: angular.IDirective = {
+               template: '<ng1-b></ng1-b>',
+               link: {pre: () => log.push('ng1A-pre')}
+             };
+
+             const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
+
+             // Define `Ng2Component`
+             @Component({selector: 'ng2', template: '<ng1-a></ng1-a>'})
+             class Ng2Component {
+             }
+
+             // Define `ng1Module`
+             const ng1Module = angular.module('ng1', [])
+                                   .directive('ng1A', () => ng1DirectiveA)
+                                   .directive('ng1B', () => ng1DirectiveB)
+                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+
+             // Define `Ng2Module`
+             @NgModule({
+               imports: [BrowserModule],
+               declarations: [adapter.upgradeNg1Component('ng1A'), Ng2Component],
+               schemas: [NO_ERRORS_SCHEMA]
+             })
+             class Ng2Module {
+             }
+
+             // Bootstrap
+             const element = html(`<ng2></ng2>`);
+
+             adapter.bootstrap(element, ['ng1']).ready(() => {
+               expect(log).toEqual(['ng1A-pre', 'ng1B-post']);
+             });
+           }));
+
+        it('should run the post-linking function after linking (link: object)', async(() => {
+             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+             const log: string[] = [];
+
+             // Define `ng1Directive`
+             const ng1DirectiveA: angular.IDirective = {
+               template: '<ng1-b></ng1-b>',
+               link: {post: () => log.push('ng1A-post')}
+             };
+
+             const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
+
+             // Define `Ng2Component`
+             @Component({selector: 'ng2', template: '<ng1-a></ng1-a>'})
+             class Ng2Component {
+             }
+
+             // Define `ng1Module`
+             const ng1Module = angular.module('ng1', [])
+                                   .directive('ng1A', () => ng1DirectiveA)
+                                   .directive('ng1B', () => ng1DirectiveB)
+                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+
+             // Define `Ng2Module`
+             @NgModule({
+               imports: [BrowserModule],
+               declarations: [adapter.upgradeNg1Component('ng1A'), Ng2Component],
+               schemas: [NO_ERRORS_SCHEMA]
+             })
+             class Ng2Module {
+             }
+
+             // Bootstrap
+             const element = html(`<ng2></ng2>`);
+
+             adapter.bootstrap(element, ['ng1']).ready(() => {
+               expect(log).toEqual(['ng1B-post', 'ng1A-post']);
+             });
+           }));
+
+        it('should run the post-linking function after linking (link: function)', async(() => {
+             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+             const log: string[] = [];
+
+             // Define `ng1Directive`
+             const ng1DirectiveA: angular.IDirective = {
+               template: '<ng1-b></ng1-b>',
+               link: () => log.push('ng1A-post')
+             };
+
+             const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
+
+             // Define `Ng2Component`
+             @Component({selector: 'ng2', template: '<ng1-a></ng1-a>'})
+             class Ng2Component {
+             }
+
+             // Define `ng1Module`
+             const ng1Module = angular.module('ng1', [])
+                                   .directive('ng1A', () => ng1DirectiveA)
+                                   .directive('ng1B', () => ng1DirectiveB)
+                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+
+             // Define `Ng2Module`
+             @NgModule({
+               imports: [BrowserModule],
+               declarations: [adapter.upgradeNg1Component('ng1A'), Ng2Component],
+               schemas: [NO_ERRORS_SCHEMA]
+             })
+             class Ng2Module {
+             }
+
+             // Bootstrap
+             const element = html(`<ng2></ng2>`);
+
+             adapter.bootstrap(element, ['ng1']).ready(() => {
+               expect(log).toEqual(['ng1B-post', 'ng1A-post']);
+             });
+           }));
+
+        it('should run the post-linking function before `$postLink`', async(() => {
+             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+             const log: string[] = [];
+
+             // Define `ng1Directive`
+             const ng1Directive: angular.IDirective = {
+               template: '',
+               link: () => log.push('ng1-post'),
+               controller: class {$postLink() { log.push('ng1-$post'); }}
+             };
+
+             // Define `Ng2Component`
+             @Component({selector: 'ng2', template: '<ng1></ng1>'})
+             class Ng2Component {
+             }
+
+             // Define `ng1Module`
+             const ng1Module = angular.module('ng1', [])
+                                   .directive('ng1', () => ng1Directive)
+                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+
+             // Define `Ng2Module`
+             @NgModule({
+               imports: [BrowserModule],
+               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component]
+             })
+             class Ng2Module {
+             }
+
+             // Bootstrap
+             const element = html(`<ng2></ng2>`);
+
+             adapter.bootstrap(element, ['ng1']).ready(() => {
+               expect(log).toEqual(['ng1-post', 'ng1-$post']);
+             });
+           }));
+      });
+
+      describe('transclusion', () => {
+        it('should support single-slot transclusion', async(() => {
+             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+             let ng2ComponentAInstance: Ng2ComponentA;
+             let ng2ComponentBInstance: Ng2ComponentB;
+
+             // Define `ng1Component`
+             const ng1Component: angular.IComponent = {
+               template: 'ng1(<div ng-transclude></div>)',
+               transclude: true
+             };
+
+             // Define `Ng2Component`
+             @Component({
+               selector: 'ng2A',
+               template: 'ng2A(<ng1>{{ value }} | <ng2B *ngIf="showB"></ng2B></ng1>)'
+             })
+             class Ng2ComponentA {
+               value = 'foo';
+               showB = false;
+               constructor() { ng2ComponentAInstance = this; }
+             }
+
+             @Component({selector: 'ng2B', template: 'ng2B({{ value }})'})
+             class Ng2ComponentB {
+               value = 'bar';
+               constructor() { ng2ComponentBInstance = this; }
+             }
+
+             // Define `ng1Module`
+             const ng1Module = angular.module('ng1Module', [])
+                                   .component('ng1', ng1Component)
+                                   .directive('ng2A', adapter.downgradeNg2Component(Ng2ComponentA));
+
+             // Define `Ng2Module`
+             @NgModule({
+               imports: [BrowserModule],
+               declarations: [adapter.upgradeNg1Component('ng1'), Ng2ComponentA, Ng2ComponentB]
+             })
+             class Ng2Module {
+             }
+
+             // Bootstrap
+             const element = html(`<ng2-a></ng2-a>`);
+
+             adapter.bootstrap(element, ['ng1Module']).ready((ref) => {
+               expect(multiTrim(element.textContent)).toBe('ng2A(ng1(foo | ))');
+
+               ng2ComponentAInstance.value = 'baz';
+               ng2ComponentAInstance.showB = true;
+               $digest(ref);
+
+               expect(multiTrim(element.textContent)).toBe('ng2A(ng1(baz | ng2B(bar)))');
+
+               ng2ComponentBInstance.value = 'qux';
+               $digest(ref);
+
+               expect(multiTrim(element.textContent)).toBe('ng2A(ng1(baz | ng2B(qux)))');
+             });
+           }));
+
+        it('should support single-slot transclusion with fallback content', async(() => {
+             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+             let ng1ControllerInstances: any[] = [];
+             let ng2ComponentInstance: Ng2Component;
+
+             // Define `ng1Component`
+             const ng1Component: angular.IComponent = {
+               template: 'ng1(<div ng-transclude>{{ $ctrl.value }}</div>)',
+               transclude: true,
+               controller: class {
+                 value = 'from-ng1'; constructor() { ng1ControllerInstances.push(this); }
+               }
+             };
+
+             // Define `Ng2Component`
+             @Component({
+               selector: 'ng2',
+               template: `
+                ng2(
+                  <ng1><div>{{ value }}</div></ng1> |
+
+                  <!-- Interpolation-only content should still be detected as transcluded content. -->
+                  <ng1>{{ value }}</ng1> |
+
+                  <ng1></ng1>
+                )`
+             })
+             class Ng2Component {
+               value = 'from-ng2';
+               constructor() { ng2ComponentInstance = this; }
+             }
+
+             // Define `ng1Module`
+             const ng1Module = angular.module('ng1Module', [])
+                                   .component('ng1', ng1Component)
+                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+
+             // Define `Ng2Module`
+             @NgModule({
+               imports: [BrowserModule],
+               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component]
+             })
+             class Ng2Module {
+             }
+
+             // Bootstrap
+             const element = html(`<ng2></ng2>`);
+
+             adapter.bootstrap(element, ['ng1Module']).ready(ref => {
+               expect(multiTrim(element.textContent, true))
+                   .toBe('ng2(ng1(from-ng2)|ng1(from-ng2)|ng1(from-ng1))');
+
+               ng1ControllerInstances.forEach(ctrl => ctrl.value = 'ng1-foo');
+               ng2ComponentInstance.value = 'ng2-bar';
+               $digest(ref);
+
+               expect(multiTrim(element.textContent, true))
+                   .toBe('ng2(ng1(ng2-bar)|ng1(ng2-bar)|ng1(ng1-foo))');
+             });
+           }));
+
+        it('should support multi-slot transclusion', async(() => {
+             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+             let ng2ComponentInstance: Ng2Component;
+
+             // Define `ng1Component`
+             const ng1Component: angular.IComponent = {
+               template:
+                   'ng1(x(<div ng-transclude="slotX"></div>) | y(<div ng-transclude="slotY"></div>))',
+               transclude: {slotX: 'contentX', slotY: 'contentY'}
+             };
+
+             // Define `Ng2Component`
+             @Component({
+               selector: 'ng2',
+               template: `
+                ng2(
+                  <ng1>
+                    <content-x>{{ x }}1</content-x>
+                    <content-y>{{ y }}1</content-y>
+                    <content-x>{{ x }}2</content-x>
+                    <content-y>{{ y }}2</content-y>
+                  </ng1>
+                )`
+             })
+             class Ng2Component {
+               x = 'foo';
+               y = 'bar';
+               constructor() { ng2ComponentInstance = this; }
+             }
+
+             // Define `ng1Module`
+             const ng1Module = angular.module('ng1Module', [])
+                                   .component('ng1', ng1Component)
+                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+
+             // Define `Ng2Module`
+             @NgModule({
+               imports: [BrowserModule],
+               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+               schemas: [NO_ERRORS_SCHEMA]
+             })
+             class Ng2Module {
+             }
+
+             // Bootstrap
+             const element = html(`<ng2></ng2>`);
+
+             adapter.bootstrap(element, ['ng1Module']).ready(ref => {
+               expect(multiTrim(element.textContent, true))
+                   .toBe('ng2(ng1(x(foo1foo2)|y(bar1bar2)))');
+
+               ng2ComponentInstance.x = 'baz';
+               ng2ComponentInstance.y = 'qux';
+               $digest(ref);
+
+               expect(multiTrim(element.textContent, true))
+                   .toBe('ng2(ng1(x(baz1baz2)|y(qux1qux2)))');
+             });
+           }));
+
+        it('should support default slot (with fallback content)', async(() => {
+             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+             let ng1ControllerInstances: any[] = [];
+             let ng2ComponentInstance: Ng2Component;
+
+             // Define `ng1Component`
+             const ng1Component: angular.IComponent = {
+               template: 'ng1(default(<div ng-transclude="">fallback-{{ $ctrl.value }}</div>))',
+               transclude: {slotX: 'contentX', slotY: 'contentY'},
+               controller:
+                   class {value = 'ng1'; constructor() { ng1ControllerInstances.push(this); }}
+             };
+
+             // Define `Ng2Component`
+             @Component({
+               selector: 'ng2',
+               template: `
+                ng2(
+                  <ng1>
+                    ({{ x }})
+                    <content-x>ignored x</content-x>
+                    {{ x }}-<span>{{ y }}</span>
+                    <content-y>ignored y</content-y>
+                    <span>({{ y }})</span>
+                  </ng1> |
+
+                  <!--
+                    Remove any whitespace, because in AngularJS versions prior to 1.6
+                    even whitespace counts as transcluded content.
+                  -->
+                  <ng1><content-x>ignored x</content-x><content-y>ignored y</content-y></ng1> |
+
+                  <!--
+                    Interpolation-only content should still be detected as transcluded content.
+                  -->
+                  <ng1>{{ x }}<content-x>ignored x</content-x>{{ y + x }}<content-y>ignored y</content-y>{{ y }}</ng1>
+                )`
+             })
+             class Ng2Component {
+               x = 'foo';
+               y = 'bar';
+               constructor() { ng2ComponentInstance = this; }
+             }
+
+             // Define `ng1Module`
+             const ng1Module = angular.module('ng1Module', [])
+                                   .component('ng1', ng1Component)
+                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+
+             // Define `Ng2Module`
+             @NgModule({
+               imports: [BrowserModule],
+               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+               schemas: [NO_ERRORS_SCHEMA]
+             })
+             class Ng2Module {
+             }
+
+             // Bootstrap
+             const element = html(`<ng2></ng2>`);
+
+             adapter.bootstrap(element, ['ng1Module']).ready(ref => {
+               expect(multiTrim(element.textContent, true))
+                   .toBe(
+                       'ng2(ng1(default((foo)foo-bar(bar)))|ng1(default(fallback-ng1))|ng1(default(foobarfoobar)))');
+
+               ng1ControllerInstances.forEach(ctrl => ctrl.value = 'ng1-plus');
+               ng2ComponentInstance.x = 'baz';
+               ng2ComponentInstance.y = 'qux';
+               $digest(ref);
+
+               expect(multiTrim(element.textContent, true))
+                   .toBe(
+                       'ng2(ng1(default((baz)baz-qux(qux)))|ng1(default(fallback-ng1-plus))|ng1(default(bazquxbazqux)))');
+             });
+           }));
+
+        it('should support optional transclusion slots (with fallback content)', async(() => {
+             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+             let ng1ControllerInstances: any[] = [];
+             let ng2ComponentInstance: Ng2Component;
+
+             // Define `ng1Component`
+             const ng1Component: angular.IComponent = {
+               template: `
+                ng1(
+                  x(<div ng-transclude="slotX">{{ $ctrl.x }}</div>) |
+                  y(<div ng-transclude="slotY">{{ $ctrl.y }}</div>)
+                )`,
+               transclude: {slotX: '?contentX', slotY: '?contentY'},
+               controller: class {
+                 x = 'ng1X'; y = 'ng1Y'; constructor() { ng1ControllerInstances.push(this); }
+               }
+             };
+
+             // Define `Ng2Component`
+             @Component({
+               selector: 'ng2',
+               template: `
+                ng2(
+                  <ng1><content-x>{{ x }}</content-x></ng1> |
+                  <ng1><content-y>{{ y }}</content-y></ng1>
+                )`
+             })
+             class Ng2Component {
+               x = 'ng2X';
+               y = 'ng2Y';
+               constructor() { ng2ComponentInstance = this; }
+             }
+
+             // Define `ng1Module`
+             const ng1Module = angular.module('ng1Module', [])
+                                   .component('ng1', ng1Component)
+                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+
+             // Define `Ng2Module`
+             @NgModule({
+               imports: [BrowserModule],
+               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+               schemas: [NO_ERRORS_SCHEMA]
+             })
+             class Ng2Module {
+             }
+
+             // Bootstrap
+             const element = html(`<ng2></ng2>`);
+
+             adapter.bootstrap(element, ['ng1Module']).ready(ref => {
+               expect(multiTrim(element.textContent, true))
+                   .toBe('ng2(ng1(x(ng2X)|y(ng1Y))|ng1(x(ng1X)|y(ng2Y)))');
+
+               ng1ControllerInstances.forEach(ctrl => {
+                 ctrl.x = 'ng1X-foo';
+                 ctrl.y = 'ng1Y-bar';
+               });
+               ng2ComponentInstance.x = 'ng2X-baz';
+               ng2ComponentInstance.y = 'ng2Y-qux';
+               $digest(ref);
+
+               expect(multiTrim(element.textContent, true))
+                   .toBe('ng2(ng1(x(ng2X-baz)|y(ng1Y-bar))|ng1(x(ng1X-foo)|y(ng2Y-qux)))');
+             });
+           }));
+
+        it('should throw if a non-optional slot is not filled', async(() => {
+             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+             let errorMessage: string;
+
+             // Define `ng1Component`
+             const ng1Component: angular.IComponent = {
+               template: '',
+               transclude: {slotX: '?contentX', slotY: 'contentY'}
+             };
+
+             // Define `Ng2Component`
+             @Component({selector: 'ng2', template: '<ng1></ng1>'})
+             class Ng2Component {
+             }
+
+             // Define `ng1Module`
+             const ng1Module =
+                 angular.module('ng1Module', [])
+                     .value('$exceptionHandler', (error: Error) => errorMessage = error.message)
+                     .component('ng1', ng1Component)
+                     .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+
+             // Define `Ng2Module`
+             @NgModule({
+               imports: [BrowserModule],
+               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component]
+             })
+             class Ng2Module {
+             }
+
+             // Bootstrap
+             const element = html(`<ng2></ng2>`);
+
+             adapter.bootstrap(element, ['ng1Module']).ready(ref => {
+               expect(errorMessage)
+                   .toContain('Required transclusion slot \'slotY\' on directive: ng1');
+             });
+           }));
+
+        it('should support structural directives in transcluded content', async(() => {
+             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+             let ng2ComponentInstance: Ng2Component;
+
+             // Define `ng1Component`
+             const ng1Component: angular.IComponent = {
+               template:
+                   'ng1(x(<div ng-transclude="slotX"></div>) | default(<div ng-transclude=""></div>))',
+               transclude: {slotX: 'contentX'}
+             };
+
+             // Define `Ng2Component`
+             @Component({
+               selector: 'ng2',
+               template: `
+                ng2(
+                  <ng1>
+                    <content-x><div *ngIf="show">{{ x }}1</div></content-x>
+                    <div *ngIf="!show">{{ y }}1</div>
+                    <content-x><div *ngIf="!show">{{ x }}2</div></content-x>
+                    <div *ngIf="show">{{ y }}2</div>
+                  </ng1>
+                )`
+             })
+             class Ng2Component {
+               x = 'foo';
+               y = 'bar';
+               show = true;
+               constructor() { ng2ComponentInstance = this; }
+             }
+
+             // Define `ng1Module`
+             const ng1Module = angular.module('ng1Module', [])
+                                   .component('ng1', ng1Component)
+                                   .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+
+             // Define `Ng2Module`
+             @NgModule({
+               imports: [BrowserModule],
+               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+               schemas: [NO_ERRORS_SCHEMA]
+             })
+             class Ng2Module {
+             }
+
+             // Bootstrap
+             const element = html(`<ng2></ng2>`);
+
+             adapter.bootstrap(element, ['ng1Module']).ready(ref => {
+               expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(foo1)|default(bar2)))');
+
+               ng2ComponentInstance.x = 'baz';
+               ng2ComponentInstance.y = 'qux';
+               ng2ComponentInstance.show = false;
+               $digest(ref);
+
+               expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz2)|default(qux1)))');
+
+               ng2ComponentInstance.show = true;
+               $digest(ref);
+
+               expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz1)|default(qux2)))');
+             });
+           }));
+      });
+
       it('should bind input properties (<) of components', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
            const ng1Module = angular.module('ng1', []);

--- a/packages/upgrade/test/static/integration/upgrade_component_spec.ts
+++ b/packages/upgrade/test/static/integration/upgrade_component_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, ElementRef, EventEmitter, Inject, Injector, Input, NO_ERRORS_SCHEMA, NgModule, Output, SimpleChanges, destroyPlatform} from '@angular/core';
+import {Component, Directive, ElementRef, ErrorHandler, EventEmitter, Inject, Injector, Input, NO_ERRORS_SCHEMA, NgModule, Output, SimpleChanges, destroyPlatform} from '@angular/core';
 import {async, fakeAsync, tick} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
@@ -1860,6 +1860,474 @@ export function main() {
              });
            }));
       });
+    });
+
+    describe('transclusion', () => {
+      it('should support single-slot transclusion', async(() => {
+           let ng2ComponentAInstance: Ng2ComponentA;
+           let ng2ComponentBInstance: Ng2ComponentB;
+
+           // Define `ng1Component`
+           const ng1Component:
+               angular.IComponent = {template: 'ng1(<div ng-transclude></div>)', transclude: true};
+
+           // Define `Ng1ComponentFacade`
+           @Directive({selector: 'ng1'})
+           class Ng1ComponentFacade extends UpgradeComponent {
+             constructor(elementRef: ElementRef, injector: Injector) {
+               super('ng1', elementRef, injector);
+             }
+           }
+
+           // Define `Ng2Component`
+           @Component({
+             selector: 'ng2A',
+             template: 'ng2A(<ng1>{{ value }} | <ng2B *ngIf="showB"></ng2B></ng1>)'
+           })
+           class Ng2ComponentA {
+             value = 'foo';
+             showB = false;
+             constructor() { ng2ComponentAInstance = this; }
+           }
+
+           @Component({selector: 'ng2B', template: 'ng2B({{ value }})'})
+           class Ng2ComponentB {
+             value = 'bar';
+             constructor() { ng2ComponentBInstance = this; }
+           }
+
+           // Define `ng1Module`
+           const ng1Module = angular.module('ng1Module', [])
+                                 .component('ng1', ng1Component)
+                                 .directive('ng2A', downgradeComponent({component: Ng2ComponentA}));
+
+           // Define `Ng2Module`
+           @NgModule({
+             imports: [BrowserModule, UpgradeModule],
+             declarations: [Ng1ComponentFacade, Ng2ComponentA, Ng2ComponentB],
+             entryComponents: [Ng2ComponentA]
+           })
+           class Ng2Module {
+             ngDoBootstrap() {}
+           }
+
+           // Bootstrap
+           const element = html(`<ng2-a></ng2-a>`);
+
+           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
+             expect(multiTrim(element.textContent)).toBe('ng2A(ng1(foo | ))');
+
+             ng2ComponentAInstance.value = 'baz';
+             ng2ComponentAInstance.showB = true;
+             $digest(adapter);
+
+             expect(multiTrim(element.textContent)).toBe('ng2A(ng1(baz | ng2B(bar)))');
+
+             ng2ComponentBInstance.value = 'qux';
+             $digest(adapter);
+
+             expect(multiTrim(element.textContent)).toBe('ng2A(ng1(baz | ng2B(qux)))');
+           });
+         }));
+
+      it('should support single-slot transclusion with fallback content', async(() => {
+           let ng1ControllerInstances: any[] = [];
+           let ng2ComponentInstance: Ng2Component;
+
+           // Define `ng1Component`
+           const ng1Component: angular.IComponent = {
+             template: 'ng1(<div ng-transclude>{{ $ctrl.value }}</div>)',
+             transclude: true,
+             controller:
+                 class {value = 'from-ng1'; constructor() { ng1ControllerInstances.push(this); }}
+           };
+
+           // Define `Ng1ComponentFacade`
+           @Directive({selector: 'ng1'})
+           class Ng1ComponentFacade extends UpgradeComponent {
+             constructor(elementRef: ElementRef, injector: Injector) {
+               super('ng1', elementRef, injector);
+             }
+           }
+
+           // Define `Ng2Component`
+           @Component({selector: 'ng2', template: 'ng2(<ng1>{{ value }}</ng1> | <ng1></ng1>)'})
+           class Ng2Component {
+             value = 'from-ng2';
+             constructor() { ng2ComponentInstance = this; }
+           }
+
+           // Define `ng1Module`
+           const ng1Module = angular.module('ng1Module', [])
+                                 .component('ng1', ng1Component)
+                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+
+           // Define `Ng2Module`
+           @NgModule({
+             imports: [BrowserModule, UpgradeModule],
+             declarations: [Ng1ComponentFacade, Ng2Component],
+             entryComponents: [Ng2Component]
+           })
+           class Ng2Module {
+             ngDoBootstrap() {}
+           }
+
+           // Bootstrap
+           const element = html(`<ng2></ng2>`);
+
+           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
+             expect(multiTrim(element.textContent)).toBe('ng2(ng1(from-ng2) | ng1(from-ng1))');
+
+             ng1ControllerInstances.forEach(ctrl => ctrl.value = 'ng1-foo');
+             ng2ComponentInstance.value = 'ng2-bar';
+             $digest(adapter);
+
+             expect(multiTrim(element.textContent)).toBe('ng2(ng1(ng2-bar) | ng1(ng1-foo))');
+           });
+         }));
+
+      it('should support multi-slot transclusion', async(() => {
+           let ng2ComponentInstance: Ng2Component;
+
+           // Define `ng1Component`
+           const ng1Component: angular.IComponent = {
+             template:
+                 'ng1(x(<div ng-transclude="slotX"></div>) | y(<div ng-transclude="slotY"></div>))',
+             transclude: {slotX: 'contentX', slotY: 'contentY'}
+           };
+
+           // Define `Ng1ComponentFacade`
+           @Directive({selector: 'ng1'})
+           class Ng1ComponentFacade extends UpgradeComponent {
+             constructor(elementRef: ElementRef, injector: Injector) {
+               super('ng1', elementRef, injector);
+             }
+           }
+
+           // Define `Ng2Component`
+           @Component({
+             selector: 'ng2',
+             template: `
+               ng2(
+                 <ng1>
+                   <content-x>{{ x }}1</content-x>
+                   <content-y>{{ y }}1</content-y>
+                   <content-x>{{ x }}2</content-x>
+                   <content-y>{{ y }}2</content-y>
+                 </ng1>
+               )`
+           })
+           class Ng2Component {
+             x = 'foo';
+             y = 'bar';
+             constructor() { ng2ComponentInstance = this; }
+           }
+
+           // Define `ng1Module`
+           const ng1Module = angular.module('ng1Module', [])
+                                 .component('ng1', ng1Component)
+                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+
+           // Define `Ng2Module`
+           @NgModule({
+             imports: [BrowserModule, UpgradeModule],
+             declarations: [Ng1ComponentFacade, Ng2Component],
+             entryComponents: [Ng2Component],
+             schemas: [NO_ERRORS_SCHEMA]
+           })
+           class Ng2Module {
+             ngDoBootstrap() {}
+           }
+
+           // Bootstrap
+           const element = html(`<ng2></ng2>`);
+
+           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
+             expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(foo1foo2)|y(bar1bar2)))');
+
+             ng2ComponentInstance.x = 'baz';
+             ng2ComponentInstance.y = 'qux';
+             $digest(adapter);
+
+             expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz1baz2)|y(qux1qux2)))');
+           });
+         }));
+
+      it('should support default slot (with fallback content)', async(() => {
+           let ng1ControllerInstances: any[] = [];
+           let ng2ComponentInstance: Ng2Component;
+
+           // Define `ng1Component`
+           const ng1Component: angular.IComponent = {
+             template: 'ng1(default(<div ng-transclude="">fallback-{{ $ctrl.value }}</div>))',
+             transclude: {slotX: 'contentX', slotY: 'contentY'},
+             controller:
+                 class {value = 'ng1'; constructor() { ng1ControllerInstances.push(this); }}
+           };
+
+           // Define `Ng1ComponentFacade`
+           @Directive({selector: 'ng1'})
+           class Ng1ComponentFacade extends UpgradeComponent {
+             constructor(elementRef: ElementRef, injector: Injector) {
+               super('ng1', elementRef, injector);
+             }
+           }
+
+           // Define `Ng2Component`
+           @Component({
+             selector: 'ng2',
+             template: `
+               ng2(
+                 <ng1>
+                   ({{ x }})
+                   <content-x>ignored x</content-x>
+                   {{ x }}-<span>{{ y }}</span>
+                   <content-y>ignored y</content-y>
+                   <span>({{ y }})</span>
+                 </ng1> |
+                 <!--
+                   Remove any whitespace, because in AngularJS versions prior to 1.6
+                   even whitespace counts as transcluded content.
+                 -->
+                 <ng1><content-x>ignored x</content-x><content-y>ignored y</content-y></ng1>
+               )`
+           })
+           class Ng2Component {
+             x = 'foo';
+             y = 'bar';
+             constructor() { ng2ComponentInstance = this; }
+           }
+
+           // Define `ng1Module`
+           const ng1Module = angular.module('ng1Module', [])
+                                 .component('ng1', ng1Component)
+                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+
+           // Define `Ng2Module`
+           @NgModule({
+             imports: [BrowserModule, UpgradeModule],
+             declarations: [Ng1ComponentFacade, Ng2Component],
+             entryComponents: [Ng2Component],
+             schemas: [NO_ERRORS_SCHEMA]
+           })
+           class Ng2Module {
+             ngDoBootstrap() {}
+           }
+
+           // Bootstrap
+           const element = html(`<ng2></ng2>`);
+
+           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
+             expect(multiTrim(element.textContent, true))
+                 .toBe('ng2(ng1(default((foo)foo-bar(bar)))|ng1(default(fallback-ng1)))');
+
+             ng1ControllerInstances.forEach(ctrl => ctrl.value = 'ng1-plus');
+             ng2ComponentInstance.x = 'baz';
+             ng2ComponentInstance.y = 'qux';
+             $digest(adapter);
+
+             expect(multiTrim(element.textContent, true))
+                 .toBe('ng2(ng1(default((baz)baz-qux(qux)))|ng1(default(fallback-ng1-plus)))');
+           });
+         }));
+
+      it('should support optional transclusion slots (with fallback content)', async(() => {
+           let ng1ControllerInstances: any[] = [];
+           let ng2ComponentInstance: Ng2Component;
+
+           // Define `ng1Component`
+           const ng1Component: angular.IComponent = {
+             template: `
+               ng1(
+                x(<div ng-transclude="slotX">{{ $ctrl.x }}</div>) |
+                y(<div ng-transclude="slotY">{{ $ctrl.y }}</div>)
+               )`,
+             transclude: {slotX: '?contentX', slotY: '?contentY'},
+             controller: class {
+               x = 'ng1X'; y = 'ng1Y'; constructor() { ng1ControllerInstances.push(this); }
+             }
+           };
+
+           // Define `Ng1ComponentFacade`
+           @Directive({selector: 'ng1'})
+           class Ng1ComponentFacade extends UpgradeComponent {
+             constructor(elementRef: ElementRef, injector: Injector) {
+               super('ng1', elementRef, injector);
+             }
+           }
+
+           // Define `Ng2Component`
+           @Component({
+             selector: 'ng2',
+             template: `
+               ng2(
+                 <ng1><content-x>{{ x }}</content-x></ng1> |
+                 <ng1><content-y>{{ y }}</content-y></ng1>
+               )`
+           })
+           class Ng2Component {
+             x = 'ng2X';
+             y = 'ng2Y';
+             constructor() { ng2ComponentInstance = this; }
+           }
+
+           // Define `ng1Module`
+           const ng1Module = angular.module('ng1Module', [])
+                                 .component('ng1', ng1Component)
+                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+
+           // Define `Ng2Module`
+           @NgModule({
+             imports: [BrowserModule, UpgradeModule],
+             declarations: [Ng1ComponentFacade, Ng2Component],
+             entryComponents: [Ng2Component],
+             schemas: [NO_ERRORS_SCHEMA]
+           })
+           class Ng2Module {
+             ngDoBootstrap() {}
+           }
+
+           // Bootstrap
+           const element = html(`<ng2></ng2>`);
+
+           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
+             expect(multiTrim(element.textContent, true))
+                 .toBe('ng2(ng1(x(ng2X)|y(ng1Y))|ng1(x(ng1X)|y(ng2Y)))');
+
+             ng1ControllerInstances.forEach(ctrl => {
+               ctrl.x = 'ng1X-foo';
+               ctrl.y = 'ng1Y-bar';
+             });
+             ng2ComponentInstance.x = 'ng2X-baz';
+             ng2ComponentInstance.y = 'ng2Y-qux';
+             $digest(adapter);
+
+             expect(multiTrim(element.textContent, true))
+                 .toBe('ng2(ng1(x(ng2X-baz)|y(ng1Y-bar))|ng1(x(ng1X-foo)|y(ng2Y-qux)))');
+           });
+         }));
+
+      it('should throw if a non-optional slot is not filled', async(() => {
+           let errorMessage: string;
+
+           // Define `ng1Component`
+           const ng1Component: angular.IComponent = {
+             template: '',
+             transclude: {slotX: '?contentX', slotY: 'contentY'}
+           };
+
+           // Define `Ng1ComponentFacade`
+           @Directive({selector: 'ng1'})
+           class Ng1ComponentFacade extends UpgradeComponent {
+             constructor(elementRef: ElementRef, injector: Injector) {
+               super('ng1', elementRef, injector);
+             }
+           }
+
+           // Define `Ng2Component`
+           @Component({selector: 'ng2', template: '<ng1></ng1>'})
+           class Ng2Component {
+           }
+
+           // Define `ng1Module`
+           const ng1Module =
+               angular.module('ng1Module', [])
+                   .value('$exceptionHandler', (error: Error) => errorMessage = error.message)
+                   .component('ng1', ng1Component)
+                   .directive('ng2', downgradeComponent({component: Ng2Component}));
+
+           // Define `Ng2Module`
+           @NgModule({
+             imports: [BrowserModule, UpgradeModule],
+             declarations: [Ng1ComponentFacade, Ng2Component],
+             entryComponents: [Ng2Component]
+           })
+           class Ng2Module {
+             ngDoBootstrap() {}
+           }
+
+           // Bootstrap
+           const element = html(`<ng2></ng2>`);
+
+           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
+             expect(errorMessage)
+                 .toContain('Required transclusion slot \'slotY\' on directive: ng1');
+           });
+         }));
+
+      it('should support structural directives in transcluded content', async(() => {
+           let ng2ComponentInstance: Ng2Component;
+
+           // Define `ng1Component`
+           const ng1Component: angular.IComponent = {
+             template:
+                 'ng1(x(<div ng-transclude="slotX"></div>) | default(<div ng-transclude=""></div>))',
+             transclude: {slotX: 'contentX'}
+           };
+
+           // Define `Ng1ComponentFacade`
+           @Directive({selector: 'ng1'})
+           class Ng1ComponentFacade extends UpgradeComponent {
+             constructor(elementRef: ElementRef, injector: Injector) {
+               super('ng1', elementRef, injector);
+             }
+           }
+
+           // Define `Ng2Component`
+           @Component({
+             selector: 'ng2',
+             template: `
+               ng2(
+                 <ng1>
+                   <content-x><div *ngIf="show">{{ x }}1</div></content-x>
+                   <div *ngIf="!show">{{ y }}1</div>
+                   <content-x><div *ngIf="!show">{{ x }}2</div></content-x>
+                   <div *ngIf="show">{{ y }}2</div>
+                 </ng1>
+               )`
+           })
+           class Ng2Component {
+             x = 'foo';
+             y = 'bar';
+             show = true;
+             constructor() { ng2ComponentInstance = this; }
+           }
+
+           // Define `ng1Module`
+           const ng1Module = angular.module('ng1Module', [])
+                                 .component('ng1', ng1Component)
+                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+
+           // Define `Ng2Module`
+           @NgModule({
+             imports: [BrowserModule, UpgradeModule],
+             declarations: [Ng1ComponentFacade, Ng2Component],
+             entryComponents: [Ng2Component],
+             schemas: [NO_ERRORS_SCHEMA]
+           })
+           class Ng2Module {
+             ngDoBootstrap() {}
+           }
+
+           // Bootstrap
+           const element = html(`<ng2></ng2>`);
+
+           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(adapter => {
+             expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(foo1)|default(bar2)))');
+
+             ng2ComponentInstance.x = 'baz';
+             ng2ComponentInstance.y = 'qux';
+             ng2ComponentInstance.show = false;
+             $digest(adapter);
+
+             expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz2)|default(qux1)))');
+
+             ng2ComponentInstance.show = true;
+             $digest(adapter);
+
+             expect(multiTrim(element.textContent, true)).toBe('ng2(ng1(x(baz1)|default(qux2)))');
+           });
+         }));
     });
 
     describe('lifecycle hooks', () => {

--- a/packages/upgrade/test/static/integration/upgrade_component_spec.ts
+++ b/packages/upgrade/test/static/integration/upgrade_component_spec.ts
@@ -1069,6 +1069,244 @@ export function main() {
          }));
     });
 
+    describe('linking', () => {
+      it('should run the pre-linking after instantiating the controller', async(() => {
+           const log: string[] = [];
+
+           // Define `ng1Directive`
+           const ng1Directive: angular.IDirective = {
+             template: '',
+             link: {pre: () => log.push('ng1-pre')},
+             controller: class {constructor() { log.push('ng1-ctrl'); }}
+           };
+
+           // Define `Ng1ComponentFacade`
+           @Directive({selector: 'ng1'})
+           class Ng1ComponentFacade extends UpgradeComponent {
+             constructor(elementRef: ElementRef, injector: Injector) {
+               super('ng1', elementRef, injector);
+             }
+           }
+
+           // Define `Ng2Component`
+           @Component({selector: 'ng2', template: '<ng1></ng1>'})
+           class Ng2Component {
+           }
+
+           // Define `ng1Module`
+           const ng1Module = angular.module('ng1', [])
+                                 .directive('ng1', () => ng1Directive)
+                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+
+           // Define `Ng2Module`
+           @NgModule({
+             imports: [BrowserModule, UpgradeModule],
+             declarations: [Ng1ComponentFacade, Ng2Component],
+             entryComponents: [Ng2Component],
+           })
+           class Ng2Module {
+             ngDoBootstrap() {}
+           }
+
+           // Bootstrap
+           const element = html(`<ng2></ng2>`);
+
+           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+             expect(log).toEqual(['ng1-ctrl', 'ng1-pre']);
+           });
+         }));
+
+      it('should run the pre-linking function before linking', async(() => {
+           const log: string[] = [];
+
+           // Define `ng1Directive`
+           const ng1DirectiveA: angular.IDirective = {
+             template: '<ng1-b></ng1-b>',
+             link: {pre: () => log.push('ng1A-pre')}
+           };
+
+           const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
+
+           // Define `Ng1ComponentAFacade`
+           @Directive({selector: 'ng1A'})
+           class Ng1ComponentAFacade extends UpgradeComponent {
+             constructor(elementRef: ElementRef, injector: Injector) {
+               super('ng1A', elementRef, injector);
+             }
+           }
+
+           // Define `Ng2Component`
+           @Component({selector: 'ng2', template: '<ng1A></ng1A>'})
+           class Ng2Component {
+           }
+
+           // Define `ng1Module`
+           const ng1Module = angular.module('ng1', [])
+                                 .directive('ng1A', () => ng1DirectiveA)
+                                 .directive('ng1B', () => ng1DirectiveB)
+                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+
+           // Define `Ng2Module`
+           @NgModule({
+             imports: [BrowserModule, UpgradeModule],
+             declarations: [Ng1ComponentAFacade, Ng2Component],
+             entryComponents: [Ng2Component],
+           })
+           class Ng2Module {
+             ngDoBootstrap() {}
+           }
+
+           // Bootstrap
+           const element = html(`<ng2></ng2>`);
+
+           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+             expect(log).toEqual(['ng1A-pre', 'ng1B-post']);
+           });
+         }));
+
+      it('should run the post-linking function after linking (link: object)', async(() => {
+           const log: string[] = [];
+
+           // Define `ng1Directive`
+           const ng1DirectiveA: angular.IDirective = {
+             template: '<ng1-b></ng1-b>',
+             link: {post: () => log.push('ng1A-post')}
+           };
+
+           const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
+
+           // Define `Ng1ComponentAFacade`
+           @Directive({selector: 'ng1A'})
+           class Ng1ComponentAFacade extends UpgradeComponent {
+             constructor(elementRef: ElementRef, injector: Injector) {
+               super('ng1A', elementRef, injector);
+             }
+           }
+
+           // Define `Ng2Component`
+           @Component({selector: 'ng2', template: '<ng1A></ng1A>'})
+           class Ng2Component {
+           }
+
+           // Define `ng1Module`
+           const ng1Module = angular.module('ng1', [])
+                                 .directive('ng1A', () => ng1DirectiveA)
+                                 .directive('ng1B', () => ng1DirectiveB)
+                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+
+           // Define `Ng2Module`
+           @NgModule({
+             imports: [BrowserModule, UpgradeModule],
+             declarations: [Ng1ComponentAFacade, Ng2Component],
+             entryComponents: [Ng2Component],
+           })
+           class Ng2Module {
+             ngDoBootstrap() {}
+           }
+
+           // Bootstrap
+           const element = html(`<ng2></ng2>`);
+
+           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+             expect(log).toEqual(['ng1B-post', 'ng1A-post']);
+           });
+         }));
+
+      it('should run the post-linking function after linking (link: function)', async(() => {
+           const log: string[] = [];
+
+           // Define `ng1Directive`
+           const ng1DirectiveA: angular.IDirective = {
+             template: '<ng1-b></ng1-b>',
+             link: () => log.push('ng1A-post')
+           };
+
+           const ng1DirectiveB: angular.IDirective = {link: () => log.push('ng1B-post')};
+
+           // Define `Ng1ComponentAFacade`
+           @Directive({selector: 'ng1A'})
+           class Ng1ComponentAFacade extends UpgradeComponent {
+             constructor(elementRef: ElementRef, injector: Injector) {
+               super('ng1A', elementRef, injector);
+             }
+           }
+
+           // Define `Ng2Component`
+           @Component({selector: 'ng2', template: '<ng1A></ng1A>'})
+           class Ng2Component {
+           }
+
+           // Define `ng1Module`
+           const ng1Module = angular.module('ng1', [])
+                                 .directive('ng1A', () => ng1DirectiveA)
+                                 .directive('ng1B', () => ng1DirectiveB)
+                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+
+           // Define `Ng2Module`
+           @NgModule({
+             imports: [BrowserModule, UpgradeModule],
+             declarations: [Ng1ComponentAFacade, Ng2Component],
+             entryComponents: [Ng2Component],
+           })
+           class Ng2Module {
+             ngDoBootstrap() {}
+           }
+
+           // Bootstrap
+           const element = html(`<ng2></ng2>`);
+
+           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+             expect(log).toEqual(['ng1B-post', 'ng1A-post']);
+           });
+         }));
+
+      it('should run the post-linking function before `$postLink`', async(() => {
+           const log: string[] = [];
+
+           // Define `ng1Directive`
+           const ng1Directive: angular.IDirective = {
+             template: '',
+             link: () => log.push('ng1-post'),
+             controller: class {$postLink() { log.push('ng1-$post'); }}
+           };
+
+           // Define `Ng1ComponentFacade`
+           @Directive({selector: 'ng1'})
+           class Ng1ComponentFacade extends UpgradeComponent {
+             constructor(elementRef: ElementRef, injector: Injector) {
+               super('ng1', elementRef, injector);
+             }
+           }
+
+           // Define `Ng2Component`
+           @Component({selector: 'ng2', template: '<ng1></ng1>'})
+           class Ng2Component {
+           }
+
+           // Define `ng1Module`
+           const ng1Module = angular.module('ng1', [])
+                                 .directive('ng1', () => ng1Directive)
+                                 .directive('ng2', downgradeComponent({component: Ng2Component}));
+
+           // Define `Ng2Module`
+           @NgModule({
+             imports: [BrowserModule, UpgradeModule],
+             declarations: [Ng1ComponentFacade, Ng2Component],
+             entryComponents: [Ng2Component],
+           })
+           class Ng2Module {
+             ngDoBootstrap() {}
+           }
+
+           // Bootstrap
+           const element = html(`<ng2></ng2>`);
+
+           bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then(() => {
+             expect(log).toEqual(['ng1-post', 'ng1-$post']);
+           });
+         }));
+    });
+
     describe('controller', () => {
       it('should support `controllerAs`', async(() => {
            // Define `ng1Directive`


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Previously, the dynamic and static versions used similar but separate implementations for upgrading components. Although there are differences, large parts of the implementations can be shared.


**What is the new behavior?**
The two versions (static and dynamic) share most of the imlementation of upgraded components (via a new helper class), which has the following effects:
- We only have to fix bugs/add features in one place and the changes propagate to both versions.
- The dynamic version is brought up-to-speed with the better implementation of the static version (which supports more features and is closer to the actual AngularJS behavior).


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
[x] Maybe (but only to the dynamic version)
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:
With the dynamic version, upgraded components will now work more similar to how pure AngularJS components would. If an application relied on the previous behavior (e.g. not running pre-/post-linking functions, not being compiled in the correct context, not running the `$onInit()` hook, not binding required controllers to the controller instance etc), its behavior might change.


**Other information**:
This builds on top of #16627.
It also ports the fixes from #16627 to the dynamic version and fixes #11044.