### PR TITLE
feat(common): accept object map for HttpClient headers & params

### DIFF
--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -26,9 +26,9 @@ import {HttpEvent, HttpResponse} from './response';
  */
 function addBody<T>(
     options: {
-      headers?: HttpHeaders,
+      headers?: HttpHeaders | {[header: string]: string | string[]},
       observe?: HttpObserve,
-      params?: HttpParams,
+      params?: HttpParams | {[param: string]: string | string[]},
       reportProgress?: boolean,
       responseType?: 'arraybuffer' | 'blob' | 'json' | 'text',
       withCredentials?: boolean,
@@ -75,9 +75,9 @@ export class HttpClient {
    */
   request(method: string, url: string, options: {
     body?: any,
-    headers?: HttpHeaders,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -89,9 +89,9 @@ export class HttpClient {
    */
   request(method: string, url: string, options: {
     body?: any,
-    headers?: HttpHeaders,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -103,9 +103,9 @@ export class HttpClient {
    */
   request(method: string, url: string, options: {
     body?: any,
-    headers?: HttpHeaders,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -117,8 +117,8 @@ export class HttpClient {
    */
   request(method: string, url: string, options: {
     body?: any,
-    headers?: HttpHeaders,
-    params?: HttpParams,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | string[]},
     observe: 'events', reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
@@ -130,8 +130,10 @@ export class HttpClient {
    */
   request(method: string, url: string, options: {
     body?: any,
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -142,8 +144,10 @@ export class HttpClient {
    */
   request(method: string, url: string, options: {
     body?: any,
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -154,9 +158,12 @@ export class HttpClient {
    */
   request(method: string, url: string, options: {
     body?: any,
-    headers?: HttpHeaders,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
     reportProgress?: boolean,
-    observe: 'events', params?: HttpParams, responseType?: 'json', withCredentials?: boolean,
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    responseType?: 'json',
+    withCredentials?: boolean,
   }): Observable<HttpEvent<any>>;
 
   /**
@@ -166,9 +173,12 @@ export class HttpClient {
    */
   request<R>(method: string, url: string, options: {
     body?: any,
-    headers?: HttpHeaders,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
     reportProgress?: boolean,
-    observe: 'events', params?: HttpParams, responseType?: 'json', withCredentials?: boolean,
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    responseType?: 'json',
+    withCredentials?: boolean,
   }): Observable<HttpEvent<R>>;
 
   /**
@@ -178,8 +188,10 @@ export class HttpClient {
    */
   request(method: string, url: string, options: {
     body?: any,
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -190,8 +202,10 @@ export class HttpClient {
    */
   request(method: string, url: string, options: {
     body?: any,
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -202,8 +216,10 @@ export class HttpClient {
    */
   request(method: string, url: string, options: {
     body?: any,
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -214,9 +230,12 @@ export class HttpClient {
    */
   request(method: string, url: string, options: {
     body?: any,
-    headers?: HttpHeaders,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
     reportProgress?: boolean,
-    observe: 'response', params?: HttpParams, responseType?: 'json', withCredentials?: boolean,
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    responseType?: 'json',
+    withCredentials?: boolean,
   }): Observable<HttpResponse<Object>>;
 
   /**
@@ -226,9 +245,12 @@ export class HttpClient {
    */
   request<R>(method: string, url: string, options: {
     body?: any,
-    headers?: HttpHeaders,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
     reportProgress?: boolean,
-    observe: 'response', params?: HttpParams, responseType?: 'json', withCredentials?: boolean,
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    responseType?: 'json',
+    withCredentials?: boolean,
   }): Observable<HttpResponse<R>>;
 
   /**
@@ -238,9 +260,9 @@ export class HttpClient {
    */
   request(method: string, url: string, options?: {
     body?: any,
-    headers?: HttpHeaders,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     responseType?: 'json',
     reportProgress?: boolean,
     withCredentials?: boolean,
@@ -253,9 +275,9 @@ export class HttpClient {
    */
   request<R>(method: string, url: string, options?: {
     body?: any,
-    headers?: HttpHeaders,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     responseType?: 'json',
     reportProgress?: boolean,
     withCredentials?: boolean,
@@ -269,8 +291,8 @@ export class HttpClient {
    */
   request(method: string, url: string, options?: {
     body?: any,
-    headers?: HttpHeaders,
-    params?: HttpParams,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | string[]},
     observe?: HttpObserve,
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
@@ -310,9 +332,9 @@ export class HttpClient {
    */
   request(first: string|HttpRequest<any>, url?: string, options: {
     body?: any,
-    headers?: HttpHeaders,
+    headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -327,9 +349,31 @@ export class HttpClient {
       // It's a string, so it represents a URL. Construct a request based on it,
       // and incorporate the remaining arguments (assuming GET unless a method is
       // provided.
+
+      // Figure out the headers.
+      let headers: HttpHeaders|undefined = undefined;
+      if (!!options.headers !== undefined) {
+        if (options.headers instanceof HttpHeaders) {
+          headers = options.headers;
+        } else {
+          headers = new HttpHeaders(options.headers);
+        }
+      }
+
+      // Sort out parameters.
+      let params: HttpParams|undefined = undefined;
+      if (!!options.params) {
+        if (options.params instanceof HttpParams) {
+          params = options.params;
+        } else {
+          params = new HttpParams({fromObject: options.params});
+        }
+      }
+
+      // Construct the request.
       req = new HttpRequest(first, url !, options.body || null, {
-        headers: options.headers,
-        params: options.params,
+        headers,
+        params,
         reportProgress: options.reportProgress,
         // By default, JSON is assumed to be returned for all calls.
         responseType: options.responseType || 'json',
@@ -410,9 +454,9 @@ export class HttpClient {
    * @return an `Observable` of the body as an `ArrayBuffer`.
    */
   delete (url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -424,9 +468,9 @@ export class HttpClient {
    * @return an `Observable` of the body as a `Blob`.
    */
   delete (url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -437,9 +481,9 @@ export class HttpClient {
    * @return an `Observable` of the body as a `string`.
    */
   delete (url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -450,8 +494,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `ArrayBuffer`.
    */
   delete (url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -461,8 +507,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `Blob`.
    */
   delete (url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -472,8 +520,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `string`.
    */
   delete (url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -483,9 +533,9 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `Object`.
    */
   delete (url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -497,9 +547,9 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `T`.
    */
   delete<T>(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -511,8 +561,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `ArrayBuffer`.
    */
   delete (url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -522,8 +574,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `Blob`.
    */
   delete (url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -533,8 +587,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `string`.
    */
   delete (url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -544,9 +600,9 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `Object`.
    */
   delete (url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -558,9 +614,9 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `T`.
    */
   delete<T>(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -572,9 +628,9 @@ export class HttpClient {
    * @return an `Observable` of the body as an `Object`.
    */
   delete (url: string, options?: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -586,9 +642,9 @@ export class HttpClient {
    * @return an `Observable` of the body as type `T`.
    */
   delete<T>(url: string, options?: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -600,9 +656,9 @@ export class HttpClient {
    * details of `delete()`'s return type based on the provided options.
    */
   delete (url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -617,9 +673,9 @@ export class HttpClient {
    * @return an `Observable` of the body as an `ArrayBuffer`.
    */
   get(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -630,9 +686,9 @@ export class HttpClient {
    * @return an `Observable` of the body as a `Blob`.
    */
   get(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -643,9 +699,9 @@ export class HttpClient {
    * @return an `Observable` of the body as a `string`.
    */
   get(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -656,8 +712,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `ArrayBuffer`.
    */
   get(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -667,8 +725,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `Blob`.
    */
   get(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -678,8 +738,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `string`.
    */
   get(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -689,9 +751,9 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `Object`.
    */
   get(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -703,9 +765,9 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `T`.
    */
   get<T>(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -717,8 +779,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `ArrayBuffer`.
    */
   get(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -728,8 +792,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `Blob`.
    */
   get(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -739,8 +805,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `string`.
    */
   get(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -750,9 +818,9 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `Object`.
    */
   get(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -764,9 +832,9 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `T`.
    */
   get<T>(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -778,9 +846,9 @@ export class HttpClient {
    * @return an `Observable` of the body as an `Object`.
    */
   get(url: string, options?: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -792,9 +860,9 @@ export class HttpClient {
    * @return an `Observable` of the body as type `T`.
    */
   get<T>(url: string, options?: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -806,9 +874,9 @@ export class HttpClient {
    * details of `get()`'s return type based on the provided options.
    */
   get(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -823,9 +891,9 @@ export class HttpClient {
    * @return an `Observable` of the body as an `ArrayBuffer`.
    */
   head(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
 
@@ -836,9 +904,9 @@ export class HttpClient {
    */
   }): Observable<ArrayBuffer>;
   head(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -849,9 +917,9 @@ export class HttpClient {
    * @return an `Observable` of the body as a `string`.
    */
   head(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -862,8 +930,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `ArrayBuffer`.
    */
   head(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -873,8 +943,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `Blob`.
    */
   head(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -884,8 +956,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `string`.
    */
   head(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -895,9 +969,9 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `Object`.
    */
   head(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -909,9 +983,9 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `T`.
    */
   head<T>(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -923,8 +997,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `ArrayBuffer`.
    */
   head(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -934,8 +1010,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `Blob`.
    */
   head(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -945,8 +1023,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `string`.
    */
   head(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -956,9 +1036,9 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `Object`.
    */
   head(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -970,9 +1050,9 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `T`.
    */
   head<T>(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -984,9 +1064,9 @@ export class HttpClient {
    * @return an `Observable` of the body as an `Object`.
    */
   head(url: string, options?: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -998,9 +1078,9 @@ export class HttpClient {
    * @return an `Observable` of the body as type `T`.
    */
   head<T>(url: string, options?: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1012,9 +1092,9 @@ export class HttpClient {
    * details of `head()`'s return type based on the provided options.
    */
   head(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -1058,9 +1138,9 @@ export class HttpClient {
    * @return an `Observable` of the body as an `ArrayBuffer`.
    */
   options(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -1071,9 +1151,9 @@ export class HttpClient {
    * @return an `Observable` of the body as a `Blob`.
    */
   options(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -1084,9 +1164,9 @@ export class HttpClient {
    * @return an `Observable` of the body as a `string`.
    */
   options(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -1097,8 +1177,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `ArrayBuffer`.
    */
   options(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -1108,8 +1190,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `Blob`.
    */
   options(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -1119,8 +1203,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `string`.
    */
   options(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -1130,9 +1216,9 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `Object`.
    */
   options(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1144,9 +1230,9 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `T`.
    */
   options<T>(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1158,8 +1244,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `ArrayBuffer`.
    */
   options(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -1169,8 +1257,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `Blob`.
    */
   options(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -1180,8 +1270,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `string`.
    */
   options(url: string, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -1191,9 +1283,9 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `Object`.
    */
   options(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1205,9 +1297,9 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `T`.
    */
   options<T>(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1219,9 +1311,9 @@ export class HttpClient {
    * @return an `Observable` of the body as an `Object`.
    */
   options(url: string, options?: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1233,9 +1325,9 @@ export class HttpClient {
    * @return an `Observable` of the body as type `T`.
    */
   options<T>(url: string, options?: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1247,9 +1339,9 @@ export class HttpClient {
    * details of `options()`'s return type based on the provided options.
    */
   options(url: string, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -1263,9 +1355,9 @@ export class HttpClient {
    * @return an `Observable` of the body as an `ArrayBuffer`.
    */
   patch(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -1276,9 +1368,9 @@ export class HttpClient {
    * @return an `Observable` of the body as a `Blob`.
    */
   patch(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -1289,9 +1381,9 @@ export class HttpClient {
    * @return an `Observable` of the body as a `string`.
    */
   patch(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -1302,8 +1394,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `ArrayBuffer`.
    */
   patch(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -1313,8 +1407,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `Blob`.
    */
   patch(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -1324,8 +1420,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `string`.
    */
   patch(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -1335,9 +1433,9 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `Object`.
    */
   patch(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1349,9 +1447,9 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `T`.
    */
   patch<T>(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1363,8 +1461,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `ArrayBuffer`.
    */
   patch(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -1374,8 +1474,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `Blob`.
    */
   patch(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -1385,8 +1487,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `string`.
    */
   patch(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -1396,9 +1500,9 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `Object`.
    */
   patch(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1410,9 +1514,9 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `T`.
    */
   patch<T>(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1424,9 +1528,9 @@ export class HttpClient {
    * @return an `Observable` of the body as an `Object`.
    */
   patch(url: string, body: any|null, options?: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1438,9 +1542,9 @@ export class HttpClient {
    * @return an `Observable` of the body as type `T`.
    */
   patch<T>(url: string, body: any|null, options?: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1452,9 +1556,9 @@ export class HttpClient {
    * details of `patch()`'s return type based on the provided options.
    */
   patch(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -1468,9 +1572,9 @@ export class HttpClient {
    * @return an `Observable` of the body as an `ArrayBuffer`.
    */
   post(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -1481,9 +1585,9 @@ export class HttpClient {
    * @return an `Observable` of the body as a `Blob`.
    */
   post(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -1494,9 +1598,9 @@ export class HttpClient {
    * @return an `Observable` of the body as a `string`.
    */
   post(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -1507,8 +1611,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `ArrayBuffer`.
    */
   post(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -1518,8 +1624,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `Blob`.
    */
   post(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -1529,8 +1637,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `string`.
    */
   post(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -1540,9 +1650,9 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `Object`.
    */
   post(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1554,9 +1664,9 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `T`.
    */
   post<T>(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1568,8 +1678,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `ArrayBuffer`.
    */
   post(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -1579,8 +1691,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `Blob`.
    */
   post(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -1590,8 +1704,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `string`.
    */
   post(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -1601,9 +1717,9 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `Object`.
    */
   post(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1615,9 +1731,9 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `T`.
    */
   post<T>(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1629,9 +1745,9 @@ export class HttpClient {
    * @return an `Observable` of the body as an `Object`.
    */
   post(url: string, body: any|null, options?: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1643,9 +1759,9 @@ export class HttpClient {
    * @return an `Observable` of the body as type `T`.
    */
   post<T>(url: string, body: any|null, options?: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1657,9 +1773,9 @@ export class HttpClient {
    * details of `post()`'s return type based on the provided options.
    */
   post(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -1673,9 +1789,9 @@ export class HttpClient {
    * @return an `Observable` of the body as an `ArrayBuffer`.
    */
   put(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -1686,9 +1802,9 @@ export class HttpClient {
    * @return an `Observable` of the body as a `Blob`.
    */
   put(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -1699,9 +1815,9 @@ export class HttpClient {
    * @return an `Observable` of the body as a `string`.
    */
   put(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -1712,8 +1828,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `ArrayBuffer`.
    */
   put(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -1723,8 +1841,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `Blob`.
    */
   put(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -1734,8 +1854,10 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `string`.
    */
   put(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'events', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'events',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -1745,9 +1867,9 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `Object`.
    */
   put(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1759,7 +1881,7 @@ export class HttpClient {
    * @return an `Observable` of all `HttpEvent`s for the request, with a body type of `T`.
    */
   put<T>(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events', responseType?: 'json', withCredentials?: boolean,
   }): Observable<HttpEvent<T>>;
 
@@ -1769,8 +1891,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `ArrayBuffer`.
    */
   put(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -1780,8 +1904,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `Blob`.
    */
   put(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -1791,8 +1917,10 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `string`.
    */
   put(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
-    observe: 'response', params?: HttpParams, reportProgress?: boolean,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
+    observe: 'response',
+    params?: HttpParams|{[param: string]: string | string[]},
+    reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -1802,9 +1930,9 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `Object`.
    */
   put(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1816,9 +1944,9 @@ export class HttpClient {
    * @return an `Observable` of the `HttpResponse` for the request, with a body type of `T`.
    */
   put<T>(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1830,9 +1958,9 @@ export class HttpClient {
    * @return an `Observable` of the body as an `Object`.
    */
   put(url: string, body: any|null, options?: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1844,9 +1972,9 @@ export class HttpClient {
    * @return an `Observable` of the body as type `T`.
    */
   put<T>(url: string, body: any|null, options?: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1858,9 +1986,9 @@ export class HttpClient {
    * details of `post()`'s return type based on the provided options.
    */
   put(url: string, body: any|null, options: {
-    headers?: HttpHeaders,
+    headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams,
+    params?: HttpParams|{[param: string]: string | string[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,

--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -89,10 +89,24 @@ export class HttpParams {
 
   constructor(options: {
     fromString?: string,
+    fromObject?: {[param: string]: string | string[]},
     encoder?: HttpParameterCodec,
   } = {}) {
     this.encoder = options.encoder || new HttpUrlEncodingCodec();
-    this.map = !!options.fromString ? paramParser(options.fromString, this.encoder) : null;
+    if (!!options.fromString) {
+      if (!!options.fromObject) {
+        throw new Error(`Cannot specify both fromString and fromObject.`);
+      }
+      this.map = paramParser(options.fromString, this.encoder);
+    } else if (!!options.fromObject) {
+      this.map = new Map<string, string[]>();
+      Object.keys(options.fromObject).forEach(key => {
+        const value = (options.fromObject as any)[key];
+        this.map !.set(key, Array.isArray(value) ? value : [value]);
+      });
+    } else {
+      this.map = null;
+    }
   }
 
   /**

--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -39,6 +39,16 @@ export function main() {
         });
         backend.expectOne('/test').flush('hello world');
       });
+      it('with headers', (done: DoneFn) => {
+        client.get('/test', {headers: {'X-Option': 'true'}}).subscribe(() => done());
+        const req = backend.expectOne('/test');
+        expect(req.request.headers.get('X-Option')).toEqual('true');
+        req.flush({});
+      });
+      it('with params', (done: DoneFn) => {
+        client.get('/test', {params: {'test': 'true'}}).subscribe(() => done());
+        backend.expectOne('/test?test=true').flush({});
+      });
       it('for an arraybuffer', (done: DoneFn) => {
         const body = new ArrayBuffer(4);
         client.get('/test', {responseType: 'arraybuffer'}).subscribe(res => {
@@ -69,6 +79,7 @@ export function main() {
       it('that returns a stream of events', (done: DoneFn) => {
         client.get('/test', {observe: 'events'}).toArray().toPromise().then(events => {
           expect(events.length).toBe(2);
+          let x = HttpResponse;
           expect(events[0].type).toBe(HttpEventType.Sent);
           expect(events[1].type).toBe(HttpEventType.Response);
           expect(events[1] instanceof HttpResponse).toBeTruthy();

--- a/tools/public_api_guard/common/http.d.ts
+++ b/tools/public_api_guard/common/http.d.ts
@@ -10,361 +10,541 @@ export declare abstract class HttpBackend implements HttpHandler {
 export declare class HttpClient {
     constructor(handler: HttpHandler);
     delete<T>(url: string, options?: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
     delete(url: string, options?: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<Object>;
     delete(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
     delete(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
     delete(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
     delete(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
     delete(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
     delete(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
     delete(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Object>>;
     delete<T>(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<T>>;
     delete(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
     delete(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
     delete(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
     delete(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
     delete<T>(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<T>>;
     get(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
     get(url: string, options?: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<Object>;
     get(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
     get(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
     get(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
     get(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
     get(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
     get<T>(url: string, options?: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
     get(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Object>>;
     get<T>(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<T>>;
     get(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
     get(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
     get(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
     get(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
     get<T>(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<T>>;
     head<T>(url: string, options?: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
     head(url: string, options?: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<Object>;
     head<T>(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<T>>;
     head(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
     head(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
     head(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
     head(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
     head<T>(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<T>>;
     head(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Object>>;
     head(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
     head(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
     head(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
     head(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
     head(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
     head(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -372,532 +552,794 @@ export declare class HttpClient {
     jsonp<T>(url: string, callbackParam: string): Observable<T>;
     jsonp(url: string, callbackParam: string): Observable<Object>;
     options(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Object>>;
     options(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
     options(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
     options(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
     options(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
     options(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
     options(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
     options<T>(url: string, options?: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
     options<T>(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<T>>;
     options(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
     options(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
     options(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
     options(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
     options<T>(url: string, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<T>>;
     options(url: string, options?: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<Object>;
     patch(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
     patch(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
     patch(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
     patch(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
     patch(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
     patch(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
     patch<T>(url: string, body: any | null, options?: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
     patch(url: string, body: any | null, options?: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<Object>;
     patch(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Object>>;
     patch<T>(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<T>>;
     patch(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
     patch(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
     patch(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
     patch(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
     patch<T>(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<T>>;
     post(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
     post(url: string, body: any | null, options?: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<Object>;
     post(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
     post(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
     post(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
     post(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
     post(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
     post<T>(url: string, body: any | null, options?: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
     post(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Object>>;
     post<T>(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<T>>;
     post(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
     post(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
     post(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
     post(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
     post<T>(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<T>>;
     put(url: string, body: any | null, options?: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<Object>;
     put<T>(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<T>>;
     put(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
     put(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
     put(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
     put(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
     put<T>(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<T>>;
     put(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Object>>;
     put(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
     put(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
     put(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
     put(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
     put(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
     put(url: string, body: any | null, options: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
     put<T>(url: string, body: any | null, options?: {
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
     request(method: string, url: string, options: {
         body?: any;
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         reportProgress?: boolean;
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<any>>;
     request<R>(method: string, url: string, options?: {
         body?: any;
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         responseType?: 'json';
         reportProgress?: boolean;
         withCredentials?: boolean;
     }): Observable<R>;
     request(method: string, url: string, options: {
         body?: any;
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
     request(method: string, url: string, options: {
         body?: any;
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
     request(method: string, url: string, options: {
         body?: any;
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
     request(method: string, url: string, options: {
         body?: any;
-        headers?: HttpHeaders;
-        params?: HttpParams;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         observe: 'events';
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -905,18 +1347,26 @@ export declare class HttpClient {
     }): Observable<HttpEvent<ArrayBuffer>>;
     request(method: string, url: string, options: {
         body?: any;
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
     request(method: string, url: string, options: {
         body?: any;
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -924,71 +1374,103 @@ export declare class HttpClient {
     request<R>(req: HttpRequest<any>): Observable<HttpEvent<R>>;
     request<R>(method: string, url: string, options: {
         body?: any;
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         reportProgress?: boolean;
         observe: 'events';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<R>>;
     request(method: string, url: string, options: {
         body?: any;
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
     request(method: string, url: string, options: {
         body?: any;
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
     request(method: string, url: string, options: {
         body?: any;
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
     request(method: string, url: string, options: {
         body?: any;
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         reportProgress?: boolean;
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
     request<R>(method: string, url: string, options: {
         body?: any;
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         reportProgress?: boolean;
         observe: 'response';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<R>>;
     request(method: string, url: string, options?: {
         body?: any;
-        headers?: HttpHeaders;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
         observe?: 'body';
-        params?: HttpParams;
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         responseType?: 'json';
         reportProgress?: boolean;
         withCredentials?: boolean;
     }): Observable<Object>;
     request(method: string, url: string, options?: {
         body?: any;
-        headers?: HttpHeaders;
-        params?: HttpParams;
+        headers?: HttpHeaders | {
+            [header: string]: string | string[];
+        };
+        params?: HttpParams | {
+            [param: string]: string | string[];
+        };
         observe?: HttpObserve;
         reportProgress?: boolean;
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
@@ -1100,6 +1582,9 @@ export interface HttpParameterCodec {
 export declare class HttpParams {
     constructor(options?: {
         fromString?: string;
+        fromObject?: {
+            [param: string]: string | string[];
+        };
         encoder?: HttpParameterCodec;
     });
     append(param: string, value: string): HttpParams;


### PR DESCRIPTION
Today, constructing a new GET request with headers looks like:

const headers = new HttpHeaders({
  'My-Header': 'header value',
});
http.get('/url', {headers}).subscribe(...);

This indirection is unnecessary. It'd be more ergonomic to write:

http.get('/url', {headers: {'My-Header': 'header value'}}).subscribe(...);

This commit allows that new syntax, both for HttpHeaders and HttpParams.
In the HttpParams case it also allows construction of HttpParams with a map.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
