### PR TITLE
ci(aio): Fix the payload script only check for changes in aio/scripts

### DIFF
--- a/aio/scripts/payload.sh
+++ b/aio/scripts/payload.sh
@@ -4,10 +4,11 @@
 set +x -eu -o pipefail
 
 readonly thisDir=$(cd $(dirname $0); pwd)
+readonly parentDir=$(dirname $thisDir)
 readonly TOKEN=${ANGULAR_PAYLOAD_FIREBASE_TOKEN:-}
 readonly PROJECT_NAME="angular-payload-size"
 
-source scripts/_payload-limits.sh
+source ${thisDir}/_payload-limits.sh
 
 failed=false
 payloadData=""
@@ -43,8 +44,8 @@ payloadData="$payloadData\"timestamp\": $timestamp, "
 
 # Add change source: application, dependencies, or 'application+dependencies'
 yarnChanged=false
-allChangedFiles=$(git diff --name-only $TRAVIS_COMMIT_RANGE $thisDir | wc -l)
-allChangedFileNames=$(git diff --name-only $TRAVIS_COMMIT_RANGE $thisDir)
+allChangedFiles=$(git diff --name-only $TRAVIS_COMMIT_RANGE $parentDir | wc -l)
+allChangedFileNames=$(git diff --name-only $TRAVIS_COMMIT_RANGE $parentDir)
 
 if [[ $allChangedFileNames == *"yarn.lock"* ]]; then
   yarnChanged=true


### PR DESCRIPTION
## PR Checklist
Does please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Payload script doesn't catch the changes inside `aio/`
It only catch the changes inside `aio/scripts`

Issue Number: N/A


## What is the new behavior?
Payload script should update the data to firebase when there's a change in aio/

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
