### PR TITLE
build(aio): render constructor overloads for API docs

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -82,7 +82,7 @@
     "concurrently": "^3.4.0",
     "cross-spawn": "^5.1.0",
     "dgeni": "^0.4.7",
-    "dgeni-packages": "^0.21.0",
+    "dgeni-packages": "^0.21.1",
     "entities": "^1.1.1",
     "eslint": "^3.19.0",
     "eslint-plugin-jasmine": "^2.2.0",

--- a/aio/tools/transforms/templates/api/class.template.html
+++ b/aio/tools/transforms/templates/api/class.template.html
@@ -7,7 +7,7 @@
 {% block additional %}{% endblock %}
 {% include "includes/description.html" %}
 {$ memberHelpers.renderMemberDetails(doc.statics, 'static-members', 'static-member', 'Static Members') $}
-{% include "includes/constructor.html" %}
+{$ memberHelpers.renderMemberDetails([doc.constructorDoc], 'constructors', 'constructor', 'Constructor') $}
 {$ memberHelpers.renderMemberDetails(doc.members, 'instance-members', 'instance-member', 'Members') $}
 {% include "includes/annotations.html" %}
 

--- a/aio/tools/transforms/templates/api/includes/class-overview.html
+++ b/aio/tools/transforms/templates/api/includes/class-overview.html
@@ -4,6 +4,8 @@
 <h2>Overview</h2>
 <code-example language="ts" hideCopy="true">
 {$ doc.docType $} {$ doc.name $}{$ doc.typeParams | escape $}{$ memberHelper.renderHeritage(doc) $} {
+{%- if doc.constructorDoc %}{% if not doc.constructorDoc.internal %}
+  <a class="code-anchor" href="#{$ doc.constructorDoc.anchor $}">{$ memberHelper.renderMember(doc.constructorDoc, 1) $}</a>{% endif %}{% endif -%}
 {%- if doc.statics.length %}{% for member in doc.statics %}{% if not member.internal %}
   <a class="code-anchor" href="#{$ member.anchor $}">{$ memberHelper.renderMember(member, 1) $}</a>{% endif %}{% endfor %}{% endif -%}
 {$ memberHelper.renderMembers(doc) $}

--- a/aio/tools/transforms/templates/api/includes/constructor.html
+++ b/aio/tools/transforms/templates/api/includes/constructor.html
@@ -1,8 +1,0 @@
-{%- if doc.constructorDoc and not doc.constructorDoc.internal %}
-<section class="constructor">
-  <a id="{$ doc.constructorDoc.name $}"></a>
-  <h2>Constructor</h2>
-  <code-example hideCopy="true" class="no-box api-heading">{$ doc.constructorDoc.name $}{$ params.paramList(doc.constructorDoc.parameters) $}</code-example>
-  {% if not doc.constructorDoc.notYetDocumented %}{$ doc.constructorDoc.description | marked $}{% endif %}
-</section>
-{% endif %}

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -2002,9 +2002,9 @@ devtools-timeline-model@1.1.6:
     chrome-devtools-frontend "1.0.401423"
     resolve "1.1.7"
 
-dgeni-packages@^0.21.0:
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.21.0.tgz#5b62ec238fb12ae802e73fdd674f07a7cfd98925"
+dgeni-packages@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.21.1.tgz#9ac24733e9bc7ae1a17172a107ede67ea370ada7"
   dependencies:
     canonical-path "0.0.2"
     catharsis "^0.8.1"


### PR DESCRIPTION
Sits on top of #18927, which should be merged first.