### PR TITLE
feat(common): accept numeric value for HttpClient params

### DIFF
--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -247,7 +247,7 @@ Adding URL parameters works in the same way. To send a request with the `id` par
 ```javascript
 http
   .post('/api/items/add', body, {
-    params: new HttpParams().set('id', '3'),
+    params: {id: 3},
   })
   .subscribe();
 ```

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -28,7 +28,7 @@ function addBody<T>(
     options: {
       headers?: HttpHeaders | {[header: string]: string | string[]},
       observe?: HttpObserve,
-      params?: HttpParams | {[param: string]: string | string[]},
+      params?: HttpParams | {[param: string]: string | number | (string | number)[]},
       reportProgress?: boolean,
       responseType?: 'arraybuffer' | 'blob' | 'json' | 'text',
       withCredentials?: boolean,
@@ -77,7 +77,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -91,7 +91,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -105,7 +105,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -118,7 +118,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     observe: 'events', reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
@@ -132,7 +132,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
@@ -146,7 +146,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
@@ -161,7 +161,7 @@ export class HttpClient {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     reportProgress?: boolean,
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     responseType?: 'json',
     withCredentials?: boolean,
   }): Observable<HttpEvent<any>>;
@@ -176,7 +176,7 @@ export class HttpClient {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     reportProgress?: boolean,
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     responseType?: 'json',
     withCredentials?: boolean,
   }): Observable<HttpEvent<R>>;
@@ -190,7 +190,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
@@ -204,7 +204,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
@@ -218,7 +218,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
@@ -233,7 +233,7 @@ export class HttpClient {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     reportProgress?: boolean,
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     responseType?: 'json',
     withCredentials?: boolean,
   }): Observable<HttpResponse<Object>>;
@@ -248,7 +248,7 @@ export class HttpClient {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     reportProgress?: boolean,
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     responseType?: 'json',
     withCredentials?: boolean,
   }): Observable<HttpResponse<R>>;
@@ -262,7 +262,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     responseType?: 'json',
     reportProgress?: boolean,
     withCredentials?: boolean,
@@ -277,7 +277,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     responseType?: 'json',
     reportProgress?: boolean,
     withCredentials?: boolean,
