### PR TITLE
docs(core): usage example for `TestBed.overrideModule()`

### DIFF
--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -114,6 +114,45 @@ export class TestBed implements Injector {
    */
   static compileComponents(): Promise<any> { return getTestBed().compileComponents(); }
 
+  /**
+   * Overrides an NgModule that is being used in a test module.
+   *
+   * ## Simple Example
+   *
+   * In this example, `FeatureModule` is imported into the testing module and then
+   * `FeatureComponent` is added to the `entryComponents` for the test.
+   *
+   * Through `MetadataOverride` it is possible to add, set, or remove properties of the NgModule
+   * metadata. Here, the property `entryComponents` is explicitly set to a fixed value.
+   *
+   * ```typescript
+   * @NgModule({
+   *   imports: [ CommonModule ],
+   *   declarations: [ FeatureComponent ]
+   * })
+   * class FeatureModule {}
+   *
+   * // 1. Imports `FeatureModule` into the testing module
+   * TestBed.configureTestingModule({
+   *   imports: [ FeatureModule ]
+   * });
+   * // 2. Override `FeatureModule` for the test
+   * TestBed.overrideModule(FeatureModule, {
+   *   set: {
+   *     entryComponents: [ FeatureComponent ]
+   *   }
+   * });
+   *
+   * const resolver: ComponentFactoryResolver = TestBed.get(ComponentFactoryResolver);
+   * const factory: ComponentFactory<FeatureComponent> =
+   *  resolver.resolveComponentFactory(FeatureComponent);
+   *
+   * expect(factory).toBeTruthy();
+   * ```
+   *
+   * @param ngModule The class token of the overridden NgModule
+   * @param override NgModule metadata that should be added/set/removed to the NgModule
+   */
   static overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): typeof TestBed {
     getTestBed().overrideModule(ngModule, override);
     return TestBed;


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: documentation
```

**What is the current behavior?** (You can also link to an open issue here)

`TestBed.overrideModule()` is undocumented.

**What is the new behavior?**

Add an usage example for overriding an `NgModule` that is imported into
the testing module.

`TestBed.overrideModule()` is one possibility to set `entryComponents` in a test run, which is discussed and asked for in #10760 and #12079.
I think that these issues are actually "solved" by adding documentation to the framework.

Also in angular/angular.io#3129, people ask for more documentation on this specific method.

Closes #10760, #12079, angular/angular.io#3129


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

