### PR TITLE
fix(router): fix wildcard route with lazy loaded module (again)

### DIFF
--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -111,28 +111,32 @@ class Recognizer {
 
     if ((route.outlet || PRIMARY_OUTLET) !== outlet) throw new NoMatch();
 
+    let snapshot: ActivatedRouteSnapshot;
+    let consumedSegments: UrlSegment[] = [];
+    let rawSlicedSegments: UrlSegment[] = [];
+
     if (route.path === '**') {
       const params = segments.length > 0 ? last(segments) !.parameters : {};
-      const snapshot = new ActivatedRouteSnapshot(
+      snapshot = new ActivatedRouteSnapshot(
           segments, params, Object.freeze(this.urlTree.queryParams), this.urlTree.fragment !,
           getData(route), outlet, route.component !, route, getSourceSegmentGroup(rawSegment),
           getPathIndexShift(rawSegment) + segments.length, getResolve(route));
-      return [new TreeNode<ActivatedRouteSnapshot>(snapshot, [])];
+    } else {
+      const result: MatchResult = match(rawSegment, route, segments);
+      consumedSegments = result.consumedSegments;
+      rawSlicedSegments = segments.slice(result.lastChild);
+
+      snapshot = new ActivatedRouteSnapshot(
+          consumedSegments, result.parameters, Object.freeze(this.urlTree.queryParams),
+          this.urlTree.fragment !, getData(route), outlet, route.component !, route,
+          getSourceSegmentGroup(rawSegment),
+          getPathIndexShift(rawSegment) + consumedSegments.length, getResolve(route));
     }
 
-    const {consumedSegments, parameters, lastChild} = match(rawSegment, route, segments);
-    const rawSlicedSegments = segments.slice(lastChild);
-    const childConfig = getChildConfig(route);
+    const childConfig: Route[] = getChildConfig(route);
 
     const {segmentGroup, slicedSegments} =
         split(rawSegment, consumedSegments, rawSlicedSegments, childConfig);
-
-    const snapshot = new ActivatedRouteSnapshot(
-        consumedSegments, parameters, Object.freeze(this.urlTree.queryParams),
-        this.urlTree.fragment !, getData(route), outlet, route.component !, route,
-        getSourceSegmentGroup(rawSegment), getPathIndexShift(rawSegment) + consumedSegments.length,
-        getResolve(route));
-
 
     if (slicedSegments.length === 0 && segmentGroup.hasChildren()) {
       const children = this.processChildren(childConfig, segmentGroup);
@@ -168,7 +172,13 @@ function getChildConfig(route: Route): Route[] {
   return [];
 }
 
-function match(segmentGroup: UrlSegmentGroup, route: Route, segments: UrlSegment[]) {
+interface MatchResult {
+  consumedSegments: UrlSegment[];
+  lastChild: number;
+  parameters: any;
+}
+
+function match(segmentGroup: UrlSegmentGroup, route: Route, segments: UrlSegment[]): MatchResult {
   if (route.path === '') {
     if (route.pathMatch === 'full' && (segmentGroup.hasChildren() || segments.length > 0)) {
       throw new NoMatch();

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -3470,10 +3470,10 @@ describe('Integration', () => {
                declarations: [LazyLoadedComponent],
                imports: [RouterModule.forChild([{path: '', component: LazyLoadedComponent}])],
              })
-             class LoadedModule {
+             class LazyLoadedModule {
              }
 
-             loader.stubbedModules = {lazy: LoadedModule};
+             loader.stubbedModules = {lazy: LazyLoadedModule};
              const fixture = createRoot(router, RootCmp);
 
              router.resetConfig([{path: '**', loadChildren: 'lazy'}]);
@@ -3482,6 +3482,7 @@ describe('Integration', () => {
              advance(fixture);
 
              expect(location.path()).toEqual('/lazy');
+             expect(fixture.nativeElement).toHaveText('lazy-loaded');
            })));
 
     describe('preloading', () => {


### PR DESCRIPTION
Closes #13848

Description:
We doesn't handle children of wildcard route properly link. It's always an empty array.

Created from #13851
