### PR TITLE
fix: don’t use the global `ng` at all with closure enhanced optimizat…

### DIFF
--- a/packages/bazel/src/ngc-wrapped/BUILD.bazel
+++ b/packages/bazel/src/ngc-wrapped/BUILD.bazel
@@ -5,7 +5,10 @@ licenses(["notice"])  # Apache 2.0
 
 ts_library(
     name = "ngc_lib",
-    srcs = ["index.ts"],
+    srcs = [
+        "index.ts",
+        "extract_i18n.ts",
+    ],
     deps = [
         # BEGIN-INTERNAL
         # Only needed when compiling within the Angular repo.
@@ -25,6 +28,17 @@ nodejs_binary(
     data = [
         ":ngc_lib",
         "@build_bazel_rules_typescript//internal:worker_protocol.proto"
+    ],
+    visibility = ["//visibility:public"],
+)
+
+nodejs_binary(
+    name = "xi18n",
+    # Entry point assumes the user is outside this WORKSPACE,
+    # and references our rules with @angular//src/ngc-wrapped
+    entry_point = "angular/src/ngc-wrapped/index.js/extract_i18n.js",
+    data = [
+        ":ngc_lib",
     ],
     visibility = ["//visibility:public"],
 )

--- a/packages/bazel/src/ngc-wrapped/extract_i18n.ts
+++ b/packages/bazel/src/ngc-wrapped/extract_i18n.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ *
+ * @fileoverview Extracts i18n messages.
+ */
+
+// Entry point
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  console.error('>>> now yet implemented!');
+  process.exitCode = 1;
+}

--- a/packages/core/src/core.externs.js
+++ b/packages/core/src/core.externs.js
@@ -8,10 +8,10 @@
  * @externs
  */
 
-/**
- * @suppress {duplicate}
- */
-var ng;
+// Note: we can't declare an extern for the global variable `ng` as
+// the namespace `ng` is already used within Google
+// for typings for angularJS (via `goog.provide('ng....')`).
+
 /**
  * @suppress {duplicate}
  */

--- a/packages/goog.d.ts
+++ b/packages/goog.d.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+
+/**
+ * Typings for google closure.
+ */
+declare namespace goog {
+  export const DEBUG: boolean;
+}

--- a/packages/platform-browser/src/dom/util.ts
+++ b/packages/platform-browser/src/dom/util.ts
@@ -28,10 +28,12 @@ export function dashCaseToCamelCase(input: string): string {
  * @param value The value to export.
  */
 export function exportNgVar(name: string, value: any): void {
-  if (!ng) {
-    global['ng'] = ng = (global['ng'] as{[key: string]: any} | undefined) || {};
+  if (typeof goog === 'undefined' || goog.DEBUG) {
+    // Note: we can't export `ng` when using closure enhanced optimization as:
+    // - closure declares globals itself for minified names, which sometimes clobber our `ng` global
+    // - we can't declare a closure extern as the namespace `ng` is already used within Google
+    //   for typings for angularJS (via `goog.provide('ng....')`).
+    const ng = global['ng'] = (global['ng'] as{[key: string]: any} | undefined) || {};
+    ng[name] = value;
   }
-  ng[name] = value;
 }
-
-let ng: {[key: string]: any}|undefined;

--- a/packages/platform-browser/tsconfig-build.json
+++ b/packages/platform-browser/tsconfig-build.json
@@ -15,7 +15,8 @@
   "files": [
     "public_api.ts",
     "../../node_modules/@types/hammerjs/index.d.ts",
-    "../../node_modules/zone.js/dist/zone.js.d.ts"
+    "../../node_modules/zone.js/dist/zone.js.d.ts",
+    "../goog.d.ts"
   ],
 
   "angularCompilerOptions": {

--- a/packages/types.d.ts
+++ b/packages/types.d.ts
@@ -15,3 +15,4 @@
 /// <reference path="../node_modules/@types/selenium-webdriver/index.d.ts" />
 /// <reference path="./es6-subset.d.ts" />
 /// <reference path="./system.d.ts" />
+/// <reference path="./goog.d.ts" />


### PR DESCRIPTION
…ions

This is needed as:
- closure declares globals itself for minified names, which sometimes clobber our `ng` global
- we can't declare a closure extern as the namespace `ng` is already used within Google for typings for angularJS (via `goog.provide('ng....')`).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
