### PR TITLE
fix(upgrade): allow accessing AngularJS injector from downgraded module

### DIFF
--- a/packages/upgrade/src/static/downgrade_module.ts
+++ b/packages/upgrade/src/static/downgrade_module.ts
@@ -42,10 +42,9 @@ export function downgradeModule<T>(
       .factory(LAZY_MODULE_REF, [
         $INJECTOR,
         ($injector: angular.IInjectorService) => {
+          setTempInjectorRef($injector);
           const result: LazyModuleRef = {
             promise: bootstrapFn(angular1Providers).then(ref => {
-              setTempInjectorRef($injector);
-
               injector = result.injector = new NgAdapterInjector(ref.injector);
               injector.get($INJECTOR);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When downgrading an Angular module using `downgradeModule()`, the AngularJS injector is not available to the Angular injector until after bootstrapping.

Issue Number: N/A


## What is the new behavior?
The AngularJS injector is available and can be retrieved from the downgraded module's constructor or `ngDoBootstrap()` method. E.g.:

```ts
@NgModule({...})
class MyToBeDowngradedModule {
  constructor(injector: Injector) {
    const $injector = injector.get('$injector');
    ...
  }
}
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
