### PR TITLE
fix(language-service): remove tsickle dependency

### DIFF
--- a/integration/language_service_plugin/scripts/test.sh
+++ b/integration/language_service_plugin/scripts/test.sh
@@ -9,6 +9,11 @@ source scripts/env.sh
 HOST="node tools/typescript_host.js"
 VALIDATE="node tools/typescript_validator.js"
 
+# Ensure the languages service can load correctly in node before typescript loads it.
+# This verifies its dependencies and emits any exceptions, both of which are  only  
+# emitted to the typescript logs (not the validated output).
+node tools/load_test.js
+
 for TYPESCRIPT in ${TYPESCRIPTS[@]}
 do
   SERVER="node typescripts/$TYPESCRIPT/node_modules/typescript/lib/tsserver.js"

--- a/integration/language_service_plugin/tools/load_test.ts
+++ b/integration/language_service_plugin/tools/load_test.ts
@@ -1,0 +1,35 @@
+const ts = require('typescript');
+const Module = require('module');
+
+const existingRequire = Module.prototype.require;
+
+const recordedRequires: string[] = [];
+
+function recordingRequire(path: string) {
+  recordedRequires.push(path);
+  return existingRequire.call(this, path);
+}
+
+Module.prototype.require = recordingRequire;
+
+try {
+  const lsf = require('@angular/language-service');
+  const ls = lsf({typescript: ts});
+
+  // Assert that the only module that should have been required are '@angular/langauge-service', 'fs', and 'path'
+
+  const allowedLoads = new Set(["@angular/language-service", "fs", "path"]);
+
+  const invalidModules = recordedRequires.filter(m => !allowedLoads.has(m));
+
+  if (invalidModules.length > 0) {
+    console.error(`FAILED: Loading the language service required: ${invalidModules.join(', ')}`);
+    process.exit(1);
+  }
+} catch (e) {
+  console.error(`FAILED: Loading the language service caused the following exception: ${e.stack || e}`);
+  process.exit(1);
+}
+
+console.log('SUCCESS: Loading passed')
+process.exit(0);

--- a/integration/language_service_plugin/tools/tsconfig.json
+++ b/integration/language_service_plugin/tools/tsconfig.json
@@ -13,6 +13,7 @@
     },
     "files": [
         "typescript_host.ts", 
-        "typescript_validator.ts"
+        "typescript_validator.ts",
+        "load_test.ts"
     ]
 }

--- a/packages/compiler-cli/src/language_services.ts
+++ b/packages/compiler-cli/src/language_services.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/*
+
+The API from compiler-cli that language-service can see.
+It is important that none the exported modules require anything other than
+Angular modules and Typescript as this will indirectly add a dependency
+to the language service.
+
+*/
+
+export {AngularCompilerOptions} from '@angular/tsc-wrapped';
+export {CompilerHost, CompilerHostContext, MetadataProvider, ModuleResolutionHostAdapter, NodeCompilerHostContext} from './compiler_host';
+export {TypeChecker} from './diagnostics/check_types';
+export {DiagnosticTemplateInfo, ExpressionDiagnostic, getExpressionDiagnostics, getExpressionScope, getTemplateExpressionDiagnostics} from './diagnostics/expression_diagnostics';
+export {AstType, DiagnosticKind, ExpressionDiagnosticsContext, TypeDiagnostic} from './diagnostics/expression_type';
+export {BuiltinType, DeclarationKind, Definition, Location, PipeInfo, Pipes, Signature, Span, Symbol, SymbolDeclaration, SymbolQuery, SymbolTable} from './diagnostics/symbols';
+export {getClassFromStaticSymbol, getClassMembers, getClassMembersFromDeclaration, getPipesTable, getSymbolQuery} from './diagnostics/typescript_symbols';

--- a/packages/compiler-cli/tsconfig-build.json
+++ b/packages/compiler-cli/tsconfig-build.json
@@ -33,6 +33,7 @@
     "index.ts",
     "src/main.ts",
     "src/extract_i18n.ts",
+    "src/language_services.ts",
     "../../node_modules/@types/node/index.d.ts",
     "../../node_modules/@types/jasmine/index.d.ts",
     "../../node_modules/zone.js/dist/zone.js.d.ts"

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -7,7 +7,7 @@
  */
 
 import {AST, AstPath, AttrAst, Attribute, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, CssSelector, DirectiveAst, Element, ElementAst, EmbeddedTemplateAst, ImplicitReceiver, NAMED_ENTITIES, NgContentAst, Node as HtmlAst, NullTemplateVisitor, ParseSpan, PropertyRead, ReferenceAst, SelectorMatcher, TagContentType, TemplateAst, TemplateAstVisitor, Text, TextAst, VariableAst, findNode, getHtmlTagDefinition, splitNsName, templateVisitAll} from '@angular/compiler';
-import {DiagnosticTemplateInfo, getExpressionScope} from '@angular/compiler-cli';
+import {DiagnosticTemplateInfo, getExpressionScope} from '@angular/compiler-cli/src/language_services';
 
 import {AstResult, AttrInfo, SelectorInfo, TemplateInfo} from './common';
 import {getExpressionCompletions} from './expressions';

--- a/packages/language-service/src/diagnostics.ts
+++ b/packages/language-service/src/diagnostics.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgAnalyzedModules, StaticSymbol} from '@angular/compiler';
-import {DiagnosticTemplateInfo, getTemplateExpressionDiagnostics} from '@angular/compiler-cli';
+import {DiagnosticTemplateInfo, getTemplateExpressionDiagnostics} from '@angular/compiler-cli/src/language_services';
 
 import {AstResult} from './common';
 import {Declarations, Diagnostic, DiagnosticKind, Diagnostics, Span, TemplateSource} from './types';

