### PR TITLE
URLSearchParams: added getKeys() support so that it more closely fo…

### DIFF
--- a/packages/http/src/url_search_params.ts
+++ b/packages/http/src/url_search_params.ts
@@ -99,9 +99,7 @@ export class URLSearchParams {
     return Array.isArray(storedParam) ? storedParam[0] : null;
   }
 
-  // we are casting IterableIterator<string> to an Array<string>, because iterables are not supported
-  // in this project yet, and as such we cannot use them in for-of loops without errors
-  getKeys(): Array<string> { return Array.from(this.paramsMap.keys()); }
+  keys(): IterableIterator<string> { return this.paramsMap.keys(); }
 
   getAll(param: string): string[] { return this.paramsMap.get(param) || []; }
 

--- a/packages/http/src/url_search_params.ts
+++ b/packages/http/src/url_search_params.ts
@@ -99,6 +99,10 @@ export class URLSearchParams {
     return Array.isArray(storedParam) ? storedParam[0] : null;
   }
 
+  // we are casting IterableIterator<string> to an Array<string>, because iterables are not supported
+  // in this project yet, and as such we cannot use them in for-of loops without errors
+  getKeys(): Array<string> { return Array.from(this.paramsMap.keys()); }
+
   getAll(param: string): string[] { return this.paramsMap.get(param) || []; }
 
   set(param: string, val: string) {

--- a/packages/http/test/url_search_params_spec.ts
+++ b/packages/http/test/url_search_params_spec.ts
@@ -167,5 +167,19 @@ export function main() {
       expect(params.toString()).toEqual('q=Q');
     });
 
+    it('should support map-like operations via getKeys()', () => {
+      const mapA = new URLSearchParams('a=1&b=2&c=3&d=4');
+      const mapB = new URLSearchParams();
+      const keys: Array<string> = mapA.getKeys();
+      for (const key of keys) {
+        mapB.set(key, mapA.getAll(key)[0]);
+      }
+      expect(mapB.get('a')).toEqual('1');
+      expect(mapB.get('b')).toEqual('2');
+      expect(mapB.get('c')).toEqual('3');
+      expect(mapB.get('d')).toEqual('4');
+      expect(mapB.toString()).toEqual('a=1&b=2&c=3&d=4');
+    });
+
   });
 }

--- a/packages/http/test/url_search_params_spec.ts
+++ b/packages/http/test/url_search_params_spec.ts
@@ -170,7 +170,7 @@ export function main() {
     it('should support map-like operations via getKeys()', () => {
       const mapA = new URLSearchParams('a=1&b=2&c=3&d=4');
       const mapB = new URLSearchParams();
-      const keys: Array<string> = mapA.getKeys();
+      const keys: Array<string> = Array.from(mapA.keys());
       for (const key of keys) {
         mapB.set(key, mapA.getAll(key)[0]);
       }


### PR DESCRIPTION
…llows map-like operations

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)  Note: I added code comments, not sure what other documentation is needed


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, there is no way to get the keys from URLSearchParams
Issue Number: N/A


## What is the new behavior?
getKeys() can now be called to retrieve an array of keys

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
