### PR TITLE
fix(language-service): infer `any` `ngForOf` of type `any`

### DIFF
--- a/packages/compiler-cli/src/diagnostics/expression_diagnostics.ts
+++ b/packages/compiler-cli/src/diagnostics/expression_diagnostics.ts
@@ -154,8 +154,8 @@ function refinedVariableType(
     }
   }
 
-  // We can't do better, just return the original type.
-  return type;
+  // We can't do better, return any
+  return info.query.getBuiltinType(BuiltinType.Any);
 }
 
 function getEventDeclaration(info: DiagnosticTemplateInfo, includeEvent?: boolean) {

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -59,6 +59,10 @@ describe('diagnostics', () => {
         (ngHost as any)._reflector = null;
         ngService.getDiagnostics(fileName);
       });
+
+      // #17611
+      it('should not report diagnostic on iteration of any',
+         () => { accept('<div *ngFor="let value of anyValue">{{value.someField}}</div>'); });
     });
 
     describe('with $event', () => {

--- a/packages/language-service/test/test_data.ts
+++ b/packages/language-service/test/test_data.ts
@@ -148,6 +148,7 @@ export class TemplateReference {
     id: 1,
     name: 'Windstorm'
   };
+  anyValue: any;
   myClick(event: any) {
 
   }


### PR DESCRIPTION
Fixes: #17611

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Reports spurious errors when using any field of type `any` in an `*ngFor`.

Issue Number: #17611

## What is the new behavior?

The element type is inferred as `any` instead of being inferred as an unbound type parameter.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
