### PR TITLE
fix(compiler): report reference to ambient symbols as errors

### DIFF
--- a/packages/compiler/src/aot/static_symbol_resolver.ts
+++ b/packages/compiler/src/aot/static_symbol_resolver.ts
@@ -390,7 +390,7 @@ export class StaticSymbolResolver {
               return self.getStaticSymbol(topLevelPath, name);
             }
             // ambient value
-            null;
+            return map;
           }
         } else {
           return super.visitStringMap(map, functionParams);

--- a/packages/compiler/test/aot/static_symbol_resolver_spec.ts
+++ b/packages/compiler/test/aot/static_symbol_resolver_spec.ts
@@ -247,7 +247,7 @@ describe('StaticSymbolResolver', () => {
         .toBeFalsy();
   });
 
-  it('should fill references to ambient symbols with undefined', () => {
+  it('should leave ambient symbols as references', () => {
     init({
       '/test.ts': `
         export var y = 1;
@@ -256,7 +256,7 @@ describe('StaticSymbolResolver', () => {
     });
 
     expect(symbolResolver.resolveSymbol(symbolCache.get('/test.ts', 'z')).metadata).toEqual([
-      undefined, symbolCache.get('/test.ts', 'z')
+      {__symbolic: 'reference', name: 'window'}, symbolCache.get('/test.ts', 'z')
     ]);
   });
 


### PR DESCRIPTION
Fixes #15188

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

The compiler will report an internal error message when an AOT application uses an ambient symbol that is unsupported by AOT.

Issue Number: #15188

## What is the new behavior?

A more reasonable error is produced.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
