### PR TITLE
fix(animations): prevent potentially error Cannot read property 'insertNode' of undefined at TransitionAnimationEngine

### DIFF
--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -659,7 +659,9 @@ export class TransitionAnimationEngine {
     // code does not contain any animation code in it, but it is
     // just being called so that the node is marked as being inserted
     if (namespaceId) {
-      this._fetchNamespace(namespaceId).insertNode(element, parent);
+      if (this._fetchNamespace(namespaceId)) {
+        this._fetchNamespace(namespaceId).insertNode(element, parent);
+      }
     }
 
     // only *directives and host elements are inserted before


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
error occasionally occur when navigating by back and forward between components which has animation trigger and structure directive

Issue Number: N/A


## What is the new behavior?
no error occur

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
show the bug as state in this stackoverflow question:
https://stackoverflow.com/questions/45589180/angular-cannot-read-property-insertnode-of-undefined-at-transitionanimationen