### PR TITLE
refactor(core): remove deprecated `OpaqueToken`

### DIFF
--- a/aio/content/examples/dependency-injection/e2e-spec.ts
+++ b/aio/content/examples/dependency-injection/e2e-spec.ts
@@ -117,7 +117,7 @@ describe('Dependency Injection Tests', function () {
       expect(element(by.css('#p8')).getText()).toEqual(expectedMsg);
     });
 
-    it('P9 (OpaqueToken) displays as expected', function () {
+    it('P9 (InjectionToken) displays as expected', function () {
       expectedMsg = 'APP_CONFIG Application title is Dependency Injection';
       expect(element(by.css('#p9')).getText()).toEqual(expectedMsg);
     });

--- a/aio/content/guide/metadata.md
+++ b/aio/content/guide/metadata.md
@@ -280,13 +280,7 @@ Most importantly, the compiler only generates code to create instances of certai
 
 ### New instances
 
-The compiler only allows metadata that create instances of these Angular classes.
-
-Class            | Module
------------------|--------------
-`OpaqueToken`    | `@angular/core`
-`InjectionToken` | `@angular/core`
-
+The compiler only allows metadata that create instances of the class `InjectionToken` from `@angular/core`.
 
 ### Annotations/Decorators
 

--- a/packages/compiler-cli/integrationtest/src/module.ts
+++ b/packages/compiler-cli/integrationtest/src/module.ts
@@ -8,8 +8,8 @@
 
 import {ApplicationRef, NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
+import {MATERIAL_SANITY_CHECKS, MdButtonModule} from '@angular/material';
 import {ServerModule} from '@angular/platform-server';
-import {MdButtonModule} from '@angular2-material/button';
 import {FlatModule} from 'flat_module';
 // Note: don't refer to third_party_src as we want to test that
 // we can compile components from node_modules!
@@ -69,6 +69,9 @@ export {SomeModule as JitSummariesSomeModule} from './jit_summaries';
   providers: [
     SomeService,
     {provide: CUSTOM, useValue: {name: 'some name'}},
+    // disable sanity check for material because it throws an error when used server-side
+    // see https://github.com/angular/material2/issues/6292
+    {provide: MATERIAL_SANITY_CHECKS, useValue: false},
   ],
   entryComponents: [
     AnimateCmp,

--- a/packages/compiler-cli/integrationtest/test/basic_spec.ts
+++ b/packages/compiler-cli/integrationtest/test/basic_spec.ts
@@ -37,8 +37,7 @@ describe('template codegen output', () => {
   });
 
   it('should write .ngfactory.js for .d.ts inputs', () => {
-    const factoryOutput =
-        path.join('node_modules', '@angular2-material', 'button', 'button.ngfactory.js');
+    const factoryOutput = path.join('node_modules', '@angular', 'common', 'index.ngfactory.js');
     expect(fs.existsSync(factoryOutput)).toBeTruthy();
   });
 

--- a/packages/compiler/src/aot/static_reflector.ts
+++ b/packages/compiler/src/aot/static_reflector.ts
@@ -44,7 +44,6 @@ export class StaticReflector implements CompileReflector {
   private methodCache = new Map<StaticSymbol, {[key: string]: boolean}>();
   private conversionMap = new Map<StaticSymbol, (context: StaticSymbol, args: any[]) => any>();
   private injectionToken: StaticSymbol;
-  private opaqueToken: StaticSymbol;
   private ROUTES: StaticSymbol;
   private ANALYZE_FOR_ENTRY_COMPONENTS: StaticSymbol;
   private annotationForParentClassWithSummaryKind =
@@ -271,7 +270,6 @@ export class StaticReflector implements CompileReflector {
 
   private initializeConversionMap(): void {
     this.injectionToken = this.findDeclaration(ANGULAR_CORE, 'InjectionToken');
-    this.opaqueToken = this.findDeclaration(ANGULAR_CORE, 'OpaqueToken');
     this.ROUTES = this.tryFindDeclaration(ANGULAR_ROUTER, 'ROUTES');
     this.ANALYZE_FOR_ENTRY_COMPONENTS =
         this.findDeclaration(ANGULAR_CORE, 'ANALYZE_FOR_ENTRY_COMPONENTS');
@@ -435,8 +433,8 @@ export class StaticReflector implements CompileReflector {
         }
         if (expression instanceof StaticSymbol) {
           // Stop simplification at builtin symbols or if we are in a reference context
-          if (expression === self.injectionToken || expression === self.opaqueToken ||
-              self.conversionMap.has(expression) || references > 0) {
+          if (expression === self.injectionToken || self.conversionMap.has(expression) ||
+              references > 0) {
             return expression;
           } else {
             const staticSymbol = expression;
@@ -563,7 +561,7 @@ export class StaticReflector implements CompileReflector {
                 staticSymbol = simplifyInContext(
                     context, expression['expression'], depth + 1, /* references */ 0);
                 if (staticSymbol instanceof StaticSymbol) {
-                  if (staticSymbol === self.injectionToken || staticSymbol === self.opaqueToken) {
+                  if (staticSymbol === self.injectionToken) {
                     // if somebody calls new InjectionToken, don't create an InjectionToken,
                     // but rather return the symbol to which the InjectionToken is assigned to.
                     return context;

--- a/packages/core/src/di.ts
+++ b/packages/core/src/di.ts
@@ -21,4 +21,4 @@ export {ReflectiveInjector} from './di/reflective_injector';
 export {StaticProvider, ValueProvider, ExistingProvider, FactoryProvider, Provider, TypeProvider, ClassProvider} from './di/provider';
 export {ResolvedReflectiveFactory, ResolvedReflectiveProvider} from './di/reflective_provider';
 export {ReflectiveKey} from './di/reflective_key';
-export {InjectionToken, OpaqueToken} from './di/injection_token';
+export {InjectionToken} from './di/injection_token';

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -9,35 +9,6 @@
 /**
  * Creates a token that can be used in a DI Provider.
  *
- * ### Example ([live demo](http://plnkr.co/edit/Ys9ezXpj2Mnoy3Uc8KBp?p=preview))
- *
- * ```typescript
- * var t = new OpaqueToken("value");
- *
- * var injector = Injector.resolveAndCreate([
- *   {provide: t, useValue: "bindingValue"}
- * ]);
- *
- * expect(injector.get(t)).toEqual("bindingValue");
- * ```
- *
- * Using an `OpaqueToken` is preferable to using strings as tokens because of possible collisions
- * caused by multiple providers using the same string as two different tokens.
- *
- * Using an `OpaqueToken` is preferable to using an `Object` as tokens because it provides better
- * error messages.
- * @deprecated since v4.0.0 because it does not support type information, use `InjectionToken<?>`
- * instead.
- */
-export class OpaqueToken {
-  constructor(protected _desc: string) {}
-
-  toString(): string { return `Token ${this._desc}`; }
-}
-
-/**
- * Creates a token that can be used in a DI Provider.
- *
  * Use an `InjectionToken` whenever the type you are injecting is not reified (does not have a
  * runtime representation) such as when injecting an interface, callable type, array or
  * parametrized type.
@@ -57,11 +28,8 @@ export class OpaqueToken {
  *
  * @stable
  */
-export class InjectionToken<T> extends OpaqueToken {
-  // This unused property is needed here so that TS can differentiate InjectionToken from
-  // OpaqueToken since otherwise they would have the same shape and be treated as equivalent.
-  private _differentiate_from_OpaqueToken_structurally: any;
-  constructor(desc: string) { super(desc); }
+export class InjectionToken<T> {
+  constructor(protected _desc: string) {}
 
   toString(): string { return `InjectionToken ${this._desc}`; }
 

--- a/packages/tsc-wrapped/test/collector_spec.ts
+++ b/packages/tsc-wrapped/test/collector_spec.ts
@@ -734,10 +734,8 @@ describe('Collector', () => {
   it('should treat exported class expressions as a class', () => {
     const source = ts.createSourceFile(
         '', `
-    export const InjectionToken: {new<T>(desc: string): InjectionToken<T>;} = class extends OpaqueToken {
-      constructor(desc: string) {
-        super(desc);
-      }
+    export const InjectionToken: {new<T>(desc: string): InjectionToken<T>;} = class {
+      constructor(protected _desc: string) {}
 
       toString(): string { return \`InjectionToken ${this._desc}\`; }
     } as any;`,

--- a/scripts/ci/offline_compiler_test.sh
+++ b/scripts/ci/offline_compiler_test.sh
@@ -17,7 +17,7 @@ PKGS=(
   jasmine@2.4.1
   webpack@2.1.0-beta.21
   source-map-loader@0.2.0
-  @angular2-material/{core,button}@2.0.0-alpha.8-1
+  @angular/{material,cdk}@2.0.0-beta.10
 )
 
 TMPDIR=${TMPDIR:-.}

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -465,8 +465,9 @@ export interface InjectDecorator {
 }
 
 /** @stable */
-export declare class InjectionToken<T> extends OpaqueToken {
-    constructor(desc: string);
+export declare class InjectionToken<T> {
+    protected _desc: string;
+    constructor(_desc: string);
     toString(): string;
 }
 
@@ -659,13 +660,6 @@ export interface OnDestroy {
 /** @stable */
 export interface OnInit {
     ngOnInit(): void;
-}
-
-/** @deprecated */
-export declare class OpaqueToken {
-    protected _desc: string;
-    constructor(_desc: string);
-    toString(): string;
 }
 
 /** @stable */


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Other... Please describe: removing deprecated code
```

## What is the current behavior?
`OpaqueToken` was deprecated since v4.

## What is the new behavior?
`OpaqueToken` has been removed. Use `InjectionToken` instead.

## Does this PR introduce a breaking change?
```
[x] Yes
```

## Other informations
I had to update the dependencies for angular material in the integration test, because the old version was still using `OpaqueToken`