### PR TITLE
docs(aio): fix host usage in styleguide

### DIFF
--- a/aio/content/examples/styleguide/src/06-03/app/shared/validator2.directive.ts
+++ b/aio/content/examples/styleguide/src/06-03/app/shared/validator2.directive.ts
@@ -4,7 +4,7 @@ import { Directive } from '@angular/core';
 @Directive({
   selector: '[tohValidator2]',
   host: {
-    'attr.role': 'button',
+    '[attr.role]': 'role',
     '(mouseenter)': 'onMouseEnter()'
   }
 })


### PR DESCRIPTION
## PR Checklist
Does please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

An attribute named `attr.role` being created, see [this plunker](http://plnkr.co/edit/pfOhRTKW2iPaHcEEIZgi?p=preview) for example.

![image](https://user-images.githubusercontent.com/6059170/27852008-df91317e-618f-11e7-862f-51f03d45832a.png)


Issue Number: N/A


## What is the new behavior?

An attribute named `role` being created, see [this plunker](http://plnkr.co/edit/BN96xf23Sbd3Nf8oa4Wm?p=preview) for example.

![image](https://user-images.githubusercontent.com/6059170/27852052-323a0fae-6190-11e7-9793-eb2c91dcd13f.png)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

More general question, should we ban the `host: { 'xxx': 'literal' }` usage since it has no equivalent in `@HostBinding`/`@HostListener` way?