### PR TITLE
build(aio): upgrade `lighthouse` and remove unnecessary build step

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -121,7 +121,7 @@
     "karma-coverage-istanbul-reporter": "^1.3.0",
     "karma-jasmine": "^1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "lighthouse": "^2.1.0",
+    "lighthouse": "^2.5.0",
     "lodash": "^4.17.4",
     "lunr": "^2.1.0",
     "protractor": "~5.1.0",

--- a/aio/package.json
+++ b/aio/package.json
@@ -25,7 +25,6 @@
     "presetup-local": "yarn presetup",
     "setup-local": "yarn aio-use-local && yarn example-use-local",
     "postsetup-local": "yarn postsetup",
-    "pretest-pwa-score-localhost": "yarn build",
     "test-pwa-score-localhost": "concurrently --kill-others --success first \"http-server dist -p 4200 --silent\" \"yarn test-pwa-score http://localhost:4200 90\"",
     "test-pwa-score": "node scripts/test-pwa-score",
     "example-e2e": "yarn example-check-local && node ./tools/examples/run-example-e2e",

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -4998,7 +4998,7 @@ lighthouse-logger@^1.0.0:
   dependencies:
     debug "^2.6.8"
 
-lighthouse@^2.1.0:
+lighthouse@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/lighthouse/-/lighthouse-2.5.0.tgz#c38c3bb0cfc5645bd59ed2550531bdc59a6c8fdd"
   dependencies:

--- a/scripts/ci/test-aio.sh
+++ b/scripts/ci/test-aio.sh
@@ -18,6 +18,13 @@ source ${thisDir}/_travis-fold.sh
   travisFoldEnd "test.aio.lint"
 
 
+  # Run PWA-score tests
+  # (Run before unit and e2e tests, which destroy the `dist/` directory.)
+  travisFoldStart "test.aio.pwaScore"
+    yarn test-pwa-score-localhost
+  travisFoldEnd "test.aio.pwaScore"
+
+
   # Run unit tests
   travisFoldStart "test.aio.unit"
     yarn test --single-run
@@ -28,12 +35,6 @@ source ${thisDir}/_travis-fold.sh
   travisFoldStart "test.aio.e2e"
     yarn e2e
   travisFoldEnd "test.aio.e2e"
-
-
-  # Run PWA-score tests
-  travisFoldStart "test.aio.pwaScore"
-    yarn test-pwa-score-localhost
-  travisFoldEnd "test.aio.pwaScore"
 
 
   # Run unit tests for aio/aio-builds-setup


### PR DESCRIPTION
1. Upgrade `lighthouse` to v2.5.0.
2. Avoid building before running the local PWA tests.
    (This is rarely used locally and can save ~4mins on CI.)