### PR TITLE
fix(core): should support event.stopImmediatePropagation

### DIFF
--- a/packages/platform-browser/src/dom/events/dom_events.ts
+++ b/packages/platform-browser/src/dom/events/dom_events.ts
@@ -31,6 +31,8 @@ const FALSE = 'FALSE';
 const ANGULAR = 'ANGULAR';
 const NATIVE_ADD_LISTENER = 'addEventListener';
 const NATIVE_REMOVE_LISTENER = 'removeEventListener';
+// use the same symbol string which is used in zone.js
+const stopSymbol = '__zone_symbol__propagationStopped';
 
 const blackListedEvents: string[] = Zone && Zone[__symbol__('BLACK_LISTED_EVENTS')];
 let blackListedMap: {[eventName: string]: string};
@@ -77,6 +79,9 @@ const globalListener = function(event: Event) {
     // itself or others
     const copiedTasks = taskDatas.slice();
     for (let i = 0; i < copiedTasks.length; i++) {
+      if ((event as any)[stopSymbol] === true) {
+        break;
+      }
       const taskData = copiedTasks[i];
       if (taskData.zone !== Zone.current) {
         // only use Zone.run when Zone.current not equals to stored zone
@@ -90,7 +95,29 @@ const globalListener = function(event: Event) {
 
 @Injectable()
 export class DomEventsPlugin extends EventManagerPlugin {
-  constructor(@Inject(DOCUMENT) doc: any, private ngZone: NgZone) { super(doc); }
+  constructor(@Inject(DOCUMENT) doc: any, private ngZone: NgZone) {
+    super(doc);
+
+    this.patchEvent();
+  }
+
+  private patchEvent() {
+    if (!Event || !Event.prototype) {
+      return;
+    }
+    const symbol = '__zone_symbol__stopImmediatePropagation';
+    if ((Event.prototype as any)[symbol]) {
+      // already patched by zone.js
+      return;
+    }
+    (Event.prototype as any)[symbol] = Event.prototype.stopImmediatePropagation;
+    Event.prototype.stopImmediatePropagation = function() {
+      if (this) {
+        this[stopSymbol] = true;
+      }
+    };
+  }
+
 
   // This plugin should come last in the list of plugins, because it accepts all
   // events.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/pull/18993

With the optimized `addEventListener`, `event.stopImmeditePropagation` will stop working and will be executed even earlier listener want to stop.


## What is the new behavior?
patch Event.stopImmediate so we can stop invoke event listeners if earlier listener stop the propagation.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
