### PR TITLE
fix(compiler): remove deprecated `Compiler.ngGetContentSelectors()`

### DIFF
--- a/packages/compiler/src/jit/compiler.ts
+++ b/packages/compiler/src/jit/compiler.ts
@@ -67,16 +67,6 @@ export class JitCompiler {
     return Promise.resolve(this._compileModuleAndAllComponents(moduleType, false));
   }
 
-  getNgContentSelectors(component: Type): string[] {
-    this._console.warn(
-        'Compiler.getNgContentSelectors is deprecated. Use ComponentFactory.ngContentSelectors instead!');
-    const template = this._compiledTemplateCache.get(component);
-    if (!template) {
-      throw new Error(`The component ${stringify(component)} is not yet compiled!`);
-    }
-    return template.compMeta.template !.ngContentSelectors;
-  }
-
   getComponentFactory(component: Type): object {
     const summary = this._metadataResolver.getDirectiveSummary(component);
     return summary.componentFactory as object;

--- a/packages/core/src/linker/compiler.ts
+++ b/packages/core/src/linker/compiler.ts
@@ -70,16 +70,6 @@ export class Compiler {
   }
 
   /**
-   * Exposes the CSS-style selectors that have been used in `ngContent` directives within
-   * the template of the given component.
-   * This is used by the `upgrade` library to compile the appropriate transclude content
-   * in the AngularJS wrapper component.
-   *
-   * @deprecated since v4. Use ComponentFactory.ngContentSelectors instead.
-   */
-  getNgContentSelectors(component: Type<any>): string[] { throw _throwError(); }
-
-  /**
    * Clears all caches.
    */
   clearCache(): void {}

--- a/packages/platform-browser-dynamic/src/compiler_factory.ts
+++ b/packages/platform-browser-dynamic/src/compiler_factory.ts
@@ -71,9 +71,6 @@ export class CompilerImpl implements Compiler {
                 componentFactories: result.componentFactories as ComponentFactory<any>[],
               }));
   }
-  getNgContentSelectors(component: Type<any>): string[] {
-    return this._delegate.getNgContentSelectors(component);
-  }
   loadAotSummaries(summaries: () => any[]) { this._delegate.loadAotSummaries(summaries); }
   hasAotSummary(ref: Type<any>): boolean { return this._delegate.hasAotSummary(ref); }
   getComponentFactory<T>(component: Type<T>): ComponentFactory<T> {

--- a/packages/platform-browser-dynamic/testing/src/compiler_factory.ts
+++ b/packages/platform-browser-dynamic/testing/src/compiler_factory.ts
@@ -57,10 +57,6 @@ export class TestingCompilerImpl implements TestingCompiler {
     return this._compiler.compileModuleAndAllComponentsAsync(moduleType);
   }
 
-  getNgContentSelectors(component: Type<any>): string[] {
-    return this._compiler.getNgContentSelectors(component);
-  }
-
   getComponentFactory<T>(component: Type<T>): ComponentFactory<T> {
     return this._compiler.getComponentFactory(component);
   }

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -182,7 +182,6 @@ export declare class Compiler {
     compileModuleAndAllComponentsSync<T>(moduleType: Type<T>): ModuleWithComponentFactories<T>;
     compileModuleAsync<T>(moduleType: Type<T>): Promise<NgModuleFactory<T>>;
     compileModuleSync<T>(moduleType: Type<T>): NgModuleFactory<T>;
-    /** @deprecated */ getNgContentSelectors(component: Type<any>): string[];
 }
 
 /** @experimental */


### PR DESCRIPTION
BREAKING CHANGE:

The method `ngGetConentSelectors()`, deprecated in Angular 4.0, has been
removed.

Use `ComponentFactory.ngContentSelectors` instead.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

`Compiler` supported a deprecated method `ngGetConentSelectors()`.

## What is the new behavior?

`ngGetContentSelectors()` is no longer supported by `Compiler`.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The method `ngGetConentSelectors()`, deprecated in Angular 4.0, has been
removed.

Use `ComponentFactory.ngContentSelectors` instead.
