### PR TITLE
feat: deprecate @angular/http in favor of @angular/common/http

### DIFF
--- a/packages/common/http/src/backend.ts
+++ b/packages/common/http/src/backend.ts
@@ -20,7 +20,7 @@ import {HttpEvent} from './response';
  *
  * In an `HttpInterceptor`, the `HttpHandler` parameter is the next interceptor in the chain.
  *
- * @experimental
+ * @stable
  */
 export abstract class HttpHandler {
   abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
@@ -34,7 +34,7 @@ export abstract class HttpHandler {
  * When injected, `HttpBackend` dispatches requests directly to the backend, without going
  * through the interceptor chain.
  *
- * @experimental
+ * @stable
  */
 export abstract class HttpBackend implements HttpHandler {
   abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -46,7 +46,7 @@ function addBody<T>(
 }
 
 /**
- * @experimental
+ * @stable
  */
 export type HttpObserve = 'body' | 'events' | 'response';
 
@@ -57,7 +57,7 @@ export type HttpObserve = 'body' | 'events' | 'response';
  * Each request method has multiple signatures, and the return type varies according to which
  * signature is called (mainly the values of `observe` and `responseType`).
  *
- * @experimental
+ * @stable
  */
 @Injectable()
 export class HttpClient {

--- a/packages/common/http/src/headers.ts
+++ b/packages/common/http/src/headers.ts
@@ -14,7 +14,7 @@ interface Update {
 
 /**
  * Immutable set of Http headers, with lazy parsing.
- * @experimental
+ * @stable
  */
 export class HttpHeaders {
   /**

--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -22,7 +22,7 @@ import {HttpEvent} from './response';
  * In rare cases, interceptors may wish to completely handle a request themselves,
  * and not delegate to the remainder of the chain. This behavior is allowed.
  *
- * @experimental
+ * @stable
  */
 export interface HttpInterceptor {
   /**
@@ -47,7 +47,7 @@ export interface HttpInterceptor {
 /**
  * `HttpHandler` which applies an `HttpInterceptor` to an `HttpRequest`.
  *
- * @experimental
+ * @stable
  */
 export class HttpInterceptorHandler implements HttpHandler {
   constructor(private next: HttpHandler, private interceptor: HttpInterceptor) {}
@@ -61,7 +61,7 @@ export class HttpInterceptorHandler implements HttpHandler {
  * A multi-provider token which represents the array of `HttpInterceptor`s that
  * are registered.
  *
- * @experimental
+ * @stable
  */
 export const HTTP_INTERCEPTORS = new InjectionToken<HttpInterceptor[]>('HTTP_INTERCEPTORS');
 

--- a/packages/common/http/src/jsonp.ts
+++ b/packages/common/http/src/jsonp.ts
@@ -35,7 +35,7 @@ export const JSONP_ERR_WRONG_RESPONSE_TYPE = 'JSONP requests must use Json respo
  *
  * In the browser, this should always be the `window` object.
  *
- * @experimental
+ * @stable
  */
 export abstract class JsonpCallbackContext { [key: string]: (data: any) => void; }
 
@@ -43,7 +43,7 @@ export abstract class JsonpCallbackContext { [key: string]: (data: any) => void;
  * `HttpBackend` that only processes `HttpRequest` with the JSONP method,
  * by performing JSONP style requests.
  *
- * @experimental
+ * @stable
  */
 @Injectable()
 export class JsonpClientBackend implements HttpBackend {
@@ -207,7 +207,7 @@ export class JsonpClientBackend implements HttpBackend {
  * An `HttpInterceptor` which identifies requests with the method JSONP and
  * shifts them to the `JsonpClientBackend`.
  *
- * @experimental
+ * @stable
  */
 @Injectable()
 export class JsonpInterceptor {

--- a/packages/common/http/src/module.ts
+++ b/packages/common/http/src/module.ts
@@ -23,7 +23,7 @@ import {HttpXsrfCookieExtractor, HttpXsrfInterceptor, HttpXsrfTokenExtractor, XS
  *
  * Meant to be used as a factory function within `HttpClientModule`.
  *
- * @experimental
+ * @stable
  */
 export function interceptingHandler(
     backend: HttpBackend, interceptors: HttpInterceptor[] | null = []): HttpHandler {
@@ -40,7 +40,7 @@ export function interceptingHandler(
  * Ordinarily JSONP callbacks are stored on the `window` object, but this may not exist
  * in test environments. In that case, callbacks are stored on an anonymous object instead.
  *
- * @experimental
+ * @stable
  */
 export function jsonpCallbackContext(): Object {
   if (typeof window === 'object') {
@@ -59,7 +59,7 @@ export function jsonpCallbackContext(): Object {
  * If no such names are provided, the default is to use `X-XSRF-TOKEN` for
  * the header name and `XSRF-TOKEN` for the cookie name.
  *
- * @experimental
+ * @stable
  */
 @NgModule({
   providers: [
@@ -107,7 +107,7 @@ export class HttpClientXsrfModule {
  * Interceptors can be added to the chain behind `HttpClient` by binding them
  * to the multiprovider for `HTTP_INTERCEPTORS`.
  *
- * @experimental
+ * @stable
  */
 @NgModule({
   imports: [
@@ -140,7 +140,7 @@ export class HttpClientModule {
  * Without this module, Jsonp requests will reach the backend
  * with method JSONP, where they'll be rejected.
  *
- * @experimental
+ * @stable
  */
 @NgModule({
   providers: [

--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -11,7 +11,7 @@
  *
  * Used by `HttpParams`.
  *
- *  @experimental
+ * @stable
  **/
 export interface HttpParameterCodec {
   encodeKey(key: string): string;
@@ -25,7 +25,7 @@ export interface HttpParameterCodec {
  * A `HttpParameterCodec` that uses `encodeURIComponent` and `decodeURIComponent` to
  * serialize and parse URL parameter keys and values.
  *
- * @experimental
+ * @stable
  */
 export class HttpUrlEncodingCodec implements HttpParameterCodec {
   encodeKey(k: string): string { return standardEncoding(k); }
@@ -79,7 +79,7 @@ interface Update {
  *
  * This class is immuatable - all mutation operations return a new instance.
  *
- * @experimental
+ * @stable
  */
 export class HttpParams {
   private map: Map<string, string[]>|null;

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -73,7 +73,7 @@ function isFormData(value: any): value is FormData {
  * assumed to be immutable. To modify a `HttpRequest`, the `clone`
  * method should be used.
  *
- * @experimental
+ * @stable
  */
 export class HttpRequest<T> {
   /**

--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -11,7 +11,7 @@ import {HttpHeaders} from './headers';
 /**
  * Type enumeration for the different kinds of `HttpEvent`.
  *
- * @experimental
+ * @stable
  */
 export enum HttpEventType {
   /**
@@ -48,7 +48,7 @@ export enum HttpEventType {
 /**
  * Base interface for progress events.
  *
- * @experimental
+ * @stable
  */
 export interface HttpProgressEvent {
   /**
@@ -71,7 +71,7 @@ export interface HttpProgressEvent {
 /**
  * A download progress event.
  *
- * @experimental
+ * @stable
  */
 export interface HttpDownloadProgressEvent extends HttpProgressEvent {
   type: HttpEventType.DownloadProgress;
@@ -87,7 +87,7 @@ export interface HttpDownloadProgressEvent extends HttpProgressEvent {
 /**
  * An upload progress event.
  *
- * @experimental
+ * @stable
  */
 export interface HttpUploadProgressEvent extends HttpProgressEvent {
   type: HttpEventType.UploadProgress;
@@ -98,7 +98,7 @@ export interface HttpUploadProgressEvent extends HttpProgressEvent {
  * when a request may be retried multiple times, to distinguish between
  * retries on the final event stream.
  *
- * @experimental
+ * @stable
  */
 export interface HttpSentEvent { type: HttpEventType.Sent; }
 
@@ -108,7 +108,7 @@ export interface HttpSentEvent { type: HttpEventType.Sent; }
  * Grouping all custom events under this type ensures they will be handled
  * and forwarded by all implementations of interceptors.
  *
- * @experimental
+ * @stable
  */
 export interface HttpUserEvent<T> { type: HttpEventType.User; }
 
@@ -118,7 +118,7 @@ export interface HttpUserEvent<T> { type: HttpEventType.User; }
  *
  * It bundles the Error object with the actual response body that failed to parse.
  *
- * @experimental
+ * @stable
  */
 export interface HttpJsonParseError {
   error: Error;
@@ -130,7 +130,7 @@ export interface HttpJsonParseError {
  *
  * Typed according to the expected type of the response.
  *
- * @experimental
+ * @stable
  */
 export type HttpEvent<T> =
     HttpSentEvent | HttpHeaderResponse | HttpResponse<T>| HttpProgressEvent | HttpUserEvent<T>;
@@ -138,7 +138,7 @@ export type HttpEvent<T> =
 /**
  * Base class for both `HttpResponse` and `HttpHeaderResponse`.
  *
- * @experimental
+ * @stable
  */
 export abstract class HttpResponseBase {
   /**
@@ -206,7 +206,7 @@ export abstract class HttpResponseBase {
  * `HttpHeaderResponse` is a `HttpEvent` available on the response
  * event stream, only when progress events are requested.
  *
- * @experimental
+ * @stable
  */
 export class HttpHeaderResponse extends HttpResponseBase {
   /**
@@ -247,7 +247,7 @@ export class HttpHeaderResponse extends HttpResponseBase {
  * `HttpResponse` is a `HttpEvent` available on the response event
  * stream.
  *
- * @experimental
+ * @stable
  */
 export class HttpResponse<T> extends HttpResponseBase {
   /**
@@ -297,7 +297,7 @@ export class HttpResponse<T> extends HttpResponseBase {
  * will contain either a wrapped Error object or the error response returned
  * from the server.
  *
- * @experimental
+ * @stable
  */
 export class HttpErrorResponse extends HttpResponseBase implements Error {
   readonly name = 'HttpErrorResponse';

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -34,14 +34,14 @@ function getResponseUrl(xhr: any): string|null {
 /**
  * A wrapper around the `XMLHttpRequest` constructor.
  *
- * @experimental
+ * @stable
  */
 export abstract class XhrFactory { abstract build(): XMLHttpRequest; }
 
 /**
  * A factory for @{link HttpXhrBackend} that uses the `XMLHttpRequest` browser API.
  *
- * @experimental
+ * @stable
  */
 @Injectable()
 export class BrowserXhr implements XhrFactory {
@@ -63,7 +63,7 @@ interface PartialResponse {
  * An `HttpBackend` which uses the XMLHttpRequest API to send
  * requests to a backend server.
  *
- * @experimental
+ * @stable
  */
 @Injectable()
 export class HttpXhrBackend implements HttpBackend {

--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -21,7 +21,7 @@ export const XSRF_HEADER_NAME = new InjectionToken<string>('XSRF_HEADER_NAME');
 /**
  * Retrieves the current XSRF token to use with the next outgoing request.
  *
- * @experimental
+ * @stable
  */
 export abstract class HttpXsrfTokenExtractor {
   /**

--- a/packages/common/http/testing/src/api.ts
+++ b/packages/common/http/testing/src/api.ts
@@ -13,7 +13,7 @@ import {TestRequest} from './request';
 /**
  * Defines a matcher for requests based on URL, method, or both.
  *
- * @experimental
+ * @stable
  */
 export interface RequestMatch {
   method?: string;
@@ -24,7 +24,7 @@ export interface RequestMatch {
  * Controller to be injected into tests, that allows for mocking and flushing
  * of requests.
  *
- * @experimental
+ * @stable
  */
 export abstract class HttpTestingController {
   /**

--- a/packages/common/http/testing/src/backend.ts
+++ b/packages/common/http/testing/src/backend.ts
@@ -25,7 +25,7 @@ import {TestRequest} from './request';
  * requests were made and then flush them. In the end, a verify() method asserts
  * that no unexpected requests were made.
  *
- * @experimental
+ * @stable
  */
 @Injectable()
 export class HttpClientTestingBackend implements HttpBackend, HttpTestingController {

--- a/packages/common/http/testing/src/module.ts
+++ b/packages/common/http/testing/src/module.ts
@@ -18,7 +18,7 @@ import {HttpClientTestingBackend} from './backend';
  *
  * Inject `HttpTestingController` to expect and flush requests in your tests.
  *
- * @experimental
+ * @stable
  */
 @NgModule({
   imports: [

--- a/packages/common/http/testing/src/request.ts
+++ b/packages/common/http/testing/src/request.ts
@@ -15,7 +15,7 @@ import {Observer} from 'rxjs/Observer';
  * This interface allows access to the underlying `HttpRequest`, and allows
  * responding with `HttpEvent`s or `HttpErrorResponse`s.
  *
- * @experimental
+ * @stable
  */
 export class TestRequest {
   /**

--- a/packages/http/src/backends/browser_xhr.ts
+++ b/packages/http/src/backends/browser_xhr.ts
@@ -13,7 +13,7 @@ import {Injectable} from '@angular/core';
  *
  * Take care not to evaluate this in non-browser contexts.
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 @Injectable()
 export class BrowserXhr {

--- a/packages/http/src/backends/jsonp_backend.ts
+++ b/packages/http/src/backends/jsonp_backend.ts
@@ -24,7 +24,7 @@ const JSONP_ERR_WRONG_METHOD = 'JSONP requests must use GET request method.';
 /**
  * Abstract base class for an in-flight JSONP request.
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export abstract class JSONPConnection implements Connection {
   /**
@@ -141,7 +141,7 @@ export class JSONPConnection_ extends JSONPConnection {
 /**
  * A {@link ConnectionBackend} that uses the JSONP strategy of making requests.
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export abstract class JSONPBackend extends ConnectionBackend {}
 

--- a/packages/http/src/backends/xhr_backend.ts
+++ b/packages/http/src/backends/xhr_backend.ts
@@ -29,7 +29,7 @@ const XSSI_PREFIX = /^\)\]\}',?\n/;
  * This class would typically not be created or interacted with directly inside applications, though
  * the {@link MockConnection} may be interacted with in tests.
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export class XHRConnection implements Connection {
   request: Request;
@@ -188,7 +188,7 @@ export class XHRConnection implements Connection {
  * with different `cookieName` and `headerName` values. See the main HTTP documentation for more
  * details.
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export class CookieXSRFStrategy implements XSRFStrategy {
   constructor(
@@ -226,7 +226,7 @@ export class CookieXSRFStrategy implements XSRFStrategy {
  *   }
  * }
  * ```
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 @Injectable()
 export class XHRBackend implements ConnectionBackend {

--- a/packages/http/src/base_request_options.ts
+++ b/packages/http/src/base_request_options.ts
@@ -37,7 +37,7 @@ import {URLSearchParams} from './url_search_params';
  * console.log('options.url:', options.url); // https://google.com
  * ```
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export class RequestOptions {
   /**
@@ -200,7 +200,7 @@ export class RequestOptions {
  * console.log('req.url:', req.url); // https://google.com
  * ```
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 @Injectable()
 export class BaseRequestOptions extends RequestOptions {

--- a/packages/http/src/base_response_options.ts
+++ b/packages/http/src/base_response_options.ts
@@ -39,7 +39,7 @@ import {ResponseOptionsArgs} from './interfaces';
  * console.log('res.json():', res.json()); // Object {name: "Jeff"}
  * ```
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export class ResponseOptions {
   // TODO: FormData | Blob
@@ -156,7 +156,7 @@ export class ResponseOptions {
  * console.log('res.text():', res.text()); // Angular;
  * ```
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 @Injectable()
 export class BaseResponseOptions extends ResponseOptions {

--- a/packages/http/src/enums.ts
+++ b/packages/http/src/enums.ts
@@ -8,7 +8,7 @@
 
 /**
  * Supported http methods.
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export enum RequestMethod {
   Get,
@@ -24,7 +24,7 @@ export enum RequestMethod {
  * All possible states in which a connection can be, based on
  * [States](http://www.w3.org/TR/XMLHttpRequest/#states) from the `XMLHttpRequest` spec, but with an
  * additional "CANCELLED" state.
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export enum ReadyState {
   Unsent,
@@ -38,7 +38,7 @@ export enum ReadyState {
 /**
  * Acceptable response types to be associated with a {@link Response}, based on
  * [ResponseType](https://fetch.spec.whatwg.org/#responsetype) from the Fetch spec.
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export enum ResponseType {
   Basic,
@@ -50,7 +50,7 @@ export enum ResponseType {
 
 /**
  * Supported content type to be automatically associated with a {@link Request}.
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export enum ContentType {
   NONE,
@@ -64,7 +64,7 @@ export enum ContentType {
 
 /**
  * Define which buffer to use to store the response
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export enum ResponseContentType {
   Text,

--- a/packages/http/src/headers.ts
+++ b/packages/http/src/headers.ts
@@ -32,7 +32,7 @@
  * console.log(thirdHeaders.get('X-My-Custom-Header')); //'Angular'
  * ```
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export class Headers {
   /** @internal header names are lower case */

--- a/packages/http/src/http.ts
+++ b/packages/http/src/http.ts
@@ -98,7 +98,7 @@ function mergeOptions(
  * http.get('request-from-mock-backend.json').subscribe((res:Response) => doSomething(res));
  * ```
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 @Injectable()
 export class Http {
@@ -186,7 +186,7 @@ export class Http {
 
 
 /**
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 @Injectable()
 export class Jsonp extends Http {

--- a/packages/http/src/http_module.ts
+++ b/packages/http/src/http_module.ts
@@ -40,7 +40,7 @@ export function jsonpFactory(jsonpBackend: JSONPBackend, requestOptions: Request
 /**
  * The module that includes http's providers
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 @NgModule({
   providers: [
@@ -60,7 +60,7 @@ export class HttpModule {
 /**
  * The module that includes jsonp's providers
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 @NgModule({
   providers: [

--- a/packages/http/src/interfaces.ts
+++ b/packages/http/src/interfaces.ts
@@ -17,14 +17,14 @@ import {URLSearchParams} from './url_search_params';
  * The primary purpose of a `ConnectionBackend` is to create new connections to fulfill a given
  * {@link Request}.
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export abstract class ConnectionBackend { abstract createConnection(request: any): Connection; }
 
 /**
  * Abstract class from which real connections are derived.
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export abstract class Connection {
   readyState: ReadyState;
@@ -35,7 +35,7 @@ export abstract class Connection {
 /**
  * An XSRFStrategy configures XSRF protection (e.g. via headers) on an HTTP request.
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export abstract class XSRFStrategy { abstract configureRequest(req: Request): void; }
 
@@ -43,7 +43,7 @@ export abstract class XSRFStrategy { abstract configureRequest(req: Request): vo
  * Interface for options to construct a RequestOptions, based on
  * [RequestInit](https://fetch.spec.whatwg.org/#requestinit) from the Fetch spec.
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export interface RequestOptionsArgs {
   url?: string|null;
@@ -66,7 +66,7 @@ export interface RequestArgs extends RequestOptionsArgs { url: string|null; }
  * Interface for options to construct a Response, based on
  * [ResponseInit](https://fetch.spec.whatwg.org/#responseinit) from the Fetch spec.
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export interface ResponseOptionsArgs {
   body?: string|Object|FormData|ArrayBuffer|Blob|null;

--- a/packages/http/src/static_request.ts
+++ b/packages/http/src/static_request.ts
@@ -52,7 +52,7 @@ import {URLSearchParams} from './url_search_params';
  * });
  * ```
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export class Request extends Body {
   /**

--- a/packages/http/src/static_response.ts
+++ b/packages/http/src/static_response.ts
@@ -32,7 +32,7 @@ import {Headers} from './headers';
  * can be accessed many times. There are other differences in the implementation, but this is the
  * most significant.
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export class Response extends Body {
   /**

--- a/packages/http/src/url_search_params.ts
+++ b/packages/http/src/url_search_params.ts
@@ -22,7 +22,7 @@ function paramParser(rawParams: string = ''): Map<string, string[]> {
   return map;
 }
 /**
- * @experimental
+ * @deprecated use @angular/common/http instead
  **/
 export class QueryEncoder {
   encodeKey(k: string): string { return standardEncoding(k); }
@@ -76,7 +76,7 @@ function standardEncoding(v: string): string {
  *
  * let params = new URLSearchParams('', new MyQueryEncoder());
  * ```
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export class URLSearchParams {
   paramsMap: Map<string, string[]>;

--- a/packages/http/src/version.ts
+++ b/packages/http/src/version.ts
@@ -14,6 +14,6 @@
 
 import {Version} from '@angular/core';
 /**
- * @stable
+ * @deprecated use @angular/common/http instead
  */
 export const VERSION = new Version('0.0.0-PLACEHOLDER');

--- a/packages/http/testing/src/mock_backend.ts
+++ b/packages/http/testing/src/mock_backend.ts
@@ -17,7 +17,7 @@ import {take} from 'rxjs/operator/take';
  *
  * Mock Connection to represent a {@link Connection} for tests.
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 export class MockConnection implements Connection {
   // TODO Name `readyState` should change to be more generic, and states could be made to be more
@@ -190,7 +190,7 @@ export class MockConnection implements Connection {
  *
  * This method only exists in the mock implementation, not in real Backends.
  *
- * @experimental
+ * @deprecated use @angular/common/http instead
  */
 @Injectable()
 export class MockBackend implements ConnectionBackend {

--- a/tools/public_api_guard/common/http.d.ts
+++ b/tools/public_api_guard/common/http.d.ts
@@ -1,12 +1,12 @@
-/** @experimental */
+/** @stable */
 export declare const HTTP_INTERCEPTORS: InjectionToken<HttpInterceptor[]>;
 
-/** @experimental */
+/** @stable */
 export declare abstract class HttpBackend implements HttpHandler {
     abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
 }
 
-/** @experimental */
+/** @stable */
 export declare class HttpClient {
     constructor(handler: HttpHandler);
     delete<T>(url: string, options?: {
@@ -996,15 +996,15 @@ export declare class HttpClient {
     }): Observable<any>;
 }
 
-/** @experimental */
+/** @stable */
 export declare class HttpClientJsonpModule {
 }
 
-/** @experimental */
+/** @stable */
 export declare class HttpClientModule {
 }
 
-/** @experimental */
+/** @stable */
 export declare class HttpClientXsrfModule {
     static disable(): ModuleWithProviders;
     static withOptions(options?: {
@@ -1013,13 +1013,13 @@ export declare class HttpClientXsrfModule {
     }): ModuleWithProviders;
 }
 
-/** @experimental */
+/** @stable */
 export interface HttpDownloadProgressEvent extends HttpProgressEvent {
     partialText?: string;
     type: HttpEventType.DownloadProgress;
 }
 
-/** @experimental */
+/** @stable */
 export declare class HttpErrorResponse extends HttpResponseBase implements Error {
     readonly error: any | null;
     readonly message: string;
@@ -1034,10 +1034,10 @@ export declare class HttpErrorResponse extends HttpResponseBase implements Error
     });
 }
 
-/** @experimental */
+/** @stable */
 export declare type HttpEvent<T> = HttpSentEvent | HttpHeaderResponse | HttpResponse<T> | HttpProgressEvent | HttpUserEvent<T>;
 
-/** @experimental */
+/** @stable */
 export declare enum HttpEventType {
     Sent = 0,
     UploadProgress = 1,
@@ -1047,12 +1047,12 @@ export declare enum HttpEventType {
     User = 5,
 }
 
-/** @experimental */
+/** @stable */
 export declare abstract class HttpHandler {
     abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
 }
 
-/** @experimental */
+/** @stable */
 export declare class HttpHeaderResponse extends HttpResponseBase {
     readonly type: HttpEventType.ResponseHeader;
     constructor(init?: {
@@ -1069,7 +1069,7 @@ export declare class HttpHeaderResponse extends HttpResponseBase {
     }): HttpHeaderResponse;
 }
 
-/** @experimental */
+/** @stable */
 export declare class HttpHeaders {
     constructor(headers?: string | {
         [name: string]: string | string[];
@@ -1083,12 +1083,12 @@ export declare class HttpHeaders {
     set(name: string, value: string | string[]): HttpHeaders;
 }
 
-/** @experimental */
+/** @stable */
 export interface HttpInterceptor {
     intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>>;
 }
 
-/** @experimental */
+/** @stable */
 export interface HttpParameterCodec {
     decodeKey(key: string): string;
     decodeValue(value: string): string;
@@ -1096,7 +1096,7 @@ export interface HttpParameterCodec {
     encodeValue(value: string): string;
 }
 
-/** @experimental */
+/** @stable */
 export declare class HttpParams {
     constructor(options?: {
         fromString?: string;
@@ -1112,14 +1112,14 @@ export declare class HttpParams {
     toString(): string;
 }
 
-/** @experimental */
+/** @stable */
 export interface HttpProgressEvent {
     loaded: number;
     total?: number;
     type: HttpEventType.DownloadProgress | HttpEventType.UploadProgress;
 }
 
-/** @experimental */
+/** @stable */
 export declare class HttpRequest<T> {
     readonly body: T | null;
     readonly headers: HttpHeaders;
@@ -1188,7 +1188,7 @@ export declare class HttpRequest<T> {
     serializeBody(): ArrayBuffer | Blob | FormData | string | null;
 }
 
-/** @experimental */
+/** @stable */
 export declare class HttpResponse<T> extends HttpResponseBase {
     readonly body: T | null;
     readonly type: HttpEventType.Response;
@@ -1215,7 +1215,7 @@ export declare class HttpResponse<T> extends HttpResponseBase {
     }): HttpResponse<V>;
 }
 
-/** @experimental */
+/** @stable */
 export declare abstract class HttpResponseBase {
     readonly headers: HttpHeaders;
     readonly ok: boolean;
@@ -1231,12 +1231,12 @@ export declare abstract class HttpResponseBase {
     }, defaultStatus?: number, defaultStatusText?: string);
 }
 
-/** @experimental */
+/** @stable */
 export interface HttpSentEvent {
     type: HttpEventType.Sent;
 }
 
-/** @experimental */
+/** @stable */
 export declare class HttpUrlEncodingCodec implements HttpParameterCodec {
     decodeKey(k: string): string;
     decodeValue(v: string): string;
@@ -1244,35 +1244,35 @@ export declare class HttpUrlEncodingCodec implements HttpParameterCodec {
     encodeValue(v: string): string;
 }
 
-/** @experimental */
+/** @stable */
 export interface HttpUserEvent<T> {
     type: HttpEventType.User;
 }
 
-/** @experimental */
+/** @stable */
 export declare class HttpXhrBackend implements HttpBackend {
     constructor(xhrFactory: XhrFactory);
     handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
 }
 
-/** @experimental */
+/** @stable */
 export declare abstract class HttpXsrfTokenExtractor {
     abstract getToken(): string | null;
 }
 
-/** @experimental */
+/** @stable */
 export declare class JsonpClientBackend implements HttpBackend {
     constructor(callbackMap: JsonpCallbackContext, document: any);
     handle(req: HttpRequest<never>): Observable<HttpEvent<any>>;
 }
 
-/** @experimental */
+/** @stable */
 export declare class JsonpInterceptor {
     constructor(jsonp: JsonpClientBackend);
     intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>>;
 }
 
-/** @experimental */
+/** @stable */
 export declare abstract class XhrFactory {
     abstract build(): XMLHttpRequest;
 }

--- a/tools/public_api_guard/common/http/testing.d.ts
+++ b/tools/public_api_guard/common/http/testing.d.ts
@@ -1,8 +1,8 @@
-/** @experimental */
+/** @stable */
 export declare class HttpClientTestingModule {
 }
 
-/** @experimental */
+/** @stable */
 export declare abstract class HttpTestingController {
     abstract expectNone(url: string, description?: string): void;
     abstract expectNone(params: RequestMatch, description?: string): void;
@@ -18,13 +18,13 @@ export declare abstract class HttpTestingController {
     }): void;
 }
 
-/** @experimental */
+/** @stable */
 export interface RequestMatch {
     method?: string;
     url?: string;
 }
 
-/** @experimental */
+/** @stable */
 export declare class TestRequest {
     readonly cancelled: boolean;
     request: HttpRequest<any>;

--- a/tools/public_api_guard/http/http.d.ts
+++ b/tools/public_api_guard/http/http.d.ts
@@ -1,38 +1,38 @@
-/** @experimental */
+/** @deprecated */
 export declare class BaseRequestOptions extends RequestOptions {
     constructor();
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class BaseResponseOptions extends ResponseOptions {
     constructor();
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class BrowserXhr {
     constructor();
     build(): any;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare abstract class Connection {
     readyState: ReadyState;
     request: Request;
     response: any;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare abstract class ConnectionBackend {
     abstract createConnection(request: any): Connection;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class CookieXSRFStrategy implements XSRFStrategy {
     constructor(_cookieName?: string, _headerName?: string);
     configureRequest(req: Request): void;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class Headers {
     constructor(headers?: Headers | {
         [name: string]: any;
@@ -53,7 +53,7 @@ export declare class Headers {
     static fromResponseHeaderString(headersString: string): Headers;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class Http {
     protected _backend: ConnectionBackend;
     protected _defaultOptions: RequestOptions;
@@ -68,21 +68,21 @@ export declare class Http {
     request(url: string | Request, options?: RequestOptionsArgs): Observable<Response>;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class HttpModule {
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class Jsonp extends Http {
     constructor(backend: ConnectionBackend, defaultOptions: RequestOptions);
     request(url: string | Request, options?: RequestOptionsArgs): Observable<Response>;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare abstract class JSONPBackend extends ConnectionBackend {
 }
 
-/** @experimental */
+/** @deprecated */
 export declare abstract class JSONPConnection implements Connection {
     readyState: ReadyState;
     request: Request;
@@ -90,17 +90,17 @@ export declare abstract class JSONPConnection implements Connection {
     abstract finished(data?: any): void;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class JsonpModule {
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class QueryEncoder {
     encodeKey(k: string): string;
     encodeValue(v: string): string;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare enum ReadyState {
     Unsent = 0,
     Open = 1,
@@ -110,7 +110,7 @@ export declare enum ReadyState {
     Cancelled = 5,
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class Request extends Body {
     headers: Headers;
     method: RequestMethod;
@@ -123,7 +123,7 @@ export declare class Request extends Body {
     getBody(): any;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare enum RequestMethod {
     Get = 0,
     Post = 1,
@@ -134,7 +134,7 @@ export declare enum RequestMethod {
     Patch = 6,
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class RequestOptions {
     body: any;
     headers: Headers | null;
@@ -148,7 +148,7 @@ export declare class RequestOptions {
     merge(options?: RequestOptionsArgs): RequestOptions;
 }
 
-/** @experimental */
+/** @deprecated */
 export interface RequestOptionsArgs {
     body?: any;
     headers?: Headers | null;
@@ -164,7 +164,7 @@ export interface RequestOptionsArgs {
     withCredentials?: boolean | null;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class Response extends Body {
     bytesLoaded: number;
     headers: Headers | null;
@@ -178,7 +178,7 @@ export declare class Response extends Body {
     toString(): string;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare enum ResponseContentType {
     Text = 0,
     Json = 1,
@@ -186,7 +186,7 @@ export declare enum ResponseContentType {
     Blob = 3,
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class ResponseOptions {
     body: string | Object | ArrayBuffer | Blob | null;
     headers: Headers | null;
@@ -196,7 +196,7 @@ export declare class ResponseOptions {
     merge(options?: ResponseOptionsArgs): ResponseOptions;
 }
 
-/** @experimental */
+/** @deprecated */
 export interface ResponseOptionsArgs {
     body?: string | Object | FormData | ArrayBuffer | Blob | null;
     headers?: Headers | null;
@@ -206,7 +206,7 @@ export interface ResponseOptionsArgs {
     url?: string | null;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare enum ResponseType {
     Basic = 0,
     Cors = 1,
@@ -215,7 +215,7 @@ export declare enum ResponseType {
     Opaque = 4,
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class URLSearchParams {
     paramsMap: Map<string, string[]>;
     rawParams: string;
@@ -233,16 +233,16 @@ export declare class URLSearchParams {
     toString(): string;
 }
 
-/** @stable */
+/** @deprecated */
 export declare const VERSION: Version;
 
-/** @experimental */
+/** @deprecated */
 export declare class XHRBackend implements ConnectionBackend {
     constructor(_browserXHR: BrowserXhr, _baseResponseOptions: ResponseOptions, _xsrfStrategy: XSRFStrategy);
     createConnection(request: Request): XHRConnection;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class XHRConnection implements Connection {
     readyState: ReadyState;
     request: Request;
@@ -251,7 +251,7 @@ export declare class XHRConnection implements Connection {
     setDetectedContentType(req: any, _xhr: any): void;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare abstract class XSRFStrategy {
     abstract configureRequest(req: Request): void;
 }

--- a/tools/public_api_guard/http/testing.d.ts
+++ b/tools/public_api_guard/http/testing.d.ts
@@ -1,4 +1,4 @@
-/** @experimental */
+/** @deprecated */
 export declare class MockBackend implements ConnectionBackend {
     connections: any;
     connectionsArray: MockConnection[];
@@ -9,7 +9,7 @@ export declare class MockBackend implements ConnectionBackend {
     verifyNoPendingRequests(): void;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class MockConnection implements Connection {
     readyState: ReadyState;
     request: Request;


### PR DESCRIPTION
As of 5.0, @angular/http is deprecated. @angular/common/http will
be the official HTTP API in Angular going forward.
