### PR TITLE
aio postinstall script missing map output file name; results in installation error

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -40,7 +40,7 @@
     "generate-zips": "node ./tools/example-zipper/generateZips",
     "sw-manifest": "ngu-sw-manifest --dist dist --in ngsw-manifest.json --out dist/ngsw-manifest.json",
     "sw-copy": "cp node_modules/@angular/service-worker/bundles/worker-basic.min.js dist/",
-    "postinstall": "uglifyjs node_modules/lunr/lunr.js -c -m -o src/assets/js/lunr.min.js --source-map",
+    "postinstall": "uglifyjs node_modules/lunr/lunr.js -c -m -o src/assets/js/lunr.min.js --source-map src/assets/js/lunr.min.js.map",
     "build-ie-polyfills": "node node_modules/webpack/bin/webpack.js -p src/ie-polyfills.js src/generated/ie-polyfills.min.js"
   },
   "engines": {


### PR DESCRIPTION
When performing "yarn install" in the angular/aio directory the following error occurs in the postbuild script.  The option --source-map requires an output file name.  This is easily fixed by appending "src/assets/js/lunr.min.js.map" to the end of the script.

$ node tools/cli-patches/patch.js && uglifyjs node_modules/lunr/lunr.js -c -m -o
 src/assets/js/lunr.min.js --source-map
fs.js:641
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

TypeError: path must be a string or Buffer

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When performing "yarn install" in the angular/aio directory the following error occurs in the postbuild script.

```
$ node tools/cli-patches/patch.js && uglifyjs node_modules/lunr/lunr.js -c -m -o
 src/assets/js/lunr.min.js --source-map
fs.js:641
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

TypeError: path must be a string or Buffer
```

  The option --source-map requires an output file name.  This is easily fixed by appending "src/assets/js/lunr.min.js.map" to the end of the script.

Issue Number: N/A


## What is the new behavior?
No build error.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
