### PR TITLE
fix(common): use correct pipe name in error messages

### DIFF
--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -49,7 +49,7 @@ export class DecimalPipe implements PipeTransform {
     const {str, error} = formatNumber(value, locale, NumberFormatStyle.Decimal, digits);
 
     if (error) {
-      throw invalidPipeArgumentError(CurrencyPipe, error);
+      throw invalidPipeArgumentError(DecimalPipe, error);
     }
 
     return str;
@@ -87,7 +87,7 @@ export class PercentPipe implements PipeTransform {
     const {str, error} = formatNumber(value, locale, NumberFormatStyle.Percent, digits);
 
     if (error) {
-      throw invalidPipeArgumentError(CurrencyPipe, error);
+      throw invalidPipeArgumentError(PercentPipe, error);
     }
 
     return str;

--- a/packages/common/test/pipes/number_pipe_spec.ts
+++ b/packages/common/test/pipes/number_pipe_spec.ts
@@ -48,8 +48,11 @@ export function main() {
         });
 
         it('should not support other objects', () => {
-          expect(() => pipe.transform({})).toThrowError();
-          expect(() => pipe.transform('123abc')).toThrowError();
+          expect(() => pipe.transform({}))
+              .toThrowError(
+                  `InvalidPipeArgument: '[object Object] is not a number' for pipe 'DecimalPipe'`);
+          expect(() => pipe.transform('123abc'))
+              .toThrowError(`InvalidPipeArgument: '123abc is not a number' for pipe 'DecimalPipe'`);
         });
 
         it('should throw if minFractionDigits is explicitly higher than maxFractionDigits', () => {
@@ -78,8 +81,11 @@ export function main() {
           expect(pipe.transform(1.2, '4.2', 'fr')).toEqual('0 120,00 %');
         });
 
-        it('should not support other objects',
-           () => { expect(() => pipe.transform({})).toThrowError(); });
+        it('should not support other objects', () => {
+          expect(() => pipe.transform({}))
+              .toThrowError(
+                  `InvalidPipeArgument: '[object Object] is not a number' for pipe 'PercentPipe'`);
+        });
       });
     });
 
@@ -102,8 +108,11 @@ export function main() {
               .toEqual('00 005,12 $');
         });
 
-        it('should not support other objects',
-           () => { expect(() => pipe.transform({})).toThrowError(); });
+        it('should not support other objects', () => {
+          expect(() => pipe.transform({}))
+              .toThrowError(
+                  `InvalidPipeArgument: '[object Object] is not a number' for pipe 'CurrencyPipe'`);
+        });
 
         it('should warn if you are using the v4 signature', () => {
           const warnSpy = spyOn(console, 'warn');


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
```

## What is the current behavior?
We don't use the correct pipe name for the InvalidPipeArgument errors

Issue Number: #19373


## What is the new behavior?
We use the correct pipe name


## Does this PR introduce a breaking change?
```
[x] No
```