### PR TITLE
fix(compiler-cli): don't join errors with comma

### DIFF
--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -43,7 +43,7 @@ export function formatDiagnostics(options: api.CompilerOptions, diags: Diagnosti
             return res;
           }
         })
-        .join();
+        .join('');
   } else
     return '';
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
`ngc` errors are joined using a comma after newline, which looks weird:
```
main.ts(15,1): error TS1128: Declaration or statement expected.
,main.ts(15,2): error TS1128: Declaration or statement expected.
,main.ts(15,3): error TS1128: Declaration or statement expected.
,main.ts(15,4): error TS1128: Declaration or statement expected.
,main.ts(15,5): error TS1128: Declaration or statement expected.
,main.ts(15,6): error TS1128: Declaration or statement expected.
```

## What is the new behavior?
`ngc` errors are joined without a comma:
```
main.ts(15,1): error TS1128: Declaration or statement expected.
main.ts(15,2): error TS1128: Declaration or statement expected.
main.ts(15,3): error TS1128: Declaration or statement expected.
main.ts(15,4): error TS1128: Declaration or statement expected.
main.ts(15,5): error TS1128: Declaration or statement expected.
main.ts(15,6): error TS1128: Declaration or statement expected.
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
/cc @tbosch 