### PR TITLE
build(aio): consider `devDependencies` when dependencies of local Angular packages

### DIFF
--- a/aio/tools/ng-packages-installer/index.js
+++ b/aio/tools/ng-packages-installer/index.js
@@ -76,15 +76,17 @@ class NgPackagesInstaller {
           // Prevent accidental publishing of the package, if something goes wrong.
           tmpConfig.private = true;
 
-          // Overwrite project dependencies to Angular packages with local files.
-          const deps = tmpConfig.dependencies || {};
-          Object.keys(deps).forEach(key2 => {
-            const pkg2 = packages[key2];
-            if (pkg2) {
-              // point the core Angular packages at the distributable folder
-              deps[key2] = `file:${pkg2.parentDir}/${key2.replace('@angular/', '')}`;
-              this._log(`Overriding dependency of local ${key} with local package: ${key2}: ${deps[key2]}`);
-            }
+          // Overwrite project dependencies/devDependencies to Angular packages with local files.
+          ['dependencies', 'devDependencies'].forEach(prop => {
+            const deps = tmpConfig[prop] || {};
+            Object.keys(deps).forEach(key2 => {
+              const pkg2 = packages[key2];
+              if (pkg2) {
+                // point the core Angular packages at the distributable folder
+                deps[key2] = `file:${pkg2.parentDir}/${key2.replace('@angular/', '')}`;
+                this._log(`Overriding dependency of local ${key} with local package: ${key2}: ${deps[key2]}`);
+              }
+            });
           });
 
           fs.writeFileSync(pkg.packageJsonPath, JSON.stringify(tmpConfig));

--- a/aio/tools/ng-packages-installer/index.spec.js
+++ b/aio/tools/ng-packages-installer/index.spec.js
@@ -81,7 +81,10 @@ describe('NgPackagesInstaller', () => {
         '@angular/tsc-wrapped': {
           parentDir: toolsDir,
           packageJsonPath: `${toolsDir}/tsc-wrapped/package.json`,
-          config: { peerDependencies: { tsickle: '^1.4.0' } }
+          config: {
+            devDependencies: { '@angular/common': '4.4.4-1ab23cd4' },
+            peerDependencies: { tsickle: '^1.4.0' }
+          }
         }
       };
       spyOn(installer, '_getDistPackages').and.callFake(() => copyJsonObj(dummyNgPackages));
@@ -160,7 +163,10 @@ describe('NgPackagesInstaller', () => {
             private: true,
             dependencies: { '@angular/tsc-wrapped': `file:${toolsDir}/tsc-wrapped` }
           }))],
-          [pkgJsonFor('tsc-wrapped'), JSON.stringify(overwriteConfigFor('tsc-wrapped', {private: true}))],
+          [pkgJsonFor('tsc-wrapped'), JSON.stringify(overwriteConfigFor('tsc-wrapped', {
+            private: true,
+            devDependencies: { '@angular/common': `file:${packagesDir}/common` }
+          }))],
         ]);
 
         expect(lastFiveArgs).toEqual(['core', 'common', 'compiler', 'compiler-cli', 'tsc-wrapped']
@@ -201,7 +207,7 @@ describe('NgPackagesInstaller', () => {
     });
   });
 
-  describe('_getDistPackages', () => {
+  describe('_getDistPackages()', () => {
     it('should include top level Angular packages', () => {
       const ngPackages = installer._getDistPackages();
       const expectedValue = jasmine.objectContaining({
@@ -259,7 +265,7 @@ describe('NgPackagesInstaller', () => {
     });
   });
 
-  describe('_printWarning', () => {
+  describe('_printWarning()', () => {
     it('should mention the message passed in the warning', () => {
       installer._printWarning();
       expect(console.warn.calls.argsFor(0)[0]).toContain('is running against the local Angular build');
@@ -282,7 +288,7 @@ describe('NgPackagesInstaller', () => {
     });
   });
 
-  describe('_installDeps', () => {
+  describe('_installDeps()', () => {
     it('should run yarn install with the given options', () => {
       installer._installDeps('option-1', 'option-2');
       expect(shelljs.exec).toHaveBeenCalledWith('yarn install option-1 option-2', { cwd: absoluteRootDir });


### PR DESCRIPTION
Previously, only `dependencies` were taken into account.
(Backported from #19655.)