### PR TITLE
feat(forms): introduce `FormArray#get` for a more consistent api

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -1301,6 +1301,12 @@ export class FormArray extends AbstractControl {
     this.updateValueAndValidity({onlySelf: true, emitEvent: false});
   }
 
+
+  /**
+   * Get the {@link AbstractControl} at the given `index` in the array.
+   */
+  get(index: number): AbstractControl { return this.controls[index]; }
+
   /**
    * Get the {@link AbstractControl} at the given `index` in the array.
    */

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -89,8 +89,8 @@ export function main() {
           new FormGroup({'c2': new FormControl('v2'), 'c3': new FormControl('v3')}),
           new FormArray([new FormControl('v4'), new FormControl('v5')])
         ]);
-        a.at(0).get('c3') !.disable();
-        (a.at(1) as FormArray).at(1).disable();
+        a.get(0).get('c3') !.disable();
+        (a.get(1) as FormArray).at(1).disable();
 
         expect(a.getRawValue()).toEqual([{'c2': 'v2', 'c3': 'v3'}, ['v4', 'v5']]);
       });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
```
[x] Feature
```

## What is the current behavior?
The method for retrieving a control from a `FormArray` previously was `FormArray#at` which is not consistent with `FormGroup#get`

## What is the new behavior?
Add `FormArray#get` with plans to deprecate `FormArray#at` at a later time

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```