### PR TITLE
refactor(common): replace `Object.assign` with the spread operator

### DIFF
--- a/packages/common/src/pipes/intl.ts
+++ b/packages/common/src/pipes/intl.ts
@@ -172,7 +172,7 @@ function nameCondition(prop: string, len: number): Intl.DateTimeFormatOptions {
 }
 
 function combine(options: Intl.DateTimeFormatOptions[]): Intl.DateTimeFormatOptions {
-  return (<any>Object).assign({}, ...options);
+  return options.reduce((merged, opt) => ({...merged, ...opt}), {});
 }
 
 function datePartGetterFactory(ret: Intl.DateTimeFormatOptions): DateFormatterFn {


### PR DESCRIPTION
## PR Checklist
Does please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
`@angular/common` relies on `Object.assign()` being available. Since it is not natively available in all supported browsers, users had to provide a polyfill.

Issue Number: N/A


## What is the new behavior?
This commit replaces `Object.assign` with the spread operator (`...`), which TypeScript will transpile to ES5-compatible code.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
