### PR TITLE
Give names to the AMD modules nested in Angular UMD distro

### DIFF
--- a/packages/animations/browser/rollup.config.js
+++ b/packages/animations/browser/rollup.config.js
@@ -20,6 +20,7 @@ export default {
   dest: '../../../dist/packages-dist/animations/bundles/animations-browser.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/animations/browser'},
   moduleName: 'ng.animations.browser',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/animations/browser/testing/rollup.config.js
+++ b/packages/animations/browser/testing/rollup.config.js
@@ -21,6 +21,7 @@ export default {
   dest: '../../../../dist/packages-dist/animations/bundles/animations-browser-testing.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/animations/browser/testing'},
   moduleName: 'ng.animations.browser.testing',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/animations/rollup.config.js
+++ b/packages/animations/rollup.config.js
@@ -21,6 +21,7 @@ export default {
   dest: '../../dist/packages-dist/animations/bundles/animations.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/animations'},
   moduleName: 'ng.animations',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/common/http/rollup.config.js
+++ b/packages/common/http/rollup.config.js
@@ -25,6 +25,7 @@ export default {
   dest: '../../../dist/packages-dist/common/bundles/common-http.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/common/http'},
   moduleName: 'ng.common.http',
   external: Object.keys(globals),
   globals: globals

--- a/packages/common/http/testing/rollup.config.js
+++ b/packages/common/http/testing/rollup.config.js
@@ -24,6 +24,7 @@ export default {
   dest: '../../../../dist/packages-dist/common/bundles/common-http-testing.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/common/http/testing'},
   moduleName: 'ng.common.http.testing',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/common/rollup.config.js
+++ b/packages/common/rollup.config.js
@@ -21,6 +21,7 @@ export default {
   format: 'umd',
   exports: 'named',
   moduleName: 'ng.common',
+  amd: {id: '@angular/common'},
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),
   globals: globals

--- a/packages/common/testing/rollup.config.js
+++ b/packages/common/testing/rollup.config.js
@@ -21,6 +21,7 @@ export default {
   dest: '../../../dist/packages-dist/common/bundles/common-testing.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/common/testing'},
   moduleName: 'ng.common.testing',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/compiler-cli/browser-rollup.config.js
