### PR TITLE
fix: don’t rely on `goog.DEBUG` but on `COMPILED` instead

### DIFF
--- a/packages/goog.d.ts
+++ b/packages/goog.d.ts
@@ -11,5 +11,14 @@
  * Typings for google closure.
  */
 declare namespace goog {
+  /**
+   * Note: Don't use this to check for advanced compilation,
+   * as it is sometimes true.
+   */
   export const DEBUG: boolean;
 }
+
+/**
+ * Use this flag to check for advanced compilation.
+ */
+declare const COMPILED: boolean;

--- a/packages/platform-browser/src/dom/util.ts
+++ b/packages/platform-browser/src/dom/util.ts
@@ -28,7 +28,7 @@ export function dashCaseToCamelCase(input: string): string {
  * @param value The value to export.
  */
 export function exportNgVar(name: string, value: any): void {
-  if (typeof goog === 'undefined' || goog.DEBUG) {
+  if (typeof COMPILED === 'undefined' || !COMPILED) {
     // Note: we can't export `ng` when using closure enhanced optimization as:
     // - closure declares globals itself for minified names, which sometimes clobber our `ng` global
     // - we can't declare a closure extern as the namespace `ng` is already used within Google


### PR DESCRIPTION
`good.DEBUG` can also be true when using advanced compilation.

Attention: This change has be applied in G3 already as a local mod!

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
