### PR TITLE
feat(forms): add options arg to abstract controls

### DIFF
--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -97,6 +97,39 @@ export function main() {
         expect(c.valid).toEqual(true);
       });
 
+      it('should support single validator from options obj', () => {
+        const c = new FormControl(null, {validators: Validators.required});
+        expect(c.valid).toEqual(false);
+        expect(c.errors).toEqual({required: true});
+
+        c.setValue('value');
+        expect(c.valid).toEqual(true);
+      });
+
+      it('should support multiple validators from options obj', () => {
+        const c =
+            new FormControl(null, {validators: [Validators.required, Validators.minLength(3)]});
+        expect(c.valid).toEqual(false);
+        expect(c.errors).toEqual({required: true});
+
+        c.setValue('aa');
+        expect(c.valid).toEqual(false);
+        expect(c.errors).toEqual({minlength: {requiredLength: 3, actualLength: 2}});
+
+        c.setValue('aaa');
+        expect(c.valid).toEqual(true);
+      });
+
+      it('should support a null validators value', () => {
+        const c = new FormControl(null, {validators: null});
+        expect(c.valid).toEqual(true);
+      });
+
+      it('should support an empty options obj', () => {
+        const c = new FormControl(null, {});
+        expect(c.valid).toEqual(true);
+      });
+
       it('should return errors', () => {
         const c = new FormControl(null, Validators.required);
         expect(c.errors).toEqual({'required': true});
@@ -220,6 +253,40 @@ export function main() {
            tick();
 
            expect(c.errors).toEqual({'async': true, 'other': true});
+         }));
+
+
+      it('should support a single async validator from options obj', fakeAsync(() => {
+           const c = new FormControl('value', {asyncValidators: asyncValidator('expected')});
+           expect(c.pending).toEqual(true);
+           tick();
+
+           expect(c.valid).toEqual(false);
+           expect(c.errors).toEqual({'async': true});
+         }));
+
+      it('should support multiple async validators from options obj', fakeAsync(() => {
+           const c = new FormControl(
+               'value', {asyncValidators: [asyncValidator('expected'), otherAsyncValidator]});
+           expect(c.pending).toEqual(true);
+           tick();
+
+           expect(c.valid).toEqual(false);
+           expect(c.errors).toEqual({'async': true, 'other': true});
+         }));
+
+      it('should support a mix of validators from options obj', fakeAsync(() => {
+           const c = new FormControl(
+               '', {validators: Validators.required, asyncValidators: asyncValidator('expected')});
+           tick();
+           expect(c.errors).toEqual({required: true});
+
+           c.setValue('value');
+           expect(c.pending).toBe(true);
+
+           tick();
+           expect(c.valid).toEqual(false);
+           expect(c.errors).toEqual({'async': true});
          }));
 
       it('should add single async validator', fakeAsync(() => {

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -9,10 +9,15 @@
 import {EventEmitter} from '@angular/core';
 import {async, fakeAsync, tick} from '@angular/core/testing';
 import {AsyncTestCompleter, beforeEach, describe, inject, it} from '@angular/core/testing/src/testing_internal';
-import {AbstractControl, FormArray, FormControl, FormGroup, Validators} from '@angular/forms';
+import {AbstractControl, FormArray, FormControl, FormGroup, ValidationErrors, Validators} from '@angular/forms';
+import {of } from 'rxjs/observable/of';
 
 
 export function main() {
+  function simpleValidator(c: AbstractControl): ValidationErrors|null {
+    return c.get('one') !.value === 'correct' ? null : {'broken': true};
+  }
+
   function asyncValidator(expected: string, timeouts = {}) {
     return (c: AbstractControl) => {
       let resolve: (result: any) => void = undefined !;
@@ -35,6 +40,8 @@ export function main() {
     Promise.resolve(null).then(() => { e.emit({'async': true}); });
     return e;
   }
+
+  function otherObservableValidator() { return of ({'other': true}) }
 
   describe('FormGroup', () => {
     describe('value', () => {
@@ -101,26 +108,6 @@ export function main() {
 
         expect(g.value).toEqual({'one': '1'});
         expect(g.valid).toBe(true);
-      });
-    });
-
-    describe('errors', () => {
-      it('should run the validator when the value changes', () => {
-        const simpleValidator = (c: FormGroup) =>
-            c.controls['one'].value != 'correct' ? {'broken': true} : null;
-
-        const c = new FormControl(null);
-        const g = new FormGroup({'one': c}, simpleValidator);
-
-        c.setValue('correct');
-
-        expect(g.valid).toEqual(true);
-        expect(g.errors).toEqual(null);
-
-        c.setValue('incorrect');
-
-        expect(g.valid).toEqual(false);
-        expect(g.errors).toEqual({'broken': true});
       });
     });
 
@@ -687,6 +674,66 @@ export function main() {
       });
     });
 
+    describe('validator', () => {
+
+      function containsValidator(c: AbstractControl): ValidationErrors|null {
+        return c.get('one') !.value && c.get('one') !.value.indexOf('c') !== -1 ? null :
+                                                                                  {'missing': true};
+      }
+
+      it('should run a single validator when the value changes', () => {
+        const c = new FormControl(null);
+        const g = new FormGroup({'one': c}, simpleValidator);
+
+        c.setValue('correct');
+
+        expect(g.valid).toEqual(true);
+        expect(g.errors).toEqual(null);
+
+        c.setValue('incorrect');
+
+        expect(g.valid).toEqual(false);
+        expect(g.errors).toEqual({'broken': true});
+      });
+
+      it('should support multiple validators from array', () => {
+        const g = new FormGroup({one: new FormControl()}, [simpleValidator, containsValidator]);
+        expect(g.valid).toEqual(false);
+        expect(g.errors).toEqual({missing: true, broken: true});
+
+        g.setValue({one: 'c'});
+        expect(g.valid).toEqual(false);
+        expect(g.errors).toEqual({broken: true});
+
+        g.setValue({one: 'correct'});
+        expect(g.valid).toEqual(true);
+      });
+
+      it('should set single validator from options obj', () => {
+        const g = new FormGroup({one: new FormControl()}, {validators: simpleValidator});
+        expect(g.valid).toEqual(false);
+        expect(g.errors).toEqual({broken: true});
+
+        g.setValue({one: 'correct'});
+        expect(g.valid).toEqual(true);
+      });
+
+      it('should set multiple validators from options obj', () => {
+        const g = new FormGroup(
+            {one: new FormControl()}, {validators: [simpleValidator, containsValidator]});
+        expect(g.valid).toEqual(false);
+        expect(g.errors).toEqual({missing: true, broken: true});
+
+        g.setValue({one: 'c'});
+        expect(g.valid).toEqual(false);
+        expect(g.errors).toEqual({broken: true});
+
+        g.setValue({one: 'correct'});
+        expect(g.valid).toEqual(true);
+      });
+
+    });
+
     describe('asyncValidator', () => {
       it('should run the async validator', fakeAsync(() => {
            const c = new FormControl('value');
@@ -697,6 +744,38 @@ export function main() {
            tick(1);
 
            expect(g.errors).toEqual({'async': true});
+           expect(g.pending).toEqual(false);
+         }));
+
+      it('should set multiple async validators from array', fakeAsync(() => {
+           const g = new FormGroup(
+               {'one': new FormControl('value')}, null !,
+               [asyncValidator('expected'), otherObservableValidator]);
+           expect(g.pending).toEqual(true);
+
+           tick();
+           expect(g.errors).toEqual({'async': true, 'other': true});
+           expect(g.pending).toEqual(false);
+         }));
+
+      it('should set single async validator from options obj', fakeAsync(() => {
+           const g = new FormGroup(
+               {'one': new FormControl('value')}, {asyncValidators: asyncValidator('expected')});
+           expect(g.pending).toEqual(true);
+
+           tick();
+           expect(g.errors).toEqual({'async': true});
+           expect(g.pending).toEqual(false);
+         }));
+
+      it('should set multiple async validators from options obj', fakeAsync(() => {
+           const g = new FormGroup(
+               {'one': new FormControl('value')},
+               {asyncValidators: [asyncValidator('expected'), otherObservableValidator]});
+           expect(g.pending).toEqual(true);
+
+           tick();
+           expect(g.errors).toEqual({'async': true, 'other': true});
            expect(g.pending).toEqual(false);
          }));
 

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -175,7 +175,7 @@ export interface Form {
 export declare class FormArray extends AbstractControl {
     controls: AbstractControl[];
     readonly length: number;
-    constructor(controls: AbstractControl[], validator?: ValidatorFn | null, asyncValidator?: AsyncValidatorFn | null);
+    constructor(controls: AbstractControl[], validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
     at(index: number): AbstractControl;
     getRawValue(): any[];
     insert(index: number, control: AbstractControl): void;
@@ -222,7 +222,7 @@ export declare class FormBuilder {
 
 /** @stable */
 export declare class FormControl extends AbstractControl {
-    constructor(formState?: any, validator?: ValidatorFn | ValidatorFn[] | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
+    constructor(formState?: any, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
     patchValue(value: any, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
@@ -283,7 +283,7 @@ export declare class FormGroup extends AbstractControl {
     };
     constructor(controls: {
         [key: string]: AbstractControl;
-    }, validator?: ValidatorFn | null, asyncValidator?: AsyncValidatorFn | null);
+    }, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
     addControl(name: string, control: AbstractControl): void;
     contains(controlName: string): boolean;
     getRawValue(): any;


### PR DESCRIPTION
FormControls, FormGroups, and FormArrays now optionally accept an options object as their second argument. Validators and async validators can be passed in as part of this options object (though they can still be passed in as the second and third arg as before).

```ts
const c = new FormControl('', {
   validators: [Validators.required],
   asyncValidators: [myAsyncValidator]
});
```

This commit also adds support for passing arrays of validators and async validators to FormGroups and FormArrays, which formerly only accepted individual functions.

```ts
const g = new FormGroup({
   one: new FormControl()
}, [myPasswordValidator, myOtherValidator]);
```

This change paves the way for adding more options to AbstractControls, such as more fine-grained control of validation timing.