### PR TITLE
fix(aio): make the footer links clickable on all browsers

### DIFF
--- a/aio/src/styles/1-layouts/_footer.scss
+++ b/aio/src/styles/1-layouts/_footer.scss
@@ -43,7 +43,7 @@ footer {
   p {
     text-align: center;
     margin: 10px 0px 5px;
-    
+
     @media (max-width: 480px) {
       text-align: left;
     }
@@ -79,7 +79,7 @@ footer {
     }
   }
 
-  
+
 
 
   @media (max-width: 700px) {
@@ -97,7 +97,7 @@ footer {
 footer::after {
     content: "";
     position: absolute;
-    z-index: 10;
+    z-index: -1;
     top: 0;
     bottom: 0;
     left: 0;


### PR DESCRIPTION
The footer background (implemented via `footer:after`) had a higher `z-index` than other footer elements and was obscuring the footer links on certain browsers (Firefox, Edge, IE), which made them unclickable.
This commit lowers the index of `footer:after`, so that links are clickable on these browsers.

Fixes #17460.