### PR TITLE
fix(aio): contributor img offset and hover fix

### DIFF
--- a/aio/src/app/embedded/contributor/contributor.component.ts
+++ b/aio/src/app/embedded/contributor/contributor.component.ts
@@ -13,16 +13,16 @@ import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
 
             <div *ngIf="person.picture" class="contributor-image" [style.background-image]="'url('+pictureBase+person.picture+')'">
                 <div class="contributor-info">
-                    <button>
-                        <a *ngIf="person.bio" aria-label="View Bio">View Bio</a>
+                    <button *ngIf="person.bio" >
+                        <a aria-label="View Bio">View Bio</a>
                     </button>
-                    <button class="icon">
-                        <a *ngIf="person.twitter" href="https://twitter.com/{{person.twitter}}" target="_blank">
+                    <button *ngIf="person.twitter" class="icon">
+                        <a href="https://twitter.com/{{person.twitter}}" target="_blank">
                             <span class="fa fa-twitter fa-2x"></span>
                         </a>
                     </button>
-                    <button class="icon">
-                        <a *ngIf="person.website" href="{{person.website}}" target="_blank">
+                    <button *ngIf="person.website" class="icon">
+                        <a href="{{person.website}}" target="_blank">
                             <span class="fa fa-link fa-2x"></span>
                         </a>
                     </button>
@@ -31,16 +31,16 @@ import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
 
             <div *ngIf="!person.picture" class="contributor-image" [style.background-image]="'url('+pictureBase+noPicture+')'">
                 <div class="contributor-info">
-                    <button>
-                        <a *ngIf="person.bio" aria-label="View Bio">View Bio</a>
+                    <button *ngIf="person.bio">
+                        <a aria-label="View Bio">View Bio</a>
                     </button>
-                    <button class="icon">
-                        <a *ngIf="person.twitter" href="https://twitter.com/{{person.twitter}}" target="_blank">
+                    <button *ngIf="person.twitter" class="icon">
+                        <a href="https://twitter.com/{{person.twitter}}" target="_blank">
                             <span class="fa fa-twitter fa-2x"></span>
                         </a>
                     </button>
-                    <button class="icon">
-                        <a *ngIf="person.website" href="{{person.website}}" target="_blank">
+                    <button *ngIf="person.website" class="icon">
+                        <a href="{{person.website}}" target="_blank">
                             <span class="fa fa-link fa-2x"></span>
                         </a>
                     </button>

--- a/aio/src/styles/2-modules/_contributor.scss
+++ b/aio/src/styles/2-modules/_contributor.scss
@@ -59,8 +59,8 @@ aio-contributor {
 
   .contributor-info {
     background: rgba($darkgray, 0.5);
-    height: 200px;
-    width: 200px;
+    height: 168px;
+    width: 168px;
     display: flex;
     flex-direction: row;
     justify-content: center;
@@ -94,7 +94,7 @@ aio-contributor {
       }
 
       &:hover {
-        color: $blue;
+        color: $lightgray;
       }
     }
   }
@@ -111,6 +111,10 @@ aio-contributor {
       border-radius: 4px;
       transform-style:preserve-3d;
       transition:transform ease 500ms;
+
+      h3 {
+        margin: 8px 0;
+      }
 
       .card-front, .card-back {
         width: 100%;
@@ -159,8 +163,8 @@ aio-contributor {
     justify-content: center;
     border-radius: 50%;
     align-items: center;
-    height: 200px;
-    width: 200px;
+    height: 168px;
+    width: 168px;
     background-size: cover;
     background-position: center;
     margin: 8px auto;


### PR DESCRIPTION
- Contributor image and hover layover resized to be a complete circle again
- Moved condition on contributor hover info (icons for Twitter, website, bio, etc) to the buttons themselves so that the content is always centered on the image when there are fewer than the 3 desired items.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```