### PR TITLE
docs(http): fix "Expecting and answering requests" example mistake

### DIFF
--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -598,7 +598,7 @@ it('expects a GET request', inject([HttpClient, HttpTestingController], (http: H
     
   // At this point, the request is pending, and no response has been
   // sent. The next step is to expect that the request happened.
-  const req = httpMock.expectOne('/test');
+  const req = httpMock.expectOne('/data');
   
   // If no request with that URL was made, or if multiple requests match,
   // expectOne() would throw. However this test makes only one request to


### PR DESCRIPTION
Simple fix for possible mistake in docs.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
~~- [ ] Tests for the changes have been added (for bug fixes / features)~~
~~- [ ] Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The test example looks like this:
```js
http
  .get('/data')
  .subscribe(data => expect(data['name']).toEqual('Test Data'));

. . .

  const req = httpMock.expectOne('/test');
```

Issue Number: N/A


## What is the new behavior?
The test example looks like this:
```js
http
  .get('/data')
  .subscribe(data => expect(data['name']).toEqual('Test Data'));

. . .

  const req = httpMock.expectOne('/data');
```

The final line above is the one in question.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information