### PR TITLE
ci: add service-worker to pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -101,7 +101,6 @@ groups:
       - vicb
       - IgorMinar #fallback
 
-
   core:
     conditions:
       files:
@@ -255,7 +254,15 @@ groups:
       - IgorMinar #fallback
       - mhevery #fallback
 
-
+  service-worker:
+    conditions:
+      files:
+        - "packages/service-worker/*"
+    users:
+      - alxhub #primary
+      - gkalpak
+      - IgorMinar #fallback
+      - mhevery #fallback
 
   benchpress:
     conditions:


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] CI related changes
```

## What is the current behavior?
The package service-worker is not listed in the pullapprove file

## What is the new behavior?
It's listed


## Does this PR introduce a breaking change?
```
[x] No
```