### PR TITLE
chore(aio): re-add biography entry for devversion

### DIFF
--- a/aio/content/marketing/contributors.json
+++ b/aio/content/marketing/contributors.json
@@ -204,6 +204,15 @@
    "group": "Angular"
  },
 
+ "paulgschwendtner": {
+   "name": "Paul Gschwendtner",
+   "picture": "devversion.jpg",
+   "twitter": "DevVersion",
+   "website": "https://github.com/DevVersion",
+   "bio": "Paul is a 17-year-old developer living in Germany. While he attends school, Paul works as a core team member on Angular Material. Paul focuses on tooling and building components for Angular.",
+   "group": "Angular"
+ },
+
  "elad": {
    "name": "Elad Bezalel",
    "picture": "eladbezalel.jpg",


### PR DESCRIPTION
With SHA 2c3e948e61a22da9e0612f882edfb830e8470b6c my biography entry has been accidentally removed.

This re-adds the biography entry (picture still present) as requested on Slack.

cc. @juleskremer 
