### PR TITLE
Remove deprecated code in the router

### DIFF
--- a/aio/content/examples/ngmodule/src/index.3.html
+++ b/aio/content/examples/ngmodule/src/index.3.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <base href="/">
+    <base href="/index.3.html">
     <title>NgModule - Contact</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -72,11 +72,6 @@ export class RouterOutlet implements OnDestroy, OnInit {
     }
   }
 
-  /** @deprecated since v4 **/
-  get locationInjector(): Injector { return this.location.injector; }
-  /** @deprecated since v4 **/
-  get locationFactoryResolver(): ComponentFactoryResolver { return this.resolver; }
-
   get isActivated(): boolean { return !!this.activated; }
 
   get component(): Object {

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -162,37 +162,6 @@ describe('bootstrap', () => {
     });
   });
 
-  it('should not run navigation when initialNavigation = legacy_disabled', (done) => {
-    @Component({selector: 'test', template: 'test'})
-    class TestCmpLegacyDisabled {
-    }
-
-    @NgModule({
-      imports: [
-        BrowserModule,
-        RouterModule.forRoot(
-            [{path: '**', component: TestCmpLegacyDisabled, resolve: {test: TestResolver}}],
-            {useHash: true, initialNavigation: 'legacy_disabled'})
-      ],
-      declarations: [RootCmp, TestCmpLegacyDisabled],
-      bootstrap: [RootCmp],
-      providers: [...testProviders, TestResolver],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    })
-    class TestModule {
-      constructor(router: Router) {
-        log.push('TestModule');
-        router.events.subscribe(e => log.push(e.constructor.name));
-      }
-    }
-
-    platformBrowserDynamic([]).bootstrapModule(TestModule).then(res => {
-      const router = res.injector.get(Router);
-      expect(log).toEqual(['TestModule', 'RootCmp']);
-      done();
-    });
-  });
-
   it('should not init router navigation listeners if a non root component is bootstrapped',
      (done) => {
        @NgModule({

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -409,8 +409,6 @@ export declare class RouterOutlet implements OnDestroy, OnInit {
     readonly component: Object;
     deactivateEvents: EventEmitter<any>;
     readonly isActivated: boolean;
-    /** @deprecated */ readonly locationFactoryResolver: ComponentFactoryResolver;
-    /** @deprecated */ readonly locationInjector: Injector;
     constructor(parentContexts: ChildrenOutletContexts, location: ViewContainerRef, resolver: ComponentFactoryResolver, name: string, changeDetector: ChangeDetectorRef);
     activateWith(activatedRoute: ActivatedRoute, resolver: ComponentFactoryResolver | null): void;
     attach(ref: ComponentRef<any>, activatedRoute: ActivatedRoute): void;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[ ] Other... Please describe: removing deprecated code
```

## What is the current behavior?
The values `true`, `false`, `legacy_enabled` and `legacy_disabled` for the router parameter `initialNavigation` are deprecated.
`RouterOutlet` properties `locationInjector` and `locationFactoryResolver` are deprecated since v4.

## What is the new behavior?
the values `true`, `false` for the router parameter `initialNavigation` have been removed as they were deprecated. Use `enabled` or `disabled` instead. The values `legacy_enabled` and `legacy_disabled` are still available but they will log a warning in dev mode and will be removed in v6.
`RouterOutlet` properties `locationInjector` and `locationFactoryResolver` have been removed as they were deprecated since v4.

## Does this PR introduce a breaking change?
```
[x] Yes
```