--- a/packages/language-service/src/expressions.ts
+++ b/packages/language-service/src/expressions.ts
@@ -7,7 +7,7 @@
  */
 
 import {AST, ASTWithSource, AstPath as AstPathBase, NullAstVisitor, visitAstChildren} from '@angular/compiler';
-import {AstType} from '@angular/compiler-cli';
+import {AstType} from '@angular/compiler-cli/src/language_services';
 
 import {BuiltinType, Span, Symbol, SymbolQuery, SymbolTable} from './types';
 import {inSpan} from './utils';

--- a/packages/language-service/src/locate_symbol.ts
+++ b/packages/language-service/src/locate_symbol.ts
@@ -7,7 +7,7 @@
  */
 
 import {AST, Attribute, BoundDirectivePropertyAst, BoundEventAst, ElementAst, TemplateAst, TemplateAstPath, findNode, tokenReference} from '@angular/compiler';
-import {getExpressionScope} from '@angular/compiler-cli';
+import {getExpressionScope} from '@angular/compiler-cli/src/language_services';
 
 import {TemplateInfo} from './common';
 import {getExpressionSymbol} from './expressions';

--- a/packages/language-service/src/reflector_host.ts
+++ b/packages/language-service/src/reflector_host.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AngularCompilerOptions, AotCompilerHost, CompilerHost, ModuleResolutionHostAdapter} from '@angular/compiler-cli';
+import {AotCompilerHost} from '@angular/compiler';
+import {AngularCompilerOptions, CompilerHost, ModuleResolutionHostAdapter} from '@angular/compiler-cli/src/language_services';
 import * as ts from 'typescript';
 
 class ReflectorModuleModuleResolutionHost implements ts.ModuleResolutionHost {

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -7,7 +7,7 @@
  */
 
 import {CompileDirectiveMetadata, CompileMetadataResolver, CompilePipeSummary, NgAnalyzedModules, StaticSymbol} from '@angular/compiler';
-import {BuiltinType, DeclarationKind, Definition, PipeInfo, Pipes, Signature, Span, Symbol, SymbolDeclaration, SymbolQuery, SymbolTable} from '@angular/compiler-cli';
+import {BuiltinType, DeclarationKind, Definition, PipeInfo, Pipes, Signature, Span, Symbol, SymbolDeclaration, SymbolQuery, SymbolTable} from '@angular/compiler-cli/src/language_services';
 
 export {
   BuiltinType,

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -7,7 +7,7 @@
  */
 
 import {AotSummaryResolver, CompileMetadataResolver, CompilerConfig, DEFAULT_INTERPOLATION_CONFIG, DirectiveNormalizer, DirectiveResolver, DomElementSchemaRegistry, HtmlParser, InterpolationConfig, JitSummaryResolver, NgAnalyzedModules, NgModuleResolver, ParseTreeResult, PipeResolver, ResourceLoader, StaticReflector, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, SummaryResolver, analyzeNgModules, createOfflineCompileUrlResolver, extractProgramSymbols} from '@angular/compiler';
-import {AngularCompilerOptions, getClassMembersFromDeclaration, getPipesTable, getSymbolQuery} from '@angular/compiler-cli';
+import {AngularCompilerOptions, getClassMembersFromDeclaration, getPipesTable, getSymbolQuery} from '@angular/compiler-cli/src/language_services';
 import {ViewEncapsulation, ɵConsole as Console} from '@angular/core';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/packages/language-service/src/utils.ts
+++ b/packages/language-service/src/utils.ts
@@ -7,7 +7,7 @@
  */
 
 import {AstPath, CompileDirectiveSummary, CompileTypeMetadata, CssSelector, DirectiveAst, ElementAst, EmbeddedTemplateAst, HtmlAstPath, Node as HtmlNode, ParseSourceSpan, RecursiveTemplateAstVisitor, RecursiveVisitor, TemplateAst, TemplateAstPath, identifierName, templateVisitAll, visitAll} from '@angular/compiler';
-import {DiagnosticTemplateInfo} from '@angular/compiler-cli';
+import {DiagnosticTemplateInfo} from '@angular/compiler-cli/src/language_services';
 import * as ts from 'typescript';
 
 import {SelectorInfo, TemplateInfo} from './common';

--- a/packages/language-service/tsconfig-build.json
+++ b/packages/language-service/tsconfig-build.json
@@ -17,6 +17,7 @@
       "@angular/common": ["../../dist/packages/common"],
       "@angular/compiler": ["../../dist/packages/compiler"],
       "@angular/compiler-cli": ["../../dist/packages/compiler-cli"],
+      "@angular/compiler-cli/*": ["../../dist/packages/compiler-cli/*"],
       "@angular/http": ["../../dist/packages/http"],
       "@angular/platform-server": ["../../dist/packages/platform-server"],
       "@angular/platform-browser": ["../../dist/packages/platform-browser"],


### PR DESCRIPTION
Removes the tsickle dependency added when tsickle was added to the
transform compiler.

Added a test to ensure stray dependencies are not added and no
errors are introduced during module flattening.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The language service bundle depends on tsickle which it doesn't use.

## What is the new behavior?

The language service no longer depends on tsickle. The code was refactored to allow better control of what is exported to the language service and a test was added to fail when additional dependencies are added.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
