### PR TITLE
fix(compiler): various squashed fixes for the new ngc

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -66,6 +66,7 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
   return dict(tsc_wrapped_tsconfig(ctx, files, srcs, **kwargs), **{
       "angularCompilerOptions": {
           "generateCodeForLibraries": False,
+          "allowEmptyCodegenFiles": True,
           # FIXME: wrong place to de-dupe
           "expectedOut": depset([o.path for o in expected_outs]).to_list()
       }

--- a/packages/compiler-cli/src/ngtools_api2.ts
+++ b/packages/compiler-cli/src/ngtools_api2.ts
@@ -89,6 +89,12 @@ export interface TsEmitArguments {
 
 export interface TsEmitCallback { (args: TsEmitArguments): ts.EmitResult; }
 
+export interface LibrarySummary {
+  fileName: string;
+  text: string;
+  sourceFile?: ts.SourceFile;
+}
+
 export interface Program {
   getTsProgram(): ts.Program;
   getTsOptionDiagnostics(cancellationToken?: ts.CancellationToken): ts.Diagnostic[];
@@ -107,7 +113,7 @@ export interface Program {
     customTransformers?: CustomTransformers,
     emitCallback?: TsEmitCallback
   }): ts.EmitResult;
-  getLibrarySummaries(): {fileName: string, content: string}[];
+  getLibrarySummaries(): LibrarySummary[];
 }
 
 // Wrapper for createProgram.

--- a/packages/compiler-cli/src/path_mapped_compiler_host.ts
+++ b/packages/compiler-cli/src/path_mapped_compiler_host.ts
@@ -126,11 +126,13 @@ export class PathMappedCompilerHost extends CompilerHost {
         continue;
       }
       if (DTS.test(rootedPath)) {
-        const metadataPath = rootedPath.replace(DTS, '.metadata.json');
-        if (this.context.fileExists(metadataPath)) {
-          return this.readMetadata(metadataPath, rootedPath);
+        const metadatas = this.readMetadata(rootedPath);
+        if (metadatas) {
+          return metadatas;
         }
       } else {
+        // Attention: don't cache this, so that e.g. the LanguageService
+        // can read in changes from source files in the metadata!
         const metadata = this.getMetadataForSourceFile(rootedPath);
         return metadata ? [metadata] : [];
       }

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -133,6 +133,9 @@ export interface CompilerOptions extends ts.CompilerOptions {
   // Whether to remove blank text nodes from compiled templates. It is `true` by default
   // in Angular 5 and will be re-visited in Angular 6.
   preserveWhitespaces?: boolean;
+
+  /** generate all possible generated files  */
+  allowEmptyCodegenFiles?: boolean;
 }
 
 export interface CompilerHost extends ts.CompilerHost {
@@ -202,6 +205,12 @@ export interface TsEmitArguments {
 }
 
 export interface TsEmitCallback { (args: TsEmitArguments): ts.EmitResult; }
+
+export interface LibrarySummary {
+  fileName: string;
+  text: string;
+  sourceFile?: ts.SourceFile;
+}
 
 export interface Program {
   /**
@@ -280,8 +289,9 @@ export interface Program {
   }): ts.EmitResult;
 
   /**
-   * Returns the .ngsummary.json files of libraries that have been compiled
-   * in this program or previous programs.
+   * Returns the .d.ts / .ngsummary.json / .ngfactory.d.ts files of libraries that have been emitted
+   * in this program or previous programs with paths that emulate the fact that these libraries
+   * have been compiled before with no outDir.
    */
-  getLibrarySummaries(): {fileName: string, content: string}[];
+  getLibrarySummaries(): LibrarySummary[];
 }

--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -14,7 +14,7 @@ import {BaseAotCompilerHost} from '../compiler_host';
 import {TypeCheckHost} from '../diagnostics/translate_diagnostics';
 import {ModuleMetadata} from '../metadata/index';
 
-import {CompilerHost, CompilerOptions} from './api';
+import {CompilerHost, CompilerOptions, LibrarySummary} from './api';
 import {GENERATED_FILES} from './util';
 
 const NODE_MODULES_PACKAGE_NAME = /node_modules\/((\w|-)+|(@(\w|-)+\/(\w|-)+))/;
@@ -37,6 +37,11 @@ interface GenSourceFile {
   emitCtx: EmitterVisitorContext;
 }
 
+export interface CodeGenerator {
+  generateFile(genFileName: string, baseFileName?: string): GeneratedFile;
+  findGeneratedFileNames(fileName: string): string[];
+}
+
 /**
  * Implements the following hosts based on an api.CompilerHost:
  * - ts.CompilerHost to be consumed by a ts.Program
@@ -48,11 +53,12 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter extends
     TypeCheckHost {
   private rootDirs: string[];
   private moduleResolutionCache: ts.ModuleResolutionCache;
-  private originalSourceFiles = new Map<string, ts.SourceFile>();
+  private originalSourceFiles = new Map<string, ts.SourceFile|undefined>();
   private originalFileExistsCache = new Map<string, boolean>();
   private generatedSourceFiles = new Map<string, GenSourceFile>();
-  private generatedCodeFor = new Set<string>();
+  private generatedCodeFor = new Map<string, string[]>();
   private emitter = new TypeScriptEmitter();
+  private librarySummaries = new Map<string, LibrarySummary>();
   getCancellationToken: () => ts.CancellationToken;
   getDefaultLibLocation: () => string;
   trace: (s: string) => void;
@@ -61,10 +67,10 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter extends
 
   constructor(
       private rootFiles: string[], options: CompilerOptions, context: CompilerHost,
-      private metadataProvider: MetadataProvider,
-      private codeGenerator: (fileName: string) => GeneratedFile[],
-      private summariesFromPreviousCompilations: Map<string, string>) {
+      private metadataProvider: MetadataProvider, private codeGenerator: CodeGenerator,
+      librarySummaries: LibrarySummary[]) {
     super(options, context);
+    librarySummaries.forEach(summary => this.librarySummaries.set(summary.fileName, summary));
     this.moduleResolutionCache = ts.createModuleResolutionCache(
         this.context.getCurrentDirectory !(), this.context.getCanonicalFileName.bind(this.context));
     const basePath = this.options.basePath !;
@@ -168,6 +174,11 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter extends
           'fileNameToModuleName from containingFile', containingFile, 'to importedFile',
           importedFile);
     }
+    const importAs = this.getImportAs(importedFile);
+    if (importAs) {
+      return importAs;
+    }
+
     // drop extension
     importedFile = importedFile.replace(EXT, '');
     const importedFilePackagName = getPackageName(importedFile);
@@ -229,15 +240,18 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter extends
 
   private getOriginalSourceFile(
       filePath: string, languageVersion?: ts.ScriptTarget,
-      onError?: ((message: string) => void)|undefined): ts.SourceFile|undefined {
-    let sf = this.originalSourceFiles.get(filePath);
-    if (sf) {
-      return sf;
+      onError?: ((message: string) => void)|undefined): ts.SourceFile|null {
+    // Note: we need the explicit check via `has` as we also cache results
+    // that were null / undefined.
+    if (this.originalSourceFiles.has(filePath)) {
+      return this.originalSourceFiles.get(filePath) !;
     }
     if (!languageVersion) {
       languageVersion = this.options.target || ts.ScriptTarget.Latest;
     }
-    sf = this.context.getSourceFile(filePath, languageVersion, onError);
+    // Note: This can also return undefined,
+    // as the TS typings are not correct!
+    const sf = this.context.getSourceFile(filePath, languageVersion, onError) || null;
     this.originalSourceFiles.set(filePath, sf);
     return sf;
   }
@@ -250,9 +264,10 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter extends
     return this.metadataProvider.getMetadata(sf);
   }
 
-  updateGeneratedFile(genFile: GeneratedFile): ts.SourceFile|null {
+  updateGeneratedFile(genFile: GeneratedFile): ts.SourceFile {
     if (!genFile.stmts) {
-      return null;
+      throw new Error(
+          `Invalid Argument: Expected a GenerateFile with statements. ${genFile.genFileUrl}`);
     }
     const oldGenFile = this.generatedSourceFiles.get(genFile.genFileUrl);
     if (!oldGenFile) {
@@ -271,10 +286,10 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter extends
     return this.addGeneratedFile(genFile, newRefs);
   }
 
-  private addGeneratedFile(genFile: GeneratedFile, externalReferences: Set<string>): ts.SourceFile
-      |null {
+  private addGeneratedFile(genFile: GeneratedFile, externalReferences: Set<string>): ts.SourceFile {
     if (!genFile.stmts) {
-      return null;
+      throw new Error(
+          `Invalid Argument: Expected a GenerateFile with statements. ${genFile.genFileUrl}`);
     }
     const {sourceText, context} = this.emitter.emitStatementsAndContext(
         genFile.srcFileUrl, genFile.genFileUrl, genFile.stmts, /* preamble */ '',
@@ -288,49 +303,95 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter extends
     return sf;
   }
 
-  private ensureCodeGeneratedFor(fileName: string): void {
-    if (this.generatedCodeFor.has(fileName)) {
-      return;
+  shouldGenerateFile(fileName: string): {generate: boolean, baseFileName?: string} {
+    // TODO(tbosch): allow generating files that are not in the rootDir
+    // See https://github.com/angular/angular/issues/19337
+    if (this.options.rootDir && !fileName.startsWith(this.options.rootDir)) {
+      return {generate: false};
     }
-    this.generatedCodeFor.add(fileName);
+    const genMatch = GENERATED_FILES.exec(fileName);
+    if (!genMatch) {
+      return {generate: false};
+    }
+    const [, base, genSuffix, suffix] = genMatch;
+    if (suffix !== 'ts') {
+      return {generate: false};
+    }
+    let baseFileName: string|undefined;
+    if (genSuffix.indexOf('ngstyle') >= 0) {
+      // Note: ngstyle files have names like `afile.css.ngstyle.ts`
+      if (!this.originalFileExists(base)) {
+        return {generate: false};
+      }
+    } else {
+      // Note: on-the-fly generated files always have a `.ts` suffix,
+      // but the file from which we generated it can be a `.ts`/ `.d.ts`
+      // (see options.generateCodeForLibraries).
+      baseFileName = [`${base}.ts`, `${base}.d.ts`].find(
+          baseFileName => this.isSourceFile(baseFileName) && this.originalFileExists(baseFileName));
+      if (!baseFileName) {
+        return {generate: false};
+      }
+    }
+    return {generate: true, baseFileName};
+  }
 
-    const baseNameFromGeneratedFile = this._getBaseNameForGeneratedSourceFile(fileName);
-    if (baseNameFromGeneratedFile) {
-      return this.ensureCodeGeneratedFor(baseNameFromGeneratedFile);
-    }
-    const sf = this.getOriginalSourceFile(fileName, this.options.target || ts.ScriptTarget.Latest);
-    if (!sf) {
-      return;
-    }
-
-    const genFileNames: string[] = [];
-    if (this.isSourceFile(fileName)) {
-      // Note: we can't exit early here,
-      // as we might need to clear out old changes to `SourceFile.referencedFiles`
-      // that were created by a previous run, given an original CompilerHost
-      // that caches source files.
-      const genFiles = this.codeGenerator(fileName);
-      genFiles.forEach(genFile => {
-        const sf = this.addGeneratedFile(genFile, genFileExternalReferences(genFile));
-        if (sf) {
-          genFileNames.push(sf.fileName);
-        }
-      });
-    }
-    addReferencesToSourceFile(sf, genFileNames);
+  shouldGenerateFilesFor(fileName: string) {
+    // TODO(tbosch): allow generating files that are not in the rootDir
+    // See https://github.com/angular/angular/issues/19337
+    return !GENERATED_FILES.test(fileName) && this.isSourceFile(fileName) &&
+        (!this.options.rootDir || pathStartsWithPrefix(this.options.rootDir, fileName));
   }
 
   getSourceFile(
       fileName: string, languageVersion: ts.ScriptTarget,
       onError?: ((message: string) => void)|undefined): ts.SourceFile {
-    this.ensureCodeGeneratedFor(fileName);
-    const genFile = this.generatedSourceFiles.get(fileName);
-    if (genFile) {
-      return genFile.sourceFile;
+    // Note: Don't exit early in this method to make sure
+    // we always have up to date references on the file!
+    let genFileNames: string[] = [];
+    let sf = this.getGeneratedFile(fileName);
+    if (!sf) {
+      const summary = this.librarySummaries.get(fileName);
+      if (summary) {
+        if (!summary.sourceFile) {
+          summary.sourceFile = ts.createSourceFile(
+              fileName, summary.text, this.options.target || ts.ScriptTarget.Latest);
+        }
+        sf = summary.sourceFile;
+        genFileNames = [];
+      }
+    }
+    if (!sf) {
+      sf = this.getOriginalSourceFile(fileName);
+      const cachedGenFiles = this.generatedCodeFor.get(fileName);
+      if (cachedGenFiles) {
+        genFileNames = cachedGenFiles;
+      } else {
+        if (!this.options.noResolve && this.shouldGenerateFilesFor(fileName)) {
+          genFileNames = this.codeGenerator.findGeneratedFileNames(fileName);
+        }
+        this.generatedCodeFor.set(fileName, genFileNames);
+      }
+    }
+    if (sf) {
+      addReferencesToSourceFile(sf, genFileNames);
     }
     // TODO(tbosch): TypeScript's typings for getSourceFile are incorrect,
     // as it can very well return undefined.
-    return this.getOriginalSourceFile(fileName, languageVersion, onError) !;
+    return sf !;
+  }
+
+  private getGeneratedFile(fileName: string): ts.SourceFile|null {
+    const genSrcFile = this.generatedSourceFiles.get(fileName);
+    if (genSrcFile) {
+      return genSrcFile.sourceFile;
+    }
+    const {generate, baseFileName} = this.shouldGenerateFile(fileName);
+    if (generate) {
+      const genFile = this.codeGenerator.generateFile(fileName, baseFileName);
+      return this.addGeneratedFile(genFile, genFileExternalReferences(genFile));
+    }
+    return null;
   }
 
   private originalFileExists(fileName: string): boolean {
@@ -344,48 +405,19 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter extends
 
   fileExists(fileName: string): boolean {
     fileName = stripNgResourceSuffix(fileName);
-    if (fileName.endsWith('.ngfactory.d.ts')) {
-      // Note: the factories of a previous program
-      // are not reachable via the regular fileExists
-      // as they might be in the outDir. So we derive their
-      // fileExist information based on the .ngsummary.json file.
-      if (this.summariesFromPreviousCompilations.has(summaryFileName(fileName))) {
-        return true;
-      }
-    }
-    // Note: Don't rely on this.generatedSourceFiles here,
-    // as it might not have been filled yet.
-    if (this._getBaseNameForGeneratedSourceFile(fileName)) {
+    if (this.librarySummaries.has(fileName) || this.generatedSourceFiles.has(fileName)) {
       return true;
     }
-    return this.summariesFromPreviousCompilations.has(fileName) ||
-        this.originalFileExists(fileName);
-  }
-
-  private _getBaseNameForGeneratedSourceFile(genFileName: string): string|undefined {
-    const genMatch = GENERATED_FILES.exec(genFileName);
-    if (!genMatch) {
-      return undefined;
+    if (this.shouldGenerateFile(fileName).generate) {
+      return true;
     }
-    const [, base, genSuffix, suffix] = genMatch;
-    if (suffix !== 'ts') {
-      return undefined;
-    }
-    if (genSuffix.indexOf('ngstyle') >= 0) {
-      // Note: ngstyle files have names like `afile.css.ngstyle.ts`
-      return base;
-    } else {
-      // Note: on-the-fly generated files always have a `.ts` suffix,
-      // but the file from which we generated it can be a `.ts`/ `.d.ts`
-      // (see options.generateCodeForLibraries).
-      return [`${base}.ts`, `${base}.d.ts`].find(
-          baseFileName => this.isSourceFile(baseFileName) && this.originalFileExists(baseFileName));
-    }
+    return this.originalFileExists(fileName);
   }
 
   loadSummary(filePath: string): string|null {
-    if (this.summariesFromPreviousCompilations.has(filePath)) {
-      return this.summariesFromPreviousCompilations.get(filePath) !;
+    const summary = this.librarySummaries.get(filePath);
+    if (summary) {
+      return summary.text;
     }
     return super.loadSummary(filePath);
   }
@@ -393,13 +425,19 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter extends
   isSourceFile(filePath: string): boolean {
     // If we have a summary from a previous compilation,
     // treat the file never as a source file.
-    if (this.summariesFromPreviousCompilations.has(summaryFileName(filePath))) {
+    if (this.librarySummaries.has(filePath)) {
       return false;
     }
     return super.isSourceFile(filePath);
   }
 
-  readFile = (fileName: string) => this.context.readFile(fileName);
+  readFile(fileName: string) {
+    const summary = this.librarySummaries.get(fileName);
+    if (summary) {
+      return summary.text;
+    }
+    return this.context.readFile(fileName);
+  }
   getDefaultLibFileName = (options: ts.CompilerOptions) =>
       this.context.getDefaultLibFileName(options)
   getCurrentDirectory = () => this.context.getCurrentDirectory();
@@ -451,10 +489,17 @@ function getPackageName(filePath: string): string|null {
 export function relativeToRootDirs(filePath: string, rootDirs: string[]): string {
   if (!filePath) return filePath;
   for (const dir of rootDirs || []) {
-    const rel = path.relative(dir, filePath);
-    if (rel.indexOf('.') != 0) return rel;
+    const rel = pathStartsWithPrefix(dir, filePath);
+    if (rel) {
+      return rel;
+    }
   }
   return filePath;
+}
+
+function pathStartsWithPrefix(prefix: string, fullPath: string): string|null {
+  const rel = path.relative(prefix, fullPath);
+  return rel.startsWith('..') ? null : rel;
 }
 
 function stripNodeModulesPrefix(filePath: string): string {
@@ -472,13 +517,4 @@ function stripNgResourceSuffix(fileName: string): string {
 
 function addNgResourceSuffix(fileName: string): string {
   return `${fileName}.$ngresource$`;
-}
-
-function summaryFileName(fileName: string): string {
-  const genFileMatch = GENERATED_FILES.exec(fileName);
-  if (genFileMatch) {
-    const base = genFileMatch[1];
-    return base + '.ngsummary.json';
-  }
-  return fileName.replace(EXT, '') + '.ngsummary.json';
 }

--- a/packages/compiler/src/aot/compiler_options.ts
+++ b/packages/compiler/src/aot/compiler_options.ts
@@ -14,8 +14,9 @@ export interface AotCompilerOptions {
   translations?: string;
   missingTranslation?: MissingTranslationStrategy;
   enableLegacyTemplate?: boolean;
+  /** TODO(tbosch): remove this flag as it is always on in the new ngc */
   enableSummariesForJit?: boolean;
   preserveWhitespaces?: boolean;
   fullTemplateTypeCheck?: boolean;
-  rootDir?: string;
+  allowEmptyCodegenFiles?: boolean;
 }

--- a/packages/compiler/src/aot/static_symbol_resolver.ts
+++ b/packages/compiler/src/aot/static_symbol_resolver.ts
@@ -45,7 +45,7 @@ export interface StaticSymbolResolverHost {
    *
    * See ImportResolver.
    */
-  fileNameToModuleName(importedFilePath: string, containingFilePath: string): string|null;
+  fileNameToModuleName(importedFilePath: string, containingFilePath: string): string;
 }
 
 const SUPPORTED_SCHEMA_VERSION = 3;
@@ -163,7 +163,7 @@ export class StaticSymbolResolver {
   /**
    * Converts a file path to a module name that can be used as an `import`.
    */
-  fileNameToModuleName(importedFilePath: string, containingFilePath: string): string|null {
+  fileNameToModuleName(importedFilePath: string, containingFilePath: string): string {
     return this.knownFileNameToModuleNames.get(importedFilePath) ||
         this.host.fileNameToModuleName(importedFilePath, containingFilePath);
   }
@@ -292,11 +292,6 @@ export class StaticSymbolResolver {
     this.resolvedFilePaths.add(filePath);
     const resolvedSymbols: ResolvedStaticSymbol[] = [];
     const metadata = this.getModuleMetadata(filePath);
-    if (metadata['importAs']) {
-      // Index bundle indices should use the importAs module name defined
-      // in the bundle.
-      this.knownFileNameToModuleNames.set(filePath, metadata['importAs']);
-    }
     if (metadata['metadata']) {
       // handle direct declarations of the symbol
       const topLevelSymbolNames =

--- a/packages/compiler/src/style_compiler.ts
+++ b/packages/compiler/src/style_compiler.ts
@@ -42,13 +42,14 @@ export class StyleCompiler {
           styleUrls: template.styleUrls,
           moduleUrl: identifierModuleUrl(comp.type)
         }),
-        true);
+        this.needsStyleShim(comp), true);
   }
 
   compileStyles(
       outputCtx: OutputContext, comp: CompileDirectiveMetadata,
-      stylesheet: CompileStylesheetMetadata): CompiledStylesheet {
-    return this._compileStyles(outputCtx, comp, stylesheet, false);
+      stylesheet: CompileStylesheetMetadata,
+      shim: boolean = this.needsStyleShim(comp)): CompiledStylesheet {
+    return this._compileStyles(outputCtx, comp, stylesheet, shim, false);
   }
 
   needsStyleShim(comp: CompileDirectiveMetadata): boolean {
@@ -57,8 +58,8 @@ export class StyleCompiler {
 
   private _compileStyles(
       outputCtx: OutputContext, comp: CompileDirectiveMetadata,
-      stylesheet: CompileStylesheetMetadata, isComponentStylesheet: boolean): CompiledStylesheet {
-    const shim = this.needsStyleShim(comp);
+      stylesheet: CompileStylesheetMetadata, shim: boolean,
+      isComponentStylesheet: boolean): CompiledStylesheet {
     const styleExpressions: o.Expression[] =
         stylesheet.styles.map(plainStyle => o.literal(this._shimIfNeeded(plainStyle, shim)));
     const dependencies: StylesCompileDependency[] = [];

--- a/packages/compiler/test/aot/test_util.ts
+++ b/packages/compiler/test/aot/test_util.ts
@@ -410,7 +410,7 @@ export class MockAotCompilerHost implements AotCompilerHost {
   fromSummaryFileName(filePath: string): string { return filePath; }
 
   // AotCompilerHost
-  fileNameToModuleName(importedFile: string, containingFile: string): string|null {
+  fileNameToModuleName(importedFile: string, containingFile: string): string {
     return importedFile.replace(EXT, '');
   }
 


### PR DESCRIPTION
introduce the option `allowEmptyCodegenFiles` to generate all generated files,
even if they are empty.
- also provides the original source files from which the file was generated
  in the write file callback
- needed e.g. for G3 when copying over pinto mod names from the original component
  to all generated files

use `importAs` from flat modules when writing summaries
- i.e. prevents incorrect entries like @angular/common/common in the .ngsummary.json files.

change interaction between ng and ts to prevent race conditions
- before Angular would rely on TS to first read the file for which we generate files,
  and then the generated files. However, this can break easily when we reuse an old program.

don’t generate files for sources that are outside of `rootDir`
(see #19337)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
