### PR TITLE
WIP: rollup bazel rule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,5 +21,6 @@ filegroup(
         "node_modules/bytebuffer/**",
         "node_modules/reflect-metadata/**",
         "node_modules/minimist/**/*.js",
+        "node_modules/rollup/**",
     ]),
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "io_angular")
+
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(

--- a/packages/core/BUILD.bazel
+++ b/packages/core/BUILD.bazel
@@ -15,14 +15,29 @@ ts_library(
 load("@build_bazel_rules_angular//:defs.bzl", "ng_module")
 
 ng_module(
-  name = "core_ng_module",
-  srcs = glob(["**/*.ts"], exclude=[
-      "test/**",
-      "testing/**",
-  ]),
-  # Needed to allow (ts_library,ng_module) pair
-  write_ng_outputs_only = True,
-  module_name = "@angular/core",
-  tsconfig = ":tsconfig-build.json",
-  compiler = "//tools/ngc-wrapped"
+    name = "core_ng_module",
+    srcs = glob(["**/*.ts"], exclude=[
+        "test/**",
+        "testing/**",
+    ]),
+    # Needed to allow (ts_library,ng_module) pair
+    write_ng_outputs_only = True,
+    module_name = "@angular/core",
+    tsconfig = ":tsconfig-build.json",
+    compiler = "//tools/ngc-wrapped",
+)
+
+load("//tools/build:rollup.bzl", "rollup_bundle")
+rollup_bundle(
+    name = "rollup",
+    entry_point = "bazel-out/local-fastbuild/bin/packages/core/index.js",
+    srcs = [":core"],
+    globals = {
+        'rxjs/Observable': 'Rx',
+        'rxjs/Subject': 'Rx',
+        'rxjs/Observer': 'Rx',
+        'rxjs/Subscription': 'Rx',
+        'rxjs/observable/merge': 'Rx.Observable',
+        'rxjs/operator/share': 'Rx.Observable.prototype'
+    }
 )

--- a/tools/build/BUILD.bazel
+++ b/tools/build/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@build_bazel_rules_typescript//:defs.bzl", "nodejs_binary")
+
+nodejs_binary(
+    name = "rollup",
+    entry_point = "rollup/bin/rollup",
+    visibility = ["//visibility:public"],
+)

--- a/tools/build/rollup.bzl
+++ b/tools/build/rollup.bzl
@@ -1,0 +1,50 @@
+# Rule for running Rollup under Bazel
+
+def _collect_es5_sources_impl(target, ctx):
+  result = set()
+  print("aspect visiting", target.label)
+  if hasattr(ctx.rule.attr, "deps"):
+    for dep in ctx.rule.attr.deps:
+      if hasattr(dep, "es5_sources"):
+        result += dep.es5_sources
+  if hasattr(target, "typescript"):
+    result += target.typescript.es5_sources
+  return struct(es5_sources = result)
+
+_collect_es5_sources = aspect(
+    _collect_es5_sources_impl,
+    attr_aspects = ["deps"],
+)
+
+def _rollup_bundle_impl(ctx):
+  inputs = set()
+  for s in ctx.attr.srcs:
+    if hasattr(s, "es5_sources"):
+      inputs += s.es5_sources
+
+  args = ["--format", "es"]
+  args += ["--input", ctx.attr.entry_point]
+  args += ["--output", ctx.outputs.bundle.path]
+  if ctx.attr.globals:
+    args += ["--external", ",".join(ctx.attr.globals.keys())]
+    args += ["--globals", ",".join([":".join([g[0], g[1]]) for g in ctx.attr.globals.items()])]
+  #print("rollup inputs", inputs)
+  ctx.action(
+      progress_message = "Rollup bundling %s" % ctx.label,
+      inputs = inputs.to_list(),
+      outputs = [ctx.outputs.bundle],
+      executable = ctx.executable._rollup,
+      arguments = args,
+  )
+  return struct()
+
+rollup_bundle = rule(implementation = _rollup_bundle_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files=True, aspects=[_collect_es5_sources]),
+        "entry_point": attr.string(mandatory=True),
+        "globals": attr.string_dict(),
+        "_rollup": attr.label(default=Label("//tools/build:rollup"), executable=True, cfg="host"),
+    },
+    outputs = {
+        "bundle": "%{name}.js"
+    })

--- a/tools/ngc-wrapped/BUILD.bazel
+++ b/tools/ngc-wrapped/BUILD.bazel
@@ -1,7 +1,5 @@
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "nodejs_binary")
 
-licenses(["notice"])  # Apache 2.0
-
 ts_library(
     name = "ngc_lib",
     srcs = ["index.ts"],
@@ -13,7 +11,7 @@ ts_library(
 
 nodejs_binary(
     name = "ngc-wrapped",
-    entry_point = "__main__/tools/ngc-wrapped/index.js",
+    entry_point = "io_angular/tools/ngc-wrapped/index.js",
     data = [":ngc_lib"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
A number of issues to deal with, because current `dist/packages-dist/core/bundles/core.umd.js` has a bunch of deltas from what bazel produces in this PR:

1. Where should this rule live? If ngrx wants to use it too, we shouldn't have it in the Angular repo. OTOH we like to keep a monorepo.
1. Right now, ts_library only knows how to produce the ES5 ("devmode") outputs, so we can't produce the ES6 rollup bundle yet.
1. need to preserve the `--module=es2015` from our `tsconfig-build.json` - mailed @robwormald the fix for https://github.com/bazelbuild/rules_typescript/issues/20
1. To use plugins, Rollup can only be configured with a config file. So we have a few choices to consider:
   1. Keep the `rollup.config.js` checked in and pass that path to the bazel rule. Good: this is similar to what the rollup docs say to do. Bad: there are path references in that file which bazel needs to control.
   1. Keep the `rollup.config.js` checked in, but bazel writes its own rollup config which requires() that one, and updates the path settings. Good: similar to what we do for `tsconfig.json`. Bad: more complex
   1. All the configuration goes in the `BUILD.bazel` file, and we generate the `rollup.config.js` file. Good: more idiomatic for Bazel. Bad: doesn't match rollup docs 
1. Current `core.umd.js` had tsickle run on it, because we started from ES6 JS files and downleveled them. I think this is actually undesirable - no one takes the ES5 UMD file and pipes it through closure compiler.
1. The `rollup_bundle` rule needs `entry_point = bazel-out/local-fastbuild/bin/packages/core/index.js` in order to find the generated JS files. That's not nice - we could
   1. Teach rollup to look in multiple rootDirs like we taught typescript (maybe a rollup plugin can do this?)
   1. Make `ts_library` give us some `outputs` so we could refer to target `//packages/core:index.js`, then we can give `entry_point` as a target, from which bazel lets us get the path