### PR TITLE
refactor(platform-browser): compiler platform-browser packages cleanly

### DIFF
--- a/packages/platform-browser-dynamic/src/resource_loader/resource_loader_impl.ts
+++ b/packages/platform-browser-dynamic/src/resource_loader/resource_loader_impl.ts
@@ -14,7 +14,7 @@ export class ResourceLoaderImpl extends ResourceLoader {
   get(url: string): Promise<string> {
     let resolve: (result: any) => void;
     let reject: (error: any) => void;
-    const promise = new Promise((res, rej) => {
+    const promise = new Promise<string>((res, rej) => {
       resolve = res;
       reject = rej;
     });

--- a/packages/platform-browser/test/dom/events/event_manager_spec.ts
+++ b/packages/platform-browser/test/dom/events/event_manager_spec.ts
@@ -109,7 +109,6 @@ class FakeEventManagerPlugin extends EventManagerPlugin {
 
 class FakeNgZone extends NgZone {
   constructor() { super({enableLongStackTrace: false}); }
-  run(fn: Function) { fn(); }
-
+  run<T>(fn: (...args: any[]) => T, applyThis?: any, applyArgs?: any[]): T { return fn(); }
   runOutsideAngular(fn: Function) { return fn(); }
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Refactoring (no functional changes, no api changes)
```

## What is the current behavior?

The platform-browser packages do not compile cleanly with TypeScript 2.4.


## What is the new behavior?

The platform-browser packages compile cleanly with TypeScript 2.4.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
