### PR TITLE
fix(compiler): allow numbers as ICU select cases

### DIFF
--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -684,7 +684,7 @@ function isExpansionFormStart(
 }
 
 function isExpansionCaseStart(peek: number): boolean {
-  return peek === chars.$EQ || chars.isAsciiLetter(peek);
+  return peek === chars.$EQ || chars.isAsciiLetter(peek) || chars.isDigit(peek);
 }
 
 function compareCharCodeCaseInsensitive(code1: number, code2: number): boolean {

--- a/packages/compiler/test/i18n/integration_common.ts
+++ b/packages/compiler/test/i18n/integration_common.ts
@@ -78,6 +78,9 @@ export function validateHtml(
   cmp.sex = 'f';
   tb.detectChanges();
   expect(el.query(By.css('#i18n-8')).nativeElement).toHaveText('femme');
+  cmp.sex = '0';
+  tb.detectChanges();
+  expect(el.query(By.css('#i18n-8')).nativeElement).toHaveText('autre');
 
   cmp.count = 123;
   tb.detectChanges();
@@ -121,7 +124,7 @@ export const HTML = `
     <div i18n id="i18n-7">{count, plural, =0 {zero} =1 {one} =2 {two} other {<b>many</b>}}</div>
     
     <div i18n id="i18n-8">
-        {sex, select, m {male} f {female}}
+        {sex, select, m {male} f {female} 0 {other}}
     </div>
     <div i18n id="i18n-8b">
         {sexB, select, m {male} f {female}}

--- a/packages/compiler/test/i18n/integration_xliff_spec.ts
+++ b/packages/compiler/test/i18n/integration_xliff_spec.ts
@@ -85,15 +85,15 @@ const XLIFF_TOMERGE = `
         <source>{VAR_PLURAL, plural, =0 {zero} =1 {one} =2 {two} other {<x id="START_BOLD_TEXT" ctype="x-b"/>many<x id="CLOSE_BOLD_TEXT" ctype="x-b"/>} }</source>
         <target>{VAR_PLURAL, plural, =0 {zero} =1 {un} =2 {deux} other {<x id="START_BOLD_TEXT" ctype="x-b"/>beaucoup<x id="CLOSE_BOLD_TEXT" ctype="x-b"/>} }</target>
       </trans-unit>
-      <trans-unit id="85ef51de59fe5a8d13fba977b6689f164420c8ca" datatype="html">
+      <trans-unit id="ba9106fca6e4e33a9b703a8c1927e2d1794dd9ff" datatype="html">
         <source>
         <x id="ICU"/>
     </source>
         <target><x id="ICU"/></target>
       </trans-unit>
-      <trans-unit id="c0ca5e58fe954d528bbfa516007a5a11690a7e99" datatype="html">
-        <source>{VAR_SELECT, select, m {male} f {female} }</source>
-        <target>{VAR_SELECT, select, m {homme} f {femme} }</target>
+      <trans-unit id="7b7916d063ebaafcd2e9dcdf697b5e184fcb8099" datatype="html">
+        <source>{VAR_SELECT, select, 0 {other} m {male} f {female} }</source>
+        <target>{VAR_SELECT, select, 0 {autre} m {homme} f {femme}}</target>
       </trans-unit>
       <trans-unit id="078b7089573c5f66a2f78dce0adaa55e6715beb1" datatype="html">
         <source>
@@ -225,7 +225,7 @@ const XLIFF_EXTRACTED = `
           <context context-type="linenumber">36</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="85ef51de59fe5a8d13fba977b6689f164420c8ca" datatype="html">
+      <trans-unit id="ba9106fca6e4e33a9b703a8c1927e2d1794dd9ff" datatype="html">
         <source>
         <x id="ICU"/>
     </source>
@@ -235,8 +235,8 @@ const XLIFF_EXTRACTED = `
           <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="c0ca5e58fe954d528bbfa516007a5a11690a7e99" datatype="html">
-        <source>{VAR_SELECT, select, m {male} f {female} }</source>
+      <trans-unit id="7b7916d063ebaafcd2e9dcdf697b5e184fcb8099" datatype="html">
+        <source>{VAR_SELECT, select, 0 {other} m {male} f {female} }</source>
         <target/>
         <context-group purpose="location">
           <context context-type="sourcefile">file.ts</context>

--- a/packages/compiler/test/i18n/integration_xmb_xtb_spec.ts
+++ b/packages/compiler/test/i18n/integration_xmb_xtb_spec.ts
@@ -64,6 +64,8 @@ const XTB = `
   <translation id="5525133077318024839">sur des balises non traductibles</translation>
   <translation id="8670732454866344690">sur des balises traductibles</translation>
   <translation id="4593805537723189714">{VAR_PLURAL, plural, =0 {zero} =1 {un} =2 {deux} other {<ph name="START_BOLD_TEXT"/>beaucoup<ph name="CLOSE_BOLD_TEXT"/>}}</translation>
+  <translation id="4360321700965841752"><ph name="ICU"/></translation>
+  <translation id="5460933846928880074">{VAR_SELECT, select, 0 {autre} m {homme} f {femme} }</translation>
   <translation id="1746565782635215"><ph name="ICU"/></translation>
   <translation id="5868084092545682515">{VAR_SELECT, select, m {homme} f {femme}}</translation>
   <translation id="4851788426695310455"><ph name="INTERPOLATION"/></translation>
@@ -84,17 +86,21 @@ const XTB = `
   <translation id="5339604010413301604"><ph name="MAP_NAME"><ex>MAP_NAME</ex></ph></translation>
 </translationbundle>`;
 
-const XMB = ` <msg id="615790887472569365"><source>file.ts:3</source>i18n attribute on tags</msg>
+const XMB = `<msg id="615790887472569365"><source>file.ts:3</source>i18n attribute on tags</msg>
   <msg id="3707494640264351337"><source>file.ts:5</source>nested</msg>
   <msg id="5539162898278769904" meaning="different meaning"><source>file.ts:7</source>nested</msg>
   <msg id="3780349238193953556"><source>file.ts:9</source><source>file.ts:10</source><ph name="START_ITALIC_TEXT"><ex>&lt;i&gt;</ex></ph>with placeholders<ph name="CLOSE_ITALIC_TEXT"><ex>&lt;/i&gt;</ex></ph></msg>
   <msg id="5525133077318024839"><source>file.ts:13</source>on not translatable node</msg>
   <msg id="8670732454866344690"><source>file.ts:14</source>on translatable node</msg>
   <msg id="4593805537723189714"><source>file.ts:19</source><source>file.ts:36</source>{VAR_PLURAL, plural, =0 {zero} =1 {one} =2 {two} other {<ph name="START_BOLD_TEXT"><ex>&lt;b&gt;</ex></ph>many<ph name="CLOSE_BOLD_TEXT"><ex>&lt;/b&gt;</ex></ph>} }</msg>
-  <msg id="1746565782635215"><source>file.ts:21,23</source><source>file.ts:24,26</source>
+  <msg id="4360321700965841752"><source>file.ts:21,23</source>
         <ph name="ICU"><ex>ICU</ex></ph>
     </msg>
-  <msg id="5868084092545682515"><source>file.ts:22</source><source>file.ts:25</source>{VAR_SELECT, select, m {male} f {female} }</msg>
+  <msg id="5460933846928880074"><source>file.ts:22</source>{VAR_SELECT, select, 0 {other} m {male} f {female} }</msg>
+  <msg id="1746565782635215"><source>file.ts:24,26</source>
+        <ph name="ICU"><ex>ICU</ex></ph>
+    </msg>
+  <msg id="5868084092545682515"><source>file.ts:25</source>{VAR_SELECT, select, m {male} f {female} }</msg>
   <msg id="4851788426695310455"><source>file.ts:28</source><ph name="INTERPOLATION"><ex>INTERPOLATION</ex></ph></msg>
   <msg id="9013357158046221374"><source>file.ts:29</source>sex = <ph name="INTERPOLATION"><ex>INTERPOLATION</ex></ph></msg>
   <msg id="8324617391167353662"><source>file.ts:30</source><ph name="CUSTOM_NAME"><ex>CUSTOM_NAME</ex></ph></msg>

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -363,6 +363,11 @@ export function main() {
           ]);
         });
 
+        it('should support ICU expressions with cases that contain numbers', () => {
+          const p = parser.parse(`{sex, select, male {m} female {f} 0 {other}}`, 'TestComp', true);
+          expect(p.errors.length).toEqual(0);
+        });
+
         it('should error when expansion case is not closed', () => {
           const p = parser.parse(`{messages.length, plural, =0 {one`, 'TestComp', true);
           expect(humanizeErrors(p.errors)).toEqual([


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
```

## What is the current behavior?
We cannot use number values for cases of select ICUs even if the number is a string value: `{gender, select, 1 {male} f {female}}` fails with error message `Invalid ICU message. Missing '}'`.

Issue Number: #17799


## What is the new behavior?
We allow numbers in select ICUs for cases

## Does this PR introduce a breaking change?
```
[x] No
```