### PR TITLE
refactor(compiler-cli): remove the dependency on fs in codegen.ts

### DIFF
--- a/packages/compiler-cli/src/codegen.ts
+++ b/packages/compiler-cli/src/codegen.ts
@@ -13,7 +13,6 @@
 import * as compiler from '@angular/compiler';
 import {MissingTranslationStrategy} from '@angular/core';
 import {AngularCompilerOptions, NgcCliOptions} from '@angular/tsc-wrapped';
-import {readFileSync} from 'fs';
 import * as ts from 'typescript';
 
 import {CompilerHost, CompilerHostContext, ModuleResolutionHostAdapter} from './compiler_host';
@@ -76,7 +75,7 @@ export class CodeGenerator {
         throw new Error(
             `The translation file (${cliOptions.i18nFile}) locale must be provided. Use the --locale option.`);
       }
-      transContent = readFileSync(cliOptions.i18nFile, 'utf8');
+      transContent = tsCompilerHost.readFile(cliOptions.i18nFile);
     }
     let missingTranslation = MissingTranslationStrategy.Warning;
     if (cliOptions.missingTranslation) {


### PR DESCRIPTION
## PR Checklist
Does please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `codegen.ts` file in `compiler-cli/src/` currently has a dependency on `fs`, specifically to read a file.

Issue Number: N/A


## What is the new behavior?
We remove the dependency on `fs`, instead replacing the call to `fs.readFileSync` with a call to the `readFile` method in the compiler host. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
