### PR TITLE
docs(aio): replace old blog link in footer

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -402,7 +402,7 @@
           "tooltip": "Press contacts, logos, and branding."
         },
         {
-          "url": "https://blog.angularjs.org/",
+          "url": "https://blog.angular.io/",
           "title": "Blog",
           "tooltip": "Angular Blog"
         }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Footer of angular.io links blog to https://blog.angularjs.org/

Issue Number: 18233

## What is the new behavior?
Footer blog link goes to https://blog.angular.io/

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```