### PR TITLE
refactor(forms): remove usage of deprecated Renderer

### DIFF
--- a/packages/forms/src/directives/checkbox_value_accessor.ts
+++ b/packages/forms/src/directives/checkbox_value_accessor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Renderer, forwardRef} from '@angular/core';
+import {Directive, ElementRef, Renderer2, forwardRef} from '@angular/core';
 
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 
@@ -36,15 +36,15 @@ export class CheckboxControlValueAccessor implements ControlValueAccessor {
   onChange = (_: any) => {};
   onTouched = () => {};
 
-  constructor(private _renderer: Renderer, private _elementRef: ElementRef) {}
+  constructor(private _renderer: Renderer2, private _elementRef: ElementRef) {}
 
   writeValue(value: any): void {
-    this._renderer.setElementProperty(this._elementRef.nativeElement, 'checked', value);
+    this._renderer.setProperty(this._elementRef.nativeElement, 'checked', value);
   }
   registerOnChange(fn: (_: any) => {}): void { this.onChange = fn; }
   registerOnTouched(fn: () => {}): void { this.onTouched = fn; }
 
   setDisabledState(isDisabled: boolean): void {
-    this._renderer.setElementProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+    this._renderer.setProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
   }
 }

--- a/packages/forms/src/directives/default_value_accessor.ts
+++ b/packages/forms/src/directives/default_value_accessor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Inject, InjectionToken, Optional, Renderer, forwardRef} from '@angular/core';
+import {Directive, ElementRef, Inject, InjectionToken, Optional, Renderer2, forwardRef} from '@angular/core';
 import {ɵgetDOM as getDOM} from '@angular/platform-browser';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 
