### PR TITLE
WIP feat(core): Allow configuring enabled Zones via sessionStorage

### DIFF
--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -30,6 +30,7 @@ module.exports = function(config) {
       'node_modules/core-js/client/core.js',
       'node_modules/zone.js/dist/zone.js',
       'node_modules/zone.js/dist/long-stack-trace-zone.js',
+      'node_modules/zone.js/dist/task-tracking.js',
       'node_modules/zone.js/dist/proxy.js',
       'node_modules/zone.js/dist/sync-test.js',
       'node_modules/zone.js/dist/jasmine-patch.js',

--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -169,6 +169,47 @@ function runNgZoneNoLog(fn: () => any) {
            });
          }), testTimeout);
     });
+
+    describe('ngZoneOverride', () => {
+      function getZoneAncestors() {
+        let currentZone = Zone.current;
+        let ancestors = [];
+        while (currentZone) {
+          ancestors.unshift(currentZone.name);
+          currentZone = currentZone.parent;
+        }
+        return ancestors;
+      }
+
+      afterEach(() => { NgZone.resetEnabledZones(); });
+
+      it('allows disabling which zones are installed', async(() => {
+           NgZone.setZoneEnabled('TaskTrackingZoneSpec', false);
+           _zone = createZone(true);
+           _zone.run(() => {
+             let ancestors = getZoneAncestors();
+             expect(ancestors).not.toContain('TaskTrackingZoneSpec');
+           });
+         }));
+
+      it('allows enabling which zones are installed', async(() => {
+           NgZone.setZoneEnabled('TaskTrackingZoneSpec', true);
+           _zone = createZone(true);
+           _zone.run(() => {
+             let ancestors = getZoneAncestors();
+             expect(ancestors).toContain('TaskTrackingZoneSpec');
+           });
+         }));
+
+      it('respects enableLongStackTrace regardless of override', async(() => {
+           _zone = createZone(true);
+           _zone.run(() => {
+             let ancestors = getZoneAncestors();
+             expect(ancestors).toContain('long-stack-trace');
+           });
+         }));
+
+    });
   });
 
   describe('NoopNgZone', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Currently, Angular will fork the long stack trace zone and other optional zones if they're loaded. There's no way to specify which zones to fork other than not including them with the application.

**What is the new behavior?**

When using task tracking with Testability, we might like to enable or disable the task tracking zone, regardless of whether or not it's spec is loaded. This change introduces a way to specify whether particular zones should be loaded or not by setting a flag saved in the session store. 

Existing behavior is preserved - if NgZone is started with enableLongStackTrace, NgZone will be forked within that zone spec.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
