### PR TITLE
fix(aio): build `scripts-js` before creating a new docker image for the preview server

### DIFF
--- a/aio/aio-builds-setup/scripts/create-image.sh
+++ b/aio/aio-builds-setup/scripts/create-image.sh
@@ -5,6 +5,14 @@ set -eux -o pipefail
 source "`dirname $0`/_env.sh"
 readonly defaultImageNameAndTag="aio-builds:latest"
 
+# Build `scripts-js/`
+# (Necessary, because only `scripts-js/dist/` is copied to the docker image.)
+(
+  cd "$SCRIPTS_JS_DIR"
+  yarn install
+  yarn build
+)
+
 # Create docker image
 readonly nameAndOptionalTag=${1:-$defaultImageNameAndTag}
 sudo docker build --tag $nameAndOptionalTag ${@:2} $DOCKERBUILD_DIR


### PR DESCRIPTION
When creating a new docker image for the preview server, the TypeScript source code in `scripts-js/` is not copied over. Instead only the generated JavaScript core in `scripts-js/dist/` are. Because of that, it is necessary to have run `yarn build` before running `docker build`, so that the new docker image contains the latest changes in `scripts-js/`.

This was previously part of the `create-image.sh` script, but was accidentally removed in 21d213dfc.