### PR TITLE
refactor(compiler): don’t always compile `.ngfactory.ts` files by def…

### DIFF
--- a/integration/hello_world__closure/tsconfig.json
+++ b/integration/hello_world__closure/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "angularCompilerOptions": {
     "annotationsAs": "static fields",
-    "annotateForClosureCompiler": true
+    "annotateForClosureCompiler": true,
+    "alwaysCompileGeneratedCode": true
   },
 
   "compilerOptions": {

--- a/packages/compiler-cli/integrationtest/tsconfig-build.json
+++ b/packages/compiler-cli/integrationtest/tsconfig-build.json
@@ -4,7 +4,8 @@
     // in the same source directory with your code.
     "genDir": ".",
     "debug": true,
-    "enableSummariesForJit": true
+    "enableSummariesForJit": true,
+    "alwaysCompileGeneratedCode": true
   },
 
   "compilerOptions": {

--- a/packages/compiler-cli/test/main_spec.ts
+++ b/packages/compiler-cli/test/main_spec.ts
@@ -199,10 +199,40 @@ describe('compiler-cli', () => {
   });
 
   describe('compile ngfactory files', () => {
+    it('should only compile ngfactory files that are referenced by root files by default',
+       (done) => {
+         writeConfig(`{
+          "extends": "./tsconfig-base.json",
+          "files": ["mymodule.ts"]
+        }`);
+         write('mymodule.ts', `
+        import {CommonModule} from '@angular/common';
+        import {NgModule} from '@angular/core';
+
+        @NgModule({
+          imports: [CommonModule]
+        })
+        export class MyModule {}
+      `);
+
+         main({p: basePath})
+             .then((exitCode) => {
+               expect(exitCode).toEqual(0);
+
+               expect(fs.existsSync(path.resolve(outDir, 'mymodule.ngfactory.js'))).toBe(false);
+
+               done();
+             })
+             .catch(e => done.fail(e));
+       });
+
     it('should report errors for ngfactory files that are not referenced by root files', (done) => {
       writeConfig(`{
           "extends": "./tsconfig-base.json",
-          "files": ["mymodule.ts"]
+          "files": ["mymodule.ts"],
+          "angularCompilerOptions": {
+            "alwaysCompileGeneratedCode": true
+          }
         }`);
       write('mymodule.ts', `
         import {NgModule, Component} from '@angular/core';
@@ -235,7 +265,10 @@ describe('compiler-cli', () => {
     it('should compile ngfactory files that are not referenced by root files', (done) => {
       writeConfig(`{
           "extends": "./tsconfig-base.json",
-          "files": ["mymodule.ts"]
+          "files": ["mymodule.ts"],
+          "angularCompilerOptions": {
+            "alwaysCompileGeneratedCode": true
+          }
         }`);
       write('mymodule.ts', `
         import {CommonModule} from '@angular/common';
@@ -289,7 +322,8 @@ describe('compiler-cli', () => {
           "extends": "./tsconfig-base.json",
           "files": ["mymodule.ts"],
           "angularCompilerOptions": {
-            "enableSummariesForJit": true
+            "enableSummariesForJit": true,
+            "alwaysCompileGeneratedCode": true
           }
         }`);
       write('mymodule.ts', `

--- a/tools/@angular/tsc-wrapped/src/main.ts
+++ b/tools/@angular/tsc-wrapped/src/main.ts
@@ -124,8 +124,11 @@ export function main(
     if (diagnostics) console.time('NG codegen');
     return codegen(ngOptions, cliOptions, program, host).then((genFiles) => {
       if (diagnostics) console.timeEnd('NG codegen');
+
       // Add the generated files to the configuration so they will become part of the program.
-      genFiles.forEach(genFileName => addGeneratedFileName(genFileName));
+      if (ngOptions.alwaysCompileGeneratedCode) {
+        genFiles.forEach(genFileName => addGeneratedFileName(genFileName));
+      }
       let definitionsHost: ts.CompilerHost = tsickleCompilerHost;
       if (!ngOptions.skipMetadataEmit) {
         // if tsickle is not not used for emitting, but we do use the MetadataWriterHost,

--- a/tools/@angular/tsc-wrapped/src/options.ts
+++ b/tools/@angular/tsc-wrapped/src/options.ts
@@ -83,8 +83,13 @@ interface Options extends ts.CompilerOptions {
   enableLegacyTemplate?: boolean;
 
   // Whether to generate .ngsummary.ts files that allow to use AOTed artifacts
-  // in JIT mode.
+  // in JIT mode. This is off by default.
   enableSummariesForJit?: boolean;
+
+  // Whether to compile generated .ngfacgtory.ts files, even when they are no
+  // matched by the `files` / `includes` in the `tsconfig.json`.
+  // This is off by default.
+  alwaysCompileGeneratedCode?: boolean;
 }
 
 export default Options;


### PR DESCRIPTION
…ault

This puts the behavior introduced in https://github.com/angular/angular/commit/573b8611bc4ab85a7436ee110526678a0ecf6c76 behind the new flag
`alwaysCompileGeneratedCode` to not break users that might have relied
on this behavior.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

