### PR TITLE
ci: validate commit messages correctly when not on master

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "rollup-plugin-sourcemaps": "0.4.2",
     "selenium-webdriver": "3.5.0",
     "semver": "5.4.1",
+    "shelljs": "^0.7.8",
     "source-map": "0.5.7",
     "source-map-support": "0.4.18",
     "systemjs": "0.18.10",

--- a/tools/gulp-tasks/validate-commit-message.js
+++ b/tools/gulp-tasks/validate-commit-message.js
@@ -6,37 +6,48 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+
 // tslint:disable:no-console
 module.exports = (gulp) => () => {
   const validateCommitMessage = require('../validate-commit-message');
-  const childProcess = require('child_process');
+  const shelljs = require('shelljs');
+
+  let baseBranch = 'master';
+  const currentVersion = require('semver').parse(require('../../package.json').version);
+  const baseHead =
+      shelljs.exec(`git ls-remote --heads origin ${currentVersion.major}.${currentVersion.minor}.*`)
+          .trim()
+          .split('\n')
+          .pop();
+  if (baseHead) {
+    const match = /refs\/heads\/(.+)/.exec(baseHead);
+    baseBranch = match && match[1] || baseBranch;
+  }
 
   // We need to fetch origin explicitly because it might be stale.
   // I couldn't find a reliable way to do this without fetch.
-  childProcess.exec(
-      'git fetch origin master && git log --reverse --format=%s HEAD ^origin/master',
-      (error, stdout, stderr) => {
-        if (error) {
-          console.log(stderr);
-          process.exit(1);
-        }
+  result = shelljs.exec(
+      `git fetch origin ${baseBranch} && git log --reverse --format=%s HEAD ^origin/${baseBranch}`);
 
-        let someCommitsInvalid = false;
-        let commitsByLine = stdout.trim().split(/\n/).filter(line => line != '');
+  if (result.code) {
+    console.log(result.stderr);
+    process.exit(1);
+  }
 
-        console.log(`Examining ${commitsByLine.length} commits between HEAD and master`);
+  const commitsByLine = result.trim().split(/\n/).filter(line => line != '');
 
-        if (commitsByLine.length == 0) {
-          console.log('There are zero new commits between this HEAD and master');
-        }
+  console.log(`Examining ${commitsByLine.length} commits between HEAD and ${baseBranch}`);
 
-        someCommitsInvalid = !commitsByLine.every(validateCommitMessage);
+  if (commitsByLine.length == 0) {
+    console.log(`There are zero new commits between this HEAD and ${baseBranch}`);
+  }
 
-        if (someCommitsInvalid) {
-          console.log('Please fix the failing commit messages before continuing...');
-          console.log(
-              'Commit message guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines');
-          process.exit(1);
-        }
-      });
+  const someCommitsInvalid = !commitsByLine.every(validateCommitMessage);
+
+  if (someCommitsInvalid) {
+    console.log('Please fix the failing commit messages before continuing...');
+    console.log(
+        'Commit message guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines');
+    process.exit(1);
+  }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6412,6 +6412,14 @@ shell-quote@1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
+shelljs@^0.7.8:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

When CircleCI tries to run the `lint` job the `validate-commit-messags` task can
look at the wrong set of commits as it always bases the commit range off `master`.

## What is the new behavior?

Now the commit range is computed by looking at the version in `package.json` and then
finding the most recent branch that matches this version.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