@@ -64,7 +64,7 @@ export class DefaultValueAccessor implements ControlValueAccessor {
   private _composing = false;
 
   constructor(
-      private _renderer: Renderer, private _elementRef: ElementRef,
+      private _renderer: Renderer2, private _elementRef: ElementRef,
       @Optional() @Inject(COMPOSITION_BUFFER_MODE) private _compositionMode: boolean) {
     if (this._compositionMode == null) {
       this._compositionMode = !_isAndroid();
@@ -73,14 +73,14 @@ export class DefaultValueAccessor implements ControlValueAccessor {
 
   writeValue(value: any): void {
     const normalizedValue = value == null ? '' : value;
-    this._renderer.setElementProperty(this._elementRef.nativeElement, 'value', normalizedValue);
+    this._renderer.setProperty(this._elementRef.nativeElement, 'value', normalizedValue);
   }
 
   registerOnChange(fn: (_: any) => void): void { this.onChange = fn; }
   registerOnTouched(fn: () => void): void { this.onTouched = fn; }
 
   setDisabledState(isDisabled: boolean): void {
-    this._renderer.setElementProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+    this._renderer.setProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
   }
 
   _handleInput(value: any): void {

--- a/packages/forms/src/directives/number_value_accessor.ts
+++ b/packages/forms/src/directives/number_value_accessor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Renderer, forwardRef} from '@angular/core';
+import {Directive, ElementRef, Renderer2, forwardRef} from '@angular/core';
 
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 
@@ -39,12 +39,12 @@ export class NumberValueAccessor implements ControlValueAccessor {
   onChange = (_: any) => {};
   onTouched = () => {};
 
-  constructor(private _renderer: Renderer, private _elementRef: ElementRef) {}
+  constructor(private _renderer: Renderer2, private _elementRef: ElementRef) {}
 
   writeValue(value: number): void {
     // The value needs to be normalized for IE9, otherwise it is set to 'null' when null
     const normalizedValue = value == null ? '' : value;
-    this._renderer.setElementProperty(this._elementRef.nativeElement, 'value', normalizedValue);
+    this._renderer.setProperty(this._elementRef.nativeElement, 'value', normalizedValue);
   }
 
   registerOnChange(fn: (_: number|null) => void): void {
@@ -53,6 +53,6 @@ export class NumberValueAccessor implements ControlValueAccessor {
   registerOnTouched(fn: () => void): void { this.onTouched = fn; }
 
   setDisabledState(isDisabled: boolean): void {
-    this._renderer.setElementProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+    this._renderer.setProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
   }
 }

--- a/packages/forms/src/directives/radio_control_value_accessor.ts
+++ b/packages/forms/src/directives/radio_control_value_accessor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Injectable, Injector, Input, OnDestroy, OnInit, Renderer, forwardRef} from '@angular/core';
+import {Directive, ElementRef, Injectable, Injector, Input, OnDestroy, OnInit, Renderer2, forwardRef} from '@angular/core';
 
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 import {NgControl} from './ng_control';
@@ -105,7 +105,7 @@ export class RadioControlValueAccessor implements ControlValueAccessor,
   @Input() value: any;
 
   constructor(
-      private _renderer: Renderer, private _elementRef: ElementRef,
+      private _renderer: Renderer2, private _elementRef: ElementRef,
       private _registry: RadioControlRegistry, private _injector: Injector) {}
 
   ngOnInit(): void {
@@ -118,7 +118,7 @@ export class RadioControlValueAccessor implements ControlValueAccessor,
 
   writeValue(value: any): void {
     this._state = value === this.value;
-    this._renderer.setElementProperty(this._elementRef.nativeElement, 'checked', this._state);
+    this._renderer.setProperty(this._elementRef.nativeElement, 'checked', this._state);
   }
 
   registerOnChange(fn: (_: any) => {}): void {
@@ -134,7 +134,7 @@ export class RadioControlValueAccessor implements ControlValueAccessor,
   registerOnTouched(fn: () => {}): void { this.onTouched = fn; }
 
   setDisabledState(isDisabled: boolean): void {
-    this._renderer.setElementProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+    this._renderer.setProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
   }
 
   private _checkName(): void {

--- a/packages/forms/src/directives/range_value_accessor.ts
+++ b/packages/forms/src/directives/range_value_accessor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Provider, Renderer, forwardRef} from '@angular/core';
+import {Directive, ElementRef, Provider, Renderer2, forwardRef} from '@angular/core';
 
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 
@@ -39,10 +39,10 @@ export class RangeValueAccessor implements ControlValueAccessor {
   onChange = (_: any) => {};
   onTouched = () => {};
 
-  constructor(private _renderer: Renderer, private _elementRef: ElementRef) {}
+  constructor(private _renderer: Renderer2, private _elementRef: ElementRef) {}
 
   writeValue(value: any): void {
-    this._renderer.setElementProperty(this._elementRef.nativeElement, 'value', parseFloat(value));
+    this._renderer.setProperty(this._elementRef.nativeElement, 'value', parseFloat(value));
   }
 
   registerOnChange(fn: (_: number|null) => void): void {
@@ -52,6 +52,6 @@ export class RangeValueAccessor implements ControlValueAccessor {
   registerOnTouched(fn: () => void): void { this.onTouched = fn; }
 
   setDisabledState(isDisabled: boolean): void {
-    this._renderer.setElementProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+    this._renderer.setProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
   }
 }

--- a/packages/forms/src/directives/select_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_control_value_accessor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Host, Input, OnDestroy, Optional, Provider, Renderer, forwardRef, ɵlooseIdentical as looseIdentical} from '@angular/core';
+import {Directive, ElementRef, Host, Input, OnDestroy, Optional, Provider, Renderer2, forwardRef, ɵlooseIdentical as looseIdentical} from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 
 export const SELECT_VALUE_ACCESSOR: Provider = {
@@ -114,16 +114,16 @@ export class SelectControlValueAccessor implements ControlValueAccessor {
 
   private _compareWith: (o1: any, o2: any) => boolean = looseIdentical;
 
-  constructor(private _renderer: Renderer, private _elementRef: ElementRef) {}
+  constructor(private _renderer: Renderer2, private _elementRef: ElementRef) {}
 
   writeValue(value: any): void {
     this.value = value;
     const id: string|null = this._getOptionId(value);
     if (id == null) {
-      this._renderer.setElementProperty(this._elementRef.nativeElement, 'selectedIndex', -1);
+      this._renderer.setProperty(this._elementRef.nativeElement, 'selectedIndex', -1);
     }
     const valueString = _buildValueString(id, value);
-    this._renderer.setElementProperty(this._elementRef.nativeElement, 'value', valueString);
+    this._renderer.setProperty(this._elementRef.nativeElement, 'value', valueString);
   }
 
   registerOnChange(fn: (value: any) => any): void {
@@ -135,7 +135,7 @@ export class SelectControlValueAccessor implements ControlValueAccessor {
   registerOnTouched(fn: () => any): void { this.onTouched = fn; }
 
   setDisabledState(isDisabled: boolean): void {
-    this._renderer.setElementProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+    this._renderer.setProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
   }
 
   /** @internal */
@@ -170,7 +170,7 @@ export class NgSelectOption implements OnDestroy {
   id: string;
 
   constructor(
-      private _element: ElementRef, private _renderer: Renderer,
+      private _element: ElementRef, private _renderer: Renderer2,
       @Optional() @Host() private _select: SelectControlValueAccessor) {
     if (this._select) this.id = this._select._registerOption();
   }
@@ -191,7 +191,7 @@ export class NgSelectOption implements OnDestroy {
 
   /** @internal */
   _setElementValue(value: string): void {
-    this._renderer.setElementProperty(this._element.nativeElement, 'value', value);
+    this._renderer.setProperty(this._element.nativeElement, 'value', value);
   }
 
   ngOnDestroy(): void {

--- a/packages/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Host, Input, OnDestroy, Optional, Provider, Renderer, forwardRef, ɵlooseIdentical as looseIdentical} from '@angular/core';
+import {Directive, ElementRef, Host, Input, OnDestroy, Optional, Provider, Renderer2, forwardRef, ɵlooseIdentical as looseIdentical} from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 
 export const SELECT_MULTIPLE_VALUE_ACCESSOR: Provider = {
@@ -94,7 +94,7 @@ export class SelectMultipleControlValueAccessor implements ControlValueAccessor 
 
   private _compareWith: (o1: any, o2: any) => boolean = looseIdentical;
 
-  constructor(private _renderer: Renderer, private _elementRef: ElementRef) {}
+  constructor(private _renderer: Renderer2, private _elementRef: ElementRef) {}
 
   writeValue(value: any): void {
     this.value = value;
@@ -138,7 +138,7 @@ export class SelectMultipleControlValueAccessor implements ControlValueAccessor 
   registerOnTouched(fn: () => any): void { this.onTouched = fn; }
 
   setDisabledState(isDisabled: boolean): void {
-    this._renderer.setElementProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+    this._renderer.setProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
   }
 
   /** @internal */
@@ -181,7 +181,7 @@ export class NgSelectMultipleOption implements OnDestroy {
   _value: any;
 
   constructor(
-      private _element: ElementRef, private _renderer: Renderer,
+      private _element: ElementRef, private _renderer: Renderer2,
       @Optional() @Host() private _select: SelectMultipleControlValueAccessor) {
     if (this._select) {
       this.id = this._select._registerOption(this);
@@ -209,12 +209,12 @@ export class NgSelectMultipleOption implements OnDestroy {
 
   /** @internal */
   _setElementValue(value: string): void {
-    this._renderer.setElementProperty(this._element.nativeElement, 'value', value);
+    this._renderer.setProperty(this._element.nativeElement, 'value', value);
   }
 
   /** @internal */
   _setSelected(selected: boolean) {
-    this._renderer.setElementProperty(this._element.nativeElement, 'selected', selected);
+    this._renderer.setProperty(this._element.nativeElement, 'selected', selected);
   }
 
   ngOnDestroy(): void {

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -109,7 +109,7 @@ export interface AsyncValidatorFn {
 export declare class CheckboxControlValueAccessor implements ControlValueAccessor {
     onChange: (_: any) => void;
     onTouched: () => void;
-    constructor(_renderer: Renderer, _elementRef: ElementRef);
+    constructor(_renderer: Renderer2, _elementRef: ElementRef);
     registerOnChange(fn: (_: any) => {}): void;
     registerOnTouched(fn: () => {}): void;
     setDisabledState(isDisabled: boolean): void;
@@ -143,7 +143,7 @@ export interface ControlValueAccessor {
 export declare class DefaultValueAccessor implements ControlValueAccessor {
     onChange: (_: any) => void;
     onTouched: () => void;
-    constructor(_renderer: Renderer, _elementRef: ElementRef, _compositionMode: boolean);
+    constructor(_renderer: Renderer2, _elementRef: ElementRef, _compositionMode: boolean);
     _compositionEnd(value: any): void;
     _compositionStart(): void;
     _handleInput(value: any): void;
@@ -448,7 +448,7 @@ export declare class NgSelectOption implements OnDestroy {
     id: string;
     ngValue: any;
     value: any;
-    constructor(_element: ElementRef, _renderer: Renderer, _select: SelectControlValueAccessor);
+    constructor(_element: ElementRef, _renderer: Renderer2, _select: SelectControlValueAccessor);
     ngOnDestroy(): void;
 }
 
@@ -467,7 +467,7 @@ export declare class RadioControlValueAccessor implements ControlValueAccessor, 
     onChange: () => void;
     onTouched: () => void;
     value: any;
-    constructor(_renderer: Renderer, _elementRef: ElementRef, _registry: RadioControlRegistry, _injector: Injector);
+    constructor(_renderer: Renderer2, _elementRef: ElementRef, _registry: RadioControlRegistry, _injector: Injector);
     fireUncheck(value: any): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
@@ -494,7 +494,7 @@ export declare class SelectControlValueAccessor implements ControlValueAccessor 
     onChange: (_: any) => void;
     onTouched: () => void;
     value: any;
-    constructor(_renderer: Renderer, _elementRef: ElementRef);
+    constructor(_renderer: Renderer2, _elementRef: ElementRef);
     registerOnChange(fn: (value: any) => any): void;
     registerOnTouched(fn: () => any): void;
     setDisabledState(isDisabled: boolean): void;
@@ -507,7 +507,7 @@ export declare class SelectMultipleControlValueAccessor implements ControlValueA
     onChange: (_: any) => void;
     onTouched: () => void;
     value: any;
-    constructor(_renderer: Renderer, _elementRef: ElementRef);
+    constructor(_renderer: Renderer2, _elementRef: ElementRef);
     registerOnChange(fn: (value: any) => any): void;
     registerOnTouched(fn: () => any): void;
     setDisabledState(isDisabled: boolean): void;


### PR DESCRIPTION
We need to get rid of the old `Renderer` usage so we can easily remove / tree-shake it away in the future.