### PR TITLE
docs(aio): replace old blog link  Fixes #18233

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -17,7 +17,7 @@
       "title": "Events"
     },
     {
-      "url": "https://blog.angular.io//",
+      "url": "https://blog.angular.io/",
       "title": "Blog"
     }
   ],

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -17,7 +17,7 @@
       "title": "Events"
     },
     {
-      "url": "https://blog.angularjs.org/",
+      "url": "https://blog.angular.io//",
       "title": "Blog"
     }
   ],
@@ -39,7 +39,7 @@
           "title": "Events"
         },
         {
-          "url": "https://blog.angularjs.org/",
+          "url": "https://blog.angular.io/",
           "title": "Blog"
         }
       ]


### PR DESCRIPTION
Now with the Link to the new Angular.io Blog

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Old Blog linked on the Angular.io Website

Issue Number: #18233


## What is the new behavior?
The new Blog is linked

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
