### PR TITLE
fix(compiler-cli): use `--locale` parameter for transformers

### DIFF
--- a/packages/compiler-cli/integrationtest/tsconfig-build.json
+++ b/packages/compiler-cli/integrationtest/tsconfig-build.json
@@ -6,7 +6,6 @@
     "debug": true,
     "enableSummariesForJit": true,
     "alwaysCompileGeneratedCode": true,
-    "locale": "fi",
     "i18nFormat": "xlf"
   },
 

--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -97,6 +97,9 @@ function readCommandLineAndConfiguration(args: any): ParsedConfiguration {
   const allDiagnostics: Diagnostics = [];
   const config = readConfiguration(project);
   const options = mergeCommandLineParams(args, config.options);
+  if (options.locale) {
+    options.i18nInLocale = options.locale;
+  }
   return {project, rootNames: config.rootNames, options, errors: config.errors};
 }
 

--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -336,7 +336,7 @@ function getAotCompilerOptions(options: CompilerOptions): AotCompilerOptions {
   let translations: string = '';
 
   if (options.i18nInFile) {
-    if (!options.locale) {
+    if (!options.i18nInLocale) {
       throw new Error(`The translation file (${options.i18nInFile}) locale must be provided.`);
     }
     translations = fs.readFileSync(options.i18nInFile, 'utf8');


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
```

## What is the current behavior?
The `--locale` parameter doesn't work with the new ngc transformers (Thank you @cexbrayat for reporting this)

## What is the new behavior?
The `--locale` parameter works again by transferring its value into the new `i18nInLocale` option.
I've removed the locale parameter from "tsconfig-build.json" so that it doesn't override the "--locale" parameter and throw an error if you don't provide it with your translations (it was the reason why this bug was never caught by the integration tests)

## Does this PR introduce a breaking change?
```
[x] No
```