### PR TITLE
docs(router): fix typo

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -70,7 +70,7 @@ import {UrlTree} from '../url_tree';
  *
  * You can tell the directive to how to handle queryParams, available options are:
  *  - 'merge' merge the queryParams into the current queryParams
- *  - 'preserve' prserve the current queryParams
+ *  - 'preserve' preserve the current queryParams
  *  - default / '' use the queryParams only
  *  same options for {@link NavigationExtras#queryParamsHandling}
  *


### PR DESCRIPTION
Just a tiny typo in the docs.

## PR Type
- [x] Documentation content changes