### PR TITLE
test: fix cli-integration tests that got broken by yarn update

### DIFF
--- a/integration/run_tests.sh
+++ b/integration/run_tests.sh
@@ -18,15 +18,17 @@ rm_cache
 mkdir $cache
 trap rm_cache EXIT
 
-# We need to install `ng` but don't want to do it globally so we plate it into `.ng-cli` folder.
-# This check prevents constant re-installing.
-if [ ! -d ".ng-cli" ]; then
-  (
-    mkdir -p .ng-cli
-    cd .ng-cli
-    yarn add @angular/cli@$ANGULAR_CLI_VERSION --cache-folder ../$cache
-  )
-fi
+# We need to install `ng` but don't want to do it globally so we place it into `.ng-cli` folder.
+(
+  mkdir -p .ng-cli
+  cd .ng-cli
+
+  # workaround for https://github.com/yarnpkg/yarn/pull/4464 which causes cli to be installed into the root node_modules
+  echo '{"name": "ng-cli"}' > package.json
+  yarn init -y
+
+  yarn add @angular/cli@$ANGULAR_CLI_VERSION --cache-folder ../$cache
+)
 ./ng-cli-create.sh cli-hello-world
 
 for testDir in $(ls | grep -v node_modules) ; do


### PR DESCRIPTION
previously we relied on yarn creating a new project/package.json in the current dirrectory,
which is incorrect. this change inits the project before installing the cli.