### PR TITLE
feat(core): allow tests to disable the automatic calls of TestBed.res…

### DIFF
--- a/packages/core/test/before_each_spec.ts
+++ b/packages/core/test/before_each_spec.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { TestBed, enableTestBedAutoReset, disableTestBedAutoReset } from '../testing';
+
+describe('before_each', () => {
+
+    describe('default behavior', () => {
+        const originalTestBedresetTestingModule = TestBed.resetTestingModule;
+        let resetTestingModuleCalled = false;
+
+        beforeAll(() => {
+            // replace TestBed.resetTestingModule with a mock function
+            TestBed.resetTestingModule = () => {
+                resetTestingModuleCalled = true;
+                return TestBed;
+            };
+        });
+
+        afterAll(() => {
+            TestBed.resetTestingModule = originalTestBedresetTestingModule;
+        });
+
+        it ('should call TestBed.resetTestingModule in beforeEach', () => {
+            expect(resetTestingModuleCalled).toBeTruthy();
+        });
+    });
+
+    describe('when disableTestBedAutoReset was called', () => {
+        const originalTestBedresetTestingModule = TestBed.resetTestingModule;
+        let resetTestingModuleCalled = false;
+
+        beforeAll(() => {
+            // replace TestBed.resetTestingModule with a mock function
+            TestBed.resetTestingModule = () => {
+                resetTestingModuleCalled = true;
+                return TestBed;
+            };
+        });
+
+        beforeAll(disableTestBedAutoReset);
+
+        afterAll(() => {
+            TestBed.resetTestingModule = originalTestBedresetTestingModule;
+        });
+
+        it ('should not call TestBed.resetTestingModule in beforeEach', () => {
+            expect(resetTestingModuleCalled).toBeFalsy();
+        });
+    });
+
+    describe('when enableTestBedAutoReset was called', () => {
+        const originalTestBedresetTestingModule = TestBed.resetTestingModule;
+        let resetTestingModuleCalled = false;
+
+        beforeAll(() => {
+            // replace TestBed.resetTestingModule with a mock function
+            TestBed.resetTestingModule = () => {
+                resetTestingModuleCalled = true;
+                return TestBed;
+            };
+        });
+
+        beforeAll(disableTestBedAutoReset);
+        beforeAll(enableTestBedAutoReset);
+
+        afterAll(() => {
+            TestBed.resetTestingModule = originalTestBedresetTestingModule;
+        });
+
+        it ('should call TestBed.resetTestingModule in beforeEach', () => {
+            expect(resetTestingModuleCalled).toBeTruthy();
+        });
+    });
+});

--- a/packages/core/testing/src/before_each.ts
+++ b/packages/core/testing/src/before_each.ts
@@ -17,16 +17,30 @@ import {TestBed} from './test_bed';
 
 declare var global: any;
 
+let resetTestingModuleInBeforeEach = true;
+
 const _global = <any>(typeof window === 'undefined' ? global : window);
 
 // Reset the test providers and the fake async zone before each test.
 if (_global.beforeEach) {
   _global.beforeEach(() => {
-    TestBed.resetTestingModule();
+    if (resetTestingModuleInBeforeEach) TestBed.resetTestingModule();
     resetFakeAsyncZone();
   });
 }
 
-// TODO(juliemr): remove this, only used because we need to export something to have compilation
-// work.
-export const __core_private_testing_placeholder__ = '';
+/**
+ * By default, Angular calls TestBed.resetTestingModule in Jasmine's beforeEach.
+ * This is not always necessary and can slow down test execution.
+ * Calling disableTestBedAutoReset disables this behavior.
+ */
+export function disableTestBedAutoReset() {
+  resetTestingModuleInBeforeEach = false;
+}
+
+/**
+ * Reenable the automatic TestBed reset.
+ */
+export function enableTestBedAutoReset() {
+  resetTestingModuleInBeforeEach = true;
+}


### PR DESCRIPTION
…etTestingModule in beforeEach

Allow a developer to temporarily disable automatic calls of TestBed.resetTestingModule, so that
a test developer can control when the TestBed should be reset. This enables faster test execution
for some test cases.

## PR Checklist
Does please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Angular automatically calls TestBed.resetTestingModule in Jasmine's beforeEach. Because of that behavior, test duration for the tests in our company's project is much longer than necessary.

Issue Number: N/A


## What is the new behavior?

Allow a developer to temporarily disable automatic calls of TestBed.resetTestingModule, so that a test developer can control when the TestBed should be reset. This enables faster test execution for some test cases. For example, a large spec for a complex component that we developed in our company, test execution time was reduced from 45 seconds to 3.5 seconds.

For complex components, we often perform some action in beforeEach and then have many "it" that only test expectations. Today, we need to reexecute the test for every it, although that would not be necessary. The alternative would be to move all expectations to a single "it". However, this would make it much harder to analyze why a test fails. The test would result in a failure after the first failed expectation, and we would not be able to see if the other expectations also failed or if they would have executed successfully.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
