### PR TITLE
docs(CONTRIBUTER.md): fixed link

### DIFF
--- a/docs/COMMITTER.md
+++ b/docs/COMMITTER.md
@@ -3,7 +3,7 @@
 Please see [Using git with Angular repositories](https://docs.google.com/document/d/1h8nijFSaa1jG_UE8v4WP7glh5qOUXnYtAtJh_gwOQHI/edit)
 for details about how we maintain a linear commit history, and the rules for committing.
 
-As a contributor, just read the instructions in [CONTRIBUTING.md](CONTRIBUTING.md) and send a pull request.
+As a contributor, just read the instructions in [CONTRIBUTING.md](../CONTRIBUTING.md) and send a pull request.
 Someone with committer access will do the rest.
 
 # Change approvals


### PR DESCRIPTION
 docs/COMMITER.md now points correctly to CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Gives 404 - Page not found
Issue Number: N/A


## What is the new behavior?

Navigates to CONTRIBUTING.md file

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
