### PR TITLE
fix(tsc-wrapped): add metadata for `type` declarations -  4.3.x and 4.4.x

### DIFF
--- a/tools/@angular/tsc-wrapped/src/collector.ts
+++ b/tools/@angular/tsc-wrapped/src/collector.ts
@@ -265,12 +265,12 @@ export class MetadataCollector {
 
     const isExportedIdentifier = (identifier: ts.Identifier) => exportMap.has(identifier.text);
     const isExported =
-        (node: ts.FunctionDeclaration | ts.ClassDeclaration | ts.InterfaceDeclaration |
+        (node: ts.FunctionDeclaration | ts.ClassDeclaration | ts.InterfaceDeclaration | ts.TypeAliasDeclaration |
          ts.EnumDeclaration) => isExport(node) || isExportedIdentifier(node.name);
     const exportedIdentifierName = (identifier: ts.Identifier) =>
         exportMap.get(identifier.text) || identifier.text;
     const exportedName =
-        (node: ts.FunctionDeclaration | ts.ClassDeclaration | ts.InterfaceDeclaration |
+        (node: ts.FunctionDeclaration | ts.ClassDeclaration | ts.InterfaceDeclaration | ts.TypeAliasDeclaration |
          ts.EnumDeclaration) => exportedIdentifierName(node.name);
 
 
@@ -364,7 +364,16 @@ export class MetadataCollector {
           }
           // Otherwise don't record metadata for the class.
           break;
-
+        case ts.SyntaxKind.TypeAliasDeclaration:
+          const typeDeclaration = <ts.TypeAliasDeclaration>node;
+          if (typeDeclaration.name && isExported(typeDeclaration)) {
+            const name = exportedName(typeDeclaration);
+            if (name) {
+              if (!metadata) metadata = {};
+              metadata[name] = {__symbolic: 'interface'};
+            }
+          }
+          break;
         case ts.SyntaxKind.InterfaceDeclaration:
           const interfaceDeclaration = <ts.InterfaceDeclaration>node;
           if (interfaceDeclaration.name && isExported(interfaceDeclaration)) {
@@ -372,7 +381,6 @@ export class MetadataCollector {
             metadata[exportedName(interfaceDeclaration)] = {__symbolic: 'interface'};
           }
           break;
-
         case ts.SyntaxKind.FunctionDeclaration:
           // Record functions that return a single value. Record the parameter
           // names substitution will be performed by the StaticReflector.

--- a/tools/@angular/tsc-wrapped/test/collector.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/collector.spec.ts
@@ -35,6 +35,7 @@ describe('Collector', () => {
       'exported-functions.ts',
       'exported-enum.ts',
       'exported-consts.ts',
+      'exported-type.ts',
       'local-symbol-ref.ts',
       'local-function-ref.ts',
       'local-symbol-ref-func.ts',
@@ -64,6 +65,13 @@ describe('Collector', () => {
     const sourceFile = program.getSourceFile('app/empty.ts');
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toBeUndefined();
+  });
+
+  it('should return an interface reference for types', () => {
+    const sourceFile = program.getSourceFile('/exported-type.ts');
+    const metadata = collector.getMetadata(sourceFile);
+    expect(metadata).toEqual(
+         {__symbolic: 'module', version: 3, metadata: {SomeType: {__symbolic: 'interface'}}});
   });
 
   it('should return an interface reference for interfaces', () => {
@@ -1233,6 +1241,9 @@ const FILES: Directory = {
       }
     }
     export declare function declaredFn();
+  `,
+  'exported-type.ts': `
+    export type SomeType = 'a' | 'b';
   `,
   'exported-enum.ts': `
     import {constValue} from './exported-consts';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
At the moment types don't have metadata, and is resulting in incorrect metadata in json when the file only contain `type`

Issue: #18675  


## What is the new behavior?
Type have now metadata

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This PR is the same as https://github.com/angular/angular/pull/18704 but for Angular 4.3.x and 4.4.x branches. 

I already did another PR and was merged for 5.x.x
