### PR TITLE
feat(compiler-cli): lower metadata `useValue` and `data` literal fields

### DIFF
--- a/packages/compiler-cli/src/diagnostics/check_types.ts
+++ b/packages/compiler-cli/src/diagnostics/check_types.ts
@@ -166,9 +166,13 @@ function diagnosticMessageToString(message: ts.DiagnosticMessageChain | string):
   return ts.flattenDiagnosticMessageText(message, '\n');
 }
 
+const REWRITE_PREFIX = /^\u0275[0-9]+$/;
+
 function createFactoryInfo(emitter: TypeScriptEmitter, file: GeneratedFile): FactoryInfo {
-  const {sourceText, context} =
-      emitter.emitStatementsAndContext(file.srcFileUrl, file.genFileUrl, file.stmts !);
+  const {sourceText, context} = emitter.emitStatementsAndContext(
+      file.srcFileUrl, file.genFileUrl, file.stmts !,
+      /* preamble */ undefined, /* emitSourceMaps */ undefined,
+      /* referenceFilter */ reference => !!(reference.name && REWRITE_PREFIX.test(reference.name)));
   const source = ts.createSourceFile(
       file.genFileUrl, sourceText, ts.ScriptTarget.Latest, /* setParentNodes */ true);
   return {source, context};

--- a/packages/compiler-cli/test/diagnostics/check_types_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/check_types_spec.ts
@@ -12,6 +12,7 @@ import * as ts from 'typescript';
 
 import {TypeChecker} from '../../src/diagnostics/check_types';
 import {Diagnostic} from '../../src/transformers/api';
+import {LowerMetadataCache} from '../../src/transformers/lower_expressions';
 
 function compile(
     rootDirs: MockData, options: AotCompilerOptions = {},
@@ -19,7 +20,7 @@ function compile(
   const rootDirArr = toMockFileArray(rootDirs);
   const scriptNames = rootDirArr.map(entry => entry.fileName).filter(isSource);
   const host = new MockCompilerHost(scriptNames, arrayToMockDir(rootDirArr));
-  const aotHost = new MockAotCompilerHost(host);
+  const aotHost = new MockAotCompilerHost(host, new LowerMetadataCache({}));
   const tsSettings = {...settings, ...tsOptions};
   const program = ts.createProgram(host.scriptNames.slice(0), tsSettings, host);
   const ngChecker = new TypeChecker(program, tsSettings, host, aotHost, options);
@@ -80,6 +81,12 @@ describe('ng type checker', () => {
     it('should accept a safe property access of a nullable field reference of a method result',
        () => { a('{{getMaybePerson()?.name}}'); });
   });
+
+  describe('with lowered expressions', () => {
+    it('should not report lowered expressions as errors', () => {
+      expectNoDiagnostics(compile([angularFiles, LOWERING_QUICKSTART]));
+    });
+  });
 });
 
 function appComponentSource(template: string): string {
@@ -126,6 +133,36 @@ const QUICKSTART: MockDirectory = {
 
         @NgModule({
           declarations: [ AppComponent ],
+          bootstrap:    [ AppComponent ]
+        })
+        export class AppModule { }
+      `
+    }
+  }
+};
+
+const LOWERING_QUICKSTART: MockDirectory = {
+  quickstart: {
+    app: {
+      'app.component.ts': appComponentSource('<h1>Hello {{name}}</h1>'),
+      'app.module.ts': `
+        import { NgModule, Component }      from '@angular/core';
+        import { toString }      from './utils';
+
+        import { AppComponent }  from './app.component';
+
+        class Foo {}
+
+        @Component({
+          template: '',
+          providers: [
+            {provide: 'someToken', useFactory: () => new Foo()}
+          ]
+        })
+        export class Bar {}
+
+        @NgModule({
+          declarations: [ AppComponent, Bar ],
           bootstrap:    [ AppComponent ]
         })
         export class AppModule { }

--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -806,4 +806,78 @@ describe('ngc transformer command-line', () => {
       });
     });
   });
