### PR TITLE
ci: is npm install needed for Circle CI?

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
           key: angular-{{ .Branch }}-{{ checksum "npm-shrinkwrap.json" }}
 
       - run: npm install
+      - run: npm run postinstall
       - run: ./node_modules/.bin/gulp lint
 
   build:


### PR DESCRIPTION
Empty PR to check if `npm install` is needed for Circle CI.