### PR TITLE
refactor(core): remove deprecated parameter for `ErrorHandler`

### DIFF
--- a/packages/core/src/error_handler.ts
+++ b/packages/core/src/error_handler.ts
@@ -42,13 +42,6 @@ export class ErrorHandler {
    */
   _console: Console = console;
 
-  constructor(
-      /**
-       * @deprecated since v4.0 parameter no longer has an effect, as ErrorHandler will never
-       * rethrow.
-       */
-      deprecatedParameter?: boolean) {}
-
   handleError(error: any): void {
     const originalError = this._findOriginalError(error);
     const context = this._findContext(error);

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -381,8 +381,6 @@ export declare function enableProdMode(): void;
 
 /** @stable */
 export declare class ErrorHandler {
-    constructor(
-        deprecatedParameter?: boolean);
     handleError(error: any): void;
 }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[ ] Other... Please describe: removing deprecated code
```

## What is the current behavior?
`ErrorHandler` was taking a parameter but was not using it.

## What is the new behavior?
`ErrorHandler` no longer takes a parameter as it was not used and deprecated since v4.

## Does this PR introduce a breaking change?
```
[x] Yes
```