### PR TITLE
fix(compiler): disallow references for select and index evaluation

### DIFF
--- a/packages/compiler/src/aot/static_reflector.ts
+++ b/packages/compiler/src/aot/static_reflector.ts
@@ -444,7 +444,7 @@ export class StaticReflector implements CompileReflector {
           } else {
             const staticSymbol = expression;
             const declarationValue = resolveReferenceValue(staticSymbol);
-            if (declarationValue) {
+            if (declarationValue != null) {
               return simplifyInContext(staticSymbol, declarationValue, depth + 1, references);
             } else {
               return staticSymbol;
@@ -522,8 +522,8 @@ export class StaticReflector implements CompileReflector {
                 }
                 return null;
               case 'index':
-                let indexTarget = simplify(expression['expression']);
-                let index = simplify(expression['index']);
+                let indexTarget = simplifyInContext(context, expression['expression'], depth, 0);
+                let index = simplifyInContext(context, expression['index'], depth, 0);
                 if (indexTarget && isPrimitive(index)) return indexTarget[index];
                 return null;
               case 'select':
@@ -535,7 +535,7 @@ export class StaticReflector implements CompileReflector {
                   selectContext =
                       self.getStaticSymbol(selectTarget.filePath, selectTarget.name, members);
                   const declarationValue = resolveReferenceValue(selectContext);
-                  if (declarationValue) {
+                  if (declarationValue != null) {
                     return simplifyInContext(
                         selectContext, declarationValue, depth + 1, references);
                   } else {


### PR DESCRIPTION
Also fixes an issue where enum values of 0 or statics of `null`,
`undefined` or '``' where not treated correctly.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #18170

The previous fix for #18170 was incomplete and didn't resolve all the cases that would produce a enum selection in location the compiler does not expect.

## What is the new behavior?

Fixes more of the cases where member values are not expected.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
