### PR TITLE
fix(aio): temporarily remove link to source from the API pages

### DIFF
--- a/aio/e2e/app.e2e-spec.ts
+++ b/aio/e2e/app.e2e-spec.ts
@@ -59,14 +59,6 @@ describe('site App', function() {
     });
   });
 
-  describe('api-docs', () => {
-    it('should show a link to github', () => {
-      page.navigateTo('api/common/NgClass');
-      expect(page.ghLink.getAttribute('href'))
-          .toMatch(/https:\/\/github.com\/angular\/angular\/tree\/.+\/packages\/common\/src\/directives\/ng_class\.ts/);
-    });
-  });
-
   describe('tutorial docs', () => {
     it('should not render a paragraph element inside the h1 element', () => {
       page.navigateTo('tutorial/toh-pt1');

--- a/aio/src/styles/2-modules/_api-info-bar.scss
+++ b/aio/src/styles/2-modules/_api-info-bar.scss
@@ -1,9 +1,9 @@
 .api-info-bar {
     max-width: 800px;
-    text-align: center;
+    text-align: left;
 
     span {
-        margin: 0 16px;
+        margin: 0 16px 0 0;
 
         @media screen and (max-width: 600px) {
             display: block;

--- a/aio/tools/transforms/templates/api/includes/info-bar.html
+++ b/aio/tools/transforms/templates/api/includes/info-bar.html
@@ -11,8 +11,4 @@
     NgModule: {@link {$ doc.ngModule $}}
   </span>
   {% endif %}
-
-  <span class="info-bar-item">
-    {$ github.githubViewLink(doc, versionInfo) $}
-  </span>
 </div>


### PR DESCRIPTION
We need to come up with a better design (possibly involving an icon button) to link to the source code (for viewing and/or editing).

Fixes #17254.