### PR TITLE
fix(core): make ng-version attribute W3C compliant

### DIFF
--- a/packages/core/src/view/refs.ts
+++ b/packages/core/src/view/refs.ts
@@ -93,7 +93,8 @@ class ComponentFactory_ extends ComponentFactory<any> {
         injector, projectableNodes || [], rootSelectorOrNode, viewDef, ngModule, EMPTY_CONTEXT);
     const component = asProviderData(view, componentNodeIndex).instance;
     if (rootSelectorOrNode) {
-      view.renderer.setAttribute(asElementData(view, 0).renderElement, 'ng-version', VERSION.full);
+      view.renderer.setAttribute(
+          asElementData(view, 0).renderElement, 'data-ng-version', VERSION.full);
     }
 
     return new ComponentRef_(view, new ViewRef_(view), component);

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -384,7 +384,7 @@ function declareTests({useJit}: {useJit: boolean}) {
       const compRef =
           modRef.componentFactoryResolver.resolveComponentFactory(App).create(Injector.NULL);
 
-      expect(getDOM().hasAttribute(compRef.location.nativeElement, 'ng-version')).toBe(false);
+      expect(getDOM().hasAttribute(compRef.location.nativeElement, 'data-ng-version')).toBe(false);
     });
   });
 }

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -234,7 +234,7 @@ export function main() {
          const refPromise = bootstrap(HelloRootCmp, testProviders);
          refPromise.then((ref) => {
            expect(el).toHaveText('hello world!');
-           expect(el.getAttribute('ng-version')).toEqual(VERSION.full);
+           expect(el.getAttribute('data-ng-version')).toEqual(VERSION.full);
            async.done();
          });
        }));

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -467,7 +467,7 @@ export function main() {
       let doc: string;
       let called: boolean;
       let expectedOutput =
-          '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">Works!<h1 innertext="fine">fine</h1></app></body></html>';
+          '<html><head></head><body><app data-ng-version="0.0.0-PLACEHOLDER">Works!<h1 innertext="fine">fine</h1></app></body></html>';
 
       beforeEach(() => {
         // PlatformConfig takes in a parsed document so that it can be cached across requests.
@@ -515,7 +515,7 @@ export function main() {
       it('works with SVG elements', async(() => {
            renderModule(SVGServerModule, {document: doc}).then(output => {
              expect(output).toBe(
-                 '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
+                 '<html><head></head><body><app data-ng-version="0.0.0-PLACEHOLDER">' +
                  '<svg><use xlink:href="#clear"></use></svg></app></body></html>');
              called = true;
            });
@@ -540,7 +540,7 @@ export function main() {
       it('should handle false values on attributes', async(() => {
            renderModule(FalseAttributesModule, {document: doc}).then(output => {
              expect(output).toBe(
-                 '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
+                 '<html><head></head><body><app data-ng-version="0.0.0-PLACEHOLDER">' +
                  '<my-child ng-reflect-attr="false">Works!</my-child></app></body></html>');
              called = true;
            });
@@ -549,7 +549,7 @@ export function main() {
       it('should handle element property "name"', async(() => {
            renderModule(NameModule, {document: doc}).then(output => {
              expect(output).toBe(
-                 '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
+                 '<html><head></head><body><app data-ng-version="0.0.0-PLACEHOLDER">' +
                  '<input name=""></app></body></html>');
              called = true;
            });
@@ -560,7 +560,7 @@ export function main() {
              // title should be added by the render hook.
              expect(output).toBe(
                  '<html><head><title>RenderHook</title></head><body>' +
-                 '<app ng-version="0.0.0-PLACEHOLDER">Works!</app></body></html>');
+                 '<app data-ng-version="0.0.0-PLACEHOLDER">Works!</app></body></html>');
              called = true;
            });
          }));
@@ -571,7 +571,7 @@ export function main() {
              // title should be added by the render hook.
              expect(output).toBe(
                  '<html><head><title>RenderHook</title><meta name="description"></head>' +
-                 '<body><app ng-version="0.0.0-PLACEHOLDER">Works!</app></body></html>');
+                 '<body><app data-ng-version="0.0.0-PLACEHOLDER">Works!</app></body></html>');
              expect(consoleSpy).toHaveBeenCalled();
              called = true;
            });
@@ -718,7 +718,7 @@ export function main() {
     describe('ServerTransferStoreModule', () => {
       let called = false;
       const defaultExpectedOutput =
-          '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">Works!</app><script id="transfer-state" type="application/json">{&q;test&q;:10}</script></body></html>';
+          '<html><head></head><body><app data-ng-version="0.0.0-PLACEHOLDER">Works!</app><script id="transfer-state" type="application/json">{&q;test&q;:10}</script></body></html>';
 
       beforeEach(() => { called = false; });
       afterEach(() => { expect(called).toBe(true); });
@@ -747,7 +747,7 @@ export function main() {
              document: '<esc-app></esc-app>'
            }).then(output => {
              expect(output).toBe(
-                 '<html><head></head><body><esc-app ng-version="0.0.0-PLACEHOLDER">Works!</esc-app>' +
+                 '<html><head></head><body><esc-app data-ng-version="0.0.0-PLACEHOLDER">Works!</esc-app>' +
                  '<script id="transfer-state" type="application/json">' +
                  '{&q;testString&q;:&q;&l;/script&g;&l;script&g;' +
                  'alert(&s;Hello&a;&s; + \\&q;World\\&q;);&q;}</script></body></html>');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Using `ng-version` attribute make the DOM generated not to pass the W3C validation.
The verification gives the following error: "Attribute ng-version not allowed on element div at this point."

Issue Number: #16283


## What is the new behavior?
Now `ng-version` attribute is compliant with W3C validation.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
If developers is using some tool relying on `ng-version` attribute or to grab the version of Angular from the rendered html it will no longer work by searching for the `ng-version` attribute.

## Other information
