### PR TITLE
ci(aio): use valid database path for Firebase payload size upload

### DIFF
--- a/aio/scripts/payload.sh
+++ b/aio/scripts/payload.sh
@@ -68,7 +68,9 @@ payloadData="{${payloadData}}"
 echo $payloadData
 
 if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-  firebase database:update --data "$payloadData" --project $PROJECT_NAME --confirm --token "$TOKEN" /payload/aio/$TRAVIS_BRANCH/$TRAVIS_COMMIT
+  readonly safeBranchName=$(echo $TRAVIS_BRANCH | sed -e 's/\./_/g')
+  readonly dbPath=/payload/aio/$safeBranchName/$TRAVIS_COMMIT
+  firebase database:update --data "$payloadData" --project $PROJECT_NAME --confirm --token "$TOKEN" $dbPath
 fi
 
 if [[ $failed = true ]]; then


### PR DESCRIPTION
Firebase does not allow `.` in the path, so when trying to upload payload size data for branches like `4.2.x`, the following error is thrown:

```
HTTP Error: 400, Invalid path: Invalid token in path
```

This commit fixes it by replacing `.` with `_` in branch names.