### PR TITLE
fix: refer to globals in a way that doesn’t break closure

### DIFF
--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -17,7 +17,7 @@ export {CodegenComponentFactoryResolver as ɵCodegenComponentFactoryResolver} fr
 export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/reflection_capabilities';
 export {GetterFn as ɵGetterFn, MethodFn as ɵMethodFn, SetterFn as ɵSetterFn} from './reflection/types';
 export {DirectRenderer as ɵDirectRenderer, RenderDebugInfo as ɵRenderDebugInfo} from './render/api';
-export {global as ɵglobal, looseIdentical as ɵlooseIdentical, stringify as ɵstringify} from './util';
+export {globalForWrite as ɵglobalForWrite, looseIdentical as ɵlooseIdentical, stringify as ɵstringify} from './util';
 export {makeDecorator as ɵmakeDecorator} from './util/decorators';
 export {isObservable as ɵisObservable, isPromise as ɵisPromise} from './util/lang';
 export {clearProviderOverrides as ɵclearProviderOverrides, overrideProvider as ɵoverrideProvider} from './view/index';

--- a/packages/core/src/profile/wtf_impl.ts
+++ b/packages/core/src/profile/wtf_impl.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {global} from '../util';
-
 /**
  * A scope function for the Web Tracing Framework (WTF).
  *
@@ -37,9 +35,11 @@ export interface Scope { (...args: any[] /** TODO #9100 */): any; }
 let trace: Trace;
 let events: Events;
 
