### PR TITLE
refactor(compiler-cli): expose ngtools api separately

### DIFF
--- a/packages/compiler-cli/ngtools2.ts
+++ b/packages/compiler-cli/ngtools2.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export {CompilerHost, CustomTransformers, Diagnostic, EmitFlags, Program, createCompilerHost, createProgram, formatDiagnostics} from './src/ngtools_api2';

--- a/packages/compiler-cli/src/ngtools_api2.ts
+++ b/packages/compiler-cli/src/ngtools_api2.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * This is a private API for @ngtools/webpack. This API should be stable for NG 5.
+ *
+ * It contains copies of the interfaces needed and wrapper functions to ensure that
+ * they are not broken accidentally.
+ *
+ * Once the ngc api is public and stable, this can be removed.
+ */
+
+import {ParseSourceSpan} from '@angular/compiler';
+import * as ts from 'typescript';
+
+import {formatDiagnostics as formatDiagnosticsOrig} from './perform-compile';
+import {createCompilerHost as createCompilerOrig} from './transformers/compiler_host';
+import {createProgram as createProgramOrig} from './transformers/program';
+
+// Interfaces from ./transformers/api;
+export interface Diagnostic {
+  message: string;
+  span?: ParseSourceSpan;
+  category: ts.DiagnosticCategory;
+}
+
+export interface CompilerOptions extends ts.CompilerOptions {
+  basePath?: string;
+  skipMetadataEmit?: boolean;
+  strictMetadataEmit?: boolean;
+  skipTemplateCodegen?: boolean;
+  flatModuleOutFile?: string;
+  flatModuleId?: string;
+  generateCodeForLibraries?: boolean;
+  annotateForClosureCompiler?: boolean;
+  annotationsAs?: 'decorators'|'static fields';
+  trace?: boolean;
+  enableLegacyTemplate?: boolean;
+  disableExpressionLowering?: boolean;
+  i18nOutLocale?: string;
+  i18nOutFormat?: string;
+  i18nOutFile?: string;
+  i18nInFormat?: string;
+  i18nInLocale?: string;
+  i18nInFile?: string;
+  i18nInMissingTranslations?: 'error'|'warning'|'ignore';
+  preserveWhitespaces?: boolean;
+}
+
+export interface CompilerHost extends ts.CompilerHost {
+  moduleNameToFileName(moduleName: string, containingFile?: string): string|null;
+  fileNameToModuleName(importedFilePath: string, containingFilePath: string): string|null;
+  resourceNameToFileName(resourceName: string, containingFilePath: string): string|null;
+  toSummaryFileName(fileName: string, referringSrcFileName: string): string;
+  fromSummaryFileName(fileName: string, referringLibFileName: string): string;
+  readResource?(fileName: string): Promise<string>|string;
+}
+
+export enum EmitFlags {
+  DTS = 1 << 0,
+  JS = 1 << 1,
+
+  Default = DTS | JS
+}
+
+export interface CustomTransformers {
+  beforeTs?: ts.TransformerFactory<ts.SourceFile>[];
+  afterTs?: ts.TransformerFactory<ts.SourceFile>[];
+}
+
+export interface TsEmitArguments {
+  program: ts.Program;
+  host: CompilerHost;
+  options: CompilerOptions;
+  targetSourceFile?: ts.SourceFile;
+  writeFile?: ts.WriteFileCallback;
+  cancellationToken?: ts.CancellationToken;
+  emitOnlyDtsFiles?: boolean;
+  customTransformers?: ts.CustomTransformers;
+}
+
+export interface TsEmitCallback { (args: TsEmitArguments): ts.EmitResult; }
+
+export interface Program {
+  getTsProgram(): ts.Program;
+  getTsOptionDiagnostics(cancellationToken?: ts.CancellationToken): ts.Diagnostic[];
+  getNgOptionDiagnostics(cancellationToken?: ts.CancellationToken): Diagnostic[];
+  getTsSyntacticDiagnostics(sourceFile?: ts.SourceFile, cancellationToken?: ts.CancellationToken):
+      ts.Diagnostic[];
+  getNgStructuralDiagnostics(cancellationToken?: ts.CancellationToken): Diagnostic[];
+  getTsSemanticDiagnostics(sourceFile?: ts.SourceFile, cancellationToken?: ts.CancellationToken):
+      ts.Diagnostic[];
+  getNgSemanticDiagnostics(fileName?: string, cancellationToken?: ts.CancellationToken):
+      Diagnostic[];
+  loadNgStructureAsync(): Promise<void>;
+  emit({emitFlags, cancellationToken, customTransformers, emitCallback}: {
+    emitFlags?: EmitFlags,
+    cancellationToken?: ts.CancellationToken,
+    customTransformers?: CustomTransformers,
+    emitCallback?: TsEmitCallback
+  }): ts.EmitResult;
+}
+
+// Wrapper for createProgram.
+export function createProgram(
+    {rootNames, options, host, oldProgram}:
+        {rootNames: string[], options: CompilerOptions, host: CompilerHost, oldProgram?: Program}):
+    Program {
+  return createProgramOrig({rootNames, options, host, oldProgram});
+}
+
+// Wrapper for createCompilerHost.
+export function createCompilerHost(
+    {options, tsHost = ts.createCompilerHost(options, true)}:
+        {options: CompilerOptions, tsHost?: ts.CompilerHost}): CompilerHost {
+  return createCompilerOrig({options, tsHost});
+}
+
+// Wrapper for formatDiagnostics.
+export type Diagnostics = Array<ts.Diagnostic|Diagnostic>;
+export function formatDiagnostics(options: CompilerOptions, diags: Diagnostics): string {
+  return formatDiagnosticsOrig(options, diags);
+}

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -245,13 +245,6 @@ export interface Program {
   loadNgStructureAsync(): Promise<void>;
 
   /**
-   * Retrieve the lazy route references in the program.
-   *
-   * Angular structural information is required to produce these routes.
-   */
-  getLazyRoutes(cancellationToken?: ts.CancellationToken): {[route: string]: string};
-
-  /**
    * Emit the files requested by emitFlags implied by the program.
    *
    * Angular structural information is required to emit files.

--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -130,8 +130,6 @@ class AngularCompilerProgram implements Program {
         });
   }
 
-  getLazyRoutes(cancellationToken?: ts.CancellationToken): {[route: string]: string} { return {}; }
-
   emit({emitFlags = EmitFlags.Default, cancellationToken, customTransformers,
         emitCallback = defaultEmitCallback}: {
     emitFlags?: EmitFlags,

--- a/packages/compiler-cli/tsconfig-build.json
+++ b/packages/compiler-cli/tsconfig-build.json
@@ -26,6 +26,7 @@
   ],
   "files": [
     "index.ts",
+    "ngtools2.ts",
     "src/main.ts",
     "src/extract_i18n.ts",
     "src/language_services.ts",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Private APIs needed for `@ngtools/webpack` were in exported from public APIs in `compiler-cli`.

## What is the new behavior?
Private APIs are exported exclusively through `@angular/compiler-cli/ngtools2`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
/cc @tbosch 