### PR TITLE
fix(compiler-cli): ignore external styles for i18n extraction

### DIFF
--- a/packages/compiler-cli/src/extract_i18n.ts
+++ b/packages/compiler-cli/src/extract_i18n.ts
@@ -18,11 +18,13 @@ import * as tsc from '@angular/tsc-wrapped';
 import * as ts from 'typescript';
 
 import {Extractor} from './extractor';
+import {IgnoreExternalStylesContext} from './ignore_external_styles_context';
 
 function extract(
     ngOptions: tsc.AngularCompilerOptions, cliOptions: tsc.I18nExtractionCliOptions,
     program: ts.Program, host: ts.CompilerHost) {
-  return Extractor.create(ngOptions, program, host, cliOptions.locale)
+  return Extractor
+      .create(ngOptions, program, host, cliOptions.locale, new IgnoreExternalStylesContext(host))
       .extract(cliOptions.i18nFormat !, cliOptions.outFile);
 }
 

--- a/packages/compiler-cli/src/ignore_external_styles_context.ts
+++ b/packages/compiler-cli/src/ignore_external_styles_context.ts
@@ -1,0 +1,25 @@
+import * as ts from 'typescript';
+import {ModuleResolutionHostAdapter} from './compiler_host';
+
+
+export class IgnoreExternalStylesContext extends ModuleResolutionHostAdapter {
+  constructor(host: ts.ModuleResolutionHost) {
+    super(host);
+
+    if (host.fileExists) {
+      this.fileExists = (path: string) => host.fileExists !(path);
+    }
+  }
+
+
+  public fileExists(path: string): boolean { return false; }
+
+
+  public readResource(path: string): Promise<string> {
+    if (!this.fileExists(path)) {
+      console.warn('Non-existant file omitted for extraction: %s', path);
+    }
+
+    return Promise.resolve(this.fileExists(path) ? this.readFile(path) : '');
+  }
+}


### PR DESCRIPTION
Fix is simple by passing a HostContext that ignores unresolvable files, as we're only extracting i18n-strings missing files shouldn't be any problem.

## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
When running `ng-xi18n` on a project with `@import '~@angular/material/_theming.scss';` the extraction fails because the path is not resolved to the node_modules directory but relative to the .scss file containing the import.


## What is the new behavior?
The added HostContext implementation simply ignores missing files by returning an empty string for those.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```