### PR TITLE
fix(common): send flushed body as error instead of null

### DIFF
--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -12,7 +12,7 @@ import 'rxjs/add/operator/toPromise';
 import {ddescribe, describe, iit, it} from '@angular/core/testing/src/testing_internal';
 
 import {HttpClient} from '../src/client';
-import {HttpEventType, HttpResponse} from '../src/response';
+import {HttpErrorResponse, HttpEventType, HttpResponse} from '../src/response';
 import {HttpClientTestingBackend} from '../testing/src/backend';
 
 export function main() {
@@ -121,6 +121,16 @@ export function main() {
         client.jsonp('/test', 'myCallback').subscribe(() => done());
         backend.expectOne({method: 'JSONP', url: '/test?myCallback=JSONP_CALLBACK'})
             .flush('hello world');
+      });
+    });
+    describe('makes a request for an error response', () => {
+      it('with a JSON body', (done: DoneFn) => {
+        client.get('/test').subscribe(() => {}, (res: HttpErrorResponse) => {
+          expect(res.error.data).toEqual('hello world');
+          done();
+        });
+        backend.expectOne('/test').flush(
+            {'data': 'hello world'}, {status: 500, statusText: 'Server error'});
       });
     });
   });

--- a/packages/common/http/testing/src/request.ts
+++ b/packages/common/http/testing/src/request.ts
@@ -61,12 +61,11 @@ export class TestRequest {
     if (statusText === undefined) {
       throw new Error('statusText is required when setting a custom status.');
     }
-    const res = {body, headers, status, statusText, url};
     if (status >= 200 && status < 300) {
-      this.observer.next(new HttpResponse<any>(res));
+      this.observer.next(new HttpResponse<any>({body, headers, status, statusText, url}));
       this.observer.complete();
     } else {
-      this.observer.error(new HttpErrorResponse(res));
+      this.observer.error(new HttpErrorResponse({error: body, headers, status, statusText, url}));
     }
   }
 


### PR DESCRIPTION
fix #18181

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #18181


## What is the new behavior?

the flushed body is now sent as the error propery of the HttpErrorResponse

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I ran the three test suites as described in the developer documentation, and some tests failed, but looked completely unrelated to the fix (and failed before applying the fix anyway).