### PR TITLE
fix(common): do not replace zero/empty string with null request body …

### DIFF
--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -371,7 +371,9 @@ export class HttpClient {
       }
 
       // Construct the request.
-      req = new HttpRequest(first, url !, options.body || null, {
+      const requestBody =
+          (options.body || options.body === '' || options.body === 0) ? options.body : null;
+      req = new HttpRequest(first, url !, requestBody, {
         headers,
         params,
         reportProgress: options.reportProgress,

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -171,7 +171,8 @@ export class HttpRequest<T> {
     // the body argument is to use a known no-body method like GET.
     if (mightHaveBody(this.method) || !!fourth) {
       // Body is the third argument, options are the fourth.
-      this.body = third as T || null;
+      const requestBody = (third as T || third === '' || third === 0) ? third as T : null;
+      this.body = requestBody;
       options = fourth;
     } else {
       // No body required, options are the third argument. The body stays null.

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -172,6 +172,7 @@ export class HttpRequest<T> {
     if (mightHaveBody(this.method) || !!fourth) {
       // Body is the third argument, options are the fourth.
       const requestBody = (third as T || third === '' || third === 0) ? third as T : null;
+
       this.body = requestBody;
       options = fourth;
     } else {

--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -262,8 +262,8 @@ export class HttpResponse<T> extends HttpResponseBase {
     body?: T | null, headers?: HttpHeaders; status?: number; statusText?: string; url?: string;
   } = {}) {
     super(init);
-    const responseBody =
-        (init.body as T || typeof init.body === 'string' || typeof init.body === 'number') ?
+    const responseBody = init.body as T || typeof init.body === 'string' ||
+            (typeof init.body === 'number' && !isNaN(init.body)) ?
         init.body as T :
         null;
     this.body = responseBody;

--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -262,7 +262,11 @@ export class HttpResponse<T> extends HttpResponseBase {
     body?: T | null, headers?: HttpHeaders; status?: number; statusText?: string; url?: string;
   } = {}) {
     super(init);
-    this.body = init.body || null;
+    const responseBody =
+        (init.body as T || typeof init.body === 'string' || typeof init.body === 'number') ?
+        init.body as T :
+        null;
+    this.body = responseBody;
   }
 
   readonly type: HttpEventType.Response = HttpEventType.Response;

--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -115,6 +115,60 @@ export function main() {
         expect(testReq.request.body).toBe(body);
         testReq.flush('hello world');
       });
+      it('with falsy string data', (done: DoneFn) => {
+        client.post('/test', '', {observe: 'response', responseType: 'text'}).subscribe(res => {
+          expect(res.ok).toBeTruthy();
+          expect(res.status).toBe(200);
+          expect(res.body).toBe('');
+          done();
+        });
+        backend.expectOne('/test').flush(null, {echoRequest: true});
+      });
+      it('with falsy numeric string data', (done: DoneFn) => {
+        client.post('/test', '0', {observe: 'response', responseType: 'text'}).subscribe(res => {
+          expect(res.ok).toBeTruthy();
+          expect(res.status).toBe(200);
+          expect(res.body).toBe('0');
+          done();
+        });
+        backend.expectOne('/test').flush(null, {echoRequest: true});
+      });
+      it('with falsy number data', (done: DoneFn) => {
+        client.post('/test', 0, {observe: 'response', responseType: 'text'}).subscribe(res => {
+          expect(res.ok).toBeTruthy();
+          expect(res.status).toBe(200);
+          expect(res.body).toBe(0);
+          done();
+        });
+        backend.expectOne('/test').flush(null, {echoRequest: true});
+      });
+      it('with non-falsy number data', (done: DoneFn) => {
+        client.post('/test', 1, {observe: 'response', responseType: 'text'}).subscribe(res => {
+          expect(res.ok).toBeTruthy();
+          expect(res.status).toBe(200);
+          expect(res.body).toBe(1);
+          done();
+        });
+        backend.expectOne('/test').flush(null, {echoRequest: true});
+      });
+      it('with falsy boolean data', (done: DoneFn) => {
+        client.post('/test', false, {observe: 'response', responseType: 'text'}).subscribe(res => {
+          expect(res.ok).toBeTruthy();
+          expect(res.status).toBe(204);
+          expect(res.body).toBe(null);
+          done();
+        });
+        backend.expectOne('/test').flush(null, {echoRequest: true});
+      });
+      it('with falsy NaN data', (done: DoneFn) => {
+        client.post('/test', NaN, {observe: 'response', responseType: 'text'}).subscribe(res => {
+          expect(res.ok).toBeTruthy();
+          expect(res.status).toBe(204);
+          expect(res.body).toBe(null);
+          done();
+        });
+        backend.expectOne('/test').flush(null, {echoRequest: true});
+      });
       it('with an arraybuffer', (done: DoneFn) => {
         const body = new ArrayBuffer(4);
         client.post('/test', body, {observe: 'response', responseType: 'text'}).subscribe(res => {

--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -117,57 +117,51 @@ export function main() {
       });
       it('with falsy string data', (done: DoneFn) => {
         client.post('/test', '', {observe: 'response', responseType: 'text'}).subscribe(res => {
-          expect(res.ok).toBeTruthy();
-          expect(res.status).toBe(200);
-          expect(res.body).toBe('');
           done();
         });
-        backend.expectOne('/test').flush(null, {echoRequest: true});
+        const testReq = backend.expectOne('/test');
+        expect(testReq.request.body).toBe('');
+        testReq.flush('hello world');
       });
       it('with falsy numeric string data', (done: DoneFn) => {
         client.post('/test', '0', {observe: 'response', responseType: 'text'}).subscribe(res => {
-          expect(res.ok).toBeTruthy();
-          expect(res.status).toBe(200);
-          expect(res.body).toBe('0');
           done();
         });
-        backend.expectOne('/test').flush(null, {echoRequest: true});
+        const testReq = backend.expectOne('/test');
+        expect(testReq.request.body).toBe('0');
+        testReq.flush('hello world');
       });
       it('with falsy number data', (done: DoneFn) => {
         client.post('/test', 0, {observe: 'response', responseType: 'text'}).subscribe(res => {
-          expect(res.ok).toBeTruthy();
-          expect(res.status).toBe(200);
-          expect(res.body).toBe(0);
           done();
         });
-        backend.expectOne('/test').flush(null, {echoRequest: true});
+        const testReq = backend.expectOne('/test');
+        expect(testReq.request.body).toBe(0);
+        testReq.flush('hello world');
       });
       it('with non-falsy number data', (done: DoneFn) => {
         client.post('/test', 1, {observe: 'response', responseType: 'text'}).subscribe(res => {
-          expect(res.ok).toBeTruthy();
-          expect(res.status).toBe(200);
-          expect(res.body).toBe(1);
           done();
         });
-        backend.expectOne('/test').flush(null, {echoRequest: true});
+        const testReq = backend.expectOne('/test');
+        expect(testReq.request.body).toBe(1);
+        testReq.flush('hello world');
       });
       it('with falsy boolean data', (done: DoneFn) => {
         client.post('/test', false, {observe: 'response', responseType: 'text'}).subscribe(res => {
-          expect(res.ok).toBeTruthy();
-          expect(res.status).toBe(204);
-          expect(res.body).toBe(null);
           done();
         });
-        backend.expectOne('/test').flush(null, {echoRequest: true});
+        const testReq = backend.expectOne('/test');
+        expect(testReq.request.body).toBe(null);
+        testReq.flush('hello world');
       });
       it('with falsy NaN data', (done: DoneFn) => {
         client.post('/test', NaN, {observe: 'response', responseType: 'text'}).subscribe(res => {
-          expect(res.ok).toBeTruthy();
-          expect(res.status).toBe(204);
-          expect(res.body).toBe(null);
           done();
         });
-        backend.expectOne('/test').flush(null, {echoRequest: true});
+        const testReq = backend.expectOne('/test');
+        expect(testReq.request.body).toBe(null);
+        testReq.flush('hello world');
       });
       it('with an arraybuffer', (done: DoneFn) => {
         const body = new ArrayBuffer(4);

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -40,6 +40,30 @@ export function main() {
         const req = new HttpRequest('TEST', TEST_URL, null);
         expect(req.method).toBe('TEST');
       });
+      it('accepts an empty string body', () => {
+        const req = new HttpRequest('POST', TEST_URL, '');
+        expect(req.body).toBe('');
+      });
+      it('accepts a falsy numeric string body', () => {
+        const req = new HttpRequest('POST', TEST_URL, '0');
+        expect(req.body).toBe('0');
+      });
+      it('accepts a falsy numeric body', () => {
+        const req = new HttpRequest('POST', TEST_URL, 0);
+        expect(req.body).toBe(0);
+      });
+      it('accepts a non-falsy numeric body', () => {
+        const req = new HttpRequest('POST', TEST_URL, 1);
+        expect(req.body).toBe(1);
+      });
+      it('transforms a falsy boolean body', () => {
+        const req = new HttpRequest('POST', TEST_URL, false);
+        expect(req.body).toBe(null);
+      });
+      it('transforms a falsy NaN body', () => {
+        const req = new HttpRequest('POST', TEST_URL, NaN);
+        expect(req.body).toBe(null);
+      });
       it('accepts a string body', () => {
         const req = new HttpRequest('POST', TEST_URL, TEST_STRING);
         expect(req.body).toBe(TEST_STRING);

--- a/packages/common/http/test/response_spec.ts
+++ b/packages/common/http/test/response_spec.ts
@@ -40,6 +40,42 @@ export function main() {
         expect(resp.ok).toBeTruthy();
         expect(resp.url).toBeNull();
       });
+      it('accepts an empty string body', () => {
+        const resp = new HttpResponse({
+          body: '',
+        });
+        expect(resp.body).toBe('');
+      });
+      it('accepts a falsy numeric string body', () => {
+        const resp = new HttpResponse({
+          body: '0',
+        });
+        expect(resp.body).toBe('0');
+      });
+      it('accepts a falsy numeric body', () => {
+        const resp = new HttpResponse({
+          body: 0,
+        });
+        expect(resp.body).toBe(0);
+      });
+      it('accepts a non-falsy numeric body', () => {
+        const resp = new HttpResponse({
+          body: 1,
+        });
+        expect(resp.body).toBe(1);
+      });
+      it('transforms a falsy boolean body', () => {
+        const resp = new HttpResponse({
+          body: false,
+        });
+        expect(resp.body).toBe(null);
+      });
+      it('transforms a falsy NaN body', () => {
+        const resp = new HttpResponse({
+          body: NaN,
+        });
+        expect(resp.body).toBe(null);
+      });
     });
     it('.ok is determined by status', () => {
       const good = new HttpResponse({status: 200});

--- a/packages/common/http/testing/src/request.ts
+++ b/packages/common/http/testing/src/request.ts
@@ -40,6 +40,7 @@ export class TestRequest {
     headers?: HttpHeaders | {[name: string]: string | string[]},
     status?: number,
     statusText?: string,
+    echoRequest?: boolean,
   } = {}): void {
     if (this.cancelled) {
       throw new Error(`Cannot flush a cancelled request.`);
@@ -47,7 +48,8 @@ export class TestRequest {
     const url = this.request.urlWithParams;
     const headers =
         (opts.headers instanceof HttpHeaders) ? opts.headers : new HttpHeaders(opts.headers);
-    body = _maybeConvertBody(this.request.responseType, body);
+    body = _maybeConvertBody(
+        this.request.responseType, opts.echoRequest === true ? this.request.body : body);
     let statusText: string|undefined = opts.statusText;
     let status: number = opts.status !== undefined ? opts.status : 200;
     if (opts.status === undefined) {
@@ -164,8 +166,11 @@ function _toJsonBody(
  */
 function _toTextBody(
     body: ArrayBuffer | Blob | string | number | Object |
-    (string | number | Object | null)[]): string {
+    (string | number | Object | null)[]): string|number {
   if (typeof body === 'string') {
+    return body;
+  }
+  if (typeof body === 'number') {
     return body;
   }
   if (typeof ArrayBuffer !== 'undefined' && body instanceof ArrayBuffer) {

--- a/packages/common/http/testing/src/request.ts
+++ b/packages/common/http/testing/src/request.ts
@@ -40,7 +40,6 @@ export class TestRequest {
     headers?: HttpHeaders | {[name: string]: string | string[]},
     status?: number,
     statusText?: string,
-    echoRequest?: boolean,
   } = {}): void {
     if (this.cancelled) {
       throw new Error(`Cannot flush a cancelled request.`);
@@ -48,8 +47,7 @@ export class TestRequest {
     const url = this.request.urlWithParams;
     const headers =
         (opts.headers instanceof HttpHeaders) ? opts.headers : new HttpHeaders(opts.headers);
-    body = _maybeConvertBody(
-        this.request.responseType, opts.echoRequest === true ? this.request.body : body);
+    body = _maybeConvertBody(this.request.responseType, body);
     let statusText: string|undefined = opts.statusText;
     let status: number = opts.status !== undefined ? opts.status : 200;
     if (opts.status === undefined) {


### PR DESCRIPTION
…in HttpClient.post

'body' parameter to HttpClient.post method was replaced by null if it evaluated as falsy

Fixes #19195

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #19195


## What is the new behavior?
The values `0` and `''` (empty string) are not replaced by `null` as the request body in the `HttpClient.post` method.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
