### PR TITLE
fix(compiler-cli): fix memory leaks in watch mode

### DIFF
--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -55,7 +55,7 @@ class AngularCompilerProgram implements Program {
 
   constructor(
       private rootNames: string[], private options: CompilerOptions, private host: CompilerHost,
-      private oldProgram?: Program) {
+      oldProgram?: Program) {
     if (options.flatModuleOutFile && !options.skipMetadataEmit) {
       const {host: bundleHost, indexName, errors} = createBundleIndexHost(options, rootNames, host);
       if (errors) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Watch-mode leaks an `AngularCompilerProgram` and everything it references per-compile which cause a massive memory leak.

## What is the new behavior?

The old program is now not retained by the new program allowing it to be collected.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
