### PR TITLE
fix(tsc-wrapped): report errors for invalid ast forms

### DIFF
--- a/tools/@angular/tsc-wrapped/src/evaluator.ts
+++ b/tools/@angular/tsc-wrapped/src/evaluator.ts
@@ -388,6 +388,9 @@ export class Evaluator {
         if (isFoldableError(expression)) {
           return recordEntry(expression, node);
         }
+        if (!elementAccessExpression.argumentExpression) {
+          return recordEntry(errorSymbol('Expression form not supported', node), node);
+        }
         const index = this.evaluateNode(elementAccessExpression.argumentExpression);
         if (isFoldableError(expression)) {
           return recordEntry(expression, node);

--- a/tools/@angular/tsc-wrapped/test/collector.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/collector.spec.ts
@@ -864,6 +864,28 @@ describe('Collector', () => {
       const metadata = collector.getMetadata(source);
       expect(metadata).toBeUndefined();
     });
+
+    it('should be able to collect an invalid access expression', () => {
+      const source = createSource(`
+        import {Component} from '@angular/core';
+
+        const value = [];
+        @Component({
+          provider: [{provide: 'some token', useValue: value[]}]
+        })
+        export class MyComponent {}
+      `);
+      const metadata = collector.getMetadata(source);
+      expect(metadata.metadata.MyComponent).toEqual({
+        __symbolic: 'class',
+        decorators: [{
+          __symbolic: 'error',
+          message: 'Expression form not supported',
+          line: 5,
+          character: 55
+        }]
+      });
+    });
   });
 
   function override(fileName: string, content: string) {


### PR DESCRIPTION
Fixes: #17993

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

The metadata collector would crash if asked to collect an invalid annotation that contains an expression of the form `a[]`. 

Issue Number: #17993 

## What is the new behavior?

The form is reported as unsupported instead of throwing an exception.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
