### PR TITLE
feat(compiler-cli): add watch mode to `ngc`

### DIFF
--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -275,6 +275,9 @@
     "@types/base64-js": {
       "version": "1.2.5"
     },
+    "@types/chokidar": {
+      "version": "1.7.2"
+    },
     "@types/fs-extra": {
       "version": "0.0.22-alpha"
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -445,6 +445,11 @@
       "from": "@types/base64-js@latest",
       "resolved": "https://registry.npmjs.org/@types/base64-js/-/base64-js-1.2.5.tgz"
     },
+    "@types/chokidar": {
+      "version": "1.7.2",
+      "from": "@types/chokidar@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/chokidar/-/chokidar-1.7.2.tgz"
+    },
     "@types/fs-extra": {
       "version": "0.0.22-alpha",
       "from": "@types/fs-extra@latest",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@bazel/typescript": "0.0.7",
     "@types/angularjs": "^1.5.13-alpha",
     "@types/base64-js": "^1.2.5",
+    "@types/chokidar": "^1.1.0",
     "@types/fs-extra": "0.0.22-alpha",
     "@types/hammerjs": "^2.0.33",
     "@types/jasmine": "^2.2.22-alpha",

--- a/packages/compiler-cli/index.ts
+++ b/packages/compiler-cli/index.ts
@@ -20,7 +20,7 @@ export {BuiltinType, DeclarationKind, Definition, PipeInfo, Pipes, Signature, Sp
 export * from './src/transformers/api';
 export * from './src/transformers/entry_points';
 
-export {performCompilation, readConfiguration, formatDiagnostics, calcProjectFileAndBasePath, createNgCompilerOptions} from './src/perform-compile';
+export {performCompilation, readConfiguration, formatDiagnostics, calcProjectFileAndBasePath, createNgCompilerOptions} from './src/perform_compile';
 
 // TODO(hansl): moving to Angular 4 need to update this API.
 export {NgTools_InternalApi_NG_2 as __NGTOOLS_PRIVATE_API_2} from './src/ngtools_api';

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -12,7 +12,8 @@
     "@angular/tsc-wrapped": "5.0.0-beta.5",
     "reflect-metadata": "^0.1.2",
     "minimist": "^1.2.0",
-    "tsickle": "^0.23.4"
+    "tsickle": "^0.23.4",
+    "chokidar": "^1.4.2"
   },
   "peerDependencies": {
     "typescript": "^2.0.2",

--- a/packages/compiler-cli/src/diagnostics/check_types.ts
+++ b/packages/compiler-cli/src/diagnostics/check_types.ts
@@ -9,7 +9,7 @@
 import {AotCompiler, AotCompilerHost, AotCompilerOptions, EmitterVisitorContext, GeneratedFile, NgAnalyzedModules, ParseSourceSpan, Statement, StaticReflector, TypeScriptEmitter, createAotCompiler} from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {Diagnostic} from '../transformers/api';
+import {DEFAULT_ERROR_CODE, Diagnostic, SOURCE} from '../transformers/api';
 
 interface FactoryInfo {
   source: ts.SourceFile;
@@ -142,8 +142,10 @@ export class TypeChecker {
           const fileName = span.start.file.url;
           const diagnosticsList = diagnosticsFor(fileName);
           diagnosticsList.push({
-            message: diagnosticMessageToString(diagnostic.messageText),
-            category: diagnostic.category, span
+            messageText: diagnosticMessageToString(diagnostic.messageText),
+            category: diagnostic.category, span,
+            source: SOURCE,
+            code: DEFAULT_ERROR_CODE
           });
         }
       }

--- a/packages/compiler-cli/src/perform_watch.ts
+++ b/packages/compiler-cli/src/perform_watch.ts
@@ -1,0 +1,223 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as chokidar from 'chokidar';
+import * as path from 'path';
+import * as ts from 'typescript';
+
+import {Diagnostics, ParsedConfiguration, PerformCompilationResult, exitCodeFromResult, performCompilation, readConfiguration} from './perform_compile';
+import * as api from './transformers/api';
+import {createCompilerHost} from './transformers/entry_points';
+
+const ChangeDiagnostics = {
+  Compilation_complete_Watching_for_file_changes: {
+    category: ts.DiagnosticCategory.Message,
+    messageText: 'Compilation complete. Watching for file changes.',
+    code: api.DEFAULT_ERROR_CODE,
+    source: api.SOURCE
+  },
+  Compilation_failed_Watching_for_file_changes: {
+    category: ts.DiagnosticCategory.Message,
+    messageText: 'Compilation failed. Watching for file changes.',
+    code: api.DEFAULT_ERROR_CODE,
+    source: api.SOURCE
+  },
+  File_change_detected_Starting_incremental_compilation: {
+    category: ts.DiagnosticCategory.Message,
+    messageText: 'File change detected. Starting incremental compilation.',
+    code: api.DEFAULT_ERROR_CODE,
+    source: api.SOURCE
+  },
+};
+
+export enum FileChangeEvent {
+  Change,
+  CreateDelete
+}
+
+export interface PerformWatchHost {
+  reportDiagnostics(diagnostics: Diagnostics): void;
+  readConfiguration(): ParsedConfiguration;
+  createCompilerHost(options: api.CompilerOptions): api.CompilerHost;
+  createEmitCallback(options: api.CompilerOptions): api.TsEmitCallback|undefined;
+  onFileChange(listener: (event: FileChangeEvent, fileName: string) => void):
+      {close: () => void, ready: (cb: () => void) => void};
+  setTimeout(callback: () => void, ms: number): any;
+  clearTimeout(timeoutId: any): void;
+}
+
+export function createPerformWatchHost(
+    configFileName: string, reportDiagnostics: (diagnostics: Diagnostics) => void,
+    createEmitCallback?: (options: api.CompilerOptions) => api.TsEmitCallback): PerformWatchHost {
+  return {
+    reportDiagnostics: reportDiagnostics,
+    createCompilerHost: options => createCompilerHost({options}),
+    readConfiguration: () => readConfiguration(configFileName),
+    createEmitCallback: options => createEmitCallback ? createEmitCallback(options) : undefined,
+    onFileChange: (listeners) => {
+      const parsed = readConfiguration(configFileName);
+      function stubReady(cb: () => void) { process.nextTick(cb); }
+      if (parsed.errors && parsed.errors.length) {
+        reportDiagnostics(parsed.errors);
+        return {close: () => {}, ready: stubReady};
+      }
+      if (!parsed.options.basePath) {
+        reportDiagnostics([{
+          category: ts.DiagnosticCategory.Error,
+          messageText: 'Invalid configuration option. baseDir not specified',
+          source: api.SOURCE,
+          code: api.DEFAULT_ERROR_CODE
+        }]);
+        return {close: () => {}, ready: stubReady};
+      }
+      const watcher = chokidar.watch(parsed.options.basePath, {
+        // ignore .dotfiles, .js and .map files.
+        // can't ignore other files as we e.g. want to recompile if an `.html` file changes as well.
+        ignored: /((^[\/\\])\..)|(\.js$)|(\.map$)|(\.metadata\.json)/,
+        ignoreInitial: true,
+        persistent: true,
+      });
+      watcher.on('all', (event: string, path: string) => {
+        switch (event) {
+          case 'change':
+            listeners(FileChangeEvent.Change, path);
+            break;
+          case 'unlink':
+          case 'add':
+            listeners(FileChangeEvent.CreateDelete, path);
+            break;
+        }
+      });
+      function ready(cb: () => void) { watcher.on('ready', cb); }
+      return {close: () => watcher.close(), ready};
+    },
+    setTimeout: (ts.sys.clearTimeout && ts.sys.setTimeout) || setTimeout,
+    clearTimeout: (ts.sys.setTimeout && ts.sys.clearTimeout) || clearTimeout,
+  };
+}
+
+/**
+ * The logic in this function is adapted from `tsc.ts` from TypeScript.
+ */
+export function performWatchCompilation(host: PerformWatchHost): {
+  close: () => void,
+  ready: (cb: () => void) => void,
+  firstCompileResult: PerformCompilationResult | undefined
+} {
+  let cachedProgram: api.Program|undefined;            // Program cached from last compilation
+  let cachedCompilerHost: api.CompilerHost|undefined;  // CompilerHost cached from last compilation
+  let cachedOptions: ParsedConfiguration|undefined;  // CompilerOptions cached from last compilation
+  let timerHandleForRecompilation: any;  // Handle for 0.25s wait timer to trigger recompilation
+
+  // Watch basePath, ignoring .dotfiles
+  const fileWatcher = host.onFileChange(watchedFileChanged);
+  const ingoreFilesForWatch = new Set<string>();
+
+  const firstCompileResult = doCompilation();
+
+  const readyPromise = new Promise(resolve => fileWatcher.ready(resolve));
+
+  return {close, ready: cb => readyPromise.then(cb), firstCompileResult};
+
+  function close() {
+    fileWatcher.close();
+    if (timerHandleForRecompilation) {
+      host.clearTimeout(timerHandleForRecompilation);
+      timerHandleForRecompilation = undefined;
+    }
+  }
+
+  // Invoked to perform initial compilation or re-compilation in watch mode
+  function doCompilation() {
+    if (!cachedOptions) {
+      cachedOptions = host.readConfiguration();
+    }
+    if (cachedOptions.errors && cachedOptions.errors.length) {
+      host.reportDiagnostics(cachedOptions.errors);
+      return;
+    }
+    if (!cachedCompilerHost) {
+      // TODO(chuckj): consider avoiding re-generating factories for libraries.
+      // Consider modifying the AotCompilerHost to be able to remember the summary files
+      // generated from previous compiliations and return false from isSourceFile for
+      // .d.ts files for which a summary file was already generated.å
+      cachedCompilerHost = host.createCompilerHost(cachedOptions.options);
+      const originalWriteFileCallback = cachedCompilerHost.writeFile;
+      cachedCompilerHost.writeFile = function(
+          fileName: string, data: string, writeByteOrderMark: boolean,
+          onError?: (message: string) => void, sourceFiles?: ts.SourceFile[]) {
+        ingoreFilesForWatch.add(path.normalize(fileName));
+        return originalWriteFileCallback(fileName, data, writeByteOrderMark, onError, sourceFiles);
+      };
+    }
+    ingoreFilesForWatch.clear();
+    const compileResult = performCompilation({
+      rootNames: cachedOptions.rootNames,
+      options: cachedOptions.options,
+      host: cachedCompilerHost,
+      oldProgram: cachedProgram,
+      emitCallback: host.createEmitCallback(cachedOptions.options)
+    });
+
+    if (compileResult.diagnostics.length) {
+      host.reportDiagnostics(compileResult.diagnostics);
+    }
+
+    const exitCode = exitCodeFromResult(compileResult);
+    if (exitCode == 0) {
+      cachedProgram = compileResult.program;
+      host.reportDiagnostics([ChangeDiagnostics.Compilation_complete_Watching_for_file_changes]);
+    } else {
+      host.reportDiagnostics([ChangeDiagnostics.Compilation_failed_Watching_for_file_changes]);
+    }
+
+    return compileResult;
+  }
+
+  function resetOptions() {
+    cachedProgram = undefined;
+    cachedCompilerHost = undefined;
+    cachedOptions = undefined;
+  }
+
+  function watchedFileChanged(event: FileChangeEvent, fileName: string) {
+    if (cachedOptions && event === FileChangeEvent.Change &&
+        // TODO(chuckj): validate that this is sufficient to skip files that were written.
+        // This assumes that the file path we write is the same file path we will receive in the
+        // change notification.
+        path.normalize(fileName) === path.normalize(cachedOptions.project)) {
+      // If the configuration file changes, forget everything and start the recompilation timer
+      resetOptions();
+    } else if (event === FileChangeEvent.CreateDelete) {
+      // If a file was added or removed, reread the configuration
+      // to determine the new list of root files.
+      cachedOptions = undefined;
+    }
+    if (!ingoreFilesForWatch.has(path.normalize(fileName))) {
+      // Ignore the file if the file is one that was written by the compiler.
+      startTimerForRecompilation();
+    }
+  }
+
+  // Upon detecting a file change, wait for 250ms and then perform a recompilation. This gives batch
+  // operations (such as saving all modified files in an editor) a chance to complete before we kick
+  // off a new compilation.
+  function startTimerForRecompilation() {
+    if (timerHandleForRecompilation) {
+      host.clearTimeout(timerHandleForRecompilation);
+    }
+    timerHandleForRecompilation = host.setTimeout(recompile, 250);
+  }
+
+  function recompile() {
+    timerHandleForRecompilation = undefined;
+    host.reportDiagnostics(
+        [ChangeDiagnostics.File_change_detected_Starting_incremental_compilation]);
+    doCompilation();
+  }
+}

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -9,10 +9,16 @@
 import {ParseSourceSpan} from '@angular/compiler';
 import * as ts from 'typescript';
 
+export const DEFAULT_ERROR_CODE = 100;
+export const UNKNOWN_ERROR_CODE = 500;
+export const SOURCE = 'angular' as 'angular';
+
 export interface Diagnostic {
-  message: string;
+  messageText: string;
   span?: ParseSourceSpan;
   category: ts.DiagnosticCategory;
+  code: number;
+  source: 'angular';
 }
 
 export interface CompilerOptions extends ts.CompilerOptions {

--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -15,7 +15,7 @@ import * as ts from 'typescript';
 import {BaseAotCompilerHost} from '../compiler_host';
 import {TypeChecker} from '../diagnostics/check_types';
 
-import {CompilerHost, CompilerOptions, CustomTransformers, Diagnostic, EmitFlags, Program, TsEmitArguments, TsEmitCallback} from './api';
+import {CompilerHost, CompilerOptions, CustomTransformers, DEFAULT_ERROR_CODE, Diagnostic, EmitFlags, Program, SOURCE, TsEmitArguments, TsEmitCallback} from './api';
 import {LowerMetadataCache, getExpressionLoweringTransformFactory} from './lower_expressions';
 import {getAngularEmitterTransformFactory} from './node_emitter_transform';
 
@@ -61,8 +61,12 @@ class AngularCompilerProgram implements Program {
       if (errors) {
         // TODO(tbosch): once we move MetadataBundler from tsc_wrapped into compiler_cli,
         // directly create ng.Diagnostic instead of using ts.Diagnostic here.
-        this._optionsDiagnostics.push(
-            ...errors.map(e => ({category: e.category, message: e.messageText as string})));
+        this._optionsDiagnostics.push(...errors.map(e => ({
+                                                      category: e.category,
+                                                      messageText: e.messageText as string,
+                                                      source: SOURCE,
+                                                      code: DEFAULT_ERROR_CODE
+                                                    })));
       } else {
         rootNames.push(indexName !);
         this.host = host = bundleHost;
@@ -219,12 +223,19 @@ class AngularCompilerProgram implements Program {
       if (parserErrors && parserErrors.length) {
         this._structuralDiagnostics =
             parserErrors.map<Diagnostic>(e => ({
-                                           message: e.contextualMessage(),
+                                           messageText: e.contextualMessage(),
                                            category: ts.DiagnosticCategory.Error,
-                                           span: e.span
+                                           span: e.span,
+                                           source: SOURCE,
+                                           code: DEFAULT_ERROR_CODE
                                          }));
       } else {
-        this._structuralDiagnostics = [{message: e.message, category: ts.DiagnosticCategory.Error}];
+        this._structuralDiagnostics = [{
+          messageText: e.message,
+          category: ts.DiagnosticCategory.Error,
+          source: SOURCE,
+          code: DEFAULT_ERROR_CODE
+        }];
       }
       this._analyzedModules = emptyModules;
       return emptyModules;
@@ -252,8 +263,12 @@ class AngularCompilerProgram implements Program {
       return this.options.skipTemplateCodegen ? [] : result;
     } catch (e) {
       if (isSyntaxError(e)) {
-        this._generatedFileDiagnostics =
-            [{message: e.message, category: ts.DiagnosticCategory.Error}];
+        this._generatedFileDiagnostics = [{
+          messageText: e.message,
+          category: ts.DiagnosticCategory.Error,
+          source: SOURCE,
+          code: DEFAULT_ERROR_CODE
+        }];
         return [];
       }
       throw e;
@@ -417,9 +432,11 @@ function getNgOptionDiagnostics(options: CompilerOptions): Diagnostic[] {
         break;
       default:
         return [{
-          message:
+          messageText:
               'Angular compiler options "annotationsAs" only supports "static fields" and "decorators"',
-          category: ts.DiagnosticCategory.Error
+          category: ts.DiagnosticCategory.Error,
+          source: SOURCE,
+          code: DEFAULT_ERROR_CODE
         }];
     }
   }

--- a/packages/compiler-cli/test/diagnostics/check_types_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/check_types_spec.ts
@@ -38,12 +38,13 @@ describe('ng type checker', () => {
     if (!diagnostics || !diagnostics.length) {
       throw new Error('Expected a diagnostic erorr message');
     } else {
-      const matches: (d: Diagnostic) => boolean =
-          typeof message === 'string' ? d => d.message == message : d => message.test(d.message);
+      const matches: (d: Diagnostic) => boolean = typeof message === 'string' ?
+          d => d.messageText == message :
+          d => message.test(d.messageText);
       const matchingDiagnostics = diagnostics.filter(matches);
       if (!matchingDiagnostics || !matchingDiagnostics.length) {
         throw new Error(
-            `Expected a diagnostics matching ${message}, received\n  ${diagnostics.map(d => d.message).join('\n  ')}`);
+            `Expected a diagnostics matching ${message}, received\n  ${diagnostics.map(d => d.messageText).join('\n  ')}`);
       }
     }
   }
@@ -136,6 +137,6 @@ const QUICKSTART: MockDirectory = {
 
 function expectNoDiagnostics(diagnostics: Diagnostic[]) {
   if (diagnostics && diagnostics.length) {
-    throw new Error(diagnostics.map(d => `${d.span}: ${d.message}`).join('\n'));
+    throw new Error(diagnostics.map(d => `${d.span}: ${d.messageText}`).join('\n'));
   }
 }

--- a/packages/compiler-cli/test/diagnostics/mocks.ts
+++ b/packages/compiler-cli/test/diagnostics/mocks.ts
@@ -191,7 +191,7 @@ export class DiagnosticContext {
           analyzeHost);
 
       analyzedModules = this._analyzedModules =
-          analyzeNgModules(programSymbols, analyzeHost, this.resolver);
+          analyzeNgModules(programSymbols, analyzeHost, this.staticSymbolResolver, this.resolver);
     }
     return analyzedModules;
   }

--- a/packages/compiler/src/aot/compiler.ts
+++ b/packages/compiler/src/aot/compiler.ts
@@ -42,8 +42,8 @@ export class AotCompiler {
 
   analyzeModulesSync(rootFiles: string[]): NgAnalyzedModules {
     const programSymbols = extractProgramSymbols(this._symbolResolver, rootFiles, this._host);
-    const analyzeResult =
-        analyzeAndValidateNgModules(programSymbols, this._host, this._metadataResolver);
+    const analyzeResult = analyzeAndValidateNgModules(
+        programSymbols, this._host, this._symbolResolver, this._metadataResolver);
     analyzeResult.ngModules.forEach(
         ngModule => this._metadataResolver.loadNgModuleDirectiveAndPipeMetadata(
             ngModule.type.reference, true));
@@ -52,8 +52,8 @@ export class AotCompiler {
 
   analyzeModulesAsync(rootFiles: string[]): Promise<NgAnalyzedModules> {
     const programSymbols = extractProgramSymbols(this._symbolResolver, rootFiles, this._host);
-    const analyzeResult =
-        analyzeAndValidateNgModules(programSymbols, this._host, this._metadataResolver);
+    const analyzeResult = analyzeAndValidateNgModules(
+        programSymbols, this._host, this._symbolResolver, this._metadataResolver);
     return Promise
         .all(analyzeResult.ngModules.map(
             ngModule => this._metadataResolver.loadNgModuleDirectiveAndPipeMetadata(
@@ -399,16 +399,24 @@ export interface NgAnalyzeModulesHost { isSourceFile(filePath: string): boolean;
 // Returns all the source files and a mapping from modules to directives
 export function analyzeNgModules(
     programStaticSymbols: StaticSymbol[], host: NgAnalyzeModulesHost,
+    staticSymbolResolver: StaticSymbolResolver,
     metadataResolver: CompileMetadataResolver): NgAnalyzedModules {
+  const programStaticSymbolsWithDecorators = programStaticSymbols.filter(
+      symbol => !symbol.filePath.endsWith('.d.ts') ||
+          staticSymbolResolver.hasDecorators(symbol.filePath));
   const {ngModules, symbolsMissingModule} =
-      _createNgModules(programStaticSymbols, host, metadataResolver);
-  return _analyzeNgModules(programStaticSymbols, ngModules, symbolsMissingModule, metadataResolver);
+      _createNgModules(programStaticSymbolsWithDecorators, host, metadataResolver);
+  return _analyzeNgModules(
+      programStaticSymbols, programStaticSymbolsWithDecorators, ngModules, symbolsMissingModule,
+      metadataResolver);
 }
 
 export function analyzeAndValidateNgModules(
     programStaticSymbols: StaticSymbol[], host: NgAnalyzeModulesHost,
+    staticSymbolResolver: StaticSymbolResolver,
     metadataResolver: CompileMetadataResolver): NgAnalyzedModules {
-  const result = analyzeNgModules(programStaticSymbols, host, metadataResolver);
+  const result =
+      analyzeNgModules(programStaticSymbols, host, staticSymbolResolver, metadataResolver);
   if (result.symbolsMissingModule && result.symbolsMissingModule.length) {
     const messages = result.symbolsMissingModule.map(
         s =>
@@ -419,8 +427,8 @@ export function analyzeAndValidateNgModules(
 }
 
 function _analyzeNgModules(
-    programSymbols: StaticSymbol[], ngModuleMetas: CompileNgModuleMetadata[],
-    symbolsMissingModule: StaticSymbol[],
+    programSymbols: StaticSymbol[], programSymbolsWithDecorators: StaticSymbol[],
+    ngModuleMetas: CompileNgModuleMetadata[], symbolsMissingModule: StaticSymbol[],
     metadataResolver: CompileMetadataResolver): NgAnalyzedModules {
   const moduleMetasByRef = new Map<any, CompileNgModuleMetadata>();
   ngModuleMetas.forEach((ngModule) => moduleMetasByRef.set(ngModule.type.reference, ngModule));
@@ -435,7 +443,10 @@ function _analyzeNgModules(
   programSymbols.forEach((symbol) => {
     const filePath = symbol.filePath;
     filePaths.add(filePath);
+  });
+  programSymbolsWithDecorators.forEach((symbol) => {
     if (metadataResolver.isInjectable(symbol)) {
+      const filePath = symbol.filePath;
       ngInjectablesByFile.set(filePath, (ngInjectablesByFile.get(filePath) || []).concat(symbol));
     }
   });

--- a/packages/compiler/src/aot/static_symbol_resolver.ts
+++ b/packages/compiler/src/aot/static_symbol_resolver.ts
@@ -250,6 +250,24 @@ export class StaticSymbolResolver {
     return this.staticSymbolCache.get(declarationFile, name, members);
   }
 
+  /**
+   * hasDecorators checks a file's metadata for the presense of decorators without evalutating the
+   * metada.
+   *
+   * @param filePath the absolute path to examine for decorators.
+   * @returns true if any class in the file has a decorator.
+   */
+  hasDecorators(filePath: string): boolean {
+    const metadata = this.getModuleMetadata(filePath);
+    if (metadata['metadata']) {
+      return Object.keys(metadata['metadata']).some((metadataKey) => {
+        const entry = metadata['metadata'][metadataKey];
+        return entry && entry.__symbolic === 'class' && entry.decorators;
+      });
+    }
+    return false;
+  }
+
   getSymbolsOf(filePath: string): StaticSymbol[] {
     // Note: Some users use libraries that were not compiled with ngc, i.e. they don't
     // have summaries, only .d.ts files. So we always need to check both, the summary

--- a/packages/compiler/src/i18n/extractor.ts
+++ b/packages/compiler/src/i18n/extractor.ts
@@ -57,8 +57,8 @@ export class Extractor {
 
   extract(rootFiles: string[]): Promise<MessageBundle> {
     const programSymbols = extractProgramSymbols(this.staticSymbolResolver, rootFiles, this.host);
-    const {files, ngModules} =
-        analyzeAndValidateNgModules(programSymbols, this.host, this.metadataResolver);
+    const {files, ngModules} = analyzeAndValidateNgModules(
+        programSymbols, this.host, this.staticSymbolResolver, this.metadataResolver);
     return Promise
         .all(ngModules.map(
             ngModule => this.metadataResolver.loadNgModuleDirectiveAndPipeMetadata(

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -151,7 +151,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
           analyzeHost);
 
       analyzedModules = this.analyzedModules =
-          analyzeNgModules(programSymbols, analyzeHost, this.resolver);
+          analyzeNgModules(programSymbols, analyzeHost, this.staticSymbolResolver, this.resolver);
     }
     return analyzedModules;
   }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Feature
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`ngc` does not have a watch mode that automatically recompiles files when they are changed on disk.

## What is the new behavior?

`ngc` now accepts `-w` and `--watch` that will watch for changes made on disk and automatically recompile the files. This is similar to `tsc`s `-w` parameter but will also emit the factory classes and metadata.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
