### PR TITLE
fix(upgrade): prevent digest in progress errors

### DIFF
--- a/packages/upgrade/src/static/upgrade_module.ts
+++ b/packages/upgrade/src/static/upgrade_module.ts
@@ -238,7 +238,7 @@ export class UpgradeModule {
                 setTimeout(() => {
                   const $rootScope = $injector.get('$rootScope');
                   const subscription =
-                      this.ngZone.onMicrotaskEmpty.subscribe(() => $rootScope.$digest());
+                      this.ngZone.onMicrotaskEmpty.subscribe(() => $rootScope.$evalAsync());
                   $rootScope.$on('$destroy', () => { subscription.unsubscribe(); });
                 }, 0);
               }


### PR DESCRIPTION
## PR Checklist
Does please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Occasionally when using ngUpgrade in a hybrid app `$digest already in progress` is sometimes thrown (its hard to pin down the exact cause of it as it happens inconsistently, but seems to be caused by changing route in a $timeout, triggered from a zone wrapped native promise)

<img width="463" alt="screen shot 2017-06-22 at 10 54 53" src="https://user-images.githubusercontent.com/6425649/27428300-96a478f0-5739-11e7-8304-eb79237cd577.png">
<img width="775" alt="screen shot 2017-06-22 at 10 55 05" src="https://user-images.githubusercontent.com/6425649/27428310-994be980-5739-11e7-815a-d12c2c458810.png">


Issue Number: N/A


## What is the new behavior?
$evalAsync is used instead which should avoid these types of errors as the digest trigger will be ignored if it's already in progress. I saw this PR: https://github.com/angular/angular/pull/9054/files which already added this change, but I couldn't work out why it was changed to a $digest. If there was a good reason for it then no worries and this PR can just be closed (the error is just annoying but doesn't actually break anything)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
