### PR TITLE
fix(tutorial): include providers in component metadata

### DIFF
--- a/aio/content/examples/toh-pt5/src/app/dashboard.component.ts
+++ b/aio/content/examples/toh-pt5/src/app/dashboard.component.ts
@@ -11,6 +11,9 @@ import { HeroService } from './hero.service';
   selector: 'my-dashboard',
   templateUrl: './dashboard.component.html',
   // #enddocregion metadata
+  // #docregion providers
+  providers: [ HeroService ],
+  // #enddocregion providers
   // #docregion css
   styleUrls: [ './dashboard.component.css' ]
   // #enddocregion css

--- a/aio/content/tutorial/toh-pt5.md
+++ b/aio/content/tutorial/toh-pt5.md
@@ -561,6 +561,14 @@ In <code>dashboard.component.ts</code>, add the following `import` statements.
 
 
 
+Include the provider like this:
+
+<code-example path="toh-pt5/src/app/dashboard.component.ts" region="class" title="src/app/dashboard.component.ts (providers)">
+
+</code-example>
+
+
+
 Now create the `DashboardComponent` class like this:
 
 


### PR DESCRIPTION
The tutorial is missing the `providers` directive in the component metadata, which
causes a browser error when running the tutorial.

fixes #17428

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: documentation update
```

**What is the current behavior?** (You can also link to an open issue here)
#17428 


**What is the new behavior?**
Updated documentation to include necessary step


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

