### PR TITLE
fix(compiler-cli): fix and re-enble expression lowering

### DIFF
--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -187,8 +187,7 @@ class AngularCompilerProgram implements Program {
     const before: ts.TransformerFactory<ts.SourceFile>[] = [];
     const after: ts.TransformerFactory<ts.SourceFile>[] = [];
     if (!this.options.disableExpressionLowering) {
-      // TODO(chuckj): fix and re-enable + tests - see https://github.com/angular/angular/pull/18388
-      // before.push(getExpressionLoweringTransformFactory(this.metadataCache));
+      before.push(getExpressionLoweringTransformFactory(this.metadataCache));
     }
     if (!this.options.skipTemplateCodegen) {
       after.push(getAngularEmitterTransformFactory(this.generatedFiles));

--- a/packages/compiler-cli/test/transformers/lower_expressions_spec.ts
+++ b/packages/compiler-cli/test/transformers/lower_expressions_spec.ts
@@ -51,11 +51,9 @@ function convert(annotatedSource: string) {
 
   for (const annotation of annotations) {
     const node = findNode(sourceFile, annotation.start, annotation.length);
-    expect(node).toBeDefined();
-    if (node) {
-      const location = node.pos;
-      requests.set(location, {name: annotation.name, kind: node.kind, location, end: node.end});
-    }
+    if (!node) throw new Error('Invalid test specification. Could not find the node to substitute');
+    const location = node.pos;
+    requests.set(location, {name: annotation.name, kind: node.kind, location, end: node.end});
   }
 
   const program = ts.createProgram(


### PR DESCRIPTION
Fixes issue uncovered by #18388 and re-enables expression
lowering disabled by #18513.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Expression lowering was disabled because of a bug uncovered by #18388.

## What is the new behavior?

Expression lowering is re-enabled and the issue uncovered by #18388 has been resolved.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
