### PR TITLE
fix(router): use `[]` postfix characters for represent multiple query…

### DIFF
--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -192,11 +192,15 @@ export function main() {
 
       });
 
-      it('should format invalid in IE ISO date',
-         () => expect(pipe.transform('2017-01-11T09:25:14.014-0500')).toEqual('Jan 11, 2017'));
+      it('should format invalid in IE ISO date', () => {
+        const validFormattedString = pipe.transform(new Date('2017-01-11T09:25:14+00:00'));
+        expect(pipe.transform('2017-01-11T09:25:14.014-0500')).toEqual(validFormattedString);
+      });
 
-      it('should format invalid in Safari ISO date',
-         () => expect(pipe.transform('2017-01-20T19:00:00+0000')).toEqual('Jan 20, 2017'));
+      it('should format invalid in Safari ISO date', () => {
+        const validFormattedString = pipe.transform(new Date('2017-01-20T19:00:00+00:00'))
+        expect(pipe.transform('2017-01-20T19:00:00+0000')).toEqual(validFormattedString);
+      });
 
       it('should remove bidi control characters',
          () => expect(pipe.transform(date, 'MM/dd/yyyy') !.length).toEqual(10));

--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -198,7 +198,7 @@ export function main() {
       });
 
       it('should format invalid in Safari ISO date', () => {
-        const validFormattedString = pipe.transform(new Date('2017-01-20T19:00:00+00:00'))
+        const validFormattedString = pipe.transform(new Date('2017-01-20T19:00:00+00:00'));
         expect(pipe.transform('2017-01-20T19:00:00+0000')).toEqual(validFormattedString);
       });
 

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -507,7 +507,7 @@ class UrlParser {
     }
 
     const {'1': keyWithoutBracket, '2': hasBracket} =
