### PR TITLE
test: git ignore e2e test folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 /dist/
 bazel-*
+e2e_test.*
 node_modules
 bower_components
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Other... Please describe: chore
```

## What is the current behavior?
When we run e2e tests locally, it creates a folder named `e2e_test.[timestamp]` which appears as new files when you want to commit

## What is the new behavior?
These folders are now gitignore to make sure that we don't commit them by mistake

## Does this PR introduce a breaking change?
```
[x] No
```