### PR TITLE
ci: update Chromium to 464641 (Chrome v59)

### DIFF
--- a/packages/compiler/test/schema/schema_extractor.ts
+++ b/packages/compiler/test/schema/schema_extractor.ts
@@ -28,6 +28,7 @@ const ALL_HTML_TAGS =
 // Elements missing from Chrome (HtmlUnknownElement), to be manually added
 const MISSING_FROM_CHROME: {[el: string]: string[]} = {
   'data^[HTMLElement]': ['value'],
+  'keygen^[HTMLElement]': ['!autofocus', 'challenge', '!disabled', 'form', 'keytype', 'name'],
   // TODO(vicb): Figure out why Chrome and WhatWG do not agree on the props
   // 'menu^[HTMLElement]': ['type', 'label'],
   'menuitem^[HTMLElement]':

--- a/scripts/ci/env.sh
+++ b/scripts/ci/env.sh
@@ -37,7 +37,7 @@ fi
 setEnvVar NODE_VERSION 6.9.5
 setEnvVar NPM_VERSION 3.10.7 # do not upgrade to >3.10.8 unless https://github.com/npm/npm/issues/14042 is resolved
 setEnvVar YARN_VERSION 0.21.3
-setEnvVar CHROMIUM_VERSION 433059 # Chrome 53 linux stable, see https://www.chromium.org/developers/calendar
+setEnvVar CHROMIUM_VERSION 464641 # Chrome 59 linux stable, see https://www.chromium.org/developers/calendar
 setEnvVar SAUCE_CONNECT_VERSION 4.3.11
 setEnvVar PROJECT_ROOT $(cd ${thisDir}/../..; pwd)
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Recent ChromeDriver versions require a newer version of Chrome/Chromium. Currently, the Chromium version used on CI is equivalent to Chrome v53.
This causes `aio` e2e tests (which rely on the `@angular/cli`) to fail.


**What is the new behavior?**
Using a newer version of Chromium (equivalent to Chrome v59).


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
