### PR TITLE
feat(common): mark NgTemplateOutlet API as stable

### DIFF
--- a/packages/common/src/directives/ng_template_outlet.ts
+++ b/packages/common/src/directives/ng_template_outlet.ts
@@ -30,7 +30,7 @@ import {Directive, EmbeddedViewRef, Input, OnChanges, SimpleChange, SimpleChange
  *
  * {@example common/ngTemplateOutlet/ts/module.ts region='NgTemplateOutlet'}
  *
- * @experimental
+ * @stable
  */
 @Directive({selector: '[ngTemplateOutlet]'})
 export class NgTemplateOutlet implements OnChanges {
@@ -72,7 +72,7 @@ export class NgTemplateOutlet implements OnChanges {
    * - templateRef has changed
    * - context has changes
    *
-   * To mark context object as changed when the corresponding object
+   * We mark context object as changed when the corresponding object
    * shape changes (new properties are added or existing properties are removed).
    * In other words we consider context with the same properties as "the same" even
    * if object reference changes (see https://github.com/angular/angular/issues/13407).

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -240,7 +240,7 @@ export declare class NgSwitchDefault {
     constructor(viewContainer: ViewContainerRef, templateRef: TemplateRef<Object>, ngSwitch: NgSwitch);
 }
 
-/** @experimental */
+/** @stable */
 export declare class NgTemplateOutlet implements OnChanges {
     /** @deprecated */ ngOutletContext: Object;
     ngTemplateOutlet: TemplateRef<any>;


### PR DESCRIPTION
@IgorMinar I've discussed this a couple of weeks ago with @mhevery . He didn't have objections to mark the `NgTemplateOutlet` API as stable  but he wanted to have your opinion as well.

I've been using this directive for widgets and application development for over a year now and haven't spotted anything suspicious. I'm sure that is is widely used so no point in keeping it as "experimental".