### PR TITLE
feat(aio): add the ability to update a PR's preview visibility

### DIFF
--- a/aio/aio-builds-setup/dockerbuild/nginx/aio-builds.conf
+++ b/aio/aio-builds-setup/dockerbuild/nginx/aio-builds.conf
@@ -88,6 +88,21 @@ server {
     resolver 127.0.0.1;
   }
 
+  # Notify about PR changes
+  location "~^/pr-updated/?$" {
+    if ($request_method != "POST") {
+      add_header Allow "POST";
+      return 405;
+    }
+
+    proxy_pass_request_headers on;
+    proxy_redirect             off;
+    proxy_method               POST;
+    proxy_pass                 http://{{$AIO_UPLOAD_HOSTNAME}}:{{$AIO_UPLOAD_PORT}}$request_uri;
+
+    resolver 127.0.0.1;
+  }
+
   # Everything else
   location / {
     return 404;

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/upload-server/build-creator.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/upload-server/build-creator.ts
@@ -18,45 +18,17 @@ export class BuildCreator extends EventEmitter {
   }
 
   // Methods - Public
-  public changePrVisibility(pr: string, makePublic: boolean): Promise<void> {
-    const {oldPrDir, newPrDir} = this.getCandidatePrDirs(pr, makePublic);
-
-    return Promise.
-      all([this.exists(oldPrDir), this.exists(newPrDir)]).
-      then(([oldPrDirExisted, newPrDirExisted]) => {
-        if (!oldPrDirExisted) {
-          throw new UploadError(404, `Request to move non-existing directory '${oldPrDir}' to '${newPrDir}'.`);
-        } else if (newPrDirExisted) {
-          throw new UploadError(409, `Request to move '${oldPrDir}' to existing directory '${newPrDir}'.`);
-        }
-
-        return Promise.resolve().
-          then(() => shell.mv(oldPrDir, newPrDir)).
-          then(() => this.listShasByDate(newPrDir)).
-          then(shas => this.emit(ChangedPrVisibilityEvent.type, new ChangedPrVisibilityEvent(+pr, shas, makePublic))).
-          then(() => undefined);
-      }).
-      catch(err => {
-        if (!(err instanceof UploadError)) {
-          err = new UploadError(500, `Error while making PR ${pr} ${makePublic ? 'public' : 'hidden'}.\n${err}`);
-        }
-
-        throw err;
-      });
-  }
-
   public create(pr: string, sha: string, archivePath: string, isPublic: boolean): Promise<void> {
     // Use only part of the SHA for more readable URLs.
     sha = sha.substr(0, SHORT_SHA_LEN);
 
-    const {oldPrDir: otherVisPrDir, newPrDir: prDir} = this.getCandidatePrDirs(pr, isPublic);
+    const {newPrDir: prDir} = this.getCandidatePrDirs(pr, isPublic);
     const shaDir = path.join(prDir, sha);
     let dirToRemoveOnError: string;
 
     return Promise.resolve().
-      then(() => this.exists(otherVisPrDir)).
       // If the same PR exists with different visibility, update the visibility first.
-      then(otherVisPrDirExisted => (otherVisPrDirExisted && this.changePrVisibility(pr, isPublic)) as any).
+      then(() => this.updatePrVisibility(pr, isPublic)).
       then(() => Promise.all([this.exists(prDir), this.exists(shaDir)])).
       then(([prDirExisted, shaDirExisted]) => {
         if (shaDirExisted) {
@@ -78,6 +50,36 @@ export class BuildCreator extends EventEmitter {
 
         if (!(err instanceof UploadError)) {
           err = new UploadError(500, `Error while uploading to directory: ${shaDir}\n${err}`);
+        }
+
+        throw err;
+      });
+  }
+
+  public updatePrVisibility(pr: string, makePublic: boolean): Promise<boolean> {
+    const {oldPrDir: otherVisPrDir, newPrDir: targetVisPrDir} = this.getCandidatePrDirs(pr, makePublic);
+
+    return Promise.
+      all([this.exists(otherVisPrDir), this.exists(targetVisPrDir)]).
+      then(([otherVisPrDirExisted, targetVisPrDirExisted]) => {
+        if (!otherVisPrDirExisted) {
+          // No visibility change: Either the visibility is up-to-date or the PR does not exist.
+          return false;
+        } else if (targetVisPrDirExisted) {
+          // Error: Directories for both visibilities exist.
+          throw new UploadError(409, `Request to move '${otherVisPrDir}' to existing directory '${targetVisPrDir}'.`);
+        }
+
+        // Visibility change: Moving `otherVisPrDir` to `targetVisPrDir`.
+        return Promise.resolve().
+          then(() => shell.mv(otherVisPrDir, targetVisPrDir)).
+          then(() => this.listShasByDate(targetVisPrDir)).
+          then(shas => this.emit(ChangedPrVisibilityEvent.type, new ChangedPrVisibilityEvent(+pr, shas, makePublic))).
+          then(() => true);
+      }).
+      catch(err => {
+        if (!(err instanceof UploadError)) {
+          err = new UploadError(500, `Error while making PR ${pr} ${makePublic ? 'public' : 'hidden'}.\n${err}`);
         }
 
         throw err;

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/upload-server/upload-server-factory.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/upload-server/upload-server-factory.ts
@@ -105,8 +105,7 @@ class UploadServerFactory {
       }
     });
     middleware.get(/^\/health-check\/?$/, (_req, res) => res.sendStatus(200));
-    middleware.get('*', req => this.throwRequestError(404, 'Unknown resource', req));
-    middleware.all('*', req => this.throwRequestError(405, 'Unsupported method', req));
+    middleware.all('*', req => this.throwRequestError(404, 'Unknown resource', req));
     middleware.use((err: any, _req: any, res: express.Response, _next: any) => this.respondWithError(res, err));
 
     return middleware;

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/constants.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/constants.ts
@@ -1,0 +1,10 @@
+// Using the values below, we can fake the response of the corresponding methods in tests. This is
+// necessary, because the test upload-server will be running as a separate node process, so we will
+// not have direct access to the code (e.g. for mocking).
+// (See also 'lib/verify-setup/start-test-upload-server.ts'.)
+
+// Special values to be used as `authHeader` in `BuildVerifier#verify()`.
+/* tslint:disable: variable-name */
+export const BV_verify_error = 'FAKE_VERIFICATION_ERROR';
+export const BV_verify_verifiedNotTrusted = 'FAKE_VERIFIED_NOT_TRUSTED';
+/* tslint:enable: variable-name */

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/constants.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/constants.ts
@@ -3,8 +3,14 @@
 // not have direct access to the code (e.g. for mocking).
 // (See also 'lib/verify-setup/start-test-upload-server.ts'.)
 
-// Special values to be used as `authHeader` in `BuildVerifier#verify()`.
 /* tslint:disable: variable-name */
+
+// Special values to be used as `authHeader` in `BuildVerifier#verify()`.
 export const BV_verify_error = 'FAKE_VERIFICATION_ERROR';
 export const BV_verify_verifiedNotTrusted = 'FAKE_VERIFIED_NOT_TRUSTED';
+
+// Special values to be used as `pr` in `BuildVerifier#getPrIsTrusted()`.
+export const BV_getPrIsTrusted_error = 32203;
+export const BV_getPrIsTrusted_notTrusted = 72457;
+
 /* tslint:enable: variable-name */

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/start-test-upload-server.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/start-test-upload-server.ts
@@ -2,16 +2,17 @@
 import {GithubPullRequests} from '../common/github-pull-requests';
 import {BUILD_VERIFICATION_STATUS, BuildVerifier} from '../upload-server/build-verifier';
 import {UploadError} from '../upload-server/upload-error';
+import * as c from './constants';
 
 // Run
 // TODO(gkalpak): Add e2e tests to cover these interactions as well.
 GithubPullRequests.prototype.addComment = () => Promise.resolve();
 BuildVerifier.prototype.verify = (expectedPr: number, authHeader: string) => {
   switch (authHeader) {
-    case 'FAKE_VERIFICATION_ERROR':
+    case c.BV_verify_error:
       // For e2e tests, fake a verification error.
       return Promise.reject(new UploadError(403, `Error while verifying upload for PR ${expectedPr}: Test`));
-    case 'FAKE_VERIFIED_NOT_TRUSTED':
+    case c.BV_verify_verifiedNotTrusted:
       // For e2e tests, fake a `verifiedNotTrusted` verification status.
       return Promise.resolve(BUILD_VERIFICATION_STATUS.verifiedNotTrusted);
     default:

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/start-test-upload-server.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/start-test-upload-server.ts
@@ -7,6 +7,19 @@ import * as c from './constants';
 // Run
 // TODO(gkalpak): Add e2e tests to cover these interactions as well.
 GithubPullRequests.prototype.addComment = () => Promise.resolve();
+BuildVerifier.prototype.getPrIsTrusted = (pr: number) => {
+  switch (pr) {
+    case c.BV_getPrIsTrusted_error:
+      // For e2e tests, fake an error.
+      return Promise.reject('Test');
+    case c.BV_getPrIsTrusted_notTrusted:
+      // For e2e tests, fake an untrusted PR (`false`).
+      return Promise.resolve(false);
+    default:
+      // For e2e tests, default to trusted PRs (`true`).
+      return Promise.resolve(true);
+  }
+};
 BuildVerifier.prototype.verify = (expectedPr: number, authHeader: string) => {
   switch (authHeader) {
     case c.BV_verify_error:

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/start-test-upload-server.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/start-test-upload-server.ts
@@ -1,7 +1,7 @@
 // Imports
 import {GithubPullRequests} from '../common/github-pull-requests';
-import {BUILD_VERIFICATION_STATUS, BuildVerifier} from './build-verifier';
-import {UploadError} from './upload-error';
+import {BUILD_VERIFICATION_STATUS, BuildVerifier} from '../upload-server/build-verifier';
+import {UploadError} from '../upload-server/upload-error';
 
 // Run
 // TODO(gkalpak): Add e2e tests to cover these interactions as well.
@@ -21,4 +21,4 @@ BuildVerifier.prototype.verify = (expectedPr: number, authHeader: string) => {
 };
 
 // tslint:disable-next-line: no-var-requires
-require('./index');
+require('../upload-server/index');

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/upload-server.e2e.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/upload-server.e2e.ts
@@ -1,6 +1,7 @@
 // Imports
 import * as fs from 'fs';
 import * as path from 'path';
+import * as c from './constants';
 import {CmdResult, helper as h} from './helper';
 
 // Tests
@@ -63,7 +64,7 @@ describe('upload-server (on HTTP)', () => {
 
 
     it('should reject requests for which the PR verification fails', done => {
-      const headers = `--header "Authorization: FAKE_VERIFICATION_ERROR" ${xFileHeader}`;
+      const headers = `--header "Authorization: ${c.BV_verify_error}" ${xFileHeader}`;
       const url = `http://${host}/create-build/${pr}/${sha9}`;
       const bodyRegex = new RegExp(`Error while verifying upload for PR ${pr}: Test`);
 
@@ -107,7 +108,7 @@ describe('upload-server (on HTTP)', () => {
 
     [true, false].forEach(isPublic => describe(`(for ${isPublic ? 'public' : 'hidden'} builds)`, () => {
       const authorizationHeader2 = isPublic ?
-        authorizationHeader : '--header "Authorization: FAKE_VERIFIED_NOT_TRUSTED"';
+        authorizationHeader : `--header "Authorization: ${c.BV_verify_verifiedNotTrusted}"`;
       const cmdPrefix = curl('', `${authorizationHeader2} ${xFileHeader}`);
 
 

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/upload-server.e2e.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/upload-server.e2e.ts
@@ -26,13 +26,13 @@ describe('upload-server (on HTTP)', () => {
 
     it('should disallow non-GET requests', done => {
       const url = `http://${host}/create-build/${pr}/${sha9}`;
-      const bodyRegex = /^Unsupported method/;
+      const bodyRegex = /^Unknown resource/;
 
       Promise.all([
-        h.runCmd(`curl -iLX PUT ${url}`).then(h.verifyResponse(405, bodyRegex)),
-        h.runCmd(`curl -iLX POST ${url}`).then(h.verifyResponse(405, bodyRegex)),
-        h.runCmd(`curl -iLX PATCH ${url}`).then(h.verifyResponse(405, bodyRegex)),
-        h.runCmd(`curl -iLX DELETE ${url}`).then(h.verifyResponse(405, bodyRegex)),
+        h.runCmd(`curl -iLX PUT ${url}`).then(h.verifyResponse(404, bodyRegex)),
+        h.runCmd(`curl -iLX POST ${url}`).then(h.verifyResponse(404, bodyRegex)),
+        h.runCmd(`curl -iLX PATCH ${url}`).then(h.verifyResponse(404, bodyRegex)),
+        h.runCmd(`curl -iLX DELETE ${url}`).then(h.verifyResponse(404, bodyRegex)),
       ]).then(done);
     });
 
@@ -376,25 +376,17 @@ describe('upload-server (on HTTP)', () => {
 
   describe(`${host}/*`, () => {
 
-    it('should respond with 404 for GET requests to unknown URLs', done => {
+    it('should respond with 404 for requests to unknown URLs', done => {
       const bodyRegex = /^Unknown resource/;
 
       Promise.all([
         h.runCmd(`curl -iL http://${host}/index.html`).then(h.verifyResponse(404, bodyRegex)),
         h.runCmd(`curl -iL http://${host}/`).then(h.verifyResponse(404, bodyRegex)),
         h.runCmd(`curl -iL http://${host}`).then(h.verifyResponse(404, bodyRegex)),
-      ]).then(done);
-    });
-
-
-    it('should respond with 405 for non-GET requests to any URL', done => {
-      const bodyRegex = /^Unsupported method/;
-
-      Promise.all([
-        h.runCmd(`curl -iLX PUT http://${host}`).then(h.verifyResponse(405, bodyRegex)),
-        h.runCmd(`curl -iLX POST http://${host}`).then(h.verifyResponse(405, bodyRegex)),
-        h.runCmd(`curl -iLX PATCH http://${host}`).then(h.verifyResponse(405, bodyRegex)),
-        h.runCmd(`curl -iLX DELETE http://${host}`).then(h.verifyResponse(405, bodyRegex)),
+        h.runCmd(`curl -iLX PUT http://${host}`).then(h.verifyResponse(404, bodyRegex)),
+        h.runCmd(`curl -iLX POST http://${host}`).then(h.verifyResponse(404, bodyRegex)),
+        h.runCmd(`curl -iLX PATCH http://${host}`).then(h.verifyResponse(404, bodyRegex)),
+        h.runCmd(`curl -iLX DELETE http://${host}`).then(h.verifyResponse(404, bodyRegex)),
       ]).then(done);
     });
 

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/package.json
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/package.json
@@ -20,12 +20,14 @@
     "test-watch": "nodemon --exec \"yarn ~~test-only\" --watch dist"
   },
   "dependencies": {
+    "body-parser": "^1.17.2",
     "express": "^4.14.1",
     "jasmine": "^2.5.3",
     "jsonwebtoken": "^7.3.0",
     "shelljs": "^0.7.6"
   },
   "devDependencies": {
+    "@types/body-parser": "^1.16.4",
     "@types/express": "^4.0.35",
     "@types/jasmine": "^2.5.43",
     "@types/jsonwebtoken": "^7.2.0",

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/test/upload-server/build-creator.spec.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/test/upload-server/build-creator.spec.ts
@@ -43,178 +43,25 @@ describe('BuildCreator', () => {
   });
 
 
-  describe('changePrVisibility()', () => {
-    let bcEmitSpy: jasmine.Spy;
-    let bcExistsSpy: jasmine.Spy;
-    let bcListShasByDate: jasmine.Spy;
-    let shellMvSpy: jasmine.Spy;
-
-    beforeEach(() => {
-      bcEmitSpy = spyOn(bc, 'emit');
-      bcExistsSpy = spyOn(bc as any, 'exists');
-      bcListShasByDate = spyOn(bc as any, 'listShasByDate');
-      shellMvSpy = spyOn(shell, 'mv');
-
-      bcExistsSpy.and.returnValues(Promise.resolve(true), Promise.resolve(false));
-      bcListShasByDate.and.returnValue([]);
-    });
-
-
-    it('should return a promise', done => {
-      const promise = bc.changePrVisibility(pr, true);
-      promise.then(done);   // Do not complete the test (and release the spies) synchronously
-                            // to avoid running the actual `extractArchive()`.
-
-      expect(promise).toEqual(jasmine.any(Promise));
-    });
-
-
-    [true, false].forEach(makePublic => {
-      const oldPrDir = makePublic ? hiddenPrDir : publicPrDir;
-      const newPrDir = makePublic ? publicPrDir : hiddenPrDir;
-
-
-      it('should rename the directory', done => {
-        bc.changePrVisibility(pr, makePublic).
-          then(() => expect(shellMvSpy).toHaveBeenCalledWith(oldPrDir, newPrDir)).
-          then(done);
-      });
-
-
-      it('should emit a ChangedPrVisibilityEvent on success', done => {
-        let emitted = false;
-
-        bcEmitSpy.and.callFake((type: string, evt: ChangedPrVisibilityEvent) => {
-          expect(type).toBe(ChangedPrVisibilityEvent.type);
-          expect(evt).toEqual(jasmine.any(ChangedPrVisibilityEvent));
-          expect(evt.pr).toBe(+pr);
-          expect(evt.shas).toEqual(jasmine.any(Array));
-          expect(evt.isPublic).toBe(makePublic);
-
-          emitted = true;
-        });
-
-        bc.changePrVisibility(pr, makePublic).
-          then(() => expect(emitted).toBe(true)).
-          then(done);
-      });
-
-
-      it('should include all shas in the emitted event', done => {
-        const shas = ['foo', 'bar', 'baz'];
-        let emitted = false;
-
-        bcListShasByDate.and.returnValue(Promise.resolve(shas));
-        bcEmitSpy.and.callFake((type: string, evt: ChangedPrVisibilityEvent) => {
-          expect(bcListShasByDate).toHaveBeenCalledWith(newPrDir);
-
-          expect(type).toBe(ChangedPrVisibilityEvent.type);
-          expect(evt).toEqual(jasmine.any(ChangedPrVisibilityEvent));
-          expect(evt.pr).toBe(+pr);
-          expect(evt.shas).toBe(shas);
-          expect(evt.isPublic).toBe(makePublic);
-
-          emitted = true;
-        });
-
-        bc.changePrVisibility(pr, makePublic).
-          then(() => expect(emitted).toBe(true)).
-          then(done);
-      });
-
-
-      describe('on error', () => {
-
-        it('should abort and skip further operations if the old directory does not exist', done => {
-          bcExistsSpy.and.callFake((dir: string) => dir !== oldPrDir);
-          bc.changePrVisibility(pr, makePublic).catch(err => {
-            expectToBeUploadError(err, 404, `Request to move non-existing directory '${oldPrDir}' to '${newPrDir}'.`);
-            expect(shellMvSpy).not.toHaveBeenCalled();
-            expect(bcListShasByDate).not.toHaveBeenCalled();
-            expect(bcEmitSpy).not.toHaveBeenCalled();
-            done();
-          });
-        });
-
-
-        it('should abort and skip further operations if the new directory does already exist', done => {
-          bcExistsSpy.and.returnValue(true);
-          bc.changePrVisibility(pr, makePublic).catch(err => {
-            expectToBeUploadError(err, 409, `Request to move '${oldPrDir}' to existing directory '${newPrDir}'.`);
-            expect(shellMvSpy).not.toHaveBeenCalled();
-            expect(bcListShasByDate).not.toHaveBeenCalled();
-            expect(bcEmitSpy).not.toHaveBeenCalled();
-            done();
-          });
-        });
-
-
-        it('should abort and skip further operations if it fails to rename the directory', done => {
-          shellMvSpy.and.throwError('');
-          bc.changePrVisibility(pr, makePublic).catch(() => {
-            expect(shellMvSpy).toHaveBeenCalled();
-            expect(bcListShasByDate).not.toHaveBeenCalled();
-            expect(bcEmitSpy).not.toHaveBeenCalled();
-            done();
-          });
-        });
-
-
-        it('should abort and skip further operations if it fails to list the SHAs', done => {
-          bcListShasByDate.and.throwError('');
-          bc.changePrVisibility(pr, makePublic).catch(() => {
-            expect(shellMvSpy).toHaveBeenCalled();
-            expect(bcListShasByDate).toHaveBeenCalled();
-            expect(bcEmitSpy).not.toHaveBeenCalled();
-            done();
-          });
-        });
-
-
-        it('should reject with an UploadError', done => {
-          shellMvSpy.and.callFake(() => { throw 'Test'; });
-          bc.changePrVisibility(pr, makePublic).catch(err => {
-            expectToBeUploadError(err, 500, `Error while making PR ${pr} ${makePublic ? 'public' : 'hidden'}.\nTest`);
-            done();
-          });
-        });
-
-
-        it('should pass UploadError instances unmodified', done => {
-          shellMvSpy.and.callFake(() => { throw new UploadError(543, 'Test'); });
-          bc.changePrVisibility(pr, makePublic).catch(err => {
-            expectToBeUploadError(err, 543, 'Test');
-            done();
-          });
-        });
-
-      });
-
-    });
-
-  });
-
-
   describe('create()', () => {
-    let bcChangePrVisibilitySpy: jasmine.Spy;
     let bcEmitSpy: jasmine.Spy;
     let bcExistsSpy: jasmine.Spy;
     let bcExtractArchiveSpy: jasmine.Spy;
+    let bcUpdatePrVisibilitySpy: jasmine.Spy;
     let shellMkdirSpy: jasmine.Spy;
     let shellRmSpy: jasmine.Spy;
 
     beforeEach(() => {
-      bcChangePrVisibilitySpy = spyOn(bc, 'changePrVisibility');
       bcEmitSpy = spyOn(bc, 'emit');
       bcExistsSpy = spyOn(bc as any, 'exists');
       bcExtractArchiveSpy = spyOn(bc as any, 'extractArchive');
+      bcUpdatePrVisibilitySpy = spyOn(bc, 'updatePrVisibility');
       shellMkdirSpy = spyOn(shell, 'mkdir');
       shellRmSpy = spyOn(shell, 'rm');
     });
 
 
     [true, false].forEach(isPublic => {
-      const otherVisPrDir = isPublic ? hiddenPrDir : publicPrDir;
       const prDir = isPublic ? publicPrDir : hiddenPrDir;
       const shaDir = isPublic ? publicShaDir : hiddenShaDir;
 
@@ -228,20 +75,12 @@ describe('BuildCreator', () => {
       });
 
 
-      it('should not update the PR\'s visibility first if not necessary', done => {
-        bc.create(pr, sha, archive, isPublic).
-          then(() => expect(bcChangePrVisibilitySpy).not.toHaveBeenCalled()).
-          then(done);
-      });
-
-
       it('should update the PR\'s visibility first if necessary', done => {
-        bcChangePrVisibilitySpy.and.callFake(() => expect(shellMkdirSpy).not.toHaveBeenCalled());
-        bcExistsSpy.and.callFake((dir: string) => dir === otherVisPrDir);
+        bcUpdatePrVisibilitySpy.and.callFake(() => expect(shellMkdirSpy).not.toHaveBeenCalled());
 
         bc.create(pr, sha, archive, isPublic).
           then(() => {
-            expect(bcChangePrVisibilitySpy).toHaveBeenCalledWith(pr, isPublic);
+            expect(bcUpdatePrVisibilitySpy).toHaveBeenCalledWith(pr, isPublic);
             expect(shellMkdirSpy).toHaveBeenCalled();
           }).
           then(done);
@@ -286,7 +125,6 @@ describe('BuildCreator', () => {
 
         beforeEach(() => {
           existsValues = {
-            [otherVisPrDir]: false,
             [prDir]: false,
             [shaDir]: false,
           };
@@ -297,14 +135,12 @@ describe('BuildCreator', () => {
 
         it('should abort and skip further operations if changing the PR\'s visibility fails', done => {
           const mockError = new UploadError(543, 'Test');
-
-          existsValues[otherVisPrDir] = true;
-          bcChangePrVisibilitySpy.and.returnValue(Promise.reject(mockError));
+          bcUpdatePrVisibilitySpy.and.returnValue(Promise.reject(mockError));
 
           bc.create(pr, sha, archive, isPublic).catch(err => {
             expect(err).toBe(mockError);
 
-            expect(bcExistsSpy).toHaveBeenCalledTimes(1);
+            expect(bcExistsSpy).not.toHaveBeenCalled();
             expect(shellMkdirSpy).not.toHaveBeenCalled();
             expect(bcExtractArchiveSpy).not.toHaveBeenCalled();
             expect(bcEmitSpy).not.toHaveBeenCalled();
@@ -327,8 +163,10 @@ describe('BuildCreator', () => {
 
 
         it('should detect existing build directory after visibility change', done => {
-          existsValues[otherVisPrDir] = true;
-          bcChangePrVisibilitySpy.and.callFake(() => existsValues[prDir] = existsValues[shaDir] = true);
+          bcUpdatePrVisibilitySpy.and.callFake(() => existsValues[prDir] = existsValues[shaDir] = true);
+
+          expect(bcExistsSpy(prDir)).toBe(false);
+          expect(bcExistsSpy(shaDir)).toBe(false);
 
           bc.create(pr, sha, archive, isPublic).catch(err => {
             expectToBeUploadError(err, 409, `Request to overwrite existing directory: ${shaDir}`);
@@ -394,6 +232,190 @@ describe('BuildCreator', () => {
         it('should pass UploadError instances unmodified', done => {
           shellMkdirSpy.and.callFake(() => { throw new UploadError(543, 'Test'); });
           bc.create(pr, sha, archive, isPublic).catch(err => {
+            expectToBeUploadError(err, 543, 'Test');
+            done();
+          });
+        });
+
+      });
+
+    });
+
+  });
+
+
+  describe('updatePrVisibility()', () => {
+    let bcEmitSpy: jasmine.Spy;
+    let bcExistsSpy: jasmine.Spy;
+    let bcListShasByDate: jasmine.Spy;
+    let shellMvSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      bcEmitSpy = spyOn(bc, 'emit');
+      bcExistsSpy = spyOn(bc as any, 'exists');
+      bcListShasByDate = spyOn(bc as any, 'listShasByDate');
+      shellMvSpy = spyOn(shell, 'mv');
+
+      bcExistsSpy.and.returnValues(Promise.resolve(true), Promise.resolve(false));
+      bcListShasByDate.and.returnValue([]);
+    });
+
+
+    it('should return a promise', done => {
+      const promise = bc.updatePrVisibility(pr, true);
+      promise.then(done);   // Do not complete the test (and release the spies) synchronously
+                            // to avoid running the actual `extractArchive()`.
+
+      expect(promise).toEqual(jasmine.any(Promise));
+    });
+
+
+    [true, false].forEach(makePublic => {
+      const oldPrDir = makePublic ? hiddenPrDir : publicPrDir;
+      const newPrDir = makePublic ? publicPrDir : hiddenPrDir;
+
+
+      it('should rename the directory', done => {
+        bc.updatePrVisibility(pr, makePublic).
+          then(() => expect(shellMvSpy).toHaveBeenCalledWith(oldPrDir, newPrDir)).
+          then(done);
+      });
+
+
+      describe('when the visibility is updated', () => {
+
+        it('should resolve to true', done => {
+          bc.updatePrVisibility(pr, makePublic).
+            then(result => expect(result).toBe(true)).
+            then(done);
+        });
+
+
+        it('should rename the directory', done => {
+          bc.updatePrVisibility(pr, makePublic).
+            then(() => expect(shellMvSpy).toHaveBeenCalledWith(oldPrDir, newPrDir)).
+            then(done);
+        });
+
+
+        it('should emit a ChangedPrVisibilityEvent on success', done => {
+          let emitted = false;
+
+          bcEmitSpy.and.callFake((type: string, evt: ChangedPrVisibilityEvent) => {
+            expect(type).toBe(ChangedPrVisibilityEvent.type);
+            expect(evt).toEqual(jasmine.any(ChangedPrVisibilityEvent));
+            expect(evt.pr).toBe(+pr);
+            expect(evt.shas).toEqual(jasmine.any(Array));
+            expect(evt.isPublic).toBe(makePublic);
+
+            emitted = true;
+          });
+
+          bc.updatePrVisibility(pr, makePublic).
+            then(() => expect(emitted).toBe(true)).
+            then(done);
+        });
+
+
+        it('should include all shas in the emitted event', done => {
+          const shas = ['foo', 'bar', 'baz'];
+          let emitted = false;
+
+          bcListShasByDate.and.returnValue(Promise.resolve(shas));
+          bcEmitSpy.and.callFake((type: string, evt: ChangedPrVisibilityEvent) => {
+            expect(bcListShasByDate).toHaveBeenCalledWith(newPrDir);
+
+            expect(type).toBe(ChangedPrVisibilityEvent.type);
+            expect(evt).toEqual(jasmine.any(ChangedPrVisibilityEvent));
+            expect(evt.pr).toBe(+pr);
+            expect(evt.shas).toBe(shas);
+            expect(evt.isPublic).toBe(makePublic);
+
+            emitted = true;
+          });
+
+          bc.updatePrVisibility(pr, makePublic).
+            then(() => expect(emitted).toBe(true)).
+            then(done);
+        });
+
+      });
+
+
+      it('should do nothing if the visibility is already up-to-date', done => {
+        bcExistsSpy.and.callFake((dir: string) => dir === newPrDir);
+        bc.updatePrVisibility(pr, makePublic).
+          then(result => {
+            expect(result).toBe(false);
+            expect(shellMvSpy).not.toHaveBeenCalled();
+            expect(bcListShasByDate).not.toHaveBeenCalled();
+            expect(bcEmitSpy).not.toHaveBeenCalled();
+          }).
+          then(done);
+      });
+
+
+      it('should do nothing if the PR directory does not exist', done => {
+        bcExistsSpy.and.returnValue(false);
+        bc.updatePrVisibility(pr, makePublic).
+          then(result => {
+            expect(result).toBe(false);
+            expect(shellMvSpy).not.toHaveBeenCalled();
+            expect(bcListShasByDate).not.toHaveBeenCalled();
+            expect(bcEmitSpy).not.toHaveBeenCalled();
+          }).
+          then(done);
+      });
+
+
+      describe('on error', () => {
+
+        it('should abort and skip further operations if both directories exist', done => {
+          bcExistsSpy.and.returnValue(true);
+          bc.updatePrVisibility(pr, makePublic).catch(err => {
+            expectToBeUploadError(err, 409, `Request to move '${oldPrDir}' to existing directory '${newPrDir}'.`);
+            expect(shellMvSpy).not.toHaveBeenCalled();
+            expect(bcListShasByDate).not.toHaveBeenCalled();
+            expect(bcEmitSpy).not.toHaveBeenCalled();
+            done();
+          });
+        });
+
+
+        it('should abort and skip further operations if it fails to rename the directory', done => {
+          shellMvSpy.and.throwError('');
+          bc.updatePrVisibility(pr, makePublic).catch(() => {
+            expect(shellMvSpy).toHaveBeenCalled();
+            expect(bcListShasByDate).not.toHaveBeenCalled();
+            expect(bcEmitSpy).not.toHaveBeenCalled();
+            done();
+          });
+        });
+
+
+        it('should abort and skip further operations if it fails to list the SHAs', done => {
+          bcListShasByDate.and.throwError('');
+          bc.updatePrVisibility(pr, makePublic).catch(() => {
+            expect(shellMvSpy).toHaveBeenCalled();
+            expect(bcListShasByDate).toHaveBeenCalled();
+            expect(bcEmitSpy).not.toHaveBeenCalled();
+            done();
+          });
+        });
+
+
+        it('should reject with an UploadError', done => {
+          shellMvSpy.and.callFake(() => { throw 'Test'; });
+          bc.updatePrVisibility(pr, makePublic).catch(err => {
+            expectToBeUploadError(err, 500, `Error while making PR ${pr} ${makePublic ? 'public' : 'hidden'}.\nTest`);
+            done();
+          });
+        });
+
+
+        it('should pass UploadError instances unmodified', done => {
+          shellMvSpy.and.callFake(() => { throw new UploadError(543, 'Test'); });
+          bc.updatePrVisibility(pr, makePublic).catch(err => {
             expectToBeUploadError(err, 543, 'Test');
             done();
           });

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/test/upload-server/upload-server-factory.spec.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/test/upload-server/upload-server-factory.spec.ts
@@ -258,12 +258,12 @@ describe('uploadServerFactory', () => {
       });
 
 
-      it('should respond with 405 for non-GET requests', done => {
+      it('should respond with 404 for non-GET requests', done => {
         verifyRequests([
-          agent.put(`/create-build/${pr}/${sha}`).expect(405),
-          agent.post(`/create-build/${pr}/${sha}`).expect(405),
-          agent.patch(`/create-build/${pr}/${sha}`).expect(405),
-          agent.delete(`/create-build/${pr}/${sha}`).expect(405),
+          agent.put(`/create-build/${pr}/${sha}`).expect(404),
+          agent.post(`/create-build/${pr}/${sha}`).expect(404),
+          agent.patch(`/create-build/${pr}/${sha}`).expect(404),
+          agent.delete(`/create-build/${pr}/${sha}`).expect(404),
         ], done);
       });
 
@@ -418,12 +418,12 @@ describe('uploadServerFactory', () => {
       });
 
 
-      it('should respond with 405 for non-GET requests', done => {
+      it('should respond with 404 for non-GET requests', done => {
         verifyRequests([
-          agent.put('/health-check').expect(405),
-          agent.post('/health-check').expect(405),
-          agent.patch('/health-check').expect(405),
-          agent.delete('/health-check').expect(405),
+          agent.put('/health-check').expect(404),
+          agent.post('/health-check').expect(404),
+          agent.patch('/health-check').expect(404),
+          agent.delete('/health-check').expect(404),
         ], done);
       });
 
@@ -442,26 +442,17 @@ describe('uploadServerFactory', () => {
     });
 
 
-    describe('GET *', () => {
-
-      it('should respond with 404', done => {
-        const responseBody = 'Unknown resource in request: GET /some/url';
-        verifyRequests([agent.get('/some/url').expect(404, responseBody)], done);
-      });
-
-    });
-
-
     describe('ALL *', () => {
 
-      it('should respond with 405', done => {
-        const responseFor = (method: string) => `Unsupported method in request: ${method.toUpperCase()} /some/url`;
+      it('should respond with 404', done => {
+        const responseFor = (method: string) => `Unknown resource in request: ${method.toUpperCase()} /some/url`;
 
         verifyRequests([
-          agent.put('/some/url').expect(405, responseFor('put')),
-          agent.post('/some/url').expect(405, responseFor('post')),
-          agent.patch('/some/url').expect(405, responseFor('patch')),
-          agent.delete('/some/url').expect(405, responseFor('delete')),
+          agent.get('/some/url').expect(404, responseFor('get')),
+          agent.put('/some/url').expect(404, responseFor('put')),
+          agent.post('/some/url').expect(404, responseFor('post')),
+          agent.patch('/some/url').expect(404, responseFor('patch')),
+          agent.delete('/some/url').expect(404, responseFor('delete')),
         ], done);
       });
 

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/yarn.lock
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/yarn.lock
@@ -2,13 +2,20 @@
 # yarn lockfile v1
 
 
+"@types/body-parser@^1.16.4":
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.16.4.tgz#96f3660e6f88a677fee7250f5a5e6d6bda3c76bb"
+  dependencies:
+    "@types/express" "*"
+    "@types/node" "*"
+
 "@types/express-serve-static-core@*":
   version "4.0.48"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.0.48.tgz#b4fa06b0fce282e582b4535ff7fac85cc90173e9"
   dependencies:
     "@types/node" "*"
 
-"@types/express@^4.0.35":
+"@types/express@*", "@types/express@^4.0.35":
   version "4.0.36"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.0.36.tgz#14eb47de7ecb10319f0a2fb1cf971aa8680758c2"
   dependencies:
@@ -236,6 +243,21 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+body-parser@^1.17.2:
+  version "1.17.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.17.2.tgz#f8892abc8f9e627d42aedafbca66bf5ab99104ee"
+  dependencies:
+    bytes "2.4.0"
+    content-type "~1.0.2"
+    debug "2.6.7"
+    depd "~1.1.0"
+    http-errors "~1.6.1"
+    iconv-lite "0.4.15"
+    on-finished "~2.3.0"
+    qs "6.4.0"
+    raw-body "~2.2.0"
+    type-is "~1.6.15"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -272,6 +294,10 @@ braces@^1.8.2:
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+
+bytes@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -1158,6 +1184,10 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+iconv-lite@0.4.15:
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
+
 ignore-by-default@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
@@ -1958,6 +1988,14 @@ range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
+raw-body@~2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.2.0.tgz#994976cf6a5096a41162840492f0bdc5d6e7fb96"
+  dependencies:
+    bytes "2.4.0"
+    iconv-lite "0.4.15"
+    unpipe "1.0.0"
+
 rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
@@ -2477,7 +2515,7 @@ unique-string@^1.0.0:
   dependencies:
     crypto-random-string "^1.0.0"
 
-unpipe@~1.0.0:
+unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 

--- a/aio/aio-builds-setup/dockerbuild/scripts-sh/upload-server-test.sh
+++ b/aio/aio-builds-setup/dockerbuild/scripts-sh/upload-server-test.sh
@@ -21,7 +21,7 @@ appName=aio-upload-server-test
 if [[ "$1" == "stop" ]]; then
   pm2 delete $appName
 else
-  pm2 start $AIO_SCRIPTS_JS_DIR/dist/lib/upload-server/index-test.js \
+  pm2 start $AIO_SCRIPTS_JS_DIR/dist/lib/verify-setup/start-test-upload-server.js \
     --log /var/log/aio/upload-server-test.log \
     --name $appName \
     --no-autorestart \

--- a/aio/aio-builds-setup/docs/overview--general.md
+++ b/aio/aio-builds-setup/docs/overview--general.md
@@ -80,13 +80,31 @@ More info on the possible HTTP status codes and their meaning can be found
 [here](overview--http-status-codes.md).
 
 
+### Updating PR visibility
+- nginx receives a natification that a PR has been updated and passes it through to the
+  upload-server. This could, for example, be sent by a GitHub webhook every time a PR's labels
+  change.
+  E.g.: `ngbuilds.io/pr-updated` (payload: `{"number":<PR>,"action":"labeled"}`)
+- The request contains the PR number (as `number`) and optionally the action that triggered the
+  request (as `action`) in the payload.
+- The upload-server verifies the payload and determines whether the `action` (if specified) could
+  have led to PR visibility changes. Only requests that omit the `action` field altogether or
+  specify an action that can affect visibility are further processed.
+  (Currently, the only actions that are considered capable of affecting visibility are `labeled` and
+  `unlabeled`.)
+- The upload-server re-checks and if necessary updates the PR's visibility.
+
+More info on the possible HTTP status codes and their meaning can be found
+[here](overview--http-status-codes.md).
+
+
 ### Serving build artifacts
 - nginx receives a request for an uploaded resource on a subdomain corresponding to the PR and SHA.
   E.g.: `pr<PR>-<SHA>.ngbuilds.io/path/to/resource`
 - nginx maps the subdomain to the correct sub-directory and serves the resource.
   E.g.: `/<PR>/<SHA>/path/to/resource`
 
-Again, more info on the possible HTTP status codes and their meaning can be found
+More info on the possible HTTP status codes and their meaning can be found
 [here](overview--http-status-codes.md).
 
 

--- a/aio/aio-builds-setup/docs/overview--http-status-codes.md
+++ b/aio/aio-builds-setup/docs/overview--http-status-codes.md
@@ -42,10 +42,6 @@ with a bried explanation of what they mean:
 - **403 (Forbidden)**:
   Unable to verify build (e.g. invalid JWT token, or unable to talk to 3rd-party APIs, etc).
 
-- **404 (Not Found)**:
-  Tried to change PR visibility but the source directory did not exist.
-  (Currently, this can only happen as a rare race condition during build deployment.)
-
 - **405 (Method Not Allowed)**:
   Request method other than POST.
 

--- a/aio/aio-builds-setup/docs/overview--http-status-codes.md
+++ b/aio/aio-builds-setup/docs/overview--http-status-codes.md
@@ -53,6 +53,28 @@ with a bried explanation of what they mean:
   Payload larger than size specified in `AIO_UPLOAD_MAX_SIZE`.
 
 
+## `https://ngbuilds.io/health-check`
+
+- **200 (OK)**:
+  The server is healthy (i.e. up and running and processing requests).
+
+
+## `https://ngbuilds.io/pr-updated`
+
+- **200 (OK)**:
+  Request processed successfully. Processing may or may not have resulted in further actions.
+
+- **400 (Bad Request)**:
+  No payload or no `number` field in payload.
+
+- **405 (Method Not Allowed)**:
+  Request method other than POST.
+
+- **409 (Conflict)**:
+  Request to overwrite existing directory (i.e. directories for both visibilities exist).
+  (Normally, this should not happen.)
+
+
 ## `https://*.ngbuilds.io/*`
 
 - **404 (Not Found)**:


### PR DESCRIPTION
This PR implements the ability to update a PR's preview visibility and exposes it as an API (`/check-pr-visibility`), so that it can be used with an automatic trigger (e.g. a GitHub webhook) to instantly update a PR's preview visibility when it changes.

This builds on top of #17756 (to avoid merge conflicts).

Fixes #16526.