### PR TITLE
build(aio): add staging environment

### DIFF
--- a/aio/.angular-cli.json
+++ b/aio/.angular-cli.json
@@ -31,6 +31,7 @@
       "environmentSource": "environments/environment.ts",
       "environments": {
         "dev": "environments/environment.ts",
+        "stage": "environments/environment.stage.ts",
         "prod": "environments/environment.prod.ts"
       }
     }

--- a/aio/package.json
+++ b/aio/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "ng": "yarn check-env && ng",
     "start": "yarn check-env && ng serve",
-    "build": "yarn check-env && yarn setup && ng build -prod -sm -vc=false && yarn sw-manifest && yarn sw-copy",
+    "prebuild": "yarn check-env && yarn setup",
+    "build": "ng build -prod -sm -vc=false",
+    "postbuild": "yarn sw-manifest && yarn sw-copy",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn ~~update-webdriver",

--- a/aio/scripts/deploy-to-firebase.sh
+++ b/aio/scripts/deploy-to-firebase.sh
@@ -8,11 +8,13 @@ readonly deployEnv=$1
 
 case $deployEnv in
   staging)
+    readonly buildEnv=stage
     readonly projectId=aio-staging
     readonly deployedUrl=https://$projectId.firebaseapp.com/
     readonly firebaseToken=$FIREBASE_TOKEN
     ;;
   production)
+    readonly buildEnv=prod
     readonly projectId=angular-io
     readonly deployedUrl=https://angular.io/
     readonly firebaseToken=$FIREBASE_TOKEN
@@ -27,7 +29,7 @@ esac
   cd "`dirname $0`/.."
 
   # Build the app
-  yarn build
+  yarn build -- --env=$buildEnv
 
   # Deploy to Firebase
   firebase use "$projectId" --token "$firebaseToken"

--- a/aio/src/environments/environment.prod.ts
+++ b/aio/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
+// This is for the production site, which is hosted at https://angular.io
 export const environment = {
   gaId: 'UA-8594346-15',
   production: true

--- a/aio/src/environments/environment.stage.ts
+++ b/aio/src/environments/environment.stage.ts
@@ -1,0 +1,5 @@
+// This is for the staging site, which is hosted at https://aio-staging.firebaseapp.org
+export const environment = {
+  gaId: 'UA-8594346-26',
+  production: true
+};


### PR DESCRIPTION
You can now specify what environment you are building
by add it to the `yarn build` command. For example:

```
yarn build -- --env=stage
```

Moreover the `deploy-to-firebase.sh` script will automatically apply the
appropriate environment.

