### PR TITLE
Clean up bzl files for compatibility with += on lists

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -114,7 +114,7 @@ def ngc_compile_action(ctx, label, inputs, outputs, messages_out, config_file_pa
   else:
     supports_workers = str(int(ctx.attr._supports_workers))
 
-  arguments = _EXTRA_NODE_OPTIONS_FLAGS
+  arguments = list(_EXTRA_NODE_OPTIONS_FLAGS)
   # One at-sign makes this a params-file, enabling the worker strategy.
   # Two at-signs escapes the argument so it's passed through to ngc
   # rather than the contents getting expanded.


### PR DESCRIPTION
In the future += on lists will mutate left-hand side lists in Skylark, therefore frozen lists should be copied first.