### PR TITLE
fix(compiler): correctly instantiate eager providers that are used vi…

### DIFF
--- a/packages/core/src/view/view.ts
+++ b/packages/core/src/view/view.ts
@@ -284,8 +284,11 @@ function createViewNodes(view: ViewData) {
       case NodeFlags.TypeFactoryProvider:
       case NodeFlags.TypeUseExistingProvider:
       case NodeFlags.TypeValueProvider: {
-        const instance = createProviderInstance(view, nodeDef);
-        nodeData = <ProviderData>{instance};
+        nodeData = nodes[i];
+        if (!nodeData && !(nodeDef.flags & NodeFlags.LazyProvider)) {
+          const instance = createProviderInstance(view, nodeDef);
+          nodeData = <ProviderData>{instance};
+        }
         break;
       }
       case NodeFlags.TypePipe: {
@@ -294,11 +297,14 @@ function createViewNodes(view: ViewData) {
         break;
       }
       case NodeFlags.TypeDirective: {
-        const instance = createDirectiveInstance(view, nodeDef);
-        nodeData = <ProviderData>{instance};
+        nodeData = nodes[i];
+        if (!nodeData) {
+          const instance = createDirectiveInstance(view, nodeDef);
+          nodeData = <ProviderData>{instance};
+        }
         if (nodeDef.flags & NodeFlags.Component) {
           const compView = asElementData(view, nodeDef.parent !.nodeIndex).componentView;
-          initView(compView, instance, instance);
+          initView(compView, nodeData.instance, nodeData.instance);
         }
         break;
       }

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -159,6 +159,25 @@ export class TestBed implements Injector {
     return TestBed;
   }
 
+  /**
+   * Overwrites all providers for the given token with the given provider definition.
+   *
+   * @deprecated as it makes all NgModules lazy. Introduced only for migrating off of it.
+   */
+  static deprecatedOverrideProvider(token: any, provider: {
+    useFactory: Function,
+    deps: any[],
+  }): void;
+  static deprecatedOverrideProvider(token: any, provider: {useValue: any;}): void;
+  static deprecatedOverrideProvider(token: any, provider: {
+    useFactory?: Function,
+    useValue?: any,
+    deps?: any[],
+  }): typeof TestBed {
+    getTestBed().deprecatedOverrideProvider(token, provider as any);
+    return TestBed;
+  }
+
   static get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND) {
     return getTestBed().get(token, notFoundValue);
   }
@@ -394,11 +413,33 @@ export class TestBed implements Injector {
     deps: any[],
   }): void;
   overrideProvider(token: any, provider: {useValue: any;}): void;
-  overrideProvider(token: any, provider: {
-    useFactory?: Function,
-    useValue?: any,
-    deps?: any[],
-  }): void {
+  overrideProvider(token: any, provider: {useFactory?: Function, useValue?: any, deps?: any[]}):
+      void {
+    this.overrideProviderImpl(token, provider);
+  }
+
+  /**
+   * Overwrites all providers for the given token with the given provider definition.
+   *
+   * @deprecated as it makes all NgModules lazy. Introduced only for migrating off of it.
+   */
+  deprecatedOverrideProvider(token: any, provider: {
+    useFactory: Function,
+    deps: any[],
+  }): void;
+  deprecatedOverrideProvider(token: any, provider: {useValue: any;}): void;
+  deprecatedOverrideProvider(
+      token: any, provider: {useFactory?: Function, useValue?: any, deps?: any[]}): void {
+    this.overrideProviderImpl(token, provider, /* deprecated */ true);
+  }
+
+  private overrideProviderImpl(
+      token: any, provider: {
+        useFactory?: Function,
+        useValue?: any,
+        deps?: any[],
+      },
+      deprecated = false): void {
     let flags: NodeFlags = 0;
     let value: any;
     if (provider.useFactory) {

--- a/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
+++ b/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
@@ -12,7 +12,7 @@ import {platformBrowserDynamicTesting} from '@angular/platform-browser-dynamic/t
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {DomRendererFactory2} from '@angular/platform-browser/src/dom/dom_renderer';
 import {BrowserTestingModule} from '@angular/platform-browser/testing';
-import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
+import {browserDetection, dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 import {ClientMessageBrokerFactory} from '../../../src/web_workers/shared/client_message_broker';
@@ -29,6 +29,10 @@ export function main() {
   describe('Web Worker Renderer v2', () => {
     // Don't run on server...
     if (!getDOM().supportsDOMEvents()) return;
+    // TODO(tbosch): investigate why this is failing on iOS7 for unrelated reasons
+    // Note: it's hard to debug this as SauceLabs starts with iOS8. Maybe drop
+    // iOS7 alltogether?
+    if (browserDetection.isIOS7) return;
 
     let uiRenderStore: RenderStore;
     let wwRenderStore: RenderStore;

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -71,6 +71,13 @@ export declare class TestBed implements Injector {
     }): void;
     configureTestingModule(moduleDef: TestModuleMetadata): void;
     createComponent<T>(component: Type<T>): ComponentFixture<T>;
+    /** @deprecated */ deprecatedOverrideProvider(token: any, provider: {
+        useFactory: Function;
+        deps: any[];
+    }): void;
+    deprecatedOverrideProvider(token: any, provider: {
+        useValue: any;
+    }): void;
     execute(tokens: any[], fn: Function, context?: any): any;
     get(token: any, notFoundValue?: any): any;
     /** @experimental */ initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): void;
@@ -94,6 +101,13 @@ export declare class TestBed implements Injector {
     }): typeof TestBed;
     static configureTestingModule(moduleDef: TestModuleMetadata): typeof TestBed;
     static createComponent<T>(component: Type<T>): ComponentFixture<T>;
+    /** @deprecated */ static deprecatedOverrideProvider(token: any, provider: {
+        useFactory: Function;
+        deps: any[];
+    }): void;
+    static deprecatedOverrideProvider(token: any, provider: {
+        useValue: any;
+    }): void;
     static get(token: any, notFoundValue?: any): any;
     /** @experimental */ static initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
     static overrideComponent(component: Type<any>, override: MetadataOverride<Component>): typeof TestBed;


### PR DESCRIPTION
…a `Injector.get`

This also fixes the problem that all `NgModule` instances
became lazy when using `TestBed.overrideProvider`.

Closes #15501

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
