### PR TITLE
feat(compiler): deprecate i18n comments in favor of `ng-container`

### DIFF
--- a/aio/content/examples/i18n/e2e-spec.ts
+++ b/aio/content/examples/i18n/e2e-spec.ts
@@ -14,7 +14,6 @@ describe('i18n E2E Tests', () => {
 
   it('should display the node texts without elements', function () {
     expect(element(by.css('my-app')).getText()).toContain('No genero ningún elemento');
-    expect(element(by.css('my-app')).getText()).toContain('Yo tampoco genero ningún elemento');
   });
 
   it('should display the translated title attribute', function () {

--- a/aio/content/examples/i18n/src/app/app.component.html
+++ b/aio/content/examples/i18n/src/app/app.component.html
@@ -11,14 +11,6 @@
 
 <br />
 
-<!--#docregion i18n-with-comment-->
-<!--i18n: optional meaning|optional description -->
-I don't output any element either
-<!--/i18n-->
-<!--#enddocregion i18n-with-comment-->
-
-<br />
-
 <!--#docregion i18n-title-translate-->
 <img [src]="logo" i18n-title title="Angular logo" />
 <!--#enddocregion i18n-title-translate-->

--- a/aio/content/examples/i18n/src/locale/messages.es.xlf
+++ b/aio/content/examples/i18n/src/locale/messages.es.xlf
@@ -12,14 +12,6 @@
         <source>I don&apos;t output any element</source>
         <target>No genero ningún elemento</target>
       </trans-unit>
-      <trans-unit id="df3cf8b55cb528cf8c00167e0b119bfb828538b5" datatype="html">
-        <source>
-I don&apos;t output any element either
-</source>
-        <target>Yo tampoco genero ningún elemento</target>
-        <note priority="1" from="description">optional description</note>
-        <note priority="1" from="meaning">optional meaning</note>
-      </trans-unit>
       <trans-unit id="701174153757adf13e7c24a248c8a873ac9f5193" datatype="html">
         <source>Angular logo</source>
         <target>Logo de Angular</target>

--- a/aio/content/examples/i18n/src/locale/messages.es.xlf.html
+++ b/aio/content/examples/i18n/src/locale/messages.es.xlf.html
@@ -21,12 +21,6 @@
         <source>I don&apos;t output any element</source>
         <target>No genero ningún elemento</target>
       </trans-unit>
-      <trans-unit id="df3cf8b55cb528cf8c00167e0b119bfb828538b5" datatype="html">
-        <source>I don&apos;t output any element either</source>
-        <target>Yo tampoco genero ningún elemento</target>
-        <note priority="1" from="description">optional description</note>
-        <note priority="1" from="meaning">optional meaning</note>
-      </trans-unit>
       <trans-unit id="701174153757adf13e7c24a248c8a873ac9f5193" datatype="html">
         <source>Angular logo</source>
         <target>Logo de Angular</target>

--- a/aio/content/guide/i18n.md
+++ b/aio/content/guide/i18n.md
@@ -178,20 +178,12 @@ Here is a _meaning_ and a _description_ and the _id_ at the end:
 
 ### Translate text without creating an element
 
-Suppose there is a stretch of text that you'd like to translate.
-You could wrap it in a `<span>` tag but for some reason (CSS comes to mind)
-you don't want to create a new DOM element merely to facilitate translation.
-
-Here are two techniques to try.
-
-(1) Wrap the text in an `<ng-container>` element. The `<ng-container>` is never rendered:
+If there is a stretch of text that you'd like to translate, you could wrap it in a `<span>` tag.
+But if you don't want to create a new DOM element merely to facilitate translation,
+you can wrap the text in an `<ng-container>` element.
+The `<ng-container>` will be transformed into an html comment:
 
 <code-example path="i18n/src/app/app.component.html" region="i18n-ng-container" title="src/app/app.component.html" linenums="false">
-</code-example>
-
-(2) Wrap the text in a pair of HTML comments:
-
-<code-example path="i18n/src/app/app.component.html" region="i18n-with-comment" title="src/app/app.component.html" linenums="false">
 </code-example>
 
 {@a translate-attributes}

--- a/packages/compiler/src/i18n/extractor_merger.ts
+++ b/packages/compiler/src/i18n/extractor_merger.ts
@@ -9,7 +9,6 @@
 import * as html from '../ml_parser/ast';
 import {InterpolationConfig} from '../ml_parser/interpolation_config';
 import {ParseTreeResult} from '../ml_parser/parser';
-
 import * as i18n from './i18n_ast';
 import {createI18nMessageFactory} from './i18n_parser';
 import {I18nError} from './parse_util';
@@ -20,6 +19,7 @@ const _I18N_ATTR_PREFIX = 'i18n-';
 const _I18N_COMMENT_PREFIX_REGEXP = /^i18n:?/;
 const MEANING_SEPARATOR = '|';
 const ID_SEPARATOR = '@@';
+let i18nCommentsWarned = false;
 
 /**
  * Extract translatable messages from an html AST
@@ -176,6 +176,14 @@ class _Visitor implements html.Visitor {
     if (!this._inI18nNode && !this._inIcu) {
       if (!this._inI18nBlock) {
         if (isOpening) {
+          // deprecated from v5 you should use <ng-container i18n> instead of i18n comments
+          if (!i18nCommentsWarned && <any>console && <any>console.warn) {
+            i18nCommentsWarned = true;
+            const details = comment.sourceSpan.details ? `, ${comment.sourceSpan.details}` : '';
+            // TODO(ocombe): use a log service once there is a public one available
+            console.warn(
+                `I18n comments are deprecated, use an <ng-container> element instead (${comment.sourceSpan.start}${details})`);
+          }
           this._inI18nBlock = true;
           this._blockStartDepth = this._depth;
           this._blockChildren = [];


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Feature
```

## What is the current behavior?
I18n comments require a lot of code to work, it's a big effort to maintain and it can easily be replaced by `<ng-container i18n></ng-container>`

## What is the new behavior?
I18n comments have been deprecated and will print a warning in dev mode

## Does this PR introduce a breaking change?
```
[x] No
```