### PR TITLE
fix(aio): add quote to module

### DIFF
--- a/aio/tools/transforms/templates/api/includes/info-bar.html
+++ b/aio/tools/transforms/templates/api/includes/info-bar.html
@@ -11,7 +11,7 @@
 </tr>
 <tr>
   <th>Module</th>
-  <td><code>import { {$ doc.name $} } from <a href="{$ doc.moduleDoc.path $}">@angular/{$ doc.moduleDoc.id $}</a>;</code></td>
+  <td><code>import { {$ doc.name $} } from <a href="{$ doc.moduleDoc.path $}">'@angular/{$ doc.moduleDoc.id $}'</a>;</code></td>
 </tr>
 <tr>
   <th>Source</th>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the API doc, quotes are missing in the Module section. For example : 

`import { NgForOf } from @angular/common;`

Issue Number: N/A


## What is the new behavior?

Quotes are now present.
