### PR TITLE
build: pin docker image to a tag for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@
 anchor_1: &job_defaults
   working_directory: ~/ng
   docker:
-    - image: angular/ngcontainer
+    - image: angular/ngcontainer:0.0.2
 
 # After checkout, rebase on top of master.
 # Similar to travis behavior, but not quite the same.


### PR DESCRIPTION
Fixes the broken build

This includes a commit to install yarn 1.0 on circleCI:
https://github.com/alexeagle/ngcontainer/commit/a102219fa217e7da7d45cefbceab10b0276c7f4a
