### PR TITLE
fix(core): compile core cleanly with TypeScript 2.4

### DIFF
--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -63,8 +63,9 @@ export interface IterableChanges<V> {
    *        of the item, after applying the operations up to this point.
    */
   forEachOperation(
-      fn: (record: IterableChangeRecord<V>, previousIndex: number, currentIndex: number) => void):
-      void;
+      fn:
+          (record: IterableChangeRecord<V>, previousIndex: number|null,
+           currentIndex: number|null) => void): void;
 
   /**
    * Iterate over changes in the order of original `Iterable` showing where the original items

--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -647,9 +647,9 @@ function commonTests() {
     it('should call onUnstable and onMicrotaskEmpty before and after each turn, respectively',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          let aResolve: (result: string | null) => void;
-         let aPromise: Promise<string>;
+         let aPromise: Promise<string|null>;
          let bResolve: (result: string | null) => void;
-         let bPromise: Promise<string>;
+         let bPromise: Promise<string|null>;
 
          runNgZoneNoLog(() => {
            macroTask(() => {

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -513,7 +513,7 @@ export interface IterableChanges<V> {
     forEachIdentityChange(fn: (record: IterableChangeRecord<V>) => void): void;
     forEachItem(fn: (record: IterableChangeRecord<V>) => void): void;
     forEachMovedItem(fn: (record: IterableChangeRecord<V>) => void): void;
-    forEachOperation(fn: (record: IterableChangeRecord<V>, previousIndex: number, currentIndex: number) => void): void;
+    forEachOperation(fn: (record: IterableChangeRecord<V>, previousIndex: number | null, currentIndex: number | null) => void): void;
     forEachPreviousItem(fn: (record: IterableChangeRecord<V>) => void): void;
     forEachRemovedItem(fn: (record: IterableChangeRecord<V>) => void): void;
 }


### PR DESCRIPTION
Fixes: #17863

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The core package does not compile cleanly with TypeScript 2.4.

Issue Number: #17863, #18454

## What is the new behavior?

The core package compiles cleanly with TypeScript 2.4.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
