### PR TITLE
fix(router): avoid applying active class to null router links

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -103,6 +103,7 @@ export class RouterLink {
   @Input() replaceUrl: boolean;
   private commands: any[] = [];
   private preserve: boolean;
+  private reachable: boolean;
 
   constructor(
       private router: Router, private route: ActivatedRoute,
@@ -114,9 +115,11 @@ export class RouterLink {
 
   @Input()
   set routerLink(commands: any[]|string) {
-    if (commands != null) {
+    if (commands !== null && commands !== undefined && commands !== []) {
+      this.reachable = true;
       this.commands = Array.isArray(commands) ? commands : [commands];
     } else {
+      this.reachable = false;
       this.commands = [];
     }
   }
@@ -152,6 +155,8 @@ export class RouterLink {
       preserveFragment: attrBoolValue(this.preserveFragment),
     });
   }
+
+  get isReachable(): boolean { return this.reachable; }
 }
 
 /**
@@ -175,7 +180,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   private commands: any[] = [];
   private subscription: Subscription;
   private preserve: boolean;
-
+  private reachable: boolean = true;
   // the url displayed on the anchor element.
   @HostBinding() href: string;
 
@@ -191,9 +196,11 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
 
   @Input()
   set routerLink(commands: any[]|string) {
-    if (commands != null) {
+    if (commands !== null && commands !== undefined && commands !== []) {
+      this.reachable = true;
       this.commands = Array.isArray(commands) ? commands : [commands];
     } else {
+      this.reachable = false;
       this.commands = [];
     }
   }
@@ -241,6 +248,8 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
       preserveFragment: attrBoolValue(this.preserveFragment),
     });
   }
+
+  get isReachable(): boolean { return this.reachable; }
 }
 
 function attrBoolValue(s: any): boolean {

--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -100,7 +100,6 @@ export class RouterLinkActive implements OnChanges,
     });
   }
 
-
   ngAfterContentInit(): void {
     this.links.changes.subscribe(_ => this.update());
     this.linksWithHrefs.changes.subscribe(_ => this.update());
@@ -136,8 +135,8 @@ export class RouterLinkActive implements OnChanges,
   }
 
   private isLinkActive(router: Router): (link: (RouterLink|RouterLinkWithHref)) => boolean {
-    return (link: RouterLink | RouterLinkWithHref) =>
-               router.isActive(link.urlTree, this.routerLinkActiveOptions.exact);
+    return (link: RouterLink | RouterLinkWithHref) => link.isReachable &&
+        router.isActive(link.urlTree, this.routerLinkActiveOptions.exact);
   }
 
   private hasActiveLinks(): boolean {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -2790,6 +2790,40 @@ describe('Integration', () => {
          expect(paragraph.textContent).toEqual('false');
        }));
 
+    it('should not set active class when routerLink is null or []', fakeAsync(() => {
+         @Component({
+           selector: 'someCmp',
+           template: `<router-outlet></router-outlet>
+            <button id="home" routerLink="/home" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">Button</button>
+            <button id="empty-array-button" routerLink="[]" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">Button</button>
+            <a routerLink="null" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">Link</a>`
+         })
+         class CmpWithUnreachableLinks {
+         }
+
+         TestBed.configureTestingModule({declarations: [CmpWithUnreachableLinks]});
+         const router: Router = TestBed.get(Router);
+         router.resetConfig([{path: 'home', component: SimpleCmp}]);
+
+         const fixture = TestBed.createComponent(CmpWithUnreachableLinks);
+
+         advance(fixture);
+         const homeButton = fixture.nativeElement.querySelector('#home');
+         const anchor = fixture.nativeElement.querySelector('a');
+         const button = fixture.nativeElement.querySelector('#empty-array-button');
+
+         expect(homeButton.className).toEqual('');
+         expect(button.className).toEqual('');
+         expect(anchor.className).toEqual('');
+
+         router.navigateByUrl('/home');
+         expect(() => advance(fixture)).not.toThrow();
+         advance(fixture);
+
+         expect(homeButton.className).toEqual('active');
+         expect(button.className).not.toEqual('active');
+         expect(anchor.className).not.toEqual('active');
+       }));
   });
 
   describe('lazy loading', () => {


### PR DESCRIPTION
Null roots should not have the active class applied to them.

Closes #18347

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #18347

## What is the new behavior?
Avoid applying the active class to null router links.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

