### PR TITLE
docs(aio): resources.json - replace “Angular 2” in titles/descriptions

### DIFF
--- a/aio/content/marketing/resources.json
+++ b/aio/content/marketing/resources.json
@@ -105,7 +105,7 @@
         "order": 3,
         "resources": {
           "-KLIzHDRfiB3d7W7vk-e": {
-            "desc": "Reactive Extensions for angular2",
+            "desc": "Reactive Extensions for Angular",
             "rev": true,
             "title": "ngrx",
             "url": "http://github.com/ngrx"
@@ -246,7 +246,7 @@
             "url": "http://ng-lightning.github.io/ng-lightning/"
           },
           "7ab": {
-            "desc": "UI components for hybrid mobile apps with bindings for both Angular 1 & 2.",
+            "desc": "UI components for hybrid mobile apps with bindings for both Angular & AngularJS.",
             "rev": true,
             "title": "Onsen UI",
             "url": "https://onsen.io/v2/"
@@ -280,11 +280,11 @@
             "url": "https://vaadin.com/elements"
           },
           "a7b": {
-            "desc": "Native Angular2 directives for Bootstrap",
+            "desc": "Native Angular directives for Bootstrap",
             "logo": "",
             "rev": true,
-            "title": "ng2-bootstrap",
-            "url": "http://valor-software.com/ng2-bootstrap/"
+            "title": "ngx-bootstrap",
+            "url": "http://valor-software.com/ngx-bootstrap/#/"
           },
           "ab": {
             "desc": "Material Design components for Angular",
@@ -348,7 +348,7 @@
           "a5b": {
             "desc": "The in-depth, complete, and up-to-date book on Angular. Become an Angular expert today.",
             "rev": true,
-            "title": "ng-book 2",
+            "title": "ng-book",
             "url": "https://www.ng-book.com/2/"
           },
           "a6b": {
@@ -417,7 +417,7 @@
             "url": "https://www.eduonix.com/courses/Web-Development/angular-2-fundamentals-for-web-developers"
           },
           "-KMUuOWwciL_S_o0fzFO": {
-            "desc": "The ngmigrate project is brought to you by Todd Motto, a Developer Advocate at Telerik, spreading the good word of Kendo UI, NativeScript and Angular 1 & 2. You can follow him on Twitter for questions, or even requests about this guide.",
+            "desc": "The ngMigrate project is brought to you by Todd Motto, a Developer Advocate at Telerik, spreading the good word of Kendo UI, NativeScript and Angular & AngularJS. You can follow him on Twitter for questions, or even requests about this guide.",
             "rev": true,
             "title": "ngMigrate",
             "url": "http://ngmigrate.telerik.com/"
@@ -466,7 +466,7 @@
             "url": "https://frontendmasters.com/courses/angular-2/"
           },
           "ac6": {
-            "desc": "French language Angular course covering TypeScript, ES6, Depdendency Injection, Observables, and more.",
+            "desc": "French language Angular course covering TypeScript, ES6, Dependency Injection, Observables, and more.",
             "rev": true,
             "title": "Wishtack's Angular Course (francais)",
             "url": "http://courses.wishtack.com/angular-2/ecmascript-6"
@@ -519,7 +519,7 @@
             "url": "http://chariotsolutions.com/course/angular2-workshop-fundamentals-architecture/"
           },
           "-KLIBoN0p9be3kwC6-ga": {
-            "desc": "Angular Academy is a 2 day hands-on public course given in-person across Canada!",
+            "desc": "Angular Academy is a two day hands-on public course given in-person across Canada!",
             "rev": true,
             "title": "Angular Academy (Canada)",
             "url": "http://www.angularacademy.ca"


### PR DESCRIPTION
closes #16965

Labeled "aio" because it touches marketing page data, not page content.

## PR Checklist
Does please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

