### PR TITLE
refactor(platform-webworker): remove deprecated `PRIMITIVE`

### DIFF
--- a/packages/platform-webworker/src/platform-webworker.ts
+++ b/packages/platform-webworker/src/platform-webworker.ts
@@ -13,7 +13,7 @@ import {WORKER_SCRIPT, platformWorkerUi} from './worker_render';
 export {VERSION} from './version';
 export {ClientMessageBroker, ClientMessageBrokerFactory, FnArg, UiArguments} from './web_workers/shared/client_message_broker';
 export {MessageBus, MessageBusSink, MessageBusSource} from './web_workers/shared/message_bus';
-export {PRIMITIVE, SerializerTypes} from './web_workers/shared/serializer';
+export {SerializerTypes} from './web_workers/shared/serializer';
 export {ReceivedMessage, ServiceMessageBroker, ServiceMessageBrokerFactory} from './web_workers/shared/service_message_broker';
 export {WORKER_UI_LOCATION_PROVIDERS} from './web_workers/ui/location_providers';
 export {WORKER_APP_LOCATION_PROVIDERS} from './web_workers/worker/location_providers';

--- a/packages/platform-webworker/src/web_workers/shared/serializer.ts
+++ b/packages/platform-webworker/src/web_workers/shared/serializer.ts
@@ -22,14 +22,6 @@ export const enum SerializerTypes {
   RENDER_STORE_OBJECT,
 }
 
-/**
- * Any type that does not need to be serialized (string, number, boolean)
- *
- * @experimental WebWorker support in Angular is currently experimental.
- * @deprecated in v4. Use SerializerTypes.PRIMITIVE instead
- */
-export const PRIMITIVE = SerializerTypes.PRIMITIVE;
-
 export class LocationType {
   constructor(
       public href: string, public protocol: string, public host: string, public hostname: string,

--- a/tools/public_api_guard/platform-webworker/platform-webworker.d.ts
+++ b/tools/public_api_guard/platform-webworker/platform-webworker.d.ts
@@ -47,9 +47,6 @@ export declare const platformWorkerApp: (extraProviders?: StaticProvider[] | und
 export declare const platformWorkerUi: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
 
 /** @experimental */
-export declare const PRIMITIVE: SerializerTypes;
-
-/** @experimental */
 export interface ReceivedMessage {
     args: any[];
     id: string;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[ ] Other... Please describe: removing deprecated code
```

## What is the current behavior?
`PRIMITIVE` was exported but no longer used.

## What is the new behavior?
`PRIMITIVE` has been removed as it was deprecated since v4. Use `SerializerTypes.PRIMITIVE` instead.

## Does this PR introduce a breaking change?
```
[x] Yes
```