### PR TITLE
fix(aio): relax search on titles further

### DIFF
--- a/aio/e2e/app.e2e-spec.ts
+++ b/aio/e2e/app.e2e-spec.ts
@@ -96,6 +96,8 @@ describe('site App', function() {
     it('should find pages when searching by a partial word in the title', () => {
       page.enterSearch('ngCont');
       expect(page.getSearchResults().map(link => link.getText())).toContain('NgControl');
+      page.enterSearch('accessor');
+      expect(page.getSearchResults().map(link => link.getText())).toContain('ControlValueAccessor');
     });
   });
 });

--- a/aio/e2e/app.po.ts
+++ b/aio/e2e/app.po.ts
@@ -51,7 +51,9 @@ export class SitePage {
   }
 
   enterSearch(query: string) {
-    element(by.css('.search-container input[type=search]')).sendKeys(query);
+    const input = element(by.css('.search-container input[type=search]'));
+    input.clear();
+    input.sendKeys(query);
   }
 
   getSearchResults() {

--- a/aio/src/app/search/search-worker.js
+++ b/aio/src/app/search/search-worker.js
@@ -88,7 +88,7 @@ function queryIndex(query) {
     if (query.length) {
       // Add a relaxed search in the title for the first word in the query
       // E.g. if the search is "ngCont guide" then we search for "ngCont guide titleWords:ngCont*"
-      var titleQuery = 'titleWords:' + query.split(' ', 1)[0] + '*';
+      var titleQuery = 'titleWords:*' + query.split(' ', 1)[0] + '*';
       var results = index.search(query + ' ' + titleQuery);
       // Map the hits into info about each page to be returned as results
       return results.map(function(hit) { return pages[hit.ref]; });


### PR DESCRIPTION
This change will now match `ControlValueAccessor` for the query `accessor`.

Closes #18872
