### PR TITLE
refactor(compiler): update i18n comments deprecation message

### DIFF
--- a/packages/compiler/src/i18n/extractor_merger.ts
+++ b/packages/compiler/src/i18n/extractor_merger.ts
@@ -182,7 +182,7 @@ class _Visitor implements html.Visitor {
             const details = comment.sourceSpan.details ? `, ${comment.sourceSpan.details}` : '';
             // TODO(ocombe): use a log service once there is a public one available
             console.warn(
-                ` I18n comments are deprecated, use an <ng - container> element instead (${comment.sourceSpan.start}${details})`);
+                `I18n comments are deprecated, use an <ng-container> element instead (${comment.sourceSpan.start}${details})`);
           }
           this._inI18nBlock = true;
           this._blockStartDepth = this._depth;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Refactoring (no functional changes, no api changes)
```

## What is the current behavior?
When my previous PR (https://github.com/angular/angular/pull/18998) was merged it didn't take my last changes to the code into account.

## What is the new behavior?
Fixed message for the i18n comments deprecation

## Does this PR introduce a breaking change?
```
[x] No
```
