### PR TITLE
fix(compiler-cli): update ngtools2 EmitFlags

### DIFF
--- a/packages/compiler-cli/src/ngtools_api2.ts
+++ b/packages/compiler-cli/src/ngtools_api2.ts
@@ -66,9 +66,12 @@ export interface CompilerHost extends ts.CompilerHost {
 export enum EmitFlags {
   DTS = 1 << 0,
   JS = 1 << 1,
+  Metadata = 1 << 2,
+  I18nBundle = 1 << 3,
   Codegen = 1 << 4,
 
-  Default = DTS | JS | Codegen
+  Default = DTS | JS | Codegen,
+  All = DTS | JS | Metadata | I18nBundle | Codegen,
 }
 
 export interface CustomTransformers {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
ngtools2 private api does not have up to date EmitFlags.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
ngtools2 private api does has up to date EmitFlags.

## Does this PR introduce a breaking change?
```
[ ] Yes
[z] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
/cc @tbosch 