### PR TITLE
fix(service-worker): add missing annotation for SwPush

### DIFF
--- a/packages/service-worker/src/push.ts
+++ b/packages/service-worker/src/push.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 
@@ -23,6 +24,7 @@ import {NgswCommChannel} from './low_level';
  *
  * @experimental
  */
+@Injectable()
 export class SwPush {
   readonly messages: Observable<object>;
   readonly subscription: Observable<PushSubscription|null>;

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import 'rxjs/add/operator/toPromise';
+import {TestBed} from '@angular/core/testing';
 
 import {NgswCommChannel} from '../src/low_level';
 import {SwPush} from '../src/push';
@@ -41,7 +42,7 @@ export function main() {
         mock.setupSw();
       });
     });
-    describe('NgswPush', () => {
+    describe('SwPush', () => {
       let push: SwPush;
       let reg: MockServiceWorkerRegistration;
       beforeEach((done: DoneFn) => {
@@ -63,8 +64,17 @@ export function main() {
           },
         });
       });
+      it('is injectable', () => {
+        TestBed.configureTestingModule({
+          providers: [
+            SwPush,
+            {provide: NgswCommChannel, useValue: comm},
+          ]
+        });
+        expect(() => TestBed.get(SwPush)).not.toThrow();
+      });
     });
-    describe('NgswUpdate', () => {
+    describe('SwUpdate', () => {
       let update: SwUpdate;
       let reg: MockServiceWorkerRegistration;
       beforeEach((done: DoneFn) => {
@@ -131,6 +141,15 @@ export function main() {
             .catch(err => { expect(err.message).toEqual('Failed to activate'); })
             .then(() => done())
             .catch(err => done.fail(err));
+      });
+      it('is injectable', () => {
+        TestBed.configureTestingModule({
+          providers: [
+            SwUpdate,
+            {provide: NgswCommChannel, useValue: comm},
+          ]
+        });
+        expect(() => TestBed.get(SwUpdate)).not.toThrow();
       });
     });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #19525 


## What is the new behavior?

Service worker being available in JIT usage.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This is just adding a static annotation, do we need integration test to cover it?