### PR TITLE
aio: fix typo in NgModule FAQs

### DIFF
--- a/aio/content/guide/ngmodule-faq.md
+++ b/aio/content/guide/ngmodule-faq.md
@@ -615,7 +615,7 @@ Once the application begins, the app root injector is closed to new providers.
 
 Time passes and application logic triggers lazy loading of a module.
 Angular must add the lazy-loaded module's providers to an injector somewhere.
-It can't added them to the app root injector because that injector is closed to new providers.
+It can't add them to the app root injector because that injector is closed to new providers.
 So Angular creates a new child injector for the lazy-loaded module context.
 
 


### PR DESCRIPTION
Fix #18133. Fix typo 'added' to 'add' in the 'Why does lazy loading create a child injector' section.

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
In https://angular.io/guide/ngmodule-faq#why-does-lazy-loading-create-a-child-injector. The second sentence of the last paragraph begins with.

> It can't added them to the app root injector ...

Bold emphasis is added by me to highlight the typo.

Issue Number: #18133


## What is the new behavior?
It should be

> It can't add them to the app root injector ...

Bold emphasis is added by me to highlight the typo.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
