### PR TITLE
refactor(core): remove deprecated `Testability#findBindings`

### DIFF
--- a/packages/core/src/testability/testability.ts
+++ b/packages/core/src/testability/testability.ts
@@ -109,12 +109,6 @@ export class Testability implements PublicTestability {
 
   getPendingRequestCount(): number { return this._pendingCount; }
 
-  /** @deprecated use findProviders */
-  findBindings(using: any, provider: string, exactMatch: boolean): any[] {
-    // TODO(juliemr): implement.
-    return [];
-  }
-
   findProviders(using: any, provider: string, exactMatch: boolean): any[] {
     // TODO(juliemr): implement.
     return [];

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -971,7 +971,6 @@ export declare abstract class TemplateRef<C> {
 export declare class Testability implements PublicTestability {
     constructor(_ngZone: NgZone);
     decreasePendingRequestCount(): number;
-    /** @deprecated */ findBindings(using: any, provider: string, exactMatch: boolean): any[];
     findProviders(using: any, provider: string, exactMatch: boolean): any[];
     getPendingRequestCount(): number;
     increasePendingRequestCount(): number;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[ ] Other... Please describe: removing deprecated code
```

## What is the current behavior?
`Testability#findBindings` is deprecated since v4.

## What is the new behavior?
`Testability#findBindings` has been removed as it was deprecated since v4. Use `Testability#findProviders` instead.

## Does this PR introduce a breaking change?
```
[x] Yes
```