### PR TITLE
refactor(platform-browser-dynamic): keep preserveWhitespaces default …

### DIFF
--- a/packages/platform-browser-dynamic/src/compiler_factory.ts
+++ b/packages/platform-browser-dynamic/src/compiler_factory.ts
@@ -162,7 +162,6 @@ export class JitCompilerFactory implements CompilerFactory {
       defaultEncapsulation: ViewEncapsulation.Emulated,
       missingTranslation: MissingTranslationStrategy.Warning,
       enableLegacyTemplate: true,
-      preserveWhitespaces: true,
     };
 
     this._defaultOptions = [compilerOptions, ...defaultOptions];


### PR DESCRIPTION
…setting in one place

CompilerConfig should be the only source of default settings for preserveWhitespaces
so let's not enforce defaults on the CompilerOptions level.

This doesn't matter much today but will become important when we want to switch 
the default value of `preserveWhitespaces` in Angular 6.