### PR TITLE
fix(router): test and adjust ChildActivation events to only fire when…

### DIFF
--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -7,7 +7,8 @@
  */
 
 import {Route} from './config';
-import {RouterStateSnapshot} from './router_state';
+import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
+
 
 /**
  * @whatItDoes Base for events the Router goes through, as opposed to events tied to a specific
@@ -264,8 +265,11 @@ export class RouteConfigLoadEnd {
 export class ChildActivationStart {
   constructor(
       /** @docsNotRequired */
-      public route: Route) {}
-  toString(): string { return `ChildActivationStart(path: '${this.route.path}')`; }
+      public snapshot: ActivatedRouteSnapshot) {}
+  toString(): string {
+    const path = this.snapshot.routeConfig && this.snapshot.routeConfig.path || '';
+    return `ChildActivationStart(path: '${path}')`;
+  }
 }
 
 /**
@@ -277,8 +281,11 @@ export class ChildActivationStart {
 export class ChildActivationEnd {
   constructor(
       /** @docsNotRequired */
-      public route: Route) {}
-  toString(): string { return `ChildActivationEnd(path: '${this.route.path}')`; }
+      public snapshot: ActivatedRouteSnapshot) {}
+  toString(): string {
+    const path = this.snapshot.routeConfig && this.snapshot.routeConfig.path || '';
+    return `ChildActivationEnd(path: '${path}')`;
+  }
 }
 
 /**

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -36,35 +36,6 @@ export class RouterEvent {
 }
 
 /**
- * @whatItDoes Base for events tied to a specific `Route`, as opposed to events for the Router
- * lifecycle. `RouteEvent`s may be fired multiple times during a single navigation and will
- * always receive the `Route` they pertain to.
- *
- * Example:
- *
- * ```
- * class MyService {
- *   constructor(public router: Router, spinner: Spinner) {
- *     router.events.filter(e => e instanceof RouteEvent).subscribe(e => {
- *       if (e instanceof ChildActivationStart) {
- *         spinner.start(e.route);
- *       } else if (e instanceof ChildActivationEnd) {
- *         spinner.end(e.route);
- *       }
- *     });
- *   }
- * }
- * ```
- *
- * @experimental
- */
-export class RouteEvent {
-  constructor(
-      /** @docsNotRequired */
-      public route: Route) {}
-}
-
-/**
  * @whatItDoes Represents an event triggered when a navigation starts.
  *
  * @stable
@@ -265,7 +236,10 @@ export class ResolveEnd extends RouterEvent {
  *
  * @experimental
  */
