### PR TITLE
Added ability to pass relativeTo to routerLink

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -6,15 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {LocationStrategy} from '@angular/common';
-import {Attribute, Directive, ElementRef, HostBinding, HostListener, Input, OnChanges, OnDestroy, Renderer2, isDevMode} from '@angular/core';
-import {Subscription} from 'rxjs/Subscription';
+import { LocationStrategy } from '@angular/common';
+import { Attribute, Directive, ElementRef, HostBinding, HostListener, Input, OnChanges, OnDestroy, Renderer2, isDevMode } from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
 
-import {QueryParamsHandling} from '../config';
-import {NavigationEnd} from '../events';
-import {Router} from '../router';
-import {ActivatedRoute} from '../router_state';
-import {UrlTree} from '../url_tree';
+import { QueryParamsHandling } from '../config';
+import { NavigationEnd } from '../events';
+import { Router } from '../router';
+import { ActivatedRoute } from '../router_state';
+import { UrlTree } from '../url_tree';
 
 /**
  * @whatItDoes Lets you link to specific parts of your app.
@@ -93,27 +93,28 @@ import {UrlTree} from '../url_tree';
  *
  * @stable
  */
-@Directive({selector: ':not(a)[routerLink]'})
+@Directive({ selector: ':not(a)[routerLink]' })
 export class RouterLink {
-  @Input() queryParams: {[k: string]: any};
+  @Input() queryParams: { [k: string]: any };
   @Input() fragment: string;
   @Input() queryParamsHandling: QueryParamsHandling;
   @Input() preserveFragment: boolean;
   @Input() skipLocationChange: boolean;
   @Input() replaceUrl: boolean;
+  @Input() relativeTo: ActivatedRoute;
   private commands: any[] = [];
   private preserve: boolean;
 
   constructor(
-      private router: Router, private route: ActivatedRoute,
-      @Attribute('tabindex') tabIndex: string, renderer: Renderer2, el: ElementRef) {
+    private router: Router, private route: ActivatedRoute,
+    @Attribute('tabindex') tabIndex: string, renderer: Renderer2, el: ElementRef) {
     if (tabIndex == null) {
       renderer.setAttribute(el.nativeElement, 'tabindex', '0');
     }
   }
 
   @Input()
-  set routerLink(commands: any[]|string) {
+  set routerLink(commands: any[] | string) {
     if (commands != null) {
       this.commands = Array.isArray(commands) ? commands : [commands];
     } else {
@@ -144,7 +145,7 @@ export class RouterLink {
 
   get urlTree(): UrlTree {
     return this.router.createUrlTree(this.commands, {
-      relativeTo: this.route,
+      relativeTo: this.relativeTo || this.route,
       queryParams: this.queryParams,
       fragment: this.fragment,
       preserveQueryParams: attrBoolValue(this.preserve),
@@ -163,15 +164,16 @@ export class RouterLink {
  *
  * @stable
  */
-@Directive({selector: 'a[routerLink]'})
+@Directive({ selector: 'a[routerLink]' })
 export class RouterLinkWithHref implements OnChanges, OnDestroy {
   @HostBinding('attr.target') @Input() target: string;
-  @Input() queryParams: {[k: string]: any};
+  @Input() queryParams: { [k: string]: any };
   @Input() fragment: string;
   @Input() queryParamsHandling: QueryParamsHandling;
   @Input() preserveFragment: boolean;
   @Input() skipLocationChange: boolean;
   @Input() replaceUrl: boolean;
+  @Input() relativeTo: ActivatedRoute;
   private commands: any[] = [];
   private subscription: Subscription;
   private preserve: boolean;
@@ -180,8 +182,8 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   @HostBinding() href: string;
 
   constructor(
-      private router: Router, private route: ActivatedRoute,
-      private locationStrategy: LocationStrategy) {
+    private router: Router, private route: ActivatedRoute,
+    private locationStrategy: LocationStrategy) {
     this.subscription = router.events.subscribe(s => {
       if (s instanceof NavigationEnd) {
         this.updateTargetUrlAndHref();
@@ -190,7 +192,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   }
 
   @Input()
-  set routerLink(commands: any[]|string) {
+  set routerLink(commands: any[] | string) {
     if (commands != null) {
       this.commands = Array.isArray(commands) ? commands : [commands];
     } else {
@@ -233,7 +235,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
 
   get urlTree(): UrlTree {
     return this.router.createUrlTree(this.commands, {
-      relativeTo: this.route,
+      relativeTo: this.relativeTo || this.route,
       queryParams: this.queryParams,
       fragment: this.fragment,
       preserveQueryParams: attrBoolValue(this.preserve),

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -6,15 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { LocationStrategy } from '@angular/common';
-import { Attribute, Directive, ElementRef, HostBinding, HostListener, Input, OnChanges, OnDestroy, Renderer2, isDevMode } from '@angular/core';
-import { Subscription } from 'rxjs/Subscription';
+import {LocationStrategy} from '@angular/common';
+import {Attribute, Directive, ElementRef, HostBinding, HostListener, Input, OnChanges, OnDestroy, Renderer2, isDevMode} from '@angular/core';
+import {Subscription} from 'rxjs/Subscription';
 
-import { QueryParamsHandling } from '../config';
-import { NavigationEnd } from '../events';
-import { Router } from '../router';
-import { ActivatedRoute } from '../router_state';
-import { UrlTree } from '../url_tree';
+import {QueryParamsHandling} from '../config';
+import {NavigationEnd} from '../events';
+import {Router} from '../router';
+import {ActivatedRoute} from '../router_state';
+import {UrlTree} from '../url_tree';
 
 /**
  * @whatItDoes Lets you link to specific parts of your app.
@@ -93,9 +93,9 @@ import { UrlTree } from '../url_tree';
  *
  * @stable
  */
-@Directive({ selector: ':not(a)[routerLink]' })
+@Directive({selector: ':not(a)[routerLink]'})
 export class RouterLink {
-  @Input() queryParams: { [k: string]: any };
+  @Input() queryParams: {[k: string]: any};
   @Input() fragment: string;
   @Input() queryParamsHandling: QueryParamsHandling;
   @Input() preserveFragment: boolean;
@@ -106,15 +106,15 @@ export class RouterLink {
   private preserve: boolean;
 
   constructor(
-    private router: Router, private route: ActivatedRoute,
-    @Attribute('tabindex') tabIndex: string, renderer: Renderer2, el: ElementRef) {
+      private router: Router, private route: ActivatedRoute,
+      @Attribute('tabindex') tabIndex: string, renderer: Renderer2, el: ElementRef) {
     if (tabIndex == null) {
       renderer.setAttribute(el.nativeElement, 'tabindex', '0');
     }
   }
 
   @Input()
-  set routerLink(commands: any[] | string) {
+  set routerLink(commands: any[]|string) {
     if (commands != null) {
       this.commands = Array.isArray(commands) ? commands : [commands];
     } else {
@@ -164,16 +164,16 @@ export class RouterLink {
  *
  * @stable
  */
-@Directive({ selector: 'a[routerLink]' })
+@Directive({selector: 'a[routerLink]'})
 export class RouterLinkWithHref implements OnChanges, OnDestroy {
   @HostBinding('attr.target') @Input() target: string;
-  @Input() queryParams: { [k: string]: any };
+  @Input() queryParams: {[k: string]: any};
   @Input() fragment: string;
   @Input() queryParamsHandling: QueryParamsHandling;
   @Input() preserveFragment: boolean;
   @Input() skipLocationChange: boolean;
   @Input() replaceUrl: boolean;
-  @Input() relativeTo: ActivatedRoute;
+  @Input() relativeTo: ActivatedRoute;  
   private commands: any[] = [];
   private subscription: Subscription;
   private preserve: boolean;
@@ -182,8 +182,8 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   @HostBinding() href: string;
 
   constructor(
-    private router: Router, private route: ActivatedRoute,
-    private locationStrategy: LocationStrategy) {
+      private router: Router, private route: ActivatedRoute,
+      private locationStrategy: LocationStrategy) {
     this.subscription = router.events.subscribe(s => {
       if (s instanceof NavigationEnd) {
         this.updateTargetUrlAndHref();
@@ -192,7 +192,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   }
 
   @Input()
-  set routerLink(commands: any[] | string) {
+  set routerLink(commands: any[]|string) {
     if (commands != null) {
       this.commands = Array.isArray(commands) ? commands : [commands];
     } else {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines:  https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
**didn't read this before committing, how do i fix?**

- [ ] Tests for the changes have been added (for bug fixes / features)
**couldn't find tests for routerLink whatsoever**

- [ ] Docs have been added / updated (for bug fixes / features)
**where are the relevant docs located?**

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
routerLink directive always navigate relatively to the current activated route
Issue Number: N/A


## What is the new behavior?
routerLink is now able to navigate relatively to other routes

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
