### PR TITLE
fix(compiler-cli): mark private method as error in template file (#16451)

### DIFF
--- a/packages/compiler-cli/src/diagnostics/expression_type.ts
+++ b/packages/compiler-cli/src/diagnostics/expression_type.ts
@@ -360,6 +360,8 @@ export class AstType implements AstVisitor {
     // The type of a method is the selected methods result type.
     const method = receiverType.members().get(ast.name);
     if (!method) return this.reportError(`Unknown method '${ast.name}'`, ast);
+    if (!method.public)
+      return this.reportError(`Member '${ast.name}' refers to a private method`, ast);
     if (!method.type) return this.reportError(`Could not find a type for '${ast.name}'`, ast);
     if (!method.type.callable) return this.reportError(`Member '${ast.name}' is not callable`, ast);
     const signature = method.type.selectSignature(ast.args.map(arg => this.getType(arg)));

--- a/packages/compiler-cli/test/diagnostics/expression_diagnostics_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/expression_diagnostics_spec.ts
@@ -165,6 +165,10 @@ describe('expression diagnostics', () => {
   it('should accept a call to a method', () => accept('{{getPerson().name.first}}'));
   it('should reject a misspelled field of a method result',
      () => reject('{{getPerson().nume.first}}', 'Identifier \'nume\' is not defined'));
+  it('should reject a private event handler',
+     () => reject(
+         '<div (click)="private_action($event)">{{person.name.first}}</div>',
+         'Member \'private_action\' refers to a private method'));
   it('should reject calling a uncallable member',
      () => reject('{{person().name.first}}', 'Member \'person\' is not callable'));
   it('should accept an event handler',
@@ -229,6 +233,7 @@ const FILES: Directory = {
 
           getPerson(): Person { return this.person; }
           click() {}
+          private private_action() {}
         }
 
         @NgModule({


### PR DESCRIPTION
Reference to a private method in the template will now report an error.

PR Close #16451

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #16451

## What is the new behavior?
Reference to a private method in the template will now report an error.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```