### PR TITLE
docs(aio): typo in metadata guide

### DIFF
--- a/aio/content/guide/metadata.md
+++ b/aio/content/guide/metadata.md
@@ -16,7 +16,7 @@ In the following example, the `@Component()` metadata object and the class const
 ```typescript
 @Component({
   selector: 'app-typical',
-  template: 'div>A typical component for {{data.name}}</div>
+  template: '<div>A typical component for {{data.name}}</div>'
 )}
 export class TypicalComponent {
   @Input() data: TypicalData;


### PR DESCRIPTION
## PR Type

Simple typo fix in aio guide

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```