### PR TITLE
build: disable sauce connect logging

### DIFF
--- a/scripts/sauce/sauce_connect_setup.sh
+++ b/scripts/sauce/sauce_connect_setup.sh
@@ -23,8 +23,12 @@ CONNECT_DIR="/tmp/sauce-connect-$RANDOM"
 CONNECT_DOWNLOAD="sc-latest-linux.tar.gz"
 
 CONNECT_LOG="$LOGS_DIR/sauce-connect"
-CONNECT_STDOUT="$LOGS_DIR/sauce-connect.stdout"
-CONNECT_STDERR="$LOGS_DIR/sauce-connect.stderr"
+# logging disabled because it's seems to be overwhelming travis and causing flakes
+# when we are cat-ing the log in print-logs.sh
+# CONNECT_STDOUT="$LOGS_DIR/sauce-connect.stdout"
+# CONNECT_STDERR="$LOGS_DIR/sauce-connect.stderr"
+CONNECT_STDOUT="/dev/null"
+CONNECT_STDERR="/dev/null"
 
 # Get Connect and start it
 mkdir -p $CONNECT_DIR


### PR DESCRIPTION
this change is expected to mitigate the flakes on CI that occur when
we cat the log in the print-logs.sh
