### PR TITLE
feat(forms): add updateOn submit option to FormControls

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -134,6 +134,7 @@ export class FormGroupDirective extends ControlContainer implements Form,
 
   onSubmit($event: Event): boolean {
     this._submitted = true;
+    this._syncPendingControls();
     this.ngSubmit.emit($event);
     return false;
   }
@@ -143,6 +144,16 @@ export class FormGroupDirective extends ControlContainer implements Form,
   resetForm(value: any = undefined): void {
     this.form.reset(value);
     this._submitted = false;
+  }
+
+  /** @internal */
+  _syncPendingControls() {
+    this.form._syncPendingControls();
+    this.directives.forEach(dir => {
+      if (dir.control._updateOn === 'submit') {
+        dir.viewToModelUpdate(dir.control._pendingValue);
+      }
+    });
   }
 
   /** @internal */

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -84,23 +84,23 @@ function setUpViewChangePipeline(control: FormControl, dir: NgControl): void {
     control._pendingValue = newValue;
     control._pendingDirty = true;
 
-    if (control._updateOn === 'change') {
-      dir.viewToModelUpdate(newValue);
-      control.markAsDirty();
-      control.setValue(newValue, {emitModelToViewChange: false});
-    }
+    if (control._updateOn === 'change') updateControl(control, dir);
   });
 }
 
 function setUpBlurPipeline(control: FormControl, dir: NgControl): void {
   dir.valueAccessor !.registerOnTouched(() => {
-    if (control._updateOn === 'blur') {
-      dir.viewToModelUpdate(control._pendingValue);
-      if (control._pendingDirty) control.markAsDirty();
-      control.setValue(control._pendingValue, {emitModelToViewChange: false});
-    }
-    control.markAsTouched();
+    control._pendingTouched = true;
+
+    if (control._updateOn === 'blur') updateControl(control, dir);
+    if (control._updateOn !== 'submit') control.markAsTouched();
   });
+}
+
+function updateControl(control: FormControl, dir: NgControl): void {
+  dir.viewToModelUpdate(control._pendingValue);
+  if (control._pendingDirty) control.markAsDirty();
+  control.setValue(control._pendingValue, {emitModelToViewChange: false});
 }
 
 function setUpModelChangePipeline(control: FormControl, dir: NgControl): void {


### PR DESCRIPTION
By default, the value and validation status of a `FormControl` updates whenever its value changes. If an application has heavy validation requirements, updating on every text change can sometimes be too expensive. #18408 introduced an `updateOn` configuration to help improve performance by delaying form control updates until "blur".

This commit introduces another `updateOn` option based on the "submit" event of the parent form.  To use it, set the `updateOn` option to `submit` when instantiating the `FormControl`.

```ts

const form = new FormGroup({
   name: new FormControl('', { 
      validators: Validators.required,
      updateOn: 'submit' 
   })
});

```

Like in AngularJS, setting `updateOn` to `submit` will delay the update of the value as well as the validation status. Updating value and validity together keeps the system easy to reason about, as the two will always be in sync.  It's also worth noting that the value/validation pipeline does still run when the form is initialized (in order to support initial values).

Upcoming PRs will address:

- Setting `updateOn` at a form-wide or application-wide level
- Support in template-driven forms
- Option for skipping initial validation run or more global error display configuration
- Better support of reactive validation strategies

See more context in [design doc](https://docs.google.com/document/d/1dlJjRXYeuHRygryK0XoFrZNqW86jH4wobftCFyYa1PA/edit#heading=h.r6gn0i8f19wz).