### PR TITLE
fix(compiler): ensure jit external id arguments names are unique

### DIFF
--- a/packages/compiler/src/output/output_jit.ts
+++ b/packages/compiler/src/output/output_jit.ts
@@ -43,7 +43,7 @@ export function jitStatements(sourceUrl: string, statements: o.Statement[]): {[k
   return evalExpression(sourceUrl, ctx, converter.getArgs());
 }
 
-class JitEmitterVisitor extends AbstractJsEmitterVisitor {
+export class JitEmitterVisitor extends AbstractJsEmitterVisitor {
   private _evalArgNames: string[] = [];
   private _evalArgValues: any[] = [];
   private _evalExportedVars: string[] = [];
@@ -69,7 +69,7 @@ class JitEmitterVisitor extends AbstractJsEmitterVisitor {
       id = this._evalArgValues.length;
       this._evalArgValues.push(value);
       const name = identifierName({reference: ast.value.runtime}) || 'val';
-      this._evalArgNames.push(`jit_${name}${id}`);
+      this._evalArgNames.push(`jit_${name}_${id}`);
     }
     ctx.print(ast, this._evalArgNames[id]);
     return null;

--- a/packages/compiler/test/output/output_jit_spec.ts
+++ b/packages/compiler/test/output/output_jit_spec.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {EmitterVisitorContext} from '@angular/compiler/src/output/abstract_emitter';
+import * as o from '@angular/compiler/src/output/output_ast';
+import {JitEmitterVisitor} from '@angular/compiler/src/output/output_jit';
+
+const anotherModuleUrl = 'somePackage/someOtherPath';
+
+export function main() {
+  describe('Output JIT', () => {
+    describe('regression', () => {
+      it('should generate unique argument names', () => {
+        const externalIds = new Array(10).fill(1).map(
+            (_, index) =>
+                new o.ExternalReference(anotherModuleUrl, `id_${index}_`, {name: `id_${index}_`}));
+        const externalIds1 = new Array(10).fill(1).map(
+            (_, index) => new o.ExternalReference(
+                anotherModuleUrl, `id_${index}_1`, {name: `id_${index}_1`}));
+        const ctx = EmitterVisitorContext.createRoot();
+        const converter = new JitEmitterVisitor();
+        converter.visitAllStatements(
+            [o.literalArr([...externalIds1, ...externalIds].map(id => o.importExpr(id))).toStmt()],
+            ctx);
+        const args = converter.getArgs();
+        expect(Object.keys(args).length).toBe(20);
+      });
+    });
+  })
+}


### PR DESCRIPTION
Fixes: #17558, #17378, #8676

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue Number: 17558

The generated name for imported identifiers was not guaranteed to be unique if the external identifier ended in a number such as`Renderer2`.

## What is the new behavior?

The generated identifiers for imported identifiers cannot collide as there is a additional character between the name and the id as recommended in #8676.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
