### PR TITLE
build(core): reduce payload size for cli-hello-world

### DIFF
--- a/integration/_payload-limits.sh
+++ b/integration/_payload-limits.sh
@@ -8,15 +8,12 @@ payloadLimits["hello_world__closure", "gzip7", "bundle"]=35000
 payloadLimits["hello_world__closure", "gzip9", "bundle"]=35000
 
 payloadLimits["cli-hello-world", "uncompressed", "inline"]=1500
-# TODO(tbosch): find out why this increased, see https://github.com/angular/angular/issues/19113
-payloadLimits["cli-hello-world", "uncompressed", "main"]=205000
+payloadLimits["cli-hello-world", "uncompressed", "main"]=175000
 payloadLimits["cli-hello-world", "uncompressed", "polyfills"]=64000
 payloadLimits["cli-hello-world", "gzip7", "inline"]=900
-# TODO(tbosch): find out why this increased, see https://github.com/angular/angular/issues/19113
-payloadLimits["cli-hello-world", "gzip7", "main"]=56000
+payloadLimits["cli-hello-world", "gzip7", "main"]=48000
 payloadLimits["cli-hello-world", "gzip7", "polyfills"]=22000
 payloadLimits["cli-hello-world", "gzip9", "inline"]=900
-# TODO(tbosch): find out why this increased, see https://github.com/angular/angular/issues/19113
-payloadLimits["cli-hello-world", "gzip9", "main"]=56000
+payloadLimits["cli-hello-world", "gzip9", "main"]=48000
 payloadLimits["cli-hello-world", "gzip9", "polyfills"]=22000
 


### PR DESCRIPTION
Given https://github.com/angular/devkit/pull/146, the payload sizes should be back to normal for cli-hello-world.