### PR TITLE
fix(language-service): do not crash when hovering over a label definition

### DIFF
--- a/packages/language-service/src/locate_symbol.ts
+++ b/packages/language-service/src/locate_symbol.ts
@@ -68,7 +68,7 @@ export function locateSymbol(info: TemplateInfo): SymbolInfo|undefined {
             }
           },
           visitReference(ast) {
-            symbol = info.template.query.getTypeSymbol(tokenReference(ast.value));
+            symbol = ast.value && info.template.query.getTypeSymbol(tokenReference(ast.value));
             span = spanOf(ast);
           },
           visitVariable(ast) {},

--- a/packages/language-service/test/hover_spec.ts
+++ b/packages/language-service/test/hover_spec.ts
@@ -68,6 +68,16 @@ describe('hover', () => {
         'property name of TestComponent');
   });
 
+  it('should be able to ignore a reference declaration', () => {
+    addCode(
+        ` @Component({template: '<div #«chart»></div>'}) export class MyComponent {  }`,
+        fileName => {
+          const markers = mockHost.getReferenceMarkers(fileName) !;
+          const hover = ngService.getHoverAt(fileName, markers.references.chart[0].start);
+          expect(hover).toBeUndefined();
+        });
+  });
+
   function hover(code: string, hoverText: string) {
     addCode(code, fileName => {
       let tests = 0;


### PR DESCRIPTION
Fixes: #17972

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue Number:  #17972

## What is the new behavior?

No longer crashes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```