### PR TITLE
ci: do not run npm tools for AIO builds

### DIFF
--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -39,6 +39,18 @@ if [[ ${CI_MODE} != "aio" && ${CI_MODE} != 'docs_test' ]]; then
   travisFoldStart "npm-install"
     node tools/npm/check-node-modules --purge || npm install
   travisFoldEnd "npm-install"
+
+
+  # Install Selenium WebDriver
+  travisFoldStart "webdriver-manager-update"
+    $(npm bin)/webdriver-manager update
+  travisFoldEnd "webdriver-manager-update"
+
+
+  # Install bower packages
+  travisFoldStart "bower-install"
+    $(npm bin)/bower install
+  travisFoldEnd "bower-install"
 fi
 
 
@@ -101,19 +113,6 @@ if [[ ${TRAVIS} && (${CI_MODE} == "browserstack_required" || ${CI_MODE} == "brow
     )
   travisFoldEnd "install-browserstack"
 fi
-
-
-# Install Selenium WebDriver
-travisFoldStart "webdriver-manager-update"
-  $(npm bin)/webdriver-manager update
-travisFoldEnd "webdriver-manager-update"
-
-
-# Install bower packages
-travisFoldStart "bower-install"
-  $(npm bin)/bower install
-travisFoldEnd "bower-install"
-
 
 # Print return arrows as a log separator
 travisFoldReturnArrows


### PR DESCRIPTION
The `npm install` was not being run for AIO builds as it is not needed (https://github.com/angular/angular/commit/46207538ef12943ec12ebf190b10ab9c1ef9f4b3).
But the `install.sh` was still running webdriver-manager update, which relied upon node_modules being there.
This did not fail before now as Travis was relying upon its cached versions of the node_modules.