### PR TITLE
fix(tsc-wrapped): add metadata for `type` declarations

### DIFF
--- a/packages/tsc-wrapped/src/collector.ts
+++ b/packages/tsc-wrapped/src/collector.ts
@@ -12,7 +12,6 @@ import {Evaluator, errorSymbol} from './evaluator';
 import {ClassMetadata, ConstructorMetadata, FunctionMetadata, InterfaceMetadata, MemberMetadata, MetadataEntry, MetadataError, MetadataMap, MetadataSymbolicBinaryExpression, MetadataSymbolicCallExpression, MetadataSymbolicExpression, MetadataSymbolicIfExpression, MetadataSymbolicIndexExpression, MetadataSymbolicPrefixExpression, MetadataSymbolicReferenceExpression, MetadataSymbolicSelectExpression, MetadataSymbolicSpreadExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata, VERSION, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataSymbolicExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSelectExpression, isMethodMetadata} from './schema';
 import {Symbols} from './symbols';
 
-
 // In TypeScript 2.1 these flags moved
 // These helpers work for both 2.0 and 2.1.
 const isExport = (ts as any).ModifierFlags ?

--- a/packages/tsc-wrapped/src/collector.ts
+++ b/packages/tsc-wrapped/src/collector.ts
@@ -693,17 +693,8 @@ function validateMetadata(
           error.character != undefined ? `:${error.line + 1}:${error.character + 1}` :
                                          `:${error.line + 1}` :
           '';
-      throw new Error(`${
-             sourceFile.fileName
-           }${
-              lineInfo
-            }: Metadata collected contains an error that will be reported at runtime: ${
-                                                                                        expandedMessage(
-                                                                                            error)
-                                                                                      }.\n  ${
-                                                                                              JSON.stringify(
-                                                                                                  error)
-                                                                                            }`);
+      throw new Error(
+          `${sourceFile.fileName}${lineInfo}: Metadata collected contains an error that will be reported at runtime: ${expandedMessage(error)}.\n  ${JSON.stringify(error)}`);
     }
   }
 
