### PR TITLE
refactor(forms): compile cleanly with TypeScript 2.4

### DIFF
--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -616,7 +616,7 @@ export function main() {
       it('should return true when the component is enabled', () => {
         expect(group.contains('required')).toEqual(true);
 
-        group.enable('optional');
+        group.enable();
 
         expect(group.contains('optional')).toEqual(true);
       });


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Refactoring (no functional changes, no api changes)
```

## What is the current behavior?

The forms tests do not compile cleanly in TypeScript 2.4.

## What is the new behavior?

The forms test compile cleanly with TypeScript 2.4.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
