### PR TITLE
fix(router): fix activation events toString and docs

### DIFF
--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -300,7 +300,7 @@ export class ActivationStart {
       public snapshot: ActivatedRouteSnapshot) {}
   toString(): string {
     const path = this.snapshot.routeConfig && this.snapshot.routeConfig.path || '';
-    return `ChildActivationStart(path: '${path}')`;
+    return `ActivationStart(path: '${path}')`;
   }
 }
 
@@ -316,7 +316,7 @@ export class ActivationEnd {
       public snapshot: ActivatedRouteSnapshot) {}
   toString(): string {
     const path = this.snapshot.routeConfig && this.snapshot.routeConfig.path || '';
-    return `ChildActivationEnd(path: '${path}')`;
+    return `ActivationEnd(path: '${path}')`;
   }
 }
 
@@ -331,9 +331,11 @@ export class ActivationEnd {
  * - {@link RoutesRecognized},
  * - {@link GuardsCheckStart},
  * - {@link ChildActivationStart},
+ * - {@link ActivationStart},
  * - {@link GuardsCheckEnd},
  * - {@link ResolveStart},
  * - {@link ResolveEnd},
+ * - {@link ActivationEnd}
  * - {@link ChildActivationEnd}
  * - {@link NavigationEnd},
  * - {@link NavigationCancel},
@@ -343,4 +345,3 @@ export class ActivationEnd {
  */
 export type Event = RouterEvent | RouteConfigLoadStart | RouteConfigLoadEnd | ChildActivationStart |
     ChildActivationEnd | ActivationStart | ActivationEnd;
-;

--- a/packages/router/src/pre_activation.ts
+++ b/packages/router/src/pre_activation.ts
@@ -211,10 +211,10 @@ export class PreActivation {
   }
 
   /**
-   * This should fire off `ChildActivationStart` events for each route being activated at this
+   * This should fire off `ActivationStart` events for each route being activated at this
    * level.
    * In other words, if you're activating `a` and `b` below, `path` will contain the
-   * `ActivatedRouteSnapshot`s for both and we will fire `ChildActivationStart` for both. Always
+   * `ActivatedRouteSnapshot`s for both and we will fire `ActivationStart` for both. Always
    * return
    * `true` so checks continue to run.
    */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

PR #19073 introduced `ActivationStart` and `ActivationEnd` events for the router, but they have the same toString as `ChildActivationStart` and `ChildActivationEnd`, and were forgotten of the list of events documentation.

## What is the new behavior?

The `toString` methods are fixes and the documentation is updated.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

@jasonaden I would like to also update the documentation of these events as it is not really clear currently what difference they have with their `ChildActivation` counterpart (the JSDoc is a copy/paste). I would gladly update the PR with a more thorough JSDoc if you give me some pointers, as I struggle to understand the difference.
