### PR TITLE
refactor(compiler): remove option `useDebug`

### DIFF
--- a/packages/core/src/linker/compiler.ts
+++ b/packages/core/src/linker/compiler.ts
@@ -96,10 +96,6 @@ export class Compiler {
  * @experimental
  */
 export type CompilerOptions = {
-  /**
-   * @deprecated since v4 this option has no effect anymore.
-   */
-  useDebug?: boolean,
   useJit?: boolean,
   defaultEncapsulation?: ViewEncapsulation,
   providers?: StaticProvider[],

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -330,8 +330,7 @@ export class TestBed implements Injector {
 
     const compilerFactory: TestingCompilerFactory =
         this.platform.injector.get(TestingCompilerFactory);
-    this._compiler =
-        compilerFactory.createTestingCompiler(this._compilerOptions.concat([{useDebug: true}]));
+    this._compiler = compilerFactory.createTestingCompiler(this._compilerOptions);
     this._compiler.loadAotSummaries(this._aotSummaries);
     this._moduleOverrides.forEach((entry) => this._compiler.overrideModule(entry[0], entry[1]));
     this._componentOverrides.forEach(

--- a/packages/platform-browser-dynamic/src/compiler_factory.ts
+++ b/packages/platform-browser-dynamic/src/compiler_factory.ts
@@ -157,7 +157,6 @@ export class JitCompilerFactory implements CompilerFactory {
   private _defaultOptions: CompilerOptions[];
   constructor(defaultOptions: CompilerOptions[]) {
     const compilerOptions: CompilerOptions = {
-      useDebug: isDevMode(),
       useJit: true,
       defaultEncapsulation: ViewEncapsulation.Emulated,
       missingTranslation: MissingTranslationStrategy.Warning,

--- a/packages/tsc-wrapped/src/options.ts
+++ b/packages/tsc-wrapped/src/options.ts
@@ -76,9 +76,6 @@ interface Options extends ts.CompilerOptions {
   // Print extra information while running the compiler
   trace?: boolean;
 
-  /** @deprecated since v4 this option has no effect anymore. */
-  debug?: boolean;
-
   // Whether to enable support for <template> and the template attribute (true by default)
   enableLegacyTemplate?: boolean;
 

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -195,7 +195,6 @@ export declare abstract class CompilerFactory {
 
 /** @experimental */
 export declare type CompilerOptions = {
-    /** @deprecated */ useDebug?: boolean;
     useJit?: boolean;
     defaultEncapsulation?: ViewEncapsulation;
     providers?: StaticProvider[];


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[ ] Other... Please describe: removing deprecated code
```

## What is the current behavior?
The option `useDebug` for the compiler has no effect and is deprecated since v4.

## What is the new behavior?
The option `useDebug` for the compiler has been removed.

## Does this PR introduce a breaking change?
```
[x] Yes
```