### PR TITLE
fix(compiler): Don't strip `/*# ... */` comment when css scoping

### DIFF
--- a/packages/compiler/src/style_url_resolver.ts
+++ b/packages/compiler/src/style_url_resolver.ts
@@ -29,19 +29,20 @@ export function extractStyleUrls(
     resolver: UrlResolver, baseUrl: string, cssText: string): StyleWithImports {
   const foundUrls: string[] = [];
 
-  const modifiedCssText =
-      cssText.replace(CSS_COMMENT_REGEXP, '').replace(CSS_IMPORT_REGEXP, (...m: string[]) => {
-        const url = m[1] || m[2];
-        if (!isStyleUrlResolvable(url)) {
-          // Do not attempt to resolve non-package absolute URLs with URI scheme
-          return m[0];
-        }
-        foundUrls.push(resolver.resolve(baseUrl, url));
-        return '';
-      });
+  const modifiedCssText = cssText.replace(CSS_STRIPPABLE_COMMENT_REGEXP, '')
+                              .replace(CSS_IMPORT_REGEXP, (...m: string[]) => {
+                                const url = m[1] || m[2];
+                                if (!isStyleUrlResolvable(url)) {
+                                  // Do not attempt to resolve non-package absolute URLs with URI
+                                  // scheme
+                                  return m[0];
+                                }
+                                foundUrls.push(resolver.resolve(baseUrl, url));
+                                return '';
+                              });
   return new StyleWithImports(modifiedCssText, foundUrls);
 }
 
 const CSS_IMPORT_REGEXP = /@import\s+(?:url\()?\s*(?:(?:['"]([^'"]*))|([^;\)\s]*))[^;]*;?/g;
-const CSS_COMMENT_REGEXP = /\/\*[\s\S]+?\*\//g;
+const CSS_STRIPPABLE_COMMENT_REGEXP = /\/\*(?!#\s*(?:sourceURL|sourceMappingURL)=)[\s\S]+?\*\//g;
 const URL_WITH_SCHEMA_REGEXP = /^([^:/?#]+):/;

--- a/packages/compiler/test/style_url_resolver_spec.ts
+++ b/packages/compiler/test/style_url_resolver_spec.ts
@@ -51,6 +51,14 @@ export function main() {
       expect(styleWithImports.styleUrls).not.toContain('http://ng.io/3.css');
     });
 
+    it('should keep /*# sourceURL... */ and /*# sourceMappingURL... */ comments', () => {
+      const css =
+          `/*regular comment*/\n/*# sourceURL=.... */\n/*# sourceMappingURL=... *//*#sourceMappingURL=... */`;
+      const styleWithSourceMaps = extractStyleUrls(urlResolver, 'http://ng.io', css);
+      expect(styleWithSourceMaps.style.trim())
+          .toEqual('/*# sourceURL=.... */\n/*# sourceMappingURL=... *//*#sourceMappingURL=... */');
+    });
+
     it('should extract "@import url()" urls', () => {
       const css = `
       @import url('3.css');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Currently, the source-mapping comments of component style is stripped by extractStyleUrls, so, css mappings don't work properly for component styles.

**What is the new behavior?**

Don't strip hash comments, so that they will be past to `style` tags properly.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

