### PR TITLE
[MERGE in 5.x] fix(compiler): check if entry components are reachable from their module

### DIFF
--- a/packages/compiler/test/aot/compiler_spec.ts
+++ b/packages/compiler/test/aot/compiler_spec.ts
@@ -266,6 +266,30 @@ describe('compiler (unbundled Angular)', () => {
     });
   });
 
+  it('should report when an entry component is not in any module', () => {
+    const FILES: MockDirectory = {
+      app: {
+        'app.ts': `
+          import {Component, NgModule} from '@angular/core';
+
+          @Component({selector: 'my-comp', template: ''})
+          export class MyComp {}
+
+          @Component({selector: 'entry-comp', template: ''})
+          export class EntryCmp {}
+
+          @NgModule({
+            declarations: [MyComp],
+            entryComponents: [EntryCmp],
+          })
+          export class MyModule {}
+        `
+      }
+    };
+    expect(() => compile([FILES, angularFiles]))
+        .toThrowError(/Cannot determine the module for class EntryCmp/);
+  });
+
   it('should add the preamble to generated files', () => {
     const FILES: MockDirectory = {
       app: {

--- a/packages/compiler/test/aot/compiler_spec.ts
+++ b/packages/compiler/test/aot/compiler_spec.ts
@@ -264,6 +264,46 @@ describe('compiler (unbundled Angular)', () => {
         }
       });
     });
+
+    // https://github.com/angular/angular/issues/17446
+    it('should report when an entry component is not reachable from its module', () => {
+      const FILES: MockDirectory = {
+        app: {
+          'app.ts': `
+                import {Component, NgModule} from '@angular/core';
+
+                @Component({selector: 'my-comp', template: ''})
+                export class MyComp {}
+
+                @Component({selector: 'routed-comp', template: ''})
+                export class RoutedCmp {}
+
+                @Component({selector: 'entry-comp', template: ''})
+                export class EntryCmp {}
+
+                @NgModule({
+                  declarations: [EntryCmp],
+                })
+                export class UnreachableModule {}
+
+                @NgModule({
+                  entryComponents: [RoutedCmp],
+                })
+                export class RoutingModule {}
+
+                @NgModule({
+                  imports: [RoutingModule],
+                  declarations: [MyComp, RoutedCmp],
+                  entryComponents: [EntryCmp],
+                  bootstrap: [MyComp],
+                })
+                export class MyModule {}
+              `
+        }
+      };
+      expect(() => compile([FILES, angularFiles]))
+          .toThrowError(/Consider adding UnreachableModule to the imports of MyModule/);
+    });
   });
 
   it('should report when an entry component is not in any module', () => {

--- a/packages/compiler/test/aot/compiler_spec.ts
+++ b/packages/compiler/test/aot/compiler_spec.ts
@@ -8,12 +8,12 @@
 
 import {GeneratedFile, toTypeScript} from '@angular/compiler';
 import {NodeFlags} from '@angular/core/src/view/index';
-import {MetadataBundler, MetadataCollector, ModuleMetadata, privateEntriesToIndex} from '@angular/tsc-wrapped';
+import {MetadataBundler, privateEntriesToIndex} from '@angular/tsc-wrapped';
 import * as ts from 'typescript';
 
 import {extractSourceMap, originalPositionFor} from '../output/source_map_util';
 
-import {EmittingCompilerHost, MockData, MockDirectory, MockMetadataBundlerHost, arrayToMockDir, arrayToMockMap, compile, expectNoDiagnostics, settings, setup, toMockFileArray} from './test_util';
+import {EmittingCompilerHost, MockDirectory, MockMetadataBundlerHost, arrayToMockDir, compile, expectNoDiagnostics, settings, setup, toMockFileArray} from './test_util';
 
 describe('compiler (unbundled Angular)', () => {
   let angularFiles = setup();
@@ -208,7 +208,7 @@ describe('compiler (unbundled Angular)', () => {
 
     });
 
-    it('should be able to supress a null access', () => {
+    it('should be able to suppress a null access', () => {
       const FILES: MockDirectory = {
         app: {
           'app.ts': `
@@ -746,7 +746,6 @@ const LIBRARY: MockDirectory = {
   }
 };
 
-const LIBRARY_USING_APP_MODULE = ['/lib-user/app/app.module.ts'];
 const LIBRARY_USING_APP: MockDirectory = {
   'lib-user': {
     app: {


### PR DESCRIPTION
**DO NOT MERGE IN THE 4.X BRANCH**

fixes #17466
