### PR TITLE
fix(compiler): update template parse error message to ng-template

### DIFF
--- a/packages/compiler/src/template_parser/template_parser.ts
+++ b/packages/compiler/src/template_parser/template_parser.ts
@@ -443,7 +443,7 @@ class TemplateParseVisitor implements html.Visitor {
           const identifier = bindParts[IDENT_KW_IDX];
           this._parseVariable(identifier, value, srcSpan, targetVars);
         } else {
-          this._reportError(`"let-" is only supported on template elements.`, srcSpan);
+          this._reportError(`"let-" is only supported on ng-template elements.`, srcSpan);
         }
 
       } else if (bindParts[KW_REF_IDX]) {

--- a/packages/compiler/test/template_parser/template_parser_spec.ts
+++ b/packages/compiler/test/template_parser/template_parser_spec.ts
@@ -1212,7 +1212,7 @@ There is no directive with "exportAs" set to "dirA" ("<div [ERROR ->]#a="dirA"><
 
         it('should report variables as errors', () => {
           expect(() => parse('<div let-a></div>', [])).toThrowError(`Template parse errors:
-"let-" is only supported on template elements. ("<div [ERROR ->]let-a></div>"): TestComp@0:5`);
+"let-" is only supported on ng-template elements. ("<div [ERROR ->]let-a></div>"): TestComp@0:5`);
         });
 
         it('should report duplicate reference names', () => {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Refactoring (no functional changes, no api changes)
```

## What is the current behavior?
I forgot to update an error message when I updated `template` to `ng-template`

## What is the new behavior?
Message updated

## Does this PR introduce a breaking change?
```
[x] No
```