### PR TITLE
fix(aio): fix scrolling to an element

### DIFF
--- a/aio/src/styles/0-base/_typography.scss
+++ b/aio/src/styles/0-base/_typography.scss
@@ -8,7 +8,7 @@ body {
 }
 
 h1 {
-  display:inline-block;
+  display: inline-block;
   font-size: 24px;
   font-weight: 500;
   margin: 8px 0px;

--- a/aio/src/styles/1-layouts/_content-layout.scss
+++ b/aio/src/styles/1-layouts/_content-layout.scss
@@ -7,7 +7,7 @@ aio-shell.page-docs {
 
 .sidenav-content {
   min-height: 100vh;
-  padding: 6rem 3rem 1rem;
+  padding: 80px 3rem 1rem;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
Previously, the top-bar's height wasn't taken into account when scrolling an element into view. As a result, the element would be hidden behind the top-bar. Taking the top-bar height into account was not necessary before #17155, because the top-bar was not fixed (i.e. it scrolled away).

This commit fixes the scrolling behavior by accounting for the top-bar's height when scrolling an element into view.

(This partially reverts #17102.)

Fixes #17219
Fixes #17226