### PR TITLE
ci(aio): freeze the lockfile for CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - restore_cache:
           key: angular-{{ .Branch }}-{{ checksum "yarn.lock" }}
 
-      - run: yarn install
+      - run: yarn install --freeze-lockfile --non-interactive
       - run: ./node_modules/.bin/gulp lint
 
   build:

--- a/aio/aio-builds-setup/dockerbuild/Dockerfile
+++ b/aio/aio-builds-setup/dockerbuild/Dockerfile
@@ -156,7 +156,7 @@ RUN find $AIO_SCRIPTS_SH_DIR -maxdepth 1 -type f -printf "%P\n" \
 # Set up the Node.js scripts
 COPY scripts-js/ $AIO_SCRIPTS_JS_DIR/
 WORKDIR $AIO_SCRIPTS_JS_DIR/
-RUN yarn install --production
+RUN yarn install --production --freeze-lockfile
 
 
 # Set up health check

--- a/aio/aio-builds-setup/scripts/create-image.sh
+++ b/aio/aio-builds-setup/scripts/create-image.sh
@@ -9,7 +9,7 @@ readonly defaultImageNameAndTag="aio-builds:latest"
 # (Necessary, because only `scripts-js/dist/` is copied to the docker image.)
 (
   cd "$SCRIPTS_JS_DIR"
-  yarn install
+  yarn install --freeze-lockfile --non-interactive
   yarn build
 )
 

--- a/aio/aio-builds-setup/scripts/test.sh
+++ b/aio/aio-builds-setup/scripts/test.sh
@@ -7,6 +7,6 @@ source "`dirname $0`/_env.sh"
 # Test `scripts-js/`
 (
   cd "$SCRIPTS_JS_DIR"
-  yarn install
+  yarn install --freeze-lockfile --non-interactive
   yarn test
 )

--- a/aio/package.json
+++ b/aio/package.json
@@ -19,7 +19,7 @@
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn ~~update-webdriver",
     "e2e": "ng e2e --no-webdriver-update",
-    "presetup": "yarn install && yarn ~~check-env && yarn boilerplate:remove",
+    "presetup": "yarn install --freeze-lockfile && yarn ~~check-env && yarn boilerplate:remove",
     "setup": "yarn aio-use-npm && yarn example-use-npm",
     "postsetup": "yarn boilerplate:add && yarn build-ie-polyfills && yarn generate-plunkers && yarn generate-zips && yarn docs",
     "presetup-local": "yarn presetup",

--- a/aio/tools/ng-packages-installer/index.js
+++ b/aio/tools/ng-packages-installer/index.js
@@ -96,7 +96,7 @@ class NgPackagesInstaller {
    * Yarn will also delete the local marker file for us.
    */
   restoreNpmDependencies() {
-    this._installDeps('--check-files');
+    this._installDeps('--freeze-lockfile', '--check-files');
   }
 
   // Protected helpers

--- a/aio/tools/ng-packages-installer/index.spec.js
+++ b/aio/tools/ng-packages-installer/index.spec.js
@@ -144,10 +144,10 @@ describe('NgPackagesInstaller', () => {
   });
 
   describe('restoreNpmDependencies()', () => {
-    it('should run `yarn install --check-files` in the specified directory', () => {
+    it('should run `yarn install` in the specified directory, with the correct options', () => {
       spyOn(installer, '_installDeps');
       installer.restoreNpmDependencies();
-      expect(installer._installDeps).toHaveBeenCalledWith('--check-files');
+      expect(installer._installDeps).toHaveBeenCalledWith('--freeze-lockfile', '--check-files');
     });
   });
 

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -52,7 +52,7 @@ if [[ ${TRAVIS} && (${CI_MODE} == "aio" || ${CI_MODE} == "aio_e2e" || ${CI_MODE}
   travisFoldStart "yarn-install.aio"
     (
       cd ${PROJECT_ROOT}/aio
-      yarn install
+      yarn install --frozen-lockfile --non-interactive
     )
   travisFoldEnd "yarn-install.aio"
 fi

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -37,7 +37,7 @@ travisFoldEnd "install-yarn"
 
 # Install all npm dependencies according to yarn.lock
 travisFoldStart "yarn-install"
-  node tools/npm/check-node-modules --purge || yarn install
+  node tools/npm/check-node-modules --purge || yarn install --freeze-lockfile --non-interactive
 travisFoldEnd "yarn-install"
 
 


### PR DESCRIPTION
The CI will now fail if the dependencies in the AIO
package.json have been modified without the
lockfile being updated.
