### PR TITLE
fix(common): use correct group separator for currency pipe

### DIFF
--- a/packages/common/src/i18n/locale_data_api.ts
+++ b/packages/common/src/i18n/locale_data_api.ts
@@ -325,7 +325,7 @@ export function getLocaleNumberSymbol(locale: string, symbol: NumberSymbol): str
     if (symbol === NumberSymbol.CurrencyDecimal) {
       return data[LocaleDataIndex.NumberSymbols][NumberSymbol.Decimal];
     } else if (symbol === NumberSymbol.CurrencyGroup) {
-      return data[LocaleDataIndex.NumberSymbols][NumberSymbol.Decimal];
+      return data[LocaleDataIndex.NumberSymbols][NumberSymbol.Group];
     }
   }
   return res;

--- a/packages/common/test/pipes/number_pipe_spec.ts
+++ b/packages/common/test/pipes/number_pipe_spec.ts
@@ -8,6 +8,7 @@
 
 import localeEn from '../../locales/en';
 import localeEsUS from '../../locales/es-US';
+import localeFr from '../../locales/fr';
 import {registerLocaleData, CurrencyPipe, DecimalPipe, PercentPipe} from '@angular/common';
 import {beforeEach, describe, expect, it} from '@angular/core/testing/src/testing_internal';
 
@@ -16,6 +17,7 @@ export function main() {
     beforeAll(() => {
       registerLocaleData(localeEn);
       registerLocaleData(localeEsUS);
+      registerLocaleData(localeFr);
     });
 
     function isNumeric(value: any): boolean { return !isNaN(value - parseFloat(value)); }
@@ -72,6 +74,8 @@ export function main() {
         it('should return correct value for numbers', () => {
           expect(pipe.transform(1.23)).toEqual('123%');
           expect(pipe.transform(1.2, '.2')).toEqual('120.00%');
+          expect(pipe.transform(1.2, '4.2')).toEqual('0,120.00%');
+          expect(pipe.transform(1.2, '4.2', 'fr')).toEqual('0 120,00 %');
         });
 
         it('should not support other objects',
@@ -93,6 +97,9 @@ export function main() {
           expect(pipe.transform(5.1234, 'USD', 'symbol')).toEqual('$5.12');
           expect(pipe.transform(5.1234, 'CAD', 'symbol')).toEqual('CA$5.12');
           expect(pipe.transform(5.1234, 'CAD', 'symbol-narrow')).toEqual('$5.12');
+          expect(pipe.transform(5.1234, 'CAD', 'symbol-narrow', '5.2-2')).toEqual('$00,005.12');
+          expect(pipe.transform(5.1234, 'CAD', 'symbol-narrow', '5.2-2', 'fr'))
+              .toEqual('00 005,12 $');
         });
 
         it('should not support other objects',


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
```

## What is the current behavior?
The currency pipe used the wrong group separator

## What is the new behavior?
It uses the correct group separator. I added more tests to avoid further problems of the same kind.

## Does this PR introduce a breaking change?
```
[x] No
```