### PR TITLE
fix(router): ensure pre actvation also if no outlet is present

### DIFF
--- a/packages/router/src/pre_activation.ts
+++ b/packages/router/src/pre_activation.ts
@@ -131,7 +131,9 @@ export class PreActivation {
 
       if (shouldRunGuardsAndResolvers) {
         const outlet = context !.outlet !;
-        this.canDeactivateChecks.push(new CanDeactivate(outlet.component, curr));
+        if (outlet && outlet.component) {
+          this.canDeactivateChecks.push(new CanDeactivate(outlet.component, curr));
+        }
       }
     } else {
       if (curr) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[X] Bugfix
```

## What is the current behavior?

If currently no `router-outlet` is present (for example it will be removed from content because of some other errors) and pre activation rules are set (such as `AuthGuard`) the routing will fail with something like:
```
ERROR Error: Uncaught (in promise): TypeError: Cannot read property 'component' of null
TypeError: Cannot read property 'component' of null
    at PreActivation.webpackJsonp.../../../router/@angular/router.es5.js.PreActivation.traverseRoutes (router.es5.js:4346)
    at router.es5.js:4308
    at Array.forEach (<anonymous>)
    at PreActivation.webpackJsonp.../../../router/@angular/router.es5.js.PreActivation.traverseChildRoutes (router.es5.js:4307)
    at PreActivation.webpackJsonp.../../../router/@angular/router.es5.js.PreActivation.traverseRoutes (router.es5.js:4338)
[..]
```

Issue Number: #18253

## What is the new behavior?

It checks if there is a component or not. If not: Simply skip the following checks (which are related to a component) instead of hard fail.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No // depends if someone depends on a hard error
```

## Other information
