### PR TITLE
docs(aio): fix typo in preview server config file comment

### DIFF
--- a/aio/aio-builds-setup/dockerbuild/dnsmasq/dnsmasq.conf
+++ b/aio/aio-builds-setup/dockerbuild/dnsmasq/dnsmasq.conf
@@ -6,7 +6,7 @@ server=8.8.4.4
 # Listen for DHCP and DNS requests only on this address.
 listen-address=127.0.0.1
 
-# Force an IP addres for these domains.
+# Force an IP address for these domains.
 address=/{{$AIO_NGINX_HOSTNAME}}/127.0.0.1
 address=/{{$AIO_UPLOAD_HOSTNAME}}/127.0.0.1
 address=/{{$TEST_AIO_NGINX_HOSTNAME}}/127.0.0.1

--- a/aio/aio-builds-setup/docs/vm-setup--update-docker-container.md
+++ b/aio/aio-builds-setup/docs/vm-setup--update-docker-container.md
@@ -9,7 +9,7 @@ VM host to update the preview server based on changes in the source code.
 The script will pull the latest changes from the origin's master branch and examine if there have
 been any changes in files inside the preview server source code directory (see below). If there are,
 it will create a new image and verify that is works as expected. Finally, it will stop and remove
-the old docker container and image, create and new container based on the new image and start it.
+the old docker container and image, create a new container based on the new image and start it.
 
 The script assumes that the preview server source code is in the repository's
 `aio/aio-builds-setup/` directory and expects the following inputs:


### PR DESCRIPTION
<sub>(I can't get much less insignificant than that 😁)</sub>