### PR TITLE
fix(router): add consistency between guards.

### DIFF
--- a/aio/content/examples/router/src/app/crisis-center/crisis-detail-resolver.service.ts
+++ b/aio/content/examples/router/src/app/crisis-center/crisis-detail-resolver.service.ts
@@ -15,7 +15,7 @@ export class CrisisDetailResolver implements Resolve<Crisis> {
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Crisis> {
     let id = route.paramMap.get('id');
 
-    return this.cs.getCrisis(id).take(1).map(crisis => {
+    return this.cs.getCrisis(id).map(crisis => {
       if (crisis) {
         return crisis;
       } else { // id not found

--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -3461,10 +3461,6 @@ That method could return a `Promise`, an `Observable`, or a synchronous return v
 
 The `CrisisService.getCrisis` method returns an Observable.
 Return that observable to prevent the route from loading until the data is fetched.
-The `Router` guards require an Observable to `complete`, meaning it has emitted all
-of its values. You use the `take` operator with an argument of `1` to ensure that the
-Observable completes after retrieving the first value from the Observable returned by the
-`getCrisis` method.
 If it doesn't return a valid `Crisis`, navigate the user back to the `CrisisListComponent`,
 canceling the previous in-flight navigation to the `CrisisDetailComponent`.
 

--- a/packages/router/rollup.config.js
+++ b/packages/router/rollup.config.js
@@ -25,6 +25,8 @@ const globals = {
   'rxjs/observable/fromPromise': 'Rx.Observable',
   'rxjs/observable/forkJoin': 'Rx.Observable',
   'rxjs/observable/of': 'Rx.Observable',
+  'rxjs/observable/merge': 'Rx.Observable',
+  'rxjs/observable/empty': 'Rx.Observable',
 
   'rxjs/operator/toPromise': 'Rx.Observable.prototype',
   'rxjs/operator/map': 'Rx.Observable.prototype',

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -22,7 +22,7 @@ import {LoadedRouterConfig, Route, Routes} from './config';
 import {RouterConfigLoader} from './router_config_loader';
 import {PRIMARY_OUTLET, Params, defaultUrlMatcher, navigationCancelingError} from './shared';
 import {UrlSegment, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
-import {andObservables, forEach, waitForMap, wrapIntoObservable} from './utils/collection';
+import {andObservable, forEach, runGuards, waitForMap} from './utils/collection';
 
 class NoMatch {
   public segmentGroup: UrlSegmentGroup|null;
@@ -415,14 +415,7 @@ class ApplyRedirects {
 
 function runCanLoadGuard(moduleInjector: Injector, route: Route): Observable<boolean> {
   const canLoad = route.canLoad;
-  if (!canLoad || canLoad.length === 0) return of (true);
-
-  const obs = map.call(from(canLoad), (injectionToken: any) => {
-    const guard = moduleInjector.get(injectionToken);
-    return wrapIntoObservable(guard.canLoad ? guard.canLoad(route) : guard(route));
-  });
-
-  return andObservables(obs);
+  return andObservable(runGuards('canLoad', canLoad, moduleInjector, [route], true));
 }
 
 function match(segmentGroup: UrlSegmentGroup, route: Route, segments: UrlSegment[]): {

--- a/packages/router/test/utils/collection.spec.ts
+++ b/packages/router/test/utils/collection.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Observable} from 'rxjs/Observable';
+import {Subscriber} from 'rxjs/Subscriber';
+import {of } from 'rxjs/observable/of';
+
+import {runGuards} from '../../src/utils/collection';
+
+describe('collection', () => {
+  describe('runGuards', () => {
+
+    it('should convert value to observable', () => {
+      const injector = {get: (token: any) => () => true};
+
+      runGuards('', ['guard'], injector, []).subscribe(v => expect(v).toBe(true), (e) => {
+        throw 'Should not reach';
+      });
+    });
+
+    it('should convert promise to observable', () => {
+      const injector = {get: (token: any) => () => Promise.resolve(true)};
+
+      runGuards('', ['guard'], injector, []).subscribe(v => expect(v).toBe(true), (e) => {
+        throw 'Should not reach';
+      });
+    });
+
+    it('should subscribe to observable', () => {
+      const injector = {get: (token: any) => () => of (true)};
+
+      runGuards('', ['guard'], injector, []).subscribe(v => expect(v).toBe(true), (e) => {
+        throw 'Should not reach';
+      });
+    });
+
+    it('should work with function guard', () => {
+      const injector = {
+        get: (token: any) => (v: string) => {
+          expect(v).toBe('arg');
+          return true;
+        }
+      };
+
+      runGuards('canActivate', ['guard'], injector, [
+        'arg'
+      ]).subscribe(v => expect(v).toBe(true), (e) => { throw 'Should not reach'; });
+    });
+
+    it('should work with object/class guard', () => {
+      const guard = {
+        canActivate: function(v: string) {
+          expect(v).toBe('arg');
+          expect(this).toBe(guard);
+          return true;
+        }
+      };
+
+      const injector = {get: (token: any) => guard};
+
+      runGuards('canActivate', ['guard'], injector, [
+        'arg'
+      ]).subscribe(v => expect(v).toBe(true), (e) => { throw 'Should not reach'; });
+    });
+
+    it('should resolve only once and complete', () => {
+      const injector = {get: (token: any) => () => of (true, false)};
+
+      const observer = {
+        next: (v: any) => expect(v).toEqual(true),
+        error: (e: any) => { throw 'Should not reach'; },
+        complete: () => {}
+      };
+
+      const nextSpy = spyOn(observer, 'next');
+      const completeSpy = spyOn(observer, 'complete');
+
+      runGuards('', ['guard'], injector, []).subscribe(observer);
+
+      expect(nextSpy.calls.count()).toEqual(1);
+      expect(completeSpy.calls.count()).toEqual(1);
+    });
+
+    it('should complete after first emit from guard', () => {
+      const injector = {
+        get: (token: any) => () =>
+                 // never ending observable
+        Observable.create((subscriber: Subscriber<boolean>) => { subscriber.next(true); })
+      };
+
+      const observer = {
+        next: (v: any) => expect(v).toBe(true),
+        error: (e: any) => { throw 'Should not reach'; },
+        complete: () => {}
+      };
+
+      const nextSpy = spyOn(observer, 'next');
+      const completeSpy = spyOn(observer, 'complete');
+
+      runGuards('', ['guard'], injector, []).subscribe(observer);
+
+      expect(nextSpy.calls.count()).toEqual(1);
+      expect(completeSpy.calls.count()).toEqual(1);
+    });
+
+    it('should emit the first item of each guards', () => {
+      const injector = {
+        get: (token: any) => () => {
+          switch (token) {
+            case 'guard1':
+              return of (1);
+            case 'guard2':
+              return of (2, 2.1);
+            case 'guard3':
+              return Observable.create((subscriber: Subscriber<number>) => {
+                subscriber.next(3);
+                subscriber.next(3.1);
+              });
+          }
+        }
+      };
+
+      const result: number[] = [];
+
+      const observer = {
+        next: (v: number) => { result.push(v); },
+        error: (e: any) => { throw 'Should not reach'; },
+        complete: () => {
+          expect(result).toEqual([1, 2, 3]);
+        }
+      };
+
+      const nextSpy = spyOn(observer, 'next');
+      const completeSpy = spyOn(observer, 'complete');
+
+      runGuards('', ['guard1', 'guard2', 'guard3'], injector, []).subscribe(observer);
+
+      expect(nextSpy.calls.count()).toEqual(3);
+      expect(completeSpy.calls.count()).toEqual(1);
+    });
+
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Guards doesn't behave the same way towards multivalued and infinite Observables : 
- `canActivate`, `canDeactive` and `canActivateChild` will only check the first value emitted and won't wait for observables to complete.
- `canLoad` will check all the values returned and wait until all observables complete.
- `resolve` will only keep the last value emitted by each observable and wait until all observable complete.

Guards will behave the same way and act nicely towards single value observable that complete immediately after its emission. But not when more complicated Observables are used, I think `canActivate`, `canDeactivated` and `canActivateChild` behavior is the right one, meaning converting any observable into a single value observable that complete right after its emission. 
This is done through the use of the `first` operator.

Thks to @trotyl I think I got the history of this : 

Initially guards would use all values emitted by observables meaning boolean guards applied a logical and on every emits while resolve was just overwriting the value (so only last emit was kept). Then this pr #10412 changed `canActivate`, `canDeactivated` and `canActivateChild` to resolve at first value but didn't change `canLoad` nor `resolve` that's why we now have inconsistency between guards.

Issue Number: #18991

## What is the new behavior?

I did 2 things : 
1) Use `first()` operator on observable inside `wrapIntoObservable()`. The idea is that when we have a signature that accepts observable, promise and values we are expecting the output observable to only emit one value. Converting a value or a promise into an Observable already produces a single emit Observable so we just need to convert Observable (which can be of any kind) into single emit Observable.
2) Create a common helper function `runGuards()` to be used by all guards so we get consistency. This function basically takes guards tokens as input and return an observable that'll emit each corresponding guard output.

1 will also affects `loadChildren` on route but I think it's safe because same logic should apply.

## Does this PR introduce a breaking change?
```
[X] Yes
[] No
```
As mentioned by @Toxicable, we can find some corner cases where this will introduce breaking changes. The same was true for #10412 and it seems it didn't bother much people.

## Other information