### PR TITLE
feat(platform-server): add hook for before renderToString

### DIFF
--- a/packages/platform-server/src/platform-server.ts
+++ b/packages/platform-server/src/platform-server.ts
@@ -8,7 +8,7 @@
 
 export {PlatformState} from './platform_state';
 export {ServerModule, platformDynamicServer, platformServer} from './server';
-export {INITIAL_CONFIG, PlatformConfig} from './tokens';
+export {INITIAL_CONFIG, PlatformConfig, SERVER_BEFORE_RENDER_LISTENER} from './tokens';
 export {renderModule, renderModuleFactory} from './utils';
 
 export * from './private_export';

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -21,7 +21,7 @@ import {ServerPlatformLocation} from './location';
 import {PlatformState} from './platform_state';
 import {ServerRendererFactory2} from './server_renderer';
 import {ServerStylesHost} from './styles_host';
-import {INITIAL_CONFIG, PlatformConfig} from './tokens';
+import {INITIAL_CONFIG, PlatformConfig, SERVER_BEFORE_RENDER_LISTENER} from './tokens';
 
 function notSupported(feature: string): Error {
   throw new Error(`platform-server does not support '${feature}'.`);

--- a/packages/platform-server/src/tokens.ts
+++ b/packages/platform-server/src/tokens.ts
@@ -7,6 +7,7 @@
  */
 
 import {InjectionToken} from '@angular/core';
+import {Observable} from 'rxjs/Observable';
 
 /**
  * Config object passed to initialize the platform.
@@ -24,3 +25,11 @@ export interface PlatformConfig {
  * @experimental
  */
 export const INITIAL_CONFIG = new InjectionToken<PlatformConfig>('Server.INITIAL_CONFIG');
+
+/**
+ * The DI token for registering functions to be run before rendering the module to string
+ *
+ * @experimental
+ */
+export const SERVER_BEFORE_RENDER_LISTENER =
+    new InjectionToken<(() => Observable<any>| Promise<any>| void)[]>('Server.RENDER_HOOK');

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -723,7 +723,7 @@ export declare class QueryList<T> {
     readonly first: T;
     readonly last: T;
     readonly length: number;
-    destroy(): void
+    destroy(): void;
     filter(fn: (item: T, index: number, array: T[]) => boolean): T[];
     find(fn: (item: T, index: number, array: T[]) => boolean): T | undefined;
     forEach(fn: (item: T, index: number, array: T[]) => void): void;

--- a/tools/public_api_guard/platform-server/index.d.ts
+++ b/tools/public_api_guard/platform-server/index.d.ts
@@ -35,6 +35,9 @@ export declare function renderModuleFactory<T>(moduleFactory: NgModuleFactory<T>
 }): Promise<string>;
 
 /** @experimental */
+export declare const SERVER_BEFORE_RENDER_LISTENER: InjectionToken<(() => void | Observable<any> | Promise<any>)[]>;
+
+/** @experimental */
 export declare class ServerModule {
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: 
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
```
[x] Feature
```

## What is the current behavior?
There is no way way to perform any logic just before renderToString is called.
You can use 
```
appRef.isStable.filter(stable => stable)
```
but since `renderModule*` uses the same method, you're relying on your subscription happening before the `renderModule*`'s one, which is brittle.

## What is the new behavior?
Add provider to allow a hook 
This will allow dev's to perform an action(s) just before the app is rendered out.

This can be used by Universal to render the TransferState script onto the document just before renderToString

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
