### PR TITLE
docs(aio): change command to open app for first time

### DIFF
--- a/aio/content/tutorial/toh-pt1.md
+++ b/aio/content/tutorial/toh-pt1.md
@@ -91,7 +91,7 @@ Enter the following command in the terminal window:
 
 
 <code-example language="sh" class="code-shell">
-  npm start
+  ng serve -o
 
 </code-example>
 


### PR DESCRIPTION
The current command given for opening the app initially, \’npm start\’, does not also open a browser window with the app as claimed, so change the command to \’ng serve -o\’ in line with the stated behavior.

## PR Checklist
Does please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The current command given for opening the app initially, \’npm start\’, does not also open a browser window with the app as claimed.

Issue Number: N/A


## What is the new behavior?
Change the command to \’ng serve -o\’ in line with the stated behavior.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
