### PR TITLE
fix(http): move destructuring inside {Request,Response}Options ctor

### DIFF
--- a/packages/http/src/base_request_options.ts
+++ b/packages/http/src/base_request_options.ts
@@ -79,9 +79,8 @@ export class RequestOptions {
   responseType: ResponseContentType|null;
 
   // TODO(Dzmitry): remove search when this.search is removed
-  constructor(
-      {method, headers, body, url, search, params, withCredentials,
-       responseType}: RequestOptionsArgs = {}) {
+  constructor(opts: RequestOptionsArgs = {}) {
+    const {method, headers, body, url, search, params, withCredentials, responseType} = opts;
     this.method = method != null ? normalizeMethodName(method) : null;
     this.headers = headers != null ? headers : null;
     this.body = body != null ? body : null;

--- a/packages/http/src/base_response_options.ts
+++ b/packages/http/src/base_response_options.ts
@@ -65,7 +65,8 @@ export class ResponseOptions {
    */
   type: ResponseType|null;
   url: string|null;
-  constructor({body, status, headers, statusText, type, url}: ResponseOptionsArgs = {}) {
+  constructor(opts: ResponseOptionsArgs = {}) {
+    const {body, status, headers, statusText, type, url} = opts;
     this.body = body != null ? body : null;
     this.status = status != null ? status : null;
     this.headers = headers != null ? headers : null;

--- a/tools/public_api_guard/http/http.d.ts
+++ b/tools/public_api_guard/http/http.d.ts
@@ -144,7 +144,7 @@ export declare class RequestOptions {
     /** @deprecated */ search: URLSearchParams;
     url: string | null;
     withCredentials: boolean | null;
-    constructor({method, headers, body, url, search, params, withCredentials, responseType}?: RequestOptionsArgs);
+    constructor(opts?: RequestOptionsArgs);
     merge(options?: RequestOptionsArgs): RequestOptions;
 }
 
@@ -192,7 +192,7 @@ export declare class ResponseOptions {
     headers: Headers | null;
     status: number | null;
     url: string | null;
-    constructor({body, status, headers, statusText, type, url}?: ResponseOptionsArgs);
+    constructor(opts?: ResponseOptionsArgs);
     merge(options?: ResponseOptionsArgs): ResponseOptions;
 }
 


### PR DESCRIPTION
Previously the RequestOptions/ResponseOptions classes had constructors
with a destructured argument hash (represented by the
{Request,Response}OptionsArgs type). This type consists entirely of
optional members.

This produces a .d.ts file which includes the constructor declaration:

constructor({param, otherParam}?: OptionsArgs);

However, this declaration doesn't type-check properly. TypeScript
determines the actual type of the hash parameter to be OptionsArgs | undefined,
which it then concludes does not have a `param` or `otherParam` member.

This is likely a bug in TypeScript. As a workaround, destructuring is moved
inside the method, where it does not produce artifacts in the .d.ts.

Fixes #16663.