### PR TITLE
fix(aio): correctly redirect `/docs/ts/latest` and `/styleguide` 

### DIFF
--- a/aio/ngsw-manifest.json
+++ b/aio/ngsw-manifest.json
@@ -19,7 +19,7 @@
   "routing": {
     "index": "/index.html",
     "routes": {
-      "/(?!e?plnkr)[^/.]*$": {
+      "^(?!/docs/ts/latest|/styleguide).*/(?!e?plnkr)[^/.]*$": {
         "match": "regex"
       }
     }


### PR DESCRIPTION
Previously, we had redirect rules for Firebase for `/docs/ts/latest` and `/styleguide`, but once the ServiceWorker was activated, it would take over routing and rewrite these requests to `/index.html`.
This commit fixes it by excluding them from ServiceWorker routing.

Fixes #17542.