### PR TITLE
refactor(platform-browser): remove deprecated `NgProbeToken`

### DIFF
--- a/packages/platform-browser/src/dom/debug/ng_probe.ts
+++ b/packages/platform-browser/src/dom/debug/ng_probe.ts
@@ -26,22 +26,13 @@ export function inspectNativeElement(element: any): core.DebugNode|null {
   return core.getDebugNode(element);
 }
 
-/**
- * Deprecated. Use the one from '@angular/core'.
- * @deprecated
- */
-export class NgProbeToken {
-  constructor(public name: string, public token: any) {}
-}
-
-export function _createNgProbe(extraTokens: NgProbeToken[], coreTokens: core.NgProbeToken[]): any {
-  const tokens = (extraTokens || []).concat(coreTokens || []);
+export function _createNgProbe(coreTokens: core.NgProbeToken[]): any {
   exportNgVar(INSPECT_GLOBAL_NAME, inspectNativeElement);
-  exportNgVar(CORE_TOKENS_GLOBAL_NAME, {...CORE_TOKENS, ..._ngProbeTokensToMap(tokens || [])});
+  exportNgVar(CORE_TOKENS_GLOBAL_NAME, {...CORE_TOKENS, ..._ngProbeTokensToMap(coreTokens || [])});
   return () => inspectNativeElement;
 }
 
-function _ngProbeTokensToMap(tokens: NgProbeToken[]): {[name: string]: any} {
+function _ngProbeTokensToMap(tokens: core.NgProbeToken[]): {[name: string]: any} {
   return tokens.reduce((prev: any, t: any) => (prev[t.name] = t.token, prev), {});
 }
 
@@ -53,7 +44,6 @@ export const ELEMENT_PROBE_PROVIDERS: core.Provider[] = [
     provide: core.APP_INITIALIZER,
     useFactory: _createNgProbe,
     deps: [
-      [NgProbeToken, new core.Optional()],
       [core.NgProbeToken, new core.Optional()],
     ],
     multi: true,

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -11,7 +11,6 @@ export {Meta, MetaDefinition} from './browser/meta';
 export {Title} from './browser/title';
 export {disableDebugTools, enableDebugTools} from './browser/tools/tools';
 export {By} from './dom/debug/by';
-export {NgProbeToken} from './dom/debug/ng_probe';
 export {DOCUMENT} from './dom/dom_tokens';
 export {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 export {HAMMER_GESTURE_CONFIG, HammerGestureConfig} from './dom/events/hammer_gestures';

--- a/tools/public_api_guard/platform-browser/platform-browser.d.ts
+++ b/tools/public_api_guard/platform-browser/platform-browser.d.ts
@@ -82,13 +82,6 @@ export declare type MetaDefinition = {
     [prop: string]: string;
 };
 
-/** @deprecated */
-export declare class NgProbeToken {
-    name: string;
-    token: any;
-    constructor(name: string, token: any);
-}
-
 /** @stable */
 export declare const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef;
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[ ] Other... Please describe: removing deprecated code
```

## What is the current behavior?
`NgProbeToken` had been moved to `@angular/core`, the one in platform-browser was no longer used.

## What is the new behavior?
`NgProbeToken` has been removed from `@angular/platform-browser` as it was deprecated since v4. Import it from `@angular/core` instead.

## Does this PR introduce a breaking change?
```
[x] Yes
```