### PR TITLE
fix(router): keep auxiliary routes when changing matrix parameters

### DIFF
--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -176,6 +176,8 @@ function createPositionApplyingDoubleDots(
 function getPath(command: any): any {
   if (typeof command === 'object' && command != null && command.outlets) {
     return command.outlets[PRIMARY_OUTLET];
+  } else if (typeof command === 'object' && command != null && !command.outlets) {
+    return command;
   }
   return `${command}`;
 }
@@ -253,6 +255,9 @@ function prefixedWith(segmentGroup: UrlSegmentGroup, startIndex: number, command
     if (curr && next && (typeof next === 'object') && next.outlets === undefined) {
       if (!compare(curr, next, path)) return noMatch;
       currentCommandIndex += 2;
+    } else if (curr && (typeof curr === 'object') && curr.outlets === undefined) {
+      Object.keys(curr).forEach(key => path.parameters[key] = curr[key]);
+      currentCommandIndex++;
     } else {
       if (!compare(curr, {}, path)) return noMatch;
       currentCommandIndex++;

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -233,6 +233,26 @@ describe('createUrlTree', () => {
       const t = create(p.root.children[PRIMARY_OUTLET], 1, p, [{outlets: {right: ['c']}}]);
       expect(serializer.serialize(t)).toEqual('/a/b/(right:c)');
     });
+
+    it('should support updating primary segments without leaving auxiliary routes', () => {
+      const p = serializer.parse('/a/b/(c//left:cp)');
+      const t = create(p.root.children[PRIMARY_OUTLET], 1, p, ['d']);
+      expect(serializer.serialize(t)).toEqual('/a/b/(d//left:cp)');
+    });
+
+    it('should support updating primary segments with existing matrix parameters without leaving auxiliary routes',
+       () => {
+         const p = serializer.parse('/a/b;x=1/(c//left:cp)');
+         const t = create(p.root.children[PRIMARY_OUTLET], 1, p, [{x: 2}, 'c']);
+         expect(serializer.serialize(t)).toEqual('/a/b;x=2/(c//left:cp)');
+       });
+
+    it('should support updating primary segments with new matrix parameters without leaving auxiliary routes',
+       () => {
+         const p = serializer.parse('/a/b/(c//left:cp)');
+         const t = create(p.root.children[PRIMARY_OUTLET], 1, p, [{x: 2}, 'c']);
+         expect(serializer.serialize(t)).toEqual('/a/b;x=2/(c//left:cp)');
+       });
   });
 
   it('should set fragment', () => {


### PR DESCRIPTION
keep auxiliary routes when changing matrix parameters and primary child route only

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
This fix attempts to be consistent with the behavior of applying no matrix parameters and
changing the child route relative to a parent route, e.g. /a/b/(c//left:cp) navigation
relative to /a/b to d keeps the auxiliary route and results in /a/b/(d//left:cp).
Additionally changing a matrix parameters of b removed the auxiliary route prior to this fix.

Issue Number: N/A


## What is the new behavior?
Now a navigation to [{x=2}, 'c'] relative to b will keep the auxiliary route intact and results
in /a/b;x=2/(c//left:cp).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No 
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
