### PR TITLE
refactor(core): remove deprecated `DebugNode#source`

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -38,11 +38,6 @@ export class DebugNode {
   get references(): {[key: string]: any} { return this._debugContext.references; }
 
   get providerTokens(): any[] { return this._debugContext.providerTokens; }
-
-  /**
-   * @deprecated since v4
-   */
-  get source(): string { return 'Deprecated since v4'; }
 }
 
 /**

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -325,7 +325,6 @@ export declare class DebugNode {
     readonly references: {
         [key: string]: any;
     };
-    /** @deprecated */ readonly source: string;
     constructor(nativeNode: any, parent: DebugNode | null, _debugContext: DebugContext);
 }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[ ] Other... Please describe: removing deprecated code
```

## What is the current behavior?
`DebugNode#source` is deprecated since v4.

## What is the new behavior?
`DebugNode#source` has been removed as it was deprecated since v4.

## Does this PR introduce a breaking change?
```
[x] Yes
```