### PR TITLE
fix(platform-server): support setting innerText property

### DIFF
--- a/packages/platform-server/src/domino_adapter.ts
+++ b/packages/platform-server/src/domino_adapter.ts
@@ -87,19 +87,25 @@ export class DominoAdapter extends BrowserDomAdapter {
   isShadowRoot(node: any): boolean { return this.getShadowRoot(node) == node; }
 
   getProperty(el: Element, name: string): any {
-    // Domino tries tp resolve href-s which we do not want. Just return the
-    // atribute value.
     if (name === 'href') {
+      // Domino tries tp resolve href-s which we do not want. Just return the
+      // atribute value.
       return this.getAttribute(el, 'href');
+    } else if (name === 'innerText') {
+      // Domino does not support innerText. Just map it to textContent.
+      return el.textContent;
     }
     return (<any>el)[name];
   }
 
   setProperty(el: Element, name: string, value: any) {
-    // Eventhough the server renderer reflects any properties to attributes
-    // map 'href' to atribute just to handle when setProperty is directly called.
     if (name === 'href') {
+      // Eventhough the server renderer reflects any properties to attributes
+      // map 'href' to atribute just to handle when setProperty is directly called.
       this.setAttribute(el, 'href', value);
+    } else if (name === 'innerText') {
+      // Domino does not support innerText. Just map it to textContent.
+      el.textContent = value;
     }
     (<any>el)[name] = value;
   }

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -30,7 +30,7 @@ function notSupported(feature: string): Error {
 export const INTERNAL_SERVER_PLATFORM_PROVIDERS: StaticProvider[] = [
   {provide: DOCUMENT, useFactory: _document, deps: [Injector]},
   {provide: PLATFORM_ID, useValue: PLATFORM_SERVER_ID},
-  {provide: PLATFORM_INITIALIZER, useFactory: initParse5Adapter, multi: true, deps: [Injector]}, {
+  {provide: PLATFORM_INITIALIZER, useFactory: initDominoAdapter, multi: true, deps: [Injector]}, {
     provide: PlatformLocation,
     useClass: ServerPlatformLocation,
     deps: [DOCUMENT, [Optional, INITIAL_CONFIG]]
@@ -40,7 +40,7 @@ export const INTERNAL_SERVER_PLATFORM_PROVIDERS: StaticProvider[] = [
   {provide: ALLOW_MULTIPLE_PLATFORMS, useValue: true}
 ];
 
-function initParse5Adapter(injector: Injector) {
+function initDominoAdapter(injector: Injector) {
   return () => { DominoAdapter.makeCurrent(); };
 }
 

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -426,7 +426,7 @@ export function main() {
       let doc: string;
       let called: boolean;
       let expectedOutput =
-          '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">Works!<h1 innertext="fine"></h1></app></body></html>';
+          '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">Works!<h1 innertext="fine">fine</h1></app></body></html>';
 
       beforeEach(() => {
         // PlatformConfig takes in a parsed document so that it can be cached across requests.


### PR DESCRIPTION
Domino doesn't support innerText. So the actual inner text wasn't
getting set if the [innerText] was set on an element in a template. Add
it to the domino adapter to map it to textContent.

Also change wrongly named initParse5Adapter to initDominoAdapter.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

