### PR TITLE
refactor(tsc-wrapped): refactor tsc-wrapped to instantiate Tsc in main rather than as an export from tsc.ts

### DIFF
--- a/tools/@angular/tsc-wrapped/src/main.ts
+++ b/tools/@angular/tsc-wrapped/src/main.ts
@@ -16,7 +16,7 @@ import {CliOptions} from './cli_options';
 import {MetadataWriterHost, SyntheticIndexHost} from './compiler_host';
 import {privateEntriesToIndex} from './index_writer';
 import NgOptions from './options';
-import {check, tsc} from './tsc';
+import {check, Tsc} from './tsc';
 import {isVinylFile, VinylFile} from './vinyl_file';
 
 export {UserError} from './tsc';
@@ -83,6 +83,7 @@ export function main(
     const basePath = path.resolve(process.cwd(), cliOptions.basePath || projectDir);
 
     // read the configuration options from wherever you store them
+    const tsc = new Tsc();
     let {parsed, ngOptions} = tsc.readConfiguration(project, basePath, options);
     ngOptions.basePath = basePath;
     let rootFileNames: string[] = parsed.fileNames.slice(0);

--- a/tools/@angular/tsc-wrapped/src/tsc.ts
+++ b/tools/@angular/tsc-wrapped/src/tsc.ts
@@ -176,4 +176,3 @@ export class Tsc implements CompilerInterface {
     return emitResult.emitSkipped ? 1 : 0;
   }
 }
-export const tsc: CompilerInterface = new Tsc();


### PR DESCRIPTION
## PR Checklist
Does please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

tsc-wrapped instantiates and exports an instance of Tsc in tsc.ts and imports this instance in main.ts

Issue Number: N/A


## What is the new behavior?

tsc-wrapped now instantiates an instance of Tsc directly in main.ts

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This PR lays groundwork for in-browser AOT compilation. The instantiation of Tsc in tsc.ts causes errors in our browser bundle; as such, I'm refactoring to avoid this issue.