### PR TITLE
fix(aio): fix topbar nav-item focus style

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -52,7 +52,7 @@
     "@angular/core": "4.2.1",
     "@angular/forms": "4.2.1",
     "@angular/http": "4.2.1",
-    "@angular/material": "^2.0.0-beta.3",
+    "@angular/material": "^2.0.0-beta.7",
     "@angular/platform-browser": "4.2.1",
     "@angular/platform-browser-dynamic": "4.2.1",
     "@angular/platform-server": "4.2.1",

--- a/aio/src/styles/1-layouts/_top-menu.scss
+++ b/aio/src/styles/1-layouts/_top-menu.scss
@@ -42,12 +42,10 @@ aio-top-menu {
     cursor: pointer;
 
     &:focus {
+      background: rgba($white, 0.15);
+      border-radius: 4px;
       outline: none;
-      // Temporarily remove the focus styling until we update to an @angular/material version that
-      // includes https://github.com/angular/material2/commit/3bc82f6dc.
-      // background: rgba($white, 0.15);
-      // border-radius: 4px;
-      // padding: 8px 16px;
+      padding: 8px 16px;
     }
   }
 }

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -111,9 +111,11 @@
   dependencies:
     tslib "^1.7.1"
 
-"@angular/material@^2.0.0-beta.3":
-  version "2.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@angular/material/-/material-2.0.0-beta.4.tgz#137ef759867213308613172c54dfe69061a10829"
+"@angular/material@^2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@angular/material/-/material-2.0.0-beta.7.tgz#2584aaf1ffbe24779916345f1ac82921ccbc2577"
+  dependencies:
+    tslib "^1.7.1"
 
 "@angular/platform-browser-dynamic@4.2.1":
   version "4.2.1"


### PR DESCRIPTION
Fixing it requires upgrading `@angular/material` to v2.0.0-beta.7.

Fixes #17216.