### PR TITLE
docs(aio): add “nougat” to compat chart

### DIFF
--- a/aio/content/guide/browser-support.md
+++ b/aio/content/guide/browser-support.md
@@ -68,7 +68,7 @@ Angular supports most recent browsers. This includes the following specific vers
     </td>
 
     <td>
-      Marshmallow (6.0)
+      Nougat (7.0)<br>Marshmallow (6.0)
     </td>
 
     <td>


### PR DESCRIPTION
closes #17262

<img src="https://user-images.githubusercontent.com/129061/26892659-dec8fb2e-4b6d-11e7-834c-49beaa7d16ca.png" style="width: 200px;"/>

