### PR TITLE
fix(compiler-cli): do not validate metadata generated from declaration files

### DIFF
--- a/packages/compiler-cli/src/transformers/lower_expressions.ts
+++ b/packages/compiler-cli/src/transformers/lower_expressions.ts
@@ -322,8 +322,14 @@ export class LowerMetadataCache implements RequestsMap {
       return value;
     };
 
+    // Do not validate or lower metadata in a declaration file. Declaration files are requested
+    // when we need to update the version of the metadata to add informatoin that might be missing
+    // in the out-of-date version that can be recovered from the .d.ts file.
+    const declarationFile = sourceFile.isDeclarationFile;
+
     const metadata = this.collector.getMetadata(
-        sourceFile, this.strict, sourceFile.isDeclarationFile ? undefined : substituteExpression);
+        sourceFile, this.strict && !declarationFile,
+        declarationFile ? undefined : substituteExpression);
 
     return {metadata, requests};
   }

--- a/packages/compiler-cli/test/transformers/lower_expressions_spec.ts
+++ b/packages/compiler-cli/test/transformers/lower_expressions_spec.ts
@@ -98,6 +98,38 @@ describe('Expression lowering', () => {
       expect(collected.requests.has(collected.annotations[0].start))
           .toBeTruthy('did not find the data field');
     });
+
+    it('should throw a validation execption for invalid files', () => {
+      const cache = new LowerMetadataCache({}, /* strict */ true);
+      const sourceFile = ts.createSourceFile(
+          'foo.ts', `
+        import {Injectable} from '@angular/core';
+
+        class SomeLocalClass {}
+        @Injectable()
+        export class SomeClass {
+          constructor(a: SomeLocalClass) {}
+        }
+      `,
+          ts.ScriptTarget.Latest, true);
+      expect(() => cache.getMetadata(sourceFile)).toThrow();
+    });
+
+    it('should not report validation errors on a .d.ts file', () => {
+      const cache = new LowerMetadataCache({}, /* strict */ true);
+      const dtsFile = ts.createSourceFile(
+          'foo.d.ts', `
+        import {Injectable} from '@angular/core';
+
+        class SomeLocalClass {}
+        @Injectable()
+        export class SomeClass {
+          constructor(a: SomeLocalClass) {}
+        }
+      `,
+          ts.ScriptTarget.Latest, true);
+      expect(() => cache.getMetadata(dtsFile)).not.toThrow();
+    });
   });
 });
 


### PR DESCRIPTION
Upgrading metadata files causes spurious reports of metadata errors.

Fixes #18867

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #18867

Upgrading metadata causes spurious error reported if requesting strict metadata emit.

## What is the new behavior?

Metadata generated for `.d.ts` is no longer validated as it is not actually written to disk. It is only used to supplement out-of-date metadata.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
