### PR TITLE
fix(router): <a href="#"> shouldn't navigate to the app root

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -246,3 +246,12 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
 function attrBoolValue(s: any): boolean {
   return s === '' || !!s;
 }
+
+/** @experimental */
+@Directive({selector: 'a[href]:not([routerLink])'})
+export class LinkWithHref {
+  @HostBinding('attr.href') @Input() href: string;
+
+  @HostListener('click')
+  onClick(): boolean { return this.href !== '#'; }
+}

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -13,7 +13,7 @@ import {Subject} from 'rxjs/Subject';
 import {of } from 'rxjs/observable/of';
 
 import {Route, Routes} from './config';
-import {RouterLink, RouterLinkWithHref} from './directives/router_link';
+import {LinkWithHref, RouterLink, RouterLinkWithHref} from './directives/router_link';
 import {RouterLinkActive} from './directives/router_link_active';
 import {RouterOutlet} from './directives/router_outlet';
 import {RouteReuseStrategy} from './route_reuse_strategy';
@@ -31,7 +31,8 @@ import {flatten} from './utils/collection';
  * @whatItDoes Contains a list of directives
  * @stable
  */
-const ROUTER_DIRECTIVES = [RouterOutlet, RouterLink, RouterLinkWithHref, RouterLinkActive];
+const ROUTER_DIRECTIVES =
+    [RouterOutlet, RouterLink, RouterLinkWithHref, RouterLinkActive, LinkWithHref];
 
 /**
  * @whatItDoes Is used in DI to configure the router.


### PR DESCRIPTION
BREAKING CHANGE: `<a href="#">` is now ignored by the router and will
no longer navigate to the app root.

To migrate the code follow the example bellow:

Before:

`<a href="#">`

After:

`<a href="#/">`

Closes #7294
Closes #12945
Closes #14370