### PR TITLE
refactor(core): add a checkIndex to the compiler view nodes

### DIFF
--- a/modules/benchmarks/src/tree/ng2_next/README.md
+++ b/modules/benchmarks/src/tree/ng2_next/README.md
@@ -6,7 +6,7 @@ more functionality from codegen into runtime to reduce generated code size.
 As we introduce more runtime code, we need to be very careful to not
 regress in performance, compared to the pure codegen solution.
 
-## Initial resuls: size of Deep Tree Benchmark
+## Initial results: size of Deep Tree Benchmark
 
 File size for Tree benchmark template,
 view class of the component + the 2 embedded view classes (without imports nor host view factory):

--- a/modules/benchmarks/src/tree/ng2_next/tree.ts
+++ b/modules/benchmarks/src/tree/ng2_next/tree.ts
@@ -26,8 +26,8 @@ let viewFlags = ViewFlags.None;
 
 function TreeComponent_Host(): ViewDefinition {
   return viewDef(viewFlags, [
-    elementDef(NodeFlags.None, null, null, 1, 'tree', null, null, null, null, TreeComponent_0),
-    directiveDef(NodeFlags.Component, null, 0, TreeComponent, []),
+    elementDef(0, NodeFlags.None, null, null, 1, 'tree', null, null, null, null, TreeComponent_0),
+    directiveDef(1, NodeFlags.Component, null, 0, TreeComponent, []),
   ]);
 }
 
