### PR TITLE
refactor(upgrade): use correct property name

### DIFF
--- a/packages/upgrade/src/dynamic/upgrade_adapter.ts
+++ b/packages/upgrade/src/dynamic/upgrade_adapter.ts
@@ -13,7 +13,7 @@ import * as angular from '../common/angular1';
 import {$$TESTABILITY, $COMPILE, $INJECTOR, $ROOT_SCOPE, COMPILER_KEY, INJECTOR_KEY, LAZY_MODULE_REF, NG_ZONE_KEY} from '../common/constants';
 import {downgradeComponent} from '../common/downgrade_component';
 import {downgradeInjectable} from '../common/downgrade_injectable';
-import {Deferred, controllerKey, onError} from '../common/util';
+import {Deferred, LazyModuleRef, controllerKey, onError} from '../common/util';
 
 import {UpgradeNg1ComponentAdapterBuilder} from './upgrade_ng1_adapter';
 
@@ -498,7 +498,7 @@ export class UpgradeAdapter {
     ng1Module.factory(INJECTOR_KEY, () => this.moduleRef !.injector.get(Injector))
         .factory(
             LAZY_MODULE_REF,
-            [INJECTOR_KEY, (injector: Injector) => ({injector, needsInNgZone: false})])
+            [INJECTOR_KEY, (injector: Injector) => ({injector, needsNgZone: false} as LazyModuleRef)])
         .constant(NG_ZONE_KEY, this.ngZone)
         .factory(COMPILER_KEY, () => this.moduleRef !.injector.get(Compiler))
         .config([

--- a/packages/upgrade/src/static/upgrade_module.ts
+++ b/packages/upgrade/src/static/upgrade_module.ts
@@ -10,7 +10,7 @@ import {Injector, NgModule, NgZone, Testability} from '@angular/core';
 
 import * as angular from '../common/angular1';
 import {$$TESTABILITY, $DELEGATE, $INJECTOR, $INTERVAL, $PROVIDE, INJECTOR_KEY, LAZY_MODULE_REF, UPGRADE_MODULE_NAME} from '../common/constants';
-import {controllerKey} from '../common/util';
+import {LazyModuleRef, controllerKey} from '../common/util';
 
 import {angular1Providers, setTempInjectorRef} from './angular1_providers';
 import {NgAdapterInjector} from './util';
@@ -166,7 +166,7 @@ export class UpgradeModule {
 
             .factory(
                 LAZY_MODULE_REF,
-                [INJECTOR_KEY, (injector: Injector) => ({injector, needsNgZone: false})])
+                [INJECTOR_KEY, (injector: Injector) => ({injector, needsNgZone: false} as LazyModuleRef)])
 
             .config([
               $PROVIDE, $INJECTOR,


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Refactoring (no functional changes, no api changes)
```


## What is the current behavior?
Wrong property name used.


## What is the new behavior?
Correct property name used.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
It doesn't make any difference in this case, because the we only check the property for truthfulness (and being undefined has the same effect as being set to false).
