### PR TITLE
ci(aio): avoid printing too large PWA report (and restore `print-logs.sh`)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,5 +76,4 @@ script:
   - ./scripts/ci/angular.sh
   # all the scripts under this line will not quickly abort in case ${TRAVIS_TEST_RESULT} is 1 (job failure)
   - ./scripts/ci/cleanup.sh
-  # Disabled so we can debug Travis build failures on Master seeming to coming from printing logs
-  # - ./scripts/ci/print-logs.sh
+  - ./scripts/ci/print-logs.sh

--- a/aio/scripts/deploy-preview.sh
+++ b/aio/scripts/deploy-preview.sh
@@ -49,6 +49,6 @@ readonly relevantChangedFilesCount=$(git diff --name-only $TRAVIS_COMMIT_RANGE |
   # Run PWA-score tests (unless the deployment is not public yet;
   # i.e. it could not be automatically verified).
   if [ $httpCode -ne 202 ]; then
-    yarn test-pwa-score -- "$DEPLOYED_URL" "$MIN_PWA_SCORE" "$PWA_RESULTS_LOG"
+    yarn test-pwa-score -- "$DEPLOYED_URL" "$MIN_PWA_SCORE"
   fi
 )

--- a/aio/scripts/deploy-to-firebase.sh
+++ b/aio/scripts/deploy-to-firebase.sh
@@ -39,5 +39,5 @@ esac
   firebase deploy --message "Commit: $TRAVIS_COMMIT" --non-interactive --token "$firebaseToken"
 
   # Run PWA-score tests
-  yarn test-pwa-score -- "$deployedUrl" "$MIN_PWA_SCORE" "$PWA_RESULTS_LOG"
+  yarn test-pwa-score -- "$deployedUrl" "$MIN_PWA_SCORE"
 )

--- a/scripts/ci/env.sh
+++ b/scripts/ci/env.sh
@@ -124,9 +124,6 @@ setEnvVar PATH $HOME/.yarn/bin:$PATH
 setEnvVar NODE_PATH ${NODE_PATH:-}:${PROJECT_ROOT}/dist/all:${PROJECT_ROOT}/dist/tools
 setEnvVar LOGS_DIR /tmp/angular-build/logs
 
-# Log file for full PWA testing results
-setEnvVar PWA_RESULTS_LOG $LOGS_DIR/pwa-results.json
-
 # strip leading "/home/travis/build/angular/angular/" or "./" path. Could this be done in one shot?
 CURRENT_SHELL_SOURCE_FILE=${BASH_SOURCE#${PROJECT_ROOT}/}
 export CURRENT_SHELL_SOURCE_FILE=${CURRENT_SHELL_SOURCE_FILE#./}


### PR DESCRIPTION
There have been some issues lately with Travis jobs failing due to `print-log.sh`. This is likely due to trying to print the Lighthouse PWA report, which is too large.

This commit stops printing that report (since it was rarely used and is pretty easy to acquire when needed) and restores the `print-logs.sh` script (that was temporarily removed with dfcca66fd).

(Related to #17854.)