### PR TITLE
docs(aio): fix missing anchor-open in i18n docs markdown 

### DIFF
--- a/aio/content/guide/i18n.md
+++ b/aio/content/guide/i18n.md
@@ -408,7 +408,7 @@ This XML element represents the translation of the `<h1>` greeting tag you marke
 
 <div class="l-sub-section">
 
-Note that the translation unit `id=introductionHeader` is derived from the  _custom_ `id`](#custom-id "Set a custom id") that you set earlier, but **without the `@@` prefix** required in the source HTML.
+Note that the translation unit `id=introductionHeader` is derived from the [_custom_ `id`](#custom-id "Set a custom id") that you set earlier, but **without the `@@` prefix** required in the source HTML.
 
 </div>
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: N/A

The Angular.io documentation on Internationalisation omits a markdown anchor-opening bracket in the section entitled [Translate text nodes](https://angular.io/guide/i18n#translate-text-nodes).  There's a hero callout (light blue) that contains raw markdown as a result:

<img width="862" alt="screenshot 2017-08-02 11 47 49" src="https://user-images.githubusercontent.com/242248/28870515-77e8a008-7778-11e7-8263-9295b5158dc1.png">

(see last part - highlighted in yellow).


## What is the new behavior?

This PR adds an opening anchor bracket.  When correcting this, I guessed at the position of the opening bracket from conventions elsewhere in the file.  I may have it wrong, but at least you'll be aware of where it's broken.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
