### PR TITLE
fix(tsc-wrapped): fix metadata symbol reference

### DIFF
--- a/packages/tsc-wrapped/src/bundler.ts
+++ b/packages/tsc-wrapped/src/bundler.ts
@@ -292,7 +292,7 @@ export class MetadataBundler {
         // keep one entry and replace the others by references
         names.forEach((name: string, i: number) => {
           if (i !== reference) {
-            result[name] = {__symbolic: 'reference', name: declaredName};
+            result[name] = {__symbolic: 'reference', name: names[reference]};
           }
         });
       }

--- a/packages/tsc-wrapped/test/bundler_spec.ts
+++ b/packages/tsc-wrapped/test/bundler_spec.ts
@@ -219,7 +219,7 @@ describe('metadata bundler', () => {
     expect(A2.name).toEqual('A');
     expect(B1.__symbolic).toEqual('class');
     expect(B2.__symbolic).toEqual('reference');
-    expect(B2.name).toEqual('B');
+    expect(B2.name).toEqual('B1');
   });
 });
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
```

## What is the current behavior?
When modules are re-exported with different names, we only keep one of the original metadata and we change the other ones as references to their declared name, but if they are never exported under their real names then we are referencing a non-existing reference

## What is the new behavior?
if all exports are renamed, then the references will point to the name of the first export instead of the original declared name


## Does this PR introduce a breaking change?
```
[x] No
```