### PR TITLE
feat(forms): add updateOn and ngFormOptions to NgForm

### DIFF
--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -388,7 +388,7 @@ export declare class NgControlStatusGroup extends AbstractControlStatus {
 }
 
 /** @stable */
-export declare class NgForm extends ControlContainer implements Form {
+export declare class NgForm extends ControlContainer implements Form, AfterViewInit {
     readonly control: FormGroup;
     readonly controls: {
         [key: string]: AbstractControl;
@@ -396,6 +396,9 @@ export declare class NgForm extends ControlContainer implements Form {
     form: FormGroup;
     readonly formDirective: Form;
     ngSubmit: EventEmitter<{}>;
+    options: {
+        updateOn?: FormHooks;
+    };
     readonly path: string[];
     readonly submitted: boolean;
     constructor(validators: any[], asyncValidators: any[]);
@@ -403,6 +406,7 @@ export declare class NgForm extends ControlContainer implements Form {
     addFormGroup(dir: NgModelGroup): void;
     getControl(dir: NgModel): FormControl;
     getFormGroup(dir: NgModelGroup): FormGroup;
+    ngAfterViewInit(): void;
     onReset(): void;
     onSubmit($event: Event): boolean;
     removeControl(dir: NgModel): void;


### PR DESCRIPTION
This commit introduces a new Input property called `ngFormOptions` to the `NgForm` directive. You can use it to set default `updateOn` values for all the form's child controls. This default will be used unless the child has already explicitly set its own `updateOn` value in `ngModelOptions`.

Potential values: `change` | `blur` | `submit`

```html
<form [ngFormOptions]="{updateOn: blur}">
  <input name="one" ngModel>  <!-- will update on blur-->
</form>
```

For more context, see [#18577](#18577).