### PR TITLE
fix(platform-server): test for style property before using it in cloakElement()

### DIFF
--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -1359,9 +1359,13 @@ function isTriggerEventValid(eventName: string): boolean {
 }
 
 function cloakElement(element: any, value?: string) {
-  const oldValue = element.style.display;
-  element.style.display = value != null ? value : 'none';
-  return oldValue;
+  if ( typeof element.style !== 'undefined' ) {
+    const oldValue = element.style.display;
+    element.style.display = value != null ? value : 'none';
+    return oldValue;
+  }
+  
+  return 'none';
 }
 
 function cloakAndComputeStyles(


### PR DESCRIPTION
## PR Checklist
Does please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
When rendering on the server (Universal / SSR)  packages/animations/browser/src/render/transition_animation_engine.ts cloakElement() is sometimes called with an element that doesn't have a style property.

![screen shot 2017-06-27 at 14 30 36](https://user-images.githubusercontent.com/478872/27587770-ed99c48e-5b45-11e7-9f7b-e75a7fe30fc0.png)

Stack:
![screen shot 2017-06-27 at 14 37 56](https://user-images.githubusercontent.com/478872/27587842-427000d6-5b46-11e7-98ac-961b19251607.png)

Issue Number: N/A

## What is the new behavior?
The change introduces a property test for the existance of the style property and doesn't use the style object when it doesn't exist.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information

I've tried to create a reproduction repo, but wasn't able to trigger the issue in a minimal setup. It seems to be related with async pipes on Observables that trigger a flush of the animation queue in the server side rendered application using an element that doesn't have (yet) an style attribute. Using above patch in cloakElement() we can suppress the encountered symptom and end up with a functional SSR rendered Universal application.