### PR TITLE
refactor(compiler): bump metadata version to 4

### DIFF
--- a/packages/compiler-cli/index.ts
+++ b/packages/compiler-cli/index.ts
@@ -15,6 +15,7 @@ export {getClassMembersFromDeclaration, getPipesTable, getSymbolQuery} from './s
 export {Extractor} from './src/extractor';
 export {VERSION} from './src/version';
 
+export * from './src/metadata';
 export * from './src/transformers/api';
 export * from './src/transformers/entry_points';
 

--- a/packages/compiler-cli/src/metadata/bundler.ts
+++ b/packages/compiler-cli/src/metadata/bundler.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import * as ts from 'typescript';
 
 import {MetadataCollector} from '../metadata/collector';
-import {ClassMetadata, ConstructorMetadata, FunctionMetadata, MemberMetadata, MetadataEntry, MetadataError, MetadataImportedSymbolReferenceExpression, MetadataMap, MetadataObject, MetadataSymbolicExpression, MetadataSymbolicReferenceExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata, VERSION, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isInterfaceMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataImportedSymbolReferenceExpression, isMetadataModuleReferenceExpression, isMetadataSymbolicExpression, isMethodMetadata} from '../metadata/schema';
+import {ClassMetadata, ConstructorMetadata, FunctionMetadata, METADATA_VERSION, MemberMetadata, MetadataEntry, MetadataError, MetadataImportedSymbolReferenceExpression, MetadataMap, MetadataObject, MetadataSymbolicExpression, MetadataSymbolicReferenceExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isInterfaceMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataImportedSymbolReferenceExpression, isMetadataModuleReferenceExpression, isMetadataSymbolicExpression, isMethodMetadata} from '../metadata/schema';
 
 
 
