### PR TITLE
refactor(common): remove deprecated `NgTemplateOutlet#ngOutletContext`

### DIFF
--- a/packages/common/src/directives/ng_template_outlet.ts
+++ b/packages/common/src/directives/ng_template_outlet.ts
@@ -42,12 +42,6 @@ export class NgTemplateOutlet implements OnChanges {
 
   constructor(private _viewContainerRef: ViewContainerRef) {}
 
-  /**
-   * @deprecated v4.0.0 - Renamed to ngTemplateOutletContext.
-   */
-  @Input()
-  set ngOutletContext(context: Object) { this.ngTemplateOutletContext = context; }
-
   ngOnChanges(changes: SimpleChanges) {
     const recreateView = this._shouldRecreateView(changes);
 

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -246,7 +246,6 @@ export declare class NgSwitchDefault {
 
 /** @stable */
 export declare class NgTemplateOutlet implements OnChanges {
-    /** @deprecated */ ngOutletContext: Object;
     ngTemplateOutlet: TemplateRef<any>;
     ngTemplateOutletContext: Object;
     constructor(_viewContainerRef: ViewContainerRef);


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[ ] Other... Please describe: removing deprecated code
```

## What is the current behavior?
`NgTemplateOutlet#ngOutletContext`  is deprecated since v4.

## What is the new behavior?
`NgTemplateOutlet#ngOutletContext` has been removed as it was deprecated since v4. Use `NgTemplateOutlet#ngTemplateOutletContext` instead.

## Does this PR introduce a breaking change?
```
[x] Yes
```