### PR TITLE
feat(router): new option for the routerLinkActive directive

### DIFF
--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -50,6 +50,15 @@ import {RouterLink, RouterLinkWithHref} from './router_link';
  * true}">Bob</a>
  * ```
  *
+ * You can configure RouterLinkActive by passing `ignoreQueryParams: true`. This will add the
+ * classes only when the url matches the link (following the `exact` rule) regardless of
+ * the query parameters.
+ *
+ * ```
+ * <a routerLink="/user/bob" routerLinkActive="active-link"
+ * [routerLinkActiveOptions]="{ignoreQueryParams: true}">Bob</a>
+ * ```
+ *
  * You can assign the RouterLinkActive instance to a template variable and directly check
  * the `isActive` status.
  * ```
@@ -88,7 +97,9 @@ export class RouterLinkActive implements OnChanges,
   private subscription: Subscription;
   public readonly isActive: boolean = false;
 
-  @Input() routerLinkActiveOptions: {exact: boolean} = {exact: false};
+  @Input()
+  routerLinkActiveOptions: {exact: boolean,
+                            ignoreQueryParams: boolean} = {exact: false, ignoreQueryParams: false};
 
   constructor(
       private router: Router, private element: ElementRef, private renderer: Renderer2,
@@ -136,8 +147,9 @@ export class RouterLinkActive implements OnChanges,
   }
 
   private isLinkActive(router: Router): (link: (RouterLink|RouterLinkWithHref)) => boolean {
-    return (link: RouterLink | RouterLinkWithHref) =>
-               router.isActive(link.urlTree, this.routerLinkActiveOptions.exact);
+    return (link: RouterLink | RouterLinkWithHref) => router.isActive(
+               link.urlTree, this.routerLinkActiveOptions.exact,
+               this.routerLinkActiveOptions.ignoreQueryParams);
   }
 
   private hasActiveLinks(): boolean {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -468,13 +468,13 @@ export class Router {
   parseUrl(url: string): UrlTree { return this.urlSerializer.parse(url); }
 
   /** Returns whether the url is activated */
-  isActive(url: string|UrlTree, exact: boolean): boolean {
+  isActive(url: string|UrlTree, exact: boolean, ignoreQueryParams: boolean): boolean {
     if (url instanceof UrlTree) {
-      return containsTree(this.currentUrlTree, url, exact);
+      return containsTree(this.currentUrlTree, url, exact, ignoreQueryParams);
     }
 
     const urlTree = this.urlSerializer.parse(url);
-    return containsTree(this.currentUrlTree, urlTree, exact);
+    return containsTree(this.currentUrlTree, urlTree, exact, ignoreQueryParams);
   }
 
   private removeEmptyProps(params: Params): Params {

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -13,14 +13,23 @@ export function createEmptyUrlTree() {
   return new UrlTree(new UrlSegmentGroup([], {}), {}, null);
 }
 
-export function containsTree(container: UrlTree, containee: UrlTree, exact: boolean): boolean {
+export function containsTree(
+    container: UrlTree, containee: UrlTree, exact: boolean, ignoreQueryParams: boolean): boolean {
   if (exact) {
-    return equalQueryParams(container.queryParams, containee.queryParams) &&
-        equalSegmentGroups(container.root, containee.root);
+    if (ignoreQueryParams) {
+      return equalSegmentGroups(container.root, containee.root);
+    } else {
+      return equalQueryParams(container.queryParams, containee.queryParams) &&
+          equalSegmentGroups(container.root, containee.root);
+    }
+  } else {
+    if (ignoreQueryParams) {
+      return containsSegmentGroup(container.root, containee.root);
+    } else {
+      return containsQueryParams(container.queryParams, containee.queryParams) &&
+          containsSegmentGroup(container.root, containee.root);
+    }
   }
-
-  return containsQueryParams(container.queryParams, containee.queryParams) &&
-      containsSegmentGroup(container.root, containee.root);
 }
 
 function equalQueryParams(

--- a/packages/router/test/url_tree.spec.ts
+++ b/packages/router/test/url_tree.spec.ts
@@ -26,123 +26,243 @@ describe('UrlTree', () => {
   });
 
   describe('containsTree', () => {
-    describe('exact = true', () => {
+    describe('exact = true, ignoreQueryParams = false', () => {
       it('should return true when two tree are the same', () => {
         const url = '/one/(one//left:three)(right:four)';
         const t1 = serializer.parse(url);
         const t2 = serializer.parse(url);
-        expect(containsTree(t1, t2, true)).toBe(true);
-        expect(containsTree(t2, t1, true)).toBe(true);
+        expect(containsTree(t1, t2, true, false)).toBe(true);
+        expect(containsTree(t2, t1, true, false)).toBe(true);
       });
 
       it('should return true when queryParams are the same', () => {
         const t1 = serializer.parse('/one/two?test=1&page=5');
         const t2 = serializer.parse('/one/two?test=1&page=5');
-        expect(containsTree(t1, t2, true)).toBe(true);
+        expect(containsTree(t1, t2, true, false)).toBe(true);
       });
 
       it('should return false when queryParams are not the same', () => {
         const t1 = serializer.parse('/one/two?test=1&page=5');
         const t2 = serializer.parse('/one/two?test=1');
-        expect(containsTree(t1, t2, true)).toBe(false);
+        expect(containsTree(t1, t2, true, false)).toBe(false);
       });
 
       it('should return false when containee is missing queryParams', () => {
         const t1 = serializer.parse('/one/two?page=5');
         const t2 = serializer.parse('/one/two');
-        expect(containsTree(t1, t2, true)).toBe(false);
+        expect(containsTree(t1, t2, true, false)).toBe(false);
       });
 
       it('should return false when paths are not the same', () => {
         const t1 = serializer.parse('/one/two(right:three)');
         const t2 = serializer.parse('/one/two2(right:three)');
-        expect(containsTree(t1, t2, true)).toBe(false);
+        expect(containsTree(t1, t2, true, false)).toBe(false);
       });
 
       it('should return false when container has an extra child', () => {
         const t1 = serializer.parse('/one/two(right:three)');
         const t2 = serializer.parse('/one/two');
-        expect(containsTree(t1, t2, true)).toBe(false);
+        expect(containsTree(t1, t2, true, false)).toBe(false);
       });
 
       it('should return false when containee has an extra child', () => {
         const t1 = serializer.parse('/one/two');
         const t2 = serializer.parse('/one/two(right:three)');
-        expect(containsTree(t1, t2, true)).toBe(false);
+        expect(containsTree(t1, t2, true, false)).toBe(false);
       });
     });
 
-    describe('exact = false', () => {
-      it('should return true when containee is missing a segment', () => {
-        const t1 = serializer.parse('/one/(two//left:three)(right:four)');
-        const t2 = serializer.parse('/one/(two//left:three)');
-        expect(containsTree(t1, t2, false)).toBe(true);
-      });
-
-      it('should return true when containee is missing some paths', () => {
-        const t1 = serializer.parse('/one/two/three');
-        const t2 = serializer.parse('/one/two');
-        expect(containsTree(t1, t2, false)).toBe(true);
-      });
-
-      it('should return true container has its paths splitted into multiple segments', () => {
-        const t1 = serializer.parse('/one/(two//left:three)');
-        const t2 = serializer.parse('/one/two');
-        expect(containsTree(t1, t2, false)).toBe(true);
-      });
-
-      it('should return false when containee has extra segments', () => {
-        const t1 = serializer.parse('/one/two');
-        const t2 = serializer.parse('/one/(two//left:three)');
-        expect(containsTree(t1, t2, false)).toBe(false);
-      });
-
-      it('should return false containee has segments that the container does not have', () => {
-        const t1 = serializer.parse('/one/(two//left:three)');
-        const t2 = serializer.parse('/one/(two//right:four)');
-        expect(containsTree(t1, t2, false)).toBe(false);
-      });
-
-      it('should return false when containee has extra paths', () => {
-        const t1 = serializer.parse('/one');
-        const t2 = serializer.parse('/one/two');
-        expect(containsTree(t1, t2, false)).toBe(false);
+    describe('exact = true, ignoreQueryParams = true', () => {
+      it('should return true when two tree are the same', () => {
+        const url = '/one/(one//left:three)(right:four)';
+        const t1 = serializer.parse(url);
+        const t2 = serializer.parse(url);
+        expect(containsTree(t1, t2, true, true)).toBe(true);
+        expect(containsTree(t2, t1, true, true)).toBe(true);
       });
 
       it('should return true when queryParams are the same', () => {
         const t1 = serializer.parse('/one/two?test=1&page=5');
         const t2 = serializer.parse('/one/two?test=1&page=5');
-        expect(containsTree(t1, t2, false)).toBe(true);
+        expect(containsTree(t1, t2, true, true)).toBe(true);
+      });
+
+      it('should return true when queryParams are not the same', () => {
+        const t1 = serializer.parse('/one/two?test=1&page=5');
+        const t2 = serializer.parse('/one/two?test=1');
+        expect(containsTree(t1, t2, true, true)).toBe(true);
+      });
+
+      it('should return true when containee is missing queryParams', () => {
+        const t1 = serializer.parse('/one/two?page=5');
+        const t2 = serializer.parse('/one/two');
+        expect(containsTree(t1, t2, true, true)).toBe(true);
+      });
+
+      it('should return false when paths are not the same', () => {
+        const t1 = serializer.parse('/one/two(right:three)');
+        const t2 = serializer.parse('/one/two2(right:three)');
+        expect(containsTree(t1, t2, true, true)).toBe(false);
+      });
+
+      it('should return false when container has an extra child', () => {
+        const t1 = serializer.parse('/one/two(right:three)');
+        const t2 = serializer.parse('/one/two');
+        expect(containsTree(t1, t2, true, true)).toBe(false);
+      });
+
+      it('should return false when containee has an extra child', () => {
+        const t1 = serializer.parse('/one/two');
+        const t2 = serializer.parse('/one/two(right:three)');
+        expect(containsTree(t1, t2, true, true)).toBe(false);
+      });
+    });
+
+    describe('exact = false, ignoreQueryParams = false', () => {
+      it('should return true when containee is missing a segment', () => {
+        const t1 = serializer.parse('/one/(two//left:three)(right:four)');
+        const t2 = serializer.parse('/one/(two//left:three)');
+        expect(containsTree(t1, t2, false, false)).toBe(true);
+      });
+
+      it('should return true when containee is missing some paths', () => {
+        const t1 = serializer.parse('/one/two/three');
+        const t2 = serializer.parse('/one/two');
+        expect(containsTree(t1, t2, false, false)).toBe(true);
+      });
+
+      it('should return true container has its paths splitted into multiple segments', () => {
+        const t1 = serializer.parse('/one/(two//left:three)');
+        const t2 = serializer.parse('/one/two');
+        expect(containsTree(t1, t2, false, false)).toBe(true);
+      });
+
+      it('should return false when containee has extra segments', () => {
+        const t1 = serializer.parse('/one/two');
+        const t2 = serializer.parse('/one/(two//left:three)');
+        expect(containsTree(t1, t2, false, false)).toBe(false);
+      });
+
+      it('should return false containee has segments that the container does not have', () => {
+        const t1 = serializer.parse('/one/(two//left:three)');
+        const t2 = serializer.parse('/one/(two//right:four)');
+        expect(containsTree(t1, t2, false, false)).toBe(false);
+      });
+
+      it('should return false when containee has extra paths', () => {
+        const t1 = serializer.parse('/one');
+        const t2 = serializer.parse('/one/two');
+        expect(containsTree(t1, t2, false, false)).toBe(false);
+      });
+
+      it('should return true when queryParams are the same', () => {
+        const t1 = serializer.parse('/one/two?test=1&page=5');
+        const t2 = serializer.parse('/one/two?test=1&page=5');
+        expect(containsTree(t1, t2, false, false)).toBe(true);
       });
 
       it('should return true when container contains containees queryParams', () => {
         const t1 = serializer.parse('/one/two?test=1&u=5');
         const t2 = serializer.parse('/one/two?u=5');
-        expect(containsTree(t1, t2, false)).toBe(true);
+        expect(containsTree(t1, t2, false, false)).toBe(true);
       });
 
       it('should return true when containee does not have queryParams', () => {
         const t1 = serializer.parse('/one/two?page=5');
         const t2 = serializer.parse('/one/two');
-        expect(containsTree(t1, t2, false)).toBe(true);
+        expect(containsTree(t1, t2, false, false)).toBe(true);
       });
 
       it('should return false when containee has but container does not have queryParams', () => {
         const t1 = serializer.parse('/one/two');
         const t2 = serializer.parse('/one/two?page=1');
-        expect(containsTree(t1, t2, false)).toBe(false);
+        expect(containsTree(t1, t2, false, false)).toBe(false);
       });
 
       it('should return false when containee has different queryParams', () => {
         const t1 = serializer.parse('/one/two?page=5');
         const t2 = serializer.parse('/one/two?test=1');
-        expect(containsTree(t1, t2, false)).toBe(false);
+        expect(containsTree(t1, t2, false, false)).toBe(false);
       });
 
       it('should return false when containee has more queryParams than container', () => {
         const t1 = serializer.parse('/one/two?page=5');
         const t2 = serializer.parse('/one/two?page=5&test=1');
-        expect(containsTree(t1, t2, false)).toBe(false);
+        expect(containsTree(t1, t2, false, false)).toBe(false);
+      });
+    });
+
+    describe('exact = false, ignoreQueryParams = true', () => {
+      it('should return true when containee is missing a segment', () => {
+        const t1 = serializer.parse('/one/(two//left:three)(right:four)');
+        const t2 = serializer.parse('/one/(two//left:three)');
+        expect(containsTree(t1, t2, false, true)).toBe(true);
+      });
+
+      it('should return true when containee is missing some paths', () => {
+        const t1 = serializer.parse('/one/two/three');
+        const t2 = serializer.parse('/one/two');
+        expect(containsTree(t1, t2, false, true)).toBe(true);
+      });
+
+      it('should return true container has its paths splitted into multiple segments', () => {
+        const t1 = serializer.parse('/one/(two//left:three)');
+        const t2 = serializer.parse('/one/two');
+        expect(containsTree(t1, t2, false, true)).toBe(true);
+      });
+
+      it('should return false when containee has extra segments', () => {
+        const t1 = serializer.parse('/one/two');
+        const t2 = serializer.parse('/one/(two//left:three)');
+        expect(containsTree(t1, t2, false, true)).toBe(false);
+      });
+
+      it('should return false containee has segments that the container does not have', () => {
+        const t1 = serializer.parse('/one/(two//left:three)');
+        const t2 = serializer.parse('/one/(two//right:four)');
+        expect(containsTree(t1, t2, false, true)).toBe(false);
+      });
+
+      it('should return false when containee has extra paths', () => {
+        const t1 = serializer.parse('/one');
+        const t2 = serializer.parse('/one/two');
+        expect(containsTree(t1, t2, false, true)).toBe(false);
+      });
+
+      it('should return true when queryParams are the same', () => {
+        const t1 = serializer.parse('/one/two?test=1&page=5');
+        const t2 = serializer.parse('/one/two?test=1&page=5');
+        expect(containsTree(t1, t2, false, true)).toBe(true);
+      });
+
+      it('should return true when container contains containees queryParams', () => {
+        const t1 = serializer.parse('/one/two?test=1&u=5');
+        const t2 = serializer.parse('/one/two?u=5');
+        expect(containsTree(t1, t2, false, true)).toBe(true);
+      });
+
+      it('should return true when containee does not have queryParams', () => {
+        const t1 = serializer.parse('/one/two?page=5');
+        const t2 = serializer.parse('/one/two');
+        expect(containsTree(t1, t2, false, true)).toBe(true);
+      });
+
+      it('should return true when containee has but container does not have queryParams', () => {
+        const t1 = serializer.parse('/one/two');
+        const t2 = serializer.parse('/one/two?page=1');
+        expect(containsTree(t1, t2, false, true)).toBe(true);
+      });
+
+      it('should return true when containee has different queryParams', () => {
+        const t1 = serializer.parse('/one/two?page=5');
+        const t2 = serializer.parse('/one/two?test=1');
+        expect(containsTree(t1, t2, false, true)).toBe(true);
+      });
+
+      it('should return true when containee has more queryParams than container', () => {
+        const t1 = serializer.parse('/one/two?page=5');
+        const t2 = serializer.parse('/one/two?page=5&test=1');
+        expect(containsTree(t1, t2, false, true)).toBe(true);
       });
     });
   });

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -335,7 +335,7 @@ export declare class Router {
     createUrlTree(commands: any[], navigationExtras?: NavigationExtras): UrlTree;
     dispose(): void;
     initialNavigation(): void;
-    isActive(url: string | UrlTree, exact: boolean): boolean;
+    isActive(url: string | UrlTree, exact: boolean, ignoreQueryParams: boolean): boolean;
     navigate(commands: any[], extras?: NavigationExtras): Promise<boolean>;
     navigateByUrl(url: string | UrlTree, extras?: NavigationExtras): Promise<boolean>;
     ngOnDestroy(): void;
@@ -394,6 +394,7 @@ export declare class RouterLinkActive implements OnChanges, OnDestroy, AfterCont
     routerLinkActive: string[] | string;
     routerLinkActiveOptions: {
         exact: boolean;
+        ignoreQueryParams: boolean;
     };
     constructor(router: Router, element: ElementRef, renderer: Renderer2, cdr: ChangeDetectorRef);
     ngAfterContentInit(): void;


### PR DESCRIPTION
Add of a new option "ignoreQueryParams" to the routerLinkActive directive: this allows checking the url tree without considering the query parameters

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The routerLinkActive directive checks if a link is active considering always the query parameters.


## What is the new behavior?
The routerLinkActive has a new option to disable query parameters check when testing if the link is
active or not.


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
