### PR TITLE
docs(aio): Clarify use of negated class binding

### DIFF
--- a/aio/content/examples/template-syntax/src/app/app.component.html
+++ b/aio/content/examples/template-syntax/src/app/app.component.html
@@ -337,9 +337,9 @@ button</button>
 <div [class.special]="isSpecial">The class binding is special</div>
 <!-- #enddocregion class-binding-3a -->
 
-<!-- binding to `class.special` trumps the class attribute -->
-<div class="special"
-     [class.special]="!isSpecial">This one is not so special</div>
+<!-- binding to `class.not-so-special` trumps the class attribute -->
+<div class="not-so-special"
+     [class.not-so-special]="!isSpecial">This one is not so special</div>
 <!-- #enddocregion class-binding-3 -->
 
 <div bind-class.special="isSpecial">This class binding is special too</div>

--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -860,7 +860,7 @@ Class binding syntax resembles property binding.
 Instead of an element property between brackets, start with the prefix `class`,
 optionally followed by a dot (`.`) and the name of a CSS class: `[class.class-name]`.
 
-The following examples show how to add and remove the application's "special" class
+The following examples show how to add and remove classes
 with class bindings.  Here's how to set the attribute without binding:
 
 <code-example path="template-syntax/src/app/app.component.html" region="class-binding-1" title="src/app/app.component.html" linenums="false">


### PR DESCRIPTION
When the `isSpecial` value is falsy, the `special` CSS class class was being set. This is confusing and the opposite of what a new user might expect. This commit changes the example to set a `not-so-special` CSS class when `isSpecial` is falsy.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
In the current documentation, the `special` CSS class is being set when `isSpecial` is false.

## What is the new behavior?
A `not-so-special` CSS class is being set when `isSpecial` is false.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