@@ -35,8 +35,9 @@ function TreeComponent_1() {
   return viewDef(
       viewFlags,
       [
-        elementDef(NodeFlags.None, null, null, 1, 'tree', null, null, null, null, TreeComponent_0),
-        directiveDef(NodeFlags.Component, null, 0, TreeComponent, [], {data: [0, 'data']}),
+        elementDef(
+            0, NodeFlags.None, null, null, 1, 'tree', null, null, null, null, TreeComponent_0),
+        directiveDef(1, NodeFlags.Component, null, 0, TreeComponent, [], {data: [0, 'data']}),
       ],
       (check, view) => {
         const cmp = view.component;
@@ -48,8 +49,9 @@ function TreeComponent_2() {
   return viewDef(
       viewFlags,
       [
-        elementDef(NodeFlags.None, null, null, 1, 'tree', null, null, null, null, TreeComponent_0),
-        directiveDef(NodeFlags.Component, null, 0, TreeComponent, [], {data: [0, 'data']}),
+        elementDef(
+            0, NodeFlags.None, null, null, 1, 'tree', null, null, null, null, TreeComponent_0),
+        directiveDef(1, NodeFlags.Component, null, 0, TreeComponent, [], {data: [0, 'data']}),
       ],
       (check, view) => {
         const cmp = view.component;
@@ -62,15 +64,15 @@ function TreeComponent_0(): ViewDefinition {
       viewFlags,
       [
         elementDef(
-            NodeFlags.None, null, null, 1, 'span', null,
+            0, NodeFlags.None, null, null, 1, 'span', null,
             [[BindingFlags.TypeElementStyle, 'backgroundColor', null]]),
-        textDef(null, [' ', ' ']),
+        textDef(1, null, [' ', ' ']),
         anchorDef(NodeFlags.EmbeddedViews, null, null, 1, null, TreeComponent_1),
         directiveDef(
-            NodeFlags.None, null, 0, NgIf, [ViewContainerRef, TemplateRef], {ngIf: [0, 'ngIf']}),
+            3, NodeFlags.None, null, 0, NgIf, [ViewContainerRef, TemplateRef], {ngIf: [0, 'ngIf']}),
         anchorDef(NodeFlags.EmbeddedViews, null, null, 1, null, TreeComponent_2),
         directiveDef(
-            NodeFlags.None, null, 0, NgIf, [ViewContainerRef, TemplateRef], {ngIf: [0, 'ngIf']}),
+            5, NodeFlags.None, null, 0, NgIf, [ViewContainerRef, TemplateRef], {ngIf: [0, 'ngIf']}),
       ],
       (check, view) => {
         const cmp = view.component;

--- a/packages/core/src/view/element.ts
+++ b/packages/core/src/view/element.ts
@@ -13,8 +13,8 @@ import {BindingDef, BindingFlags, ElementData, ElementHandleEventFn, NodeDef, No
 import {NOOP, calcBindingFlags, checkAndUpdateBinding, dispatchEvent, elementEventFullName, getParentRenderElement, resolveDefinition, resolveRendererType2, splitMatchedQueriesDsl, splitNamespace} from './util';
 
 export function anchorDef(
-    flags: NodeFlags, matchedQueriesDsl: [string | number, QueryValueType][],
-    ngContentIndex: number, childCount: number, handleEvent?: ElementHandleEventFn,
+    flags: NodeFlags, matchedQueriesDsl: null | [string | number, QueryValueType][],
+    ngContentIndex: null | number, childCount: number, handleEvent?: null | ElementHandleEventFn,
     templateFactory?: ViewDefinitionFactory): NodeDef {
   flags |= NodeFlags.TypeElement;
   const {matchedQueries, references, matchedQueryIds} = splitMatchedQueriesDsl(matchedQueriesDsl);
@@ -22,13 +22,14 @@ export function anchorDef(
 
   return {
     // will bet set by the view definition
-    index: -1,
+    nodeIndex: -1,
     parent: null,
     renderParent: null,
     bindingIndex: -1,
     outputIndex: -1,
     // regular values
     flags,
+    checkIndex: -1,
     childFlags: 0,
     directChildFlags: 0,
     childMatchedQueries: 0, matchedQueries, matchedQueryIds, references, ngContentIndex, childCount,
@@ -54,11 +55,12 @@ export function anchorDef(
 }
 
 export function elementDef(
-    flags: NodeFlags, matchedQueriesDsl: [string | number, QueryValueType][],
-    ngContentIndex: number, childCount: number, namespaceAndName: string | null,
-    fixedAttrs: [string, string][] = [],
-    bindings?: [BindingFlags, string, string | SecurityContext][], outputs?: ([string, string])[],
-    handleEvent?: ElementHandleEventFn, componentView?: ViewDefinitionFactory,
+    checkIndex: number, flags: NodeFlags,
+    matchedQueriesDsl: null | [string | number, QueryValueType][], ngContentIndex: null | number,
+    childCount: number, namespaceAndName: string | null, fixedAttrs: null | [string, string][] = [],
+    bindings?: null | [BindingFlags, string, string | SecurityContext | null][],
+    outputs?: null | ([string, string])[], handleEvent?: null | ElementHandleEventFn,
+    componentView?: null | ViewDefinitionFactory,
     componentRendererType?: RendererType2 | null): NodeDef {
   if (!handleEvent) {
     handleEvent = NOOP;
@@ -111,12 +113,13 @@ export function elementDef(
   flags |= NodeFlags.TypeElement;
   return {
     // will bet set by the view definition
-    index: -1,
+    nodeIndex: -1,
     parent: null,
     renderParent: null,
     bindingIndex: -1,
     outputIndex: -1,
     // regular values
+    checkIndex,
     flags,
     childFlags: 0,
     directChildFlags: 0,
@@ -175,7 +178,7 @@ export function listenToElementOutputs(view: ViewData, compView: ViewData, def: 
   for (let i = 0; i < def.outputs.length; i++) {
     const output = def.outputs[i];
     const handleEventClosure = renderEventHandlerClosure(
-        view, def.index, elementEventFullName(output.target, output.eventName));
+        view, def.nodeIndex, elementEventFullName(output.target, output.eventName));
     let listenTarget: 'window'|'document'|'body'|'component'|null = output.target;
     let listenerView = view;
     if (output.target === 'component') {
@@ -224,7 +227,7 @@ function checkAndUpdateElementValue(view: ViewData, def: NodeDef, bindingIdx: nu
     return false;
   }
   const binding = def.bindings[bindingIdx];
-  const elData = asElementData(view, def.index);
+  const elData = asElementData(view, def.nodeIndex);
   const renderNode = elData.renderElement;
   const name = binding.name !;
   switch (binding.flags & BindingFlags.Types) {

--- a/packages/core/src/view/ng_content.ts
+++ b/packages/core/src/view/ng_content.ts
@@ -9,15 +9,16 @@
 import {NodeDef, NodeFlags, ViewData} from './types';
 import {RenderNodeAction, getParentRenderElement, visitProjectedRenderNodes} from './util';
 
-export function ngContentDef(ngContentIndex: number, index: number): NodeDef {
+export function ngContentDef(ngContentIndex: null | number, index: number): NodeDef {
   return {
     // will bet set by the view definition
-    index: -1,
+    nodeIndex: -1,
     parent: null,
     renderParent: null,
     bindingIndex: -1,
     outputIndex: -1,
     // regular values
+    checkIndex: -1,
     flags: NodeFlags.TypeNgContent,
     childFlags: 0,
     directChildFlags: 0,

--- a/packages/core/src/view/ng_module.ts
+++ b/packages/core/src/view/ng_module.ts
@@ -7,10 +7,10 @@
  */
 
 import {resolveForwardRef} from '../di/forward_ref';
-import {Injector, THROW_IF_NOT_FOUND} from '../di/injector';
+import {Injector} from '../di/injector';
 import {NgModuleRef} from '../linker/ng_module_factory';
 
-import {DepDef, DepFlags, NgModuleData, NgModuleDefinition, NgModuleDefinitionFactory, NgModuleProviderDef, NodeFlags} from './types';
+import {DepDef, DepFlags, NgModuleData, NgModuleDefinition, NgModuleProviderDef, NodeFlags} from './types';
 import {splitDepsDsl, tokenKey} from './util';
 
 const NOT_CREATED = new Object();
@@ -89,80 +89,60 @@ export function resolveNgModuleDep(
 
 
 function _createProviderInstance(ngModule: NgModuleData, providerDef: NgModuleProviderDef): any {
-  let injectable: any;
   switch (providerDef.flags & NodeFlags.Types) {
     case NodeFlags.TypeClassProvider:
-      injectable = _createClass(ngModule, providerDef.value, providerDef.deps);
-      break;
+      return _createClass(ngModule, providerDef.value, providerDef.deps);
     case NodeFlags.TypeFactoryProvider:
-      injectable = _callFactory(ngModule, providerDef.value, providerDef.deps);
-      break;
+      return _callFactory(ngModule, providerDef.value, providerDef.deps);
     case NodeFlags.TypeUseExistingProvider:
-      injectable = resolveNgModuleDep(ngModule, providerDef.deps[0]);
-      break;
+      return resolveNgModuleDep(ngModule, providerDef.deps[0]);
     case NodeFlags.TypeValueProvider:
-      injectable = providerDef.value;
-      break;
+      return providerDef.value;
   }
-  return injectable;
 }
 
 function _createClass(ngModule: NgModuleData, ctor: any, deps: DepDef[]): any {
   const len = deps.length;
-  let injectable: any;
   switch (len) {
     case 0:
-      injectable = new ctor();
-      break;
+      return new ctor();
     case 1:
-      injectable = new ctor(resolveNgModuleDep(ngModule, deps[0]));
-      break;
+      return new ctor(resolveNgModuleDep(ngModule, deps[0]));
     case 2:
-      injectable =
-          new ctor(resolveNgModuleDep(ngModule, deps[0]), resolveNgModuleDep(ngModule, deps[1]));
-      break;
+      return new ctor(resolveNgModuleDep(ngModule, deps[0]), resolveNgModuleDep(ngModule, deps[1]));
     case 3:
-      injectable = new ctor(
+      return new ctor(
           resolveNgModuleDep(ngModule, deps[0]), resolveNgModuleDep(ngModule, deps[1]),
           resolveNgModuleDep(ngModule, deps[2]));
-      break;
     default:
       const depValues = new Array(len);
       for (let i = 0; i < len; i++) {
         depValues[i] = resolveNgModuleDep(ngModule, deps[i]);
       }
-      injectable = new ctor(...depValues);
+      return new ctor(...depValues);
   }
-  return injectable;
 }
 
 function _callFactory(ngModule: NgModuleData, factory: any, deps: DepDef[]): any {
   const len = deps.length;
-  let injectable: any;
   switch (len) {
     case 0:
-      injectable = factory();
-      break;
+      return factory();
     case 1:
-      injectable = factory(resolveNgModuleDep(ngModule, deps[0]));
-      break;
+      return factory(resolveNgModuleDep(ngModule, deps[0]));
     case 2:
-      injectable =
-          factory(resolveNgModuleDep(ngModule, deps[0]), resolveNgModuleDep(ngModule, deps[1]));
-      break;
+      return factory(resolveNgModuleDep(ngModule, deps[0]), resolveNgModuleDep(ngModule, deps[1]));
     case 3:
-      injectable = factory(
+      return factory(
           resolveNgModuleDep(ngModule, deps[0]), resolveNgModuleDep(ngModule, deps[1]),
           resolveNgModuleDep(ngModule, deps[2]));
-      break;
     default:
       const depValues = Array(len);
       for (let i = 0; i < len; i++) {
         depValues[i] = resolveNgModuleDep(ngModule, deps[i]);
       }
-      injectable = factory(...depValues);
+      return factory(...depValues);
   }
-  return injectable;
 }
 
 export function callNgModuleLifecycle(ngModule: NgModuleData, lifecycles: NodeFlags) {

--- a/packages/core/src/view/pure_expression.ts
+++ b/packages/core/src/view/pure_expression.ts
@@ -9,16 +9,16 @@
 import {BindingDef, BindingFlags, NodeDef, NodeFlags, PureExpressionData, ViewData, asPureExpressionData} from './types';
 import {calcBindingFlags, checkAndUpdateBinding} from './util';
 
-export function purePipeDef(argCount: number): NodeDef {
+export function purePipeDef(checkIndex: number, argCount: number): NodeDef {
   // argCount + 1 to include the pipe as first arg
-  return _pureExpressionDef(NodeFlags.TypePurePipe, new Array(argCount + 1));
+  return _pureExpressionDef(NodeFlags.TypePurePipe, checkIndex, new Array(argCount + 1));
 }
 
-export function pureArrayDef(argCount: number): NodeDef {
-  return _pureExpressionDef(NodeFlags.TypePureArray, new Array(argCount));
+export function pureArrayDef(checkIndex: number, argCount: number): NodeDef {
+  return _pureExpressionDef(NodeFlags.TypePureArray, checkIndex, new Array(argCount));
 }
 
-export function pureObjectDef(propToIndex: {[p: string]: number}): NodeDef {
+export function pureObjectDef(checkIndex: number, propToIndex: {[p: string]: number}): NodeDef {
   const keys = Object.keys(propToIndex);
   const nbKeys = keys.length;
   const propertyNames = new Array(nbKeys);
@@ -28,10 +28,11 @@ export function pureObjectDef(propToIndex: {[p: string]: number}): NodeDef {
     propertyNames[index] = key;
   }
 
-  return _pureExpressionDef(NodeFlags.TypePureObject, propertyNames);
+  return _pureExpressionDef(NodeFlags.TypePureObject, checkIndex, propertyNames);
 }
 
-function _pureExpressionDef(flags: NodeFlags, propertyNames: string[]): NodeDef {
+function _pureExpressionDef(
+    flags: NodeFlags, checkIndex: number, propertyNames: string[]): NodeDef {
   const bindings: BindingDef[] = new Array(propertyNames.length);
   for (let i = 0; i < propertyNames.length; i++) {
     const prop = propertyNames[i];
@@ -46,12 +47,13 @@ function _pureExpressionDef(flags: NodeFlags, propertyNames: string[]): NodeDef 
   }
   return {
     // will bet set by the view definition
-    index: -1,
+    nodeIndex: -1,
     parent: null,
     renderParent: null,
     bindingIndex: -1,
     outputIndex: -1,
     // regular values
+    checkIndex,
     flags,
     childFlags: 0,
     directChildFlags: 0,
@@ -93,7 +95,7 @@ export function checkAndUpdatePureExpressionInline(
   if (bindLen > 9 && checkAndUpdateBinding(view, def, 9, v9)) changed = true;
 
   if (changed) {
-    const data = asPureExpressionData(view, def.index);
+    const data = asPureExpressionData(view, def.nodeIndex);
     let value: any;
     switch (def.flags & NodeFlags.Types) {
       case NodeFlags.TypePureArray:
@@ -175,7 +177,7 @@ export function checkAndUpdatePureExpressionDynamic(
     }
   }
   if (changed) {
-    const data = asPureExpressionData(view, def.index);
+    const data = asPureExpressionData(view, def.nodeIndex);
     let value: any;
     switch (def.flags & NodeFlags.Types) {
       case NodeFlags.TypePureArray:

--- a/packages/core/src/view/query.ts
+++ b/packages/core/src/view/query.ts
@@ -22,13 +22,14 @@ export function queryDef(
 
   return {
     // will bet set by the view definition
-    index: -1,
+    nodeIndex: -1,
     parent: null,
     renderParent: null,
     bindingIndex: -1,
     outputIndex: -1,
     // regular values
-    flags,
+    // TODO(vicb): check
+    checkIndex: -1, flags,
     childFlags: 0,
     directChildFlags: 0,
     childMatchedQueries: 0,
@@ -58,7 +59,7 @@ export function dirtyParentQueries(view: ViewData) {
     let tplDef = view.parentNodeDef !;
     view = view.parent;
     // content queries
-    const end = tplDef.index + tplDef.childCount;
+    const end = tplDef.nodeIndex + tplDef.childCount;
     for (let i = 0; i <= end; i++) {
       const nodeDef = view.def.nodes[i];
       if ((nodeDef.flags & NodeFlags.TypeContentQuery) &&
@@ -66,7 +67,7 @@ export function dirtyParentQueries(view: ViewData) {
           (nodeDef.query !.filterId & queryIds) === nodeDef.query !.filterId) {
         asQueryList(view, i).setDirty();
       }
-      if ((nodeDef.flags & NodeFlags.TypeElement && i + nodeDef.childCount < tplDef.index) ||
+      if ((nodeDef.flags & NodeFlags.TypeElement && i + nodeDef.childCount < tplDef.nodeIndex) ||
           !(nodeDef.childFlags & NodeFlags.TypeContentQuery) ||
           !(nodeDef.childFlags & NodeFlags.DynamicQuery)) {
         // skip elements that don't contain the template element or no query.
@@ -89,7 +90,7 @@ export function dirtyParentQueries(view: ViewData) {
 }
 
 export function checkAndUpdateQuery(view: ViewData, nodeDef: NodeDef) {
-  const queryList = asQueryList(view, nodeDef.index);
+  const queryList = asQueryList(view, nodeDef.nodeIndex);
   if (!queryList.dirty) {
     return;
   }
@@ -98,8 +99,9 @@ export function checkAndUpdateQuery(view: ViewData, nodeDef: NodeDef) {
   if (nodeDef.flags & NodeFlags.TypeContentQuery) {
     const elementDef = nodeDef.parent !.parent !;
     newValues = calcQueryValues(
-        view, elementDef.index, elementDef.index + elementDef.childCount, nodeDef.query !, []);
-    directiveInstance = asProviderData(view, nodeDef.parent !.index).instance;
+        view, elementDef.nodeIndex, elementDef.nodeIndex + elementDef.childCount, nodeDef.query !,
+        []);
+    directiveInstance = asProviderData(view, nodeDef.parent !.nodeIndex).instance;
   } else if (nodeDef.flags & NodeFlags.TypeViewQuery) {
     newValues = calcQueryValues(view, 0, view.def.nodes.length - 1, nodeDef.query !, []);
     directiveInstance = view.component;
@@ -175,24 +177,17 @@ export function getQueryValue(
     view: ViewData, nodeDef: NodeDef, queryValueType: QueryValueType): any {
   if (queryValueType != null) {
     // a match
-    let value: any;
     switch (queryValueType) {
       case QueryValueType.RenderElement:
-        value = asElementData(view, nodeDef.index).renderElement;
-        break;
+        return asElementData(view, nodeDef.nodeIndex).renderElement;
       case QueryValueType.ElementRef:
-        value = new ElementRef(asElementData(view, nodeDef.index).renderElement);
-        break;
+        return new ElementRef(asElementData(view, nodeDef.nodeIndex).renderElement);
       case QueryValueType.TemplateRef:
-        value = asElementData(view, nodeDef.index).template;
-        break;
+        return asElementData(view, nodeDef.nodeIndex).template;
       case QueryValueType.ViewContainerRef:
-        value = asElementData(view, nodeDef.index).viewContainer;
-        break;
+        return asElementData(view, nodeDef.nodeIndex).viewContainer;
       case QueryValueType.Provider:
-        value = asProviderData(view, nodeDef.index).instance;
-        break;
+        return asProviderData(view, nodeDef.nodeIndex).instance;
     }
-    return value;
   }
 }

--- a/packages/core/src/view/refs.ts
+++ b/packages/core/src/view/refs.ts
@@ -88,7 +88,7 @@ class ComponentFactory_ extends ComponentFactory<any> {
       throw new Error('ngModule should be provided');
     }
     const viewDef = resolveDefinition(this.viewDefFactory);
-    const componentNodeIndex = viewDef.nodes[0].element !.componentProvider !.index;
+    const componentNodeIndex = viewDef.nodes[0].element !.componentProvider !.nodeIndex;
     const view = Services.createRootView(
         injector, projectableNodes || [], rootSelectorOrNode, viewDef, ngModule, EMPTY_CONTEXT);
     const component = asProviderData(view, componentNodeIndex).instance;
@@ -113,7 +113,7 @@ class ComponentRef_ extends ComponentRef<any> {
     this.instance = _component;
   }
   get location(): ElementRef {
-    return new ElementRef(asElementData(this._view, this._elDef.index).renderElement);
+    return new ElementRef(asElementData(this._view, this._elDef.nodeIndex).renderElement);
   }
   get injector(): Injector { return new Injector_(this._view, this._elDef); }
   get componentType(): Type<any> { return <any>this._component.constructor; }
@@ -318,7 +318,7 @@ class TemplateRef_ extends TemplateRef<any> implements TemplateData {
   }
 
   get elementRef(): ElementRef {
-    return new ElementRef(asElementData(this._parentView, this._def.index).renderElement);
+    return new ElementRef(asElementData(this._parentView, this._def.nodeIndex).renderElement);
   }
 }
 
@@ -340,12 +340,12 @@ class Injector_ implements Injector {
 export function nodeValue(view: ViewData, index: number): any {
   const def = view.def.nodes[index];
   if (def.flags & NodeFlags.TypeElement) {
-    const elData = asElementData(view, def.index);
+    const elData = asElementData(view, def.nodeIndex);
     return def.element !.template ? elData.template : elData.renderElement;
   } else if (def.flags & NodeFlags.TypeText) {
-    return asTextData(view, def.index).renderText;
+    return asTextData(view, def.nodeIndex).renderText;
   } else if (def.flags & (NodeFlags.CatProvider | NodeFlags.TypePipe)) {
-    return asProviderData(view, def.index).instance;
+    return asProviderData(view, def.nodeIndex).instance;
   }
   throw new Error(`Illegal state: read nodeValue for node index ${index}`);
 }

--- a/packages/core/src/view/services.ts
+++ b/packages/core/src/view/services.ts
@@ -194,7 +194,7 @@ function applyProviderOverridesToView(def: ViewDefinition): ViewDefinition {
       }
       if (lastElementDef && nodeDef.flags & NodeFlags.CatProviderNoDirective &&
           providerOverrides.has(nodeDef.provider !.token)) {
-        elIndicesWithOverwrittenProviders.push(lastElementDef !.index);
+        elIndicesWithOverwrittenProviders.push(lastElementDef !.nodeIndex);
         lastElementDef = null;
       }
     }
@@ -260,22 +260,22 @@ function applyProviderOverridesToNgModule(def: NgModuleDefinition): NgModuleDefi
 }
 
 function prodCheckAndUpdateNode(
-    view: ViewData, nodeIndex: number, argStyle: ArgumentType, v0?: any, v1?: any, v2?: any,
+    view: ViewData, checkIndex: number, argStyle: ArgumentType, v0?: any, v1?: any, v2?: any,
     v3?: any, v4?: any, v5?: any, v6?: any, v7?: any, v8?: any, v9?: any): any {
-  const nodeDef = view.def.nodes[nodeIndex];
+  const nodeDef = view.def.nodes[checkIndex];
   checkAndUpdateNode(view, nodeDef, argStyle, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9);
   return (nodeDef.flags & NodeFlags.CatPureExpression) ?
-      asPureExpressionData(view, nodeIndex).value :
+      asPureExpressionData(view, checkIndex).value :
       undefined;
 }
 
 function prodCheckNoChangesNode(
-    view: ViewData, nodeIndex: number, argStyle: ArgumentType, v0?: any, v1?: any, v2?: any,
+    view: ViewData, checkIndex: number, argStyle: ArgumentType, v0?: any, v1?: any, v2?: any,
     v3?: any, v4?: any, v5?: any, v6?: any, v7?: any, v8?: any, v9?: any): any {
-  const nodeDef = view.def.nodes[nodeIndex];
+  const nodeDef = view.def.nodes[checkIndex];
   checkNoChangesNode(view, nodeDef, argStyle, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9);
   return (nodeDef.flags & NodeFlags.CatPureExpression) ?
-      asPureExpressionData(view, nodeIndex).value :
+      asPureExpressionData(view, checkIndex).value :
       undefined;
 }
 
@@ -333,7 +333,7 @@ function debugUpdateDirectives(view: ViewData, checkType: CheckType) {
       debugSetCurrentNode(view, nextDirectiveWithBinding(view, nodeIndex));
     }
     return (nodeDef.flags & NodeFlags.CatPureExpression) ?
-        asPureExpressionData(view, nodeDef.index).value :
+        asPureExpressionData(view, nodeDef.nodeIndex).value :
         undefined;
   }
 }
@@ -357,7 +357,7 @@ function debugUpdateRenderer(view: ViewData, checkType: CheckType) {
       debugSetCurrentNode(view, nextRenderNodeWithBinding(view, nodeIndex));
     }
     return (nodeDef.flags & NodeFlags.CatPureExpression) ?
-        asPureExpressionData(view, nodeDef.index).value :
+        asPureExpressionData(view, nodeDef.nodeIndex).value :
         undefined;
   }
 }
@@ -378,7 +378,7 @@ function debugCheckAndUpdateNode(
         }
       }
       const elDef = nodeDef.parent !;
-      const el = asElementData(view, elDef.index).renderElement;
+      const el = asElementData(view, elDef.nodeIndex).renderElement;
       if (!elDef.element !.name) {
         // a comment.
         view.renderer.setValue(el, `bindings=${JSON.stringify(bindingValues, null, 2)}`);
@@ -468,7 +468,7 @@ class DebugContext_ implements DebugContext {
   }
   private get elOrCompView() {
     // Has to be done lazily as we use the DebugContext also during creation of elements...
-    return asElementData(this.elView, this.elDef.index).componentView || this.view;
+    return asElementData(this.elView, this.elDef.nodeIndex).componentView || this.view;
   }
   get injector(): Injector { return createInjector(this.elView, this.elDef); }
   get component(): any { return this.elOrCompView.component; }
@@ -476,7 +476,8 @@ class DebugContext_ implements DebugContext {
   get providerTokens(): any[] {
     const tokens: any[] = [];
     if (this.elDef) {
-      for (let i = this.elDef.index + 1; i <= this.elDef.index + this.elDef.childCount; i++) {
+      for (let i = this.elDef.nodeIndex + 1; i <= this.elDef.nodeIndex + this.elDef.childCount;
+           i++) {
         const childDef = this.elView.def.nodes[i];
         if (childDef.flags & NodeFlags.CatProvider) {
           tokens.push(childDef.provider !.token);
@@ -491,7 +492,8 @@ class DebugContext_ implements DebugContext {
     if (this.elDef) {
       collectReferences(this.elView, this.elDef, references);
 
-      for (let i = this.elDef.index + 1; i <= this.elDef.index + this.elDef.childCount; i++) {
+      for (let i = this.elDef.nodeIndex + 1; i <= this.elDef.nodeIndex + this.elDef.childCount;
+           i++) {
         const childDef = this.elView.def.nodes[i];
         if (childDef.flags & NodeFlags.CatProvider) {
           collectReferences(this.elView, childDef, references);
@@ -514,10 +516,10 @@ class DebugContext_ implements DebugContext {
     let logNodeIndex: number;
     if (this.nodeDef.flags & NodeFlags.TypeText) {
       logViewDef = this.view.def;
-      logNodeIndex = this.nodeDef.index;
+      logNodeIndex = this.nodeDef.nodeIndex;
     } else {
       logViewDef = this.elView.def;
-      logNodeIndex = this.elDef.index;
+      logNodeIndex = this.elDef.nodeIndex;
     }
     // Note: we only generate a log function for text and element nodes
     // to make the generated code as small as possible.
@@ -555,7 +557,7 @@ function findHostElement(view: ViewData): ElementData|null {
     view = view.parent !;
   }
   if (view.parent) {
-    return asElementData(view.parent, viewParentEl(view) !.index);
+    return asElementData(view.parent, viewParentEl(view) !.nodeIndex);
   }
   return null;
 }

--- a/packages/core/src/view/text.ts
+++ b/packages/core/src/view/text.ts
@@ -9,7 +9,8 @@
 import {BindingDef, BindingFlags, NodeDef, NodeFlags, TextData, ViewData, asTextData} from './types';
 import {checkAndUpdateBinding, getParentRenderElement} from './util';
 
-export function textDef(ngContentIndex: number, staticText: string[]): NodeDef {
+export function textDef(
+    checkIndex: number, ngContentIndex: number | null, staticText: string[]): NodeDef {
   const bindings: BindingDef[] = new Array(staticText.length - 1);
   for (let i = 1; i < staticText.length; i++) {
     bindings[i - 1] = {
@@ -24,12 +25,13 @@ export function textDef(ngContentIndex: number, staticText: string[]): NodeDef {
 
   return {
     // will bet set by the view definition
-    index: -1,
+    nodeIndex: -1,
     parent: null,
     renderParent: null,
     bindingIndex: -1,
     outputIndex: -1,
     // regular values
+    checkIndex,
     flags: NodeFlags.TypeText,
     childFlags: 0,
     directChildFlags: 0,
@@ -88,7 +90,7 @@ export function checkAndUpdateTextInline(
     if (bindLen > 7) value += _addInterpolationPart(v7, bindings[7]);
     if (bindLen > 8) value += _addInterpolationPart(v8, bindings[8]);
     if (bindLen > 9) value += _addInterpolationPart(v9, bindings[9]);
-    const renderNode = asTextData(view, def.index).renderText;
+    const renderNode = asTextData(view, def.nodeIndex).renderText;
     view.renderer.setValue(renderNode, value);
   }
   return changed;
@@ -110,7 +112,7 @@ export function checkAndUpdateTextDynamic(view: ViewData, def: NodeDef, values: 
       value = value + _addInterpolationPart(values[i], bindings[i]);
     }
     value = def.text !.prefix + value;
-    const renderNode = asTextData(view, def.index).renderText;
+    const renderNode = asTextData(view, def.nodeIndex).renderText;
     view.renderer.setValue(renderNode, value);
   }
   return changed;

--- a/packages/core/src/view/types.ts
+++ b/packages/core/src/view/types.ts
@@ -103,11 +103,15 @@ export const enum ViewFlags {
  */
 export interface NodeDef {
   flags: NodeFlags;
-  index: number;
+  // Index of the node in view data and view definition (those are the same)
+  nodeIndex: number;
+  // Index of the node in the check functions
+  // Differ from nodeIndex when nodes are added or removed at runtime (ie after compilation)
+  checkIndex: number;
   parent: NodeDef|null;
   renderParent: NodeDef|null;
   /** this is checked against NgContentDef.index to find matched nodes */
-  ngContentIndex: number;
+  ngContentIndex: number|null;
   /** number of transitive children */
   childCount: number;
   /** aggregated NodeFlags for all transitive children (does not include self) **/

--- a/packages/core/src/view/util.ts
+++ b/packages/core/src/view/util.ts
@@ -102,7 +102,7 @@ export function checkBindingNoChanges(
   const oldValue = view.oldValues[def.bindingIndex + bindingIdx];
   if ((view.state & ViewState.BeforeFirstCheck) || !devModeEqual(oldValue, value)) {
     throw expressionChangedAfterItHasBeenCheckedError(
-        Services.createDebugContext(view, def.index), oldValue, value,
+        Services.createDebugContext(view, def.nodeIndex), oldValue, value,
         (view.state & ViewState.BeforeFirstCheck) !== 0);
   }
 }
@@ -143,7 +143,7 @@ export function dispatchEvent(
 export function declaredViewContainer(view: ViewData): ElementData|null {
   if (view.parent) {
     const parentView = view.parent;
-    return asElementData(parentView, view.parentNodeDef !.index);
+    return asElementData(parentView, view.parentNodeDef !.nodeIndex);
   }
   return null;
 }
@@ -165,9 +165,9 @@ export function viewParentEl(view: ViewData): NodeDef|null {
 export function renderNode(view: ViewData, def: NodeDef): any {
   switch (def.flags & NodeFlags.Types) {
     case NodeFlags.TypeElement:
-      return asElementData(view, def.index).renderElement;
+      return asElementData(view, def.nodeIndex).renderElement;
     case NodeFlags.TypeText:
-      return asTextData(view, def.index).renderText;
+      return asTextData(view, def.nodeIndex).renderText;
   }
 }
 
@@ -233,7 +233,7 @@ export function getParentRenderElement(view: ViewData, renderHost: any, def: Nod
              ViewEncapsulation.Native)) {
       // only children of non components, or children of components with native encapsulation should
       // be attached.
-      return asElementData(view, def.renderParent !.index).renderElement;
+      return asElementData(view, def.renderParent !.nodeIndex).renderElement;
     }
   } else {
     return renderHost;
@@ -292,8 +292,8 @@ export function visitProjectedRenderNodes(
   }
   const hostView = compView !.parent;
   const hostElDef = viewParentEl(compView !);
-  const startIndex = hostElDef !.index + 1;
-  const endIndex = hostElDef !.index + hostElDef !.childCount;
+  const startIndex = hostElDef !.nodeIndex + 1;
+  const endIndex = hostElDef !.nodeIndex + hostElDef !.childCount;
   for (let i = startIndex; i <= endIndex; i++) {
     const nodeDef = hostView !.def.nodes[i];
     if (nodeDef.ngContentIndex === ngContentIndex) {
@@ -328,21 +328,21 @@ function visitRenderNode(
         execRenderNodeAction(view, rn, action, parentNode, nextSibling, target);
       }
       if (nodeDef.bindingFlags & (BindingFlags.SyntheticHostProperty)) {
-        const compView = asElementData(view, nodeDef.index).componentView;
+        const compView = asElementData(view, nodeDef.nodeIndex).componentView;
         execRenderNodeAction(compView, rn, action, parentNode, nextSibling, target);
       }
     } else {
       execRenderNodeAction(view, rn, action, parentNode, nextSibling, target);
     }
     if (nodeDef.flags & NodeFlags.EmbeddedViews) {
-      const embeddedViews = asElementData(view, nodeDef.index).viewContainer !._embeddedViews;
+      const embeddedViews = asElementData(view, nodeDef.nodeIndex).viewContainer !._embeddedViews;
       for (let k = 0; k < embeddedViews.length; k++) {
         visitRootRenderNodes(embeddedViews[k], action, parentNode, nextSibling, target);
       }
     }
     if (nodeDef.flags & NodeFlags.TypeElement && !nodeDef.element !.name) {
       visitSiblingRenderNodes(
-          view, action, nodeDef.index + 1, nodeDef.index + nodeDef.childCount, parentNode,
+          view, action, nodeDef.nodeIndex + 1, nodeDef.nodeIndex + nodeDef.childCount, parentNode,
           nextSibling, target);
     }
   }

--- a/packages/core/test/view/anchor_spec.ts
+++ b/packages/core/test/view/anchor_spec.ts
@@ -6,47 +6,35 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation, getDebugNode} from '@angular/core';
-import {DebugContext, NodeDef, NodeFlags, RootData, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, elementDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
+import {getDebugNode} from '@angular/core';
+import {NodeFlags, anchorDef, asElementData, elementDef} from '@angular/core/src/view/index';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
-import {createRootView, isBrowser} from './helper';
+import {compViewDef, createAndGetRootNodes} from './helper';
 
 export function main() {
   describe(`View Anchor`, () => {
-    function compViewDef(
-        nodes: NodeDef[], updateDirectives?: ViewUpdateFn,
-        updateRenderer?: ViewUpdateFn): ViewDefinition {
-      return viewDef(ViewFlags.None, nodes, updateDirectives, updateRenderer);
-    }
-
-    function createAndGetRootNodes(
-        viewDef: ViewDefinition, ctx?: any): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(viewDef, ctx);
-      const rootNodes = rootRenderNodes(view);
-      return {rootNodes, view};
-    }
 
     describe('create', () => {
       it('should create anchor nodes without parents', () => {
         const rootNodes = createAndGetRootNodes(compViewDef([
-                            anchorDef(NodeFlags.None, null !, null !, 0)
+                            anchorDef(NodeFlags.None, null, null, 0)
                           ])).rootNodes;
         expect(rootNodes.length).toBe(1);
       });
 
       it('should create views with multiple root anchor nodes', () => {
-        const rootNodes = createAndGetRootNodes(compViewDef([
-                            anchorDef(NodeFlags.None, null !, null !, 0),
-                            anchorDef(NodeFlags.None, null !, null !, 0)
-                          ])).rootNodes;
+        const rootNodes =
+            createAndGetRootNodes(compViewDef([
+              anchorDef(NodeFlags.None, null, null, 0), anchorDef(NodeFlags.None, null, null, 0)
+            ])).rootNodes;
         expect(rootNodes.length).toBe(2);
       });
 
       it('should create anchor nodes with parents', () => {
         const rootNodes = createAndGetRootNodes(compViewDef([
-                            elementDef(NodeFlags.None, null !, null !, 1, 'div'),
-                            anchorDef(NodeFlags.None, null !, null !, 0),
+                            elementDef(0, NodeFlags.None, null, null, 1, 'div'),
+                            anchorDef(NodeFlags.None, null, null, 0),
                           ])).rootNodes;
         expect(getDOM().childNodes(rootNodes[0]).length).toBe(1);
       });
@@ -54,7 +42,7 @@ export function main() {
       it('should add debug information to the renderer', () => {
         const someContext = new Object();
         const {view, rootNodes} = createAndGetRootNodes(
-            compViewDef([anchorDef(NodeFlags.None, null !, null !, 0)]), someContext);
+            compViewDef([anchorDef(NodeFlags.None, null, null, 0)]), someContext);
         expect(getDebugNode(rootNodes[0]) !.nativeNode).toBe(asElementData(view, 0).renderElement);
       });
     });

--- a/packages/core/test/view/component_view_spec.ts
+++ b/packages/core/test/view/component_view_spec.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation} from '@angular/core';
-import {ArgumentType, BindingFlags, NodeCheckFn, NodeDef, NodeFlags, OutputType, RootData, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewState, ViewUpdateFn, anchorDef, asElementData, asProviderData, directiveDef, elementDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
+import {SecurityContext} from '@angular/core';
+import {ArgumentType, BindingFlags, NodeCheckFn, NodeFlags, Services, ViewData, ViewFlags, ViewState, asElementData, directiveDef, elementDef, rootRenderNodes} from '@angular/core/src/view/index';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
-import {callMostRecentEventListenerHandler, createRootView, isBrowser, recordNodeToRemove} from './helper';
+import {callMostRecentEventListenerHandler, compViewDef, createAndGetRootNodes, createRootView, isBrowser, recordNodeToRemove} from './helper';
+
 
 
 /**
@@ -21,18 +22,6 @@ const addEventListener = '__zone_symbol__addEventListener';
 
 export function main() {
   describe(`Component Views`, () => {
-    function compViewDef(
-        nodes: NodeDef[], updateDirectives?: ViewUpdateFn, updateRenderer?: ViewUpdateFn,
-        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
-      return viewDef(viewFlags, nodes, updateDirectives, updateRenderer);
-    }
-
-    function createAndGetRootNodes(viewDef: ViewDefinition): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(viewDef);
-      const rootNodes = rootRenderNodes(view);
-      return {rootNodes, view};
-    }
-
     it('should create and attach component views', () => {
       let instance: AComp = undefined !;
       class AComp {
@@ -41,11 +30,11 @@ export function main() {
 
       const {view, rootNodes} = createAndGetRootNodes(compViewDef([
         elementDef(
-            NodeFlags.None, null !, null !, 1, 'div', null !, null !, null !, null !,
+            0, NodeFlags.None, null, null, 1, 'div', null, null, null, null,
             () => compViewDef([
-              elementDef(NodeFlags.None, null !, null !, 0, 'span'),
+              elementDef(0, NodeFlags.None, null, null, 0, 'span'),
             ])),
-        directiveDef(NodeFlags.Component, null !, 0, AComp, []),
+        directiveDef(1, NodeFlags.Component, null, 0, AComp, []),
       ]));
 
       const compView = asElementData(view, 0).componentView;
@@ -69,7 +58,7 @@ export function main() {
         it('should select root elements based on a selector', () => {
           const view = createRootView(
               compViewDef([
-                elementDef(NodeFlags.None, null !, null !, 0, 'div'),
+                elementDef(0, NodeFlags.None, null, null, 0, 'div'),
               ]),
               {}, [], 'root');
           const rootNodes = rootRenderNodes(view);
@@ -79,7 +68,7 @@ export function main() {
         it('should select root elements based on a node', () => {
           const view = createRootView(
               compViewDef([
-                elementDef(NodeFlags.None, null !, null !, 0, 'div'),
+                elementDef(0, NodeFlags.None, null, null, 0, 'div'),
               ]),
               {}, [], rootNode);
           const rootNodes = rootRenderNodes(view);
@@ -87,9 +76,9 @@ export function main() {
         });
 
         it('should set attributes on the root node', () => {
-          const view = createRootView(
+          createRootView(
               compViewDef([
-                elementDef(NodeFlags.None, null !, null !, 0, 'div', [['a', 'b']]),
+                elementDef(0, NodeFlags.None, null, null, 0, 'div', [['a', 'b']]),
               ]),
               {}, [], rootNode);
           expect(rootNode.getAttribute('a')).toBe('b');
@@ -97,9 +86,9 @@ export function main() {
 
         it('should clear the content of the root node', () => {
           rootNode.appendChild(document.createElement('div'));
-          const view = createRootView(
+          createRootView(
               compViewDef([
-                elementDef(NodeFlags.None, null !, null !, 0, 'div', [['a', 'b']]),
+                elementDef(0, NodeFlags.None, null, null, 0, 'div', [['a', 'b']]),
               ]),
               {}, [], rootNode);
           expect(rootNode.childNodes.length).toBe(0);
@@ -121,12 +110,12 @@ export function main() {
 
         const {view, rootNodes} = createAndGetRootNodes(
           compViewDef([
-            elementDef(NodeFlags.None, null!, null!, 1, 'div', null!, null!, null!, null!, () => compViewDef(
+            elementDef(0, NodeFlags.None, null, null, 1, 'div', null, null, null, null, () => compViewDef(
               [
-                elementDef(NodeFlags.None, null!, null!, 0, 'span', null!, [[BindingFlags.TypeElementAttribute, 'a', SecurityContext.NONE]]),
-              ], null!, update
+                elementDef(0, NodeFlags.None, null, null, 0, 'span', null, [[BindingFlags.TypeElementAttribute, 'a', SecurityContext.NONE]]),
+              ], null, update
             )),
-            directiveDef(NodeFlags.Component, null!, 0, AComp, []),
+            directiveDef(1, NodeFlags.Component, null, 0, AComp, []),
           ]));
         const compView = asElementData(view, 0).componentView;
 
@@ -155,13 +144,13 @@ export function main() {
 
         const {view, rootNodes} = createAndGetRootNodes(compViewDef([
           elementDef(
-              NodeFlags.None, null !, null !, 1, 'div', null !, null !, null !, null !,
+              0, NodeFlags.None, null, null, 1, 'div', null, null, null, null,
               () => compViewDef(
                   [
-                    elementDef(NodeFlags.None, null !, null !, 0, 'span'),
+                    elementDef(0, NodeFlags.None, null, null, 0, 'span'),
                   ],
                   update)),
-          directiveDef(NodeFlags.Component, null !, 0, AComp, [], null !, null !),
+          directiveDef(1, NodeFlags.Component, null, 0, AComp, [], null, null),
         ]));
 
         const compView = asElementData(view, 0).componentView;
@@ -192,17 +181,17 @@ export function main() {
           const {view} = createAndGetRootNodes(compViewDef(
               [
                 elementDef(
-                    NodeFlags.None, null !, null !, 1, 'div', null !, null !, null !, null !,
+                    0, NodeFlags.None, null, null, 1, 'div', null, null, null, null,
                     () => {
                       return compViewDef(
                           [
                             elementDef(
-                                NodeFlags.None, null !, null !, 0, 'span', null !, null !,
+                                0, NodeFlags.None, null, null, 0, 'span', null, null,
                                 [[null !, 'click']]),
                           ],
-                          update, null !, ViewFlags.OnPush);
+                          update, null, ViewFlags.OnPush);
                     }),
-                directiveDef(NodeFlags.Component, null !, 0, AComp, [], {a: [0, 'a']}),
+                directiveDef(1, NodeFlags.Component, null, 0, AComp, [], {a: [0, 'a']}),
               ],
               (check, view) => { check(view, 1, ArgumentType.Inline, compInputValue); }));
 
@@ -245,17 +234,15 @@ export function main() {
         const update = jasmine.createSpy('updater');
 
         const {view, rootNodes} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null!, null!, 1, 'div', null!, null!, null!, null!, () => compViewDef(
-                  [
-                    elementDef(NodeFlags.None, null!, null!, 0, 'span', null!, [[BindingFlags.TypeElementAttribute, 'a', SecurityContext.NONE]]),
-                  ],
-                  null!, update)),
-          directiveDef(
-              NodeFlags.Component, null!, 0, AComp, [], null!, null!,
-              ),
+          elementDef(
+              0, NodeFlags.None, null, null, 1, 'div', null, null, null, null,
+              () => compViewDef(
+                  [elementDef(
+                      0, NodeFlags.None, null, null, 0, 'span', null,
+                      [[BindingFlags.TypeElementAttribute, 'a', SecurityContext.NONE]])],
+                  null, update)),
+          directiveDef(1, NodeFlags.Component, null, 0, AComp, [], null, null, ),
         ]));
-
-        const compView = asElementData(view, 0).componentView;
 
         update.and.callFake((check: NodeCheckFn, view: ViewData) => { throw new Error('Test'); });
         expect(() => Services.checkAndUpdateView(view)).toThrowError('Test');
@@ -280,12 +267,12 @@ export function main() {
 
         const {view, rootNodes} = createAndGetRootNodes(compViewDef([
           elementDef(
-              NodeFlags.None, null !, null !, 1, 'div', null !, null !, null !, null !,
+              0, NodeFlags.None, null, null, 1, 'div', null, null, null, null,
               () => compViewDef([
-                elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-                directiveDef(NodeFlags.OnDestroy, null !, 0, ChildProvider, [])
+                elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+                directiveDef(1, NodeFlags.OnDestroy, null, 0, ChildProvider, [])
               ])),
-          directiveDef(NodeFlags.Component, null !, 0, AComp, [], null !, null !, ),
+          directiveDef(1, NodeFlags.Component, null, 0, AComp, [], null, null, ),
         ]));
 
         Services.destroyView(view);
@@ -294,11 +281,8 @@ export function main() {
       });
 
       it('should throw on dirty checking destroyed views', () => {
-        const {view, rootNodes} = createAndGetRootNodes(compViewDef(
-            [
-              elementDef(NodeFlags.None, null !, null !, 0, 'div'),
-            ],
-            (view) => {}));
+        const {view, rootNodes} = createAndGetRootNodes(
+            compViewDef([elementDef(0, NodeFlags.None, null, null, 0, 'div')]));
 
         Services.destroyView(view);
 

--- a/packages/core/test/view/embedded_view_spec.ts
+++ b/packages/core/test/view/embedded_view_spec.ts
@@ -6,31 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation} from '@angular/core';
-import {ArgumentType, BindingFlags, NodeCheckFn, NodeDef, NodeFlags, RootData, Services, ViewData, ViewDefinition, ViewDefinitionFactory, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, attachEmbeddedView, detachEmbeddedView, directiveDef, elementDef, moveEmbeddedView, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
-import {inject} from '@angular/core/testing';
+import {SecurityContext} from '@angular/core';
+import {ArgumentType, BindingFlags, NodeCheckFn, NodeFlags, Services, ViewData, anchorDef, asElementData, attachEmbeddedView, detachEmbeddedView, directiveDef, elementDef, moveEmbeddedView, rootRenderNodes} from '@angular/core/src/view/index';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
-import {createEmbeddedView, createRootView, isBrowser} from './helper';
+import {compViewDef, compViewDefFactory, createAndGetRootNodes, createEmbeddedView} from './helper';
 
 export function main() {
   describe(`Embedded Views`, () => {
-    function compViewDef(
-        nodes: NodeDef[], updateDirectives?: ViewUpdateFn, updateRenderer?: ViewUpdateFn,
-        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
-      return viewDef(viewFlags, nodes, updateDirectives, updateRenderer);
-    }
-
-    function embeddedViewDef(nodes: NodeDef[], update?: ViewUpdateFn): ViewDefinitionFactory {
-      return () => viewDef(ViewFlags.None, nodes, update);
-    }
-
-    function createAndGetRootNodes(
-        viewDef: ViewDefinition, context: any = null): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(viewDef, context);
-      const rootNodes = rootRenderNodes(view);
-      return {rootNodes, view};
-    }
 
     it('should create embedded views with the right context', () => {
       const parentContext = new Object();
@@ -38,10 +21,10 @@ export function main() {
 
       const {view: parentView} = createAndGetRootNodes(
           compViewDef([
-            elementDef(NodeFlags.None, null !, null !, 1, 'div'),
+            elementDef(0, NodeFlags.None, null, null, 1, 'div'),
             anchorDef(
-                NodeFlags.EmbeddedViews, null !, null !, 0, null !,
-                embeddedViewDef([elementDef(NodeFlags.None, null !, null !, 0, 'span')])),
+                NodeFlags.EmbeddedViews, null, null, 0, null,
+                compViewDefFactory([elementDef(0, NodeFlags.None, null, null, 0, 'span')])),
           ]),
           parentContext);
 
@@ -52,14 +35,13 @@ export function main() {
 
     it('should attach and detach embedded views', () => {
       const {view: parentView, rootNodes} = createAndGetRootNodes(compViewDef([
-        elementDef(NodeFlags.None, null !, null !, 2, 'div'),
-        anchorDef(NodeFlags.EmbeddedViews, null !, null !, 0, null !, embeddedViewDef([
-                    elementDef(NodeFlags.None, null !, null !, 0, 'span', [['name', 'child0']])
+        elementDef(0, NodeFlags.None, null, null, 2, 'div'),
+        anchorDef(NodeFlags.EmbeddedViews, null, null, 0, null, compViewDefFactory([
+                    elementDef(0, NodeFlags.None, null, null, 0, 'span', [['name', 'child0']])
                   ])),
-        anchorDef(
-            NodeFlags.None, null !, null !, 0, null !,
-            embeddedViewDef(
-                [elementDef(NodeFlags.None, null !, null !, 0, 'span', [['name', 'child1']])]))
+        anchorDef(NodeFlags.None, null, null, 0, null, compViewDefFactory([elementDef(
+                                                           0, NodeFlags.None, null, null, 0, 'span',
+                                                           [['name', 'child1']])]))
       ]));
       const viewContainerData = asElementData(parentView, 1);
       const rf = parentView.root.rendererFactory;
@@ -86,14 +68,13 @@ export function main() {
 
     it('should move embedded views', () => {
       const {view: parentView, rootNodes} = createAndGetRootNodes(compViewDef([
-        elementDef(NodeFlags.None, null !, null !, 2, 'div'),
-        anchorDef(NodeFlags.EmbeddedViews, null !, null !, 0, null !, embeddedViewDef([
-                    elementDef(NodeFlags.None, null !, null !, 0, 'span', [['name', 'child0']])
+        elementDef(0, NodeFlags.None, null, null, 2, 'div'),
+        anchorDef(NodeFlags.EmbeddedViews, null, null, 0, null, compViewDefFactory([
+                    elementDef(0, NodeFlags.None, null, null, 0, 'span', [['name', 'child0']])
                   ])),
-        anchorDef(
-            NodeFlags.None, null !, null !, 0, null !,
-            embeddedViewDef(
-                [elementDef(NodeFlags.None, null !, null !, 0, 'span', [['name', 'child1']])]))
+        anchorDef(NodeFlags.None, null, null, 0, null, compViewDefFactory([elementDef(
+                                                           0, NodeFlags.None, null, null, 0, 'span',
+                                                           [['name', 'child1']])]))
       ]));
       const viewContainerData = asElementData(parentView, 1);
 
@@ -115,10 +96,10 @@ export function main() {
 
     it('should include embedded views in root nodes', () => {
       const {view: parentView} = createAndGetRootNodes(compViewDef([
-        anchorDef(NodeFlags.EmbeddedViews, null !, null !, 0, null !, embeddedViewDef([
-                    elementDef(NodeFlags.None, null !, null !, 0, 'span', [['name', 'child0']])
+        anchorDef(NodeFlags.EmbeddedViews, null, null, 0, null, compViewDefFactory([
+                    elementDef(0, NodeFlags.None, null, null, 0, 'span', [['name', 'child0']])
                   ])),
-        elementDef(NodeFlags.None, null !, null !, 0, 'span', [['name', 'after']])
+        elementDef(1, NodeFlags.None, null, null, 0, 'span', [['name', 'after']])
       ]));
 
       const childView0 = createEmbeddedView(parentView, parentView.def.nodes[0]);
@@ -138,12 +119,12 @@ export function main() {
           });
 
       const {view: parentView, rootNodes} = createAndGetRootNodes(compViewDef([
-        elementDef(NodeFlags.None, null !, null !, 1, 'div'),
+        elementDef(0, NodeFlags.None, null, null, 1, 'div'),
         anchorDef(
-            NodeFlags.EmbeddedViews, null !, null !, 0, null !,
-            embeddedViewDef(
+            NodeFlags.EmbeddedViews, null, null, 0, null,
+            compViewDefFactory(
                 [elementDef(
-                    NodeFlags.None, null !, null !, 0, 'span', null !,
+                    0, NodeFlags.None, null, null, 0, 'span', null,
                     [[BindingFlags.TypeElementAttribute, 'name', SecurityContext.NONE]])],
                 update))
       ]));
@@ -175,10 +156,10 @@ export function main() {
       }
 
       const {view: parentView} = createAndGetRootNodes(compViewDef([
-        elementDef(NodeFlags.None, null !, null !, 1, 'div'),
-        anchorDef(NodeFlags.EmbeddedViews, null !, null !, 0, null !, embeddedViewDef([
-                    elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-                    directiveDef(NodeFlags.OnDestroy, null !, 0, ChildProvider, [])
+        elementDef(0, NodeFlags.None, null, null, 1, 'div'),
+        anchorDef(NodeFlags.EmbeddedViews, null, null, 0, null, compViewDefFactory([
+                    elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+                    directiveDef(1, NodeFlags.OnDestroy, null, 0, ChildProvider, [])
                   ]))
       ]));
 

--- a/packages/core/test/view/helper.ts
+++ b/packages/core/test/view/helper.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, NgModuleRef, RootRenderer, Sanitizer} from '@angular/core';
-import {ArgumentType, NodeCheckFn, NodeDef, RootData, Services, ViewData, ViewDefinition, initServicesIfNeeded} from '@angular/core/src/view/index';
+import {Injector, NgModuleRef} from '@angular/core';
+import {ArgumentType, NodeCheckFn, NodeDef, Services, ViewData, ViewDefinition, ViewDefinitionFactory, ViewFlags, ViewUpdateFn, initServicesIfNeeded, rootRenderNodes, viewDef} from '@angular/core/src/view/index';
 import {TestBed} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
@@ -39,6 +39,39 @@ export function createRootView(
 
 export function createEmbeddedView(parent: ViewData, anchorDef: NodeDef, context?: any): ViewData {
   return Services.createEmbeddedView(parent, anchorDef, anchorDef.element !.template !, context);
+}
+
+export function compViewDef(
+    nodes: NodeDef[], updateDirectives?: null | ViewUpdateFn, updateRenderer?: null | ViewUpdateFn,
+    viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
+  const def = viewDef(viewFlags, nodes, updateDirectives, updateRenderer);
+
+  def.nodes.forEach((node, index) => {
+    if (node.nodeIndex !== index) {
+      throw new Error('nodeIndex should be the same as the index of the node');
+    }
+
+    // This check should be removed when we start reordering nodes at runtime
+    if (node.checkIndex > -1 && node.checkIndex !== node.nodeIndex) {
+      throw new Error(
+          `nodeIndex and checkIndex should be the same, got ${node.nodeIndex} !== ${node.checkIndex}`);
+    }
+  });
+
+  return def;
+}
+
+export function compViewDefFactory(
+    nodes: NodeDef[], updateDirectives?: null | ViewUpdateFn, updateRenderer?: null | ViewUpdateFn,
+    viewFlags: ViewFlags = ViewFlags.None): ViewDefinitionFactory {
+  return () => compViewDef(nodes, updateDirectives, updateRenderer, viewFlags);
+}
+
+export function createAndGetRootNodes(
+    viewDef: ViewDefinition, ctx?: any): {rootNodes: any[], view: ViewData} {
+  const view = createRootView(viewDef, ctx);
+  const rootNodes = rootRenderNodes(view);
+  return {rootNodes, view};
 }
 
 let removeNodes: Node[];

--- a/packages/core/test/view/provider_spec.ts
+++ b/packages/core/test/view/provider_spec.ts
@@ -6,31 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, ChangeDetectorRef, DoCheck, ElementRef, ErrorHandler, EventEmitter, Injector, OnChanges, OnDestroy, OnInit, RenderComponentType, Renderer, Renderer2, RootRenderer, Sanitizer, SecurityContext, SimpleChange, TemplateRef, ViewContainerRef, ViewEncapsulation, WrappedValue, getDebugNode} from '@angular/core';
+import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, ChangeDetectorRef, DoCheck, ElementRef, ErrorHandler, EventEmitter, Injector, OnChanges, OnDestroy, OnInit, Renderer, Renderer2, SimpleChange, TemplateRef, ViewContainerRef,} from '@angular/core';
 import {getDebugContext} from '@angular/core/src/errors';
-import {ArgumentType, BindingFlags, DebugContext, DepFlags, NodeDef, NodeFlags, RootData, Services, ViewData, ViewDefinition, ViewDefinitionFactory, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, asProviderData, directiveDef, elementDef, providerDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
-import {TestBed, inject, withModule} from '@angular/core/testing';
+import {ArgumentType, DepFlags, NodeFlags, Services, anchorDef, asElementData, directiveDef, elementDef, providerDef, textDef} from '@angular/core/src/view/index';
+import {TestBed, withModule} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
-import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, createRootView, isBrowser} from './helper';
+import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, createRootView, createAndGetRootNodes, compViewDef, compViewDefFactory} from './helper';
 
 export function main() {
   describe(`View Providers`, () => {
-    function compViewDef(
-        nodes: NodeDef[], updateDirectives?: ViewUpdateFn, updateRenderer?: ViewUpdateFn,
-        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
-      return viewDef(viewFlags, nodes, updateDirectives, updateRenderer);
-    }
-
-    function embeddedViewDef(nodes: NodeDef[], update?: ViewUpdateFn): ViewDefinitionFactory {
-      return () => viewDef(ViewFlags.None, nodes, update);
-    }
-
-    function createAndGetRootNodes(viewDef: ViewDefinition): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(viewDef, {});
-      const rootNodes = rootRenderNodes(view);
-      return {rootNodes, view};
-    }
 
     describe('create', () => {
       let instance: SomeService;
@@ -43,8 +28,8 @@ export function main() {
 
       it('should create providers eagerly', () => {
         createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-          directiveDef(NodeFlags.None, null !, 0, SomeService, [])
+          elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+          directiveDef(1, NodeFlags.None, null, 0, SomeService, [])
         ]));
 
         expect(instance instanceof SomeService).toBe(true);
@@ -57,11 +42,11 @@ export function main() {
         }
 
         createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null !, null !, 2, 'span'),
+          elementDef(0, NodeFlags.None, null, null, 2, 'span'),
           providerDef(
-              NodeFlags.TypeClassProvider | NodeFlags.LazyProvider, null !, LazyService,
-              LazyService, []),
-          directiveDef(NodeFlags.None, null !, 0, SomeService, [Injector])
+              NodeFlags.TypeClassProvider | NodeFlags.LazyProvider, null, LazyService, LazyService,
+              []),
+          directiveDef(2, NodeFlags.None, null, 0, SomeService, [Injector])
         ]));
 
         expect(lazy).toBeUndefined();
@@ -71,9 +56,9 @@ export function main() {
 
       it('should create value providers', () => {
         createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null !, null !, 2, 'span'),
-          providerDef(NodeFlags.TypeValueProvider, null !, 'someToken', 'someValue', []),
-          directiveDef(NodeFlags.None, null !, 0, SomeService, ['someToken']),
+          elementDef(0, NodeFlags.None, null, null, 2, 'span'),
+          providerDef(NodeFlags.TypeValueProvider, null, 'someToken', 'someValue', []),
+          directiveDef(2, NodeFlags.None, null, 0, SomeService, ['someToken']),
         ]));
 
         expect(instance.dep).toBe('someValue');
@@ -83,9 +68,9 @@ export function main() {
         function someFactory() { return 'someValue'; }
 
         createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null !, null !, 2, 'span'),
-          providerDef(NodeFlags.TypeFactoryProvider, null !, 'someToken', someFactory, []),
-          directiveDef(NodeFlags.None, null !, 0, SomeService, ['someToken']),
+          elementDef(0, NodeFlags.None, null, null, 2, 'span'),
+          providerDef(NodeFlags.TypeFactoryProvider, null, 'someToken', someFactory, []),
+          directiveDef(2, NodeFlags.None, null, 0, SomeService, ['someToken']),
         ]));
 
         expect(instance.dep).toBe('someValue');
@@ -93,12 +78,11 @@ export function main() {
 
       it('should create useExisting providers', () => {
         createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null !, null !, 3, 'span'),
-          providerDef(NodeFlags.TypeValueProvider, null !, 'someExistingToken', 'someValue', []),
+          elementDef(0, NodeFlags.None, null, null, 3, 'span'),
+          providerDef(NodeFlags.TypeValueProvider, null, 'someExistingToken', 'someValue', []),
           providerDef(
-              NodeFlags.TypeUseExistingProvider, null !, 'someToken', null !,
-              ['someExistingToken']),
-          directiveDef(NodeFlags.None, null !, 0, SomeService, ['someToken']),
+              NodeFlags.TypeUseExistingProvider, null, 'someToken', null, ['someExistingToken']),
+          directiveDef(3, NodeFlags.None, null, 0, SomeService, ['someToken']),
         ]));
 
         expect(instance.dep).toBe('someValue');
@@ -114,9 +98,9 @@ export function main() {
           createRootView(
               compViewDef([
                 elementDef(
-                    NodeFlags.None, null !, null !, 1, 'div', null !, null !, null !, null !,
-                    () => compViewDef([textDef(null !, ['a'])])),
-                directiveDef(NodeFlags.Component, null !, 0, SomeService, [])
+                    0, NodeFlags.None, null, null, 1, 'div', null, null, null, null,
+                    () => compViewDef([textDef(0, null, ['a'])])),
+                directiveDef(1, NodeFlags.Component, null, 0, SomeService, [])
               ]),
               TestBed.get(Injector), [], getDOM().createElement('div'));
         } catch (e) {
@@ -134,9 +118,9 @@ export function main() {
 
         it('should inject deps from the same element', () => {
           createAndGetRootNodes(compViewDef([
-            elementDef(NodeFlags.None, null !, null !, 2, 'span'),
-            directiveDef(NodeFlags.None, null !, 0, Dep, []),
-            directiveDef(NodeFlags.None, null !, 0, SomeService, [Dep])
+            elementDef(0, NodeFlags.None, null, null, 2, 'span'),
+            directiveDef(1, NodeFlags.None, null, 0, Dep, []),
+            directiveDef(2, NodeFlags.None, null, 0, SomeService, [Dep])
           ]));
 
           expect(instance.dep instanceof Dep).toBeTruthy();
@@ -144,34 +128,38 @@ export function main() {
 
         it('should inject deps from a parent element', () => {
           createAndGetRootNodes(compViewDef([
-            elementDef(NodeFlags.None, null !, null !, 3, 'span'),
-            directiveDef(NodeFlags.None, null !, 0, Dep, []),
-            elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-            directiveDef(NodeFlags.None, null !, 0, SomeService, [Dep])
+            elementDef(0, NodeFlags.None, null, null, 3, 'span'),
+            directiveDef(1, NodeFlags.None, null, 0, Dep, []),
+            elementDef(2, NodeFlags.None, null, null, 1, 'span'),
+            directiveDef(3, NodeFlags.None, null, 0, SomeService, [Dep])
           ]));
 
           expect(instance.dep instanceof Dep).toBeTruthy();
         });
 
         it('should not inject deps from sibling root elements', () => {
-          const nodes = [
-            elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-            directiveDef(NodeFlags.None, null !, 0, Dep, []),
-            elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-            directiveDef(NodeFlags.None, null !, 0, SomeService, [Dep])
+          const rootElNodes = [
+            elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+            directiveDef(1, NodeFlags.None, null, 0, Dep, []),
+            elementDef(2, NodeFlags.None, null, null, 1, 'span'),
+            directiveDef(3, NodeFlags.None, null, 0, SomeService, [Dep]),
           ];
 
-          // root elements
-          expect(() => createAndGetRootNodes(compViewDef(nodes)))
+          expect(() => createAndGetRootNodes(compViewDef(rootElNodes)))
               .toThrowError(
                   'StaticInjectorError[Dep]: \n' +
                   '  StaticInjectorError[Dep]: \n' +
                   '    NullInjectorError: No provider for Dep!');
 
-          // non root elements
-          expect(
-              () => createAndGetRootNodes(compViewDef(
-                  [elementDef(NodeFlags.None, null !, null !, 4, 'span')].concat(nodes))))
+          const nonRootElNodes = [
+            elementDef(0, NodeFlags.None, null, null, 4, 'span'),
+            elementDef(1, NodeFlags.None, null, null, 1, 'span'),
+            directiveDef(2, NodeFlags.None, null, 0, Dep, []),
+            elementDef(3, NodeFlags.None, null, null, 1, 'span'),
+            directiveDef(4, NodeFlags.None, null, 0, SomeService, [Dep]),
+          ];
+
+          expect(() => createAndGetRootNodes(compViewDef(nonRootElNodes)))
               .toThrowError(
                   'StaticInjectorError[Dep]: \n' +
                   '  StaticInjectorError[Dep]: \n' +
@@ -181,12 +169,12 @@ export function main() {
         it('should inject from a parent element in a parent view', () => {
           createAndGetRootNodes(compViewDef([
             elementDef(
-                NodeFlags.None, null !, null !, 1, 'div', null !, null !, null !, null !,
+                0, NodeFlags.None, null, null, 1, 'div', null, null, null, null,
                 () => compViewDef([
-                  elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-                  directiveDef(NodeFlags.None, null !, 0, SomeService, [Dep])
+                  elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+                  directiveDef(1, NodeFlags.None, null, 0, SomeService, [Dep])
                 ])),
-            directiveDef(NodeFlags.Component, null !, 0, Dep, []),
+            directiveDef(1, NodeFlags.Component, null, 0, Dep, []),
           ]));
 
           expect(instance.dep instanceof Dep).toBeTruthy();
@@ -194,8 +182,8 @@ export function main() {
 
         it('should throw for missing dependencies', () => {
           expect(() => createAndGetRootNodes(compViewDef([
-                   elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-                   directiveDef(NodeFlags.None, null !, 0, SomeService, ['nonExistingDep'])
+                   elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+                   directiveDef(1, NodeFlags.None, null, 0, SomeService, ['nonExistingDep'])
                  ])))
               .toThrowError(
                   'StaticInjectorError[nonExistingDep]: \n' +
@@ -205,21 +193,22 @@ export function main() {
 
         it('should use null for optional missing dependencies', () => {
           createAndGetRootNodes(compViewDef([
-            elementDef(NodeFlags.None, null !, null !, 1, 'span'),
+            elementDef(0, NodeFlags.None, null, null, 1, 'span'),
             directiveDef(
-                NodeFlags.None, null !, 0, SomeService, [[DepFlags.Optional, 'nonExistingDep']])
+                1, NodeFlags.None, null, 0, SomeService,
+                [[DepFlags.Optional, 'nonExistingDep']])
           ]));
           expect(instance.dep).toBe(null);
         });
 
         it('should skip the current element when using SkipSelf', () => {
           createAndGetRootNodes(compViewDef([
-            elementDef(NodeFlags.None, null !, null !, 4, 'span'),
-            providerDef(NodeFlags.TypeValueProvider, null !, 'someToken', 'someParentValue', []),
-            elementDef(NodeFlags.None, null !, null !, 2, 'span'),
-            providerDef(NodeFlags.TypeValueProvider, null !, 'someToken', 'someValue', []),
+            elementDef(0, NodeFlags.None, null, null, 4, 'span'),
+            providerDef(NodeFlags.TypeValueProvider, null, 'someToken', 'someParentValue', []),
+            elementDef(2, NodeFlags.None, null, null, 2, 'span'),
+            providerDef(NodeFlags.TypeValueProvider, null, 'someToken', 'someValue', []),
             directiveDef(
-                NodeFlags.None, null !, 0, SomeService, [[DepFlags.SkipSelf, 'someToken']])
+                4, NodeFlags.None, null, 0, SomeService, [[DepFlags.SkipSelf, 'someToken']])
           ]));
           expect(instance.dep).toBe('someParentValue');
         });
@@ -227,8 +216,8 @@ export function main() {
         it('should ask the root injector',
            withModule({providers: [{provide: 'rootDep', useValue: 'rootValue'}]}, () => {
              createAndGetRootNodes(compViewDef([
-               elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-               directiveDef(NodeFlags.None, null !, 0, SomeService, ['rootDep'])
+               elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+               directiveDef(1, NodeFlags.None, null, 0, SomeService, ['rootDep'])
              ]));
 
              expect(instance.dep).toBe('rootValue');
@@ -237,8 +226,8 @@ export function main() {
         describe('builtin tokens', () => {
           it('should inject ViewContainerRef', () => {
             createAndGetRootNodes(compViewDef([
-              anchorDef(NodeFlags.EmbeddedViews, null !, null !, 1),
-              directiveDef(NodeFlags.None, null !, 0, SomeService, [ViewContainerRef])
+              anchorDef(NodeFlags.EmbeddedViews, null, null, 1),
+              directiveDef(1, NodeFlags.None, null, 0, SomeService, [ViewContainerRef]),
             ]));
 
             expect(instance.dep.createEmbeddedView).toBeTruthy();
@@ -246,10 +235,9 @@ export function main() {
 
           it('should inject TemplateRef', () => {
             createAndGetRootNodes(compViewDef([
-              anchorDef(
-                  NodeFlags.None, null !, null !, 1, null !,
-                  embeddedViewDef([anchorDef(NodeFlags.None, null !, null !, 0)])),
-              directiveDef(NodeFlags.None, null !, 0, SomeService, [TemplateRef])
+              anchorDef(NodeFlags.None, null, null, 1, null, compViewDefFactory([anchorDef(
+                                                                 NodeFlags.None, null, null, 0)])),
+              directiveDef(1, NodeFlags.None, null, 0, SomeService, [TemplateRef]),
             ]));
 
             expect(instance.dep.createEmbeddedView).toBeTruthy();
@@ -257,8 +245,8 @@ export function main() {
 
           it('should inject ElementRef', () => {
             const {view} = createAndGetRootNodes(compViewDef([
-              elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-              directiveDef(NodeFlags.None, null !, 0, SomeService, [ElementRef])
+              elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+              directiveDef(1, NodeFlags.None, null, 0, SomeService, [ElementRef]),
             ]));
 
             expect(instance.dep.nativeElement).toBe(asElementData(view, 0).renderElement);
@@ -266,8 +254,8 @@ export function main() {
 
           it('should inject Injector', () => {
             const {view} = createAndGetRootNodes(compViewDef([
-              elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-              directiveDef(NodeFlags.None, null !, 0, SomeService, [Injector])
+              elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+              directiveDef(1, NodeFlags.None, null, 0, SomeService, [Injector]),
             ]));
 
             expect(instance.dep.get(SomeService)).toBe(instance);
@@ -275,8 +263,8 @@ export function main() {
 
           it('should inject ChangeDetectorRef for non component providers', () => {
             const {view} = createAndGetRootNodes(compViewDef([
-              elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-              directiveDef(NodeFlags.None, null !, 0, SomeService, [ChangeDetectorRef])
+              elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+              directiveDef(1, NodeFlags.None, null, 0, SomeService, [ChangeDetectorRef])
             ]));
 
             expect(instance.dep._view).toBe(view);
@@ -285,11 +273,11 @@ export function main() {
           it('should inject ChangeDetectorRef for component providers', () => {
             const {view, rootNodes} = createAndGetRootNodes(compViewDef([
               elementDef(
-                  NodeFlags.None, null !, null !, 1, 'div', null !, null !, null !, null !,
+                  0, NodeFlags.None, null, null, 1, 'div', null, null, null, null,
                   () => compViewDef([
-                    elementDef(NodeFlags.None, null !, null !, 0, 'span'),
+                    elementDef(0, NodeFlags.None, null, null, 0, 'span'),
                   ])),
-              directiveDef(NodeFlags.Component, null !, 0, SomeService, [ChangeDetectorRef]),
+              directiveDef(1, NodeFlags.Component, null, 0, SomeService, [ChangeDetectorRef]),
             ]));
 
             const compView = asElementData(view, 0).componentView;
@@ -299,9 +287,9 @@ export function main() {
           it('should inject RendererV1', () => {
             createAndGetRootNodes(compViewDef([
               elementDef(
-                  NodeFlags.None, null !, null !, 1, 'span', null !, null !, null !, null !,
-                  () => compViewDef([anchorDef(NodeFlags.None, null !, null !, 0)])),
-              directiveDef(NodeFlags.Component, null !, 0, SomeService, [Renderer])
+                  0, NodeFlags.None, null, null, 1, 'span', null, null, null, null,
+                  () => compViewDef([anchorDef(NodeFlags.None, null, null, 0)])),
+              directiveDef(1, NodeFlags.Component, null, 0, SomeService, [Renderer])
             ]));
 
             expect(instance.dep.createElement).toBeTruthy();
@@ -310,9 +298,9 @@ export function main() {
           it('should inject Renderer2', () => {
             createAndGetRootNodes(compViewDef([
               elementDef(
-                  NodeFlags.None, null !, null !, 1, 'span', null !, null !, null !, null !,
-                  () => compViewDef([anchorDef(NodeFlags.None, null !, null !, 0)])),
-              directiveDef(NodeFlags.Component, null !, 0, SomeService, [Renderer2])
+                  0, NodeFlags.None, null, null, 1, 'span', null, null, null, null,
+                  () => compViewDef([anchorDef(NodeFlags.None, null, null, 0)])),
+              directiveDef(1, NodeFlags.Component, null, 0, SomeService, [Renderer2])
             ]));
 
             expect(instance.dep.createElement).toBeTruthy();
@@ -337,9 +325,9 @@ export function main() {
 
           const {view, rootNodes} = createAndGetRootNodes(compViewDef(
               [
-                elementDef(NodeFlags.None, null !, null !, 1, 'span'),
+                elementDef(0, NodeFlags.None, null, null, 1, 'span'),
                 directiveDef(
-                    NodeFlags.None, null !, 0, SomeService, [], {a: [0, 'a'], b: [1, 'b']})
+                    1, NodeFlags.None, null, 0, SomeService, [], {a: [0, 'a'], b: [1, 'b']})
               ],
               (check, view) => {
                 checkNodeInlineOrDynamic(check, view, 1, inlineDynamic, ['v1', 'v2']);
@@ -373,13 +361,11 @@ export function main() {
         }
 
         const handleEvent = jasmine.createSpy('handleEvent');
-        const subscribe = spyOn(emitter, 'subscribe').and.callThrough();
 
         const {view, rootNodes} = createAndGetRootNodes(compViewDef([
-          elementDef(
-              NodeFlags.None, null !, null !, 1, 'span', null !, null !, null !, handleEvent),
+          elementDef(0, NodeFlags.None, null, null, 1, 'span', null, null, null, handleEvent),
           directiveDef(
-              NodeFlags.None, null !, 0, SomeService, [], null !, {emitter: 'someEventName'})
+              1, NodeFlags.None, null, 0, SomeService, [], null, {emitter: 'someEventName'})
         ]));
 
         emitter.emit('someEventInstance');
@@ -399,10 +385,10 @@ export function main() {
 
         const {view, rootNodes} = createAndGetRootNodes(compViewDef([
           elementDef(
-              NodeFlags.None, null !, null !, 1, 'span', null !, null !, null !,
+              0, NodeFlags.None, null, null, 1, 'span', null, null, null,
               () => { throw new Error('Test'); }),
           directiveDef(
-              NodeFlags.None, null !, 0, SomeService, [], null !, {emitter: 'someEventName'})
+              1, NodeFlags.None, null, 0, SomeService, [], null, {emitter: 'someEventName'})
         ]));
 
         emitter.emit('someEventInstance');
@@ -440,10 +426,10 @@ export function main() {
             NodeFlags.AfterViewChecked | NodeFlags.OnDestroy;
         const {view, rootNodes} = createAndGetRootNodes(compViewDef(
             [
-              elementDef(NodeFlags.None, null !, null !, 3, 'span'),
-              directiveDef(allFlags, null !, 0, SomeService, [], {a: [0, 'a']}),
-              elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-              directiveDef(allFlags, null !, 0, SomeService, [], {a: [0, 'a']})
+              elementDef(0, NodeFlags.None, null, null, 3, 'span'),
+              directiveDef(1, allFlags, null, 0, SomeService, [], {a: [0, 'a']}),
+              elementDef(2, NodeFlags.None, null, null, 1, 'span'),
+              directiveDef(3, allFlags, null, 0, SomeService, [], {a: [0, 'a']})
             ],
             (check, view) => {
               check(view, 1, ArgumentType.Inline, 'someValue');
@@ -499,9 +485,9 @@ export function main() {
 
         const {view, rootNodes} = createAndGetRootNodes(compViewDef(
             [
-              elementDef(NodeFlags.None, null !, null !, 1, 'span'),
+              elementDef(0, NodeFlags.None, null, null, 1, 'span'),
               directiveDef(
-                  NodeFlags.OnChanges, null !, 0, SomeService, [], {a: [0, 'nonMinifiedA']})
+                  1, NodeFlags.OnChanges, null, 0, SomeService, [], {a: [0, 'nonMinifiedA']})
             ],
             (check, view) => { check(view, 1, ArgumentType.Inline, currValue); }));
 
@@ -520,8 +506,8 @@ export function main() {
         }
 
         const {view, rootNodes} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-          directiveDef(NodeFlags.AfterContentChecked, null !, 0, SomeService, [], {a: [0, 'a']}),
+          elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+          directiveDef(1, NodeFlags.AfterContentChecked, null, 0, SomeService, [], {a: [0, 'a']}),
         ]));
 
         let err: any;
@@ -543,8 +529,8 @@ export function main() {
         }
 
         const {view, rootNodes} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-          directiveDef(NodeFlags.OnDestroy, null !, 0, SomeService, [], {a: [0, 'a']}),
+          elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+          directiveDef(1, NodeFlags.OnDestroy, null, 0, SomeService, [], {a: [0, 'a']}),
         ]));
 
         let err: any;

--- a/packages/core/test/view/pure_expression_spec.ts
+++ b/packages/core/test/view/pure_expression_spec.ts
@@ -7,23 +7,12 @@
  */
 
 import {PipeTransform} from '@angular/core';
-import {NodeDef, NodeFlags, Services, ViewData, ViewDefinition, ViewFlags, ViewUpdateFn, asProviderData, directiveDef, elementDef, nodeValue, pipeDef, pureArrayDef, pureObjectDef, purePipeDef, rootRenderNodes, viewDef} from '@angular/core/src/view/index';
+import {NodeFlags, Services, asProviderData, directiveDef, elementDef, nodeValue, pipeDef, pureArrayDef, pureObjectDef, purePipeDef} from '@angular/core/src/view/index';
 
-import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, createRootView} from './helper';
+import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, compViewDef, createAndGetRootNodes} from './helper';
 
 export function main() {
   describe(`View Pure Expressions`, () => {
-    function compViewDef(
-        nodes: NodeDef[], updateDirectives?: ViewUpdateFn, updateRenderer?: ViewUpdateFn,
-        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
-      return viewDef(viewFlags, nodes, updateDirectives, updateRenderer);
-    }
-
-    function createAndGetRootNodes(viewDef: ViewDefinition): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(viewDef);
-      const rootNodes = rootRenderNodes(view);
-      return {rootNodes, view};
-    }
 
     class Service {
       data: any;
@@ -37,9 +26,9 @@ export function main() {
 
           const {view, rootNodes} = createAndGetRootNodes(compViewDef(
               [
-                elementDef(NodeFlags.None, null !, null !, 2, 'span'),
-                pureArrayDef(2),
-                directiveDef(NodeFlags.None, null !, 0, Service, [], {data: [0, 'data']}),
+                elementDef(0, NodeFlags.None, null, null, 2, 'span'),
+                pureArrayDef(1, 2),
+                directiveDef(2, NodeFlags.None, null, 0, Service, [], {data: [0, 'data']}),
               ],
               (check, view) => {
                 const pureValue = checkNodeInlineOrDynamic(check, view, 1, inlineDynamic, values);
@@ -75,8 +64,9 @@ export function main() {
 
           const {view, rootNodes} = createAndGetRootNodes(compViewDef(
               [
-                elementDef(NodeFlags.None, null !, null !, 2, 'span'), pureObjectDef({a: 0, b: 1}),
-                directiveDef(NodeFlags.None, null !, 0, Service, [], {data: [0, 'data']})
+                elementDef(0, NodeFlags.None, null, null, 2, 'span'),
+                pureObjectDef(1, {a: 0, b: 1}),
+                directiveDef(2, NodeFlags.None, null, 0, Service, [], {data: [0, 'data']})
               ],
               (check, view) => {
                 const pureValue = checkNodeInlineOrDynamic(check, view, 1, inlineDynamic, values);
@@ -115,10 +105,10 @@ export function main() {
 
           const {view, rootNodes} = createAndGetRootNodes(compViewDef(
               [
-                elementDef(NodeFlags.None, null !, null !, 3, 'span'),
+                elementDef(0, NodeFlags.None, null !, null !, 3, 'span'),
                 pipeDef(NodeFlags.None, SomePipe, []),
-                purePipeDef(2),
-                directiveDef(NodeFlags.None, null !, 0, Service, [], {data: [0, 'data']}),
+                purePipeDef(2, 2),
+                directiveDef(3, NodeFlags.None, null, 0, Service, [], {data: [0, 'data']}),
               ],
               (check, view) => {
                 const pureValue = checkNodeInlineOrDynamic(

--- a/packages/core/test/view/query_spec.ts
+++ b/packages/core/test/view/query_spec.ts
@@ -6,32 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ElementRef, Injector, QueryList, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, TemplateRef, ViewContainerRef, ViewEncapsulation, getDebugNode} from '@angular/core';
+import {ElementRef, QueryList, TemplateRef, ViewContainerRef} from '@angular/core';
 import {getDebugContext} from '@angular/core/src/errors';
-import {BindingFlags, DebugContext, NodeDef, NodeFlags, QueryBindingType, QueryValueType, RootData, Services, ViewData, ViewDefinition, ViewDefinitionFactory, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, asProviderData, attachEmbeddedView, detachEmbeddedView, directiveDef, elementDef, queryDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
-import {inject} from '@angular/core/testing';
-import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
+import {NodeDef, NodeFlags, QueryBindingType, QueryValueType, Services, anchorDef, asElementData, asProviderData, attachEmbeddedView, detachEmbeddedView, directiveDef, elementDef, queryDef} from '@angular/core/src/view/index';
 
-import {createEmbeddedView, createRootView} from './helper';
+import {compViewDef, compViewDefFactory, createAndGetRootNodes, createEmbeddedView} from './helper';
 
 export function main() {
   describe(`Query Views`, () => {
-    function compViewDef(
-        nodes: NodeDef[], updateDirectives?: ViewUpdateFn, updateRenderer?: ViewUpdateFn,
-        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
-      return viewDef(viewFlags, nodes, updateDirectives, updateRenderer);
-    }
-
-    function embeddedViewDef(nodes: NodeDef[], update?: ViewUpdateFn): ViewDefinitionFactory {
-      return () => viewDef(ViewFlags.None, nodes, update);
-    }
-
-    function createAndGetRootNodes(
-        viewDef: ViewDefinition, context: any = null): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(viewDef, context);
-      const rootNodes = rootRenderNodes(view);
-      return {rootNodes, view};
-    }
 
     const someQueryId = 1;
 
@@ -41,43 +23,50 @@ export function main() {
       a: QueryList<AService>;
     }
 
-    function contentQueryProviders() {
+    function contentQueryProviders(checkIndex: number) {
       return [
-        directiveDef(NodeFlags.None, null !, 1, QueryService, []),
+        directiveDef(checkIndex, NodeFlags.None, null, 1, QueryService, []),
         queryDef(
             NodeFlags.TypeContentQuery | NodeFlags.DynamicQuery, someQueryId,
             {'a': QueryBindingType.All})
       ];
     }
 
-    function compViewQueryProviders(extraChildCount: number, nodes: NodeDef[]) {
+    const cQPLength = contentQueryProviders(0).length;
+
+    // nodes first checkIndex should be 1 (to account for the `queryDef`
+    function compViewQueryProviders(checkIndex: number, extraChildCount: number, nodes: NodeDef[]) {
       return [
         elementDef(
-            NodeFlags.None, null !, null !, 1 + extraChildCount, 'div', null !, null !, null !,
-            null !, () => compViewDef([
-                      queryDef(
-                          NodeFlags.TypeViewQuery | NodeFlags.DynamicQuery, someQueryId,
-                          {'a': QueryBindingType.All}),
-                      ...nodes
-                    ])),
-        directiveDef(NodeFlags.Component, null !, 0, QueryService, [], null !, null !, ),
+            checkIndex, NodeFlags.None, null, null, 1 + extraChildCount, 'div', null, null, null,
+            null, () => compViewDef([
+                    queryDef(
+                        NodeFlags.TypeViewQuery | NodeFlags.DynamicQuery, someQueryId,
+                        {'a': QueryBindingType.All}),
+                    ...nodes
+                  ])),
+        directiveDef(
+            checkIndex + 1, NodeFlags.Component, null !, 0, QueryService, [], null !, null !, ),
       ];
     }
 
-    function aServiceProvider() {
+    const cVQLength = compViewQueryProviders(0, 0, []).length;
+
+
+    function aServiceProvider(checkIndex: number) {
       return directiveDef(
-          NodeFlags.None, [[someQueryId, QueryValueType.Provider]], 0, AService, []);
+          checkIndex, NodeFlags.None, [[someQueryId, QueryValueType.Provider]], 0, AService, []);
     }
 
     describe('content queries', () => {
 
       it('should query providers on the same element and child elements', () => {
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null !, null !, 5, 'div'),
-          ...contentQueryProviders(),
-          aServiceProvider(),
-          elementDef(NodeFlags.None, null !, null !, 1, 'div'),
-          aServiceProvider(),
+          elementDef(0, NodeFlags.None, null, null, 5, 'div'),
+          ...contentQueryProviders(1),
+          aServiceProvider(1 + cQPLength),
+          elementDef(2 + cQPLength, NodeFlags.None, null, null, 1, 'div'),
+          aServiceProvider(3 + cQPLength),
         ]));
 
         const qs: QueryService = asProviderData(view, 1).instance;
@@ -92,13 +81,14 @@ export function main() {
       });
 
       it('should not query providers on sibling or parent elements', () => {
+
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null !, null !, 6, 'div'),
-          aServiceProvider(),
-          elementDef(NodeFlags.None, null !, null !, 2, 'div'),
-          ...contentQueryProviders(),
-          elementDef(NodeFlags.None, null !, null !, 1, 'div'),
-          aServiceProvider(),
+          elementDef(0, NodeFlags.None, null, null, 6, 'div'),
+          aServiceProvider(1),
+          elementDef(2, NodeFlags.None, null, null, 2, 'div'),
+          ...contentQueryProviders(3),
+          elementDef(3 + cQPLength, NodeFlags.None, null, null, 1, 'div'),
+          aServiceProvider(4 + cQPLength),
         ]));
 
         Services.checkAndUpdateView(view);
@@ -112,10 +102,10 @@ export function main() {
       it('should query providers in the view', () => {
         const {view} = createAndGetRootNodes(compViewDef([
           ...compViewQueryProviders(
-              0,
+              0, 0,
               [
-                elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-                aServiceProvider(),
+                elementDef(1, NodeFlags.None, null, null, 1, 'span'),
+                aServiceProvider(2),
               ]),
         ]));
 
@@ -129,12 +119,8 @@ export function main() {
 
       it('should not query providers on the host element', () => {
         const {view} = createAndGetRootNodes(compViewDef([
-          ...compViewQueryProviders(
-              1,
-              [
-                elementDef(NodeFlags.None, null !, null !, 0, 'span'),
-              ]),
-          aServiceProvider(),
+          ...compViewQueryProviders(0, 1, [elementDef(1, NodeFlags.None, null, null, 0, 'span')]),
+          aServiceProvider(cVQLength),
         ]));
 
         Services.checkAndUpdateView(view);
@@ -146,13 +132,13 @@ export function main() {
     describe('embedded views', () => {
       it('should query providers in embedded views', () => {
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null !, null !, 5, 'div'),
-          ...contentQueryProviders(),
-          anchorDef(NodeFlags.EmbeddedViews, null !, null !, 2, null !, embeddedViewDef([
-                      elementDef(NodeFlags.None, null !, null !, 1, 'div'),
-                      aServiceProvider(),
+          elementDef(0, NodeFlags.None, null, null, 5, 'div'),
+          ...contentQueryProviders(1),
+          anchorDef(NodeFlags.EmbeddedViews, null, null, 2, null, compViewDefFactory([
+                      elementDef(0, NodeFlags.None, null, null, 1, 'div'),
+                      aServiceProvider(1),
                     ])),
-          ...contentQueryProviders(),
+          ...contentQueryProviders(2 + cQPLength),
         ]));
 
         const childView = createEmbeddedView(view, view.def.nodes[3]);
@@ -172,15 +158,15 @@ export function main() {
 
       it('should query providers in embedded views only at the template declaration', () => {
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null !, null !, 3, 'div'),
-          ...contentQueryProviders(),
-          anchorDef(NodeFlags.EmbeddedViews, null !, null !, 0, null !, embeddedViewDef([
-                      elementDef(NodeFlags.None, null !, null !, 1, 'div'),
-                      aServiceProvider(),
+          elementDef(0, NodeFlags.None, null, null, 3, 'div'),
+          ...contentQueryProviders(1),
+          anchorDef(NodeFlags.EmbeddedViews, null, null, 0, null, compViewDefFactory([
+                      elementDef(0, NodeFlags.None, null, null, 1, 'div'),
+                      aServiceProvider(1),
                     ])),
-          elementDef(NodeFlags.None, null !, null !, 3, 'div'),
-          ...contentQueryProviders(),
-          anchorDef(NodeFlags.EmbeddedViews, null !, null !, 0),
+          elementDef(2 + cQPLength, NodeFlags.None, null, null, 3, 'div'),
+          ...contentQueryProviders(3 + cQPLength),
+          anchorDef(NodeFlags.EmbeddedViews, null, null, 0),
         ]));
 
         const childView = createEmbeddedView(view, view.def.nodes[3]);
@@ -201,11 +187,11 @@ export function main() {
 
       it('should update content queries if embedded views are added or removed', () => {
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null !, null !, 3, 'div'),
-          ...contentQueryProviders(),
-          anchorDef(NodeFlags.EmbeddedViews, null !, null !, 0, null !, embeddedViewDef([
-                      elementDef(NodeFlags.None, null !, null !, 1, 'div'),
-                      aServiceProvider(),
+          elementDef(0, NodeFlags.None, null, null, 3, 'div'),
+          ...contentQueryProviders(1),
+          anchorDef(NodeFlags.EmbeddedViews, null, null, 0, null, compViewDefFactory([
+                      elementDef(0, NodeFlags.None, null, null, 1, 'div'),
+                      aServiceProvider(1),
                     ])),
         ]));
 
@@ -230,11 +216,11 @@ export function main() {
       it('should update view queries if embedded views are added or removed', () => {
         const {view} = createAndGetRootNodes(compViewDef([
           ...compViewQueryProviders(
-              0,
+              0, 0,
               [
-                anchorDef(NodeFlags.EmbeddedViews, null !, null !, 0, null !, embeddedViewDef([
-                            elementDef(NodeFlags.None, null !, null !, 1, 'div'),
-                            aServiceProvider(),
+                anchorDef(NodeFlags.EmbeddedViews, null, null, 0, null, compViewDefFactory([
+                            elementDef(0, NodeFlags.None, null, null, 1, 'div'),
+                            aServiceProvider(1),
                           ])),
               ]),
         ]));
@@ -265,13 +251,13 @@ export function main() {
         }
 
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null !, null !, 4, 'div'),
-          directiveDef(NodeFlags.None, null !, 1, QueryService, []),
+          elementDef(0, NodeFlags.None, null, null, 4, 'div'),
+          directiveDef(1, NodeFlags.None, null, 1, QueryService, []),
           queryDef(
               NodeFlags.TypeContentQuery | NodeFlags.DynamicQuery, someQueryId,
               {'a': QueryBindingType.All}),
-          aServiceProvider(),
-          aServiceProvider(),
+          aServiceProvider(3),
+          aServiceProvider(4),
         ]));
 
         Services.checkAndUpdateView(view);
@@ -290,13 +276,13 @@ export function main() {
         }
 
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null !, null !, 4, 'div'),
-          directiveDef(NodeFlags.None, null !, 1, QueryService, []),
+          elementDef(0, NodeFlags.None, null, null, 4, 'div'),
+          directiveDef(1, NodeFlags.None, null, 1, QueryService, []),
           queryDef(
               NodeFlags.TypeContentQuery | NodeFlags.DynamicQuery, someQueryId,
               {'a': QueryBindingType.First}),
-          aServiceProvider(),
-          aServiceProvider(),
+          aServiceProvider(3),
+          aServiceProvider(4),
         ]));
 
         Services.checkAndUpdateView(view);
@@ -313,8 +299,8 @@ export function main() {
         }
 
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, [[someQueryId, QueryValueType.ElementRef]], null !, 2, 'div'),
-          directiveDef(NodeFlags.None, null !, 1, QueryService, []),
+          elementDef(0, NodeFlags.None, [[someQueryId, QueryValueType.ElementRef]], null, 2, 'div'),
+          directiveDef(1, NodeFlags.None, null, 1, QueryService, []),
           queryDef(
               NodeFlags.TypeContentQuery | NodeFlags.DynamicQuery, someQueryId,
               {'a': QueryBindingType.First}),
@@ -333,9 +319,9 @@ export function main() {
 
         const {view} = createAndGetRootNodes(compViewDef([
           anchorDef(
-              NodeFlags.None, [[someQueryId, QueryValueType.TemplateRef]], null !, 2, null !,
-              embeddedViewDef([anchorDef(NodeFlags.None, null !, null !, 0)])),
-          directiveDef(NodeFlags.None, null !, 1, QueryService, []),
+              NodeFlags.None, [[someQueryId, QueryValueType.TemplateRef]], null, 2, null,
+              compViewDefFactory([anchorDef(NodeFlags.None, null, null, 0)])),
+          directiveDef(1, NodeFlags.None, null, 1, QueryService, []),
           queryDef(
               NodeFlags.TypeContentQuery | NodeFlags.DynamicQuery, someQueryId,
               {'a': QueryBindingType.First}),
@@ -354,8 +340,8 @@ export function main() {
 
         const {view} = createAndGetRootNodes(compViewDef([
           anchorDef(
-              NodeFlags.EmbeddedViews, [[someQueryId, QueryValueType.ViewContainerRef]], null !, 2),
-          directiveDef(NodeFlags.None, null !, 1, QueryService, []),
+              NodeFlags.EmbeddedViews, [[someQueryId, QueryValueType.ViewContainerRef]], null, 2),
+          directiveDef(1, NodeFlags.None, null, 1, QueryService, []),
           queryDef(
               NodeFlags.TypeContentQuery | NodeFlags.DynamicQuery, someQueryId,
               {'a': QueryBindingType.First}),
@@ -375,12 +361,12 @@ export function main() {
         }
 
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null !, null !, 3, 'div'),
-          directiveDef(NodeFlags.None, null !, 1, QueryService, []),
+          elementDef(0, NodeFlags.None, null, null, 3, 'div'),
+          directiveDef(1, NodeFlags.None, null, 1, QueryService, []),
           queryDef(
               NodeFlags.TypeContentQuery | NodeFlags.DynamicQuery, someQueryId,
               {'a': QueryBindingType.All}),
-          aServiceProvider(),
+          aServiceProvider(3),
         ]));
 
 

--- a/packages/core/test/view/services_spec.ts
+++ b/packages/core/test/view/services_spec.ts
@@ -6,27 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation, getDebugNode} from '@angular/core';
-import {DebugContext, NodeDef, NodeFlags, QueryValueType, RootData, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, asProviderData, asTextData, directiveDef, elementDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
-import {inject} from '@angular/core/testing';
-import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
+import {DebugContext, NodeFlags, QueryValueType, Services, asElementData, asTextData, directiveDef, elementDef, textDef} from '@angular/core/src/view/index';
 
-import {createRootView, isBrowser} from './helper';
+import {compViewDef, createAndGetRootNodes} from './helper';
 
 export function main() {
   describe('View Services', () => {
-    function compViewDef(
-        nodes: NodeDef[], updateDirectives?: ViewUpdateFn, updateRenderer?: ViewUpdateFn,
-        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
-      return viewDef(viewFlags, nodes, updateDirectives, updateRenderer);
-    }
-
-    function createAndGetRootNodes(
-        viewDef: ViewDefinition, context: any = null): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(viewDef, context);
-      const rootNodes = rootRenderNodes(view);
-      return {rootNodes, view};
-    }
 
     describe('DebugContext', () => {
       class AComp {}
@@ -36,12 +21,13 @@ export function main() {
       function createViewWithData() {
         const {view} = createAndGetRootNodes(compViewDef([
           elementDef(
-              NodeFlags.None, null !, null !, 1, 'div', null !, null !, null !, null !,
+              0, NodeFlags.None, null, null, 1, 'div', null, null, null, null,
               () => compViewDef([
-                elementDef(NodeFlags.None, [['ref', QueryValueType.ElementRef]], null !, 2, 'span'),
-                directiveDef(NodeFlags.None, null !, 0, AService, []), textDef(null !, ['a'])
+                elementDef(
+                    0, NodeFlags.None, [['ref', QueryValueType.ElementRef]], null, 2, 'span'),
+                directiveDef(1, NodeFlags.None, null, 0, AService, []), textDef(2, null, ['a'])
               ])),
-          directiveDef(NodeFlags.Component, null !, 0, AComp, []),
+          directiveDef(1, NodeFlags.Component, null, 0, AComp, []),
         ]));
         return view;
       }

--- a/packages/core/test/view/text_spec.ts
+++ b/packages/core/test/view/text_spec.ts
@@ -6,46 +6,34 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation, WrappedValue, getDebugNode} from '@angular/core';
-import {ArgumentType, DebugContext, NodeDef, NodeFlags, RootData, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asTextData, elementDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
-import {inject} from '@angular/core/testing';
+import {getDebugNode} from '@angular/core';
+import {NodeFlags, Services, asTextData, elementDef, textDef} from '@angular/core/src/view/index';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
-import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, createRootView, isBrowser} from './helper';
+import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, compViewDef, createAndGetRootNodes} from './helper';
 
 export function main() {
   describe(`View Text`, () => {
-    function compViewDef(
-        nodes: NodeDef[], updateDirectives?: ViewUpdateFn, updateRenderer?: ViewUpdateFn,
-        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
-      return viewDef(viewFlags, nodes, updateDirectives, updateRenderer);
-    }
-
-    function createAndGetRootNodes(
-        viewDef: ViewDefinition, context?: any): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(viewDef, context);
-      const rootNodes = rootRenderNodes(view);
-      return {rootNodes, view};
-    }
 
     describe('create', () => {
       it('should create text nodes without parents', () => {
-        const rootNodes = createAndGetRootNodes(compViewDef([textDef(null !, ['a'])])).rootNodes;
+        const rootNodes = createAndGetRootNodes(compViewDef([textDef(0, null, ['a'])])).rootNodes;
         expect(rootNodes.length).toBe(1);
         expect(getDOM().getText(rootNodes[0])).toBe('a');
       });
 
       it('should create views with multiple root text nodes', () => {
         const rootNodes = createAndGetRootNodes(compViewDef([
-                            textDef(null !, ['a']), textDef(null !, ['b'])
+                            textDef(0, null, ['a']),
+                            textDef(1, null, ['b']),
                           ])).rootNodes;
         expect(rootNodes.length).toBe(2);
       });
 
       it('should create text nodes with parents', () => {
         const rootNodes = createAndGetRootNodes(compViewDef([
-                            elementDef(NodeFlags.None, null !, null !, 1, 'div'),
-                            textDef(null !, ['a']),
+                            elementDef(0, NodeFlags.None, null, null, 1, 'div'),
+                            textDef(1, null, ['a']),
                           ])).rootNodes;
         expect(rootNodes.length).toBe(1);
         const textNode = getDOM().firstChild(rootNodes[0]);
@@ -55,7 +43,7 @@ export function main() {
       it('should add debug information to the renderer', () => {
         const someContext = new Object();
         const {view, rootNodes} =
-            createAndGetRootNodes(compViewDef([textDef(null !, ['a'])]), someContext);
+            createAndGetRootNodes(compViewDef([textDef(0, null, ['a'])]), someContext);
         expect(getDebugNode(rootNodes[0]) !.nativeNode).toBe(asTextData(view, 0).renderText);
       });
     });
@@ -65,7 +53,7 @@ export function main() {
         it(`should update via strategy ${inlineDynamic}`, () => {
           const {view, rootNodes} = createAndGetRootNodes(compViewDef(
               [
-                textDef(null !, ['0', '1', '2']),
+                textDef(0, null, ['0', '1', '2']),
               ],
               null !, (check, view) => {
                 checkNodeInlineOrDynamic(check, view, 0, inlineDynamic, ['a', 'b']);
@@ -73,7 +61,6 @@ export function main() {
 
           Services.checkAndUpdateView(view);
 
-          const node = rootNodes[0];
           expect(getDOM().getText(rootNodes[0])).toBe('0a1b2');
         });
 

--- a/packages/core/test/view/view_def_spec.ts
+++ b/packages/core/test/view/view_def_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NodeFlags, QueryValueType, ViewData, ViewDefinition, ViewFlags, anchorDef, directiveDef, elementDef, textDef, viewDef} from '@angular/core/src/view/index';
+import {NodeFlags, QueryValueType, ViewDefinition, ViewFlags, anchorDef, directiveDef, elementDef, textDef, viewDef} from '@angular/core/src/view/index';
 import {filterQueryId} from '@angular/core/src/view/util';
 
 export function main() {
@@ -14,14 +14,14 @@ export function main() {
 
     describe('parent', () => {
       function parents(viewDef: ViewDefinition): (number | null)[] {
-        return viewDef.nodes.map(node => node.parent ? node.parent.index : null);
+        return viewDef.nodes.map(node => node.parent ? node.parent.nodeIndex : null);
       }
 
       it('should calculate parents for one level', () => {
         const vd = viewDef(ViewFlags.None, [
-          elementDef(NodeFlags.None, null !, null !, 2, 'span'),
-          textDef(null !, ['a']),
-          textDef(null !, ['a']),
+          elementDef(0, NodeFlags.None, null, null, 2, 'span'),
+          textDef(1, null, ['a']),
+          textDef(2, null, ['a']),
         ]);
 
         expect(parents(vd)).toEqual([null, 0, 0]);
@@ -29,11 +29,11 @@ export function main() {
 
       it('should calculate parents for one level, multiple roots', () => {
         const vd = viewDef(ViewFlags.None, [
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-          textDef(null !, ['a']),
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-          textDef(null !, ['a']),
-          textDef(null !, ['a']),
+          elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+          textDef(1, null, ['a']),
+          elementDef(2, NodeFlags.None, null, null, 1, 'span'),
+          textDef(3, null, ['a']),
+          textDef(4, null, ['a']),
         ]);
 
         expect(parents(vd)).toEqual([null, 0, null, 2, null]);
@@ -41,12 +41,12 @@ export function main() {
 
       it('should calculate parents for multiple levels', () => {
         const vd = viewDef(ViewFlags.None, [
-          elementDef(NodeFlags.None, null !, null !, 2, 'span'),
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-          textDef(null !, ['a']),
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-          textDef(null !, ['a']),
-          textDef(null !, ['a']),
+          elementDef(0, NodeFlags.None, null, null, 2, 'span'),
+          elementDef(1, NodeFlags.None, null, null, 1, 'span'),
+          textDef(2, null, ['a']),
+          elementDef(3, NodeFlags.None, null, null, 1, 'span'),
+          textDef(4, null, ['a']),
+          textDef(5, null, ['a']),
         ]);
 
         expect(parents(vd)).toEqual([null, 0, 1, null, 3, null]);
@@ -65,8 +65,8 @@ export function main() {
 
       it('should calculate childFlags for one level', () => {
         const vd = viewDef(ViewFlags.None, [
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-          directiveDef(NodeFlags.AfterContentChecked, null !, 0, AService, [])
+          elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+          directiveDef(1, NodeFlags.AfterContentChecked, null, 0, AService, [])
         ]);
 
         expect(childFlags(vd)).toEqual([
@@ -80,9 +80,9 @@ export function main() {
 
       it('should calculate childFlags for two levels', () => {
         const vd = viewDef(ViewFlags.None, [
-          elementDef(NodeFlags.None, null !, null !, 2, 'span'),
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-          directiveDef(NodeFlags.AfterContentChecked, null !, 0, AService, [])
+          elementDef(0, NodeFlags.None, null, null, 2, 'span'),
+          elementDef(1, NodeFlags.None, null, null, 1, 'span'),
+          directiveDef(2, NodeFlags.AfterContentChecked, null, 0, AService, [])
         ]);
 
         expect(childFlags(vd)).toEqual([
@@ -98,11 +98,11 @@ export function main() {
 
       it('should calculate childFlags for one level, multiple roots', () => {
         const vd = viewDef(ViewFlags.None, [
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-          directiveDef(NodeFlags.AfterContentChecked, null !, 0, AService, []),
-          elementDef(NodeFlags.None, null !, null !, 2, 'span'),
-          directiveDef(NodeFlags.AfterContentInit, null !, 0, AService, []),
-          directiveDef(NodeFlags.AfterViewChecked, null !, 0, AService, []),
+          elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+          directiveDef(1, NodeFlags.AfterContentChecked, null, 0, AService, []),
+          elementDef(2, NodeFlags.None, null, null, 2, 'span'),
+          directiveDef(3, NodeFlags.AfterContentInit, null, 0, AService, []),
+          directiveDef(4, NodeFlags.AfterViewChecked, null, 0, AService, []),
         ]);
 
         expect(childFlags(vd)).toEqual([
@@ -120,12 +120,12 @@ export function main() {
 
       it('should calculate childFlags for multiple levels', () => {
         const vd = viewDef(ViewFlags.None, [
-          elementDef(NodeFlags.None, null !, null !, 2, 'span'),
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-          directiveDef(NodeFlags.AfterContentChecked, null !, 0, AService, []),
-          elementDef(NodeFlags.None, null !, null !, 2, 'span'),
-          directiveDef(NodeFlags.AfterContentInit, null !, 0, AService, []),
-          directiveDef(NodeFlags.AfterViewInit, null !, 0, AService, []),
+          elementDef(0, NodeFlags.None, null, null, 2, 'span'),
+          elementDef(1, NodeFlags.None, null, null, 1, 'span'),
+          directiveDef(2, NodeFlags.AfterContentChecked, null !, 0, AService, []),
+          elementDef(3, NodeFlags.None, null, null, 2, 'span'),
+          directiveDef(4, NodeFlags.AfterContentInit, null, 0, AService, []),
+          directiveDef(5, NodeFlags.AfterViewInit, null, 0, AService, []),
         ]);
 
         expect(childFlags(vd)).toEqual([
@@ -151,8 +151,8 @@ export function main() {
 
       it('should calculate childMatchedQueries for one level', () => {
         const vd = viewDef(ViewFlags.None, [
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-          directiveDef(NodeFlags.None, [[1, QueryValueType.Provider]], 0, AService, [])
+          elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+          directiveDef(1, NodeFlags.None, [[1, QueryValueType.Provider]], 0, AService, [])
         ]);
 
         expect(childMatchedQueries(vd)).toEqual([filterQueryId(1), 0]);
@@ -160,9 +160,9 @@ export function main() {
 
       it('should calculate childMatchedQueries for two levels', () => {
         const vd = viewDef(ViewFlags.None, [
-          elementDef(NodeFlags.None, null !, null !, 2, 'span'),
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-          directiveDef(NodeFlags.None, [[1, QueryValueType.Provider]], 0, AService, [])
+          elementDef(0, NodeFlags.None, null, null, 2, 'span'),
+          elementDef(1, NodeFlags.None, null, null, 1, 'span'),
+          directiveDef(2, NodeFlags.None, [[1, QueryValueType.Provider]], 0, AService, [])
         ]);
 
         expect(childMatchedQueries(vd)).toEqual([filterQueryId(1), filterQueryId(1), 0]);
@@ -170,11 +170,11 @@ export function main() {
 
       it('should calculate childMatchedQueries for one level, multiple roots', () => {
         const vd = viewDef(ViewFlags.None, [
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-          directiveDef(NodeFlags.None, [[1, QueryValueType.Provider]], 0, AService, []),
-          elementDef(NodeFlags.None, null !, null !, 2, 'span'),
-          directiveDef(NodeFlags.None, [[2, QueryValueType.Provider]], 0, AService, []),
-          directiveDef(NodeFlags.None, [[3, QueryValueType.Provider]], 0, AService, []),
+          elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+          directiveDef(1, NodeFlags.None, [[1, QueryValueType.Provider]], 0, AService, []),
+          elementDef(2, NodeFlags.None, null, null, 2, 'span'),
+          directiveDef(3, NodeFlags.None, [[2, QueryValueType.Provider]], 0, AService, []),
+          directiveDef(4, NodeFlags.None, [[3, QueryValueType.Provider]], 0, AService, []),
         ]);
 
         expect(childMatchedQueries(vd)).toEqual([
@@ -184,12 +184,12 @@ export function main() {
 
       it('should calculate childMatchedQueries for multiple levels', () => {
         const vd = viewDef(ViewFlags.None, [
-          elementDef(NodeFlags.None, null !, null !, 2, 'span'),
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
-          directiveDef(NodeFlags.None, [[1, QueryValueType.Provider]], 0, AService, []),
-          elementDef(NodeFlags.None, null !, null !, 2, 'span'),
-          directiveDef(NodeFlags.None, [[2, QueryValueType.Provider]], 0, AService, []),
-          directiveDef(NodeFlags.None, [[3, QueryValueType.Provider]], 0, AService, []),
+          elementDef(0, NodeFlags.None, null, null, 2, 'span'),
+          elementDef(1, NodeFlags.None, null, null, 1, 'span'),
+          directiveDef(2, NodeFlags.None, [[1, QueryValueType.Provider]], 0, AService, []),
+          elementDef(3, NodeFlags.None, null, null, 2, 'span'),
+          directiveDef(4, NodeFlags.None, [[2, QueryValueType.Provider]], 0, AService, []),
+          directiveDef(5, NodeFlags.None, [[3, QueryValueType.Provider]], 0, AService, []),
         ]);
 
         expect(childMatchedQueries(vd)).toEqual([
@@ -199,13 +199,13 @@ export function main() {
 
       it('should included embedded views into childMatchedQueries', () => {
         const vd = viewDef(ViewFlags.None, [
-          elementDef(NodeFlags.None, null !, null !, 1, 'span'),
+          elementDef(0, NodeFlags.None, null, null, 1, 'span'),
           anchorDef(
-              NodeFlags.None, null !, null !, 0, null !,
+              NodeFlags.None, null, null, 0, null,
               () => viewDef(
                   ViewFlags.None,
                   [
-                    elementDef(NodeFlags.None, [[1, QueryValueType.Provider]], null !, 0, 'span'),
+                    elementDef(0, NodeFlags.None, [[1, QueryValueType.Provider]], null, 0, 'span'),
                   ]))
         ]);
 


### PR DESCRIPTION
Important changes in this PR:
- Add a checkIndex for all nodes that have an associated check function (Element, Text, Directive and PureExpression),
- `node.index` becomes `node.nodeIndex`. Adding `node.checkIndex`,
- Add the `checkIndex` parameter to the node def function,
- Add the `checkIndex` parameter passing in the generated code,
- Change node def functions to reflect generated code by adding `|null`.

It's probably not needed to review all the changes in the unit tests - reviewing only one file should be enough to understand the pattern:
- add the checkIndex where expected,
- factorize code in helper,
- change `null!` for `null`,
- removed unused imports

Commit message
```
Each node now has two index: nodeIndex and checkIndex.

nodeIndex is the index in both the view definition and the view data.
checkIndex is the index in in the update function (update directives and update
renderer).

While nodeIndex and checkIndex have the same value for now, having both of them
will allow changing the structure of view definition after compilation (ie for
runtime translations).
```

