### PR TITLE
fix(aio): scroll to top immediately when doc changes

### DIFF
--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -185,6 +185,9 @@ export class AppComponent implements OnInit {
     // Stop fetching timeout (which, when render is fast, means progress bar never shown)
     clearTimeout(this.isFetchingTimeout);
 
+    // Put page in a clean visual state
+    this.scrollService.scrollToTop();
+
     // Scroll 500ms after the doc-viewer has finished rendering the new doc
     // The delay is to allow time for async layout to complete
     setTimeout(() => {


### PR DESCRIPTION
**WIP** - Tests needed _after_ the behavior introduced by this page has been confirmed as desirable.

This PR causes the page to scroll to the top immediately when rendered. Then, if necessary (as when there is a bookmark in the url such as `~/guide/cli-quickstart#project-file-review`), it scrolls down to it.

There was (and there remains) a half second lag before the final scrolling (either to top or bookmark). A scroll lag _is necessary_ to allow async building of a page to complete, especially on launch, before scrolling to the _final_ position. 

But, before this PR, during that half second the page isn't in a good place either.

Example:
1. Go to a guide page
2. Scroll to footer
3. Click "About" link

The doc viewer navigates to the "About" page, waits 1/2 second, then scrolls to the top of that page. During the 1/2 second, the header (title) is hidden under the toolbar. When scroll-to-top finally occurs, the page jumps down and the header appears. _No bueno_.

Scrolling immediately to the top and then to the final destination after the lag cures the problem.