+
+  describe('expression lowering', () => {
+    const shouldExist = (fileName: string) => {
+      if (!fs.existsSync(path.resolve(basePath, fileName))) {
+        throw new Error(`Expected ${fileName} to be emitted (basePath: ${basePath})`);
+      }
+    };
+
+    it('should be able to lower supported expressions', () => {
+      writeConfig(`{
+        "extends": "./tsconfig-base.json",
+        "files": ["module.ts"]
+      }`);
+      write('module.ts', `
+        import {NgModule, InjectionToken} from '@angular/core';
+        import {AppComponent} from './app';
+
+        export interface Info {
+          route: string;
+          data: string;
+        }
+
+        export const T1 = new InjectionToken<string>('t1');
+        export const T2 = new InjectionToken<string>('t2');
+        export const T3 = new InjectionToken<number>('t3');
+        export const T4 = new InjectionToken<Info[]>('t4');
+
+        enum SomeEnum {
+          OK,
+          Cancel
+        }
+
+        function calculateString() {
+          return 'someValue';
+        }
+
+        const routeLikeData = [{
+           route: '/home',
+           data: calculateString() 
+        }];
+
+        @NgModule({
+          declarations: [AppComponent],
+          providers: [
+            { provide: T1, useValue: calculateString() },
+            { provide: T2, useFactory: () => 'someValue' },
+            { provide: T3, useValue: SomeEnum.OK },
+            { provide: T4, useValue: routeLikeData }
+          ]
+        })
+        export class MyModule {}
+      `);
+      write('app.ts', `
+        import {Component, Inject} from '@angular/core';
+        import * as m from './module';
+
+        @Component({
+          selector: 'my-app',
+          template: ''
+        })
+        export class AppComponent {
+          constructor(
+            @Inject(m.T1) private t1: string,
+            @Inject(m.T2) private t2: string,
+            @Inject(m.T3) private t3: number,
+            @Inject(m.T4) private t4: m.Info[],
+          ) {}
+        }
+      `);
+
+      expect(mainSync(['-p', basePath], s => {})).toBe(0);
+      shouldExist('built/module.js');
+    });
+  });
 });

--- a/packages/compiler-cli/test/transformers/lower_expressions_spec.ts
+++ b/packages/compiler-cli/test/transformers/lower_expressions_spec.ts
@@ -6,29 +6,92 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ModuleMetadata} from '@angular/tsc-wrapped';
 import * as ts from 'typescript';
 
