### PR TITLE
docs(aio): document the special treatment of undefined

### DIFF
--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -143,7 +143,7 @@ The `hero` in `{{hero.name}}`
 refers to the template input variable, not the component's property.
 
 Template expressions cannot refer to anything in
-the global namespace. They can't refer to `window` or `document`. They
+the global namespace (except `undefined`). They can't refer to `window` or `document`. They
 can't call `console.log` or `Math.max`. They are restricted to referencing
 members of the expression context.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

In **Template Syntax** guide, it's saying that no global variables (properties of `[[global]]`) are allowed in template, but that's not true, Angular allowed `undefined` in template at [lexer level](https://github.com/angular/angular/blob/master/packages/compiler/src/expression_parser/lexer.ts#L21).

In JavaScript, `undefined` is no keyword nor literal, just a normal identifier which will usually fallback to global namespace if has no overwrite.

## What is the new behavior?

Angular should either document the special treatment about `undefined` or stop supporting it.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
