### PR TITLE
feat(compiler-cli): add parameters to ngc main needed by bazel rules

### DIFF
--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -385,6 +385,7 @@ function createProgramWithStubsHost(
     getCanonicalFileName = (fileName: string) => originalHost.getCanonicalFileName(fileName);
     useCaseSensitiveFileNames = () => originalHost.useCaseSensitiveFileNames();
     getNewLine = () => originalHost.getNewLine();
+    realPath = (p: string) => p;
     fileExists = (fileName: string) =>
         this.generatedFiles.has(fileName) || originalHost.fileExists(fileName);
   };


### PR DESCRIPTION
## What is the current behavior?

All options are derived from reading the tsconfig.json file.

## What is the new behavior?

The caller of `main` can read the config file and pass the parsed options to `main` allowing the caller to read options intended for it.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```