@@ -292,7 +292,7 @@ export class HttpClient {
   request(method: string, url: string, options?: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     observe?: HttpObserve,
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
@@ -334,7 +334,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -456,7 +456,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -470,7 +470,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -483,7 +483,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -496,7 +496,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
@@ -509,7 +509,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
@@ -522,7 +522,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
@@ -535,7 +535,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -549,7 +549,7 @@ export class HttpClient {
   delete<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -563,7 +563,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
@@ -576,7 +576,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
@@ -589,7 +589,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
@@ -602,7 +602,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -616,7 +616,7 @@ export class HttpClient {
   delete<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -630,7 +630,7 @@ export class HttpClient {
   delete (url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -644,7 +644,7 @@ export class HttpClient {
   delete<T>(url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -658,7 +658,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -675,7 +675,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -688,7 +688,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -701,7 +701,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -714,7 +714,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
@@ -727,7 +727,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
@@ -740,7 +740,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
@@ -753,7 +753,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -767,7 +767,7 @@ export class HttpClient {
   get<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -781,7 +781,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
@@ -794,7 +794,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
@@ -807,7 +807,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
@@ -820,7 +820,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -834,7 +834,7 @@ export class HttpClient {
   get<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -848,7 +848,7 @@ export class HttpClient {
   get(url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -862,7 +862,7 @@ export class HttpClient {
   get<T>(url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -876,7 +876,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -893,7 +893,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
 
@@ -906,7 +906,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -919,7 +919,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -932,7 +932,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
@@ -945,7 +945,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
@@ -958,7 +958,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
@@ -971,7 +971,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -985,7 +985,7 @@ export class HttpClient {
   head<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -999,7 +999,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
@@ -1012,7 +1012,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
@@ -1025,7 +1025,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
@@ -1038,7 +1038,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1052,7 +1052,7 @@ export class HttpClient {
   head<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1066,7 +1066,7 @@ export class HttpClient {
   head(url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1080,7 +1080,7 @@ export class HttpClient {
   head<T>(url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1094,7 +1094,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -1140,7 +1140,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -1153,7 +1153,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -1166,7 +1166,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -1179,7 +1179,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
@@ -1192,7 +1192,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
@@ -1205,7 +1205,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
@@ -1218,7 +1218,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1232,7 +1232,7 @@ export class HttpClient {
   options<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1246,7 +1246,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
@@ -1259,7 +1259,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
@@ -1272,7 +1272,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
@@ -1285,7 +1285,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1299,7 +1299,7 @@ export class HttpClient {
   options<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1313,7 +1313,7 @@ export class HttpClient {
   options(url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1327,7 +1327,7 @@ export class HttpClient {
   options<T>(url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1341,7 +1341,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -1357,7 +1357,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -1370,7 +1370,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -1383,7 +1383,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -1396,7 +1396,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
@@ -1409,7 +1409,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
@@ -1422,7 +1422,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
@@ -1435,7 +1435,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1449,7 +1449,7 @@ export class HttpClient {
   patch<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1463,7 +1463,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
@@ -1476,7 +1476,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
@@ -1489,7 +1489,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
@@ -1502,7 +1502,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1516,7 +1516,7 @@ export class HttpClient {
   patch<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1530,7 +1530,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1544,7 +1544,7 @@ export class HttpClient {
   patch<T>(url: string, body: any|null, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1558,7 +1558,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -1574,7 +1574,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -1587,7 +1587,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -1600,7 +1600,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -1613,7 +1613,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
@@ -1626,7 +1626,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
@@ -1639,7 +1639,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
@@ -1652,7 +1652,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1666,7 +1666,7 @@ export class HttpClient {
   post<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1680,7 +1680,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
@@ -1693,7 +1693,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
@@ -1706,7 +1706,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
@@ -1719,7 +1719,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1733,7 +1733,7 @@ export class HttpClient {
   post<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1747,7 +1747,7 @@ export class HttpClient {
   post(url: string, body: any|null, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1761,7 +1761,7 @@ export class HttpClient {
   post<T>(url: string, body: any|null, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1775,7 +1775,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -1791,7 +1791,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -1804,7 +1804,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -1817,7 +1817,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -1830,7 +1830,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
@@ -1843,7 +1843,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
@@ -1856,7 +1856,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
@@ -1869,7 +1869,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1893,7 +1893,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
@@ -1906,7 +1906,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
@@ -1919,7 +1919,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
@@ -1932,7 +1932,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1946,7 +1946,7 @@ export class HttpClient {
   put<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1960,7 +1960,7 @@ export class HttpClient {
   put(url: string, body: any|null, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1974,7 +1974,7 @@ export class HttpClient {
   put<T>(url: string, body: any|null, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1988,7 +1988,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: HttpParams|{[param: string]: string | number | (string | number)[]},
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,

--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -82,7 +82,7 @@ export interface HttpParamsOptions {
   fromString?: string;
 
   /** Object map of the HTTP params. Mutally exclusive with `fromString`. */
-  fromObject?: {[param: string]: string | string[]};
+  fromObject?: {[param: string]: string | number | (string | number)[]};
 
   /** Encoding codec used to parse and serialize the params. */
   encoder?: HttpParameterCodec;

--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -45,9 +45,25 @@ export function main() {
         expect(req.request.headers.get('X-Option')).toEqual('true');
         req.flush({});
       });
-      it('with params', (done: DoneFn) => {
+      it('with string params only', (done: DoneFn) => {
         client.get('/test', {params: {'test': 'true'}}).subscribe(() => done());
         backend.expectOne('/test?test=true').flush({});
+      });
+      it('with numeric and string params', (done: DoneFn) => {
+        client
+            .get('/test', {
+              params: {'test-string': 'true', 'test-numeric': 12.3, 'test-array': [1, 2, 'abc']}
+            })
+            .subscribe(() => done());
+        backend
+            .expectOne(
+                '/test?' +
+                'test-string=true&' +
+                'test-numeric=12.3&' +
+                'test-array=1&' +
+                'test-array=2&' +
+                'test-array=abc')
+            .flush({});
       });
       it('for an arraybuffer', (done: DoneFn) => {
         const body = new ArrayBuffer(4);

--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -110,6 +110,11 @@ export function isNavigationCancelingError(error: Error) {
 // Matches the route configuration (`route`) against the actual URL (`segments`).
 export function defaultUrlMatcher(
     segments: UrlSegment[], segmentGroup: UrlSegmentGroup, route: Route): UrlMatchResult|null {
+  if (!route.hasOwnProperty('path')) {
+    // This is an invalid router config
+    return null;
+  }
+
   const parts = route.path !.split('/');
 
   if (parts.length > segments.length) {

--- a/tools/public_api_guard/common/http.d.ts
+++ b/tools/public_api_guard/common/http.d.ts
@@ -15,7 +15,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -27,7 +27,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -39,7 +39,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -51,7 +51,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -63,7 +63,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -75,7 +75,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -87,7 +87,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -99,7 +99,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -111,7 +111,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -123,7 +123,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -135,7 +135,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -147,7 +147,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -159,7 +159,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -171,7 +171,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -183,7 +183,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -195,7 +195,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -207,7 +207,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -219,7 +219,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -231,7 +231,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -243,7 +243,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -255,7 +255,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -267,7 +267,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -279,7 +279,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -291,7 +291,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -303,7 +303,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -315,7 +315,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -327,7 +327,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -339,7 +339,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -351,7 +351,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -363,7 +363,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -375,7 +375,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -387,7 +387,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -399,7 +399,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -411,7 +411,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -423,7 +423,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -435,7 +435,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -447,7 +447,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -459,7 +459,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -471,7 +471,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -483,7 +483,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -495,7 +495,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -507,7 +507,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -519,7 +519,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -531,7 +531,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -543,7 +543,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -557,7 +557,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -569,7 +569,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -581,7 +581,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -593,7 +593,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -605,7 +605,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -617,7 +617,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -629,7 +629,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -641,7 +641,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -653,7 +653,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -665,7 +665,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -677,7 +677,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -689,7 +689,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -701,7 +701,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -713,7 +713,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -725,7 +725,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -737,7 +737,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -749,7 +749,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -761,7 +761,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -773,7 +773,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -785,7 +785,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -797,7 +797,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -809,7 +809,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -821,7 +821,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -833,7 +833,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -845,7 +845,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -857,7 +857,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -869,7 +869,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -881,7 +881,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -893,7 +893,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -905,7 +905,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -917,7 +917,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -929,7 +929,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -941,7 +941,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -953,7 +953,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -965,7 +965,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -977,7 +977,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -989,7 +989,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -1001,7 +1001,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -1013,7 +1013,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -1025,7 +1025,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -1037,7 +1037,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -1049,7 +1049,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -1061,7 +1061,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -1073,7 +1073,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -1085,7 +1085,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -1097,7 +1097,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -1109,7 +1109,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -1121,7 +1121,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -1133,7 +1133,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -1145,7 +1145,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -1157,7 +1157,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -1177,7 +1177,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -1189,7 +1189,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -1201,7 +1201,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -1213,7 +1213,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -1225,7 +1225,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -1237,7 +1237,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -1249,7 +1249,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -1261,7 +1261,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType?: 'json';
@@ -1275,7 +1275,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         responseType?: 'json';
         withCredentials?: boolean;
@@ -1287,7 +1287,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         responseType?: 'json';
         reportProgress?: boolean;
@@ -1300,7 +1300,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -1313,7 +1313,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -1326,7 +1326,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -1338,7 +1338,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         observe: 'events';
         reportProgress?: boolean;
@@ -1352,7 +1352,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -1365,7 +1365,7 @@ export declare class HttpClient {
         };
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -1380,7 +1380,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         observe: 'events';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         responseType?: 'json';
         withCredentials?: boolean;
@@ -1392,7 +1392,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -1405,7 +1405,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'blob';
@@ -1418,7 +1418,7 @@ export declare class HttpClient {
         };
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         reportProgress?: boolean;
         responseType: 'text';
@@ -1432,7 +1432,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         responseType?: 'json';
         withCredentials?: boolean;
@@ -1445,7 +1445,7 @@ export declare class HttpClient {
         reportProgress?: boolean;
         observe: 'response';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         responseType?: 'json';
         withCredentials?: boolean;
@@ -1457,7 +1457,7 @@ export declare class HttpClient {
         };
         observe?: 'body';
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         responseType?: 'json';
         reportProgress?: boolean;
@@ -1469,7 +1469,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         params?: HttpParams | {
-            [param: string]: string | string[];
+            [param: string]: string | number | (string | number)[];
         };
         observe?: HttpObserve;
         reportProgress?: boolean;


### PR DESCRIPTION
The `HttpParamsOptions.fromObject` property accepts only `string` or `string[]` which leads to:
* our users have to covert numeric into string by themselves;
* additional type adaptation work on the server side, such as the logic of the service side have to
  receive a number with a string type variable and then convert it to a number;

 All these indirections are unnecessary.

fixes #19071

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `HttpParamsOptions.fromObject` property accepts only `string` or `string[]` value, and do not accept `number` or `number[]` value.

Here is a example comes from [the fundamentals of HttpClient](https://angular.io/guide/http#url-parameters):

```
http
  .post('/api/items/add', body, {
    params: {id: '3'}, // <- our users have to convert this numeric value to a string value.
  })
  .subscribe();
```

Issue Number: #19071


## What is the new behavior?
The `HttpParamsOptions.fromObject` property accepts both `string` or `number` or `(string|number)[]` value.

the former example can be simplified:

```
http
  .post('/api/items/add', body, {
    params: {id: 3}, // <- our users can directly provide a numeric value now
  })
  .subscribe();
```

And, the server-side-guy do not need to use a string value to receive `id` property anymore.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
