### PR TITLE
fix(common): limiting size of memory leak in async pipe

### DIFF
--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -74,8 +74,9 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
   private _subscription: ISubscription|Promise<any>|null = null;
   private _obj: Observable<any>|Promise<any>|EventEmitter<any>|null = null;
   private _strategy: SubscriptionStrategy = null !;
+  private _ref: ChangeDetectorRef|null;
 
-  constructor(private _ref: ChangeDetectorRef) {}
+  constructor(_ref: ChangeDetectorRef) { this._ref = _ref; }
 
   ngOnDestroy(): void {
     if (this._subscription) {
@@ -134,12 +135,15 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
     this._latestReturnedValue = null;
     this._subscription = null;
     this._obj = null;
+    this._ref = null;
   }
 
   private _updateLatestValue(async: any, value: Object): void {
     if (async === this._obj) {
       this._latestValue = value;
-      this._ref.markForCheck();
+      if (this._ref) {
+        this._ref.markForCheck();
+      }
     }
   }
 }

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -99,6 +99,17 @@ export function main() {
                async.done();
              }, 0);
            }));
+
+        it('should reset reference to changeDetectorRef',
+           inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+             pipe.transform(emitter);
+             pipe.ngOnDestroy();
+
+             setTimeout(() => {
+               expect(pipe['_ref']).toBe(null);
+               async.done();
+             }, 0);
+           }));
       });
     });
 


### PR DESCRIPTION
Interim fix to limit size of the memory leak in async pipe due to #17624

## PR Checklist
Does please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #17624 

Reference to `ChangeDetectorRef` is not freed on `ngOnDestroy` leading to bigger memory leak (eg. there might be still detached DOM nodes in ViewRef that cannot be garbage collected).

## What is the new behavior?

This is interim fix. Still waiting for final fix in ReactiveX/rxjs#2675
On disposing of async pipe, the reference to `ChangeDetectorRef` is cleared, so garbage collector can free more memory.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
