### PR TITLE
fix(compiler-cli): find lazy routes in nested module import arrays

### DIFF
--- a/packages/compiler-cli/integrationtest/ngtools_src/lazy.module.ts
+++ b/packages/compiler-cli/integrationtest/ngtools_src/lazy.module.ts
@@ -14,11 +14,11 @@ export class LazyComponent {
 }
 
 @NgModule({
-  imports: [RouterModule.forChild([
+  imports: [[RouterModule.forChild([
     {path: '', component: LazyComponent, pathMatch: 'full'},
     {path: 'feature', loadChildren: './feature/feature.module#FeatureModule'},
     {path: 'lazy-feature', loadChildren: './feature/lazy-feature.module#LazyFeatureModule'}
-  ])],
+  ])]],
   declarations: [LazyComponent]
 })
 export class LazyModule {


### PR DESCRIPTION
Fixes: #17531

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Lazy routes are not found in modules imports that are in nested arrays.

Issue Number: #17531

## What is the new behavior?

The lazy routes are found.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
