### PR TITLE
fix(aio): invalid formatting in architecure.md

### DIFF
--- a/aio/content/guide/architecture.md
+++ b/aio/content/guide/architecture.md
@@ -124,7 +124,7 @@ For example, import Angular's `Component` decorator from the `@angular/core` lib
 
 <code-example path="architecture/src/app/app.component.ts" region="import" linenums="false"></code-example>
 
-You also import NgModules_ from Angular _libraries_ using JavaScript import statements:
+You also import NgModules from Angular _libraries_ using JavaScript import statements:
 
 <code-example path="architecture/src/app/mini-app.ts" region="import-browser-module" linenums="false"></code-example>
 


### PR DESCRIPTION
Fixes the formatting by removing an extra underscore. Introduced in https://github.com/angular/angular/commit/e110a80cafb4d8677d13a51e3c7e967a577ca6d1#diff-9ac9c6a9277eea9856d75249a7c0a40aL127.