-export class RouteConfigLoadStart extends RouteEvent {
+export class RouteConfigLoadStart {
+  constructor(
+      /** @docsNotRequired */
+      public route: Route) {}
   toString(): string { return `RouteConfigLoadStart(path: ${this.route.path})`; }
 }
 
@@ -274,7 +248,10 @@ export class RouteConfigLoadStart extends RouteEvent {
  *
  * @experimental
  */
-export class RouteConfigLoadEnd extends RouteEvent {
+export class RouteConfigLoadEnd {
+  constructor(
+      /** @docsNotRequired */
+      public route: Route) {}
   toString(): string { return `RouteConfigLoadEnd(path: ${this.route.path})`; }
 }
 
@@ -284,7 +261,10 @@ export class RouteConfigLoadEnd extends RouteEvent {
  *
  * @experimental
  */
-export class ChildActivationStart extends RouteEvent {
+export class ChildActivationStart {
+  constructor(
+      /** @docsNotRequired */
+      public route: Route) {}
   toString(): string { return `ChildActivationStart(path: '${this.route.path}')`; }
 }
 
@@ -294,7 +274,10 @@ export class ChildActivationStart extends RouteEvent {
  *
  * @experimental
  */
-export class ChildActivationEnd extends RouteEvent {
+export class ChildActivationEnd {
+  constructor(
+      /** @docsNotRequired */
+      public route: Route) {}
   toString(): string { return `ChildActivationEnd(path: '${this.route.path}')`; }
 }
 
@@ -319,4 +302,5 @@ export class ChildActivationEnd extends RouteEvent {
  *
  * @stable
  */
-export type Event = RouterEvent | RouteEvent;
+export type Event = RouterEvent | RouteConfigLoadStart | RouteConfigLoadEnd | ChildActivationStart |
+    ChildActivationEnd;

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -11,7 +11,7 @@ export {Data, LoadChildren, LoadChildrenCallback, ResolveData, Route, Routes, Ru
 export {RouterLink, RouterLinkWithHref} from './directives/router_link';
 export {RouterLinkActive} from './directives/router_link_active';
 export {RouterOutlet} from './directives/router_outlet';
-export {ChildActivationEnd, ChildActivationStart, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouteEvent, RoutesRecognized} from './events';
+export {ChildActivationEnd, ChildActivationStart, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouterEvent, RoutesRecognized} from './events';
 export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, Resolve} from './interfaces';
 export {DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
 export {NavigationExtras, Router} from './router';

--- a/packages/router/src/pre_activation.ts
+++ b/packages/router/src/pre_activation.ts
@@ -202,8 +202,8 @@ export class PreActivation {
     const checks$ = from(this.canActivateChecks);
     const runningChecks$ = concatMap.call(
         checks$, (check: CanActivate) => andObservables(from([
-                   this.fireChildActivationStart(check.path), this.runCanActivateChild(check.path),
-                   this.runCanActivate(check.route)
+                   this.fireChildActivationStart(check.route.parent),
+                   this.runCanActivateChild(check.path), this.runCanActivate(check.route)
                  ])));
     return every.call(runningChecks$, (result: boolean) => result === true);
     // this.fireChildActivationStart(check.path),
@@ -217,16 +217,11 @@ export class PreActivation {
    * return
    * `true` so checks continue to run.
    */
-  private fireChildActivationStart(path: ActivatedRouteSnapshot[]): Observable<boolean> {
-    if (!this.forwardEvent) return of (true);
-    const childActivations = path.slice(0, path.length - 1).reverse().filter(_ => _ !== null);
-
-    return andObservables(map.call(from(childActivations), (snapshot: ActivatedRouteSnapshot) => {
-      if (this.forwardEvent && snapshot._routeConfig) {
-        this.forwardEvent(new ChildActivationStart(snapshot._routeConfig));
-      }
-      return of (true);
-    }));
+  private fireChildActivationStart(snapshot: ActivatedRouteSnapshot|null): Observable<boolean> {
+    if (snapshot !== null && this.forwardEvent) {
+      this.forwardEvent(new ChildActivationStart(snapshot));
+    }
+    return of (true);
   }
   private runCanActivate(future: ActivatedRouteSnapshot): Observable<boolean> {
     const canActivate = future._routeConfig ? future._routeConfig.canActivate : null;

--- a/packages/router/src/pre_activation.ts
+++ b/packages/router/src/pre_activation.ts
@@ -19,7 +19,7 @@ import {mergeMap} from 'rxjs/operator/mergeMap';
 import {reduce} from 'rxjs/operator/reduce';
 
 import {LoadedRouterConfig, ResolveData, RunGuardsAndResolvers} from './config';
-import {ChildActivationStart, RouteEvent} from './events';
+import {ChildActivationStart, Event} from './events';
 import {ChildrenOutletContexts, OutletContext} from './router_outlet_context';
 import {ActivatedRouteSnapshot, RouterStateSnapshot, equalParamsAndUrlSegments, inheritedParamsDataResolve} from './router_state';
 import {andObservables, forEach, shallowEqual, wrapIntoObservable} from './utils/collection';
@@ -43,7 +43,7 @@ export class PreActivation {
 
   constructor(
       private future: RouterStateSnapshot, private curr: RouterStateSnapshot,
-      private moduleInjector: Injector, private forwardEvent?: (evt: RouteEvent) => void) {}
+      private moduleInjector: Injector, private forwardEvent?: (evt: Event) => void) {}
 
   initalize(parentContexts: ChildrenOutletContexts): void {
     const futureRoot = this.future._root;

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -21,7 +21,7 @@ import {applyRedirects} from './apply_redirects';
 import {LoadedRouterConfig, QueryParamsHandling, Route, Routes, validateConfig} from './config';
 import {createRouterState} from './create_router_state';
 import {createUrlTree} from './create_url_tree';
-import {ChildActivationEnd, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouterEvent, RoutesRecognized} from './events';
+import {ChildActivationEnd, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RoutesRecognized} from './events';
 import {PreActivation} from './pre_activation';
 import {recognize} from './recognize';
 import {DefaultRouteReuseStrategy, DetachedRouteHandleInternal, RouteReuseStrategy} from './route_reuse_strategy';
@@ -864,8 +864,8 @@ class ActivateRoutes {
     const children: {[outlet: string]: any} = nodeChildrenAsMap(currNode);
     futureNode.children.forEach(
         c => { this.activateRoutes(c, children[c.value.outlet], contexts); });
-    if (futureNode.children.length && futureNode.value.routeConfig) {
-      this.forwardEvent(new ChildActivationEnd(futureNode.value.routeConfig));
+    if (futureNode.children.length) {
+      this.forwardEvent(new ChildActivationEnd(futureNode.value.snapshot));
     }
   }
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -21,7 +21,7 @@ import {applyRedirects} from './apply_redirects';
 import {LoadedRouterConfig, QueryParamsHandling, Route, Routes, validateConfig} from './config';
 import {createRouterState} from './create_router_state';
 import {createUrlTree} from './create_url_tree';
-import {ChildActivationEnd, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouteEvent, RoutesRecognized} from './events';
+import {ChildActivationEnd, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouterEvent, RoutesRecognized} from './events';
 import {PreActivation} from './pre_activation';
 import {recognize} from './recognize';
 import {DefaultRouteReuseStrategy, DetachedRouteHandleInternal, RouteReuseStrategy} from './route_reuse_strategy';
@@ -628,7 +628,7 @@ export class Router {
             const moduleInjector = this.ngModule.injector;
             preActivation = new PreActivation(
                 snapshot, this.currentRouterState.snapshot, moduleInjector,
-                (evt: RouteEvent) => this.triggerEvent(evt));
+                (evt: Event) => this.triggerEvent(evt));
             preActivation.initalize(this.rootContexts);
             return {appliedUrl, snapshot};
           });
@@ -764,7 +764,7 @@ export class Router {
 class ActivateRoutes {
   constructor(
       private routeReuseStrategy: RouteReuseStrategy, private futureState: RouterState,
-      private currState: RouterState, private forwardEvent: (evt: RouteEvent) => void) {}
+      private currState: RouterState, private forwardEvent: (evt: Event) => void) {}
 
   activate(parentContexts: ChildrenOutletContexts): void {
     const futureRoot = this.futureState._root;

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -83,8 +83,9 @@ describe('bootstrap', () => {
       const data = router.routerState.snapshot.root.firstChild !.data;
       expect(data['test']).toEqual('test-data');
       expect(log).toEqual([
-        'TestModule', 'NavigationStart', 'RoutesRecognized', 'GuardsCheckStart', 'GuardsCheckEnd',
-        'ResolveStart', 'ResolveEnd', 'RootCmp', 'NavigationEnd'
+        'TestModule', 'NavigationStart', 'RoutesRecognized', 'GuardsCheckStart',
+        'ChildActivationStart', 'GuardsCheckEnd', 'ResolveStart', 'ResolveEnd', 'RootCmp',
+        'ChildActivationEnd', 'NavigationEnd'
       ]);
       done();
     });
@@ -121,7 +122,7 @@ describe('bootstrap', () => {
          // ResolveEnd has not been emitted yet because bootstrap returned too early
          expect(log).toEqual([
            'TestModule', 'RootCmp', 'NavigationStart', 'RoutesRecognized', 'GuardsCheckStart',
-           'GuardsCheckEnd', 'ResolveStart'
+           'ChildActivationStart', 'GuardsCheckEnd', 'ResolveStart'
          ]);
 
          router.events.subscribe((e) => {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -11,7 +11,7 @@ import {ChangeDetectionStrategy, Component, Injectable, NgModule, NgModuleFactor
 import {ComponentFixture, TestBed, fakeAsync, inject, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {ActivatedRoute, ActivatedRouteSnapshot, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, PRIMARY_OUTLET, ParamMap, Params, PreloadAllModules, PreloadingStrategy, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouteEvent, RouteReuseStrategy, Router, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlTree} from '@angular/router';
+import {ActivatedRoute, ActivatedRouteSnapshot, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, PRIMARY_OUTLET, ParamMap, Params, PreloadAllModules, PreloadingStrategy, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouteReuseStrategy, Router, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlTree} from '@angular/router';
 import {Observable} from 'rxjs/Observable';
 import {Observer} from 'rxjs/Observer';
 import {of } from 'rxjs/observable/of';
@@ -428,7 +428,7 @@ describe('Integration', () => {
        }]);
 
        const recordedEvents: any[] = [];
-       router.events.forEach(e => e instanceof RouteEvent || recordedEvents.push(e));
+       router.events.forEach(e => e instanceof RouterEvent && recordedEvents.push(e));
 
        router.navigateByUrl('/team/22/user/victor');
        advance(fixture);
@@ -986,7 +986,7 @@ describe('Integration', () => {
              [{path: 'simple', component: SimpleCmp, resolve: {error: 'resolveError'}}]);
 
          const recordedEvents: any[] = [];
-         router.events.subscribe(e => e instanceof RouteEvent || recordedEvents.push(e));
+         router.events.subscribe(e => e instanceof RouterEvent && recordedEvents.push(e));
 
          let e: any = null;
          router.navigateByUrl('/simple') !.catch(error => e = error);
@@ -3344,7 +3344,7 @@ describe('Integration', () => {
            }]);
 
            const events: any[] = [];
-           router.events.subscribe(e => e instanceof RouteEvent || events.push(e));
+           router.events.subscribe(e => e instanceof RouterEvent && events.push(e));
 
            // supported URL
            router.navigateByUrl('/include/user/kate');
@@ -3408,7 +3408,7 @@ describe('Integration', () => {
            }]);
 
            const events: any[] = [];
-           router.events.subscribe(e => e instanceof RouteEvent || events.push(e));
+           router.events.subscribe(e => e instanceof RouterEvent && events.push(e));
 
            location.go('/include/user/kate(aux:excluded)');
            advance(fixture);

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -705,15 +705,18 @@ describe('Integration', () => {
        expect(user.recordedParams).toEqual([{name: 'init'}, {name: 'fedor'}]);
 
        expectEvents(recordedEvents, [
-         [NavigationStart, '/user/init'], [RoutesRecognized, '/user/init'],
-         [GuardsCheckStart, '/user/init'], [GuardsCheckEnd, '/user/init'],
-         [ResolveStart, '/user/init'], [ResolveEnd, '/user/init'], [NavigationEnd, '/user/init'],
+         [NavigationStart, '/user/init'],   [RoutesRecognized, '/user/init'],
+         [GuardsCheckStart, '/user/init'],  [ChildActivationStart],
+         [GuardsCheckEnd, '/user/init'],    [ResolveStart, '/user/init'],
+         [ResolveEnd, '/user/init'],        [ChildActivationEnd],
+         [NavigationEnd, '/user/init'],
 
          [NavigationStart, '/user/victor'], [NavigationCancel, '/user/victor'],
 
-         [NavigationStart, '/user/fedor'], [RoutesRecognized, '/user/fedor'],
-         [GuardsCheckStart, '/user/fedor'], [GuardsCheckEnd, '/user/fedor'],
-         [ResolveStart, '/user/fedor'], [ResolveEnd, '/user/fedor'],
+         [NavigationStart, '/user/fedor'],  [RoutesRecognized, '/user/fedor'],
+         [GuardsCheckStart, '/user/fedor'], [ChildActivationStart],
+         [GuardsCheckEnd, '/user/fedor'],   [ResolveStart, '/user/fedor'],
+         [ResolveEnd, '/user/fedor'],       [ChildActivationEnd],
          [NavigationEnd, '/user/fedor']
        ]);
      })));
@@ -740,8 +743,8 @@ describe('Integration', () => {
          [NavigationStart, '/invalid'], [NavigationError, '/invalid'],
 
          [NavigationStart, '/user/fedor'], [RoutesRecognized, '/user/fedor'],
-         [GuardsCheckStart, '/user/fedor'], [GuardsCheckEnd, '/user/fedor'],
-         [ResolveStart, '/user/fedor'], [ResolveEnd, '/user/fedor'],
+         [GuardsCheckStart, '/user/fedor'], [ChildActivationStart], [GuardsCheckEnd, '/user/fedor'],
+         [ResolveStart, '/user/fedor'], [ResolveEnd, '/user/fedor'], [ChildActivationEnd],
          [NavigationEnd, '/user/fedor']
        ]);
      })));
@@ -1463,10 +1466,10 @@ describe('Integration', () => {
              expect(location.path()).toEqual('/');
              expectEvents(recordedEvents, [
                [NavigationStart, '/team/22'], [RoutesRecognized, '/team/22'],
-               [GuardsCheckStart, '/team/22'], [GuardsCheckEnd, '/team/22'],
+               [GuardsCheckStart, '/team/22'], [ChildActivationStart], [GuardsCheckEnd, '/team/22'],
                [NavigationCancel, '/team/22']
              ]);
-             expect((recordedEvents[3] as GuardsCheckEnd).shouldActivate).toBe(false);
+             expect((recordedEvents[4] as GuardsCheckEnd).shouldActivate).toBe(false);
            })));
       });
 
@@ -2389,9 +2392,11 @@ describe('Integration', () => {
                  [RoutesRecognized, '/lazyTrue/loaded'],
                  [GuardsCheckStart, '/lazyTrue/loaded'],
                  [ChildActivationStart],
+                 [ChildActivationStart],
                  [GuardsCheckEnd, '/lazyTrue/loaded'],
                  [ResolveStart, '/lazyTrue/loaded'],
                  [ResolveEnd, '/lazyTrue/loaded'],
+                 [ChildActivationEnd],
                  [ChildActivationEnd],
                  [NavigationEnd, '/lazyTrue/loaded'],
                ]);
@@ -2423,8 +2428,9 @@ describe('Integration', () => {
              [NavigationCancel, '/lazyFalse/loaded'],
 
              [NavigationStart, '/blank'], [RoutesRecognized, '/blank'],
-             [GuardsCheckStart, '/blank'], [GuardsCheckEnd, '/blank'], [ResolveStart, '/blank'],
-             [ResolveEnd, '/blank'], [NavigationEnd, '/blank']
+             [GuardsCheckStart, '/blank'], [ChildActivationStart], [GuardsCheckEnd, '/blank'],
+             [ResolveStart, '/blank'], [ResolveEnd, '/blank'], [ChildActivationEnd],
+             [NavigationEnd, '/blank']
            ]);
          })));
 

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -60,12 +60,18 @@ export interface CanLoad {
 }
 
 /** @experimental */
-export declare class ChildActivationEnd extends RouteEvent {
+export declare class ChildActivationEnd {
+    route: Route;
+    constructor(
+        route: Route);
     toString(): string;
 }
 
 /** @experimental */
-export declare class ChildActivationStart extends RouteEvent {
+export declare class ChildActivationStart {
+    route: Route;
+    constructor(
+        route: Route);
     toString(): string;
 }
 
@@ -97,7 +103,7 @@ export declare class DefaultUrlSerializer implements UrlSerializer {
 export declare type DetachedRouteHandle = {};
 
 /** @stable */
-export declare type Event = RouterEvent | RouteEvent;
+export declare type Event = RouterEvent | RouteConfigLoadStart | RouteConfigLoadEnd | ChildActivationStart | ChildActivationEnd;
 
 /** @stable */
 export interface ExtraOptions {
@@ -284,20 +290,19 @@ export interface Route {
 }
 
 /** @experimental */
-export declare class RouteConfigLoadEnd extends RouteEvent {
-    toString(): string;
-}
-
-/** @experimental */
-export declare class RouteConfigLoadStart extends RouteEvent {
-    toString(): string;
-}
-
-/** @experimental */
-export declare class RouteEvent {
+export declare class RouteConfigLoadEnd {
     route: Route;
     constructor(
         route: Route);
+    toString(): string;
+}
+
+/** @experimental */
+export declare class RouteConfigLoadStart {
+    route: Route;
+    constructor(
+        route: Route);
+    toString(): string;
 }
 
 /** @stable */
@@ -337,6 +342,15 @@ export declare abstract class RouteReuseStrategy {
     abstract shouldDetach(route: ActivatedRouteSnapshot): boolean;
     abstract shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean;
     abstract store(route: ActivatedRouteSnapshot, handle: DetachedRouteHandle | null): void;
+}
+
+/** @experimental */
+export declare class RouterEvent {
+    id: number;
+    url: string;
+    constructor(
+        id: number,
+        url: string);
 }
 
 /** @stable */

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -61,17 +61,17 @@ export interface CanLoad {
 
 /** @experimental */
 export declare class ChildActivationEnd {
-    route: Route;
+    snapshot: ActivatedRouteSnapshot;
     constructor(
-        route: Route);
+        snapshot: ActivatedRouteSnapshot);
     toString(): string;
 }
 
 /** @experimental */
 export declare class ChildActivationStart {
-    route: Route;
+    snapshot: ActivatedRouteSnapshot;
     constructor(
-        route: Route);
+        snapshot: ActivatedRouteSnapshot);
     toString(): string;
 }
 


### PR DESCRIPTION
… the child is actually changing

The PR changes the public `RouteEvent` base class. But this class was never published in a release and has only been on `master`. Testing within Google pointed out an issue with the original feature, so this PR corrects the feature so it can be pushed in `v5`.

The problem was with the `fireChildActivationStart` function. It was taking a `path` param, which was an array of `ActivatedRouteSnapshot`s. The function was being fired for each piece of the route that was being activated. This resulted in far too many `ChildActivationStart` events being fired, and being fired on routes that weren't actually getting activated. This change fires the event only for those routes that are actually being activated.