### PR TITLE
fix(aio): fix patch script on windows

### DIFF
--- a/aio/tools/cli-patches/patch.js
+++ b/aio/tools/cli-patches/patch.js
@@ -4,9 +4,9 @@ const sh = require('shelljs');
 PATCH_LOCK = 'node_modules/@angular/cli/models/webpack-configs/.patched';
 
 if (!fs.existsSync(PATCH_LOCK)) {
+  sh.exec('patch -p0 -i tools/cli-patches/ngo-loader.patch');
+  sh.exec('patch -p0 -i node_modules/purify/angular-cli.patch');
+  sh.exec('patch -p0 -i tools/cli-patches/scope-hoisting.patch');
+  sh.exec('patch -p0 -i tools/cli-patches/uglify-config.patch');
   sh.touch(PATCH_LOCK);
-  sh.exec(`patch -p0 -i tools/cli-patches/ngo-loader.patch &&
-           patch -p0 -i node_modules/purify/angular-cli.patch &&
-           patch -p0 -i tools/cli-patches/scope-hoisting.patch &&
-           patch -p0 -i tools/cli-patches/uglify-config.patch`);
 }


### PR DESCRIPTION
Running the patch script on Windows (with `patch` available) yields an invalid syntax warning, and does not apply patches.

```
kamik@T460p MINGW64 /d/work/angular/aio (master)
$ yarn postinstall
yarn postinstall v0.24.6
$ node tools/cli-patches/patch.js && uglifyjs node_modules/lunr/lunr.js -c -m -o src/assets/js/lunr.min.js --source-map
The syntax of the command is incorrect.
Done in 1.52s.
```

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: AIO build bugfix
```

**What is the current behavior?** (You can also link to an open issue here)
Running the patch script on Windows (with `patch` available) yields an invalid syntax warning, and does not apply patches.

```
kamik@T460p MINGW64 /d/work/angular/aio (master)
$ yarn postinstall
yarn postinstall v0.24.6
$ node tools/cli-patches/patch.js && uglifyjs node_modules/lunr/lunr.js -c -m -o src/assets/js/lunr.min.js --source-map
The syntax of the command is incorrect.
Done in 1.52s.
```


**What is the new behavior?**
Patches are applied correctly.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

