### PR TITLE
build(aio): boilerplate wont be removed by default now

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -15,7 +15,7 @@
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn ~~update-webdriver",
     "e2e": "ng e2e --no-webdriver-update",
-    "setup": "yarn && yarn build-ie-polyfills && yarn boilerplate:add && yarn generate-plunkers && yarn generate-zips && yarn docs",
+    "setup": "yarn && yarn build-ie-polyfills && yarn boilerplate:remove && yarn boilerplate:add && yarn generate-plunkers && yarn generate-zips && yarn docs",
     "pretest-pwa-score-local": "yarn build",
     "test-pwa-score-local": "concurrently --kill-others --success first \"http-server dist -p 4200 --silent\" \"yarn test-pwa-score -- http://localhost:4200 90\"",
     "test-pwa-score": "node scripts/test-pwa-score",

--- a/aio/tools/examples/add-example-boilerplate.js
+++ b/aio/tools/examples/add-example-boilerplate.js
@@ -30,7 +30,6 @@ const files = {
 
 // requires admin access because it adds symlinks
 function add() {
-  remove();
   const realPath = path.join(SHARED_PATH, '/node_modules');
   const nodeModulesPaths = getNodeModulesPaths(EXAMPLES_PATH);
 


### PR DESCRIPTION
This was decided on a sync. Now it won't remove by default (since it is a pretty bit destructive)

Fixes #17563 