### PR TITLE
fix(tsc-wrapped): skip collecting metadata for default functions

### DIFF
--- a/tools/@angular/tsc-wrapped/src/collector.ts
+++ b/tools/@angular/tsc-wrapped/src/collector.ts
@@ -377,7 +377,7 @@ export class MetadataCollector {
           // Record functions that return a single value. Record the parameter
           // names substitution will be performed by the StaticReflector.
           const functionDeclaration = <ts.FunctionDeclaration>node;
-          if (isExported(functionDeclaration)) {
+          if (isExported(functionDeclaration) && functionDeclaration.name) {
             if (!metadata) metadata = {};
             const name = exportedName(functionDeclaration);
             const maybeFunc = maybeGetSimpleFunction(functionDeclaration);


### PR DESCRIPTION
Fixes: #17518

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

`ngc` crashes when collecting metadata for a ,module that exports a unnamed default function.

Issue Number: #17518 

## What is the new behavior?

`ngc` no longer crashes. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