+// Declare global variable in a closure friendly way.
+declare const wtf: WTF|undefined;
+
 export function detectWTF(): boolean {
-  const wtf: WTF = (global as any /** TODO #9100 */)['wtf'];
-  if (wtf) {
+  if (typeof wtf !== 'undefined') {
     trace = wtf['trace'];
     if (trace) {
       events = trace['events'];

--- a/packages/core/src/reflection/reflection_capabilities.ts
+++ b/packages/core/src/reflection/reflection_capabilities.ts
@@ -7,7 +7,7 @@
  */
 
 import {Type, isType} from '../type';
-import {global, stringify} from '../util';
+import {stringify} from '../util';
 import {ANNOTATIONS, PARAMETERS, PROP_METADATA} from '../util/decorators';
 
 import {PlatformReflectionCapabilities} from './platform_reflection_capabilities';
@@ -19,10 +19,19 @@ import {GetterFn, MethodFn, SetterFn} from './types';
  */
 export const DELEGATE_CTOR = /^function\s+\S+\(\)\s*{[\s\S]+\.apply\(this,\s*arguments\)/;
 
+// Declare global variable in a closure friendly way.
+declare const Reflect: any;
+
 export class ReflectionCapabilities implements PlatformReflectionCapabilities {
   private _reflect: any;
 
-  constructor(reflect?: any) { this._reflect = reflect || global['Reflect']; }
+  constructor(reflect?: any) {
+    if (typeof Reflect !== 'undefined') {
+      this._reflect = Reflect;
+    } else {
+      this._reflect = reflect;
+    }
+  }
 
   isReflectionEnabled(): boolean { return true; }
 

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -21,15 +21,41 @@ const __self = typeof self !== 'undefined' && typeof WorkerGlobalScope !== 'unde
     self instanceof WorkerGlobalScope && self;
 const __global = typeof global !== 'undefined' && global;
 const _global: {[name: string]: any} = __window || __global || __self;
-export {_global as global};
 
-// When Symbol.iterator doesn't exist, retrieves the key used in es6-shim
+/**
+ * Attention: Always use `declare const ...` when reading globals,
+ * so that tsickle produces externs for closure.
+ *
+ * Only use this export for setting globals,
+ * but still add a `declare const ...` so that tsickle
+ * keeps producing the right externs, even if
+ * that variable is not used.
+ *
+ * Pattern for reading optional values:
+ * ```
+ * declare var xzy: string;
+ * if (typeof xzy !== 'undefined') { ... }
+ * ```
+ *
+ * Pattern for creating globals lazily
+ * ```
+ * // still needed for closure, even if not read!
+ * declar var xzy: string;
+ *
+ * if (typeof xzy === 'undefined') {
+ *   globalForWrite.xzy = 'test';
+ * }
+ * console.log(xzy); // don't use globalForWrite.xzy for reading!
+ * ```
+ */
+export {_global as globalForWrite};
+
 declare const Symbol: any;
+// When Symbol.iterator doesn't exist, retrieves the key used in es6-shim
 let _symbolIterator: any = null;
 export function getSymbolIterator(): string|symbol {
   if (!_symbolIterator) {
-    const Symbol = _global['Symbol'];
-    if (Symbol && Symbol.iterator) {
+    if (typeof Symbol !== 'undefined' && Symbol.iterator) {
       _symbolIterator = Symbol.iterator;
     } else {
       // es6-shim specific logic

--- a/packages/core/test/linker/source_map_integration_node_only_spec.ts
+++ b/packages/core/test/linker/source_map_integration_node_only_spec.ts
@@ -10,7 +10,7 @@ import {ResourceLoader} from '@angular/compiler';
 import {SourceMap} from '@angular/compiler/src/output/source_map';
 import {extractSourceMap, originalPositionFor} from '@angular/compiler/test/output/source_map_util';
 import {MockResourceLoader} from '@angular/compiler/testing/src/resource_loader_mock';
-import {Attribute, Component, Directive, ErrorHandler, ɵglobal} from '@angular/core';
+import {Attribute, Component, Directive, ErrorHandler, ɵglobalForWrite as globalForWrite} from '@angular/core';
 import {getErrorLogger} from '@angular/core/src/errors';
 import {ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
 
@@ -20,7 +20,7 @@ export function main() {
     let resourceLoader: MockResourceLoader;
 
     beforeEach(() => {
-      jitSpy = spyOn(ɵglobal, 'Function').and.callThrough();
+      jitSpy = spyOn(globalForWrite, 'Function').and.callThrough();
       resourceLoader = new MockResourceLoader();
       TestBed.configureCompiler({providers: [{provide: ResourceLoader, useValue: resourceLoader}]});
     });

--- a/packages/core/test/linker/system_ng_module_factory_loader_spec.ts
+++ b/packages/core/test/linker/system_ng_module_factory_loader_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {Compiler, SystemJsNgModuleLoader} from '@angular/core';
-import {global} from '@angular/core/src/util';
+import {globalForWrite} from '@angular/core/src/util';
 import {async} from '@angular/core/testing';
 import {afterEach, beforeEach, describe, expect, it} from '@angular/core/testing/src/testing_internal';
 
@@ -24,14 +24,14 @@ export function main() {
   describe('SystemJsNgModuleLoader', () => {
     let oldSystem: any = null;
     beforeEach(() => {
-      oldSystem = global['System'];
-      global['System'] = mockSystem({
+      oldSystem = globalForWrite['System'];
+      globalForWrite['System'] = mockSystem({
         'test.ngfactory':
             {'default': 'test module factory', 'NamedNgFactory': 'test NamedNgFactory'},
         'prefixed/test/suffixed': {'NamedNgFactory': 'test module factory'}
       });
     });
-    afterEach(() => { global['System'] = oldSystem; });
+    afterEach(() => { globalForWrite['System'] = oldSystem; });
 
     it('loads a default factory by appending the factory suffix', async(() => {
          const loader = new SystemJsNgModuleLoader(new Compiler());

--- a/packages/core/test/reflection/reflector_spec.ts
+++ b/packages/core/test/reflection/reflector_spec.ts
@@ -8,7 +8,7 @@
 
 import {Reflector} from '@angular/core/src/reflection/reflection';
 import {DELEGATE_CTOR, ReflectionCapabilities} from '@angular/core/src/reflection/reflection_capabilities';
-import {global} from '@angular/core/src/util';
+import {globalForWrite} from '@angular/core/src/util';
 import {makeDecorator, makeParamDecorator, makePropDecorator} from '@angular/core/src/util/decorators';
 
 interface ClassDecoratorFactory {

--- a/packages/core/testing/src/testing_internal.ts
+++ b/packages/core/testing/src/testing_internal.ts
@@ -7,7 +7,6 @@
  */
 
 import {ɵisPromise as isPromise} from '@angular/core';
-import {global} from '@angular/core/src/util';
 
 import {AsyncTestCompleter} from './async_test_completer';
 import {getTestBed, inject} from './test_bed';
@@ -20,18 +19,11 @@ export * from './ng_zone_mock';
 
 export const proxy: ClassDecorator = (t: any) => t;
 
-const _global = <any>(typeof window === 'undefined' ? global : window);
+const _afterEach: Function = afterEach;
+export {_afterEach as afterEach};
 
-export const afterEach: Function = _global.afterEach;
-export const expect: (actual: any) => jasmine.Matchers = _global.expect;
-
-const jsmBeforeEach = _global.beforeEach;
-const jsmDescribe = _global.describe;
-const jsmDDescribe = _global.fdescribe;
-const jsmXDescribe = _global.xdescribe;
-const jsmIt = _global.it;
-const jsmIIt = _global.fit;
-const jsmXIt = _global.xit;
+const _expect: (actual: any) => jasmine.Matchers = expect;
+export {_expect as expect};
 
 const runnerStack: BeforeEachRunner[] = [];
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 3000;
@@ -58,9 +50,9 @@ class BeforeEachRunner {
 }
 
 // Reset the test providers before each test
-jsmBeforeEach(() => { testBed.resetTestingModule(); });
+beforeEach(() => { testBed.resetTestingModule(); });
 
-function _describe(jsmFn: Function, ...args: any[]) {
+function _describeImpl(jsmFn: Function, ...args: any[]) {
   const parentRunner = runnerStack.length === 0 ? null : runnerStack[runnerStack.length - 1];
   const runner = new BeforeEachRunner(parentRunner !);
   runnerStack.push(runner);
@@ -69,27 +61,32 @@ function _describe(jsmFn: Function, ...args: any[]) {
   return suite;
 }
 
-export function describe(...args: any[]): void {
-  return _describe(jsmDescribe, ...args);
+function _describe(...args: any[]): void {
+  return _describeImpl(describe, ...args);
 }
+export {_describe as describe};
 
-export function ddescribe(...args: any[]): void {
-  return _describe(jsmDDescribe, ...args);
+function _ddescribe(...args: any[]): void {
+  return _describeImpl(fdescribe, ...args);
 }
+export {_ddescribe as ddescribe};
 
-export function xdescribe(...args: any[]): void {
-  return _describe(jsmXDescribe, ...args);
+function _xdescribe(...args: any[]): void {
+  return _describeImpl(xdescribe, ...args);
 }
+export {_xdescribe as xdescribe};
 
-export function beforeEach(fn: Function): void {
+function _beforeEach(fn: Function): void {
   if (runnerStack.length > 0) {
     // Inside a describe block, beforeEach() uses a BeforeEachRunner
     runnerStack[runnerStack.length - 1].beforeEach(fn);
   } else {
     // Top level beforeEach() are delegated to jasmine
-    jsmBeforeEach(fn);
+    beforeEach(fn as any);
   }
 }
+
+export {_beforeEach as beforeEach};
 
 /**
  * Allows overriding default providers defined in test_injector.js.
@@ -104,7 +101,7 @@ export function beforeEach(fn: Function): void {
  *   ]);
  */
 export function beforeEachProviders(fn: Function): void {
-  jsmBeforeEach(() => {
+  beforeEach(() => {
     const providers = fn();
     if (!providers) return;
     testBed.configureTestingModule({providers: providers});
@@ -112,7 +109,7 @@ export function beforeEachProviders(fn: Function): void {
 }
 
 
-function _it(jsmFn: Function, name: string, testFn: Function, testTimeOut: number): void {
+function _itImpl(jsmFn: Function, name: string, testFn: Function, testTimeOut: number): void {
   if (runnerStack.length == 0) {
     // This left here intentionally, as we should never get here, and it aids debugging.
     debugger;
@@ -148,17 +145,20 @@ function _it(jsmFn: Function, name: string, testFn: Function, testTimeOut: numbe
   }, timeOut);
 }
 
-export function it(name: any, fn: any, timeOut: any = null): void {
-  return _it(jsmIt, name, fn, timeOut);
+function _it(name: any, fn: any, timeOut: any = null): void {
+  return _itImpl(it, name, fn, timeOut);
 }
+export {_it as it};
 
-export function xit(name: any, fn: any, timeOut: any = null): void {
-  return _it(jsmXIt, name, fn, timeOut);
+function _xit(name: any, fn: any, timeOut: any = null): void {
+  return _itImpl(xit, name, fn, timeOut);
 }
+export {_xit as xit};
 
-export function iit(name: any, fn: any, timeOut: any = null): void {
-  return _it(jsmIIt, name, fn, timeOut);
+function _iit(name: any, fn: any, timeOut: any = null): void {
+  return _itImpl(fit, name, fn, timeOut);
 }
+export {_iit as iit};
 
 export class SpyObject {
   constructor(type?: any) {

--- a/packages/platform-browser-dynamic/src/resource_loader/resource_loader_cache.ts
+++ b/packages/platform-browser-dynamic/src/resource_loader/resource_loader_cache.ts
@@ -7,7 +7,9 @@
  */
 
 import {ResourceLoader} from '@angular/compiler';
-import {ɵglobal as global} from '@angular/core';
+
+// Declare global variable in a closure friendly way.
+declare const $templateCache: {[url: string]: string}|undefined;
 
 /**
  * An implementation of ResourceLoader that uses a template cache to avoid doing an actual
@@ -21,10 +23,11 @@ export class CachedResourceLoader extends ResourceLoader {
 
   constructor() {
     super();
-    this._cache = (<any>global).$templateCache;
-    if (this._cache == null) {
+    const cache = typeof $templateCache !== 'undefined' ? $templateCache : null;
+    if (!cache) {
       throw new Error('CachedResourceLoader: Template cache was not found in $templateCache.');
     }
+    this._cache = cache;
   }
 
   get(url: string): Promise<string> {

--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -7,7 +7,6 @@
  */
 
 import {ɵparseCookieValue as parseCookieValue} from '@angular/common';
-import {ɵglobal as global} from '@angular/core';
 
 import {setRootDomAdapter} from '../dom/dom_adapter';
 
@@ -65,8 +64,11 @@ const _chromeNumKeyPadMap = {
 
 let nodeContains: (a: any, b: any) => boolean;
 
-if (global['Node']) {
-  nodeContains = global['Node'].prototype.contains || function(node) {
+// Note: we rely on the global node typings here,
+// including closure knowing to not rename `Node`
+// and not collide with this name.
+if (typeof Node !== 'undefined') {
+  nodeContains = Node.prototype.contains || function(node) {
     return !!(this.compareDocumentPosition(node) & 16);
   };
 }

--- a/packages/platform-browser/src/browser/tools/tools.ts
+++ b/packages/platform-browser/src/browser/tools/tools.ts
@@ -7,10 +7,8 @@
  */
 
 import {ComponentRef} from '@angular/core';
-import {exportNgVar} from '../../dom/util';
+import {getNgGlobal} from '../../dom/util';
 import {AngularProfiler} from './common_tools';
-
-const PROFILER_GLOBAL_NAME = 'profiler';
 
 /**
  * Enabled Angular debug tools that are accessible via your browser's
@@ -26,7 +24,7 @@ const PROFILER_GLOBAL_NAME = 'profiler';
  * @experimental All debugging apis are currently experimental.
  */
 export function enableDebugTools<T>(ref: ComponentRef<T>): ComponentRef<T> {
-  exportNgVar(PROFILER_GLOBAL_NAME, new AngularProfiler(ref));
+  getNgGlobal().profiler = new AngularProfiler(ref);
   return ref;
 }
 
@@ -36,5 +34,5 @@ export function enableDebugTools<T>(ref: ComponentRef<T>): ComponentRef<T> {
  * @experimental All debugging apis are currently experimental.
  */
 export function disableDebugTools(): void {
-  exportNgVar(PROFILER_GLOBAL_NAME, null);
+  getNgGlobal().profiler = undefined;
 }

--- a/packages/platform-browser/src/dom/debug/ng_probe.ts
+++ b/packages/platform-browser/src/dom/debug/ng_probe.ts
@@ -7,15 +7,12 @@
  */
 
 import * as core from '@angular/core';
-import {exportNgVar} from '../util';
+import {getNgGlobal} from '../util';
 
 const CORE_TOKENS = {
   'ApplicationRef': core.ApplicationRef,
   'NgZone': core.NgZone,
 };
-
-const INSPECT_GLOBAL_NAME = 'probe';
-const CORE_TOKENS_GLOBAL_NAME = 'coreTokens';
 
 /**
  * Returns a {@link DebugElement} for the given native DOM element, or
@@ -27,8 +24,8 @@ export function inspectNativeElement(element: any): core.DebugNode|null {
 }
 
 export function _createNgProbe(coreTokens: core.NgProbeToken[]): any {
-  exportNgVar(INSPECT_GLOBAL_NAME, inspectNativeElement);
-  exportNgVar(CORE_TOKENS_GLOBAL_NAME, {...CORE_TOKENS, ..._ngProbeTokensToMap(coreTokens || [])});
+  getNgGlobal().inspect = inspectNativeElement;
+  getNgGlobal().coreTokens = {...CORE_TOKENS, ..._ngProbeTokensToMap(coreTokens || [])};
   return () => inspectNativeElement;
 }
 

--- a/packages/platform-browser/src/dom/events/dom_events.ts
+++ b/packages/platform-browser/src/dom/events/dom_events.ts
@@ -6,7 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, NgZone, ɵglobal as global} from '@angular/core';
+import {Inject, Injectable, NgZone} from '@angular/core';
+// Import zero symbols from zone.js. This causes the zone ambient type to be
+// added to the type-checker, without emitting any runtime module load statement
+import {} from 'zone.js';
 
 import {DOCUMENT} from '../dom_tokens';
 
@@ -18,8 +21,8 @@ import {EventManagerPlugin} from './event_manager';
  * efficient bookkeeping than Zone can, because we have additional information. This speeds up
  * addEventListener by 3x.
  */
-const Zone = global['Zone'];
-const __symbol__ = Zone && Zone['__symbol__'] || function<T>(v: T): T {
+const __symbol__ =
+    typeof Zone !== 'undefined' && (Zone as any)['__symbol__'] || function<T>(v: T): T {
   return v;
 };
 const ADD_EVENT_LISTENER: 'addEventListener' = __symbol__('addEventListener');
@@ -32,7 +35,8 @@ const ANGULAR = 'ANGULAR';
 const NATIVE_ADD_LISTENER = 'addEventListener';
 const NATIVE_REMOVE_LISTENER = 'removeEventListener';
 
-const blackListedEvents: string[] = Zone && Zone[__symbol__('BLACK_LISTED_EVENTS')];
+const blackListedEvents: string[] =
+    (typeof Zone !== 'undefined') && (Zone as any)[__symbol__('BLACK_LISTED_EVENTS')];
 let blackListedMap: {[eventName: string]: string};
 if (blackListedEvents) {
   blackListedMap = {};

--- a/packages/platform-browser/src/dom/util.ts
+++ b/packages/platform-browser/src/dom/util.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵglobal as global} from '@angular/core';
+import {DebugNode, ɵglobalForWrite as globalForWrite} from '@angular/core';
+
+import {AngularProfiler} from '../browser/tools/common_tools';
 
 const CAMEL_CASE_REGEXP = /([A-Z])/g;
 const DASH_CASE_REGEXP = /-([a-z])/g;
@@ -20,18 +22,37 @@ export function dashCaseToCamelCase(input: string): string {
   return input.replace(DASH_CASE_REGEXP, (...m: string[]) => m[1].toUpperCase());
 }
 
+// Declare global variable in a closure friendly way.
+declare let ng: any;
+
 /**
- * Exports the value under a given `name` in the global property `ng`. For example `ng.probe` if
- * `name` is `'probe'`.
- * @param name Name under which it will be exported. Keep in mind this will be a property of the
- * global `ng` object.
- * @param value The value to export.
+ * Wrapper around the namespace `ng` to lasily initialize it
+ * and to access properties in a way so that closure
+ * compiler won't rename them.
+ *
+ * Note: We have to use globalForWrite also for reading
+ * as otherwise closure will complain when this is used together with ng1,
+ * as there `ng` is a namespace as closure does not like redeclaring namespaces.
  */
-export function exportNgVar(name: string, value: any): void {
-  if (!ng) {
-    global['ng'] = ng = (global['ng'] as{[key: string]: any} | undefined) || {};
+export class NgGlobal {
+  constructor() { globalForWrite.ng = {}; }
+  get profiler() { return globalForWrite.ng['profiler']; }
+  set profiler(value: AngularProfiler|undefined) { globalForWrite.ng['profiler'] = value; }
+  get inspect() { return globalForWrite.ng['inspect']; }
+  set inspect(value: ((element: any) => DebugNode | null)|undefined) {
+    globalForWrite.ng['inspect'] = value;
   }
-  ng[name] = value;
+  get coreTokens() { return globalForWrite.ng['coreTokens']; }
+  set coreTokens(value: {[name: string]: any}|undefined) {
+    globalForWrite.ng['coreTokens'] = value;
+  }
 }
 
-let ng: {[key: string]: any}|undefined;
+let _ngGlobal: NgGlobal;
+
+export function getNgGlobal(): NgGlobal {
+  if (!_ngGlobal) {
+    _ngGlobal = new NgGlobal();
+  }
+  return _ngGlobal;
+}

--- a/packages/platform-browser/test/browser/tools/spies.ts
+++ b/packages/platform-browser/test/browser/tools/spies.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, ɵglobal as global} from '@angular/core';
+import {Injector} from '@angular/core';
 import {ApplicationRef} from '@angular/core/src/application_ref';
 import {SpyObject} from '@angular/core/testing/src/testing_internal';
+import {getNgGlobal} from '@angular/platform-browser/src/dom/util';
 
 export class SpyApplicationRef extends SpyObject {
   constructor() { super(ApplicationRef); }
@@ -24,5 +25,5 @@ export class SpyComponentRef extends SpyObject {
 }
 
 export function callNgProfilerTimeChangeDetection(config?: any /** TODO #9100 */): void {
-  (<any>global).ng.profiler.timeChangeDetection(config);
+  getNgGlobal().profiler !.timeChangeDetection(config);
 }

--- a/packages/platform-browser/testing/src/browser_util.ts
+++ b/packages/platform-browser/testing/src/browser_util.ts
@@ -6,10 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgZone, ɵglobal as global} from '@angular/core';
+import {NgZone} from '@angular/core';
 import {ɵgetDOM as getDOM} from '@angular/platform-browser';
 
 export let browserDetection: BrowserDetection;
+
+// Declare global variable in a closure friendly way.
+declare const Intl: any;
+// Declare global variable in a closure friendly way.
+declare const IntlPolyfill: any;
 
 export class BrowserDetection {
   private _overrideUa: string|null;
@@ -54,7 +59,9 @@ export class BrowserDetection {
   // 1) IE11/Edge: they have a native Intl API, but with some discrepancies
   // 2) IE9/IE10: they use the polyfill, and so no discrepancies
   get supportsNativeIntlApi(): boolean {
-    return !!(<any>global).Intl && (<any>global).Intl !== (<any>global).IntlPolyfill;
+    const _Intl = typeof Intl !== 'undefined' ? Intl : null;
+    const _IntlPolyfill = typeof IntlPolyfill !== 'undefined' ? IntlPolyfill : null;
+    return !!_Intl && _Intl !== _IntlPolyfill;
   }
 
   get isChromeDesktop(): boolean {

--- a/packages/platform-browser/testing/src/matchers.ts
+++ b/packages/platform-browser/testing/src/matchers.ts
@@ -7,10 +7,7 @@
  */
 
 
-import {ɵglobal as global} from '@angular/core';
 import {ɵgetDOM as getDOM} from '@angular/platform-browser';
-
-
 
 /**
  * Jasmine matchers that check Angular specific conditions.
@@ -85,7 +82,7 @@ export interface NgMatchers extends jasmine.Matchers {
   not: NgMatchers;
 }
 
-const _global = <any>(typeof window === 'undefined' ? global : window);
+const _expect = expect as(actual: any) => NgMatchers;
 
 /**
  * Jasmine matching function with Angular matchers mixed in.
@@ -94,7 +91,7 @@ const _global = <any>(typeof window === 'undefined' ? global : window);
  *
  * {@example testing/ts/matchers.ts region='toHaveText'}
  */
-export const expect: (actual: any) => NgMatchers = <any>_global.expect;
+export {_expect as expect};
 
 
 // Some Map polyfills don't polyfill Map.toString correctly, which
@@ -111,7 +108,7 @@ export const expect: (actual: any) => NgMatchers = <any>_global.expect;
   return `{ ${res.join(',')} }`;
 };
 
-_global.beforeEach(function() {
+beforeEach(function() {
   jasmine.addMatchers({
     // Custom handler for Map as Jasmine does not support it yet
     toEqual: function(util) {


### PR DESCRIPTION
Always create a `declare const …` so that tsickle will produce the right externs. 
This way, closure won’t create collisions between globals and
symbols that closure put on the global scope.

For reading, the `declare const` is enough.
For writing, we need to keep using `global` from `@angular/core`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
