### PR TITLE
fix for 4.2.x

### DIFF
--- a/packages/compiler/src/compiler_util/expression_converter.ts
+++ b/packages/compiler/src/compiler_util/expression_converter.ts
@@ -177,7 +177,7 @@ class _BuiltinAstConverter extends cdAst.AstTransformer {
     const args = ast.values.map(ast => ast.visit(this, context));
 
     return new BuiltinFunctionCall(
-        ast.span, args, this._converterFactory.createLiteralMapConverter(ast.keys.map(k => k.key)));
+        ast.span, args, this._converterFactory.createLiteralMapConverter(ast.keys));
   }
 }
 

--- a/packages/compiler/src/compiler_util/expression_converter.ts
+++ b/packages/compiler/src/compiler_util/expression_converter.ts
@@ -177,7 +177,7 @@ class _BuiltinAstConverter extends cdAst.AstTransformer {
     const args = ast.values.map(ast => ast.visit(this, context));
 
     return new BuiltinFunctionCall(
-        ast.span, args, this._converterFactory.createLiteralMapConverter(ast.keys));
+        ast.span, args, this._converterFactory.createLiteralMapConverter(ast.keys.map(k => k.key)));
   }
 }
 

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -136,8 +136,12 @@ export class LiteralArray extends AST {
   }
 }
 
+export type LiteralMapKey = {
+  key: string; quoted: boolean;
+};
+
 export class LiteralMap extends AST {
-  constructor(span: ParseSpan, public keys: any[], public values: any[]) { super(span); }
+  constructor(span: ParseSpan, public keys: LiteralMapKey[], public values: any[]) { super(span); }
   visit(visitor: AstVisitor, context: any = null): any {
     return visitor.visitLiteralMap(this, context);
   }

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -11,9 +11,8 @@ import {CompilerInjectable} from '../injectable';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../ml_parser/interpolation_config';
 import {escapeRegExp} from '../util';
 
-import {AST, ASTWithSource, AstVisitor, Binary, BindingPipe, Chain, Conditional, EmptyExpr, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, NonNullAssert, ParseSpan, ParserError, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead, TemplateBinding} from './ast';
+import {AST, ASTWithSource, AstVisitor, Binary, BindingPipe, Chain, Conditional, EmptyExpr, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralMapKey, LiteralPrimitive, MethodCall, NonNullAssert, ParseSpan, ParserError, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead, TemplateBinding} from './ast';
 import {EOF, Lexer, Token, TokenType, isIdentifier, isQuote} from './lexer';
-
 
 export class SplitInterpolation {
   constructor(public strings: string[], public expressions: string[], public offsets: number[]) {}
@@ -605,15 +604,16 @@ export class _ParseAST {
   }
 
   parseLiteralMap(): LiteralMap {
-    const keys: string[] = [];
+    const keys: LiteralMapKey[] = [];
     const values: AST[] = [];
     const start = this.inputIndex;
     this.expectCharacter(chars.$LBRACE);
     if (!this.optionalCharacter(chars.$RBRACE)) {
       this.rbracesExpected++;
       do {
+        const quoted = this.next.isString();
         const key = this.expectIdentifierOrKeywordOrString();
-        keys.push(key);
+        keys.push({key, quoted});
         this.expectCharacter(chars.$COLON);
         values.push(this.parsePipe());
       } while (this.optionalCharacter(chars.$COMMA));

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -165,7 +165,7 @@ export function main() {
 
         it('should parse map', () => {
           checkAction('{}');
-          checkAction('{a: 1}[2]');
+          checkAction('{a: 1, "b": 2}[2]');
           checkAction('{}["a"]');
         });
 
@@ -263,7 +263,7 @@ export function main() {
           checkBinding('a(b | c)', 'a((b | c))');
           checkBinding('a.b(c.d(e) | f)', 'a.b((c.d(e) | f))');
           checkBinding('[1, 2, 3] | a', '([1, 2, 3] | a)');
-          checkBinding('{a: 1} | b', '({a: 1} | b)');
+          checkBinding('{a: 1, "b": 2} | c', '({a: 1, "b": 2} | c)');
           checkBinding('a[b] | c', '(a[b] | c)');
           checkBinding('a?.b | c', '(a?.b | c)');
           checkBinding('true | a', '(true | a)');

--- a/packages/compiler/test/expression_parser/unparser.ts
+++ b/packages/compiler/test/expression_parser/unparser.ts
@@ -124,7 +124,9 @@ class Unparser implements AstVisitor {
     for (let i = 0; i < ast.keys.length; i++) {
       if (!isFirst) this._expression += ', ';
       isFirst = false;
-      this._expression += `${ast.keys[i]}: `;
+      const key = ast.keys[i];
+      this._expression += key.quoted ? JSON.stringify(key.key) : key.key;
+      this._expression += ': ';
       this._visit(ast.values[i]);
     }
 

--- a/packages/platform-browser/src/dom/dom_tokens.ts
+++ b/packages/platform-browser/src/dom/dom_tokens.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {DOCUMENT as commonDOCUMENT} from '@angular/common';
 import {InjectionToken} from '@angular/core';
 
-import {DOCUMENT as commonDOCUMENT} from '@angular/common';
 
 /**
  * A DI Token representing the main rendering context. In a browser this is the DOM Document.

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -34,6 +34,9 @@ export declare class DecimalPipe implements PipeTransform {
 }
 
 /** @stable */
+export declare const DOCUMENT: InjectionToken<Document>;
+
+/** @stable */
 export declare class HashLocationStrategy extends LocationStrategy {
     constructor(_platformLocation: PlatformLocation, _baseHref?: string);
     back(): void;

--- a/tools/public_api_guard/platform-browser/platform-browser.d.ts
+++ b/tools/public_api_guard/platform-browser/platform-browser.d.ts
@@ -16,7 +16,7 @@ export declare class By {
 /** @experimental */
 export declare function disableDebugTools(): void;
 
-/** @stable */
+/** @deprecated */
 export declare const DOCUMENT: InjectionToken<Document>;
 
 /** @stable */


### PR DESCRIPTION
`feat(compiler): adds support for quoted object keys in the parser` was not merged in the 4.2.x branch most probably because it's labelled as a "feat".

While this is a "feat"ure, it is used by further commit. Those commits as a whole is a "fix" (see #17945 for a breakdown of the commits).

For some reason I had to add a second commit with a missing change (was not part of the cherry pick - but [is here in 4.3](https://github.com/angular/angular/blob/09f1609f819f54256bdba69f6e3bf29d5ad40249/packages/compiler/src/compiler_util/expression_converter.ts#L180))

Also the second commit contain a `gulp format` change which should hopefully be ok (I ran a fresh `npm i` on my local 4.2.x checkout)

/cc @jasonaden 