### PR TITLE
ci(aio): fail the build if the PWA score is too low

### DIFF
--- a/aio/scripts/deploy-to-firebase.sh
+++ b/aio/scripts/deploy-to-firebase.sh
@@ -36,6 +36,5 @@ esac
   firebase deploy --message "Commit: $TRAVIS_COMMIT" --non-interactive --token "$firebaseToken"
 
   # Run PWA-score tests
-  # TODO(gkalpak): Figure out why this fails and re-enable.
-  yarn test-pwa-score -- "$deployedUrl" "$MIN_PWA_SCORE" "$PWA_RESULTS_LOG" || true
+  yarn test-pwa-score -- "$deployedUrl" "$MIN_PWA_SCORE" "$PWA_RESULTS_LOG"
 )


### PR DESCRIPTION
Previously, there was an issue with testing the PWA score on staging and failing the build was temporarily disabled. It works now, so we need to enable failing the build is the score drops below some threshold.