### PR TITLE
refactor(compiler): bump metadata version to 4 

### DIFF
--- a/integration/bazel/package.json
+++ b/integration/bazel/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@angular/bazel": "file:../../dist/packages-dist/bazel",
     "@angular/compiler-cli": "file:../../dist/packages-dist/compiler-cli",
+    "@angular/tsc-wrapped": "file:../../dist/packages-dist/tsc-wrapped",
     "@bazel/typescript": "0.0.7",
     "typescript": "~2.3.1"
   },

--- a/packages/compiler-cli/test/aot_host_spec.ts
+++ b/packages/compiler-cli/test/aot_host_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ModuleMetadata} from '@angular/tsc-wrapped';
+import {ModuleMetadata, VERSION} from '@angular/tsc-wrapped';
 import * as ts from 'typescript';
 
 import {CompilerHost} from '../src/compiler_host';
@@ -163,7 +163,7 @@ describe('CompilerHost', () => {
 
   it('should be able to read a metadata file', () => {
     expect(hostNestedGenDir.getMetadataFor('node_modules/@angular/core.d.ts')).toEqual([
-      {__symbolic: 'module', version: 3, metadata: {foo: {__symbolic: 'class'}}}
+      {__symbolic: 'module', version: VERSION, metadata: {foo: {__symbolic: 'class'}}}
     ]);
   });
 
@@ -181,13 +181,14 @@ describe('CompilerHost', () => {
     expect(hostNestedGenDir.getMetadataFor('node_modules/@angular/missing.d.ts')).toBeUndefined();
   });
 
-  it('should add missing v3 metadata from v1 metadata and .d.ts files', () => {
+  it(`should add missing v${VERSION} metadata from v1 metadata and .d.ts files`, () => {
     expect(hostNestedGenDir.getMetadataFor('metadata_versions/v1.d.ts')).toEqual([
       {__symbolic: 'module', version: 1, metadata: {foo: {__symbolic: 'class'}}}, {
         __symbolic: 'module',
-        version: 3,
+        version: VERSION,
         metadata: {
           foo: {__symbolic: 'class'},
+          aType: {__symbolic: 'interface'},
           Bar: {__symbolic: 'class', members: {ngOnInit: [{__symbolic: 'method'}]}},
           BarChild: {__symbolic: 'class', extends: {__symbolic: 'reference', name: 'Bar'}},
           ReExport: {__symbolic: 'reference', module: './lib/utils2', name: 'ReExport'},
@@ -197,9 +198,9 @@ describe('CompilerHost', () => {
     ]);
   });
 
-  it('should upgrade a missing metadata file into v3', () => {
+  it(`should upgrade a missing metadata file into v${VERSION}`, () => {
     expect(hostNestedGenDir.getMetadataFor('metadata_versions/v1_empty.d.ts')).toEqual([
-      {__symbolic: 'module', version: 3, metadata: {}, exports: [{from: './lib/utils'}]}
+      {__symbolic: 'module', version: VERSION, metadata: {}, exports: [{from: './lib/utils'}]}
     ]);
   });
 });
@@ -207,7 +208,7 @@ describe('CompilerHost', () => {
 const dummyModule = 'export let foo: any[];';
 const dummyMetadata: ModuleMetadata = {
   __symbolic: 'module',
-  version: 3,
+  version: VERSION,
   metadata:
       {foo: {__symbolic: 'error', message: 'Variable not initialized', line: 0, character: 11}}
 };
@@ -230,7 +231,7 @@ const FILES: Entry = {
         '@angular': {
           'core.d.ts': dummyModule,
           'core.metadata.json':
-              `{"__symbolic":"module", "version": 3, "metadata": {"foo": {"__symbolic": "class"}}}`,
+              `{"__symbolic":"module", "version": ${VERSION}, "metadata": {"foo": {"__symbolic": "class"}}}`,
           'router': {'index.d.ts': dummyModule, 'src': {'providers.d.ts': dummyModule}},
           'unused.d.ts': dummyModule,
           'empty.d.ts': 'export declare var a: string;',
@@ -243,6 +244,8 @@ const FILES: Entry = {
           export {ReExport};
 
           export {Export} from './lib/utils2';
+
+          export type aType = number;
 
           export declare class Bar {
             ngOnInit() {}

--- a/packages/compiler/src/aot/static_symbol_resolver.ts
+++ b/packages/compiler/src/aot/static_symbol_resolver.ts
@@ -48,7 +48,7 @@ export interface StaticSymbolResolverHost {
   fileNameToModuleName(importedFilePath: string, containingFilePath: string): string|null;
 }
 
-const SUPPORTED_SCHEMA_VERSION = 3;
+const SUPPORTED_SCHEMA_VERSION = 4;
 
 /**
  * This class is responsible for loading metadata per symbol,

--- a/packages/compiler/test/aot/static_reflector_spec.ts
+++ b/packages/compiler/test/aot/static_reflector_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {StaticReflector, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, StaticSymbolResolverHost, core as compilerCore} from '@angular/compiler';
-import {CollectorOptions} from '@angular/tsc-wrapped';
+import {CollectorOptions, VERSION} from '@angular/tsc-wrapped';
 
 import {MockStaticSymbolResolverHost, MockSummaryResolver} from './static_symbol_resolver_spec';
 
@@ -883,7 +883,7 @@ describe('StaticReflector', () => {
 const DEFAULT_TEST_DATA: {[key: string]: any} = {
   '/tmp/@angular/common/src/forms-deprecated/directives.d.ts': [{
     '__symbolic': 'module',
-    'version': 3,
+    'version': VERSION,
     'metadata': {
       'FORM_DIRECTIVES': [{
         '__symbolic': 'reference',
@@ -894,7 +894,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   }],
   '/tmp/@angular/common/src/directives/ng_for.d.ts': {
     '__symbolic': 'module',
-    'version': 3,
+    'version': VERSION,
     'metadata': {
       'NgFor': {
         '__symbolic': 'class',
@@ -924,19 +924,19 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
     }
   },
   '/tmp/@angular/core/src/linker/view_container_ref.d.ts':
-      {version: 3, 'metadata': {'ViewContainerRef': {'__symbolic': 'class'}}},
+      {version: VERSION, 'metadata': {'ViewContainerRef': {'__symbolic': 'class'}}},
   '/tmp/@angular/core/src/linker/template_ref.d.ts': {
-    version: 3,
+    version: VERSION,
     'module': './template_ref',
     'metadata': {'TemplateRef': {'__symbolic': 'class'}}
   },
   '/tmp/@angular/core/src/change_detection/differs/iterable_differs.d.ts':
-      {version: 3, 'metadata': {'IterableDiffers': {'__symbolic': 'class'}}},
+      {version: VERSION, 'metadata': {'IterableDiffers': {'__symbolic': 'class'}}},
   '/tmp/@angular/core/src/change_detection/change_detector_ref.d.ts':
-      {version: 3, 'metadata': {'ChangeDetectorRef': {'__symbolic': 'class'}}},
+      {version: VERSION, 'metadata': {'ChangeDetectorRef': {'__symbolic': 'class'}}},
   '/tmp/src/app/hero-detail.component.d.ts': {
     '__symbolic': 'module',
-    'version': 3,
+    'version': VERSION,
     'metadata': {
       'HeroDetailComponent': {
         '__symbolic': 'class',
@@ -971,10 +971,10 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
       }
     }
   },
-  '/src/extern.d.ts': {'__symbolic': 'module', 'version': 3, metadata: {s: 's'}},
+  '/src/extern.d.ts': {'__symbolic': 'module', 'version': VERSION, metadata: {s: 's'}},
   '/tmp/src/error-reporting.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: VERSION,
     metadata: {
       SomeClass: {
         __symbolic: 'class',
@@ -994,7 +994,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   },
   '/tmp/src/error-references.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: VERSION,
     metadata: {
       Link1: {__symbolic: 'reference', module: 'src/error-references', name: 'Link2'},
       Link2: {__symbolic: 'reference', module: 'src/error-references', name: 'ErrorSym'},
@@ -1004,7 +1004,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   },
   '/tmp/src/function-declaration.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: VERSION,
     metadata: {
       one: {
         __symbolic: 'function',
@@ -1031,7 +1031,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   },
   '/tmp/src/function-reference.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: VERSION,
     metadata: {
       one: {
         __symbolic: 'call',
@@ -1058,7 +1058,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   },
   '/tmp/src/function-recursive.d.ts': {
     __symbolic: 'modules',
-    version: 3,
+    version: VERSION,
     metadata: {
       recursive: {
         __symbolic: 'function',
@@ -1103,7 +1103,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   },
   '/tmp/src/spread.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: VERSION,
     metadata: {spread: [0, {__symbolic: 'spread', expression: [1, 2, 3, 4]}, 5]}
   },
   '/tmp/src/custom-decorator.ts': `

--- a/packages/compiler/test/aot/static_symbol_resolver_spec.ts
+++ b/packages/compiler/test/aot/static_symbol_resolver_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {StaticSymbol, StaticSymbolCache, StaticSymbolResolver, StaticSymbolResolverHost, Summary, SummaryResolver} from '@angular/compiler';
-import {CollectorOptions, MetadataCollector} from '@angular/tsc-wrapped';
+import {CollectorOptions, MetadataCollector, VERSION} from '@angular/tsc-wrapped';
 import * as ts from 'typescript';
 
 
@@ -37,7 +37,7 @@ describe('StaticSymbolResolver', () => {
         () => symbolResolver.resolveSymbol(
             symbolResolver.getSymbolByModule('src/version-error', 'e')))
         .toThrow(new Error(
-            'Metadata version mismatch for module /tmp/src/version-error.d.ts, found version 100, expected 3'));
+            `Metadata version mismatch for module /tmp/src/version-error.d.ts, found version 100, expected ${VERSION}`));
   });
 
   it('should throw an exception for version 2 metadata', () => {
@@ -144,14 +144,14 @@ describe('StaticSymbolResolver', () => {
           {
             '/test.d.ts': [{
               '__symbolic': 'module',
-              'version': 3,
+              'version': VERSION,
               'metadata': {
                 'a': {'__symbolic': 'reference', 'name': 'b', 'module': './test2'},
               }
             }],
             '/test2.d.ts': [{
               '__symbolic': 'module',
-              'version': 3,
+              'version': VERSION,
               'metadata': {
                 'b': {'__symbolic': 'reference', 'name': 'c', 'module': './test3'},
               }
@@ -287,7 +287,7 @@ describe('StaticSymbolResolver', () => {
     init({
       '/test.d.ts': [{
         '__symbolic': 'module',
-        'version': 3,
+        'version': VERSION,
         'metadata': {
           'AParam': {__symbolic: 'class'},
           'AClass': {
@@ -483,7 +483,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   '/tmp/src/version-2-error.d.ts': {'__symbolic': 'module', 'version': 2, metadata: {e: 's'}},
   '/tmp/src/reexport/reexport.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: VERSION,
     metadata: {},
     exports: [
       {from: './src/origin1', export: ['One', 'Two', {name: 'Three', as: 'Four'}]},
@@ -492,7 +492,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   },
   '/tmp/src/reexport/src/origin1.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: VERSION,
     metadata: {
       One: {__symbolic: 'class'},
       Two: {__symbolic: 'class'},
@@ -501,26 +501,26 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   },
   '/tmp/src/reexport/src/origin5.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: VERSION,
     metadata: {
       Five: {__symbolic: 'class'},
     },
   },
   '/tmp/src/reexport/src/origin30.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: VERSION,
     metadata: {
       Thirty: {__symbolic: 'class'},
     },
   },
   '/tmp/src/reexport/src/originNone.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: VERSION,
     metadata: {},
   },
   '/tmp/src/reexport/src/reexport2.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: VERSION,
     metadata: {},
     exports: [{from: './originNone'}, {from: './origin30'}]
   }

--- a/packages/compiler/test/aot/summary_serializer_spec.ts
+++ b/packages/compiler/test/aot/summary_serializer_spec.ts
@@ -9,6 +9,7 @@
 import {AotSummaryResolver, AotSummaryResolverHost, CompileSummaryKind, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, StaticSymbolResolverHost} from '@angular/compiler';
 import {deserializeSummaries, serializeSummaries} from '@angular/compiler/src/aot/summary_serializer';
 import {summaryFileName} from '@angular/compiler/src/aot/util';
+import {VERSION} from '@angular/tsc-wrapped';
 
 import {MockStaticSymbolResolverHost} from './static_symbol_resolver_spec';
 import {MockAotSummaryResolverHost, createMockOutputContext} from './summary_resolver_spec';
@@ -196,7 +197,7 @@ export function main() {
           export var local = 'a';
         `,
                '/tmp/non_summary.d.ts':
-                   {__symbolic: 'module', version: 3, metadata: {'external': 'b'}}
+                   {__symbolic: 'module', version: VERSION, metadata: {'external': 'b'}}
              });
          const serialized = serializeSummaries(
              'someFile.ts', createMockOutputContext(), summaryResolver, symbolResolver, [{

--- a/packages/tsc-wrapped/src/schema.ts
+++ b/packages/tsc-wrapped/src/schema.ts
@@ -15,7 +15,7 @@
 // semantics of the file in an array. For example, when generating a version 2 file, if version 1
 // can accurately represent the metadata, generate both version 1 and version 2 in an array.
 
-export const VERSION = 3;
+export const VERSION = 4;
 
 export type MetadataEntry = ClassMetadata | InterfaceMetadata | FunctionMetadata | MetadataValue;
 

--- a/packages/tsc-wrapped/test/collector_spec.ts
+++ b/packages/tsc-wrapped/test/collector_spec.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 
 import {MetadataCollector} from '../src/collector';
-import {ClassMetadata, ConstructorMetadata, MetadataEntry, ModuleMetadata, isClassMetadata, isMetadataGlobalReferenceExpression} from '../src/schema';
+import {ClassMetadata, ConstructorMetadata, MetadataEntry, ModuleMetadata, VERSION, isClassMetadata, isMetadataGlobalReferenceExpression} from '../src/schema';
 
 import {Directory, Host, expectValidSources} from './typescript.mocks';
 
@@ -71,14 +71,14 @@ describe('Collector', () => {
     const sourceFile = program.getSourceFile('/exported-type.ts');
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual(
-        {__symbolic: 'module', version: 3, metadata: {SomeType: {__symbolic: 'interface'}}});
+        {__symbolic: 'module', version: VERSION, metadata: {SomeType: {__symbolic: 'interface'}}});
   });
 
   it('should return an interface reference for interfaces', () => {
     const sourceFile = program.getSourceFile('app/hero.ts');
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual(
-        {__symbolic: 'module', version: 3, metadata: {Hero: {__symbolic: 'interface'}}});
+        {__symbolic: 'module', version: VERSION, metadata: {Hero: {__symbolic: 'interface'}}});
   });
 
   it('should be able to collect a simple component\'s metadata', () => {
@@ -86,7 +86,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 3,
+      version: VERSION,
       metadata: {
         HeroDetailComponent: {
           __symbolic: 'class',
@@ -127,7 +127,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 3,
+      version: VERSION,
       metadata: {
         AppComponent: {
           __symbolic: 'class',
@@ -181,7 +181,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 3,
+      version: VERSION,
       metadata: {
         HEROES: [
           {'id': 11, 'name': 'Mr. Nice', '$quoted$': ['id', 'name']},
@@ -260,7 +260,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(unsupported1);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 3,
+      version: VERSION,
       metadata: {
         a: {__symbolic: 'error', message: 'Destructuring not supported', line: 1, character: 16},
         b: {__symbolic: 'error', message: 'Destructuring not supported', line: 1, character: 19},
@@ -302,7 +302,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 3,
+      version: VERSION,
       metadata: {
         SimpleClass: {__symbolic: 'class'},
         AbstractClass: {__symbolic: 'class'},
@@ -316,7 +316,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(exportedFunctions);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 3,
+      version: VERSION,
       metadata: {
         one: {
           __symbolic: 'function',


### PR DESCRIPTION
The first 5 commits are from https://github.com/angular/angular/pull/18788.

Also adds auto upgrade from lower version based
on the .d.ts file (e.g. from version 3 to 4).

This is needed as we are now also capturing type aliases
in metadata files (and we rely on this),
see 6e3498c.