### PR TITLE
feat(core,upgrade): scheduling change detection

### DIFF
--- a/packages/core/src/application_module.ts
+++ b/packages/core/src/application_module.ts
@@ -8,7 +8,7 @@
 
 import {ApplicationInitStatus} from './application_init';
 import {ApplicationRef, ApplicationRef_} from './application_ref';
-import {APP_ID_RANDOM_PROVIDER} from './application_tokens';
+import { APP_ID_RANDOM_PROVIDER, APP_CHANGE_DETECT_PROVIDER } from './application_tokens';
 import {IterableDiffers, KeyValueDiffers, defaultIterableDiffers, defaultKeyValueDiffers} from './change_detection/change_detection';
 import {Inject, Optional, SkipSelf} from './di/metadata';
 import {LOCALE_ID} from './i18n/tokens';
@@ -47,6 +47,7 @@ export function _localeFactory(locale?: string): string {
       useFactory: _localeFactory,
       deps: [[new Inject(LOCALE_ID), new Optional(), new SkipSelf()]]
     },
+    APP_CHANGE_DETECT_PROVIDER,
   ]
 })
 export class ApplicationModule {

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -17,9 +17,9 @@ import {scheduleMicroTask, stringify} from '../src/util';
 import {isPromise} from '../src/util/lang';
 
 import {ApplicationInitStatus} from './application_init';
-import {APP_BOOTSTRAP_LISTENER, PLATFORM_INITIALIZER} from './application_tokens';
+import { APP_BOOTSTRAP_LISTENER, PLATFORM_INITIALIZER, APP_CHANGE_DETECT, ChangeDetect} from './application_tokens';
 import {Console} from './console';
-import {Injectable, InjectionToken, Injector, Provider, ReflectiveInjector} from './di';
+import {Inject, Injectable, InjectionToken, Injector, Provider, ReflectiveInjector} from './di';
 import {CompilerFactory, CompilerOptions} from './linker/compiler';
 import {ComponentFactory, ComponentRef} from './linker/component_factory';
 import {ComponentFactoryBoundToModule, ComponentFactoryResolver} from './linker/component_factory_resolver';
@@ -469,12 +469,12 @@ export class ApplicationRef_ extends ApplicationRef {
       private _zone: NgZone, private _console: Console, private _injector: Injector,
       private _exceptionHandler: ErrorHandler,
       private _componentFactoryResolver: ComponentFactoryResolver,
-      private _initStatus: ApplicationInitStatus) {
+      private _initStatus: ApplicationInitStatus, @Inject(APP_CHANGE_DETECT) private _detectChanges: ChangeDetect) {
     super();
     this._enforceNoNewChanges = isDevMode();
 
     this._zone.onMicrotaskEmpty.subscribe(
-        {next: () => { this._zone.run(() => { this.tick(); }); }});
+        {next: this._detectChanges.bind(this, this, this._zone)});
 
     const isCurrentlyStable = new Observable<boolean>((observer: Observer<boolean>) => {
       this._stable = this._zone.isStable && !this._zone.hasPendingMacrotasks &&

--- a/packages/core/src/application_tokens.ts
+++ b/packages/core/src/application_tokens.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectionToken} from './di';
+import {InjectionToken, Inject, Optional, SkipSelf} from './di';
 import {ComponentRef} from './linker/component_factory';
+import {ApplicationRef} from './application_ref';
+import {NgZone} from './zone/ng_zone';
 
 
 /**
@@ -68,3 +70,23 @@ export const APP_BOOTSTRAP_LISTENER =
  * @experimental
  */
 export const PACKAGE_ROOT_URL = new InjectionToken<string>('Application Packages Root URL');
+
+export type ChangeDetect = (ref: ApplicationRef, zone: NgZone) => void;
+
+export const APP_CHANGE_DETECT = new InjectionToken<ChangeDetect>('AppChangeDetect');
+
+export const defaultAppChangeDetect: ChangeDetect = (ref, zone) => { zone.run(() => { ref.tick(); }); }
+
+export function _changeDetectFactory(changeDetect?: ChangeDetect): ChangeDetect {
+  return changeDetect || defaultAppChangeDetect;
+}
+
+/**
+ * A callback used to change detect the application.
+ * @experimental
+ */
+export const APP_CHANGE_DETECT_PROVIDER = {
+  provide: APP_CHANGE_DETECT,
+  useFactory: _changeDetectFactory,
+  deps: [[new Inject(APP_CHANGE_DETECT), new Optional(), new SkipSelf()]]
+};

--- a/packages/core/src/zone.ts
+++ b/packages/core/src/zone.ts
@@ -7,4 +7,4 @@
  */
 
 // Public API for Zone
-export {NgZone} from './zone/ng_zone';
+export {NgZone, NoNgZone} from './zone/ng_zone';

--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -98,7 +98,7 @@ export class NgZone {
   readonly onUnstable: EventEmitter<any> = new EventEmitter(false);
 
   /**
-   * Notifies when there is no more microtasks enqueue in the current VM Turn.
+   * Notifies when there is no more microtasks enqueued in the current VM Turn.
    * This is a hint for Angular to do change detection, which may enqueue more microtasks.
    * For this reason this event can fire multiple times per VM Turn.
    */
@@ -112,7 +112,7 @@ export class NgZone {
   readonly onStable: EventEmitter<any> = new EventEmitter(false);
 
   /**
-   * Notify that an error has been delivered.
+   * Notifies that an error has been delivered.
    */
   readonly onError: EventEmitter<any> = new EventEmitter(false);
 
@@ -275,4 +275,26 @@ function onEnter(zone: NgZonePrivate) {
 function onLeave(zone: NgZonePrivate) {
   zone._nesting--;
   checkStable(zone);
+}
+
+/**
+ * Provides a noop implementation of `NgZone` which does nothing. This zone requires explicit calls
+ * to framework to perform rendering.
+ *
+ * @stable
+ */
+export class NoNgZone implements NgZone {
+  readonly hasPendingMicrotasks: boolean = false;
+  readonly hasPendingMacrotasks: boolean = false;
+  readonly isStable: boolean = true;
+  readonly onUnstable: EventEmitter<any> = new EventEmitter();
+  readonly onMicrotaskEmpty: EventEmitter<any> = new EventEmitter();
+  readonly onStable: EventEmitter<any> = new EventEmitter();
+  readonly onError: EventEmitter<any> = new EventEmitter();
+
+  run(fn: () => any): any { return fn(); }
+
+  runGuarded(fn: () => any): any { return fn(); }
+
+  runOutsideAngular(fn: () => any): any { return fn(); }
 }

--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -84,18 +84,37 @@ import {EventEmitter} from '../event_emitter';
  * @experimental
  */
 export class NgZone {
-  private outer: Zone;
-  private inner: Zone;
+  readonly hasPendingMicrotasks: boolean = false;
+  readonly hasPendingMacrotasks: boolean = false;
 
-  private _hasPendingMicrotasks: boolean = false;
-  private _hasPendingMacrotasks: boolean = false;
+  /**
+   * Whether there are no outstanding microtasks or macrotasks.
+   */
+  readonly isStable: boolean = true;
 
-  private _isStable = true;
-  private _nesting: number = 0;
-  private _onUnstable: EventEmitter<any> = new EventEmitter(false);
-  private _onMicrotaskEmpty: EventEmitter<any> = new EventEmitter(false);
-  private _onStable: EventEmitter<any> = new EventEmitter(false);
-  private _onErrorEvents: EventEmitter<any> = new EventEmitter(false);
+  /**
+   * Notifies when code enters Angular Zone. This gets fired first on VM Turn.
+   */
+  readonly onUnstable: EventEmitter<any> = new EventEmitter(false);
+
+  /**
+   * Notifies when there is no more microtasks enqueue in the current VM Turn.
+   * This is a hint for Angular to do change detection, which may enqueue more microtasks.
+   * For this reason this event can fire multiple times per VM Turn.
+   */
+  readonly onMicrotaskEmpty: EventEmitter<any> = new EventEmitter(false);
+
+  /**
+   * Notifies when the last `onMicrotaskEmpty` has run and there are no more microtasks, which
+   * implies we are about to relinquish VM turn.
+   * This event gets called just once.
+   */
+  readonly onStable: EventEmitter<any> = new EventEmitter(false);
+
+  /**
+   * Notify that an error has been delivered.
+   */
+  readonly onError: EventEmitter<any> = new EventEmitter(false);
 
   constructor({enableLongStackTrace = false}) {
     if (typeof Zone == 'undefined') {
@@ -103,18 +122,20 @@ export class NgZone {
     }
 
     Zone.assertZonePatched();
+    const self = this as any as NgZonePrivate;
+    self._nesting = 0;
 
-    this.outer = this.inner = Zone.current;
+    self._outer = self._inner = Zone.current;
 
     if ((Zone as any)['wtfZoneSpec']) {
-      this.inner = this.inner.fork((Zone as any)['wtfZoneSpec']);
+      self._inner = self._inner.fork((Zone as any)['wtfZoneSpec']);
     }
 
     if (enableLongStackTrace && (Zone as any)['longStackTraceZoneSpec']) {
-      this.inner = this.inner.fork((Zone as any)['longStackTraceZoneSpec']);
+      self._inner = self._inner.fork((Zone as any)['longStackTraceZoneSpec']);
     }
 
-    this.forkInnerZoneWithAngularBehavior();
+    forkInnerZoneWithAngularBehavior(self);
   }
 
   static isInAngularZone(): boolean { return Zone.current.get('isAngularZone') === true; }
@@ -124,6 +145,7 @@ export class NgZone {
       throw new Error('Expected to be in Angular Zone, but it is not!');
     }
   }
+
   static assertNotInAngularZone(): void {
     if (NgZone.isInAngularZone()) {
       throw new Error('Expected to not be in Angular Zone, but it is!');
@@ -142,13 +164,13 @@ export class NgZone {
    *
    * If a synchronous error happens it will be rethrown and not reported via `onError`.
    */
-  run(fn: () => any): any { return this.inner.run(fn); }
+  run(fn: () => any): any { return (this as any as NgZonePrivate)._inner.run(fn); }
 
   /**
    * Same as `run`, except that synchronous errors are caught and forwarded via `onError` and not
    * rethrown.
    */
-  runGuarded(fn: () => any): any { return this.inner.runGuarded(fn); }
+  runGuarded(fn: () => any): any { return (this as any as NgZonePrivate)._inner.runGuarded(fn); }
 
   /**
    * Executes the `fn` function synchronously in Angular's parent zone and returns value returned by
@@ -163,125 +185,94 @@ export class NgZone {
    *
    * Use {@link #run} to reenter the Angular zone and do work that updates the application model.
    */
-  runOutsideAngular(fn: () => any): any { return this.outer.run(fn); }
+  runOutsideAngular(fn: () => any): any { return (this as any as NgZonePrivate)._outer.run(fn); }
+}
 
-  /**
-   * Notifies when code enters Angular Zone. This gets fired first on VM Turn.
-   */
-  get onUnstable(): EventEmitter<any> { return this._onUnstable; }
+interface NgZonePrivate extends NgZone {
+  _outer: Zone;
+  _inner: Zone;
+  _nesting: number;
 
-  /**
-   * Notifies when there is no more microtasks enqueue in the current VM Turn.
-   * This is a hint for Angular to do change detection, which may enqueue more microtasks.
-   * For this reason this event can fire multiple times per VM Turn.
-   */
-  get onMicrotaskEmpty(): EventEmitter<any> { return this._onMicrotaskEmpty; }
+  hasPendingMicrotasks: boolean;
+  hasPendingMacrotasks: boolean;
+  isStable: boolean;
+}
 
-  /**
-   * Notifies when the last `onMicrotaskEmpty` has run and there are no more microtasks, which
-   * implies we are about to relinquish VM turn.
-   * This event gets called just once.
-   */
-  get onStable(): EventEmitter<any> { return this._onStable; }
+function checkStable(zone: NgZonePrivate) {
+  if (zone._nesting == 0 && !zone.hasPendingMicrotasks && !zone.isStable) {
+    try {
+      zone._nesting++;
+      zone.onMicrotaskEmpty.emit(null);
+    } finally {
+      zone._nesting--;
+      if (!zone.hasPendingMicrotasks) {
+        try {
+          zone.runOutsideAngular(() => zone.onStable.emit(null));
+        } finally {
+          zone.isStable = true;
+        }
+      }
+    }
+  }
+}
 
-  /**
-   * Notify that an error has been delivered.
-   */
-  get onError(): EventEmitter<any> { return this._onErrorEvents; }
-
-  /**
-   * Whether there are no outstanding microtasks or macrotasks.
-   */
-  get isStable(): boolean { return this._isStable; }
-
-  get hasPendingMicrotasks(): boolean { return this._hasPendingMicrotasks; }
-
-  get hasPendingMacrotasks(): boolean { return this._hasPendingMacrotasks; }
-
-  private checkStable() {
-    if (this._nesting == 0 && !this._hasPendingMicrotasks && !this._isStable) {
+function forkInnerZoneWithAngularBehavior(zone: NgZonePrivate) {
+  zone._inner = zone._inner.fork({
+    name: 'angular',
+    properties: <any>{'isAngularZone': true},
+    onInvokeTask: (delegate: ZoneDelegate, current: Zone, target: Zone, task: Task, applyThis: any,
+                   applyArgs: any): any => {
       try {
-        this._nesting++;
-        this._onMicrotaskEmpty.emit(null);
+        onEnter(zone);
+        return delegate.invokeTask(target, task, applyThis, applyArgs);
       } finally {
-        this._nesting--;
-        if (!this._hasPendingMicrotasks) {
-          try {
-            this.runOutsideAngular(() => this._onStable.emit(null));
-          } finally {
-            this._isStable = true;
-          }
-        }
+        onLeave(zone);
       }
-    }
-  }
-
-  private forkInnerZoneWithAngularBehavior() {
-    this.inner = this.inner.fork({
-      name: 'angular',
-      properties: <any>{'isAngularZone': true},
-      onInvokeTask: (delegate: ZoneDelegate, current: Zone, target: Zone, task: Task,
-                     applyThis: any, applyArgs: any): any => {
-        try {
-          this.onEnter();
-          return delegate.invokeTask(target, task, applyThis, applyArgs);
-        } finally {
-          this.onLeave();
-        }
-      },
+    },
 
 
-      onInvoke: (delegate: ZoneDelegate, current: Zone, target: Zone, callback: Function,
-                 applyThis: any, applyArgs: any[], source: string): any => {
-        try {
-          this.onEnter();
-          return delegate.invoke(target, callback, applyThis, applyArgs, source);
-        } finally {
-          this.onLeave();
-        }
-      },
+    onInvoke: (delegate: ZoneDelegate, current: Zone, target: Zone, callback: Function,
+               applyThis: any, applyArgs: any[], source: string): any => {
+      try {
+        onEnter(zone);
+        return delegate.invoke(target, callback, applyThis, applyArgs, source);
+      } finally {
+        onLeave(zone);
+      }
+    },
 
-      onHasTask:
-          (delegate: ZoneDelegate, current: Zone, target: Zone, hasTaskState: HasTaskState) => {
-            delegate.hasTask(target, hasTaskState);
-            if (current === target) {
-              // We are only interested in hasTask events which originate from our zone
-              // (A child hasTask event is not interesting to us)
-              if (hasTaskState.change == 'microTask') {
-                this.setHasMicrotask(hasTaskState.microTask);
-              } else if (hasTaskState.change == 'macroTask') {
-                this.setHasMacrotask(hasTaskState.macroTask);
-              }
+    onHasTask:
+        (delegate: ZoneDelegate, current: Zone, target: Zone, hasTaskState: HasTaskState) => {
+          delegate.hasTask(target, hasTaskState);
+          if (current === target) {
+            // We are only interested in hasTask events which originate from our zone
+            // (A child hasTask event is not interesting to us)
+            if (hasTaskState.change == 'microTask') {
+              zone.hasPendingMicrotasks = hasTaskState.microTask;
+              checkStable(zone);
+            } else if (hasTaskState.change == 'macroTask') {
+              zone.hasPendingMacrotasks = hasTaskState.macroTask;
             }
-          },
+          }
+        },
 
-      onHandleError: (delegate: ZoneDelegate, current: Zone, target: Zone, error: any): boolean => {
-        delegate.handleError(target, error);
-        this.triggerError(error);
-        return false;
-      }
-    });
-  }
-
-  private onEnter() {
-    this._nesting++;
-    if (this._isStable) {
-      this._isStable = false;
-      this._onUnstable.emit(null);
+    onHandleError: (delegate: ZoneDelegate, current: Zone, target: Zone, error: any): boolean => {
+      delegate.handleError(target, error);
+      zone.onError.emit(error);
+      return false;
     }
+  });
+}
+
+function onEnter(zone: NgZonePrivate) {
+  zone._nesting++;
+  if (zone.isStable) {
+    zone.isStable = false;
+    zone.onUnstable.emit(null);
   }
+}
 
-  private onLeave() {
-    this._nesting--;
-    this.checkStable();
-  }
-
-  private setHasMicrotask(hasMicrotasks: boolean) {
-    this._hasPendingMicrotasks = hasMicrotasks;
-    this.checkStable();
-  }
-
-  private setHasMacrotask(hasMacrotasks: boolean) { this._hasPendingMacrotasks = hasMacrotasks; }
-
-  private triggerError(error: any) { this._onErrorEvents.emit(error); }
+function onLeave(zone: NgZonePrivate) {
+  zone._nesting--;
+  checkStable(zone);
 }

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, Compiler, CompilerFactory, Component, NgModule, NgZone, PlatformRef, TemplateRef, Type, ViewChild, ViewContainerRef} from '@angular/core';
+import {APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, Compiler, CompilerFactory, Component, NgModule, NgZone, NoNgZone, PlatformRef, TemplateRef, Type, ViewChild, ViewContainerRef} from '@angular/core';
 import {ApplicationRef, ApplicationRef_} from '@angular/core/src/application_ref';
 import {ErrorHandler} from '@angular/core/src/error_handler';
 import {ComponentRef} from '@angular/core/src/linker/component_factory';
@@ -287,6 +287,15 @@ export function main() {
       it('should add bootstrapped module into platform modules list', async(() => {
            defaultPlatform.bootstrapModule(createModule({bootstrap: [SomeComponent]}))
                .then(module => expect((<any>defaultPlatform)._modules).toContain(module));
+         }));
+
+      it('should bootstrap with NoNgZone', async(() => {
+           defaultPlatform
+               .bootstrapModule(createModule({bootstrap: [SomeComponent]}), {ngZone: 'none'})
+               .then(module => {
+                 const ngZone = module.injector.get(NgZone);
+                 expect(ngZone instanceof NoNgZone).toBe(true);
+               });
          }));
     });
 

--- a/packages/core/test/testability/testability_spec.ts
+++ b/packages/core/test/testability/testability_spec.ts
@@ -28,22 +28,20 @@ function microTask(fn: Function): void {
 @Injectable()
 class MockNgZone extends NgZone {
   /** @internal */
-  _onUnstableStream: EventEmitter<any>;
-  get onUnstable() { return this._onUnstableStream; }
+  onUnstable: EventEmitter<any>;
 
   /** @internal */
-  _onStableStream: EventEmitter<any>;
-  get onStable() { return this._onStableStream; }
+  onStable: EventEmitter<any>;
 
   constructor() {
     super({enableLongStackTrace: false});
-    this._onUnstableStream = new EventEmitter(false);
-    this._onStableStream = new EventEmitter(false);
+    this.onUnstable = new EventEmitter(false);
+    this.onStable = new EventEmitter(false);
   }
 
-  unstable(): void { this._onUnstableStream.emit(null); }
+  unstable(): void { this.onUnstable.emit(null); }
 
-  stable(): void { this._onStableStream.emit(null); }
+  stable(): void { this.onStable.emit(null); }
 }
 
 export function main() {

--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgZone} from '@angular/core/src/zone/ng_zone';
+import {EventEmitter, NgZone, NoNgZone} from '@angular/core';
 import {async, fakeAsync, flushMicrotasks} from '@angular/core/testing';
 import {AsyncTestCompleter, Log, beforeEach, describe, expect, inject, it, xit} from '@angular/core/testing/src/testing_internal';
 import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
+
 import {scheduleMicroTask} from '../../src/util';
 
 const needsLongerTimers = browserDetection.isSlow || browserDetection.isEdge;
@@ -166,6 +167,25 @@ export function main() {
              });
            });
          }), testTimeout);
+    });
+  });
+
+  describe('NoNgZone', () => {
+    const ngZone = new NoNgZone();
+
+    it('should run', () => {
+      let works = false;
+      ngZone.run(() => {
+        ngZone.runGuarded(() => { ngZone.runOutsideAngular(() => { works = true; }); });
+      });
+      expect(works).toBe(true);
+    });
+
+    it('should have eventEmitters', () => {
+      expect(ngZone.onError instanceof EventEmitter).toBe(true);
+      expect(ngZone.onStable instanceof EventEmitter).toBe(true);
+      expect(ngZone.onUnstable instanceof EventEmitter).toBe(true);
+      expect(ngZone.onMicrotaskEmpty instanceof EventEmitter).toBe(true);
     });
   });
 }

