### PR TITLE
fix(@angular/compiler-cli): use forward slashes for ts.resolveModuleName

### DIFF
--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -61,8 +61,8 @@ class CompilerHostMixin {
       containingFile = path.join(this.basePath, 'index.ts');
     }
     const resolved = ts.resolveModuleName(
-                           m, containingFile, this.options, this.moduleResolutionHost,
-                           this.moduleResolutionCache)
+                           m, containingFile.replace(/\\/g, '/'), this.options,
+                           this.moduleResolutionHost, this.moduleResolutionCache)
                          .resolvedModule;
     if (resolved) {
       if (this.options.traceResolution) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Windows paths have back slashes, but TypeScript expects to always have forward slashes.

In other places where this call happens (like `src/compiler_host.ts`) the same fix is present.


## What is the new behavior?
Back slashes are replaces by forward slashes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
/cc @tbosch 