### PR TITLE
perf(aio): update to new version of build-optimizer

### DIFF
--- a/aio/scripts/_payload-limits.sh
+++ b/aio/scripts/_payload-limits.sh
@@ -3,7 +3,7 @@
 set -u -e -o pipefail
 
 declare -A limitUncompressed
-limitUncompressed=(["inline"]=1600 ["main"]=600000 ["polyfills"]=35000)
+limitUncompressed=(["inline"]=1600 ["main"]=550000 ["polyfills"]=35000)
 declare -A limitGzip7
 limitGzip7=(["inline"]=1000 ["main"]=140000 ["polyfills"]=12500)
 declare -A limitGzip9

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -2,12 +2,11 @@
 # yarn lockfile v1
 
 
-"@angular-devkit/build-optimizer@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/build-optimizer/-/build-optimizer-0.0.3.tgz#092bdf732b79a779ce540f9bb99d6590dd971204"
+"@angular-devkit/build-optimizer@0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/build-optimizer/-/build-optimizer-0.0.13.tgz#cf397af76abe899aa909d4a735106694ca1f08cf"
   dependencies:
     loader-utils "^1.1.0"
-    magic-string "^0.19.1"
     source-map "^0.5.6"
     typescript "^2.3.3"
 
@@ -27,7 +26,7 @@
   version "1.3.0-rc.3"
   resolved "https://registry.yarnpkg.com/@angular/cli/-/cli-1.3.0-rc.3.tgz#5a6999382f956b6109d3042569659972bca38a63"
   dependencies:
-    "@angular-devkit/build-optimizer" "0.0.3"
+    "@angular-devkit/build-optimizer" "0.0.13"
     "@ngtools/json-schema" "1.1.0"
     "@ngtools/webpack" "1.6.0-rc.3"
     autoprefixer "^6.5.3"


### PR DESCRIPTION
This PR updates AIO to use the latest version of build-optimizer (0.0.13), which contains some hot fixes to improve AIO code size.