### PR TITLE
refactor(router): compile router cleanly with TypeScript 2.4

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -533,7 +533,7 @@ export class Router {
     let resolve: any = null;
     let reject: any = null;
 
-    const promise = new Promise((res, rej) => {
+    const promise = new Promise<boolean>((res, rej) => {
       resolve = res;
       reject = rej;
     });

--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -116,5 +116,5 @@ export function wrapIntoObservable<T>(value: T | NgModuleFactory<T>| Promise<T>|
     return fromPromise(Promise.resolve(value));
   }
 
-  return of (value);
+  return of (value as T);
 }

--- a/packages/router/test/config.spec.ts
+++ b/packages/router/test/config.spec.ts
@@ -45,7 +45,7 @@ describe('config', () => {
       expect(() => {
         validateConfig([
           {path: 'a', component: ComponentA},
-          [{path: 'b', component: ComponentB}, {path: 'c', component: ComponentC}]
+          [{path: 'b', component: ComponentB}, {path: 'c', component: ComponentC}] as any
         ]);
       }).toThrowError(`Invalid configuration of route '': Array cannot be specified`);
     });

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1820,7 +1820,7 @@ describe('Integration', () => {
 
         function delayPromise(delay: number): Promise<boolean> {
           let resolve: (val: boolean) => void;
-          const promise = new Promise(res => resolve = res);
+          const promise = new Promise<boolean>(res => resolve = res);
           setTimeout(() => resolve(true), delay);
           return promise;
         }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Refactoring (no functional changes, no api changes)
```

## What is the current behavior?

The router package does not compile cleanly with TypeScript 2.4.

## What is the new behavior?

The router package compiles cleanly with TypeScript 2.4.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
