### PR TITLE
fix(aio): clean up non-public previews

### DIFF
--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/common/constants.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/common/constants.ts
@@ -1,0 +1,2 @@
+// Constants
+export const HIDDEN_DIR_PREFIX = 'hidden--';

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/upload-server/build-creator.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/upload-server/build-creator.ts
@@ -4,15 +4,13 @@ import {EventEmitter} from 'events';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as shell from 'shelljs';
+import {HIDDEN_DIR_PREFIX} from '../common/constants';
 import {assertNotMissingOrEmpty} from '../common/utils';
 import {ChangedPrVisibilityEvent, CreatedBuildEvent} from './build-events';
 import {UploadError} from './upload-error';
 
 // Classes
 export class BuildCreator extends EventEmitter {
-  // Properties - Public, Static
-  public static HIDDEN_DIR_PREFIX = 'hidden--';
-
   // Constructor
   constructor(protected buildsDir: string) {
     super();
@@ -114,7 +112,7 @@ export class BuildCreator extends EventEmitter {
   }
 
   protected getCandidatePrDirs(pr: string, isPublic: boolean) {
-    const hiddenPrDir = path.join(this.buildsDir, BuildCreator.HIDDEN_DIR_PREFIX + pr);
+    const hiddenPrDir = path.join(this.buildsDir, HIDDEN_DIR_PREFIX + pr);
     const publicPrDir = path.join(this.buildsDir, pr);
 
     const oldPrDir = isPublic ? hiddenPrDir : publicPrDir;

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/helper.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/helper.ts
@@ -4,8 +4,8 @@ import * as fs from 'fs';
 import * as http from 'http';
 import * as path from 'path';
 import * as shell from 'shelljs';
+import {HIDDEN_DIR_PREFIX} from '../common/constants';
 import {getEnvVar} from '../common/utils';
-import {BuildCreator} from '../upload-server/build-creator';
 
 // Constans
 const TEST_AIO_BUILDS_DIR = getEnvVar('TEST_AIO_BUILDS_DIR');
@@ -104,7 +104,7 @@ class Helper {
   }
 
   public getPrDir(pr: string, isPublic: boolean): string {
-    const prDirName = isPublic ? pr : BuildCreator.HIDDEN_DIR_PREFIX + pr;
+    const prDirName = isPublic ? pr : HIDDEN_DIR_PREFIX + pr;
     return path.join(this.buildsDir, prDirName);
   }
 


### PR DESCRIPTION
The previous clean-up code for PR directories on the preview server assumed that all directories were named after the PR number. With the changes introduced in #17640 it is possible to have PR directories that do not follow that naming convention (e.g. "non-public" directories).

This PR ensures that both public and non-public directories are removed when cleaning up.