### PR TITLE
fix(tsc-wrapped): add metadata for `type` declarations

### DIFF
--- a/packages/tsc-wrapped/src/collector.ts
+++ b/packages/tsc-wrapped/src/collector.ts
@@ -287,13 +287,14 @@ export class MetadataCollector {
     const isExportedIdentifier = (identifier?: ts.Identifier) =>
         identifier && exportMap.has(identifier.text);
     const isExported =
-        (node: ts.FunctionDeclaration | ts.ClassDeclaration | ts.InterfaceDeclaration |
-         ts.EnumDeclaration) => isExport(node) || isExportedIdentifier(node.name);
+        (node: ts.FunctionDeclaration | ts.ClassDeclaration | ts.TypeAliasDeclaration |
+         ts.InterfaceDeclaration | ts.EnumDeclaration) =>
+            isExport(node) || isExportedIdentifier(node.name);
     const exportedIdentifierName = (identifier?: ts.Identifier) =>
         identifier && (exportMap.get(identifier.text) || identifier.text);
     const exportedName =
         (node: ts.FunctionDeclaration | ts.ClassDeclaration | ts.InterfaceDeclaration |
-         ts.EnumDeclaration) => exportedIdentifierName(node.name);
+         ts.TypeAliasDeclaration | ts.EnumDeclaration) => exportedIdentifierName(node.name);
 
 
     // Predeclare classes and functions
@@ -388,6 +389,17 @@ export class MetadataCollector {
             }
           }
           // Otherwise don't record metadata for the class.
+          break;
+
+        case ts.SyntaxKind.TypeAliasDeclaration:
+          const typeDeclaration = <ts.TypeAliasDeclaration>node;
+          if (typeDeclaration.name && isExported(typeDeclaration)) {
+            const name = exportedName(typeDeclaration);
+            if (name) {
+              if (!metadata) metadata = {};
+              metadata[name] = {__symbolic: 'interface'};
+            }
+          }
           break;
 
         case ts.SyntaxKind.InterfaceDeclaration:

--- a/packages/tsc-wrapped/test/collector_spec.ts
+++ b/packages/tsc-wrapped/test/collector_spec.ts
@@ -34,6 +34,7 @@ describe('Collector', () => {
       'exported-classes.ts',
       'exported-functions.ts',
       'exported-enum.ts',
+      'exported-type.ts',
       'exported-consts.ts',
       'local-symbol-ref.ts',
       'local-function-ref.ts',
@@ -64,6 +65,13 @@ describe('Collector', () => {
     const sourceFile = program.getSourceFile('app/empty.ts');
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toBeUndefined();
+  });
+
+  it('should return an interface reference for types', () => {
+    const sourceFile = program.getSourceFile('/exported-type.ts');
+    const metadata = collector.getMetadata(sourceFile);
+    expect(metadata).toEqual(
+        {__symbolic: 'module', version: 3, metadata: {SomeType: {__symbolic: 'interface'}}});
   });
 
   it('should return an interface reference for interfaces', () => {
@@ -945,7 +953,7 @@ describe('Collector', () => {
     it('should be able to substitute a lambda', () => {
       const source = createSource(`
         const b = 1;
-        export const a = () => b; 
+        export const a = () => b;
       `);
       const metadata = collector.getMetadata(source, /* strict */ false, (value, node) => {
         if (node.kind === ts.SyntaxKind.ArrowFunction) {
@@ -965,7 +973,7 @@ describe('Collector', () => {
       });
       const source = createSource(`
         const b = 1;
-        export const a = () => b; 
+        export const a = () => b;
       `);
       const metadata = collector.getMetadata(source, /* strict */ false, (value, node) => {
         if (node.kind === ts.SyntaxKind.ArrowFunction) {
@@ -1271,6 +1279,9 @@ const FILES: Directory = {
       }
     }
     export declare function declaredFn();
+  `,
+  'exported-type.ts': `
+    export type SomeType = 'a' | 'b';
   `,
   'exported-enum.ts': `
     import {constValue} from './exported-consts';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
At the moment types don't have metadata, and is resulting in incorrect metadata in json when the file only contain `type`

Issue: #18675  


## What is the new behavior?
Type have now metadata

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
