### PR TITLE
fix(tsc-wrapped): deduplicate metadata for re-exported modules

### DIFF
--- a/packages/compiler/test/aot/compiler_spec.ts
+++ b/packages/compiler/test/aot/compiler_spec.ts
@@ -863,6 +863,7 @@ const LIBRARY: MockDirectory = {
     'public-api.ts': `
       export * from './src/bolder.component';
       export * from './src/bolder.module';
+      export {BolderModule as ReExportedModule} from './src/bolder.module';
     `,
     src: {
       'bolder.component.ts': `


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
```

## What is the current behavior?
If we export the same module with multiple names (`export {... as ...}` the metadata are duplicated

## What is the new behavior?
The metadata for re-exported modules reference the first export instead of being duplicated

## Does this PR introduce a breaking change?
```
[x] No
```

/cc @jelbourn  This fixes the material build