### PR TITLE
fix(compiler-cli): point browser rollup config to new location of

### DIFF
--- a/packages/compiler-cli/browser-rollup.config.js
+++ b/packages/compiler-cli/browser-rollup.config.js
@@ -18,7 +18,7 @@ var tslibLocation = normalize('../../node_modules/tslib');
 var esm = 'esm/';
 
 var locations = {
-  'tsc-wrapped': normalize('../../dist/tools/@angular') + '/',
+  'tsc-wrapped': normalize('../../dist/packages-dist') + '/',
   'compiler-cli': normalize('../../dist/packages') + '/'
 };
 


### PR DESCRIPTION
tsc-wrapped

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Fixes browser rollup config for ngc to point to new location of tsc-wrapped.

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Browser rollup config for ngc doesn't properly resolve location of tsc-wrapped due to prior move of that package

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Browser rollup config properly resolves location of tsc-wrapped

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
