### PR TITLE
fix(aio): fix layout of the webpack guide

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -62,6 +62,12 @@
     },
 
     {
+      "url": "guide/webpack",
+      "title": "Webpack: An Introduction",
+      "hidden": true
+    },
+
+    {
       "url": "guide/quickstart",
       "title": "Getting Started",
       "tooltip": "A gentle introduction to Angular."


### PR DESCRIPTION
This is possibly a temporary fix for the layout, until we decide whether we want to remove the guide or properly add it to the SideNav menu.

Fixes #17912.