### PR TITLE
feat(core): add source to `StaticInjectorError` message

### DIFF
--- a/packages/core/src/view/ng_module.ts
+++ b/packages/core/src/view/ng_module.ts
@@ -25,7 +25,7 @@ export function moduleProvideDef(
   // lowered the expression and then stopped evaluating it,
   // i.e. also didn't unwrap it.
   value = resolveForwardRef(value);
-  const depDefs = splitDepsDsl(deps);
+  const depDefs = splitDepsDsl(deps, token.name);
   return {
     // will bet set by the module definition
     index: -1,

--- a/packages/core/src/view/provider.ts
+++ b/packages/core/src/view/provider.ts
@@ -83,7 +83,7 @@ export function _def(
   // i.e. also didn't unwrap it.
   value = resolveForwardRef(value);
 
-  const depDefs = splitDepsDsl(deps);
+  const depDefs = splitDepsDsl(deps, token.name);
 
   return {
     // will bet set by the view definition

--- a/packages/core/src/view/util.ts
+++ b/packages/core/src/view/util.ts
@@ -7,10 +7,10 @@
  */
 
 import {WrappedValue, devModeEqual} from '../change_detection/change_detection';
+import {SOURCE} from '../di/injector';
 import {ViewEncapsulation} from '../metadata/view';
 import {RendererType2} from '../render/api';
 import {looseIdentical, stringify} from '../util';
-
 import {expressionChangedAfterItHasBeenCheckedError} from './errors';
 import {BindingDef, BindingFlags, Definition, DefinitionFactory, DepDef, DepFlags, ElementData, NodeDef, NodeFlags, QueryValueType, Services, ViewData, ViewDefinition, ViewDefinitionFactory, ViewFlags, ViewState, asElementData, asTextData} from './types';
 
@@ -209,7 +209,7 @@ export function splitMatchedQueriesDsl(
   return {matchedQueries, references, matchedQueryIds};
 }
 
-export function splitDepsDsl(deps: ([DepFlags, any] | any)[]): DepDef[] {
+export function splitDepsDsl(deps: ([DepFlags, any] | any)[], sourceName?: string): DepDef[] {
   return deps.map(value => {
     let token: any;
     let flags: DepFlags;
@@ -218,6 +218,9 @@ export function splitDepsDsl(deps: ([DepFlags, any] | any)[]): DepDef[] {
     } else {
       flags = DepFlags.None;
       token = value;
+    }
+    if (token && (typeof token === 'function' || typeof token === 'object') && sourceName) {
+      Object.defineProperty(token, SOURCE, {value: sourceName, configurable: true});
     }
     return {flags, token, tokenKey: tokenKey(token)};
   });

--- a/packages/core/test/view/provider_spec.ts
+++ b/packages/core/test/view/provider_spec.ts
@@ -147,8 +147,8 @@ export function main() {
 
           expect(() => createAndGetRootNodes(compViewDef(rootElNodes)))
               .toThrowError(
-                  'StaticInjectorError[Dep]: \n' +
-                  '  StaticInjectorError[Dep]: \n' +
+                  'StaticInjectorError(DynamicTestModule)[SomeService -> Dep]: \n' +
+                  '  StaticInjectorError(Platform: core)[SomeService -> Dep]: \n' +
                   '    NullInjectorError: No provider for Dep!');
 
           const nonRootElNodes = [
@@ -161,8 +161,8 @@ export function main() {
 
           expect(() => createAndGetRootNodes(compViewDef(nonRootElNodes)))
               .toThrowError(
-                  'StaticInjectorError[Dep]: \n' +
-                  '  StaticInjectorError[Dep]: \n' +
+                  'StaticInjectorError(DynamicTestModule)[SomeService -> Dep]: \n' +
+                  '  StaticInjectorError(Platform: core)[SomeService -> Dep]: \n' +
                   '    NullInjectorError: No provider for Dep!');
         });
 
@@ -186,8 +186,8 @@ export function main() {
                    directiveDef(1, NodeFlags.None, null, 0, SomeService, ['nonExistingDep'])
                  ])))
               .toThrowError(
-                  'StaticInjectorError[nonExistingDep]: \n' +
-                  '  StaticInjectorError[nonExistingDep]: \n' +
+                  'StaticInjectorError(DynamicTestModule)[nonExistingDep]: \n' +
+                  '  StaticInjectorError(Platform: core)[nonExistingDep]: \n' +
                   '    NullInjectorError: No provider for nonExistingDep!');
         });
 

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationInitStatus, CompilerOptions, Component, Directive, InjectionToken, Injector, ModuleWithComponentFactories, NgModule, NgModuleFactory, NgModuleRef, NgZone, Optional, Pipe, PlatformRef, Provider, SchemaMetadata, SkipSelf, Type, ɵDepFlags as DepFlags, ɵNodeFlags as NodeFlags, ɵclearProviderOverrides as clearProviderOverrides, ɵoverrideProvider as overrideProvider, ɵstringify as stringify} from '@angular/core';
+import {ApplicationInitStatus, CompilerOptions, Component, Directive, InjectionToken, Injector, ModuleWithComponentFactories, NgModule, NgModuleFactory, NgModuleRef, NgZone, Optional, Pipe, PlatformRef, Provider, SchemaMetadata, SkipSelf, StaticProvider, Type, ɵDepFlags as DepFlags, ɵNodeFlags as NodeFlags, ɵclearProviderOverrides as clearProviderOverrides, ɵoverrideProvider as overrideProvider, ɵstringify as stringify} from '@angular/core';
 
 import {AsyncTestCompleter} from './async_test_completer';
 import {ComponentFixture} from './component_fixture';
@@ -328,8 +328,12 @@ export class TestBed implements Injector {
       }
     }
     const ngZone = new NgZone({enableLongStackTrace: true});
