### PR TITLE
fix(compiler): generate correct imports for type check blocks

### DIFF
--- a/packages/compiler-cli/integrationtest/test/i18n_spec.ts
+++ b/packages/compiler-cli/integrationtest/test/i18n_spec.ts
@@ -34,10 +34,10 @@ const EXPECTED_XMB = `<?xml version="1.0" encoding="UTF-8" ?>
 <!ELEMENT ex (#PCDATA)>
 ]>
 <messagebundle>
-  <msg id="8136548302122759730" desc="desc" meaning="meaning"><source>src/basic.ts:1</source>translate me</msg>
-  <msg id="3492007542396725315"><source>src/basic.ts:5</source><source>src/entry_components.ts:1</source>Welcome</msg>
   <msg id="126808141597411718"><source>node_modules/third_party/other_comp.d.ts:1,2</source>other-3rdP-component
 multi-lines</msg>
+  <msg id="8136548302122759730" desc="desc" meaning="meaning"><source>src/basic.ts:1</source>translate me</msg>
+  <msg id="3492007542396725315"><source>src/basic.ts:5</source><source>src/entry_components.ts:1</source>Welcome</msg>
 </messagebundle>
 `;
 
@@ -45,6 +45,14 @@ const EXPECTED_XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="fr" datatype="plaintext" original="ng2.template">
     <body>
+      <trans-unit id="b0a17f08a4bd742b2acf39780c257c2f519d33ed" datatype="html">
+        <source>other-3rdP-component
+multi-lines</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">node_modules/third_party/other_comp.d.ts</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="76e1eccb1b772fa9f294ef9c146ea6d0efa8a2d4" datatype="html">
         <source>translate me</source>
         <context-group purpose="location">
@@ -65,14 +73,6 @@ const EXPECTED_XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b0a17f08a4bd742b2acf39780c257c2f519d33ed" datatype="html">
-        <source>other-3rdP-component
-multi-lines</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">node_modules/third_party/other_comp.d.ts</context>
-          <context context-type="linenumber">1</context>
-        </context-group>
-      </trans-unit>
     </body>
   </file>
 </xliff>
@@ -81,6 +81,15 @@ multi-lines</source>
 const EXPECTED_XLIFF2 = `<?xml version="1.0" encoding="UTF-8" ?>
 <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en">
   <file original="ng.template" id="ngi18n">
+    <unit id="126808141597411718">
+      <notes>
+        <note category="location">node_modules/third_party/other_comp.d.ts:1,2</note>
+      </notes>
+      <segment>
+        <source>other-3rdP-component
+multi-lines</source>
+      </segment>
+    </unit>
     <unit id="8136548302122759730">
       <notes>
         <note category="description">desc</note>
@@ -98,15 +107,6 @@ const EXPECTED_XLIFF2 = `<?xml version="1.0" encoding="UTF-8" ?>
       </notes>
       <segment>
         <source>Welcome</source>
-      </segment>
-    </unit>
-    <unit id="126808141597411718">
-      <notes>
-        <note category="location">node_modules/third_party/other_comp.d.ts:1,2</note>
-      </notes>
-      <segment>
-        <source>other-3rdP-component
-multi-lines</source>
       </segment>
     </unit>
   </file>

--- a/packages/compiler-cli/test/diagnostics/check_types_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/check_types_spec.ts
@@ -114,6 +114,11 @@ describe('ng type checker', () => {
        () => { a('{{maybePerson!.name}}'); });
     it('should accept a safe property access of a nullable person',
        () => { a('{{maybePerson?.name}}'); });
+
+    it('should accept using a library pipe', () => { a('{{1 | libPipe}}'); });
+    it('should accept using a library directive',
+       () => { a('<div libDir #libDir="libDir">{{libDir.name}}</div>'); });
+
     it('should accept a function call', () => { a('{{getName()}}'); });
     it('should reject an invalid method', () => {
       r('<div>{{getFame()}}</div>',
@@ -211,13 +216,37 @@ function appComponentSource(): string {
 const QUICKSTART = {
   'src/app.component.ts': appComponentSource(),
   'src/app.component.html': '<h1>Hello {{name}}</h1>',
+  'src/lib.ts': `
+    import {Pipe, Directive} from '@angular/core';
+
+    @Pipe({ name: 'libPipe' })
+    export class LibPipe {
+      transform(n: number): number { return n + 1; }
+    }
+
+    @Directive({
+      selector: '[libDir]',
+      exportAs: 'libDir'
+    })
+    export class LibDirective {
+      name: string;
+    }
+  `,
   'src/app.module.ts': `
     import { NgModule }      from '@angular/core';
     import { AppComponent, APipe, ADirective }  from './app.component';
+    import { LibDirective, LibPipe } from './lib';
+
+    @NgModule({
+      declarations: [ LibPipe, LibDirective ],
+      exports: [ LibPipe, LibDirective ],
+    })
+    export class LibModule { }
 
     @NgModule({
       declarations: [ AppComponent, APipe, ADirective ],
-      bootstrap:    [ AppComponent ]
+      bootstrap:    [ AppComponent ],
+      imports:      [ LibModule ]
     })
     export class AppModule { }
   `

--- a/packages/compiler/src/aot/compiler.ts
+++ b/packages/compiler/src/aot/compiler.ts
@@ -204,8 +204,8 @@ export class AotCompiler {
       // and they also cause TypeScript to include these files into the program too,
       // which will make them part of the analyzedFiles.
       const externalReferences: StaticSymbol[] = [
-        ...ngModuleMeta.declaredDirectives.map(d => d.reference),
-        ...ngModuleMeta.declaredPipes.map(d => d.reference),
+        ...ngModuleMeta.transitiveModule.directives.map(d => d.reference),
+        ...ngModuleMeta.transitiveModule.pipes.map(d => d.reference),
         ...ngModuleMeta.importedModules.map(m => m.type.reference),
         ...ngModuleMeta.exportedModules.map(m => m.type.reference),
       ];


### PR DESCRIPTION
Fixes: #19485

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue Number: #19485 

The compiler would not generate all the necessary variables to ensure correct imports for type-check blocks.

## What is the new behavior?

All the require variables are generated ensuring the correct imports are generated.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
