### PR TITLE
fix(aio): do not log messages in production

### DIFF
--- a/aio/src/app/embedded/contributor/contributor.service.spec.ts
+++ b/aio/src/app/embedded/contributor/contributor.service.spec.ts
@@ -4,7 +4,6 @@ import { MockBackend } from '@angular/http/testing';
 
 import { ContributorService } from './contributor.service';
 import { Contributor, ContributorGroup } from './contributors.model';
-import { Logger } from 'app/shared/logger.service';
 
 describe('ContributorService', () => {
 
@@ -21,8 +20,7 @@ describe('ContributorService', () => {
         ContributorService,
         { provide: ConnectionBackend, useClass: MockBackend },
         { provide: RequestOptions, useClass: BaseRequestOptions },
-        Http,
-        Logger
+        Http
     ]);
 
     backend = injector.get(ConnectionBackend);

--- a/aio/src/app/embedded/contributor/contributor.service.ts
+++ b/aio/src/app/embedded/contributor/contributor.service.ts
@@ -5,7 +5,6 @@ import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/publishLast';
 
-import { Logger } from 'app/shared/logger.service';
 import { Contributor, ContributorGroup } from './contributors.model';
 import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
 
@@ -16,7 +15,7 @@ const knownGroups = ['Angular', 'Community'];
 export class ContributorService {
   contributors: Observable<ContributorGroup[]>;
 
-  constructor(private http: Http, private logger: Logger) {
+  constructor(private http: Http) {
     this.contributors = this.getContributors();
   }
 

--- a/aio/src/app/embedded/resource/resource.service.spec.ts
+++ b/aio/src/app/embedded/resource/resource.service.spec.ts
@@ -4,7 +4,6 @@ import { MockBackend } from '@angular/http/testing';
 
 import { ResourceService } from './resource.service';
 import { Category, SubCategory, Resource } from './resource.model';
-import { Logger } from 'app/shared/logger.service';
 
 describe('ResourceService', () => {
 
@@ -21,8 +20,7 @@ describe('ResourceService', () => {
       ResourceService,
       { provide: ConnectionBackend, useClass: MockBackend },
       { provide: RequestOptions, useClass: BaseRequestOptions },
-      Http,
-      Logger
+      Http
     ]);
 
     backend = injector.get(ConnectionBackend);

--- a/aio/src/app/embedded/resource/resource.service.ts
+++ b/aio/src/app/embedded/resource/resource.service.ts
@@ -5,7 +5,6 @@ import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/publishLast';
 
-import { Logger } from 'app/shared/logger.service';
 import { Category, Resource, SubCategory } from './resource.model';
 import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
 
@@ -15,7 +14,7 @@ const resourcesPath = CONTENT_URL_PREFIX + 'resources.json';
 export class ResourceService {
   categories: Observable<Category[]>;
 
-  constructor(private http: Http, private logger: Logger) {
+  constructor(private http: Http) {
     this.categories = this.getCategories();
   }
 

--- a/aio/src/app/navigation/navigation.service.spec.ts
+++ b/aio/src/app/navigation/navigation.service.spec.ts
@@ -4,7 +4,6 @@ import { MockBackend } from '@angular/http/testing';
 import { CurrentNodes, NavigationService, NavigationViews, NavigationNode, VersionInfo } from 'app/navigation/navigation.service';
 import { LocationService } from 'app/shared/location.service';
 import { MockLocationService } from 'testing/location.service';
-import { Logger } from 'app/shared/logger.service';
 
 describe('NavigationService', () => {
 
@@ -22,8 +21,7 @@ describe('NavigationService', () => {
         { provide: LocationService, useFactory: () => new MockLocationService('a') },
         { provide: ConnectionBackend, useClass: MockBackend },
         { provide: RequestOptions, useClass: BaseRequestOptions },
-        Http,
-        Logger
+        Http
     ]);
   });
 

--- a/aio/src/app/navigation/navigation.service.ts
+++ b/aio/src/app/navigation/navigation.service.ts
@@ -8,7 +8,6 @@ import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/publishLast';
 import 'rxjs/add/operator/publishReplay';
 
-import { Logger } from 'app/shared/logger.service';
 import { LocationService } from 'app/shared/location.service';
 import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
 
@@ -37,7 +36,7 @@ export class NavigationService {
    */
   currentNodes: Observable<CurrentNodes>;
 
-  constructor(private http: Http, private location: LocationService, private logger: Logger) {
+  constructor(private http: Http, private location: LocationService) {
     const navigationInfo = this.fetchNavigationInfo();
     this.navigationViews = this.getNavigationViews(navigationInfo);
 

--- a/aio/src/app/shared/logger.service.ts
+++ b/aio/src/app/shared/logger.service.ts
@@ -1,10 +1,14 @@
 import { Injectable } from '@angular/core';
+import { environment } from '../../environments/environment';
+
 
 @Injectable()
 export class Logger {
 
   log(value: any, ...rest) {
-    console.log(value, ...rest);
+    if (!environment.production) {
+      console.log(value, ...rest);
+    }
   }
 
   error(value: any, ...rest) {


### PR DESCRIPTION
In dev mode, all messages passed to `Logger` will be logged.
In production mode, only warnings and errors will be logged.

Fixes #17453.

##
(This PR also removes some unnecessary Logger dependencies.)