### PR TITLE
refactor(upgrade): compile upgrade cleanly with TypeScript 2.4

### DIFF
--- a/packages/upgrade/test/static/integration/upgrade_component_spec.ts
+++ b/packages/upgrade/test/static/integration/upgrade_component_spec.ts
@@ -1028,7 +1028,10 @@ export function main() {
            // Define `ng1Component`
            const ng1ComponentA: angular.IComponent = {template: 'ng1A(<ng1-b></ng1-b>)'};
            const ng1DirectiveB: angular.IDirective = {
-             compile: tElem => grandParentNodeName = tElem.parent !().parent !()[0].nodeName
+             compile: tElem => {
+               grandParentNodeName = tElem.parent !().parent !()[0].nodeName;
+               return {};
+             }
            };
 
            // Define `Ng1ComponentAFacade`


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Refactoring (no functional changes, no api changes)
```

## What is the current behavior?

Some upgrade package files do not compile cleanly with TypeScript 2.4.

## What is the new behavior?

Upgrade package compiles cleanly with TypeScript 2.4.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
