### PR TITLE
fix(language-service): rollup `tslib` into the language service package

### DIFF
--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -7,9 +7,6 @@
   "typings": "./language-service.d.ts",
   "author": "angular",
   "license": "MIT",
-  "dependencies": {
-    "tslib": "^1.7.1"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"

--- a/packages/language-service/rollup.config.js
+++ b/packages/language-service/rollup.config.js
@@ -12,6 +12,7 @@ import * as path from 'path';
 var m = /^\@angular\/((\w|\-)+)(\/(\w|\d|\/|\-)+)?$/;
 var location = normalize('../../dist/packages-dist') + '/';
 var rxjsLocation = normalize('../../node_modules/rxjs');
+var tslibLocation = normalize('../../node_modules/tslib');
 var esm = 'esm/';
 
 var locations = {
@@ -45,6 +46,9 @@ function resolve(id, from) {
   if (id && id.startsWith('rxjs/')) {
     const resolved = `${rxjsLocation}${id.replace('rxjs', '')}.js`;
     return resolved;
+  }
+  if (id == 'tslib') {
+    return tslibLocation + '/tslib.es6.js';
   }
 }
 


### PR DESCRIPTION
Fixes: #17614

## PR Type
What kind of change does this PR introduce?

```
[x] Build related changes
```

## What is the current behavior?

Issue Number: #17614


## What is the new behavior?

Language service no longer has a `tslib` dependency.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
