### PR TITLE
build(common): don't generate tsickle re-export file for locales package

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -223,9 +223,11 @@ compilePackage() {
   else
     local package_name=$(basename "${2}")
     $NGC -p ${1}/tsconfig-build.json
-    echo "======           Create ${1}/../${package_name}.d.ts re-export file for tsickle"
-    echo "$(cat ${LICENSE_BANNER}) ${N} export * from './${package_name}/${package_name}'" > ${2}/../${package_name}.d.ts
-    echo "{\"__symbolic\":\"module\",\"version\":3,\"metadata\":{},\"exports\":[{\"from\":\"./${package_name}/${package_name}\"}],\"flatModuleIndexRedirect\":true}" > ${2}/../${package_name}.metadata.json
+    if [[ "${package_name}" != "locales" ]]; then
+      echo "======           Create ${1}/../${package_name}.d.ts re-export file for tsickle"
+      echo "$(cat ${LICENSE_BANNER}) ${N} export * from './${package_name}/${package_name}'" > ${2}/../${package_name}.d.ts
+      echo "{\"__symbolic\":\"module\",\"version\":3,\"metadata\":{},\"exports\":[{\"from\":\"./${package_name}/${package_name}\"}],\"flatModuleIndexRedirect\":true}" > ${2}/../${package_name}.metadata.json
+    fi
   fi
 
   for DIR in ${1}/* ; do

--- a/integration/bazel/angular.tsconfig.json
+++ b/integration/bazel/angular.tsconfig.json
@@ -16,8 +16,6 @@
   "exclude": [
       "node_modules/@angular/bazel/**",
       "node_modules/@angular/compiler-cli/**",
-      // Workaround bug introduced by 079d884
-      "node_modules/@angular/common/locales.d.ts",
       "node_modules/@angular/common/locales/**",
       "node_modules/@angular/tsc-wrapped/**"
   ]


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Build related changes
```

## What is the current behavior?
We generate a re-export file for the i18n `locales` package, but this package has no index and the re-export file points to a inexistent file.

## What is the new behavior?
We don't generate this re-export file for the `locales` package


## Does this PR introduce a breaking change?
```
[x] No
```