### PR TITLE
build: remove duplicate dependency on TypeScript

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -21,9 +21,9 @@ following products on your development machine:
   [Windows](http://windows.github.com)); [GitHub's Guide to Installing
   Git](https://help.github.com/articles/set-up-git) is a good source of information.
 
-* [Node.js](http://nodejs.org), (version `>=5.4.1 <6`) which is used to run a development web server,
+* [Node.js](http://nodejs.org), (version `>=6.9.5 <7.0.0`) which is used to run a development web server,
   run tests, and generate distributable files. We also use Node's Package Manager, `npm`
-  (version `>=3.5.3 <4.0`), which comes with Node. Depending on your system, you can install Node either from
+  (version `>=3.10.7 <4.0.0`), which comes with Node. Depending on your system, you can install Node either from
   source or as a pre-packaged bundle.
 
 * [Java Development Kit](http://www.oracle.com/technetwork/es/java/javase/downloads/index.html) which is used

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "4.2.0-beta.1",
+  "version": "4.3.0-beta.1",
   "dependencies": {
     "@types/angularjs": {
       "version": "1.5.13-alpha"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "4.2.0-beta.1",
+  "version": "4.3.0-beta.1",
   "dependencies": {
     "@types/angularjs": {
       "version": "1.5.13-alpha",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "reflect-metadata": "^0.1.3",
     "rxjs": "^5.0.1",
     "tslib": "^1.7.1",
-    "typescript": "^2.3.2",
     "zone.js": "^0.8.12"
   },
   "optionalDependencies": {
@@ -96,7 +95,7 @@
     "tsickle": "^0.21.1",
     "tslint": "^4.1.1",
     "tslint-eslint-rules": "^3.1.0",
-    "typescript": "^2.1.5",
+    "typescript": "^2.3.2",
     "universal-analytics": "^0.3.9",
     "vrsource-tslint-rules": "^4.0.0",
     "webpack": "^1.12.6",


### PR DESCRIPTION
## PR Checklist
Does please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
TypeScript is unnecessarily specified as both a dependency and a devDependency.

Issue Number: N/A


## What is the new behavior?
TypeScript is only specified as a dependency.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
TypeScript was added as a dependency in 9a7f5d5. I assume the intention was to upgrade the existing devDependency instead.

(This PR also updates the require Node/npm versions in DEVELOPER.md, based on the values in package.json -> engines.)