### PR TITLE
build(upgrade): update AngularJS typings

### DIFF
--- a/modules/angular1_router/src/ng_outlet.ts
+++ b/modules/angular1_router/src/ng_outlet.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-///<reference path="../typings/angularjs/angular.d.ts"/>
+///<reference path="../typings/angular/angular.d.ts"/>
 
 
 

--- a/modules/tsconfig.json
+++ b/modules/tsconfig.json
@@ -22,7 +22,7 @@
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "target": "es5",
-    "types": ["angularjs"]
+    "types": ["angular"]
   },
   "exclude": [
     "angular1_router",

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -2,8 +2,8 @@
   "name": "angular-srcs",
   "version": "5.0.0-beta.0",
   "dependencies": {
-    "@types/angularjs": {
-      "version": "1.5.13-alpha"
+    "@types/angular": {
+      "version": "1.6.28"
     },
     "@types/base64-js": {
       "version": "1.2.5"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,10 +2,10 @@
   "name": "angular-srcs",
   "version": "5.0.0-beta.0",
   "dependencies": {
-    "@types/angularjs": {
-      "version": "1.5.13-alpha",
-      "from": "@types/angularjs@latest",
-      "resolved": "https://registry.npmjs.org/@types/angularjs/-/angularjs-1.5.13-alpha.tgz"
+    "@types/angular": {
+      "version": "1.6.28",
+      "from": "@types/angular@latest",
+      "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.6.28.tgz"
     },
     "@types/base64-js": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "fsevents": "^1.0.14"
   },
   "devDependencies": {
-    "@types/angularjs": "^1.5.13-alpha",
+    "@types/angular": "^1.6.28",
     "@types/base64-js": "^1.2.5",
     "@types/fs-extra": "0.0.22-alpha",
     "@types/hammerjs": "^2.0.33",

--- a/packages/compiler/test/aot/static_symbol_resolver_spec.ts
+++ b/packages/compiler/test/aot/static_symbol_resolver_spec.ts
@@ -55,7 +55,7 @@ describe('StaticSymbolResolver', () => {
   });
 
   it('should be able to produce a symbol for a module with no file', () => {
-    expect(symbolResolver.getStaticSymbol('angularjs', 'SomeAngularSymbol')).toBeDefined();
+    expect(symbolResolver.getStaticSymbol('angular', 'SomeAngularSymbol')).toBeDefined();
   });
 
   it('should be able to split the metadata per symbol', () => {

--- a/packages/examples/tsconfig-build.json
+++ b/packages/examples/tsconfig-build.json
@@ -20,7 +20,7 @@
     "target": "es5",
     "lib": ["es2015", "dom"],
     "skipLibCheck": true,
-    "types": ["jasmine", "node", "angularjs", "systemjs"]
+    "types": ["jasmine", "node", "angular", "systemjs"]
   },
   "include": [
     "./**/*.ts",

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -22,7 +22,7 @@
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "target": "es5",
-    "types": ["angularjs"]
+    "types": ["angular"]
   },
   "exclude": [
     "compiler-cli/integrationtest",


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?
```
[x] Build related changes
```

## What is the current behavior?
We are using [@types/angularjs][1], which are outdated (haven't been updated for over a year).


## What is the new behavior?
We use [@types/angular][2], which are regularly updated (based on the definitions on [DefinitelyTyped][3]).


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
This should make `upgrade` compatible with TypeScript 2.4 (as discussed in https://github.com/angular/angular/pull/18461#discussion_r130866320). 

[1]: https://www.npmjs.com/package/@types/angularjs
[2]: https://www.npmjs.com/package/@types/angular
[3]: https://github.com/DefinitelyTyped/DefinitelyTyped