### PR TITLE
docs: fix link texts

### DIFF
--- a/packages/core/src/application_tokens.ts
+++ b/packages/core/src/application_tokens.ts
@@ -13,7 +13,7 @@ import {ComponentRef} from './linker/component_factory';
 /**
  * A DI Token representing a unique string id assigned to the application by Angular and used
  * primarily for prefixing application attributes and CSS styles when
- * {@link ViewEncapsulation#Emulated} is being used.
+ * {@link ViewEncapsulation#Emulated ViewEncapsulation.Emulated} is being used.
  *
  * If you need to avoid randomly generated value to be used as an application id, you can provide
  * a custom value via a DI provider <!-- TODO: provider --> configuring the root {@link Injector}

--- a/packages/core/src/change_detection/change_detector_ref.ts
+++ b/packages/core/src/change_detection/change_detector_ref.ts
@@ -11,7 +11,7 @@
  */
 export abstract class ChangeDetectorRef {
   /**
-   * Marks all {@link ChangeDetectionStrategy#OnPush} ancestors as to be checked.
+   * Marks all {@link ChangeDetectionStrategy#OnPush OnPush} ancestors as to be checked.
    *
    * <!-- TODO: Add a link to a chapter on OnPush components -->
    *
@@ -53,9 +53,8 @@ export abstract class ChangeDetectorRef {
    *
    * The detached change detector will not be checked until it is reattached.
    *
-   * This can also be used in combination with {@link ChangeDetectorRef#detectChanges} to implement
-   * local change
-   * detection checks.
+   * This can also be used in combination with {@link ChangeDetectorRef#detectChanges detectChanges}
+   * to implement local change detection checks.
    *
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->
    * <!-- TODO: Add a live demo once ref.detectChanges is merged into master -->
@@ -106,9 +105,8 @@ export abstract class ChangeDetectorRef {
   /**
    * Checks the change detector and its children.
    *
-   * This can also be used in combination with {@link ChangeDetectorRef#detach} to implement local
-   * change detection
-   * checks.
+   * This can also be used in combination with {@link ChangeDetectorRef#detach detach} to implement
+   * local change detection checks.
    *
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->
    * <!-- TODO: Add a live demo once ref.detectChanges is merged into master -->
@@ -123,7 +121,7 @@ export abstract class ChangeDetectorRef {
    * check
    * every five seconds.
    *
-   * See {@link ChangeDetectorRef#detach} for more information.
+   * See {@link ChangeDetectorRef#detach detach} for more information.
    */
   abstract detectChanges(): void;
 

--- a/packages/core/src/di/reflective_injector.ts
+++ b/packages/core/src/di/reflective_injector.ts
@@ -83,7 +83,7 @@ export abstract class ReflectiveInjector implements Injector {
    * });
    * ```
    *
-   * See {@link ReflectiveInjector#fromResolvedProviders} for more info.
+   * See {@link ReflectiveInjector#fromResolvedProviders fromResolvedProviders} for more info.
    */
   static resolve(providers: Provider[]): ResolvedReflectiveProvider[] {
     return resolveReflectiveProviders(providers);
@@ -113,7 +113,8 @@ export abstract class ReflectiveInjector implements Injector {
    *
    * This function is slower than the corresponding `fromResolvedProviders`
    * because it needs to resolve the passed-in providers first.
-   * See {@link ReflectiveInjector#resolve} and {@link ReflectiveInjector#fromResolvedProviders}.
+   * See {@link ReflectiveInjector#resolve resolve} and
+   * {@link ReflectiveInjector#fromResolvedProviders fromResolvedProviders}.
    */
   static resolveAndCreate(providers: Provider[], parent?: Injector): ReflectiveInjector {
     const ResolvedReflectiveProviders = ReflectiveInjector.resolve(providers);
@@ -190,7 +191,8 @@ export abstract class ReflectiveInjector implements Injector {
    *
    * This function is slower than the corresponding `createChildFromResolved`
    * because it needs to resolve the passed-in providers first.
-   * See {@link ReflectiveInjector#resolve} and {@link ReflectiveInjector#createChildFromResolved}.
+   * See {@link ReflectiveInjector#resolve resolve} and
+   * {@link ReflectiveInjector#createChildFromResolved createChildFromResolved}.
    */
   abstract resolveAndCreateChild(providers: Provider[]): ReflectiveInjector;
 

--- a/packages/core/src/linker/template_ref.ts
+++ b/packages/core/src/linker/template_ref.ts
@@ -18,9 +18,8 @@ import {EmbeddedViewRef} from './view_ref';
  * the constructor of the directive using the `TemplateRef` Token. Alternatively you can query for
  * the `TemplateRef` from a Component or a Directive via {@link Query}.
  *
- * To instantiate Embedded Views based on a Template, use
- * {@link ViewContainerRef#createEmbeddedView}, which will create the View and attach it to the
- * View Container.
+ * To instantiate Embedded Views based on a Template, use {@link ViewContainerRef#
+ * createEmbeddedView}, which will create the View and attach it to the View Container.
  * @stable
  */
 export abstract class TemplateRef<C> {

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -73,8 +73,8 @@ export abstract class ViewContainerRef {
    * Instantiates a single {@link Component} and inserts its Host View into this container at the
    * specified `index`.
    *
-   * The component is instantiated using its {@link ComponentFactory} which can be
-   * obtained via {@link ComponentFactoryResolver#resolveComponentFactory}.
+   * The component is instantiated using its {@link ComponentFactory} which can be obtained via
+   * {@link ComponentFactoryResolver#resolveComponentFactory resolveComponentFactory}.
    *
    * If `index` is not specified, the new View will be inserted as the last View in the container.
    *

--- a/packages/core/src/metadata/view.ts
+++ b/packages/core/src/metadata/view.ts
@@ -9,15 +9,15 @@
 /**
  * Defines template and style encapsulation options available for Component's {@link Component}.
  *
- * See {@link Component#encapsulation}.
+ * See {@link Component#encapsulation encapsulation}.
  * @stable
  */
 export enum ViewEncapsulation {
   /**
    * Emulate `Native` scoping of styles by adding an attribute containing surrogate id to the Host
-   * Element and pre-processing the style rules provided via
-   * {@link Component#styles} or {@link Component#styleUrls}, and adding the new Host Element
-   * attribute to all selectors.
+   * Element and pre-processing the style rules provided via {@link Component#styles styles} or
+   * {@link Component#styleUrls styleUrls}, and adding the new Host Element attribute to all
+   * selectors.
    *
    * This is the default option.
    */

--- a/packages/core/src/render/api.ts
+++ b/packages/core/src/render/api.ts
@@ -99,9 +99,8 @@ export const Renderer2Interceptor = new InjectionToken<Renderer2[]>('Renderer2In
  *
  * Use this service to bypass Angular's templating and make custom UI changes that can't be
  * expressed declaratively. For example if you need to set a property or an attribute whose name is
- * not statically known, use {@link Renderer#setElementProperty} or {@link
- * Renderer#setElementAttribute}
- * respectively.
+ * not statically known, use {@link Renderer#setElementProperty setElementProperty} or
+ * {@link Renderer#setElementAttribute setElementAttribute} respectively.
  *
  * If you are implementing a custom renderer, you must implement this interface.
  *

--- a/packages/forms/src/directives/reactive_directives/form_group_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_name.ts
@@ -40,7 +40,7 @@ export const formGroupNameProvider: any = {
  * controls into their own nested object.
  *
  * **Access the group**: You can access the associated {@link FormGroup} using the
- * {@link AbstractControl#get} method. Ex: `this.form.get('name')`.
+ * {@link AbstractControl#get get} method. Ex: `this.form.get('name')`.
  *
  * You can also access individual controls within the group using dot syntax.
  * Ex: `this.form.get('name.first')`
@@ -111,7 +111,7 @@ export const formArrayNameProvider: any = {
  * form controls dynamically.
  *
  * **Access the array**: You can access the associated {@link FormArray} using the
- * {@link AbstractControl#get} method on the parent {@link FormGroup}.
+ * {@link AbstractControl#get get} method on the parent {@link FormGroup}.
  * Ex: `this.form.get('cities')`.
  *
  * **Get the value**: the `value` property is always synced and available on the
@@ -119,17 +119,17 @@ export const formArrayNameProvider: any = {
  *
  * **Set the value**: You can set an initial value for each child control when instantiating
  * the {@link FormArray}, or you can set the value programmatically later using the
- * {@link FormArray}'s {@link AbstractControl#setValue} or {@link AbstractControl#patchValue}
- * methods.
+ * {@link FormArray}'s {@link AbstractControl#setValue setValue} or
+ * {@link AbstractControl#patchValue patchValue} methods.
  *
  * **Listen to value**: If you want to listen to changes in the value of the array, you can
- * subscribe to the {@link FormArray}'s {@link AbstractControl#valueChanges} event.  You can also
- * listen to its {@link AbstractControl#statusChanges} event to be notified when the validation
- * status is re-calculated.
+ * subscribe to the {@link FormArray}'s {@link AbstractControl#valueChanges valueChanges} event.
+ * You can also listen to its {@link AbstractControl#statusChanges statusChanges} event to be
+ * notified when the validation status is re-calculated.
  *
- * **Add new controls**: You can add new controls to the {@link FormArray} dynamically by
- * calling its {@link FormArray#push} method.
- *  Ex: `this.form.get('cities').push(new FormControl());`
+ * **Add new controls**: You can add new controls to the {@link FormArray} dynamically by calling
+ * its {@link FormArray#push push} method.
+ * Ex: `this.form.get('cities').push(new FormControl());`
  *
  * ### Example
  *

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -755,9 +755,9 @@ export class FormControl extends AbstractControl {
   /**
    * Patches the value of a control.
    *
-   * This function is functionally the same as {@link FormControl#setValue} at this level.
-   * It exists for symmetry with {@link FormGroup#patchValue} on `FormGroups` and `FormArrays`,
-   * where it does behave differently.
+   * This function is functionally the same as {@link FormControl#setValue setValue} at this level.
+   * It exists for symmetry with {@link FormGroup#patchValue patchValue} on `FormGroups` and
+   * `FormArrays`, where it does behave differently.
    */
   patchValue(value: any, options: {
     onlySelf?: boolean,
@@ -956,8 +956,8 @@ export class FormGroup extends AbstractControl {
   /**
    * Registers a control with the group's list of controls.
    *
-   * This method does not update value or validity of the control, so for
-   * most cases you'll want to use {@link FormGroup#addControl} instead.
+   * This method does not update the value or validity of the control, so for most cases you'll want
+   * to use {@link FormGroup#addControl addControl} instead.
    */
   registerControl(name: string, control: AbstractControl): AbstractControl {
     if (this.controls[name]) return this.controls[name];
@@ -1000,8 +1000,8 @@ export class FormGroup extends AbstractControl {
   /**
    * Check whether there is an enabled control with the given name in the group.
    *
-   * It will return false for disabled controls. If you'd like to check for
-   * existence in the group only, use {@link AbstractControl#get} instead.
+   * It will return false for disabled controls. If you'd like to check for existence in the group
+   * only, use {@link AbstractControl#get get} instead.
    */
   contains(controlName: string): boolean {
     return this.controls.hasOwnProperty(controlName) && this.controls[controlName].enabled;

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -69,10 +69,12 @@ import {UrlTree} from '../url_tree';
  * ```
  *
  * You can tell the directive to how to handle queryParams, available options are:
