### PR TITLE
refactor(core): remove toString() method from DefaultIterableDiffer

### DIFF
--- a/packages/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/packages/core/src/change_detection/differs/default_iterable_differ.ts
@@ -567,34 +567,6 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
     }
     return record;
   }
-
-
-  toString(): string {
-    const list: IterableChangeRecord_<V>[] = [];
-    this.forEachItem((record: IterableChangeRecord_<V>) => list.push(record));
-
-    const previous: IterableChangeRecord_<V>[] = [];
-    this.forEachPreviousItem((record: IterableChangeRecord_<V>) => previous.push(record));
-
-    const additions: IterableChangeRecord_<V>[] = [];
-    this.forEachAddedItem((record: IterableChangeRecord_<V>) => additions.push(record));
-
-    const moves: IterableChangeRecord_<V>[] = [];
-    this.forEachMovedItem((record: IterableChangeRecord_<V>) => moves.push(record));
-
-    const removals: IterableChangeRecord_<V>[] = [];
-    this.forEachRemovedItem((record: IterableChangeRecord_<V>) => removals.push(record));
-
-    const identityChanges: IterableChangeRecord_<V>[] = [];
-    this.forEachIdentityChange((record: IterableChangeRecord_<V>) => identityChanges.push(record));
-
-    return 'collection: ' + list.join(', ') + '\n' +
-        'previous: ' + previous.join(', ') + '\n' +
-        'additions: ' + additions.join(', ') + '\n' +
-        'moves: ' + moves.join(', ') + '\n' +
-        'removals: ' + removals.join(', ') + '\n' +
-        'identityChanges: ' + identityChanges.join(', ') + '\n';
-  }
 }
 
 /**
@@ -627,12 +599,6 @@ export class IterableChangeRecord_<V> implements IterableChangeRecord<V> {
 
 
   constructor(public item: V, public trackById: any) {}
-
-  toString(): string {
-    return this.previousIndex === this.currentIndex ? stringify(this.item) :
-                                                      stringify(this.item) + '[' +
-            stringify(this.previousIndex) + '->' + stringify(this.currentIndex) + ']';
-  }
 }
 
 // A linked list of CollectionChangeRecords with the same IterableChangeRecord_.item
@@ -752,8 +718,6 @@ class _DuplicateMap<V> {
   get isEmpty(): boolean { return this.map.size === 0; }
 
   clear() { this.map.clear(); }
-
-  toString(): string { return '_DuplicateMap(' + stringify(this.map) + ')'; }
 }
 
 function getPreviousIndex(

--- a/packages/core/test/change_detection/differs/default_iterable_differ_spec.ts
+++ b/packages/core/test/change_detection/differs/default_iterable_differ_spec.ts
@@ -9,7 +9,7 @@
 import {DefaultIterableDiffer, DefaultIterableDifferFactory} from '@angular/core/src/change_detection/differs/default_iterable_differ';
 
 import {TestIterable} from '../../change_detection/iterable';
-import {iterableChangesAsString} from '../../change_detection/util';
+import {iterableChangesAsString, iterableDifferToString} from '../../change_detection/util';
 
 class ItemWithId {
   constructor(private id: string) {}
@@ -43,18 +43,18 @@ export function main() {
         const l: any = new TestIterable();
 
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({collection: []}));
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({collection: []}));
 
         l.list = [1];
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['1[null->0]'],
           additions: ['1[null->0]']
         }));
 
         l.list = [2, 1];
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['2[null->0]', '1[0->1]'],
           previous: ['1[0->1]'],
           additions: ['2[null->0]'],
@@ -65,18 +65,18 @@ export function main() {
       it('should detect additions', () => {
         const l: any[] = [];
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({collection: []}));
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({collection: []}));
 
         l.push('a');
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['a[null->0]'],
           additions: ['a[null->0]']
         }));
 
         l.push('b');
         differ.check(l);
-        expect(differ.toString())
+        expect(iterableDifferToString(differ))
             .toEqual(iterableChangesAsString(
                 {collection: ['a', 'b[null->1]'], previous: ['a'], additions: ['b[null->1]']}));
       });
@@ -87,7 +87,7 @@ export function main() {
 
         l = [1, 0];
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['1[null->0]', '0[0->1]'],
           previous: ['0[0->1]'],
           additions: ['1[null->0]'],
@@ -96,7 +96,7 @@ export function main() {
 
         l = [2, 1, 0];
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['2[null->0]', '1[0->1]', '0[1->2]'],
           previous: ['1[0->1]', '0[1->2]'],
           additions: ['2[null->0]'],
@@ -112,7 +112,7 @@ export function main() {
         l.push(2);
         l.push(1);
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['2[1->0]', '1[0->1]'],
           previous: ['1[0->1]', '2[1->0]'],
           moves: ['2[1->0]', '1[0->1]']
@@ -126,7 +126,7 @@ export function main() {
         l.splice(1, 1);
         l.splice(0, 0, 'b');
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['b[1->0]', 'a[0->1]', 'c'],
           previous: ['a[0->1]', 'b[1->0]', 'c'],
           moves: ['b[1->0]', 'a[0->1]']
@@ -135,7 +135,7 @@ export function main() {
         l.splice(1, 1);
         l.push('a');
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['b', 'c[2->1]', 'a[1->2]'],
           previous: ['b', 'a[1->2]', 'c[2->1]'],
           moves: ['c[2->1]', 'a[1->2]']
@@ -148,21 +148,21 @@ export function main() {
 
         l.push('a');
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['a[null->0]'],
           additions: ['a[null->0]']
         }));
 
         l.push('b');
         differ.check(l);
-        expect(differ.toString())
+        expect(iterableDifferToString(differ))
             .toEqual(iterableChangesAsString(
                 {collection: ['a', 'b[null->1]'], previous: ['a'], additions: ['b[null->1]']}));
 
         l.push('c');
         l.push('d');
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['a', 'b', 'c[null->2]', 'd[null->3]'],
           previous: ['a', 'b'],
           additions: ['c[null->2]', 'd[null->3]']
@@ -170,7 +170,7 @@ export function main() {
 
         l.splice(2, 1);
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['a', 'b', 'd[3->2]'],
           previous: ['a', 'b', 'c[2->null]', 'd[3->2]'],
           moves: ['d[3->2]'],
@@ -183,7 +183,7 @@ export function main() {
         l.push('b');
         l.push('a');
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['d[2->0]', 'c[null->1]', 'b[1->2]', 'a[0->3]'],
           previous: ['a[0->3]', 'b[1->2]', 'd[2->0]'],
           additions: ['c[null->1]'],
@@ -195,7 +195,7 @@ export function main() {
         const l = [NaN];
         differ.check(l);
         differ.check(l);
-        expect(differ.toString())
+        expect(iterableDifferToString(differ))
             .toEqual(iterableChangesAsString({collection: [NaN], previous: [NaN]}));
       });
 
@@ -205,7 +205,7 @@ export function main() {
 
         l.unshift('foo');
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['foo[null->0]', 'NaN[0->1]', 'NaN[1->2]'],
           previous: ['NaN[0->1]', 'NaN[1->2]'],
           additions: ['foo[null->0]'],
@@ -219,7 +219,7 @@ export function main() {
 
         l.splice(1, 1);
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['a', 'c[2->1]'],
           previous: ['a', 'b[1->null]', 'c[2->1]'],
           moves: ['c[2->1]'],
@@ -228,7 +228,7 @@ export function main() {
 
         l.splice(1, 0, 'b');
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['a', 'b[null->1]', 'c[1->2]'],
           previous: ['a', 'c[1->2]'],
           additions: ['b[null->1]'],
@@ -243,7 +243,7 @@ export function main() {
 
         l.splice(0, 1);
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['a', 'a', 'b[3->2]', 'b[4->3]'],
           previous: ['a', 'a', 'a[2->null]', 'b[3->2]', 'b[4->3]'],
           moves: ['b[3->2]', 'b[4->3]'],
@@ -257,7 +257,7 @@ export function main() {
 
         l.splice(0, 0, 'b');
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['b[2->0]', 'a[0->1]', 'a[1->2]', 'b', 'b[null->4]'],
           previous: ['a[0->1]', 'a[1->2]', 'b[2->0]', 'b'],
           additions: ['b[null->4]'],
@@ -274,7 +274,7 @@ export function main() {
         l.push('a');
         l.push('c');
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['b[1->0]', 'a[0->1]', 'c'],
           previous: ['a[0->1]', 'b[1->0]', 'c'],
           moves: ['b[1->0]', 'a[0->1]']
@@ -288,7 +288,7 @@ export function main() {
         l[1] = 'b';
         l[5] = 'c';
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['a', 'b[null->1]', '*[1->2]', 'd', '-', 'c[null->5]', '-[5->6]', 'e'],
           previous: ['a', '*[1->2]', '*[2->null]', 'd', '-', '-[5->6]', '-[6->null]', 'e'],
           additions: ['b[null->1]', 'c[null->5]'],
@@ -468,7 +468,7 @@ export function main() {
 
         it('should treat null as an empty list', () => {
           differ.diff(['a', 'b']);
-          expect(differ.diff(null !) !.toString()).toEqual(iterableChangesAsString({
+          expect(iterableDifferToString(differ.diff(null !) !)).toEqual(iterableChangesAsString({
             previous: ['a[0->null]', 'b[1->null]'],
             removals: ['a[0->null]', 'b[1->null]']
           }));
@@ -497,14 +497,14 @@ export function main() {
       it('should treat seen records as identity changes, not additions', () => {
         let l = buildItemList(['a', 'b', 'c']);
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: [`{id: a}[null->0]`, `{id: b}[null->1]`, `{id: c}[null->2]`],
           additions: [`{id: a}[null->0]`, `{id: b}[null->1]`, `{id: c}[null->2]`]
         }));
 
         l = buildItemList(['a', 'b', 'c']);
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: [`{id: a}`, `{id: b}`, `{id: c}`],
           identityChanges: [`{id: a}`, `{id: b}`, `{id: c}`],
           previous: [`{id: a}`, `{id: b}`, `{id: c}`]
@@ -517,7 +517,7 @@ export function main() {
 
         l = [new ComplexItem('a', 'orange'), new ComplexItem('b', 'red')];
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: [`{id: a, color: orange}`, `{id: b, color: red}`],
           identityChanges: [`{id: a, color: orange}`, `{id: b, color: red}`],
           previous: [`{id: a, color: orange}`, `{id: b, color: red}`]
@@ -530,7 +530,7 @@ export function main() {
 
         l = buildItemList(['b', 'a', 'c']);
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['{id: b}[1->0]', '{id: a}[0->1]', '{id: c}'],
           identityChanges: ['{id: b}[1->0]', '{id: a}[0->1]', '{id: c}'],
           previous: ['{id: a}[0->1]', '{id: b}[1->0]', '{id: c}'],
@@ -545,7 +545,7 @@ export function main() {
 
         l = buildItemList(['b', 'a', 'a']);
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['{id: b}[null->0]', '{id: a}[0->1]', '{id: a}[1->2]'],
           identityChanges: ['{id: a}[0->1]', '{id: a}[1->2]'],
           previous: ['{id: a}[0->1]', '{id: a}[1->2]'],
@@ -561,7 +561,7 @@ export function main() {
 
         l.splice(2, 1);
         differ.check(l);
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['{id: a}', '{id: b}'],
           previous: ['{id: a}', '{id: b}', '{id: c}[2->null]'],
           removals: ['{id: c}[2->null]']
@@ -581,7 +581,7 @@ export function main() {
         differ.check(['e', 'f', 'g', 'h']);
         differ.check(['e', 'f', 'h']);
 
-        expect(differ.toString()).toEqual(iterableChangesAsString({
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['e', 'f', 'h'],
           previous: ['e', 'f', 'h', 'h[3->null]'],
           removals: ['h[3->null]'],

--- a/packages/core/test/change_detection/util.ts
+++ b/packages/core/test/change_detection/util.ts
@@ -6,10 +6,45 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {IterableChangeRecord, IterableChanges} from '@angular/core/src/change_detection/differs/iterable_differs';
 import {KeyValueChangeRecord, KeyValueChanges} from '@angular/core/src/change_detection/differs/keyvalue_differs';
 
 import {looseIdentical, stringify} from '../../src/util';
 
+export function iterableDifferToString<V>(iterableChanges: IterableChanges<V>) {
+  const collection: string[] = [];
+  iterableChanges.forEachItem(
+      (record: IterableChangeRecord<V>) => collection.push(icrAsString(record)));
+
+  const previous: string[] = [];
+  iterableChanges.forEachPreviousItem(
+      (record: IterableChangeRecord<V>) => previous.push(icrAsString(record)));
+
+  const additions: string[] = [];
+  iterableChanges.forEachAddedItem(
+      (record: IterableChangeRecord<V>) => additions.push(icrAsString(record)));
+
+  const moves: string[] = [];
+  iterableChanges.forEachMovedItem(
+      (record: IterableChangeRecord<V>) => moves.push(icrAsString(record)));
+
+  const removals: string[] = [];
+  iterableChanges.forEachRemovedItem(
+      (record: IterableChangeRecord<V>) => removals.push(icrAsString(record)));
+
+  const identityChanges: string[] = [];
+  iterableChanges.forEachIdentityChange(
+      (record: IterableChangeRecord<V>) => identityChanges.push(icrAsString(record)));
+
+  return iterableChangesAsString(
+      {collection, previous, additions, moves, removals, identityChanges});
+}
+
+function icrAsString<V>(icr: IterableChangeRecord<V>): string {
+  return icr.previousIndex === icr.currentIndex ? stringify(icr.item) :
+                                                  stringify(icr.item) + '[' +
+          stringify(icr.previousIndex) + '->' + stringify(icr.currentIndex) + ']';
+}
 
 export function iterableChangesAsString(
     {collection = [] as any, previous = [] as any, additions = [] as any, moves = [] as any,

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -355,7 +355,6 @@ export declare class DefaultIterableDiffer<V> implements IterableDiffer<V>, Iter
     forEachPreviousItem(fn: (record: IterableChangeRecord_<V>) => void): void;
     forEachRemovedItem(fn: (record: IterableChangeRecord_<V>) => void): void;
     onDestroy(): void;
-    toString(): string;
 }
 
 /** @experimental */


### PR DESCRIPTION
toString() from DefaultIterableDiffer is only used in tests and should not
be part of the production code. toString() methods from differs add
~ 0.3KB (min+gzip) to the production bundle size.