--- a/packages/core/testing/src/ng_zone_mock.ts
+++ b/packages/core/testing/src/ng_zone_mock.ts
@@ -14,11 +14,12 @@ import {EventEmitter, Injectable, NgZone} from '@angular/core';
  */
 @Injectable()
 export class MockNgZone extends NgZone {
-  private _mockOnStable: EventEmitter<any> = new EventEmitter(false);
+  onStable: EventEmitter<any>;
 
-  constructor() { super({enableLongStackTrace: false}); }
-
-  get onStable() { return this._mockOnStable; }
+  constructor() {
+    super({enableLongStackTrace: false});
+    this.onStable = new EventEmitter(false);
+  }
 
   run(fn: Function): any { return fn(); }
 

--- a/packages/core/testing/src/ng_zone_mock.ts
+++ b/packages/core/testing/src/ng_zone_mock.ts
@@ -14,12 +14,9 @@ import {EventEmitter, Injectable, NgZone} from '@angular/core';
  */
 @Injectable()
 export class MockNgZone extends NgZone {
-  onStable: EventEmitter<any>;
+  onStable: EventEmitter<any> = new EventEmitter(false);
 
-  constructor() {
-    super({enableLongStackTrace: false});
-    this.onStable = new EventEmitter(false);
-  }
+  constructor() { super({enableLongStackTrace: false}); }
 
   run(fn: Function): any { return fn(); }
 

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -1,3 +1,4 @@
+import { APP_CHANGE_DETECT, defaultAppChangeDetect } from './../../../core/src/application_tokens';
 /**
  * @license
  * Copyright Google Inc. All Rights Reserved.
@@ -13,6 +14,7 @@ import {Console} from '@angular/core/src/console';
 import {ComponentRef} from '@angular/core/src/linker/component_factory';
 import {Testability, TestabilityRegistry} from '@angular/core/src/testability/testability';
 import {AsyncTestCompleter, Log, afterEach, beforeEach, beforeEachProviders, ddescribe, describe, iit, inject, it} from '@angular/core/testing/src/testing_internal';
+import {NgZone} from '@angular/core/src/zone/ng_zone';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
@@ -303,6 +305,20 @@ export function main() {
 
          refPromise.then(ref => {
            expect(ref.injector.get(LOCALE_ID)).toEqual('fr-FR');
+           async.done();
+         });
+       }));
+
+    it('should not override change detection callback provided during bootstrap',
+       inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+
+         const changeDetect = (ref: ApplicationRef, zone: NgZone) => { zone.run(() => ref.tick())};
+         
+         const refPromise =
+             bootstrap(HelloRootCmp, [testProviders], [{provide: APP_CHANGE_DETECT, useValue: changeDetect}]);
+
+         refPromise.then(ref => {
+           expect(ref.injector.get(ApplicationRef)._detectChanges).toBe(changeDetect);
            async.done();
          });
        }));

--- a/packages/upgrade/src/common/util.ts
+++ b/packages/upgrade/src/common/util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Type} from '@angular/core';
+import { Type, InjectionToken, Inject, Optional, SkipSelf, NgZone } from '@angular/core';
 import * as angular from './angular1';
 
 export function onError(e: any) {
@@ -82,3 +82,21 @@ export function hookupNgModel(ngModel: angular.INgModelController, component: an
 export function strictEquals(val1: any, val2: any): boolean {
   return val1 === val2 || (val1 !== val1 && val2 !== val2);
 }
+
+export type UpgradeChangeDetect = ($rootScope: angular.IRootScopeService, zone: NgZone) => void;
+
+export const defaultUpgradeChangeDetect: UpgradeChangeDetect = ($rootScope) => $rootScope.$digest()
+
+export function _upgradeChangeDetectFactory(changeDetect?: UpgradeChangeDetect): UpgradeChangeDetect {
+  return changeDetect || defaultUpgradeChangeDetect;
+}
+
+/**
+ * A callback used to change detect the application.
+ * @experimental
+ */
+export const UPGRADE_CHANGE_DETECT_PROVIDER = {
+  provide: 'UPGRADE_CHANGE_DETECT',
+  useFactory: _upgradeChangeDetectFactory,
+  deps: [[new Inject('UPGRADE_CHANGE_DETECT'), new Optional(), new SkipSelf()]]
+};

--- a/packages/upgrade/src/dynamic/upgrade_adapter.ts
+++ b/packages/upgrade/src/dynamic/upgrade_adapter.ts
@@ -561,9 +561,9 @@ export class UpgradeAdapter {
                     constructor: function DynamicNgUpgradeModule() {},
                     ngDoBootstrap: function() {}
                   });
-              (platformRef as any)
-                  ._bootstrapModuleWithZone(
-                      DynamicNgUpgradeModule, this.compilerOptions, this.ngZone)
+              platformRef
+                  .bootstrapModule(
+                      DynamicNgUpgradeModule, [this.compilerOptions, {ngZone: this.ngZone}])
                   .then((ref: NgModuleRef<any>) => {
                     this.moduleRef = ref;
                     this.ngZone.run(() => {

--- a/packages/upgrade/src/dynamic/upgrade_adapter.ts
+++ b/packages/upgrade/src/dynamic/upgrade_adapter.ts
@@ -13,7 +13,7 @@ import * as angular from '../common/angular1';
 import {$$TESTABILITY, $COMPILE, $INJECTOR, $ROOT_SCOPE, COMPILER_KEY, INJECTOR_KEY, NG_ZONE_KEY} from '../common/constants';
 import {downgradeComponent} from '../common/downgrade_component';
 import {downgradeInjectable} from '../common/downgrade_injectable';
-import {Deferred, controllerKey, onError} from '../common/util';
+import { Deferred, controllerKey, onError, UPGRADE_CHANGE_DETECT_PROVIDER } from '../common/util';
 
 import {UpgradeNg1ComponentAdapterBuilder} from './upgrade_ng1_adapter';
 
@@ -553,6 +553,7 @@ export class UpgradeAdapter {
                     providers: [
                       {provide: $INJECTOR, useFactory: () => ng1Injector},
                       {provide: $COMPILE, useFactory: () => ng1Injector.get($COMPILE)},
+                      UPGRADE_CHANGE_DETECT_PROVIDER,
                       this.upgradedProviders
                     ],
                     imports: [this.ng2AppModule],
@@ -578,8 +579,9 @@ export class UpgradeAdapter {
                   })
                   .then(() => this.ng2BootstrapDeferred.resolve(ng1Injector), onError)
                   .then(() => {
+                    const changeDetect = this.moduleRef !.injector.get('UPGRADE_CHANGE_DETECT');
                     let subscription =
-                        this.ngZone.onMicrotaskEmpty.subscribe({next: () => rootScope.$digest()});
+                        this.ngZone.onMicrotaskEmpty.subscribe({next: changeDetect.bind(this, rootScope, this.ngZone)});
                     rootScope.$on('$destroy', () => { subscription.unsubscribe(); });
                   });
             })

--- a/packages/upgrade/src/static/angular1_providers.ts
+++ b/packages/upgrade/src/static/angular1_providers.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import { UPGRADE_CHANGE_DETECT_PROVIDER } from '../common/util';
 import * as angular from '../common/angular1';
 
 // We have to do a little dance to get the ng1 injector into the module injector.

--- a/packages/upgrade/src/static/upgrade_module.ts
+++ b/packages/upgrade/src/static/upgrade_module.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, NgModule, NgZone, Testability, ɵNOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from '@angular/core';
+import { Injector, NgModule, NgZone, Testability, ɵNOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR, Inject } from '@angular/core';
 
 import * as angular from '../common/angular1';
 import {$$TESTABILITY, $DELEGATE, $INJECTOR, $INTERVAL, $PROVIDE, INJECTOR_KEY, UPGRADE_MODULE_NAME} from '../common/constants';
-import {controllerKey} from '../common/util';
+import { controllerKey, UPGRADE_CHANGE_DETECT_PROVIDER, UpgradeChangeDetect } from '../common/util';
 
 import {angular1Providers, setTempInjectorRef} from './angular1_providers';
 
@@ -129,7 +129,7 @@ import {angular1Providers, setTempInjectorRef} from './angular1_providers';
  *
  * @experimental
  */
-@NgModule({providers: [angular1Providers]})
+@NgModule({providers: [angular1Providers, UPGRADE_CHANGE_DETECT_PROVIDER]})
 export class UpgradeModule {
   /**
    * The AngularJS `$injector` for the upgrade application.
@@ -237,8 +237,9 @@ export class UpgradeModule {
                 // stabilizing
                 setTimeout(() => {
                   const $rootScope = $injector.get('$rootScope');
+                  const changeDetect = this.injector.get('UPGRADE_CHANGE_DETECT');
                   const subscription =
-                      this.ngZone.onMicrotaskEmpty.subscribe(() => $rootScope.$digest());
+                      this.ngZone.onMicrotaskEmpty.subscribe(changeDetect.bind(this, $rootScope, this.ngZone));
                   $rootScope.$on('$destroy', () => { subscription.unsubscribe(); });
                 }, 0);
               }

--- a/packages/upgrade/test/dynamic/upgrade_spec.ts
+++ b/packages/upgrade/test/dynamic/upgrade_spec.ts
@@ -74,7 +74,7 @@ export function main() {
 
       it('supports the compilerOptions argument', async(() => {
            const platformRef = platformBrowserDynamic();
-           spyOn(platformRef, '_bootstrapModuleWithZone').and.callThrough();
+           spyOn(platformRef, 'bootstrapModule').and.callThrough();
 
            const ng1Module = angular.module('ng1', []);
            const Ng2 = Component({
@@ -94,8 +94,9 @@ export function main() {
            const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2AppModule, {providers: []});
            ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
            adapter.bootstrap(element, ['ng1']).ready((ref) => {
-             expect((platformRef as any)._bootstrapModuleWithZone)
-                 .toHaveBeenCalledWith(jasmine.any(Function), {providers: []}, jasmine.any(Object));
+             expect((platformRef as any).bootstrapModule)
+                 .toHaveBeenCalledWith(
+                     jasmine.any(Function), [{providers: []}, jasmine.any(Object)]);
              ref.dispose();
            });
          }));

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -662,6 +662,20 @@ export declare class NgZone {
 export declare const NO_ERRORS_SCHEMA: SchemaMetadata;
 
 /** @stable */
+export declare class NoNgZone implements NgZone {
+    readonly hasPendingMacrotasks: boolean;
+    readonly hasPendingMicrotasks: boolean;
+    readonly isStable: boolean;
+    readonly onError: EventEmitter<any>;
+    readonly onMicrotaskEmpty: EventEmitter<any>;
+    readonly onStable: EventEmitter<any>;
+    readonly onUnstable: EventEmitter<any>;
+    run(fn: () => any): any;
+    runGuarded(fn: () => any): any;
+    runOutsideAngular(fn: () => any): any;
+}
+
+/** @stable */
 export interface OnChanges {
     ngOnChanges(changes: SimpleChanges): void;
 }
@@ -719,8 +733,8 @@ export declare const platformCore: (extraProviders?: Provider[] | undefined) => 
 export declare abstract class PlatformRef {
     readonly abstract destroyed: boolean;
     readonly abstract injector: Injector;
-    /** @stable */ abstract bootstrapModule<M>(moduleType: Type<M>, compilerOptions?: CompilerOptions | CompilerOptions[]): Promise<NgModuleRef<M>>;
-    /** @experimental */ abstract bootstrapModuleFactory<M>(moduleFactory: NgModuleFactory<M>): Promise<NgModuleRef<M>>;
+    /** @stable */ abstract bootstrapModule<M>(moduleType: Type<M>, compilerOptions?: (CompilerOptions & BootstrapOptions) | Array<CompilerOptions & BootstrapOptions>): Promise<NgModuleRef<M>>;
+    /** @experimental */ abstract bootstrapModuleFactory<M>(moduleFactory: NgModuleFactory<M>, options?: BootstrapOptions): Promise<NgModuleRef<M>>;
     abstract destroy(): void;
     abstract onDestroy(callback: () => void): void;
 }


### PR DESCRIPTION
This PR allows users to configure how change detection happens. Currently this isn't configurable, and both in Angular and AngularJS apps we will change detect on every ngZone.onMicrotaskEmpty. But this might not be the desirable behavior. Thus this PR allows users to configure when to change detect (so they can do something like throttle change detection).