### PR TITLE
ci(aio): correctly serialize commit messages with "double-quotes"

### DIFF
--- a/scripts/ci/payload-size.sh
+++ b/scripts/ci/payload-size.sh
@@ -43,7 +43,7 @@ addMessage() {
   # because $TRAVIS_COMMIT_RANGE will contain the previous SHA which will not be in the
   # force push or commit, hence we default to last commit.
   message=$(git log --oneline $TRAVIS_COMMIT_RANGE -- || git log --oneline -n1)
-  message=$(echo $message | sed 's/"/\\"/g' | sed 's/\\/\\\\/g')
+  message=$(echo $message | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
   payloadData="$payloadData\"message\": \"$message\""
 }
 


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?
```
[x] CI related changes
```


## What is the current behavior?
Commits containing double-quotes were not serialized correctly (as valid JSON), so the payload data (which include the commit message) can not be uploaded to firebase.


## What is the new behavior?
Commits containing double-quotes are correctly serialized, so that the payload data can be uploaded to firebase.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
PR #19184 includes the equivalent change for the 4.4.x branch.
