### PR TITLE
fix(common): pipe thrown errors reference themselves

### DIFF
--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -49,7 +49,7 @@ export class DecimalPipe implements PipeTransform {
     const {str, error} = formatNumber(value, locale, NumberFormatStyle.Decimal, digits);
 
     if (error) {
-      throw invalidPipeArgumentError(CurrencyPipe, error);
+      throw invalidPipeArgumentError(DecimalPipe, error);
     }
 
     return str;
@@ -87,7 +87,7 @@ export class PercentPipe implements PipeTransform {
     const {str, error} = formatNumber(value, locale, NumberFormatStyle.Percent, digits);
 
     if (error) {
-      throw invalidPipeArgumentError(CurrencyPipe, error);
+      throw invalidPipeArgumentError(PercentPipe, error);
     }
 
     return str;


### PR DESCRIPTION
Pipes now reference themselves when throwing an error rather than just the CurrencyPipe

fixes #19373

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://github.com/angular/angular/issues/19373

Issue Number: #19373


## What is the new behavior?
Logged error reference correct Pipe.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