-    const ngZoneInjector =
-        Injector.create([{provide: NgZone, useValue: ngZone}], this.platform.injector);
+    const providers: StaticProvider[] = [{provide: NgZone, useValue: ngZone}];
+    const ngZoneInjector = Injector.create({
+      providers: providers,
+      parent: this.platform.injector,
+      name: this._moduleFactory.moduleType.name
+    });
     this._moduleRef = this._moduleFactory.create(ngZoneInjector);
     // ApplicationInitStatus.runInitializers() is marked @internal to core. So casting to any
     // before accessing it.

--- a/packages/examples/core/di/ts/provider_spec.ts
+++ b/packages/examples/core/di/ts/provider_spec.ts
@@ -135,7 +135,7 @@ export function main() {
           name = 'square';
         }
 
-        const injector = Injector.create([{provide: Square, deps: []}]);
+        const injector = Injector.create({providers: [{provide: Square, deps: []}]});
 
         const shape: Square = injector.get(Square);
         expect(shape.name).toEqual('square');

--- a/packages/upgrade/src/common/downgrade_component_adapter.ts
+++ b/packages/upgrade/src/common/downgrade_component_adapter.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, ChangeDetectorRef, ComponentFactory, ComponentRef, EventEmitter, Injector, OnChanges, SimpleChange, SimpleChanges, Testability, TestabilityRegistry, Type} from '@angular/core';
+import {ApplicationRef, ChangeDetectorRef, ComponentFactory, ComponentRef, EventEmitter, Injector, OnChanges, SimpleChange, SimpleChanges, StaticProvider, Testability, TestabilityRegistry, Type} from '@angular/core';
 
 import * as angular from './angular1';
 import {PropertyBinding} from './component_info';
@@ -54,8 +54,9 @@ export class DowngradeComponentAdapter {
   }
 
   createComponent(projectableNodes: Node[][]) {
-    const childInjector =
-        Injector.create([{provide: $SCOPE, useValue: this.componentScope}], this.parentInjector);
+    const providers: StaticProvider[] = [{provide: $SCOPE, useValue: this.componentScope}];
+    const childInjector = Injector.create(
+        {providers: providers, parent: this.parentInjector, name: 'DowngradeComponentAdapter'});
 
     this.componentRef =
         this.componentFactory.create(childInjector, projectableNodes, this.element[0]);

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -476,7 +476,12 @@ export declare abstract class Injector {
     /** @deprecated */ abstract get(token: any, notFoundValue?: any): any;
     static NULL: Injector;
     static THROW_IF_NOT_FOUND: Object;
-    static create(providers: StaticProvider[], parent?: Injector): Injector;
+    /** @deprecated */ static create(providers: StaticProvider[], parent?: Injector): Injector;
+    static create(options: {
+        providers: StaticProvider[];
+        parent?: Injector;
+        name?: string;
+    }): Injector;
 }
 
 /** @stable */


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Feature
```

## What is the current behavior?
We need more info on `StaticInjectorError` to help with debugging

Issue Number: #19302


## What is the new behavior?
We add the source component (or module) that tried to inject the missing provider, and we also add the source from the injector which triggered the error

Notes:
- I couldn't get the name of the module containing the component with the failing injector, only the name of the main module (that created the injector).
- I added a property on tokens named `__source`, we could use a different property name (I wasn't inspired), but I'm not sure if it's ok to add a property name like that.
- I'm not sure if adding "Platform: core" for the root injector is really useful, I could remove it


## Does this PR introduce a breaking change?
```
[x] No
```