### PR TITLE
build: ignore node_modules for tslint

### DIFF
--- a/tools/gulp-tasks/lint.js
+++ b/tools/gulp-tasks/lint.js
@@ -13,6 +13,9 @@ module.exports = (gulp) => () => {
         './tools/**/*.ts',
         './*.ts',
 
+        // Ignore node_modules directories
+        '!**/node_modules/**',
+
         // Ignore TypeScript mocks because it's not managed by us
         '!./tools/@angular/tsc-wrapped/test/typescript.mocks.ts',
 


### PR DESCRIPTION
This is required to exclude node_modules installed by integration tests