-import {LoweringRequest, RequestLocationMap, getExpressionLoweringTransformFactory} from '../../src/transformers/lower_expressions';
+import {LowerMetadataCache, LoweringRequest, RequestLocationMap, getExpressionLoweringTransformFactory} from '../../src/transformers/lower_expressions';
 import {Directory, MockAotContext, MockCompilerHost} from '../mocks';
 
 describe('Expression lowering', () => {
-  it('should be able to lower a simple expression', () => {
-    expect(convert('const a = 1 +◊b: 2◊;')).toBe('const b = 2; const a = 1 + b; export { b };');
+  describe('transform', () => {
+    it('should be able to lower a simple expression', () => {
+      expect(convert('const a = 1 +◊b: 2◊;')).toBe('const b = 2; const a = 1 + b; export { b };');
+    });
+
+    it('should be able to lower an expression in a decorator', () => {
+      expect(convert(`
+          import {Component} from '@angular/core';
+
+          @Component({
+            provider: [{provide: 'someToken', useFactory:◊l: () => null◊}]
+          })
+          class MyClass {}
+      `)).toContain('const l = () => null; exports.l = l;');
+    });
   });
 
-  it('should be able to lower an expression in a decorator', () => {
-    expect(convert(`
+  describe('collector', () => {
+    it('should request a lowering for useValue', () => {
+      const collected = collect(`
         import {Component} from '@angular/core';
-        
+
+        enum SomeEnum {
+          OK,
+          NotOK
+        }
+
         @Component({
-          provider: [{provide: 'someToken', useFactory:◊l: () => null◊}]
+          provider: [{provide: 'someToken', useValue:◊enum: SomeEnum.OK◊}]
         })
-        class MyClass {}
-    `)).toContain('const l = () => null; exports.l = l;');
+        export class MyClass {}
+      `);
+      expect(collected.requests.has(collected.annotations[0].start))
+          .toBeTruthy('did not find the useValue');
+    });
+
+    it('should request a lowering for useFactory', () => {
+      const collected = collect(`
+        import {Component} from '@angular/core';
+
+        @Component({
+          provider: [{provide: 'someToken', useFactory:◊lambda: () => null◊}]
+        })
+        export class MyClass {}
+      `);
+      expect(collected.requests.has(collected.annotations[0].start))
+          .toBeTruthy('did not find the useFactory');
+    });
+
+    it('should request a lowering for data', () => {
+      const collected = collect(`
+        import {Component} from '@angular/core';
+
+        enum SomeEnum {
+          OK,
+          NotOK
+        }
+
+        @Component({
+          provider: [{provide: 'someToken', data:◊enum: SomeEnum.OK◊}]
+        })
+        export class MyClass {}
+      `);
+      expect(collected.requests.has(collected.annotations[0].start))
+          .toBeTruthy('did not find the data field');
+    });
   });
 });
 
-function convert(annotatedSource: string) {
+// Helpers
+
+interface Annotation {
+  start: number;
+  length: number;
+  name: string;
+}
+
+function getAnnotations(annotatedSource: string):
+    {unannotatedSource: string, annotations: Annotation[]} {
   const annotations: {start: number, length: number, name: string}[] = [];
   let adjustment = 0;
   const unannotatedSource = annotatedSource.replace(
@@ -38,6 +101,13 @@ function convert(annotatedSource: string) {
         adjustment -= text.length - source.length;
         return source;
       });
+  return {unannotatedSource, annotations};
+}
+
+// Transform helpers
+
+function convert(annotatedSource: string) {
+  const {annotations, unannotatedSource} = getAnnotations(annotatedSource);
 
   const baseFileName = 'someFile';
   const moduleName = '/' + baseFileName;
@@ -102,4 +172,17 @@ function normalizeResult(result: string): string {
       .replace(/ +/g, ' ')
       .replace(/^ /g, '')
       .replace(/ $/g, '');
+}
+
+// Collector helpers
+
+function collect(annotatedSource: string) {
+  const {annotations, unannotatedSource} = getAnnotations(annotatedSource);
+  const cache = new LowerMetadataCache({});
+  const sourceFile = ts.createSourceFile(
+      'someName.ts', unannotatedSource, ts.ScriptTarget.Latest, /* setParentNodes */ true);
+  return {
+    metadata: cache.getMetadata(sourceFile),
+    requests: cache.getRequests(sourceFile), annotations
+  };
 }

--- a/packages/tsc-wrapped/src/evaluator.ts
+++ b/packages/tsc-wrapped/src/evaluator.ts
@@ -284,7 +284,9 @@ export class Evaluator {
                 error = propertyValue;
                 return true;  // Stop the forEachChild.
               } else {
-                obj[<string>propertyName] = propertyValue;
+                obj[<string>propertyName] = isPropertyAssignment(assignment) ?
+                    recordEntry(propertyValue, assignment.initializer) :
+                    propertyValue;
               }
           }
         });


### PR DESCRIPTION
With this commit the compiler will "lower" expressions into exported
variables for values the compiler does not need to know statically
to be able to generate a factory. For example:

```
  providers: [{provider: 'token', useValue: calculated()}]
```

used to be an error as the expression `calculated()` is not supported
by the compiler because `calculated` is not a
[known function](https://angular.io/guide/metadata#annotationsdecorators)

With this commit this is rewritten, during emit of the .js file, into
something like:

```
export var ɵ0 = calculated();

  ...

  provdiers: [{provider: 'token', useValue: ɵ0}]
```

the compiler then will generate a reference to the exported `ɵ0` instead
of failing to evaluate `calculated()`.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Feature
```

## What is the current behavior?

An a reference to a local value, a call expression, new expression, or a lambda in a provider metadata will always cause a compile time error.

## What is the new behavior?

Arbitrary expressions are allowed following a `useValue`, `useFactory` or `data` field in metadata as they are rewritten, during emit, to a variable exported from the module allowing the compiler to import the variable without needing to understand the expression.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
