### PR TITLE
build(common): inject deprecated `getPluralCase` for treeshaking

### DIFF
--- a/packages/common/src/common_module.ts
+++ b/packages/common/src/common_module.ts
@@ -8,7 +8,7 @@
 
 import {NgModule} from '@angular/core';
 import {COMMON_DIRECTIVES} from './directives/index';
-import {NgLocaleLocalization, NgLocalization, USE_V4_PLURALS} from './i18n/localization';
+import {DEPRECATED_PLURAL_FN, NgLocaleLocalization, NgLocalization, getPluralCase} from './i18n/localization';
 import {COMMON_DEPRECATED_I18N_PIPES} from './pipes/deprecated/index';
 import {COMMON_PIPES} from './pipes/index';
 
@@ -38,7 +38,7 @@ export class CommonModule {
 @NgModule({
   declarations: [COMMON_DEPRECATED_I18N_PIPES],
   exports: [COMMON_DEPRECATED_I18N_PIPES],
-  providers: [{provide: USE_V4_PLURALS, useValue: true}],
+  providers: [{provide: DEPRECATED_PLURAL_FN, useValue: getPluralCase}],
 })
 export class DeprecatedI18NPipesModule {
 }

--- a/packages/common/src/i18n/localization.ts
+++ b/packages/common/src/i18n/localization.ts
@@ -13,7 +13,7 @@ import {Plural, getLocalePluralCase} from './locale_data_api';
 /**
  * @deprecated from v5
  */
-export const USE_V4_PLURALS = new InjectionToken<boolean>('UseV4Plurals');
+export const DEPRECATED_PLURAL_FN = new InjectionToken<boolean>('UseV4Plurals');
 
 /**
  * @experimental
@@ -60,13 +60,15 @@ export function getPluralCategory(
 export class NgLocaleLocalization extends NgLocalization {
   constructor(
       @Inject(LOCALE_ID) protected locale: string,
-      @Optional() @Inject(USE_V4_PLURALS) protected useV4Plurals?: boolean) {
+      /** @deprecated from v5 */
+      @Optional() @Inject(DEPRECATED_PLURAL_FN) protected deprecatedPluralFn?:
+          ((locale: string, value: number|string) => Plural)|null) {
     super();
   }
 
   getPluralCategory(value: any, locale?: string): string {
-    const plural = this.useV4Plurals ? getPluralCase(locale || this.locale, value) :
-                                       getLocalePluralCase(locale || this.locale)(value);
+    const plural = this.deprecatedPluralFn ? this.deprecatedPluralFn(locale || this.locale, value) :
+                                             getLocalePluralCase(locale || this.locale)(value);
 
     switch (plural) {
       case Plural.Zero:
@@ -91,7 +93,7 @@ export class NgLocaleLocalization extends NgLocalization {
  * @deprecated from v5 the plural case function is in locale data files common/locales/*.ts
  * @experimental
  */
-function getPluralCase(locale: string, nLike: number | string): Plural {
+export function getPluralCase(locale: string, nLike: number | string): Plural {
   // TODO(vicb): lazy compute
   if (typeof nLike === 'string') {
     nLike = parseInt(<string>nLike, 10);

--- a/packages/common/test/common_module_spec.ts
+++ b/packages/common/test/common_module_spec.ts
@@ -9,13 +9,18 @@
 
 import {TestBed, inject} from '@angular/core/testing';
 import {DeprecatedI18NPipesModule} from '../src/common_module';
-import {USE_V4_PLURALS} from '../src/i18n/localization';
+import {Plural} from '../src/i18n/locale_data_api';
+import {DEPRECATED_PLURAL_FN, getPluralCase} from '../src/i18n/localization';
 
 export function main() {
   describe('DeprecatedI18NPipesModule', () => {
     beforeEach(() => { TestBed.configureTestingModule({imports: [DeprecatedI18NPipesModule]}); });
 
-    it('should define the token USE_V4_PLURALS to true',
-       inject([USE_V4_PLURALS], (useV4Plurals: true) => { expect(useV4Plurals).toEqual(true); }));
+    it('should define the token DEPRECATED_PLURAL_FN',
+       inject(
+           [DEPRECATED_PLURAL_FN],
+           (injectedGetPluralCase?: (locale: string, value: number | string) => Plural) => {
+             expect(injectedGetPluralCase).toEqual(getPluralCase);
+           }));
   });
 }

--- a/packages/common/test/i18n/localization_spec.ts
+++ b/packages/common/test/i18n/localization_spec.ts
@@ -12,7 +12,8 @@ import localeZgh from '../../locales/zgh';
 import localeFr from '../../locales/fr';
 import {LOCALE_ID} from '@angular/core';
 import {TestBed, inject} from '@angular/core/testing';
-import {NgLocaleLocalization, NgLocalization, getPluralCategory, USE_V4_PLURALS} from '../../src/i18n/localization';
+import {NgLocaleLocalization, NgLocalization, getPluralCategory, DEPRECATED_PLURAL_FN, getPluralCase} from '../../src/i18n/localization';
+import {Plural} from '../../src/i18n/locale_data_api';
 import {registerLocaleData} from '../../src/i18n/locale_data';
 
 export function main() {
@@ -48,8 +49,10 @@ export function main() {
       describe('ro with v4 plurals', () => {
         beforeEach(() => {
           TestBed.configureTestingModule({
-            providers:
-                [{provide: LOCALE_ID, useValue: 'ro'}, {provide: USE_V4_PLURALS, useValue: true}],
+            providers: [
+              {provide: LOCALE_ID, useValue: 'ro'},
+              {provide: DEPRECATED_PLURAL_FN, useValue: getPluralCase}
+            ],
           });
         });
 
@@ -83,8 +86,10 @@ export function main() {
       describe('sr with v4 plurals', () => {
         beforeEach(() => {
           TestBed.configureTestingModule({
-            providers:
-                [{provide: LOCALE_ID, useValue: 'sr'}, {provide: USE_V4_PLURALS, useValue: true}],
+            providers: [
+              {provide: LOCALE_ID, useValue: 'sr'},
+              {provide: DEPRECATED_PLURAL_FN, useValue: getPluralCase}
+            ],
           });
         });
 
@@ -93,9 +98,10 @@ export function main() {
     });
 
     describe('NgLocaleLocalization', () => {
-      function ngLocaleLocalizationTests(useV4Plurals: boolean) {
+      function ngLocaleLocalizationTests(
+          getPluralCase: ((locale: string, value: number | string) => Plural) | null) {
         it('should return the correct values for the "en" locale', () => {
-          const l10n = new NgLocaleLocalization('en-US', useV4Plurals);
+          const l10n = new NgLocaleLocalization('en-US', getPluralCase);
 
           expect(l10n.getPluralCategory(0)).toEqual('other');
           expect(l10n.getPluralCategory(1)).toEqual('one');
@@ -103,7 +109,7 @@ export function main() {
         });
 
         it('should return the correct values for the "ro" locale', () => {
-          const l10n = new NgLocaleLocalization('ro', useV4Plurals);
+          const l10n = new NgLocaleLocalization('ro', getPluralCase);
 
           expect(l10n.getPluralCategory(0)).toEqual('few');
           expect(l10n.getPluralCategory(1)).toEqual('one');
@@ -115,7 +121,7 @@ export function main() {
         });
 
         it('should return the correct values for the "sr" locale', () => {
-          const l10n = new NgLocaleLocalization('sr', useV4Plurals);
+          const l10n = new NgLocaleLocalization('sr', getPluralCase);
 
           expect(l10n.getPluralCategory(1)).toEqual('one');
           expect(l10n.getPluralCategory(31)).toEqual('one');
@@ -162,7 +168,7 @@ export function main() {
         });
 
         it('should return the default value for a locale with no rule', () => {
-          const l10n = new NgLocaleLocalization('zgh', useV4Plurals);
+          const l10n = new NgLocaleLocalization('zgh', getPluralCase);
 
           expect(l10n.getPluralCategory(0)).toEqual('other');
           expect(l10n.getPluralCategory(1)).toEqual('other');
@@ -172,13 +178,14 @@ export function main() {
         });
       }
 
-      ngLocaleLocalizationTests(true);
-      ngLocaleLocalizationTests(false);
+      ngLocaleLocalizationTests(null);
+      ngLocaleLocalizationTests(getPluralCase);
     });
 
-    function pluralCategoryTests(useV4Plurals: boolean) {
+    function pluralCategoryTests(
+        getPluralCase: ((locale: string, value: number | string) => Plural) | null) {
       it('should return plural category', () => {
-        const l10n = new NgLocaleLocalization('fr', useV4Plurals);
+        const l10n = new NgLocaleLocalization('fr', getPluralCase);
 
         expect(getPluralCategory(0, ['one', 'other'], l10n)).toEqual('one');
         expect(getPluralCategory(1, ['one', 'other'], l10n)).toEqual('one');
@@ -186,7 +193,7 @@ export function main() {
       });
 
       it('should return discrete cases', () => {
-        const l10n = new NgLocaleLocalization('fr', useV4Plurals);
+        const l10n = new NgLocaleLocalization('fr', getPluralCase);
 
         expect(getPluralCategory(0, ['one', 'other', '=0'], l10n)).toEqual('=0');
         expect(getPluralCategory(1, ['one', 'other'], l10n)).toEqual('one');
@@ -195,7 +202,7 @@ export function main() {
       });
 
       it('should fallback to other when the case is not present', () => {
-        const l10n = new NgLocaleLocalization('ro', useV4Plurals);
+        const l10n = new NgLocaleLocalization('ro', getPluralCase);
         expect(getPluralCategory(1, ['one', 'other'], l10n)).toEqual('one');
         // 2 -> 'few'
         expect(getPluralCategory(2, ['one', 'other'], l10n)).toEqual('other');
@@ -204,7 +211,7 @@ export function main() {
       describe('errors', () => {
         it('should report an error when the "other" category is not present', () => {
           expect(() => {
-            const l10n = new NgLocaleLocalization('ro', useV4Plurals);
+            const l10n = new NgLocaleLocalization('ro', getPluralCase);
             // 2 -> 'few'
             getPluralCategory(2, ['one'], l10n);
           }).toThrowError('No plural message found for value "2"');
@@ -213,8 +220,8 @@ export function main() {
     }
 
     describe('getPluralCategory', () => {
-      pluralCategoryTests(false);
-      pluralCategoryTests(true);
+      pluralCategoryTests(null);
+      pluralCategoryTests(getPluralCase);
     });
   });
 }

--- a/tools/public_api_guard/common/index.d.ts
+++ b/tools/public_api_guard/common/index.d.ts
@@ -286,9 +286,10 @@ export declare class NgIfContext {
 
 /** @experimental */
 export declare class NgLocaleLocalization extends NgLocalization {
+    /** @deprecated */ protected deprecatedPluralFn: ((locale: string, value: string | number) => Plural) | null | undefined;
     protected locale: string;
-    protected useV4Plurals: boolean | undefined;
-    constructor(locale: string, useV4Plurals?: boolean | undefined);
+    constructor(locale: string,
+        deprecatedPluralFn?: ((locale: string, value: string | number) => Plural) | null | undefined);
     getPluralCategory(value: any, locale?: string): string;
 }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Build related changes
```

## What is the current behavior?
The deprecated `getPluralCase` function cannot be treeshaken by webpack because it's referenced directly inside of `NgLocaleLocalization`

Issue Number: #19115


## What is the new behavior?
`getPluralCase` is now injected with the deprecated common module, webpack should be able to remove it if the deprecated common module is not injected.


## Does this PR introduce a breaking change?
```
[x] No
```