### PR TITLE
docs(aio): fixing links

### DIFF
--- a/aio/content/guide/structural-directives.md
+++ b/aio/content/guide/structural-directives.md
@@ -100,7 +100,7 @@ Technically it's a directive with a template.
 
 An [*attribute* directive](guide/attribute-directives) changes the appearance or behavior
 of an element, component, or another directive.
-For example, the built-in [`NgStyle`](guide/template-syntax#ngStyle) directive
+For example, the built-in [NgStyle](guide/template-syntax#ngStyle) directive
 changes several element styles at the same time.
 
 You can apply many _attribute_ directives to one host element.
@@ -243,7 +243,7 @@ Only the finished product ends up in the DOM.
 Angular consumed the `<ng-template>` content during its actual rendering and
 replaced the `<ng-template>` with a diagnostic comment.
 
-The [`NgFor`](guide/structural-directives#ngFor) and [`NgSwitch...`](guide/structural-directives#ngSwitch) directives follow the same pattern.
+The [NgFor](guide/structural-directives#ngFor) and [NgSwitch](guide/structural-directives#ngSwitch)... directives follow the same pattern.
 
 
 {@a ngFor}
@@ -317,9 +317,9 @@ which `NgFor` has initialized with the hero for the current iteration.
 describes additional `NgFor` directive properties and context properties.
 
 These microsyntax mechanisms are available to you when you write your own structural directives.
-Studying the
-[source code for `NgIf`](https://github.com/angular/angular/blob/master/packages/common/src/directives/ng_if.ts "Source: NgIf")
-and [`NgFor`](https://github.com/angular/angular/blob/master/packages/common/src/directives/ng_for_of.ts "Source: NgFor")
+Studying the source code for
+[NgIf](https://github.com/angular/angular/blob/master/packages/common/src/directives/ng_if.ts "Source: NgIf")
+and [NgFor](https://github.com/angular/angular/blob/master/packages/common/src/directives/ng_for_of.ts "Source: NgFor")
 is a great way to learn more.
 
 
@@ -689,10 +689,7 @@ from the Angular-generated `<ng-template>` and inserts that view in a
 [_view container_](api/core/ViewContainerRef "API: ViewContainerRef")
 adjacent to the directive's original `<p>` host element.
 
-You'll acquire the `<ng-template>` contents with a
-[`TemplateRef`](api/core/TemplateRef "API: TemplateRef")
-and access the _view container_ through a
-[`ViewContainerRef`](api/core/ViewContainerRef "API: ViewContainerRef").
+You'll acquire the `<ng-template>` contents with a `TemplateRef` and access the _view container_ through a `ViewContainerRef`.
 
 You inject both in the directive constructor as private variables of the class.
 

--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -1155,13 +1155,13 @@ other HTML elements, attributes, properties, and components.
 They are usually applied to elements as if they were HTML attributes, hence the name.
 
 Many details are covered in the [_Attribute Directives_](guide/attribute-directives) guide.
-Many NgMdules such as the [`RouterModule`](guide/router "Routing and Navigation")
-and the [`FormsModule`](guide/forms "Forms") define their own attribute directives.
+Many NgModules such as the [RouterModule](guide/router "Routing and Navigation")
+and the [FormsModule](guide/forms "Forms") define their own attribute directives.
 This section is an introduction to the most commonly used attribute directives:
 
-* [`NgClass`](guide/template-syntax#ngClass) - add and remove a set of CSS classes
-* [`NgStyle`](guide/template-syntax#ngStyle) - add and remove a set of HTML styles
-* [`NgModel`](guide/template-syntax#ngModel) - two-way data binding to an HTML form element
+* [NgClass](guide/template-syntax#ngClass) - add and remove a set of CSS classes
+* [NgStyle](guide/template-syntax#ngStyle) - add and remove a set of HTML styles
+* [NgModel](guide/template-syntax#ngModel) - two-way data binding to an HTML form element
 <a href="#top-of-page">back to top</a>
 
 <hr/>
@@ -1360,9 +1360,9 @@ to group elements when there is no suitable host element for the directive.
 
 _This_ section is an introduction to the common structural directives:
 
-* [`NgIf`](guide/template-syntax#ngIf) - conditionally add or remove an element from the DOM
-* [`NgFor`](guide/template-syntax#ngFor) - repeat a template for each item in a list
-* [`NgSwitch`](guide/template-syntax#ngSwitch) - a set of directives that switch among alternative views
+* [NgIf](guide/template-syntax#ngIf) - conditionally add or remove an element from the DOM
+* [NgFor](guide/template-syntax#ngFor) - repeat a template for each item in a list
+* [NgSwitch](guide/template-syntax#ngSwitch) - a set of directives that switch among alternative views
 
 <hr/>
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[x] Documentation content changes
```

## What is the current behavior?
Some links in the guides are hidden behind api links. When the links are written like this:
```
[`NgStyle`](mylink...)
```
then the link to the api docs for `NgStyle` takes over and the original link is lost. It will link to api/xxx/NgStyle instead of "mylink".

## What is the new behavior?
Removed the backticks around api code names when we have links

## Does this PR introduce a breaking change?
```
[x] No
```