### PR TITLE
docs(aio): update typescript for examples/webpack to same as cli

### DIFF
--- a/aio/content/examples/webpack/package.webpack.json
+++ b/aio/content/examples/webpack/package.webpack.json
@@ -41,7 +41,7 @@
     "raw-loader": "^0.5.1",
     "rimraf": "^2.5.2",
     "style-loader": "^0.13.1",
-    "typescript": "~2.0.10",
+    "typescript": "~2.3.1",
     "webpack": "2.2.1",
     "webpack-dev-server": "2.4.1",
     "webpack-merge": "^3.0.0"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```
**AIO** Webpack example update

**What is the current behavior?** (You can also link to an open issue here)
Running `npm install` for `aio/content/examples/webpack` installs typescript `~2.0.10`which leads to errors when running `npm run build`:

```
[at-loader] Checking finished with 16 errors
Error in bail mode: [at-loader] ./node_modules/@angular/common/src/platform_id.d.ts:8:42
    TS1039: Initializers are not allowed in ambient contexts.
```


**What is the new behavior?**
Using the same version as `angular-cli` uses (https://github.com/angular/angular-cli/blob/master/package.json#L95) allows both `npm run build` and `npm start` to work as expected.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
As it didn't work with the current typescript version, I used the version used by angular-cli in order to satisfy the build. Maybe it could be a better idea to inline it with https://github.com/angular/angular/pull/17382 and use `2.3.2` ?
