### PR TITLE
refactor(compiler-cli): update generation of browser compiler bundle

### DIFF
--- a/packages/compiler-cli/browser-rollup.config.js
+++ b/packages/compiler-cli/browser-rollup.config.js
@@ -18,7 +18,7 @@ var tslibLocation = normalize('../../node_modules/tslib');
 var esm = 'esm/';
 
 var locations = {
-  'tsc-wrapped': normalize('../../dist/tools/@angular') + '/',
+  'tsc-wrapped': normalize('../../dist/packages-dist') + '/',
   'compiler-cli': normalize('../../dist/packages') + '/'
 };
 
@@ -41,7 +41,8 @@ function resolve(id, from) {
     var esm_suffix = esm_suffixes[packageName] || '';
     var loc = locations[packageName] || location;
     var r = loc !== location && (loc + esm_suffix + packageName + (match[3] || '/index') + '.js') ||
-        loc + packageName + '/@angular/' + packageName + '.es5.js';
+        loc + packageName + '/esm5/' +
+            'index.js';
     // console.log('** ANGULAR MAPPED **: ', r);
     return r;
   }
@@ -55,10 +56,17 @@ function resolve(id, from) {
 }
 
 // hack to get around issues with default exports
-var banner = `ts['default'] = ts['default'] || ts; fs['default'] = fs['default'] || fs;`;
+var banner = `
+ts['default'] = ts['default'] || ts; fs['default'] = fs['default'] || fs;
+var commonjsHelpers = {
+  unwrapExports: function (x) {
+    return x && x.__esModule ? x['default'] : x;
+  }
+};
+`;
 
 export default {
-  entry: '../../dist/packages-dist/compiler-cli/src/ngc.js',
+  entry: '../../dist/packages-dist/compiler-cli/index.js',
   dest: './browser-bundle.umd.js',
   format: 'umd',
   moduleName: 'ng.compiler_cli_browser',

--- a/packages/compiler-cli/index.ts
+++ b/packages/compiler-cli/index.ts
@@ -18,7 +18,7 @@ export {getClassMembersFromDeclaration, getPipesTable, getSymbolQuery} from './s
 export {BuiltinType, DeclarationKind, Definition, PipeInfo, Pipes, Signature, Span, Symbol, SymbolDeclaration, SymbolQuery, SymbolTable} from './src/diagnostics/symbols';
 
 export * from './src/transformers/api';
-export * from './src/transformers/entry_points';
+export {createCompilerHost, createProgram} from './src/transformers/entry_points';
 
 export {performCompilation, readConfiguration, formatDiagnostics, calcProjectFileAndBasePath, createNgCompilerOptions} from './src/perform_compile';
 

--- a/packages/tsc-wrapped/src/collector.ts
+++ b/packages/tsc-wrapped/src/collector.ts
@@ -12,6 +12,10 @@ import {Evaluator, errorSymbol} from './evaluator';
 import {ClassMetadata, ConstructorMetadata, FunctionMetadata, InterfaceMetadata, MemberMetadata, MetadataEntry, MetadataError, MetadataMap, MetadataSymbolicBinaryExpression, MetadataSymbolicCallExpression, MetadataSymbolicExpression, MetadataSymbolicIfExpression, MetadataSymbolicIndexExpression, MetadataSymbolicPrefixExpression, MetadataSymbolicReferenceExpression, MetadataSymbolicSelectExpression, MetadataSymbolicSpreadExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata, VERSION, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataSymbolicExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSelectExpression, isMethodMetadata} from './schema';
 import {Symbols} from './symbols';
 
+// hack for the browser bundle to get around thinking objects from ./schema are defined here
+export {ClassMetadata, ConstructorMetadata, FunctionMetadata, InterfaceMetadata, MemberMetadata, MetadataEntry, MetadataError, MetadataMap, MetadataSymbolicBinaryExpression, MetadataSymbolicCallExpression, MetadataSymbolicExpression, MetadataSymbolicIfExpression, MetadataSymbolicIndexExpression, MetadataSymbolicPrefixExpression, MetadataSymbolicReferenceExpression, MetadataSymbolicSelectExpression, MetadataSymbolicSpreadExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata, VERSION, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataSymbolicExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSelectExpression, isMethodMetadata} from './schema';
+
+
 // In TypeScript 2.1 these flags moved
 // These helpers work for both 2.0 and 2.1.
 const isExport = (ts as any).ModifierFlags ?


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Update the browser.rollup.config.js for the compiler-cli to use new compiler API. Some modifications to exports to support this.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Browser compiler bundle rollup config does not properly generate a umd of the compiler.

Issue Number: N/A


## What is the new behavior?

Browser compiler bundle rollup config updated to properly generate bundle.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
