### PR TITLE
fix(http): introduce named type for HttpParams options

### DIFF
--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -15,7 +15,7 @@ import {map} from 'rxjs/operator/map';
 
 import {HttpHandler} from './backend';
 import {HttpHeaders} from './headers';
-import {HttpParams} from './params';
+import {HttpParams, HttpParamsOptions} from './params';
 import {HttpRequest} from './request';
 import {HttpEvent, HttpResponse} from './response';
 
@@ -366,7 +366,7 @@ export class HttpClient {
         if (options.params instanceof HttpParams) {
           params = options.params;
         } else {
-          params = new HttpParams({fromObject: options.params});
+          params = new HttpParams({ fromObject: options.params } as HttpParamsOptions);
         }
       }
 

--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -73,6 +73,21 @@ interface Update {
   op: 'a'|'d'|'s';
 }
 
+/** Options used to construct an `HttpParams` instance. */
+export interface HttpParamsOptions {
+  /**
+   * String representation of the HTTP params in URL-query-string format. Mutually exclusive with
+   * `fromObject`.
+   */
+  fromString?: string;
+
+  /** Object map of the HTTP params. Mutally exclusive with `fromString`. */
+  fromObject?: {[param: string]: string | string[]};
+
+  /** Encoding codec used to parse and serialize the params. */
+  encoder?: HttpParameterCodec;
+}
+
 /**
  * An HTTP request/response body that represents serialized parameters,
  * per the MIME type `application/x-www-form-urlencoded`.
@@ -87,11 +102,7 @@ export class HttpParams {
   private updates: Update[]|null = null;
   private cloneFrom: HttpParams|null = null;
 
-  constructor(options: {
-    fromString?: string,
-    fromObject?: {[param: string]: string | string[]},
-    encoder?: HttpParameterCodec,
-  } = {}) {
+  constructor(options: HttpParamsOptions = {} as HttpParamsOptions) {
     this.encoder = options.encoder || new HttpUrlEncodingCodec();
     if (!!options.fromString) {
       if (!!options.fromObject) {
@@ -175,7 +186,7 @@ export class HttpParams {
   }
 
   private clone(update: Update): HttpParams {
-    const clone = new HttpParams({encoder: this.encoder});
+    const clone = new HttpParams({ encoder: this.encoder } as HttpParamsOptions);
     clone.cloneFrom = this.cloneFrom || this;
     clone.updates = (this.updates || []).concat([update]);
     return clone;

--- a/tools/public_api_guard/common/http.d.ts
+++ b/tools/public_api_guard/common/http.d.ts
@@ -1580,13 +1580,7 @@ export interface HttpParameterCodec {
 
 /** @stable */
 export declare class HttpParams {
-    constructor(options?: {
-        fromString?: string;
-        fromObject?: {
-            [param: string]: string | string[];
-        };
-        encoder?: HttpParameterCodec;
-    });
+    constructor(options?: HttpParamsOptions);
     append(param: string, value: string): HttpParams;
     delete(param: string, value?: string): HttpParams;
     get(param: string): string | null;


### PR DESCRIPTION
This is necessary to enable type-based optimizations with Closure.
Without explicity making these options the same named type, Closure
thinks they are different types and cannot disambiguate the `fromObject`
property.

@alxhub @alexeagle let's discuss this together Monday morning