### PR TITLE
fix(forms): do not emit from FormControl when value has not changed

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EventEmitter} from '@angular/core';
+import {EventEmitter, ɵlooseIdentical as looseIdentical} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {composeAsyncValidators, composeValidators} from './directives/shared';
 import {AsyncValidatorFn, ValidationErrors, ValidatorFn} from './directives/validators';
@@ -708,6 +708,9 @@ export class FormControl extends AbstractControl {
     if (this._onChange.length && options.emitModelToViewChange !== false) {
       this._onChange.forEach(
           (changeFn) => changeFn(this._value, options.emitViewToModelChange !== false));
+    }
+    if(typeof options.emitEvent === 'undefined' && typeof value != 'object' && typeof this._value != 'object' ){
+      options.emitEvent = !looseIdentical(value, this._value);
     }
     this.updateValueAndValidity(options);
   }

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -659,6 +659,16 @@ export function main() {
 
       beforeEach(() => { c = new FormControl('old', Validators.required); });
 
+      it('should not emit when options.emitEvent is undefined and values are equal', fakeAsync(() => {
+          let count = 0;
+          c.statusChanges.subscribe(value => ++count);
+
+          c.setValue('new');
+          c.setValue('new');
+          tick();
+          expect(count).toEqual(1);
+        }));
+
       it('should fire an event after the value has been updated',
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
            c.valueChanges.subscribe({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
```

## What is the current behavior?
valueChanges emits when the value remains the same 
see here for repo: https://stackblitz.com/edit/angular-template-reactive-forms-ntxpad?file=app%2Fapp.module.ts
check console to see values emitting
Issue Number: #18574


## What is the new behavior?
do not emit when emitEvent is `undefined` and the new value is somewhat equal to the previous value

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
It's possible that this could be a breaking changes, all of the tests pass but it's possible that developers could be relying on valueChanges emitting when the value hasn't changed