### PR TITLE
fix(common): allow URL parameters to be encoded

### DIFF
--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -55,16 +55,7 @@ function paramParser(rawParams: string, codec: HttpParameterCodec): Map<string, 
   return map;
 }
 function standardEncoding(v: string): string {
-  return encodeURIComponent(v)
-      .replace(/%40/gi, '@')
-      .replace(/%3A/gi, ':')
-      .replace(/%24/gi, '$')
-      .replace(/%2C/gi, ',')
-      .replace(/%3B/gi, ';')
-      .replace(/%2B/gi, '+')
-      .replace(/%3D/gi, '=')
-      .replace(/%3F/gi, '?')
-      .replace(/%2F/gi, '/');
+  return encodeURIComponent(v);
 }
 
 interface Update {


### PR DESCRIPTION
Back ends for several languages (including Python, PHP and Node.js) expect to receive encoded parameters with some standard conventions, when they receive them as raw decoded strings they can't parse those parameters. This removes the custom decoding of parameters to raw strings and leaves the default standard encoding for HttpClient.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ :heavy_check_mark:  ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ N/A ] Tests for the changes have been added (for bug fixes / features)
> I only removed code, and the code I removed was not directly tested.
- [ N/A ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, when creating URL parameters, some characters are decoded and converted to raw strings after the `encodeURIComponent()` had encoded them. The characters are: `@`, `:`, `$`, `,`, `;`, `+`, `=`, `?`, `/`.

This creates communication problems with back ends in at least Python, PHP and Node.js.

Check the referenced issues for more details on all the possible problems this creates.

Issue Number: #11058 #18884 #18274 #14531 #13077 #18261


## What is the new behavior?

With this PR, when using `HttpParams`, the parameters will be encoded as normally, without being decoded by Angular before sending them in the URL to the server.

I will create a parallel PR that will solve the problem for cases using `URLSearchParams`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x ] No
```

...or would you consider this a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
