### PR TITLE
fix(animations): Fix "'hasOwnProperty' of undefined" crash

### DIFF
--- a/packages/animations/browser/src/render/web_animations/web_animations_player.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_player.ts
@@ -64,7 +64,7 @@ export class WebAnimationsPlayer implements AnimationPlayer {
 
     const keyframes = this.keyframes.map(styles => copyStyles(styles, false));
     const previousStyleProps = Object.keys(this.previousStyles);
-    if (previousStyleProps.length) {
+    if (previousStyleProps.length && keyframes.length) {
       let startingKeyframe = keyframes[0];
       let missingStyleProps: string[] = [];
       previousStyleProps.forEach(prop => {


### PR DESCRIPTION
Fix random crashes with:

    TypeError: Cannot read property 'hasOwnProperty' of undefined
    at Array.forEach (native)
    at e.init
    at t.e._queuePlayer
    at t.e.animateTransition
    ...

This commit fixes #16470 and closes #15858 (which has been abandoned
for a while).

---

## PR Checklist
Does please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No