### PR TITLE
perf(compiler): fix perf issue in loading aot summaries in jit compiler

### DIFF
--- a/packages/compiler/src/jit/compiler.ts
+++ b/packages/compiler/src/jit/compiler.ts
@@ -382,14 +382,22 @@ class ModuleBoundCompiler implements Compiler {
 }
 
 
-function flattenSummaries(fn: () => any[], out: CompileTypeSummary[] = []): CompileTypeSummary[] {
-  fn().forEach((entry) => {
+function flattenSummaries(
+    fn: () => any[], out: CompileTypeSummary[] = [],
+    seen = new Set<() => any[]>()): CompileTypeSummary[] {
+  if (seen.has(fn)) {
+    return out;
+  }
+  seen.add(fn);
+  const summaries = fn();
+  for (let i = 0; i < summaries.length; i++) {
+    const entry = summaries[i];
     if (typeof entry === 'function') {
-      flattenSummaries(entry, out);
+      flattenSummaries(entry, out, seen);
     } else {
       out.push(entry);
     }
-  });
+  }
   return out;
 }
 


### PR DESCRIPTION
The current `flattenSummaries` function re-process the same NgModule
summary even if it has been processed before. Certain modules like
CommonModule are repeated multiple times in the module tree and it is
expanded out every time.

This was making unit tests using AOT summaries really slow. This will
also slow down JIT bootstrap applications that load AOT summaries for
component libraries.

The fix is to remember which summaries were seen before and not to
process them again.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```