@@ -718,17 +709,8 @@ function validateMetadata(
       if (shouldReportNode(node)) {
         if (node) {
           const {line, character} = sourceFile.getLineAndCharacterOfPosition(node.getStart());
-          throw new Error(`${
-                 sourceFile.fileName
-               }:${
-                   line + 1
-                 }:${
-                     character + 1
-                   }: Error encountered in metadata generated for exported symbol '${
-                                                                                     name
-                                                                                   }': \n ${
-                                                                                            e.message
-                                                                                          }`);
+          throw new Error(
+              `${sourceFile.fileName}:${line + 1}:${character + 1}: Error encountered in metadata generated for exported symbol '${name}': \n ${e.message}`);
         }
         throw new Error(
             `Error encountered in metadata generated for exported symbol ${name}: \n ${e.message}`);
@@ -767,9 +749,7 @@ function expandedMessage(error: any): string {
   switch (error.message) {
     case 'Reference to non-exported class':
       if (error.context && error.context.className) {
-        return `Reference to a non-exported class ${
-                                                    error.context.className
-                                                  }. Consider exporting the class`;
+        return `Reference to a non-exported class ${error.context.className}. Consider exporting the class`;
       }
       break;
     case 'Variable not initialized':
@@ -788,9 +768,7 @@ function expandedMessage(error: any): string {
           'unction calls are not supported. Consider replacing the function or lambda with a reference to an exported function';
     case 'Reference to a local symbol':
       if (error.context && error.context.name) {
-        return `Reference to a local (non-exported) symbol '${
-                                                              error.context.name
-                                                            }'. Consider exporting the symbol`;
+        return `Reference to a local (non-exported) symbol '${error.context.name}'. Consider exporting the symbol`;
       }
   }
   return error.message;

--- a/packages/tsc-wrapped/src/collector.ts
+++ b/packages/tsc-wrapped/src/collector.ts
@@ -8,9 +8,10 @@
 
 import * as ts from 'typescript';
 
-import {errorSymbol, Evaluator} from './evaluator';
-import {ClassMetadata, ConstructorMetadata, FunctionMetadata, InterfaceMetadata, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataSymbolicExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSelectExpression, isMethodMetadata, MemberMetadata, MetadataEntry, MetadataError, MetadataMap, MetadataSymbolicBinaryExpression, MetadataSymbolicCallExpression, MetadataSymbolicExpression, MetadataSymbolicIfExpression, MetadataSymbolicIndexExpression, MetadataSymbolicPrefixExpression, MetadataSymbolicReferenceExpression, MetadataSymbolicSelectExpression, MetadataSymbolicSpreadExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata, VERSION} from './schema';
+import {Evaluator, errorSymbol} from './evaluator';
+import {ClassMetadata, ConstructorMetadata, FunctionMetadata, InterfaceMetadata, MemberMetadata, MetadataEntry, MetadataError, MetadataMap, MetadataSymbolicBinaryExpression, MetadataSymbolicCallExpression, MetadataSymbolicExpression, MetadataSymbolicIfExpression, MetadataSymbolicIndexExpression, MetadataSymbolicPrefixExpression, MetadataSymbolicReferenceExpression, MetadataSymbolicSelectExpression, MetadataSymbolicSpreadExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata, VERSION, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataSymbolicExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSelectExpression, isMethodMetadata} from './schema';
 import {Symbols} from './symbols';
+
 
 // In TypeScript 2.1 these flags moved
 // These helpers work for both 2.0 and 2.1.
@@ -94,9 +95,9 @@ export class MetadataCollector {
       return errorSymbol(message, node, context, sourceFile);
     }
 
-    function maybeGetSimpleFunction(functionDeclaration: ts.FunctionDeclaration|
-                                    ts.MethodDeclaration): {func: FunctionMetadata, name: string}|
-        undefined {
+    function maybeGetSimpleFunction(
+        functionDeclaration: ts.FunctionDeclaration |
+        ts.MethodDeclaration): {func: FunctionMetadata, name: string}|undefined {
       if (functionDeclaration.name && functionDeclaration.name.kind == ts.SyntaxKind.Identifier) {
         const nameNode = <ts.Identifier>functionDeclaration.name;
         const functionName = nameNode.text;
@@ -125,7 +126,7 @@ export class MetadataCollector {
     function classMetadataOf(classDeclaration: ts.ClassDeclaration): ClassMetadata {
       const result: ClassMetadata = {__symbolic: 'class'};
 
-      function getDecorators(decorators: ts.Decorator[]|undefined): MetadataSymbolicExpression[]|
+      function getDecorators(decorators: ts.Decorator[] | undefined): MetadataSymbolicExpression[]|
           undefined {
         if (decorators && decorators.length)
           return decorators.map(decorator => objFromDecorator(decorator));
@@ -174,7 +175,7 @@ export class MetadataCollector {
 
       // static member
       let statics: {[name: string]: MetadataValue | FunctionMetadata}|null = null;
-      function recordStaticMember(name: string, value: MetadataValue|FunctionMetadata) {
+      function recordStaticMember(name: string, value: MetadataValue | FunctionMetadata) {
         if (!statics) statics = {};
         statics[name] = value;
       }
@@ -195,10 +196,11 @@ export class MetadataCollector {
             }
             const methodDecorators = getDecorators(method.decorators);
             const parameters = method.parameters;
-            const parameterDecoratorData: ((MetadataSymbolicExpression | MetadataError)[]|
-                                           undefined)[] = [];
-            const parametersData: (MetadataSymbolicReferenceExpression|MetadataError|
-                                   MetadataSymbolicSelectExpression|null)[] = [];
+            const parameterDecoratorData:
+                ((MetadataSymbolicExpression | MetadataError)[] | undefined)[] = [];
+            const parametersData:
+                (MetadataSymbolicReferenceExpression | MetadataError |
+                 MetadataSymbolicSelectExpression | null)[] = [];
             let hasDecoratorData: boolean = false;
             let hasParameterData: boolean = false;
             for (const parameter of parameters) {
@@ -274,7 +276,7 @@ export class MetadataCollector {
 
           if (!moduleSpecifier) {
             // If there is a module specifier there is also an exportClause
-            exportClause!.elements.forEach(spec => {
+            exportClause !.elements.forEach(spec => {
               const exportedAs = spec.name.text;
               const name = (spec.propertyName || spec.name).text;
               exportMap.set(name, exportedAs);
@@ -456,8 +458,7 @@ export class MetadataCollector {
                   operator: '+',
                   left: {
                     __symbolic: 'select',
-                    expression: recordEntry({__symbolic: 'reference', name: enumName}, node),
-                    name
+                    expression: recordEntry({__symbolic: 'reference', name: enumName}, node), name
                   }
                 };
               } else {
@@ -556,8 +557,7 @@ export class MetadataCollector {
       }
       const result: ModuleMetadata = {
         __symbolic: 'module',
-        version: this.options.version || VERSION,
-        metadata
+        version: this.options.version || VERSION, metadata
       };
       if (exports) result.exports = exports;
       return result;
@@ -571,7 +571,8 @@ function validateMetadata(
     metadata: {[name: string]: MetadataEntry}) {
   let locals: Set<string> = new Set(['Array', 'Object', 'Set', 'Map', 'string', 'number', 'any']);
 
-  function validateExpression(expression: MetadataValue|MetadataSymbolicExpression|MetadataError) {
+  function validateExpression(
+      expression: MetadataValue | MetadataSymbolicExpression | MetadataError) {
     if (!expression) {
       return;
     } else if (Array.isArray(expression)) {
@@ -648,11 +649,11 @@ function validateMetadata(
     }
     if (classData.members) {
       Object.getOwnPropertyNames(classData.members)
-          .forEach(name => classData.members![name].forEach((m) => validateMember(classData, m)));
+          .forEach(name => classData.members ![name].forEach((m) => validateMember(classData, m)));
     }
     if (classData.statics) {
       Object.getOwnPropertyNames(classData.statics).forEach(name => {
-        const staticMember = classData.statics![name];
+        const staticMember = classData.statics ![name];
         if (isFunctionMetadata(staticMember)) {
           validateExpression(staticMember.value);
         } else {
@@ -675,7 +676,7 @@ function validateMetadata(
     }
   }
 
-  function shouldReportNode(node: ts.Node|undefined) {
+  function shouldReportNode(node: ts.Node | undefined) {
     if (node) {
       const nodeStart = node.getStart();
       return !(
@@ -688,12 +689,11 @@ function validateMetadata(
   function reportError(error: MetadataError) {
     const node = nodeMap.get(error);
     if (shouldReportNode(node)) {
-      const lineInfo = error.line != undefined ? error.character != undefined ?
-                                                 `:${error.line + 1}:${error.character + 1}` :
-                                                 `:${error.line + 1}` :
-                                                 '';
-      throw new Error(
-          `${
+      const lineInfo = error.line != undefined ?
+          error.character != undefined ? `:${error.line + 1}:${error.character + 1}` :
+                                         `:${error.line + 1}` :
+          '';
+      throw new Error(`${
              sourceFile.fileName
            }${
               lineInfo
@@ -718,8 +718,7 @@ function validateMetadata(
       if (shouldReportNode(node)) {
         if (node) {
           const {line, character} = sourceFile.getLineAndCharacterOfPosition(node.getStart());
-          throw new Error(
-              `${
+          throw new Error(`${
                  sourceFile.fileName
                }:${
                    line + 1
@@ -742,7 +741,7 @@ function validateMetadata(
 function namesOf(parameters: ts.NodeArray<ts.ParameterDeclaration>): string[] {
   const result: string[] = [];
 
-  function addNamesOf(name: ts.Identifier|ts.BindingPattern) {
+  function addNamesOf(name: ts.Identifier | ts.BindingPattern) {
     if (name.kind == ts.SyntaxKind.Identifier) {
       const identifier = <ts.Identifier>name;
       result.push(identifier.text);

--- a/packages/tsc-wrapped/test/collector_spec.ts
+++ b/packages/tsc-wrapped/test/collector_spec.ts
@@ -34,6 +34,7 @@ describe('Collector', () => {
       'exported-classes.ts',
       'exported-functions.ts',
       'exported-enum.ts',
+      'exported-type.ts',
       'exported-consts.ts',
       'local-symbol-ref.ts',
       'local-function-ref.ts',
@@ -64,6 +65,13 @@ describe('Collector', () => {
     const sourceFile = program.getSourceFile('app/empty.ts');
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toBeUndefined();
+  });
+
+  it('should return an type reference for type', () => {
+    const sourceFile = program.getSourceFile('exported-type.ts');
+    const metadata = collector.getMetadata(sourceFile);
+    expect(metadata).toEqual(
+        {__symbolic: 'module', version: 3, metadata: {SomeType: {__symbolic: 'type'}}});
   });
 
   it('should return an interface reference for interfaces', () => {
@@ -945,7 +953,7 @@ describe('Collector', () => {
     it('should be able to substitute a lambda', () => {
       const source = createSource(`
         const b = 1;
-        export const a = () => b; 
+        export const a = () => b;
       `);
       const metadata = collector.getMetadata(source, /* strict */ false, (value, node) => {
         if (node.kind === ts.SyntaxKind.ArrowFunction) {
@@ -965,7 +973,7 @@ describe('Collector', () => {
       });
       const source = createSource(`
         const b = 1;
-        export const a = () => b; 
+        export const a = () => b;
       `);
       const metadata = collector.getMetadata(source, /* strict */ false, (value, node) => {
         if (node.kind === ts.SyntaxKind.ArrowFunction) {
@@ -1271,6 +1279,9 @@ const FILES: Directory = {
       }
     }
     export declare function declaredFn();
+  `,
+  'exported-type.ts': `
+    export SomeType = 'a' | 'b';
   `,
   'exported-enum.ts': `
     import {constValue} from './exported-consts';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
At the moment types don't have metadata, and is resulting in incorrect metadata in json when the file only contain `type`

Issue NuN/Amber: 


## What is the new behavior?
Type have now metadata

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
