### PR TITLE
feat(core): allow tests to disable the automatic calls of TestBed.res…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+<a name="4.3.0-beta.0"></a>
+# [4.3.0-beta.0](https://github.com/angular/angular/compare/4.2.1...4.3.0-beta.0) (2017-06-22)
+
+
+### Bug Fixes
+
+* **animations:** compute removal node height correctly ([185075d](https://github.com/angular/angular/commit/185075d))
+* **animations:** do not treat a `0` animation state as `void` ([451257a](https://github.com/angular/angular/commit/451257a))
+* **animations:** properly collect :enter nodes in a partially updated collection ([6ca4692](https://github.com/angular/angular/commit/6ca4692)), closes [#17440](https://github.com/angular/angular/issues/17440)
+* **animations:** remove duplicate license header ([e096a85](https://github.com/angular/angular/commit/e096a85))
+* **compiler:** avoid emitting self importing factories ([4352dd2](https://github.com/angular/angular/commit/4352dd2))
+* **compiler-cli:** find lazy routes in nested module import arrays ([8c89cc4](https://github.com/angular/angular/commit/8c89cc4))
+* **core:** argument destructuring sometimes breaks strictNullChecks ([c59c390](https://github.com/angular/angular/commit/c59c390))
+* **forms:** roll back breaking change with min/max directives ([3e685f9](https://github.com/angular/angular/commit/3e685f9)), closes [#17491](https://github.com/angular/angular/issues/17491)
+* **language-service:** infer `any` `ngForOf` of type `any` ([f194f18](https://github.com/angular/angular/commit/f194f18))
+* **language-service:** rollup `tslib` into the language service package ([4e6be15](https://github.com/angular/angular/commit/4e6be15))
+* **router:** update the version placeholder so that it gets replaced during the build ([d3c92a3](https://github.com/angular/angular/commit/d3c92a3)), closes [#17403](https://github.com/angular/angular/issues/17403)
+* **tsc-wrapped:** skip collecting metadata for default functions ([46ddf50](https://github.com/angular/angular/commit/46ddf50))
+
+
+### Features
+
+* **core:** update zone.js to 0.8.12 ([5ac3919](https://github.com/angular/angular/commit/5ac3919))
+
+
+
 <a name="4.2.4"></a>
 ## [4.2.4](https://github.com/angular/angular/compare/4.2.3...4.2.4) (2017-06-21)
 

--- a/packages/core/test/before_each_spec.ts
+++ b/packages/core/test/before_each_spec.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { TestBed, enableTestBedAutoReset, disableTestBedAutoReset } from '../testing';
+
+describe('before_each', () => {
+
+    describe('default behavior', () => {
+        const originalTestBedresetTestingModule = TestBed.resetTestingModule;
+        let resetTestingModuleCalled = false;
+
+        beforeAll(() => {
+            // replace TestBed.resetTestingModule with a mock function
+            TestBed.resetTestingModule = () => {
+                resetTestingModuleCalled = true;
+                return TestBed;
+            };
+        });
+
+        afterAll(() => {
+            TestBed.resetTestingModule = originalTestBedresetTestingModule;
+        });
+
+        it ('should call TestBed.resetTestingModule in beforeEach', () => {
+            expect(resetTestingModuleCalled).toBeTruthy();
+        });
+    });
+
+    describe('when disableTestBedAutoReset was called', () => {
+        const originalTestBedresetTestingModule = TestBed.resetTestingModule;
+        let resetTestingModuleCalled = false;
+
+        beforeAll(() => {
+            // replace TestBed.resetTestingModule with a mock function
+            TestBed.resetTestingModule = () => {
+                resetTestingModuleCalled = true;
+                return TestBed;
+            };
+        });
+
+        beforeAll(disableTestBedAutoReset);
+
+        afterAll(() => {
+            TestBed.resetTestingModule = originalTestBedresetTestingModule;
+        });
+
+        it ('should not call TestBed.resetTestingModule in beforeEach', () => {
+            expect(resetTestingModuleCalled).toBeFalsy();
+        });
+    });
+
+    describe('when enableTestBedAutoReset was called', () => {
+        const originalTestBedresetTestingModule = TestBed.resetTestingModule;
+        let resetTestingModuleCalled = false;
+
+        beforeAll(() => {
+            // replace TestBed.resetTestingModule with a mock function
+            TestBed.resetTestingModule = () => {
+                resetTestingModuleCalled = true;
+                return TestBed;
+            };
+        });
+
+        beforeAll(disableTestBedAutoReset);
+        beforeAll(enableTestBedAutoReset);
+
+        afterAll(() => {
+            TestBed.resetTestingModule = originalTestBedresetTestingModule;
+        });
+
+        it ('should call TestBed.resetTestingModule in beforeEach', () => {
+            expect(resetTestingModuleCalled).toBeTruthy();
+        });
+    });
+});

--- a/packages/core/test/before_each_spec.ts
+++ b/packages/core/test/before_each_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+<<<<<<< HEAD
 import { TestBed, enableTestBedAutoReset, disableTestBedAutoReset } from '../testing';
 
 describe('before_each', () => {
@@ -77,4 +78,68 @@ describe('before_each', () => {
             expect(resetTestingModuleCalled).toBeTruthy();
         });
     });
+=======
+import {TestBed, disableTestBedAutoReset, enableTestBedAutoReset} from '../testing';
+
+describe('before_each', () => {
+
+  describe('default behavior', () => {
+    const originalTestBedresetTestingModule = TestBed.resetTestingModule;
+    let resetTestingModuleCalled = false;
+
+    beforeAll(() => {
+      // replace TestBed.resetTestingModule with a mock function
+      TestBed.resetTestingModule = () => {
+        resetTestingModuleCalled = true;
+        return TestBed;
+      };
+    });
+
+    afterAll(() => { TestBed.resetTestingModule = originalTestBedresetTestingModule; });
+
+    it('should call TestBed.resetTestingModule in beforeEach',
+       () => { expect(resetTestingModuleCalled).toBeTruthy(); });
+  });
+
+  describe('when disableTestBedAutoReset was called', () => {
+    const originalTestBedresetTestingModule = TestBed.resetTestingModule;
+    let resetTestingModuleCalled = false;
+
+    beforeAll(() => {
+      // replace TestBed.resetTestingModule with a mock function
+      TestBed.resetTestingModule = () => {
+        resetTestingModuleCalled = true;
+        return TestBed;
+      };
+    });
+
+    beforeAll(disableTestBedAutoReset);
+
+    afterAll(() => { TestBed.resetTestingModule = originalTestBedresetTestingModule; });
+
+    it('should not call TestBed.resetTestingModule in beforeEach',
+       () => { expect(resetTestingModuleCalled).toBeFalsy(); });
+  });
+
+  describe('when enableTestBedAutoReset was called', () => {
+    const originalTestBedresetTestingModule = TestBed.resetTestingModule;
+    let resetTestingModuleCalled = false;
+
+    beforeAll(() => {
+      // replace TestBed.resetTestingModule with a mock function
+      TestBed.resetTestingModule = () => {
+        resetTestingModuleCalled = true;
+        return TestBed;
+      };
+    });
+
+    beforeAll(disableTestBedAutoReset);
+    beforeAll(enableTestBedAutoReset);
+
+    afterAll(() => { TestBed.resetTestingModule = originalTestBedresetTestingModule; });
+
+    it('should call TestBed.resetTestingModule in beforeEach',
+       () => { expect(resetTestingModuleCalled).toBeTruthy(); });
+  });
+>>>>>>> dac4928... feat(core): allow tests to disable the automatic calls of TestBed.resetTestingModule in beforeEach
 });

--- a/packages/core/testing/src/before_each.ts
+++ b/packages/core/testing/src/before_each.ts
@@ -17,16 +17,30 @@ import {TestBed} from './test_bed';
 
 declare var global: any;
 
+let resetTestingModuleInBeforeEach = true;
+
 const _global = <any>(typeof window === 'undefined' ? global : window);
 
 // Reset the test providers and the fake async zone before each test.
 if (_global.beforeEach) {
   _global.beforeEach(() => {
-    TestBed.resetTestingModule();
+    if (resetTestingModuleInBeforeEach) TestBed.resetTestingModule();
     resetFakeAsyncZone();
   });
 }
 
-// TODO(juliemr): remove this, only used because we need to export something to have compilation
-// work.
-export const __core_private_testing_placeholder__ = '';
+/**
+ * By default, Angular calls TestBed.resetTestingModule in Jasmine's beforeEach.
+ * This is not always necessary and can slow down test execution.
+ * Calling disableTestBedAutoReset disables this behavior.
+ */
+export function disableTestBedAutoReset() {
+  resetTestingModuleInBeforeEach = false;
+}
+
+/**
+ * Reenable the automatic TestBed reset.
+ */
+export function enableTestBedAutoReset() {
+  resetTestingModuleInBeforeEach = true;
+}

--- a/packages/core/testing/src/before_each.ts
+++ b/packages/core/testing/src/before_each.ts
@@ -17,9 +17,9 @@ import {TestBed} from './test_bed';
 
 declare var global: any;
 
-let resetTestingModuleInBeforeEach = true;
-
 const _global = <any>(typeof window === 'undefined' ? global : window);
+
+let resetTestingModuleInBeforeEach = true;
 
 // Reset the test providers and the fake async zone before each test.
 if (_global.beforeEach) {
@@ -43,4 +43,8 @@ export function disableTestBedAutoReset() {
  */
 export function enableTestBedAutoReset() {
   resetTestingModuleInBeforeEach = true;
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> dac4928... feat(core): allow tests to disable the automatic calls of TestBed.resetTestingModule in beforeEach


### PR DESCRIPTION
…etTestingModule in beforeEach

Allow a developer to temporarily disable automatic calls of TestBed.resetTestingModule, so that a test developer can control when the TestBed should be reset. This enables faster test execution for some test cases.


## PR Checklist
Does please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Angular automatically calls TestBed.resetTestingModule in Jasmine's beforeEach. Because of that behavior, test duration for the tests in our company's project is much longer than necessary.

Issue Number: N/A


## What is the new behavior?

Allow a developer to temporarily disable automatic calls of TestBed.resetTestingModule, so that a test developer can control when the TestBed should be reset. This enables faster test execution for some test cases. For example, a large spec for a complex component that we developed in our company, test execution time was reduced from 45 seconds to 3.5 seconds.

For complex components, we often perform some action in beforeEach and then have many "it" that only test expectations. Today, we need to reexecute the test for every it, although that would not be necessary. The alternative would be to move all expectations to a single "it". However, this would make it much harder to analyze why a test fails. The test would result in a failure after the first failed expectation, and we would not be able to see if the other expectations also failed or if they would have executed successfully.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I did not add documentation as I don't know how to to that. In CONTRIBUTING.md, I only found "All public API methods must be documented. (Details TBC)"
