### PR TITLE
build(packaging): increase node memory for tests

### DIFF
--- a/scripts/ci/test-js.sh
+++ b/scripts/ci/test-js.sh
@@ -30,8 +30,8 @@ travisFoldEnd "test.unit.node"
 # rebuild to revert files in @angular/compiler/test
 # TODO(tbosch): remove this and teach karma to serve the right files
 travisFoldStart "test.unit.rebuildHack"
-  node dist/packages-dist/tsc-wrapped/src/main -p packages/tsconfig.json
-  node dist/packages-dist/tsc-wrapped/src/main -p modules/tsconfig.json
+  node --max-old-space-size=3000 dist/packages-dist/tsc-wrapped/src/main -p packages/tsconfig.json
+  node --max-old-space-size=3000 dist/packages-dist/tsc-wrapped/src/main -p modules/tsconfig.json
 travisFoldStart "test.unit.rebuildHack"
 
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[x] Build related changes
```

## What is the current behavior?
Node tests often fail because of memory issues with the following error message:
```sh
FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
 1: node::Abort() [node]
 2: 0x1096a4c [node]
 3: v8::Utils::ReportApiFailure(char const*, char const*) [node]
 4: v8::internal::V8::FatalProcessOutOfMemory(char const*, bool) [node]
 5: v8::internal::Factory::NewFixedArray(int, v8::internal::PretenureFlag) [node]
 6: v8::internal::DeoptimizationInputData::New(v8::internal::Isolate*, int, v8::internal::PretenureFlag) [node]
 7: v8::internal::LCodeGenBase::PopulateDeoptimizationData(v8::internal::Handle<v8::internal::Code>) [node]
 8: v8::internal::LChunk::Codegen() [node]
 9: v8::internal::OptimizedCompileJob::GenerateCode() [node]
10: v8::internal::Compiler::FinalizeOptimizedCompileJob(v8::internal::OptimizedCompileJob*) [node]
11: v8::internal::OptimizingCompileDispatcher::InstallOptimizedFunctions() [node]
12: v8::internal::Runtime_TryInstallOptimizedCode(int, v8::internal::Object**, v8::internal::Isolate*) [node]
13: 0x3d42ac1092a7
/home/travis/build/angular/angular/scripts/ci/test-js.sh: line 33:  6423 Aborted                 (core dumped) node dist/packages-dist/tsc-wrapped/src/main -p packages/tsconfig.json
```

Example of failing build: https://travis-ci.org/angular/angular/jobs/265271719

With the PR https://github.com/angular/angular/pull/18731 I've fixed the first builds, but apparently this script does exactly the same build a second time, and this one fails too for the reason.
This fixes it, and hopefully there shouldn't be any other build of all the packages that fails after this one.

## What is the new behavior?
Increased node memory for the tests so that they don't crash, until we can fix the problem or switch to bazel

## Does this PR introduce a breaking change?
```
[x] No
```