### PR TITLE
build(test.sh): increase node memory for tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -22,8 +22,8 @@ else
   if [[ $1 == 'node' ]]; then
     # Note: .metadata.json files are needed for the language service tests!
     echo "Creating .metadata.json files..."
-    node dist/all/@angular/tsc-wrapped/src/main -p packages
-    node dist/all/@angular/tsc-wrapped/src/main -p modules
+    node --max-old-space-size=3000 dist/all/@angular/tsc-wrapped/src/main -p packages
+    node --max-old-space-size=3000 dist/all/@angular/tsc-wrapped/src/main -p modules
   fi
   node dist/tools/tsc-watch/ $1 watch
 fi


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[x] Build related changes
```

## What is the current behavior?
Node tests often fail because of memory issues with the following error message:
```sh
FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
 1: node::Abort() [node]
 2: 0x1096a4c [node]
 3: v8::Utils::ReportApiFailure(char const*, char const*) [node]
 4: v8::internal::V8::FatalProcessOutOfMemory(char const*, bool) [node]
 5: v8::internal::Factory::NewFixedArray(int, v8::internal::PretenureFlag) [node]
 6: v8::internal::DeoptimizationInputData::New(v8::internal::Isolate*, int, v8::internal::PretenureFlag) [node]
 7: v8::internal::LCodeGenBase::PopulateDeoptimizationData(v8::internal::Handle<v8::internal::Code>) [node]
 8: v8::internal::LChunk::Codegen() [node]
 9: v8::internal::OptimizedCompileJob::GenerateCode() [node]
10: v8::internal::Compiler::FinalizeOptimizedCompileJob(v8::internal::OptimizedCompileJob*) [node]
11: v8::internal::OptimizingCompileDispatcher::InstallOptimizedFunctions() [node]
12: v8::internal::Runtime_TryInstallOptimizedCode(int, v8::internal::Object**, v8::internal::Isolate*) [node]
13: 0x3d42ac1092a7
/home/travis/build/angular/angular/scripts/ci/test-js.sh: line 33:  6423 Aborted                 (core dumped) node dist/packages-dist/tsc-wrapped/src/main -p packages/tsconfig.json
```

Example of failing build: https://travis-ci.org/angular/angular/jobs/265271719

## What is the new behavior?
Increased node memory for the tests so that they don't crash, until we can fix the problem or switch to bazel

## Does this PR introduce a breaking change?
```
[x] No
```