### PR TITLE
fix(compiler): `TestBed.overrideProvider` should keep imported `NgModule`s eager

### DIFF
--- a/packages/core/src/view/types.ts
+++ b/packages/core/src/view/types.ts
@@ -506,6 +506,7 @@ export interface ProviderOverride {
   flags: NodeFlags;
   value: any;
   deps: ([DepFlags, any]|any)[];
+  deprecatedBehavior: boolean;
 }
 
 export interface Services {

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -467,7 +467,7 @@ export class TestBed implements Injector {
       }
       return [depFlags, depToken];
     });
-    overrideProvider({token, flags, deps, value});
+    overrideProvider({token, flags, deps, value, deprecatedBehavior: deprecated});
   }
 
   createComponent<T>(component: Type<T>): ComponentFixture<T> {

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -468,6 +468,46 @@ export function main() {
             expect(modFactory.create(getTestBed()).injector.get('a')).toBe('mockA: parentDepValue');
           });
 
+          it('should keep imported NgModules eager', () => {
+            let someModule: SomeModule|undefined;
+
+            @NgModule()
+            class SomeModule {
+              constructor() { someModule = this; }
+            }
+
+            TestBed.configureTestingModule({
+              providers: [
+                {provide: 'a', useValue: 'aValue'},
+              ],
+              imports: [SomeModule]
+            });
+            TestBed.overrideProvider('a', {useValue: 'mockValue'});
+
+            expect(TestBed.get('a')).toBe('mockValue');
+            expect(someModule).toBeAnInstanceOf(SomeModule);
+          });
+
+          it('should keep imported NgModules lazy with deprecatedOverrideProvider', () => {
+            let someModule: SomeModule|undefined;
+
+            @NgModule()
+            class SomeModule {
+              constructor() { someModule = this; }
+            }
+
+            TestBed.configureTestingModule({
+              providers: [
+                {provide: 'a', useValue: 'aValue'},
+              ],
+              imports: [SomeModule]
+            });
+            TestBed.deprecatedOverrideProvider('a', {useValue: 'mockValue'});
+
+            expect(TestBed.get('a')).toBe('mockValue');
+            expect(someModule).toBeUndefined();
+          });
+
           describe('injecting eager providers into an eager overwritten provider', () => {
             @NgModule({
               providers: [


### PR DESCRIPTION
The first 2 commits are from https://github.com/angular/angular/pull/19558. Before this PR is merged, we need to change some tests in G3 to use the new `TestBed.deprecatedOverrideProvider` so they won't break.