### PR TITLE
aio: fix slow docs-test run

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -29,7 +29,7 @@
     "docs": "dgeni ./tools/transforms/angular.io-package",
     "docs-watch": "node tools/transforms/authors-package/watchr.js",
     "docs-lint": "eslint --ignore-path=\"tools/transforms/.eslintignore\" tools/transforms",
-    "docs-test": "jasmine tools/transforms/**/*.spec.js",
+    "docs-test": "node tools/transforms/test.js",
     "~~update-webdriver": "webdriver-manager update --standalone false --gecko false",
     "boilerplate:add": "node ./tools/examples/add-example-boilerplate add",
     "boilerplate:remove": "node ./tools/examples/add-example-boilerplate remove",

--- a/aio/tools/transforms/angular-content-package/index.js
+++ b/aio/tools/transforms/angular-content-package/index.js
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 const Package = require('dgeni').Package;
-const globby = require('globby');
+const glob = require('glob');
 const ignore = require('ignore');
 const fs = require('fs');
 const path = require('canonical-path');
@@ -23,7 +23,7 @@ module.exports = new Package('angular-content', [basePackage, contentPackage])
     const gitignoreFile = fs.readFileSync(path.resolve(GUIDE_EXAMPLES_PATH, '.gitignore'), 'utf8');
     const gitignore = ignore().add(gitignoreFile);
 
-    const examplePaths = globby.sync('**/*', { cwd: GUIDE_EXAMPLES_PATH, mark: true, dot: true })
+    const examplePaths = glob.sync('**/*', { cwd: GUIDE_EXAMPLES_PATH, dot: true, ignore: '**/node_modules/**', mark: true })
                             .filter(filePath => filePath !== '.gitignore') // we are not interested in the .gitignore file itself
                             .filter(filePath => !/\/$/.test(filePath)); // this filter removes the folders, leaving only files
     const filteredExamplePaths = gitignore.filter(examplePaths) // filter out files that match the .gitignore rules

--- a/aio/tools/transforms/test.js
+++ b/aio/tools/transforms/test.js
@@ -1,0 +1,17 @@
+/*
+ * Use this script to run the tests for the doc generation
+ * We cannot use the Jasmine CLI directly because it doesn't seem to
+ * understand the glob and only runs one spec file.
+ *
+ * Equally we cannot use a jasmine.json config file because it doesn't
+ * allow us to set the projectBaseDir, which means that you have to run
+ * jasmine CLI from this directory.
+ *
+ * Using a file like this gives us full control and keeps the package.json
+ * file clean and simple.
+ */
+
+const Jasmine = require('jasmine');
+const jasmine = new Jasmine({ projectBaseDir: __dirname });
+jasmine.loadConfig({ spec_files: ['**/*.spec.js'] });
+jasmine.execute();


### PR DESCRIPTION
Parsing all the node_modules in the example boilerplate was causing doc gen to run slowly,
which is causing flaky integration tests.

Also not all the tests were being run as the Jasmine CLI config was not correct.