### PR TITLE
fix(tsc-wrapped): deduplicate metadata only when the module is the same - [4.4.x]

### DIFF
--- a/tools/@angular/tsc-wrapped/src/bundler.ts
+++ b/tools/@angular/tsc-wrapped/src/bundler.ts
@@ -263,24 +263,25 @@ export class MetadataBundler {
     Array.from(this.symbolMap.values()).forEach(symbol => {
       if (symbol.referenced && !symbol.reexport) {
         let name = symbol.name;
-        const declaredName = symbol.declaration !.name;
+        const identifier = `${symbol.declaration!.module}:${symbol.declaration !.name}`;
         if (symbol.isPrivate && !symbol.privateName) {
           name = newPrivateName();
           symbol.privateName = name;
         }
-        if (symbolsMap.has(declaredName)) {
-          const names = symbolsMap.get(declaredName);
+        if (symbolsMap.has(identifier)) {
+          const names = symbolsMap.get(identifier);
           names !.push(name);
         } else {
-          symbolsMap.set(declaredName, [name]);
+          symbolsMap.set(identifier, [name]);
         }
         result[name] = symbol.value !;
       }
     });
 
     // check for duplicated entries
-    symbolsMap.forEach((names: string[], declaredName: string) => {
+    symbolsMap.forEach((names: string[], identifier: string) => {
       if (names.length > 1) {
+        const [module, declaredName] = identifier.split(':');
         // prefer the export that uses the declared name (if any)
         let reference = names.indexOf(declaredName);
         if (reference === -1) {

--- a/tools/@angular/tsc-wrapped/test/bundler_spec.ts
+++ b/tools/@angular/tsc-wrapped/test/bundler_spec.ts
@@ -197,26 +197,32 @@ describe('metadata bundler', () => {
     const host = new MockStringBundlerHost('/', {
       'public-api.ts': `
         export {A as A2, A, B as B1, B as B2} from './src/core';
+        export {A as A3} from './src/alternate';
       `,
       'src': {
         'core.ts': `
           export class A {}
           export class B {}
         `,
+        'alternate.ts': ` 
+          export class A {} 
+        `,
       }
     });
 
     const bundler = new MetadataBundler('/public-api', undefined, host);
     const result = bundler.getMetadataBundle();
-    const {A, A2, B1, B2} = result.metadata.metadata as{
+    const {A, A2, A3, B1, B2} = result.metadata.metadata as{
       A: ClassMetadata,
       A2: MetadataGlobalReferenceExpression,
+      A3: ClassMetadata,
       B1: ClassMetadata,
       B2: MetadataGlobalReferenceExpression
     };
     expect(A.__symbolic).toEqual('class');
     expect(A2.__symbolic).toEqual('reference');
     expect(A2.name).toEqual('A');
+    expect(A3.__symbolic).toEqual('class');
     expect(B1.__symbolic).toEqual('class');
     expect(B2.__symbolic).toEqual('reference');
     expect(B2.name).toEqual('B1');


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
We deduplicate metadata based on declared name only, but different modules can export symbols with the same name

Issue Number: #19219


## What is the new behavior?
We take the module into account


## Does this PR introduce a breaking change?
```
[x] No
```

Note: this is only for the 4.4.x branch