### PR TITLE
build(aio): upgrade jasmine to v2.6.4

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@angular/cli": "angular/cli-builds#webpack-next",
     "@angular/compiler-cli": "4.2.1",
-    "@types/jasmine": "^2.5.47",
+    "@types/jasmine": "^2.5.52",
     "@types/node": "~6.0.60",
     "archiver": "^1.3.0",
     "canonical-path": "^0.0.2",
@@ -93,7 +93,7 @@
     "http-server": "^0.9.0",
     "ignore": "^3.3.3",
     "image-size": "^0.5.1",
-    "jasmine-core": "^2.6.3",
+    "jasmine-core": "^2.6.4",
     "jasmine-spec-reporter": "^4.1.0",
     "jsdom": "^9.12.0",
     "karma": "^1.7.0",

--- a/aio/src/test.ts
+++ b/aio/src/test.ts
@@ -42,14 +42,6 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 
-// HACK: Chrome 59 disconnects if there are too many synchronous tests in a row
-// because it appears to lock up the thread that communicates to Karma's socket
-// This async beforeEach gets called on every spec and releases the JS thread long
-// enough for the socket to continue to communicate.
-// The downside is that it creates a minor performance penalty of around 10-15%
-// increase in the time it takes to run out unit tests.
-beforeEach((done) => done());
-
 declare var System: any;
 // Then we find all the tests.
 System.import('./test-specs.ts')

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -167,9 +167,9 @@
     magic-string "^0.19.0"
     source-map "^0.5.6"
 
-"@types/jasmine@^2.5.47":
-  version "2.5.47"
-  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.5.47.tgz#bbba9bcf0e95e7890c6f4a47394e8bacaa960eb6"
+"@types/jasmine@^2.5.52":
+  version "2.5.52"
+  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.5.52.tgz#6ea5435d5c71562296e63ef27a4718f94f2fbb13"
 
 "@types/node@*", "@types/node@^6.0.46", "@types/node@~6.0.60":
   version "6.0.73"
@@ -3854,9 +3854,9 @@ istanbul-reports@^1.1.1:
   dependencies:
     handlebars "^4.0.3"
 
-jasmine-core@^2.6.3, jasmine-core@~2.6.0:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.6.3.tgz#45072950e4a42b1e322fe55c001100a465d77815"
+jasmine-core@^2.6.4, jasmine-core@~2.6.0:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.6.4.tgz#dec926cd0a9fa287fb6db5c755fa487e74cecac5"
 
 jasmine-spec-reporter@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
This version fixes the DISCONNECTED errors (described in #17543) and removes the need to the workaround (8af203c).
The relevant jasmine commit is jasmine/jasmine@c60d66994.