### PR TITLE
Defend against null css

### DIFF
--- a/packages/compiler/src/style_url_resolver.ts
+++ b/packages/compiler/src/style_url_resolver.ts
@@ -26,7 +26,7 @@ export function isStyleUrlResolvable(url: string): boolean {
  * are either relative or don't have a `package:` scheme
  */
 export function extractStyleUrls(
-    resolver: UrlResolver, baseUrl: string, cssText: string): StyleWithImports {
+    resolver: UrlResolver, baseUrl: string, cssText: string = ''): StyleWithImports {
   const foundUrls: string[] = [];
 
   const modifiedCssText = cssText.replace(CSS_STRIPPABLE_COMMENT_REGEXP, '')


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
Currently if this function is called with a null `cssText` it blows up.
I've spent a long time trying to debug this, since some of my files are empty.

Issue Number: None here, but https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/397


## What is the new behavior?
Add a default parameter to `cssText`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
Please please please sneak this, or some other fix/documentation into a release for the compiler. It's killing me.


Alternatively I would be open to a better error message if `cssText` is null so that we can debug the problem easier in the case of typos.