### PR TITLE
fix(core): throw error message when @Output not initialized

### DIFF
--- a/packages/core/src/util/lang.ts
+++ b/packages/core/src/util/lang.ts
@@ -21,6 +21,7 @@ export function isPromise(obj: any): obj is Promise<any> {
  * Determine if the argument is an Observable
  */
 export function isObservable(obj: any | Observable<any>): obj is Observable<any> {
-  // TODO: use Symbol.observable when https://github.com/ReactiveX/rxjs/issues/2415 will be resolved
+  // TODO: use isObservable once we update pass rxjs 6.1
+  // https://github.com/ReactiveX/rxjs/blob/master/CHANGELOG.md#610-2018-05-03
   return !!obj && typeof obj.subscribe === 'function';
 }

--- a/packages/core/src/view/provider.ts
+++ b/packages/core/src/view/provider.ts
@@ -137,9 +137,15 @@ export function createDirectiveInstance(view: ViewData, def: NodeDef): any {
   if (def.outputs.length) {
     for (let i = 0; i < def.outputs.length; i++) {
       const output = def.outputs[i];
-      const subscription = instance[output.propName !].subscribe(
-          eventHandlerClosure(view, def.parent !.nodeIndex, output.eventName));
-      view.disposables ![def.outputIndex + i] = subscription.unsubscribe.bind(subscription);
+      const outputObservable = instance[output.propName !];
+      if (typeof outputObservable === 'object') {
+        const subscription = outputObservable.subscribe(
+            eventHandlerClosure(view, def.parent !.nodeIndex, output.eventName));
+        view.disposables ![def.outputIndex + i] = subscription.unsubscribe.bind(subscription);
+      } else {
+        throw new Error(
+            `@Output ${output.propName} not initialized in '${instance.constructor.name}'.`);
+      }
     }
   }
   return instance;

--- a/packages/core/src/view/provider.ts
+++ b/packages/core/src/view/provider.ts
@@ -13,6 +13,7 @@ import {TemplateRef} from '../linker/template_ref';
 import {ViewContainerRef} from '../linker/view_container_ref';
 import {Renderer as RendererV1, Renderer2} from '../render/api';
 import {stringify} from '../util';
+import {isObservable} from '../util/lang';
 
 import {createChangeDetectorRef, createInjector, createRendererV1} from './refs';
 import {BindingDef, BindingFlags, DepDef, DepFlags, NodeDef, NodeFlags, OutputDef, OutputType, ProviderData, QueryValueType, Services, ViewData, ViewFlags, ViewState, asElementData, asProviderData, shouldCallLifecycleInitHook} from './types';
@@ -138,7 +139,7 @@ export function createDirectiveInstance(view: ViewData, def: NodeDef): any {
     for (let i = 0; i < def.outputs.length; i++) {
       const output = def.outputs[i];
       const outputObservable = instance[output.propName !];
-      if (typeof outputObservable === 'object') {
+      if (isObservable(outputObservable)) {
         const subscription = outputObservable.subscribe(
             eventHandlerClosure(view, def.parent !.nodeIndex, output.eventName));
         view.disposables ![def.outputIndex + i] = subscription.unsubscribe.bind(subscription);

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -3171,6 +3171,9 @@
     "name": "isObservable"
   },
   {
+    "name": "isObservable$1"
+  },
+  {
     "name": "isPrefixEnd"
   },
   {

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -346,6 +346,20 @@ function declareTests({useJit}: {useJit: boolean}) {
         expect(tc.injector.get(EventDir)).not.toBeNull();
       });
 
+      it('should display correct error message for uninitialized @Output', () => {
+        @Directive({selector: '[uninitializedOuput]'})
+        class UninitializedOuput {
+          @Output() customEvent;
+          doSomething() {
+          }
+        }
+
+        TestBed.configureTestingModule({declarations: [MyComp, UninitializedOuput]});
+        const template = '<p (customEvent)="doNothing()"></p>';
+        TestBed.overrideComponent(MyComp, {set: {template}});
+        TestBed.createComponent(MyComp).toThrowError('@Output customEvent not initialized in \'UninitializedOuput\'.');
+      });
+
       it('should read directives metadata from their binding token', () => {
         TestBed.configureTestingModule({declarations: [MyComp, PrivateImpl, NeedsPublicApi]});
         const template = '<div public-api><div needs-public-api></div></div>';

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -349,7 +349,7 @@ function declareTests({useJit}: {useJit: boolean}) {
       it('should display correct error message for uninitialized @Output', () => {
         @Component({selector: 'my-uninitialized-output', template: '<p>It works!</p>'})
         class UninitializedOutputComp {
-          @Output() customEvent: EventEmitter<any>;
+          @Output() customEvent !: EventEmitter<any>;
         }
 
         const template =

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -347,17 +347,18 @@ function declareTests({useJit}: {useJit: boolean}) {
       });
 
       it('should display correct error message for uninitialized @Output', () => {
-        @Directive({selector: '[uninitializedOuput]'})
-        class UninitializedOuput {
-          @Output() customEvent;
-          doSomething() {
-          }
+        @Component({selector: 'my-uninitialized-output', template: '<p>It works!</p>'})
+        class UninitializedOutputComp {
+          @Output() customEvent: EventEmitter<any>;
         }
 
-        TestBed.configureTestingModule({declarations: [MyComp, UninitializedOuput]});
-        const template = '<p (customEvent)="doNothing()"></p>';
+        const template =
+            '<my-uninitialized-output (customEvent)="doNothing()"></my-uninitialized-output>';
         TestBed.overrideComponent(MyComp, {set: {template}});
-        TestBed.createComponent(MyComp).toThrowError('@Output customEvent not initialized in \'UninitializedOuput\'.');
+
+        TestBed.configureTestingModule({declarations: [MyComp, UninitializedOutputComp]});
+        expect(() => TestBed.createComponent(MyComp))
+            .toThrowError('@Output customEvent not initialized in \'UninitializedOutputComp\'.');
       });
 
       it('should read directives metadata from their binding token', () => {


### PR DESCRIPTION
Closes #3664

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Listing an event in a directive without creating an associated EventEmitter instance results in cryptic error.

Issue Number: #3664


## What is the new behavior?
Better error messages when an `@Output` property is not initialized.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
