### PR TITLE
feat(common): add ngComponentOutletInput and ngComponentOutletOutput

### DIFF
--- a/goldens/public-api/common/common.d.ts
+++ b/goldens/public-api/common/common.d.ts
@@ -209,7 +209,13 @@ export declare class NgComponentOutlet implements OnChanges, OnDestroy {
     ngComponentOutlet: Type<any>;
     ngComponentOutletContent: any[][];
     ngComponentOutletInjector: Injector;
+    ngComponentOutletInput: {
+        [key: string]: any;
+    };
     ngComponentOutletNgModuleFactory: NgModuleFactory<any>;
+    ngComponentOutletOutput: {
+        [key: string]: any;
+    };
     constructor(_viewContainerRef: ViewContainerRef);
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;


### PR DESCRIPTION
 Encapsulating input and output binding logic inside ngComponentOutlet
could reduce boilerplate when creating dynamic components and make
code less error-prone.
Ease of creating dynamic components could also make development
experience better.

Should close: #15915, #15360
Possibly closes #15275 using component inheritance
Address remaining issues in #11168
Related PR: #15362

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is no declarative way to bind the input and output of dynamically created components.

Issue Number: #15915, #15360


## What is the new behavior?
Provides the corresponding api in the same way as ngComponentOutletContent and so on.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
In this implementation, users need to use a new object to inform change detection that something passed to `ngComponentOutletInput` or `ngComponentOutletOutput`  has changed, just like the default behavior of a property.
I had implemented in another way so that we do a shallow checking for binding object properties. Though that might introduce some convenience, it requires `ngDoCheck` and is not really aligned with the default behavior. But if that's preferred, I could change back to that version.
Thanks!