### PR TITLE
feat(platform-server): provide a way to hook into renderModule*

### DIFF
--- a/packages/platform-server/src/platform-server.ts
+++ b/packages/platform-server/src/platform-server.ts
@@ -8,7 +8,7 @@
 
 export {PlatformState} from './platform_state';
 export {ServerModule, platformDynamicServer, platformServer} from './server';
-export {INITIAL_CONFIG, PlatformConfig} from './tokens';
+export {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, PlatformConfig} from './tokens';
 export {renderModule, renderModuleFactory} from './utils';
 
 export * from './private_export';

--- a/packages/platform-server/src/tokens.ts
+++ b/packages/platform-server/src/tokens.ts
@@ -24,3 +24,12 @@ export interface PlatformConfig {
  * @experimental
  */
 export const INITIAL_CONFIG = new InjectionToken<PlatformConfig>('Server.INITIAL_CONFIG');
+
+/**
+ * A function that will be executed when calling `renderModuleFactory` or `renderModule` just
+ * before current platform state is rendered to string.
+ *
+ * @experimental
+ */
+export const BEFORE_APP_SERIALIZED =
+    new InjectionToken<Array<() => void>>('Server.RENDER_MODULE_HOOK');

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -14,7 +14,7 @@ import {toPromise} from 'rxjs/operator/toPromise';
 
 import {PlatformState} from './platform_state';
 import {platformDynamicServer, platformServer} from './server';
-import {INITIAL_CONFIG} from './tokens';
+import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG} from './tokens';
 
 interface PlatformOptions {
   document?: string;
@@ -45,7 +45,22 @@ the server-rendered app can be properly bootstrapped into a client app.`);
     return toPromise
         .call(first.call(filter.call(applicationRef.isStable, (isStable: boolean) => isStable)))
         .then(() => {
-          const output = platform.injector.get(PlatformState).renderToString();
+          const platformState = platform.injector.get(PlatformState);
+
+          // Run any BEFORE_APP_SERIALIZED callbacks just before rendering to string.
+          const callbacks = moduleRef.injector.get(BEFORE_APP_SERIALIZED, null);
+          if (callbacks) {
+            for (const callback of callbacks) {
+              try {
+                callback();
+              } catch (e) {
+                // Ignore exceptions.
+                console.warn('Ignoring BEFORE_APP_SERIALIZED Exception: ', e);
+              }
+            }
+          }
+
+          const output = platformState.renderToString();
           platform.destroy();
           return output;
         });

--- a/tools/public_api_guard/platform-server/index.d.ts
+++ b/tools/public_api_guard/platform-server/index.d.ts
@@ -1,4 +1,7 @@
 /** @experimental */
+export declare const BEFORE_APP_SERIALIZED: InjectionToken<(() => void)[]>;
+
+/** @experimental */
 export declare const INITIAL_CONFIG: InjectionToken<PlatformConfig>;
 
 /** @experimental */


### PR DESCRIPTION
A multi BEFORE_APP_SERIALIZED provider can provide function that will be called with the current document just before the document is rendered to
string.

This hook can for example be used for the state transfer module to serialize any server state that needs to be transported to the client, just before the current platform state is rendered to string.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
When using the renderModule* functions from @angular/platform-server there is no way to change the document state after the app is stable but before the current document is serialized to string.

Issue Number: N/A


## What is the new behavior?
Users can provide a RENDER_MODULE_HOOK multi-provider that can insert/change document state just before it is rendered.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
