### PR TITLE
fix(common): parse error response body for responseType "json"

### DIFF
--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -155,6 +155,8 @@ http
   );
 ```
 
+In case the request expected a `responseType = "json"` and the backend responded with a JSON body, `err.error` will be parsed to an object literal. This allows applications to transport a meaningful error description even for HTTP status codes in the 4xx/5xx range. The JSON error reponse body could be used to phrase an elaborated message, telling the user what exactly went wrong.
+
 #### `.retry()`
 
 One way to deal with errors is to simply retry the request. This strategy can be useful when the errors are transient and unlikely to repeat.

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -180,7 +180,7 @@ export class HttpXhrBackend implements HttpBackend {
 
         // Check whether the body needs to be parsed as JSON (in many cases the browser
         // will have done that already).
-        if (ok && req.responseType === 'json' && typeof body === 'string') {
+        if (req.responseType === 'json' && typeof body === 'string') {
           // Attempt the parse. If it fails, a parse error should be delivered to the user.
           body = body.replace(XSSI_PREFIX, '');
           try {

--- a/packages/common/http/test/xhr_spec.ts
+++ b/packages/common/http/test/xhr_spec.ts
@@ -98,6 +98,19 @@ export function main() {
       expect(events.length).toBe(2);
       const res = events[1] as any as HttpErrorResponse;
       expect(res.error !.data).toBe('some data');
+    it('handles a json error response for 4xx status', () => {
+      const events = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+      factory.mock.mockFlush(400, 'Bad Request', JSON.stringify({data: 'some data'}));
+      const res = events[1] as HttpResponse<{data: string}>;
+      expect(typeof res.body === 'object');
+      expect(res.body !.data).toBe('some data');
+    });
+    it('handles a json error response for 5xx status', () => {
+      const events = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+      factory.mock.mockFlush(500, 'Internal Server Error', JSON.stringify({data: 'some data'}));
+      const res = events[1] as HttpResponse<{data: string}>;
+      expect(typeof res.body === 'object');
+      expect(res.body !.data).toBe('some data');
     });
     it('handles a json string response', () => {
       const events = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

For `req.responseType = "json"`, a non-2xx response body is always "text"

Issue Number: #18682


## What is the new behavior?

For `req.responseType = "json"`, response body is `JSON.parse()`'d


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```



## Other information
