### PR TITLE
docs(http): Make name of injected HttpTestingController consistent

### DIFF
--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -611,7 +611,7 @@ it('expects a GET request', inject([HttpClient, HttpTestingController], (http: H
   req.flush({name: 'Test Data'});
   
   // Finally, assert that there are no outstanding requests.
-  mockHttp.verify();
+  httpMock.verify();
 }));
 ```
 
@@ -619,7 +619,7 @@ The last step, verifying that no requests remain outstanding, is common enough f
 
 ```javascript
 afterEach(inject([HttpTestingController], (httpMock: HttpTestingController) => {
-  mockHttp.verify();
+  httpMock.verify();
 }));
 ```
 
@@ -628,7 +628,7 @@ afterEach(inject([HttpTestingController], (httpMock: HttpTestingController) => {
 If matching by URL isn't sufficient, it's possible to implement your own matching function. For example, you could look for an outgoing request that has an Authorization header:
 
 ```javascript
-const req = mockHttp.expectOne((req) => req.headers.has('Authorization'));
+const req = httpMock.expectOne((req) => req.headers.has('Authorization'));
 ```
 
 Just as with the `expectOne()` by URL in the test above, if 0 or 2+ requests match this expectation, it will throw.
@@ -639,7 +639,7 @@ If you need to respond to duplicate requests in your test, use the `match()` API
 
 ```javascript
 // Expect that 5 pings have been made and flush them.
-const reqs = mockHttp.match('/ping');
+const reqs = httpMock.match('/ping');
 expect(reqs.length).toBe(5);
 reqs.forEach(req => req.flush());
 ```


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The example code in the docs for testing the new http client injects `HttpTestingController` but inconsistently references it with `httpMock` and `mockHttp`

Issue Number: N/A


## What is the new behavior?
Choose to name that variable `httpMock` everywhere.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
