### PR TITLE
docs(aio): fix numbered list in testing.md

### DIFF
--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -160,6 +160,7 @@ This guide describes specific choices that are known to work well.
 ### Setup
 
 There are two fast paths to getting started with unit testing.
+
 1. Start a new project following the instructions in [Setup](guide/setup "Setup").
 
 1. Start a new project with the


### PR DESCRIPTION
This list renders OK in the github UI but not at https://angular.io/guide/testing#setup

## PR Type
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The list renders as two `1.` entries instead of `1.` and `2.` and there is a missing line break before the first list item.

## What is the new behavior?
This commit should fix the list. Note that I don't have the tools to render it as angular.io does, so I can't confirm my fix.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```