### PR TITLE
ci: give ownership of ngc-wrapped to compiler-cli maintainers

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -70,6 +70,7 @@ groups:
           - "tools/*"
         exclude:
           - "tools/public_api_guard/*"
+          - "tools/ngc-wrapped/*"
           - "aio/*"
     users:
       - IgorMinar #primary
@@ -137,6 +138,7 @@ groups:
       files:
         - "packages/tsc-wrapped/*"
         - "packages/compiler-cli/*"
+        - "tools/ngc-wrapped/*"
     users:
       - alexeagle
       - chuckjaz


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] CI related changes
```

## What is the current behavior?

`tools/ngc-wrapped` is captured in the build-and-ci group. It should be considered part of the compiler.

## What is the new behavior?

Excluded from `build-and-ci` and added to `compiler-cli`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
