### PR TITLE
feat(core): `SimpleChange` interface now accepts `T`

### DIFF
--- a/integration/hello_world__closure/package.json
+++ b/integration/hello_world__closure/package.json
@@ -13,7 +13,7 @@
     "@angular/tsc-wrapped": "file:../../dist/packages-dist/tsc-wrapped",
     "google-closure-compiler": "20170409.0.0",
     "rxjs": "5.3.1",
-    "typescript": "2.1.6",
+    "typescript": "^2.3.4",
     "zone.js": "0.8.6"
   },
   "devDependencies": {

--- a/integration/hello_world__systemjs_umd/package.json
+++ b/integration/hello_world__systemjs_umd/package.json
@@ -19,7 +19,7 @@
     "plugin-typescript": "6.0.4",
     "rxjs": "file:../../node_modules/rxjs",
     "systemjs": "0.20.2",
-    "typescript": "2.1.6",
+    "typescript": "^2.3.4",
     "zone.js": "0.7.6"
   },
   "devDependencies": {

--- a/integration/typings_test_ts21/package.json
+++ b/integration/typings_test_ts21/package.json
@@ -19,7 +19,7 @@
     "@angular/upgrade": "file:../../dist/packages-dist/upgrade",
     "@types/jasmine": "2.5.41",
     "rxjs": "file:../../node_modules/rxjs",
-    "typescript": "2.1.6",
+    "typescript": "^2.3.4",
     "zone.js": "0.7.6"
   },
   "scripts": {

--- a/integration/typings_test_ts22/package.json
+++ b/integration/typings_test_ts22/package.json
@@ -19,7 +19,7 @@
     "@angular/upgrade": "file:../../dist/packages-dist/upgrade",
     "@types/jasmine": "2.5.41",
     "rxjs": "file:../../node_modules/rxjs",
-    "typescript": "2.2.1",
+    "typescript": "^2.3.4",
     "zone.js": "0.7.6"
   },
   "scripts": {

--- a/integration/typings_test_ts23/package.json
+++ b/integration/typings_test_ts23/package.json
@@ -19,7 +19,7 @@
     "@angular/upgrade": "file:../../dist/packages-dist/upgrade",
     "@types/jasmine": "2.5.41",
     "rxjs": "file:../../node_modules/rxjs",
-    "typescript": "2.3.2",
+    "typescript": "^2.3.4",
     "zone.js": "0.7.6"
   },
   "scripts": {

--- a/packages/core/src/change_detection/change_detection_util.ts
+++ b/packages/core/src/change_detection/change_detection_util.ts
@@ -70,7 +70,7 @@ export class ValueUnwrapper {
  * Represents a basic change from a previous to a new value.
  * @stable
  */
-export class SimpleChange<T = any> {
+export class SimpleChange<T> {
   constructor(public previousValue: T, public currentValue: T, public firstChange: boolean) {}
 
   /**

--- a/packages/core/src/change_detection/change_detection_util.ts
+++ b/packages/core/src/change_detection/change_detection_util.ts
@@ -70,8 +70,8 @@ export class ValueUnwrapper {
  * Represents a basic change from a previous to a new value.
  * @stable
  */
-export class SimpleChange {
-  constructor(public previousValue: any, public currentValue: any, public firstChange: boolean) {}
+export class SimpleChange<T = any> {
+  constructor(public previousValue: T, public currentValue: T, public firstChange: boolean) {}
 
   /**
    * Check whether the new value is the first value assigned.

--- a/packages/core/src/metadata/lifecycle_hooks.ts
+++ b/packages/core/src/metadata/lifecycle_hooks.ts
@@ -14,7 +14,9 @@ import {SimpleChange} from '../change_detection/change_detection_util';
  * values are instances of {@link SimpleChange}. See {@link OnChanges}
  * @stable
  */
-export interface SimpleChanges { [propName: string]: SimpleChange<any>; }
+export type SimpleChanges<T = any> = {
+    [P in keyof T]?: SimpleChange<T[P]>;
+}
 
 /**
  * @whatItDoes Lifecycle hook that is called when any data-bound property of a directive changes.

--- a/packages/core/src/metadata/lifecycle_hooks.ts
+++ b/packages/core/src/metadata/lifecycle_hooks.ts
@@ -14,7 +14,7 @@ import {SimpleChange} from '../change_detection/change_detection_util';
  * values are instances of {@link SimpleChange}. See {@link OnChanges}
  * @stable
  */
-export interface SimpleChanges { [propName: string]: SimpleChange; }
+export interface SimpleChanges { [propName: string]: SimpleChange<any>; }
 
 /**
  * @whatItDoes Lifecycle hook that is called when any data-bound property of a directive changes.

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -603,7 +603,7 @@ export function main() {
            tick();
            expect(ngModel.control.disabled).toEqual(false);
 
-           ngModel.ngOnChanges({isDisabled: new SimpleChange<string | boolean>('', false, false)});
+           ngModel.ngOnChanges({isDisabled: new SimpleChange<string|boolean>('', false, false)});
            tick();
            expect(ngModel.control.disabled).toEqual(false);
 
@@ -611,7 +611,7 @@ export function main() {
            tick();
            expect(ngModel.control.disabled).toEqual(false);
 
-           ngModel.ngOnChanges({isDisabled: new SimpleChange<string | number>('', 0, false)});
+           ngModel.ngOnChanges({isDisabled: new SimpleChange<string|number>('', 0, false)});
            tick();
            expect(ngModel.control.disabled).toEqual(false);
 

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -603,7 +603,7 @@ export function main() {
            tick();
            expect(ngModel.control.disabled).toEqual(false);
 
-           ngModel.ngOnChanges({isDisabled: new SimpleChange('', false, false)});
+           ngModel.ngOnChanges({isDisabled: new SimpleChange<string | boolean>('', false, false)});
            tick();
            expect(ngModel.control.disabled).toEqual(false);
 
@@ -611,7 +611,7 @@ export function main() {
            tick();
            expect(ngModel.control.disabled).toEqual(false);
 
-           ngModel.ngOnChanges({isDisabled: new SimpleChange('', 0, false)});
+           ngModel.ngOnChanges({isDisabled: new SimpleChange<string | number>('', 0, false)});
            tick();
            expect(ngModel.control.disabled).toEqual(false);
 

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -926,11 +926,11 @@ export declare function sequence(steps: AnimationMetadata[]): AnimationSequenceM
 export declare function setTestabilityGetter(getter: GetTestability): void;
 
 /** @stable */
-export declare class SimpleChange {
-    currentValue: any;
+export declare class SimpleChange<T = any> {
+    currentValue: T;
     firstChange: boolean;
-    previousValue: any;
-    constructor(previousValue: any, currentValue: any, firstChange: boolean);
+    previousValue: T;
+    constructor(previousValue: T, currentValue: T, firstChange: boolean);
     isFirstChange(): boolean;
 }
 


### PR DESCRIPTION
…iousValue` and `currentValue` type

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
SimpleChange now supports generics

Issue Number: N/A


## What is the new behavior?
```
ngOnChanges(changes: {options?: SimpleChange<ComponentOptions>}) {
```

## Does this PR introduce a breaking change?
```
[X] Yes
[] No
```

This
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Angular now requires TypeScript  `2.3.x` or greater as it has uses default generics