### PR TITLE
fix(compiler-cli): fix relative source paths on windows for extracted msg

### DIFF
--- a/packages/compiler-cli/src/extractor.ts
+++ b/packages/compiler-cli/src/extractor.ts
@@ -67,8 +67,9 @@ export class Extractor {
         serializer = new compiler.Xliff();
     }
     return bundle.write(
-        serializer,
-        (sourcePath: string) => sourcePath.replace(path.join(this.options.basePath, '/'), ''));
+        serializer, (sourcePath: string) => this.options.basePath ?
+            path.relative(this.options.basePath, sourcePath) :
+            sourcePath);
   }
 
   getExtension(formatName: string): string {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
```

## What is the current behavior?
The extracted source file paths was supposed to be relative, but we used a simple replace that doesn't work on windows (because we used two paths formatted differently), and the path was absolute instead of relative.

Issue Number: #16639


## What is the new behavior?
The paths are relative on all platforms

## Does this PR introduce a breaking change?
```
[x] No
```