### PR TITLE
fix(tsc-wrapped): don't rewrite imports when annotating for closure

### DIFF
--- a/tools/@angular/tsc-wrapped/src/main.ts
+++ b/tools/@angular/tsc-wrapped/src/main.ts
@@ -111,7 +111,7 @@ export function main(
     }
 
     const tsickleCompilerHostOptions:
-        tsickle.Options = {googmodule: false, untyped: true, convertIndexImportShorthand: true};
+        tsickle.Options = {googmodule: false, untyped: true, convertIndexImportShorthand: false};
 
     const tsickleHost: tsickle.TsickleHost = {
       shouldSkipTsickleProcessing: (fileName) => /\.d\.ts$/.test(fileName),

--- a/tools/@angular/tsc-wrapped/test/main.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/main.spec.ts
@@ -75,7 +75,7 @@ describe('tsc-wrapped', () => {
           // No helpers since decorators were lowered
           expect(out).not.toContain('__decorate');
           // Expand `export *` and fix index import
-          expect(out).toContain(`export { A, B } from './dep/index'`);
+          expect(out).toContain(`export { A, B } from './dep'`);
           // Annotated for Closure compiler
           expect(out).toContain('* @param {?} x');
           // Comments should stay multi-line
@@ -112,7 +112,7 @@ describe('tsc-wrapped', () => {
         .then(() => {
           const out = readOut('js');
           // Expand `export *` and fix index import
-          expect(out).toContain(`export { A, B } from './dep/index'`);
+          expect(out).toContain(`export { A, B } from './dep'`);
           // Annotated for Closure compiler
           expect(out).toContain('* @param {?} x');
           done();
@@ -367,7 +367,7 @@ describe('tsc-wrapped', () => {
         .catch(e => done.fail(e));
   });
 
-  it('should expand shorthand imports for ES2015 modules', (done) => {
+  it('should not expand shorthand imports for ES2015 modules', (done) => {
     write('tsconfig.json', `{
       "compilerOptions": {
         "experimentalDecorators": true,
@@ -387,13 +387,13 @@ describe('tsc-wrapped', () => {
     main(basePath, {basePath})
         .then(() => {
           const fileOutput = readOut('js');
-          expect(fileOutput).toContain(`export { A, B } from './dep/index'`);
+          expect(fileOutput).toContain(`export { A, B } from './dep'`);
           done();
         })
         .catch(e => done.fail(e));
   });
 
-  it('should expand shorthand imports for ES5 CommonJS modules', (done) => {
+  it('should not expand shorthand imports for ES5 CommonJS modules', (done) => {
     write('tsconfig.json', `{
       "compilerOptions": {
         "experimentalDecorators": true,
@@ -413,7 +413,7 @@ describe('tsc-wrapped', () => {
     main(basePath, {basePath})
         .then(() => {
           const fileOutput = readOut('js');
-          expect(fileOutput).toContain(`var index_1 = require("./dep/index");`);
+          expect(fileOutput).toContain(`var dep_1 = require("./dep");`);
           done();
         })
         .catch(e => done.fail(e));


### PR DESCRIPTION
Port of f24ea59f74552113f8e8586d2d69045254512aa to 4.4.x

Closure no longer needs to have the imports rewritten so avoid
rewriting as this can cause issues when the source directory
structure differs from what is deployed.

Fixes: #17171

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #17171

## What is the new behavior?

No longer rewrites imports when compiling for Closure as closure no longer needs the rewriting.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
