### PR TITLE
fix(aio): temporarily remove the focus style of top-bar nav items

### DIFF
--- a/aio/src/styles/1-layouts/_top-menu.scss
+++ b/aio/src/styles/1-layouts/_top-menu.scss
@@ -43,9 +43,11 @@ aio-top-menu {
 
     &:focus {
       outline: none;
-      background: rgba($white, 0.15);
-      border-radius: 4px;
-      padding: 8px 16px;
+      // Temporarily remove the focus styling until we update to an @angular/material version that
+      // includes https://github.com/angular/material2/commit/3bc82f6dc.
+      // background: rgba($white, 0.15);
+      // border-radius: 4px;
+      // padding: 8px 16px;
     }
   }
 }


### PR DESCRIPTION
Temporarily addresses #17216 until we upgrade to an `@angular/material` version that includes angular/material2@3bc82f6dc.