### PR TITLE
ci(aio): correctly serialize commit messages with "double-quotes"

### DIFF
--- a/aio/scripts/payload.sh
+++ b/aio/scripts/payload.sh
@@ -61,7 +61,7 @@ else
   # Nothing changed in aio/
   exit 0
 fi
-message=$(echo $TRAVIS_COMMIT_MESSAGE | sed 's/"/\\"/g' | sed 's/\\/\\\\/g')
+message=$(echo $TRAVIS_COMMIT_MESSAGE | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
 payloadData="$payloadData\"change\": \"$change\", \"message\": \"$message\""
 
 payloadData="{${payloadData}}"


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?
```
[x] CI related changes
```


## What is the current behavior?
Commits containing double-quotes were not serialized correctly (as valid JSON), so the payload data (which include the commit message) can not be uploaded to firebase.


## What is the new behavior?
Commits containing double-quotes are correctly serialized, so that the payload data can be uploaded to firebase.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
PR #19183 includes the equivalent change for the master branch.
