### PR TITLE
Fix styling dynamically created components in ViewEncapsulation.Emulated mode

### DIFF
--- a/packages/core/src/view/services.ts
+++ b/packages/core/src/view/services.ts
@@ -121,7 +121,7 @@ function createRootData(
     projectableNodes: any[][], rootSelectorOrNode: any): RootData {
   const sanitizer = ngModule.injector.get(Sanitizer);
   const errorHandler = ngModule.injector.get(ErrorHandler);
-  const renderer = rendererFactory.createRenderer(null, null);
+  const renderer = elInjector.get(Renderer2, rendererFactory.createRenderer(null, null));
   return {
     ngModule,
     injector: elInjector, projectableNodes,


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number:  #12215


## What is the new behavior?
Dynamically created components with ViewContainerRef.createComponent() has the _ngcontent-* attribute in ViewEncapsulation.Emulated mode so can be styled easily
