### PR TITLE
fix(forms): Add input type File onChange detection

### DIFF
--- a/packages/forms/src/directives.ts
+++ b/packages/forms/src/directives.ts
@@ -10,6 +10,7 @@ import {NgModule, Type} from '@angular/core';
 
 import {CheckboxControlValueAccessor} from './directives/checkbox_value_accessor';
 import {DefaultValueAccessor} from './directives/default_value_accessor';
+import {FileValueAccessor} from './directives/file_value_accessor';
 import {NgControlStatus, NgControlStatusGroup} from './directives/ng_control_status';
 import {NgForm} from './directives/ng_form';
 import {NgModel} from './directives/ng_model';
@@ -29,6 +30,7 @@ import {CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MinLength
 export {CheckboxControlValueAccessor} from './directives/checkbox_value_accessor';
 export {ControlValueAccessor} from './directives/control_value_accessor';
 export {DefaultValueAccessor} from './directives/default_value_accessor';
+export {FileValueAccessor} from './directives/file_value_accessor';
 export {NgControl} from './directives/ng_control';
 export {NgControlStatus, NgControlStatusGroup} from './directives/ng_control_status';
 export {NgForm} from './directives/ng_form';
@@ -50,6 +52,7 @@ export const SHARED_FORM_DIRECTIVES: Type<any>[] = [
   NgSelectMultipleOption,
   DefaultValueAccessor,
   NumberValueAccessor,
+  FileValueAccessor,
   RangeValueAccessor,
   CheckboxControlValueAccessor,
   SelectControlValueAccessor,

--- a/packages/forms/src/directives/file_value_accessor.ts
+++ b/packages/forms/src/directives/file_value_accessor.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Directive, ElementRef, Renderer2, forwardRef} from '@angular/core';
+
+import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
+
+export const FILE_VALUE_ACCESSOR: any = {
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => FileValueAccessor),
+  multi: true
+};
+
+/**
+ * The accessor for listening to changes a file value that is used by the
+ * {@link NgModel}, {@link FormControlDirective}, and {@link FormControlName} directives.
+ *
+ *  ### Example
+ *  ```
+ *  <input type="file" ngModel>
+ *  ```
+ */
+@Directive({
+  selector:
+      'input[type=file][formControlName],input[type=file][formControl],input[type=file][ngModel]',
+  host: {
+    '(change)': 'onChange($event.target.value)',
+    '(input)': 'onChange($event.target.value)',
+    '(blur)': 'onTouched()'
+  },
+  providers: [FILE_VALUE_ACCESSOR]
+})
+export class FileValueAccessor implements ControlValueAccessor {
+  onChange = (_: any) => {};
+  onTouched = () => {};
+
+  constructor(private _renderer: Renderer2, private _elementRef: ElementRef) {}
+
+  writeValue(value: any): void {}
+
+  registerOnChange(fn: (_: any) => void): void { this.onChange = fn; };
+
+  registerOnTouched(fn: () => void): void { this.onTouched = fn; }
+
+  setDisabledState(isDisabled: boolean): void {
+    this._renderer.setProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+  }
+}

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -15,6 +15,7 @@ import {CheckboxControlValueAccessor} from './checkbox_value_accessor';
 import {ControlContainer} from './control_container';
 import {ControlValueAccessor} from './control_value_accessor';
 import {DefaultValueAccessor} from './default_value_accessor';
+import {FileValueAccessor} from './file_value_accessor';
 import {NgControl} from './ng_control';
 import {normalizeAsyncValidator, normalizeValidator} from './normalize_validator';
 import {NumberValueAccessor} from './number_value_accessor';
@@ -137,6 +138,7 @@ const BUILTIN_ACCESSORS = [
   CheckboxControlValueAccessor,
   RangeValueAccessor,
   NumberValueAccessor,
+  FileValueAccessor,
   SelectControlValueAccessor,
   SelectMultipleControlValueAccessor,
   RadioControlValueAccessor,

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -151,6 +151,31 @@ export function main() {
       });
     });
 
+    describe('should support <type=file>', () => {
+      it('with basic use case', () => {
+        const fixture = initTest(FormControlFileInput);
+        const control = new FormControl();
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+
+        // model -> view
+        const input = fixture.debugElement.query(By.css('input'));
+        expect(input.nativeElement.value).toEqual('');
+      });
+
+      it('when value is cleared in the UI', () => {
+        const fixture = initTest(FormControlFileInput);
+        const control = new FormControl('', Validators.required);
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css('input'));
+
+        expect(control.valid).toBe(false);
+        expect(control.value).toEqual('');
+      });
+    });
+
     describe('select controls', () => {
 
       describe('in reactive forms', () => {
@@ -1024,6 +1049,12 @@ export class FormGroupComp {
   form: FormGroup;
   myGroup: FormGroup;
   event: Event;
+}
+
+@Component(
+    {selector: 'form-control-file-input', template: `<input type="file" [formControl]="control">`})
+class FormControlFileInput {
+  control: FormControl;
 }
 
 @Component({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
With the browser Chrome, the validator on input type file doesn't fired. Because the input event doesn't applied, only the change event is fired.
2 Validators used : one to validate the file extension and another one to validate the file size.
Issue Number: N/A


## What is the new behavior?

The Validator function has fired
## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
