### PR TITLE
test(aio): fix docs example e2e test

### DIFF
--- a/aio/content/examples/i18n/e2e-spec.ts
+++ b/aio/content/examples/i18n/e2e-spec.ts
@@ -14,7 +14,6 @@ describe('i18n E2E Tests', () => {
 
   it('should display the node texts without elements', function () {
     expect(element(by.css('my-app')).getText()).toContain('No genero ningún elemento');
-    expect(element(by.css('my-app')).getText()).toContain('Yo tampoco genero ningún elemento');
   });
 
   it('should display the translated title attribute', function () {

--- a/aio/content/examples/i18n/messages.xlf
+++ b/aio/content/examples/i18n/messages.xlf
@@ -14,14 +14,6 @@
         <source>I don&apos;t output any element</source>
         <target/>
       </trans-unit>
-      <trans-unit id="df3cf8b55cb528cf8c00167e0b119bfb828538b5" datatype="html">
-        <source>
-I don&apos;t output any element either
-</source>
-        <target/>
-        <note priority="1" from="description">optional description</note>
-        <note priority="1" from="meaning">optional meaning</note>
-      </trans-unit>
       <trans-unit id="701174153757adf13e7c24a248c8a873ac9f5193" datatype="html">
         <source>Angular logo</source>
         <target/>

--- a/aio/content/examples/i18n/src/locale/messages.es.xlf
+++ b/aio/content/examples/i18n/src/locale/messages.es.xlf
@@ -12,14 +12,6 @@
         <source>I don&apos;t output any element</source>
         <target>No genero ningún elemento</target>
       </trans-unit>
-      <trans-unit id="df3cf8b55cb528cf8c00167e0b119bfb828538b5" datatype="html">
-        <source>
-I don&apos;t output any element either
-</source>
-        <target>Yo tampoco genero ningún elemento</target>
-        <note priority="1" from="description">optional description</note>
-        <note priority="1" from="meaning">optional meaning</note>
-      </trans-unit>
       <trans-unit id="701174153757adf13e7c24a248c8a873ac9f5193" datatype="html">
         <source>Angular logo</source>
         <target>Logo de Angular</target>

--- a/aio/content/examples/i18n/src/locale/messages.es.xlf.html
+++ b/aio/content/examples/i18n/src/locale/messages.es.xlf.html
@@ -21,12 +21,6 @@
         <source>I don&apos;t output any element</source>
         <target>No genero ningún elemento</target>
       </trans-unit>
-      <trans-unit id="df3cf8b55cb528cf8c00167e0b119bfb828538b5" datatype="html">
-        <source>I don&apos;t output any element either</source>
-        <target>Yo tampoco genero ningún elemento</target>
-        <note priority="1" from="description">optional description</note>
-        <note priority="1" from="meaning">optional meaning</note>
-      </trans-unit>
       <trans-unit id="701174153757adf13e7c24a248c8a873ac9f5193" datatype="html">
         <source>Angular logo</source>
         <target>Logo de Angular</target>


### PR DESCRIPTION
Remove an assertion that is no longer true. This was supposed to be removed in #18998, but was somehow dropped from 66a5dab85 (probably due to a bad rebase).

(Travis has been failing due to this since https://travis-ci.org/angular/angular/jobs/272321759.)
