### PR TITLE
build(aio): ignore .ngsummary.ts files in examples

### DIFF
--- a/aio/content/examples/.gitignore
+++ b/aio/content/examples/.gitignore
@@ -45,6 +45,7 @@ dist/
 # aot
 **/*.ngfactory.ts
 **/*.ngsummary.json
+**/*.ngsummary.ts
 **/*.shim.ngstyle.ts
 **/*.metadata.json
 !aot/bs-config.json


### PR DESCRIPTION
It is a 4.2 feature, but I realized after I had the PR ready. It doesn't matter if we merge it Ahead of Time.