### PR TITLE
fix(aio): tidy up layout of api filter page

### DIFF
--- a/aio/src/app/embedded/api/api-list.component.html
+++ b/aio/src/app/embedded/api/api-list.component.html
@@ -1,4 +1,4 @@
-<div class="l-flex-wrap info-banner api-filter">
+<div class="l-flex-wrap api-filter">
 
   <aio-select (change)="setType($event.option)"
               [options]="types"

--- a/aio/src/styles/2-modules/_api-list.scss
+++ b/aio/src/styles/2-modules/_api-list.scss
@@ -1,11 +1,7 @@
 /* API EDIT ICON */
 #api {
-  .info-banner .material-icons {
+  .api-filter .material-icons {
     right: 48px;
-
-    @media screen and (max-width: 600px) {
-        left: 50px;
-    }
   }
 }
 
@@ -25,21 +21,25 @@ aio-api-list {
       display: flex;
       flex-direction: column;
       margin: 0 auto;
+
+      h2 {
+        margin-top: 16px;
+      }
     }
 }
 
-aio-api-list > div {
-    display: flex;
-    margin: 32px auto;
+.api-filter {
+  display: flex;
+  margin: 0 auto;
 
-    @media (max-width: 600px) {
-        flex-direction: column;
-        margin: 16px auto;
-    }
+  @media (max-width: 600px) {
+      flex-direction: column;
+      margin: 16px auto;
+  }
 
-    .form-select-menu, .form-search {
-        margin: 8px;
-    }
+  .form-select-menu, .form-search {
+      margin: 8px;
+  }
 }
 
 $phone-breakpoint: 480px;
@@ -165,7 +165,7 @@ $tablet-breakpoint: 800px;
 
 .docs-content .api-list {
   list-style: none;
-  margin: 0 0 48px -8px;
+  margin: 0 0 32px -8px;
   padding: 0;
   overflow: hidden;
 

--- a/aio/src/styles/2-modules/_api-list.scss
+++ b/aio/src/styles/2-modules/_api-list.scss
@@ -175,7 +175,7 @@ $tablet-breakpoint: 800px;
 
   li {
     font-size: 14px;
-    margin: 8px;
+    margin: 8px 0;
     line-height: 14px;
     padding: 0;
     float: left;
@@ -192,7 +192,7 @@ $tablet-breakpoint: 800px;
       color: $blue-grey-600;
       display: inline-block;
       line-height: 16px;
-      padding: 0 16px 0 0;
+      padding: 0 16px 0;
       text-decoration: none;
       transition: all .3s;
       overflow: hidden;


### PR DESCRIPTION
* Remove the "info-banner" styling from the filters.
* Fix alignment of the search box on a narrow screen (closes #17395)
* Remove unnecessary whitespace before section headers
* Ensure that we get 3 columns of results in wide view