### PR TITLE
fix(compiler-cli): don't rewrite imports when annotating for closure

### DIFF
--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -53,7 +53,7 @@ function createEmitCallback(options: api.CompilerOptions): api.TsEmitCallback|un
     fileNameToModuleId: (fileName) => fileName,
     googmodule: false,
     untyped: true,
-    convertIndexImportShorthand: true, transformDecorators, transformTypesToClosure,
+    convertIndexImportShorthand: false, transformDecorators, transformTypesToClosure,
   };
 
   return ({


### PR DESCRIPTION
Closure no longer needs to have the imports rewritten avoid rewriting
as this can cause issues when the source directory structure differs
from what is deployed.

Fixes: #19026


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #19026 

Tsickle import rewriting is no longer needed and can often cause issues for other tools and no longer match the deployed source structure.

## What is the new behavior?

The imports are no longer rewritten for closure as closure no longer requires it.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
