### PR TITLE
docs(toh-pt5.md): correctly indent example 

### DIFF
--- a/aio/content/tutorial/toh-pt5.md
+++ b/aio/content/tutorial/toh-pt5.md
@@ -923,8 +923,15 @@ Use an ES2015 `import` statement *and* add it to the `NgModule.imports` list.
 Here is the revised `AppModule`, compared to its pre-refactor state:
 
 <code-tabs>
-  <code-pane path="toh-pt5/src/app/app.module.ts" title="src/app/app.module.ts (after)"></code-pane>
-  <code-pane path="toh-pt5/src/app/app.module.3.ts" title="src/app/app.module.ts (before)"></code-pane>
+
+  <code-pane path="toh-pt5/src/app/app.module.ts" title="src/app/app.module.ts (after)">
+
+  </code-pane>
+
+  <code-pane path="toh-pt5/src/app/app.module.3.ts" title="src/app/app.module.ts (before)">
+
+  </code-pane>
+
 </code-tabs>
 
 The revised and simplified `AppModule` is focused on identifying the key pieces of the app.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```
Indentation fix in the raw documentation so that the component renders correctly.

**What is the current behavior?** (You can also link to an open issue here)
At https://angular.io/docs/ts/latest/tutorial/toh-pt5.html (subheader "Update AppModule"), the following text displays instead of the tabs component:

```
+makeTabs( toh-5/ts/src/app/app.module.ts, toh-5/ts/src/app/app.module.3.ts, null, src/app/app.module.ts (after), src/app/app.module.ts (before)) :marked The revised and simplified AppModule is focused on identifying the key pieces of the app.
```



**What is the new behavior?**

The tabbed component displays properly.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```