@@ -114,7 +114,7 @@ export class MetadataBundler {
     return {
       metadata: {
         __symbolic: 'module',
-        version: VERSION,
+        version: METADATA_VERSION,
         exports: exports.length ? exports : undefined, metadata, origins,
         importAs: this.importAs !
       },

--- a/packages/compiler-cli/src/metadata/collector.ts
+++ b/packages/compiler-cli/src/metadata/collector.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 
 import {Evaluator, errorSymbol} from './evaluator';
-import {ClassMetadata, ConstructorMetadata, FunctionMetadata, InterfaceMetadata, MemberMetadata, MetadataEntry, MetadataError, MetadataMap, MetadataSymbolicBinaryExpression, MetadataSymbolicCallExpression, MetadataSymbolicExpression, MetadataSymbolicIfExpression, MetadataSymbolicIndexExpression, MetadataSymbolicPrefixExpression, MetadataSymbolicReferenceExpression, MetadataSymbolicSelectExpression, MetadataSymbolicSpreadExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata, VERSION, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataSymbolicExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSelectExpression, isMethodMetadata} from './schema';
+import {ClassMetadata, ConstructorMetadata, FunctionMetadata, InterfaceMetadata, METADATA_VERSION, MemberMetadata, MetadataEntry, MetadataError, MetadataMap, MetadataSymbolicBinaryExpression, MetadataSymbolicCallExpression, MetadataSymbolicExpression, MetadataSymbolicIfExpression, MetadataSymbolicIndexExpression, MetadataSymbolicPrefixExpression, MetadataSymbolicReferenceExpression, MetadataSymbolicSelectExpression, MetadataSymbolicSpreadExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataSymbolicExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSelectExpression, isMethodMetadata} from './schema';
 import {Symbols} from './symbols';
 
 const isStatic = (node: ts.Node) => ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Static;
@@ -549,7 +549,7 @@ export class MetadataCollector {
       }
       const result: ModuleMetadata = {
         __symbolic: 'module',
-        version: this.options.version || VERSION, metadata
+        version: this.options.version || METADATA_VERSION, metadata
       };
       if (exports) result.exports = exports;
       return result;

--- a/packages/compiler-cli/src/metadata/schema.ts
+++ b/packages/compiler-cli/src/metadata/schema.ts
@@ -8,14 +8,15 @@
 
 // Metadata Schema
 
-// If you make a backwards incompatible change to the schema, increment the VERSION number.
+// If you make a backwards incompatible change to the schema, increment the METADTA_VERSION number.
 
 // If you make a backwards compatible change to the metadata (such as adding an option field) then
-// leave VERSION the same. If possible, as many versions of the metadata that can represent the
-// semantics of the file in an array. For example, when generating a version 2 file, if version 1
-// can accurately represent the metadata, generate both version 1 and version 2 in an array.
+// leave METADATA_VERSION the same. If possible, supply as many versions of the metadata that can
+// represent the semantics of the file in an array. For example, when generating a version 2 file,
+// if version 1 can accurately represent the metadata, generate both version 1 and version 2 in
+// an array.
 
-export const VERSION = 3;
+export const METADATA_VERSION = 4;
 
 export type MetadataEntry = ClassMetadata | InterfaceMetadata | FunctionMetadata | MetadataValue;
 

--- a/packages/compiler-cli/test/aot_host_spec.ts
+++ b/packages/compiler-cli/test/aot_host_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ModuleMetadata} from '@angular/compiler-cli/src/metadata/index';
+import {METADATA_VERSION, ModuleMetadata} from '@angular/compiler-cli';
 import * as ts from 'typescript';
 
 import {CompilerHost} from '../src/compiler_host';
@@ -163,7 +163,7 @@ describe('CompilerHost', () => {
 
   it('should be able to read a metadata file', () => {
     expect(hostNestedGenDir.getMetadataFor('node_modules/@angular/core.d.ts')).toEqual([
-      {__symbolic: 'module', version: 3, metadata: {foo: {__symbolic: 'class'}}}
+      {__symbolic: 'module', version: METADATA_VERSION, metadata: {foo: {__symbolic: 'class'}}}
     ]);
   });
 
@@ -181,13 +181,14 @@ describe('CompilerHost', () => {
     expect(hostNestedGenDir.getMetadataFor('node_modules/@angular/missing.d.ts')).toBeUndefined();
   });
 
-  it('should add missing v3 metadata from v1 metadata and .d.ts files', () => {
+  it(`should add missing v${METADATA_VERSION} metadata from v1 metadata and .d.ts files`, () => {
     expect(hostNestedGenDir.getMetadataFor('metadata_versions/v1.d.ts')).toEqual([
       {__symbolic: 'module', version: 1, metadata: {foo: {__symbolic: 'class'}}}, {
         __symbolic: 'module',
-        version: 3,
+        version: METADATA_VERSION,
         metadata: {
           foo: {__symbolic: 'class'},
+          aType: {__symbolic: 'interface'},
           Bar: {__symbolic: 'class', members: {ngOnInit: [{__symbolic: 'method'}]}},
           BarChild: {__symbolic: 'class', extends: {__symbolic: 'reference', name: 'Bar'}},
           ReExport: {__symbolic: 'reference', module: './lib/utils2', name: 'ReExport'},
@@ -197,9 +198,29 @@ describe('CompilerHost', () => {
     ]);
   });
 
-  it('should upgrade a missing metadata file into v3', () => {
-    expect(hostNestedGenDir.getMetadataFor('metadata_versions/v1_empty.d.ts')).toEqual([
-      {__symbolic: 'module', version: 3, metadata: {}, exports: [{from: './lib/utils'}]}
+  it(`should upgrade a missing metadata file into v${METADATA_VERSION}`, () => {
+    expect(hostNestedGenDir.getMetadataFor('metadata_versions/v1_empty.d.ts')).toEqual([{
+      __symbolic: 'module',
+      version: METADATA_VERSION,
+      metadata: {},
+      exports: [{from: './lib/utils'}]
+    }]);
+  });
+
+  it(`should upgrade v3 metadata into v${METADATA_VERSION}`, () => {
+    expect(hostNestedGenDir.getMetadataFor('metadata_versions/v3.d.ts')).toEqual([
+      {__symbolic: 'module', version: 3, metadata: {foo: {__symbolic: 'class'}}}, {
+        __symbolic: 'module',
+        version: METADATA_VERSION,
+        metadata: {
+          foo: {__symbolic: 'class'},
+          aType: {__symbolic: 'interface'},
+          Bar: {__symbolic: 'class', members: {ngOnInit: [{__symbolic: 'method'}]}},
+          BarChild: {__symbolic: 'class', extends: {__symbolic: 'reference', name: 'Bar'}},
+          ReExport: {__symbolic: 'reference', module: './lib/utils2', name: 'ReExport'},
+        }
+        // Note: exports is missing because it was elided in the original.
+      }
     ]);
   });
 });
@@ -207,7 +228,7 @@ describe('CompilerHost', () => {
 const dummyModule = 'export let foo: any[];';
 const dummyMetadata: ModuleMetadata = {
   __symbolic: 'module',
-  version: 3,
+  version: METADATA_VERSION,
   metadata:
       {foo: {__symbolic: 'error', message: 'Variable not initialized', line: 0, character: 11}}
 };
@@ -230,7 +251,7 @@ const FILES: Entry = {
         '@angular': {
           'core.d.ts': dummyModule,
           'core.metadata.json':
-              `{"__symbolic":"module", "version": 3, "metadata": {"foo": {"__symbolic": "class"}}}`,
+              `{"__symbolic":"module", "version": ${METADATA_VERSION}, "metadata": {"foo": {"__symbolic": "class"}}}`,
           'router': {'index.d.ts': dummyModule, 'src': {'providers.d.ts': dummyModule}},
           'unused.d.ts': dummyModule,
           'empty.d.ts': 'export declare var a: string;',
@@ -244,6 +265,8 @@ const FILES: Entry = {
 
           export {Export} from './lib/utils2';
 
+          export type aType = number;
+
           export declare class Bar {
             ngOnInit() {}
           }
@@ -253,7 +276,22 @@ const FILES: Entry = {
             `{"__symbolic":"module", "version": 1, "metadata": {"foo": {"__symbolic": "class"}}}`,
         'v1_empty.d.ts': `
           export * from './lib/utils';
-        `
+        `,
+        'v3.d.ts': `
+          import {ReExport} from './lib/utils2';
+          export {ReExport};
+
+          export {Export} from './lib/utils2';
+
+          export type aType = number;
+
+          export declare class Bar {
+            ngOnInit() {}
+          }
+          export declare class BarChild extends Bar {}
+        `,
+        'v3.metadata.json':
+            `{"__symbolic":"module", "version": 3, "metadata": {"foo": {"__symbolic": "class"}}}`,
       }
     }
   }

--- a/packages/compiler-cli/test/metadata/collector_spec.ts
+++ b/packages/compiler-cli/test/metadata/collector_spec.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 
 import {MetadataCollector} from '../../src/metadata/collector';
-import {ClassMetadata, ConstructorMetadata, MetadataEntry, ModuleMetadata, isClassMetadata, isMetadataGlobalReferenceExpression} from '../../src/metadata/schema';
+import {ClassMetadata, ConstructorMetadata, METADATA_VERSION, MetadataEntry, ModuleMetadata, isClassMetadata, isMetadataGlobalReferenceExpression} from '../../src/metadata/schema';
 
 import {Directory, Host, expectValidSources} from './typescript.mocks';
 
@@ -73,7 +73,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 3,
+      version: METADATA_VERSION,
       metadata: {
         DeclaredClass: {__symbolic: 'class'},
         declaredFn: {__symbolic: 'function'},
@@ -84,15 +84,21 @@ describe('Collector', () => {
   it('should return an interface reference for types', () => {
     const sourceFile = program.getSourceFile('/exported-type.ts');
     const metadata = collector.getMetadata(sourceFile);
-    expect(metadata).toEqual(
-        {__symbolic: 'module', version: 3, metadata: {SomeType: {__symbolic: 'interface'}}});
+    expect(metadata).toEqual({
+      __symbolic: 'module',
+      version: METADATA_VERSION,
+      metadata: {SomeType: {__symbolic: 'interface'}}
+    });
   });
 
   it('should return an interface reference for interfaces', () => {
     const sourceFile = program.getSourceFile('app/hero.ts');
     const metadata = collector.getMetadata(sourceFile);
-    expect(metadata).toEqual(
-        {__symbolic: 'module', version: 3, metadata: {Hero: {__symbolic: 'interface'}}});
+    expect(metadata).toEqual({
+      __symbolic: 'module',
+      version: METADATA_VERSION,
+      metadata: {Hero: {__symbolic: 'interface'}}
+    });
   });
 
   it('should be able to collect a simple component\'s metadata', () => {
@@ -100,7 +106,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 3,
+      version: METADATA_VERSION,
       metadata: {
         HeroDetailComponent: {
           __symbolic: 'class',
@@ -141,7 +147,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 3,
+      version: METADATA_VERSION,
       metadata: {
         AppComponent: {
           __symbolic: 'class',
@@ -195,7 +201,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 3,
+      version: METADATA_VERSION,
       metadata: {
         HEROES: [
           {'id': 11, 'name': 'Mr. Nice', '$quoted$': ['id', 'name']},
@@ -274,7 +280,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(unsupported1);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 3,
+      version: METADATA_VERSION,
       metadata: {
         a: {__symbolic: 'error', message: 'Destructuring not supported', line: 1, character: 16},
         b: {__symbolic: 'error', message: 'Destructuring not supported', line: 1, character: 19},
@@ -316,7 +322,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 3,
+      version: METADATA_VERSION,
       metadata: {
         SimpleClass: {__symbolic: 'class'},
         AbstractClass: {__symbolic: 'class'},
@@ -330,7 +336,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(exportedFunctions);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 3,
+      version: METADATA_VERSION,
       metadata: {
         one: {
           __symbolic: 'function',

--- a/packages/compiler/src/aot/static_symbol_resolver.ts
+++ b/packages/compiler/src/aot/static_symbol_resolver.ts
@@ -48,7 +48,7 @@ export interface StaticSymbolResolverHost {
   fileNameToModuleName(importedFilePath: string, containingFilePath: string): string;
 }
 
-const SUPPORTED_SCHEMA_VERSION = 3;
+const SUPPORTED_SCHEMA_VERSION = 4;
 
 /**
  * This class is responsible for loading metadata per symbol,

--- a/packages/compiler/test/aot/static_reflector_spec.ts
+++ b/packages/compiler/test/aot/static_reflector_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {StaticReflector, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, StaticSymbolResolverHost, core as compilerCore} from '@angular/compiler';
-import {CollectorOptions} from '@angular/compiler-cli/src/metadata/index';
+import {CollectorOptions, METADATA_VERSION} from '@angular/compiler-cli';
 
 import {MockStaticSymbolResolverHost, MockSummaryResolver} from './static_symbol_resolver_spec';
 
@@ -883,7 +883,7 @@ describe('StaticReflector', () => {
 const DEFAULT_TEST_DATA: {[key: string]: any} = {
   '/tmp/@angular/common/src/forms-deprecated/directives.d.ts': [{
     '__symbolic': 'module',
-    'version': 3,
+    'version': METADATA_VERSION,
     'metadata': {
       'FORM_DIRECTIVES': [{
         '__symbolic': 'reference',
@@ -894,7 +894,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   }],
   '/tmp/@angular/common/src/directives/ng_for.d.ts': {
     '__symbolic': 'module',
-    'version': 3,
+    'version': METADATA_VERSION,
     'metadata': {
       'NgFor': {
         '__symbolic': 'class',
@@ -924,19 +924,19 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
     }
   },
   '/tmp/@angular/core/src/linker/view_container_ref.d.ts':
-      {version: 3, 'metadata': {'ViewContainerRef': {'__symbolic': 'class'}}},
+      {version: METADATA_VERSION, 'metadata': {'ViewContainerRef': {'__symbolic': 'class'}}},
   '/tmp/@angular/core/src/linker/template_ref.d.ts': {
-    version: 3,
+    version: METADATA_VERSION,
     'module': './template_ref',
     'metadata': {'TemplateRef': {'__symbolic': 'class'}}
   },
   '/tmp/@angular/core/src/change_detection/differs/iterable_differs.d.ts':
-      {version: 3, 'metadata': {'IterableDiffers': {'__symbolic': 'class'}}},
+      {version: METADATA_VERSION, 'metadata': {'IterableDiffers': {'__symbolic': 'class'}}},
   '/tmp/@angular/core/src/change_detection/change_detector_ref.d.ts':
-      {version: 3, 'metadata': {'ChangeDetectorRef': {'__symbolic': 'class'}}},
+      {version: METADATA_VERSION, 'metadata': {'ChangeDetectorRef': {'__symbolic': 'class'}}},
   '/tmp/src/app/hero-detail.component.d.ts': {
     '__symbolic': 'module',
-    'version': 3,
+    'version': METADATA_VERSION,
     'metadata': {
       'HeroDetailComponent': {
         '__symbolic': 'class',
@@ -971,10 +971,10 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
       }
     }
   },
-  '/src/extern.d.ts': {'__symbolic': 'module', 'version': 3, metadata: {s: 's'}},
+  '/src/extern.d.ts': {'__symbolic': 'module', 'version': METADATA_VERSION, metadata: {s: 's'}},
   '/tmp/src/error-reporting.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: METADATA_VERSION,
     metadata: {
       SomeClass: {
         __symbolic: 'class',
@@ -994,7 +994,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   },
   '/tmp/src/error-references.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: METADATA_VERSION,
     metadata: {
       Link1: {__symbolic: 'reference', module: 'src/error-references', name: 'Link2'},
       Link2: {__symbolic: 'reference', module: 'src/error-references', name: 'ErrorSym'},
@@ -1004,7 +1004,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   },
   '/tmp/src/function-declaration.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: METADATA_VERSION,
     metadata: {
       one: {
         __symbolic: 'function',
@@ -1031,7 +1031,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   },
   '/tmp/src/function-reference.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: METADATA_VERSION,
     metadata: {
       one: {
         __symbolic: 'call',
@@ -1058,7 +1058,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   },
   '/tmp/src/function-recursive.d.ts': {
     __symbolic: 'modules',
-    version: 3,
+    version: METADATA_VERSION,
     metadata: {
       recursive: {
         __symbolic: 'function',
@@ -1103,7 +1103,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   },
   '/tmp/src/spread.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: METADATA_VERSION,
     metadata: {spread: [0, {__symbolic: 'spread', expression: [1, 2, 3, 4]}, 5]}
   },
   '/tmp/src/custom-decorator.ts': `

--- a/packages/compiler/test/aot/static_symbol_resolver_spec.ts
+++ b/packages/compiler/test/aot/static_symbol_resolver_spec.ts
@@ -7,9 +7,10 @@
  */
 
 import {StaticSymbol, StaticSymbolCache, StaticSymbolResolver, StaticSymbolResolverHost, Summary, SummaryResolver} from '@angular/compiler';
+import {CollectorOptions, METADATA_VERSION} from '@angular/compiler-cli';
 import {MetadataCollector} from '@angular/compiler-cli/src/metadata/collector';
-import {CollectorOptions} from '@angular/compiler-cli/src/metadata/index';
 import * as ts from 'typescript';
+
 
 
 // This matches .ts files but not .d.ts files.
@@ -38,7 +39,7 @@ describe('StaticSymbolResolver', () => {
         () => symbolResolver.resolveSymbol(
             symbolResolver.getSymbolByModule('src/version-error', 'e')))
         .toThrow(new Error(
-            'Metadata version mismatch for module /tmp/src/version-error.d.ts, found version 100, expected 3'));
+            `Metadata version mismatch for module /tmp/src/version-error.d.ts, found version 100, expected ${METADATA_VERSION}`));
   });
 
   it('should throw an exception for version 2 metadata', () => {
@@ -155,14 +156,14 @@ describe('StaticSymbolResolver', () => {
           {
             '/test.d.ts': [{
               '__symbolic': 'module',
-              'version': 3,
+              'version': METADATA_VERSION,
               'metadata': {
                 'a': {'__symbolic': 'reference', 'name': 'b', 'module': './test2'},
               }
             }],
             '/test2.d.ts': [{
               '__symbolic': 'module',
-              'version': 3,
+              'version': METADATA_VERSION,
               'metadata': {
                 'b': {'__symbolic': 'reference', 'name': 'c', 'module': './test3'},
               }
@@ -299,7 +300,7 @@ describe('StaticSymbolResolver', () => {
     init({
       '/test.d.ts': [{
         '__symbolic': 'module',
-        'version': 3,
+        'version': METADATA_VERSION,
         'metadata': {
           'AParam': {__symbolic: 'class'},
           'AClass': {
@@ -504,7 +505,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   '/tmp/src/version-2-error.d.ts': {'__symbolic': 'module', 'version': 2, metadata: {e: 's'}},
   '/tmp/src/reexport/reexport.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: METADATA_VERSION,
     metadata: {
       Six: {__symbolic: 'class'},
     },
@@ -515,7 +516,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   },
   '/tmp/src/reexport/src/origin1.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: METADATA_VERSION,
     metadata: {
       One: {__symbolic: 'class'},
       Two: {__symbolic: 'class'},
@@ -525,26 +526,26 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
   },
   '/tmp/src/reexport/src/origin5.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: METADATA_VERSION,
     metadata: {
       Five: {__symbolic: 'class'},
     },
   },
   '/tmp/src/reexport/src/origin30.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: METADATA_VERSION,
     metadata: {
       Thirty: {__symbolic: 'class'},
     },
   },
   '/tmp/src/reexport/src/originNone.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: METADATA_VERSION,
     metadata: {},
   },
   '/tmp/src/reexport/src/reexport2.d.ts': {
     __symbolic: 'module',
-    version: 3,
+    version: METADATA_VERSION,
     metadata: {},
     exports: [{from: './originNone'}, {from: './origin30'}]
   }

--- a/packages/compiler/test/aot/summary_serializer_spec.ts
+++ b/packages/compiler/test/aot/summary_serializer_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {AotSummaryResolver, AotSummaryResolverHost, CompileSummaryKind, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, StaticSymbolResolverHost} from '@angular/compiler';
+import {METADATA_VERSION} from '@angular/compiler-cli';
 import {deserializeSummaries, serializeSummaries} from '@angular/compiler/src/aot/summary_serializer';
 import {summaryFileName} from '@angular/compiler/src/aot/util';
 
@@ -242,7 +243,7 @@ export function main() {
           export var local = 'a';
         `,
                '/tmp/non_summary.d.ts':
-                   {__symbolic: 'module', version: 3, metadata: {'external': 'b'}}
+                   {__symbolic: 'module', version: METADATA_VERSION, metadata: {'external': 'b'}}
              });
          const serialized = serializeSummaries(
              'someFile.ts', createMockOutputContext(), summaryResolver, symbolResolver, [{

--- a/packages/tsconfig-metadata.json
+++ b/packages/tsconfig-metadata.json
@@ -19,6 +19,8 @@
   ],
 
   "angularCompilerOptions": {
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "annotateForClosureCompiler": false,
+    "annotationsAs": "decorators"
   }
 }

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -58,7 +58,7 @@ travisFoldEnd "tsc tools"
 
 
 travisFoldStart "tsc all"
-  $(npm bin)/tsc -p packages
   node dist/tools/@angular/compiler-cli/src/main -p packages/tsconfig-metadata.json
+  $(npm bin)/tsc -p packages
   $(npm bin)/tsc -p modules
 travisFoldEnd "tsc all"


### PR DESCRIPTION
Also adds auto upgrade from lower version based
on the .d.ts file (e.g. from version 3 to 4).

This is needed as we are now also capturing type aliases
in metadata files (and we rely on this),
see 6e3498ca8e6752c0d59c19c89e3211744e80f6d8.


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

The compiler requires a modified version of metadata but could not detect when metadata met the requirements.

## What is the new behavior?

Metadata that meets the compiler requirements are now marked as version 4. Older version of the metadata are upgraded automatically from the corresponding .d.ts.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
