### PR TITLE
refactor(core): remove deprecated code in iterables

### DIFF
--- a/packages/core/src/change_detection.ts
+++ b/packages/core/src/change_detection.ts
@@ -12,4 +12,4 @@
  * Change detection enables data binding in Angular.
  */
 
-export {ChangeDetectionStrategy, ChangeDetectorRef, CollectionChangeRecord, DefaultIterableDiffer, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers, NgIterable, PipeTransform, SimpleChange, SimpleChanges, TrackByFn, TrackByFunction, WrappedValue} from './change_detection/change_detection';
+export {ChangeDetectionStrategy, ChangeDetectorRef, CollectionChangeRecord, DefaultIterableDiffer, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers, NgIterable, PipeTransform, SimpleChange, SimpleChanges, TrackByFunction, WrappedValue} from './change_detection/change_detection';

--- a/packages/core/src/change_detection.ts
+++ b/packages/core/src/change_detection.ts
@@ -12,4 +12,4 @@
  * Change detection enables data binding in Angular.
  */
 
-export {ChangeDetectionStrategy, ChangeDetectorRef, CollectionChangeRecord, DefaultIterableDiffer, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers, NgIterable, PipeTransform, SimpleChange, SimpleChanges, TrackByFunction, WrappedValue} from './change_detection/change_detection';
+export {ChangeDetectionStrategy, ChangeDetectorRef, CollectionChangeRecord, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers, NgIterable, PipeTransform, SimpleChange, SimpleChanges, TrackByFunction, WrappedValue} from './change_detection/change_detection';

