### PR TITLE
refactor(compiler): cleanly compile with TypeScript 2.4

### DIFF
--- a/packages/compiler/test/aot/static_symbol_resolver_spec.ts
+++ b/packages/compiler/test/aot/static_symbol_resolver_spec.ts
@@ -459,7 +459,7 @@ export class MockStaticSymbolResolverHost implements StaticSymbolResolverHost {
           const errors =
               diagnostics
                   .map(d => {
-                    const {line, character} = ts.getLineAndCharacterOfPosition(d.file, d.start);
+                    const {line, character} = ts.getLineAndCharacterOfPosition(d.file !, d.start !);
                     return `(${line}:${character}): ${d.messageText}`;
                   })
                   .join('\n');

--- a/packages/compiler/test/aot/test_util.ts
+++ b/packages/compiler/test/aot/test_util.ts
@@ -559,8 +559,8 @@ export function expectNoDiagnostics(program: ts.Program) {
 
   function lineInfo(diagnostic: ts.Diagnostic): string {
     if (diagnostic.file) {
-      const start = diagnostic.start;
-      let end = diagnostic.start + diagnostic.length;
+      const start = diagnostic.start !;
+      let end = diagnostic.start ! + diagnostic.length !;
       const source = diagnostic.file.text;
       let lineStart = start;
       let lineEnd = end;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Refactor
```

## What is the current behavior?

The compiler package does not compile cleanly with TypeScript 2.4

Issue Number: #18454

## What is the new behavior?

The compiler package compiles cleanly with TypeScript 2.4

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
