### PR TITLE
fix(common): update closure-locale generation for tree shaking

### DIFF
--- a/packages/common/locales/closure-locale.ts
+++ b/packages/common/locales/closure-locale.ts
@@ -13,7 +13,7 @@ import {registerLocaleData} from '../src/i18n/locale_data';
 
 let l: any;
 
-switch (goog.LOCALE.replace(/_/g, '-')) {
+switch (goog.LOCALE) {
   case 'af':
     l = [
       'af',
@@ -3058,6 +3058,7 @@ switch (goog.LOCALE.replace(/_/g, '-')) {
     break;
   case 'mo':
   case 'ro-MD':
+  case 'ro_MD':
     l = [
       'ro-MD',
       [
@@ -3373,6 +3374,7 @@ switch (goog.LOCALE.replace(/_/g, '-')) {
   case 'no':
   case 'nb':
   case 'no-NO':
+  case 'no_NO':
     l = [
       'nb',
       [
@@ -3570,6 +3572,7 @@ switch (goog.LOCALE.replace(/_/g, '-')) {
     break;
   case 'pt':
   case 'pt-BR':
+  case 'pt_BR':
     l = [
       'pt',
       [
@@ -3772,6 +3775,7 @@ switch (goog.LOCALE.replace(/_/g, '-')) {
     break;
   case 'sh':
   case 'sr-Latn':
+  case 'sr_Latn':
     l = [
       'sr-Latn',
       [
@@ -4640,7 +4644,9 @@ switch (goog.LOCALE.replace(/_/g, '-')) {
   case 'zh-CN':
   case 'zh_CN':
   case 'zh-Hans-CN':
+  case 'zh_Hans_CN':
   case 'zh-Hans':
+  case 'zh_Hans':
     l = [
       'zh-Hans',
       [
@@ -4683,7 +4689,9 @@ switch (goog.LOCALE.replace(/_/g, '-')) {
   case 'zh-HK':
   case 'zh_HK':
   case 'zh-Hant-HK':
+  case 'zh_Hant_HK':
   case 'zh-Hant':
+  case 'zh_Hant':
     l = [
       'zh-Hant',
       [
@@ -4722,7 +4730,9 @@ switch (goog.LOCALE.replace(/_/g, '-')) {
   case 'zh-TW':
   case 'zh_TW':
   case 'zh-Hant-TW':
+  case 'zh_Hant_TW':
   case 'zh-Hant':
+  case 'zh_Hant':
     l = [
       'zh-Hant',
       [

--- a/packages/common/src/i18n/locale_data.ts
+++ b/packages/common/src/i18n/locale_data.ts
@@ -18,7 +18,7 @@ export const LOCALE_DATA: {[localeId: string]: any} = {};
  * @experimental i18n support is experimental.
  */
 export function registerLocaleData(data: any, extraData?: any) {
-  const localeId = data[LocaleDataIndex.LocaleId].toLowerCase();
+  const localeId = data[LocaleDataIndex.LocaleId].toLowerCase().replace(/_/g, '-');
   LOCALE_DATA[localeId] = data;
   if (extraData) {
     LOCALE_DATA[localeId][LocaleDataIndex.ExtraData] = extraData;

--- a/tools/gulp-tasks/cldr/closure.js
+++ b/tools/gulp-tasks/cldr/closure.js
@@ -74,13 +74,17 @@ function generateAllLocalesFile(LOCALES, ALIASES) {
     let localeData;
     const equivalentLocales = [locale];
     if (locale.match(/-/)) {
-      equivalentLocales.push(locale.replace('-', '_'));
+      equivalentLocales.push(locale.replace(/-/g, '_'));
     }
 
     // check for aliases
     const alias = ALIASES[locale];
     if (alias) {
       equivalentLocales.push(alias);
+
+      if (alias.match(/-/)) {
+        equivalentLocales.push(alias.replace(/-/g, '_'));
+      }
 
       // to avoid duplicated "case" we regroup all locales in the same "case"
       // the simplest way to do that is to have alias aliases
@@ -91,6 +95,10 @@ function generateAllLocalesFile(LOCALES, ALIASES) {
         const aliasValue = ALIASES[alias];
         if (aliasKeys.indexOf(alias) !== -1 && equivalentLocales.indexOf(aliasValue) === -1) {
           equivalentLocales.push(aliasValue);
+
+          if (aliasValue.match(/-/)) {
+            equivalentLocales.push(aliasValue.replace(/-/g, '_'));
+          }
         }
       }
     }
@@ -114,7 +122,7 @@ import {registerLocaleData} from '../src/i18n/locale_data';
 
 let l: any;
 
-switch (goog.LOCALE.replace(/_/g, '-')) {
+switch (goog.LOCALE) {
 ${LOCALES.map(locale => generateCases(locale)).join('')}}
 
 if(l) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Build related changes
[x] Bug fixes
```

## What is the current behavior?
Wrong code in closure-locale generation script that prevents tree shaking

## What is the new behavior?
Fixed the script

## Does this PR introduce a breaking change?
```
[x] No
```