- *  - 'merge' merge the queryParams into the current queryParams
- *  - 'preserve' preserve the current queryParams
- *  - default / '' use the queryParams only
- *  same options for {@link NavigationExtras#queryParamsHandling}
+ *  - `'merge'`: merge the queryParams into the current queryParams
+ *  - `'preserve'`: preserve the current queryParams
+ *  - default/`''`: use the queryParams only
+ *
+ * Same options for {@link NavigationExtras#queryParamsHandling
+ * NavigationExtras#queryParamsHandling}.
  *
  * ```
  * <a [routerLink]="['/user/bob']" [queryParams]="{debug: true}" queryParamsHandling="merge">
@@ -87,9 +89,9 @@ import {UrlTree} from '../url_tree';
  * Then the following link `<a [routerLink]="['/user/jim']">Jim</a>` will generate the link
  * `/user/(jim//aux:team)`.
  *
- * @ngModule RouterModule
+ * See {@link Router#createUrlTree createUrlTree} for more information.
  *
- * See {@link Router#createUrlTree} for more information.
+ * @ngModule RouterModule
  *
  * @stable
  */


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] Documentation content changes
```

## What is the current behavior?
Some links to methods don't show the method name as link text, but the corresponding class.


## What is the new behavior?
Links to methods show the method name as link text (when appropriate).


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
Fixes #19701.