### PR TITLE
fix(forms): fix disabled attribute handling

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -88,9 +88,6 @@ export class FormControlDirective extends NgControl implements OnChanges {
               ngOnChanges(changes: SimpleChanges): void {
                 if (this._isControlChanged(changes)) {
                   setUpControl(this.form, this);
-                  if (this.control.disabled && this.valueAccessor !.setDisabledState) {
-                    this.valueAccessor !.setDisabledState !(true);
-                  }
                   this.form.updateValueAndValidity({emitEvent: false});
                 }
                 if (isPropertyUpdated(changes, this.viewModel)) {

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -57,6 +57,7 @@ export function setUpControl(control: FormControl, dir: NgControl): void {
   });
 
   if (dir.valueAccessor !.setDisabledState) {
+    dir.valueAccessor !.setDisabledState !(control.disabled);
     control.registerOnDisabledChange(
         (isDisabled: boolean) => { dir.valueAccessor !.setDisabledState !(isDisabled); });
   }

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -582,6 +582,37 @@ export function main() {
              expect(inputs[0].nativeElement.disabled).toBe(false);
            });
 
+        it('should remove disabled attribute when re-instantiated as enabled', () => {
+          const fixture = initTest(FormControlComp);
+          const input = fixture.debugElement.query(By.css('input'));
+
+          const disabledControl = new FormControl({value: 'some value', disabled: true});
+          fixture.componentInstance.control = disabledControl;
+          fixture.detectChanges();
+          expect(input.nativeElement.disabled).toBe(true);
+
+          const enabledControl = new FormControl({value: 'some value', disabled: false});
+          fixture.componentInstance.control = enabledControl;
+          fixture.detectChanges();
+          expect(input.nativeElement.disabled).toBe(false);
+        });
+
+        it('should remove disabled attribute when setControl() is called with enabled control',
+           () => {
+             const fixture = initTest(FormGroupComp);
+             const input = fixture.debugElement.query(By.css('input'));
+
+             const disabledControl = new FormControl({value: 'some value', disabled: true});
+             const form = new FormGroup({'login': disabledControl});
+             fixture.componentInstance.form = form;
+             fixture.detectChanges();
+             expect(input.nativeElement.disabled).toBe(true);
+
+             const enabledControl = new FormControl({value: 'some value', disabled: false});
+             fixture.componentInstance.form.setControl('login', enabledControl);
+             fixture.detectChanges();
+             expect(input.nativeElement.disabled).toBe(false);
+           });
 
         it('should not add disabled attribute to custom controls when disable() is called', () => {
           const fixture = initTest(MyInputForm, MyInput);


### PR DESCRIPTION
Update the disabled attribute of DOM element when setting a new FormControl instance either directly or via setControl().

Fixes #17806

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

```
myGroup.setControl('ctrl', new FormControl({ value: 'Control is disabled', disabled: true }));
// Input dom element has disabled attribute. Correct.

myGroup.setControl('ctrl', new FormControl({ value: 'Control should be enabled', disabled: false }));
// Input dom element still has disabled attribute. WRONG! Should not have.
```

Full issue with plunker demo: #17806

## What is the new behavior?

```
myGroup.setControl('ctrl', new FormControl({ value: 'Control is disabled', disabled: true }));
// Input dom element has disabled attribute. Correct.

myGroup.setControl('ctrl', new FormControl({ value: 'Control should be enabled', disabled: false }));
// Input dom element does not have disabled attribute anymore. Correct.
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```