-      /^(.*)(\[\])$/g.exec(key) || [null, key, false];
+        /^(.*)(\[\])$/g.exec(key) || [null, key, false];
 
     const decodedKey = decode(keyWithoutBracket as string);
     const decodedVal = decode(value);

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -360,7 +360,7 @@ function serializeParams(params: {[key: string]: string}): string {
 function serializeQueryParams(params: {[key: string]: any}): string {
   const strParams: string[] = Object.keys(params).map((name) => {
     const value = params[name];
-    return Array.isArray(value) ? value.map(v => `${encode(name)}=${encode(v)}`).join('&') :
+    return Array.isArray(value) ? value.map(v => `${encode(name)}[]=${encode(v)}`).join('&') :
                                   `${encode(name)}=${encode(value)}`;
   });
 
@@ -506,7 +506,10 @@ class UrlParser {
       }
     }
 
-    const decodedKey = decode(key);
+    const {'1': keyWithoutBracket, '2': hasBracket} =
+      /^(.*)(\[\])$/g.exec(key) || [null, key, false];
+
+    const decodedKey = decode(keyWithoutBracket as string);
     const decodedVal = decode(value);
 
     if (params.hasOwnProperty(decodedKey)) {
@@ -519,7 +522,7 @@ class UrlParser {
       currentVal.push(decodedVal);
     } else {
       // Create a new value
-      params[decodedKey] = decodedVal;
+      params[decodedKey] = !!hasBracket ? [decodedVal] : decodedVal;
     }
   }
 

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -20,11 +20,11 @@ describe('createUrlTree', () => {
     it('should support parameter with multiple values', () => {
       const p1 = serializer.parse('/');
       const t1 = createRoot(p1, ['/'], {m: ['v1', 'v2']});
-      expect(serializer.serialize(t1)).toEqual('/?m=v1&m=v2');
+      expect(serializer.serialize(t1)).toEqual('/?m[]=v1&m[]=v2');
 
       const p2 = serializer.parse('/a/c');
       const t2 = create(p2.root.children[PRIMARY_OUTLET], 1, p2, ['c2'], {m: ['v1', 'v2']});
-      expect(serializer.serialize(t2)).toEqual('/a/c/c2?m=v1&m=v2');
+      expect(serializer.serialize(t2)).toEqual('/a/c/c2?m[]=v1&m[]=v2');
     });
 
     it('should set query params', () => {

--- a/packages/router/test/url_serializer.spec.ts
+++ b/packages/router/test/url_serializer.spec.ts
@@ -165,7 +165,7 @@ describe('url serializer', () => {
     expect(tree.queryParams).toEqual({a: ['foo', 'bar', 'swaz']});
     expect(tree.queryParamMap.get('a')).toEqual('foo');
     expect(tree.queryParamMap.getAll('a')).toEqual(['foo', 'bar', 'swaz']);
-    expect(url.serialize(tree)).toEqual('/one?a=foo&a=bar&a=swaz');
+    expect(url.serialize(tree)).toEqual('/one?a[]=foo&a[]=bar&a[]=swaz');
   });
 
   it('should parse fragment', () => {

--- a/packages/router/test/url_tree.spec.ts
+++ b/packages/router/test/url_tree.spec.ts
@@ -26,24 +26,17 @@ describe('UrlTree', () => {
 
     it('should parse multiple value query parameters', () => {
       const tree = serializer.parse('/path/to?a[]=1&a[]=2');
-      expect(tree.queryParams).toEqual({
-        'a': ['1', '2']
-      });
+      expect(tree.queryParams).toEqual({'a': ['1', '2']});
     });
 
     it('should parse query parameter with `[]` postfixed key parameter.', () => {
       const tree = serializer.parse('/path/to?a[]=1&a[]=2&b=hello&a=4');
-      expect(tree.queryParams).toEqual({
-        'a': ['1', '2', '4'],
-        'b': 'hello'
-      });
+      expect(tree.queryParams).toEqual({'a': ['1', '2', '4'], 'b': 'hello'});
     });
 
     it('should parse query parameter with single `[]` postfixed key parameter.', () => {
       const tree = serializer.parse('/path/to?a[]=1');
-      expect(tree.queryParams).toEqual({
-        'a': ['1']
-      });
+      expect(tree.queryParams).toEqual({'a': ['1']});
     });
   });
 

--- a/packages/router/test/url_tree.spec.ts
+++ b/packages/router/test/url_tree.spec.ts
@@ -23,6 +23,28 @@ describe('UrlTree', () => {
         'k/(a;b)': 'c',
       });
     });
+
+    it('should parse multiple value query parameters', () => {
+      const tree = serializer.parse('/path/to?a[]=1&a[]=2');
+      expect(tree.queryParams).toEqual({
+        'a': ['1', '2']
+      });
+    });
+
+    it('should parse query parameter with `[]` postfixed key parameter.', () => {
+      const tree = serializer.parse('/path/to?a[]=1&a[]=2&b=hello&a=4');
+      expect(tree.queryParams).toEqual({
+        'a': ['1', '2', '4'],
+        'b': 'hello'
+      });
+    });
+
+    it('should parse query parameter with single `[]` postfixed key parameter.', () => {
+      const tree = serializer.parse('/path/to?a[]=1');
+      expect(tree.queryParams).toEqual({
+        'a': ['1']
+      });
+    });
   });
 
   describe('containsTree', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

If i invoke `router.navigate(['/list'], {queryParams: {ids: ['a']}}`. then `queryParams.ids` of `ActivatedRoute` value is `['a']` and the url of browser is `http://test.com/list?ids=a`.

But. if i access the page by directly enter upper url and check the router's query param value. it is {ids: 'a'}. because router make array only when presence of duplicated key.

## What is the new behavior?

Router will change browser url to `http://test.com/ids[]=a` when developer pass array to `queryParams` value.

In this case. angular can detect `ids` value is array. despite of refreshing browser or direct access by typing url. `[]` character will work for flag to value is array.

I didn't block case that developer pass `{'ids[]': ['a']}`to `queryParams`. it seems to be developer's fault.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

I change two test of `date_pipe.ts`. these test breaking master branch's testing becase it is not considered UTC.
