### PR TITLE
fix(compiler): support host binding when property name being keyword

### DIFF
--- a/packages/compiler/src/directive_resolver.ts
+++ b/packages/compiler/src/directive_resolver.ts
@@ -90,15 +90,15 @@ export class DirectiveResolver {
             throw new Error(
                 `@HostBinding parameter should be a property name, 'class.<name>', or 'attr.<name>'.`);
           }
-          host[`[${hostBinding.hostPropertyName}]`] = propName;
+          host[`[${hostBinding.hostPropertyName}]`] = `this.${propName}`;
         } else {
-          host[`[${propName}]`] = propName;
+          host[`[${propName}]`] = `this.${propName}`;
         }
       });
       const hostListeners = propertyMetadata[propName].filter(a => createHostListener.isTypeOf(a));
       hostListeners.forEach(hostListener => {
         const args = hostListener.args || [];
-        host[`(${hostListener.eventName})`] = `${propName}(${args.join(',')})`;
+        host[`(${hostListener.eventName})`] = `this.${propName}(${args.join(',')})`;
       });
       const query = findLast(
           propertyMetadata[propName], (a) => QUERY_METADATA_IDENTIFIERS.some(i => i.isTypeOf(a)));


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #18698 .

When using `@HostBinding()` with property named `true`, `false` or `null`, it would be treated as binding to corresponding literal instead of class property.

## What is the new behavior?

Binding to class property correctly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