+++ b/packages/compiler-cli/browser-rollup.config.js
@@ -53,6 +53,7 @@ export default {
   entry: '../../dist/packages-dist/compiler-cli/src/ngc.js',
   dest: './browser-bundle.umd.js',
   format: 'umd',
+  amd: {id: '@angular/compiler-cli-browser'},
   moduleName: 'ng.compiler_cli_browser',
   exports: 'named',
   external: [

--- a/packages/compiler/rollup.config.js
+++ b/packages/compiler/rollup.config.js
@@ -20,6 +20,7 @@ export default {
   dest: '../../dist/packages-dist/compiler/bundles/compiler.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/compiler'},
   moduleName: 'ng.compiler',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/compiler/testing/rollup.config.js
+++ b/packages/compiler/testing/rollup.config.js
@@ -22,6 +22,7 @@ export default {
   dest: '../../../dist/packages-dist/compiler/bundles/compiler-testing.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/compiler/testing'},
   moduleName: 'ng.compiler.testing',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -23,6 +23,7 @@ export default {
   dest: '../../dist/packages-dist/core/bundles/core.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/core'},
   moduleName: 'ng.core',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/core/testing/rollup.config.js
+++ b/packages/core/testing/rollup.config.js
@@ -20,6 +20,7 @@ export default {
   dest: '../../../dist/packages-dist/core/bundles/core-testing.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/core/testing'},
   moduleName: 'ng.core.testing',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/forms/rollup.config.js
+++ b/packages/forms/rollup.config.js
@@ -26,6 +26,7 @@ export default {
   dest: '../../dist/packages-dist/forms/bundles/forms.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/forms'},
   moduleName: 'ng.forms',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/http/rollup.config.js
+++ b/packages/http/rollup.config.js
@@ -22,6 +22,7 @@ export default {
   dest: '../../dist/packages-dist/http/bundles/http.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/http'},
   moduleName: 'ng.http',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/http/testing/rollup.config.js
+++ b/packages/http/testing/rollup.config.js
@@ -25,6 +25,7 @@ export default {
   dest: '../../../dist/packages-dist/http/bundles/http-testing.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/http/testing'},
   moduleName: 'ng.http.testing',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/language-service/rollup.config.js
+++ b/packages/language-service/rollup.config.js
@@ -64,6 +64,12 @@ export default {
   entry: '../../dist/packages-dist/language-service/esm5/language-service.js',
   dest: '../../dist/packages-dist/language-service/bundles/language-service.umd.js',
   format: 'amd',
+  amd: {
+      // Don't name this module, causes
+      // Loading the language service caused the following exception: TypeError:
+      // $deferred.modules.map is not a function
+      // id: '@angular/language-service'
+  },
   moduleName: 'ng.language_service',
   exports: 'named',
   external: [

--- a/packages/platform-browser-dynamic/rollup.config.js
+++ b/packages/platform-browser-dynamic/rollup.config.js
@@ -21,6 +21,7 @@ export default {
   dest: '../../dist/packages-dist/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/platform-browser-dynamic'},
   moduleName: 'ng.platformBrowserDynamic',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/platform-browser-dynamic/testing/rollup.config.js
+++ b/packages/platform-browser-dynamic/testing/rollup.config.js
@@ -26,6 +26,7 @@ export default {
       '../../../dist/packages-dist/platform-browser-dynamic/bundles/platform-browser-dynamic-testing.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/platform-browser-dynamic/testing'},
   moduleName: 'ng.platformBrowserDynamic.testing',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/platform-browser/animations/rollup.config.js
+++ b/packages/platform-browser/animations/rollup.config.js
@@ -22,6 +22,7 @@ export default {
   dest: '../../../dist/packages-dist/platform-browser/bundles/platform-browser-animations.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/platform-browser/animations'},
   moduleName: 'ng.platformBrowser.animations',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/platform-browser/rollup.config.js
+++ b/packages/platform-browser/rollup.config.js
@@ -19,6 +19,7 @@ export default {
   dest: '../../dist/packages-dist/platform-browser/bundles/platform-browser.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/platform-browser'},
   moduleName: 'ng.platformBrowser',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/platform-browser/testing/rollup.config.js
+++ b/packages/platform-browser/testing/rollup.config.js
@@ -20,6 +20,7 @@ export default {
   dest: '../../../dist/packages-dist/platform-browser/bundles/platform-browser-testing.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/platform-browser/testing'},
   moduleName: 'ng.platformBrowser.testing',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/platform-server/rollup.config.js
+++ b/packages/platform-server/rollup.config.js
@@ -26,6 +26,7 @@ export default {
   dest: '../../dist/packages-dist/platform-server/bundles/platform-server.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/platform-server'},
   moduleName: 'ng.platformServer',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/platform-server/testing/rollup.config.js
+++ b/packages/platform-server/testing/rollup.config.js
@@ -24,6 +24,7 @@ export default {
   dest: '../../../dist/packages-dist/platform-server/bundles/platform-server-testing.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/platform-server/testing'},
   moduleName: 'ng.platformServer.testing',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/platform-webworker-dynamic/rollup.config.js
+++ b/packages/platform-webworker-dynamic/rollup.config.js
@@ -24,6 +24,7 @@ export default {
       '../../dist/packages-dist/platform-webworker-dynamic/bundles/platform-webworker-dynamic.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/platform-webworker-dynamic'},
   moduleName: 'ng.platformWebworkerDynamic',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/platform-webworker/rollup.config.js
+++ b/packages/platform-webworker/rollup.config.js
@@ -22,6 +22,7 @@ export default {
   dest: '../../dist/packages-dist/platform-webworker/bundles/platform-webworker.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/platform-webworker'},
   moduleName: 'ng.platformWebworker',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/router/rollup.config.js
+++ b/packages/router/rollup.config.js
@@ -44,6 +44,7 @@ export default {
   dest: '../../dist/packages-dist/router/bundles/router.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/router'},
   moduleName: 'ng.router',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/router/testing/rollup.config.js
+++ b/packages/router/testing/rollup.config.js
@@ -22,6 +22,7 @@ export default {
   dest: '../../../dist/packages-dist/router/bundles/router-testing.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/router/testing'},
   moduleName: 'ng.router.testing',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/router/upgrade/rollup.config.js
+++ b/packages/router/upgrade/rollup.config.js
@@ -21,6 +21,7 @@ export default {
   dest: '../../../dist/packages-dist/router/bundles/router-upgrade.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/router/upgrade'},
   moduleName: 'ng.router.upgrade',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/upgrade/rollup.config.js
+++ b/packages/upgrade/rollup.config.js
@@ -27,6 +27,7 @@ export default {
   dest: '../../dist/packages-dist/upgrade/bundles/upgrade.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/upgrade'},
   moduleName: 'ng.upgrade',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),

--- a/packages/upgrade/static/rollup.config.js
+++ b/packages/upgrade/static/rollup.config.js
@@ -18,6 +18,7 @@ export default {
   dest: '../../../dist/packages-dist/upgrade/bundles/upgrade-static.umd.js',
   format: 'umd',
   exports: 'named',
+  amd: {id: '@angular/upgrade/static'},
   moduleName: 'ng.upgrade.static',
   plugins: [resolve(), sourcemaps()],
   external: Object.keys(globals),


### PR DESCRIPTION
This allows the UMD bundles to be used in the following way:

load Angular in a script tag:
`<script src="https://unpkg.com/@angular/core@4.4.3/bundles/core.umd.js"></script>`

Instead of accessing the result by the global `ng` namespace, you can now use an AMD/UMD require

`require('@angular/core')`
and this can work without an XHR or any path mapping config like a system.config.js

This allows us to simply concat together angular and the user sources, so long as everyone names their UMD modules, which is faster than using rollup or webpack in development mode.

See http://requirejs.org/docs/whyamd.html#namedmodules

Difference in the Angular bundles as a result of this change:
```
$ diff ~/Downloads/common.umd.js dist/packages-dist/common/bundles/common.umd.js
8c8
< 	typeof define === 'function' && define.amd ? define(['exports', '@angular/core'], factory) :
---
> 	typeof define === 'function' && define.amd ? define('@angular/common', ['exports', '@angular/core'], factory) :
```