--- a/packages/core/src/change_detection/change_detection.ts
+++ b/packages/core/src/change_detection/change_detection.ts
@@ -18,7 +18,7 @@ export {ChangeDetectionStrategy, ChangeDetectorStatus, isDefaultChangeDetectionS
 export {DefaultIterableDifferFactory} from './differs/default_iterable_differ';
 export {DefaultIterableDiffer} from './differs/default_iterable_differ';
 export {DefaultKeyValueDifferFactory} from './differs/default_keyvalue_differ';
-export {CollectionChangeRecord, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, NgIterable, TrackByFn, TrackByFunction} from './differs/iterable_differs';
+export {CollectionChangeRecord, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, NgIterable, TrackByFunction} from './differs/iterable_differs';
 export {KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers} from './differs/keyvalue_differs';
 export {PipeTransform} from './pipe_transform';
 

--- a/packages/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/packages/core/src/change_detection/differs/default_iterable_differ.ts
@@ -8,8 +8,6 @@
 
 import {looseIdentical, stringify} from '../../util';
 import {isListLikeIterable, iterateListLike} from '../change_detection_util';
-import {ChangeDetectorRef} from '../change_detector_ref';
-
 import {IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, NgIterable, TrackByFunction} from './iterable_differs';
 
 
@@ -17,14 +15,8 @@ export class DefaultIterableDifferFactory implements IterableDifferFactory {
   constructor() {}
   supports(obj: Object|null|undefined): boolean { return isListLikeIterable(obj); }
 
-  create<V>(trackByFn?: TrackByFunction<V>): DefaultIterableDiffer<V>;
-
-  /**
-   * @deprecated v4.0.0 - ChangeDetectorRef is not used and is no longer a parameter
-   */
-  create<V>(cdRefOrTrackBy?: ChangeDetectorRef|TrackByFunction<V>, trackByFn?: TrackByFunction<V>):
-      DefaultIterableDiffer<V> {
-    return new DefaultIterableDiffer<V>(trackByFn || <TrackByFunction<any>>cdRefOrTrackBy);
+  create<V>(trackByFn?: TrackByFunction<V>): DefaultIterableDiffer<V> {
+    return new DefaultIterableDiffer<V>(trackByFn);
   }
 }
 

--- a/packages/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/packages/core/src/change_detection/differs/default_iterable_differ.ts
@@ -22,9 +22,6 @@ export class DefaultIterableDifferFactory implements IterableDifferFactory {
 
 const trackByIdentity = (index: number, item: any) => item;
 
-/**
- * @deprecated v4.0.0 - Should not be part of public API.
- */
 export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChanges<V> {
   private _length: number = 0;
   private _collection: NgIterable<V>|null = null;

--- a/packages/core/src/change_detection/differs/default_keyvalue_differ.ts
+++ b/packages/core/src/change_detection/differs/default_keyvalue_differ.ts
@@ -8,7 +8,6 @@
 
 import {looseIdentical, stringify} from '../../util';
 import {isJsObject} from '../change_detection_util';
-import {ChangeDetectorRef} from '../change_detector_ref';
 import {KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory} from './keyvalue_differs';
 
 
@@ -16,14 +15,7 @@ export class DefaultKeyValueDifferFactory<K, V> implements KeyValueDifferFactory
   constructor() {}
   supports(obj: any): boolean { return obj instanceof Map || isJsObject(obj); }
 
-  create<K, V>(): DefaultKeyValueDiffer<K, V>;
-
-  /**
-   * @deprecated v4.0.0 - ChangeDetectorRef is not used and is no longer a parameter
-   */
-  create<K, V>(cd?: ChangeDetectorRef): KeyValueDiffer<K, V> {
-    return new DefaultKeyValueDiffer<K, V>();
-  }
+  create<K, V>(): KeyValueDiffer<K, V> { return new DefaultKeyValueDiffer<K, V>(); }
 }
 
 export class DefaultKeyValueDiffer<K, V> implements KeyValueDiffer<K, V>, KeyValueChanges<K, V> {

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -7,7 +7,6 @@
  */
 
 import {Optional, SkipSelf, StaticProvider} from '../../di';
-import {ChangeDetectorRef} from '../change_detector_ref';
 
 
 /**
@@ -127,12 +126,6 @@ export interface TrackByFunction<T> { (index: number, item: T): any; }
 export interface IterableDifferFactory {
   supports(objects: any): boolean;
   create<V>(trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
-
-  /**
-   * @deprecated v4.0.0 - ChangeDetectorRef is not used and is no longer a parameter
-   */
-  create<V>(_cdr?: ChangeDetectorRef|TrackByFunction<V>, trackByFn?: TrackByFunction<V>):
-      IterableDiffer<V>;
 }
 
 /**

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -82,7 +82,8 @@ export interface IterableChanges<V> {
   /** Iterate over all removed items. */
   forEachRemovedItem(fn: (record: IterableChangeRecord<V>) => void): void;
 
-  /** Iterate over all items which had their identity (as computed by the `trackByFn`) changed. */
+  /** Iterate over all items which had their identity (as computed by the `TrackByFunction`)
+   * changed. */
   forEachIdentityChange(fn: (record: IterableChangeRecord<V>) => void): void;
 }
 
@@ -101,7 +102,7 @@ export interface IterableChangeRecord<V> {
   /** The item. */
   readonly item: V;
 
-  /** Track by identity as computed by the `trackByFn`. */
+  /** Track by identity as computed by the `TrackByFunction`. */
   readonly trackById: any;
 }
 
@@ -109,14 +110,6 @@ export interface IterableChangeRecord<V> {
  * @deprecated v4.0.0 - Use IterableChangeRecord instead.
  */
 export interface CollectionChangeRecord<V> extends IterableChangeRecord<V> {}
-
-
-/**
- * Nolonger used.
- *
- * @deprecated v4.0.0 - Use TrackByFunction instead
- */
-export interface TrackByFn { (index: number, item: any): any; }
 
 /**
  * An optional function passed into {@link NgForOf} that defines how to track

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -133,11 +133,7 @@ export interface IterableDifferFactory {
  * @stable
  */
 export class IterableDiffers {
-  /**
-   * @deprecated v4.0.0 - Should be private
-   */
-  factories: IterableDifferFactory[];
-  constructor(factories: IterableDifferFactory[]) { this.factories = factories; }
+  constructor(private factories: IterableDifferFactory[]) {}
 
   static create(factories: IterableDifferFactory[], parent?: IterableDiffers): IterableDiffers {
     if (parent != null) {

--- a/packages/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/packages/core/src/change_detection/differs/keyvalue_differs.ts
@@ -7,8 +7,6 @@
  */
 
 import {Optional, SkipSelf, StaticProvider} from '../../di';
-import {ChangeDetectorRef} from '../change_detector_ref';
-
 
 
 /**
@@ -110,11 +108,6 @@ export interface KeyValueDifferFactory {
    * Create a `KeyValueDiffer`.
    */
   create<K, V>(): KeyValueDiffer<K, V>;
-
-  /**
-   * @deprecated v4.0.0 - ChangeDetectorRef is not used and is no longer a parameter
-   */
-  create<K, V>(_cdr?: ChangeDetectorRef): KeyValueDiffer<K, V>;
 }
 
 /**

--- a/packages/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/packages/core/src/change_detection/differs/keyvalue_differs.ts
@@ -115,12 +115,7 @@ export interface KeyValueDifferFactory {
  * @stable
  */
 export class KeyValueDiffers {
-  /**
-   * @deprecated v4.0.0 - Should be private.
-   */
-  factories: KeyValueDifferFactory[];
-
-  constructor(factories: KeyValueDifferFactory[]) { this.factories = factories; }
+  constructor(private factories: KeyValueDifferFactory[]) {}
 
   static create<S>(factories: KeyValueDifferFactory[], parent?: KeyValueDiffers): KeyValueDiffers {
     if (parent) {

--- a/packages/core/test/change_detection/differs/iterable_differs_spec.ts
+++ b/packages/core/test/change_detection/differs/iterable_differs_spec.ts
@@ -38,31 +38,12 @@ export function main() {
       expect(differs.find('some object')).toBe(factory2);
     });
 
-    it('should copy over differs from the parent repo', () => {
-      factory1.spy('supports').and.returnValue(true);
-      factory2.spy('supports').and.returnValue(false);
-
-      const parent = IterableDiffers.create(<any>[factory1]);
-      const child = IterableDiffers.create(<any>[factory2], parent);
-
-      expect(child.factories).toEqual([factory2, factory1]);
-    });
-
     describe('.extend()', () => {
       it('should throw if calling extend when creating root injector', () => {
         const injector = Injector.create([IterableDiffers.extend([])]);
 
         expect(() => injector.get(IterableDiffers))
             .toThrowError(/Cannot extend IterableDiffers without a parent injector/);
-      });
-
-      it('should extend di-inherited differs', () => {
-        const parent = new IterableDiffers([factory1]);
-        const injector = Injector.create([{provide: IterableDiffers, useValue: parent}]);
-        const childInjector = Injector.create([IterableDiffers.extend([factory2])], injector);
-
-        expect(injector.get(IterableDiffers).factories).toEqual([factory1]);
-        expect(childInjector.get(IterableDiffers).factories).toEqual([factory2, factory1]);
       });
     });
   });

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -514,7 +514,6 @@ export interface IterableDiffer<V> {
 /** @stable */
 export interface IterableDifferFactory {
     create<V>(trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
-    /** @deprecated */ create<V>(_cdr?: ChangeDetectorRef | TrackByFunction<V>, trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
     supports(objects: any): boolean;
 }
 
@@ -557,7 +556,6 @@ export interface KeyValueDiffer<K, V> {
 /** @stable */
 export interface KeyValueDifferFactory {
     create<K, V>(): KeyValueDiffer<K, V>;
-    /** @deprecated */ create<K, V>(_cdr?: ChangeDetectorRef): KeyValueDiffer<K, V>;
     supports(objects: any): boolean;
 }
 

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -989,11 +989,6 @@ export declare class TestabilityRegistry {
     registerApplication(token: any, testability: Testability): void;
 }
 
-/** @deprecated */
-export interface TrackByFn {
-    (index: number, item: any): any;
-}
-
 /** @stable */
 export interface TrackByFunction<T> {
     (index: number, item: T): any;

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -329,24 +329,6 @@ export declare class DebugNode {
     constructor(nativeNode: any, parent: DebugNode | null, _debugContext: DebugContext);
 }
 
-/** @deprecated */
-export declare class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChanges<V> {
-    readonly collection: V[] | Iterable<V> | null;
-    readonly isDirty: boolean;
-    readonly length: number;
-    constructor(trackByFn?: TrackByFunction<V>);
-    check(collection: NgIterable<V>): boolean;
-    diff(collection: NgIterable<V>): DefaultIterableDiffer<V> | null;
-    forEachAddedItem(fn: (record: IterableChangeRecord_<V>) => void): void;
-    forEachIdentityChange(fn: (record: IterableChangeRecord_<V>) => void): void;
-    forEachItem(fn: (record: IterableChangeRecord_<V>) => void): void;
-    forEachMovedItem(fn: (record: IterableChangeRecord_<V>) => void): void;
-    forEachOperation(fn: (item: IterableChangeRecord<V>, previousIndex: number | null, currentIndex: number | null) => void): void;
-    forEachPreviousItem(fn: (record: IterableChangeRecord_<V>) => void): void;
-    forEachRemovedItem(fn: (record: IterableChangeRecord_<V>) => void): void;
-    onDestroy(): void;
-}
-
 /** @experimental */
 export declare function destroyPlatform(): void;
 
@@ -519,7 +501,6 @@ export interface IterableDifferFactory {
 
 /** @stable */
 export declare class IterableDiffers {
-    /** @deprecated */ factories: IterableDifferFactory[];
     constructor(factories: IterableDifferFactory[]);
     find(iterable: any): IterableDifferFactory;
     static create(factories: IterableDifferFactory[], parent?: IterableDiffers): IterableDiffers;
@@ -561,7 +542,6 @@ export interface KeyValueDifferFactory {
 
 /** @stable */
 export declare class KeyValueDiffers {
-    /** @deprecated */ factories: KeyValueDifferFactory[];
     constructor(factories: KeyValueDifferFactory[]);
     find(kv: any): KeyValueDifferFactory;
     static create<S>(factories: KeyValueDifferFactory[], parent?: KeyValueDiffers): KeyValueDiffers;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[ ] Other... Please describe: removing deprecated code
```

## What is the current behavior?
- `TrackByFn` was no longer used but still exported
- `DifferFactory.create`  took a ChangeDetectionRef as a first argument but it was not used
- `DefaultIterableDiffer`, `KeyValueDiffers#factories` & `IterableDiffers#factories` were public but were meant to be private/internal

## What is the new behavior?
- `TrackByFn` has been removed because it was deprecated since v4. Use `TrackByFunction` instead.
- `DifferFactory.create` no longer takes ChangeDetectionRef as a first argument as it was not used and deprecated since v4.
- `DefaultIterableDiffer`, `KeyValueDiffers#factories` & `IterableDiffers#factories` are no longer public, they have been removed from the public API as they were deprecated since v4.

## Does this PR introduce a breaking change?
```
[x] Yes
```