### PR TITLE
fix(compiler-cli): do not add references to files outside of `rootDir`

### DIFF
--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -363,7 +363,8 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter extends
         genFileNames = cachedGenFiles;
       } else {
         if (!this.options.noResolve && this.shouldGenerateFilesFor(fileName)) {
-          genFileNames = this.codeGenerator.findGeneratedFileNames(fileName);
+          genFileNames = this.codeGenerator.findGeneratedFileNames(fileName).filter(
+              fileName => this.shouldGenerateFile(fileName).generate);
         }
         this.generatedCodeFor.set(fileName, genFileNames);
       }

--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -1349,4 +1349,46 @@ describe('ngc transformer command-line', () => {
     it('should recompile when the css file changes',
        expectRecompile(() => { write('greet.css', `p.greeting { color: blue }`); }));
   });
+
+  describe('regressions', () => {
+    // #19765
+    it('should not report an error when the resolved .css file is in outside rootDir', () => {
+      write('src/tsconfig.json', `{
+        "extends": "../tsconfig-base.json",
+        "compilerOptions": {
+          "outDir": "../dist",
+          "rootDir": ".",
+          "rootDirs": [
+            ".",
+            "../dist"
+          ]
+        },
+        "files": ["test-module.ts"]
+      }`);
+      write('src/lib/test.component.ts', `
+        import {Component} from '@angular/core';
+
+        @Component({
+          template: '<p>hello</p>',
+          styleUrls: ['./test.component.css']
+        })
+        export class TestComponent {}
+      `);
+      write('dist/dummy.txt', '');  // Force dist to be created
+      write('dist/lib/test.component.css', `
+        p { color: blue }
+      `);
+      write('src/test-module.ts', `
+        import {NgModule} from '@angular/core';
+        import {TestComponent} from './lib/test.component';
+
+        @NgModule({declarations: [TestComponent]})
+        export class TestModule {}
+      `);
+      const messages: string[] = [];
+      const exitCode =
+          main(['-p', path.join(basePath, 'src/tsconfig.json')], message => messages.push(message));
+      expect(exitCode).toBe(0, 'Compile failed unexpectedly.\n  ' + messages.join('\n  '));
+    });
+  });
 });

--- a/packages/compiler-cli/test/transformers/compiler_host_spec.ts
+++ b/packages/compiler-cli/test/transformers/compiler_host_spec.ts
@@ -252,10 +252,10 @@ describe('NgCompilerHost', () => {
     it('should clear old generated references if the original host cached them', () => {
       codeGenerator.findGeneratedFileNames.and.returnValue(['/tmp/src/index.ngfactory.ts']);
 
-      const ngHost = createNgHost();
       const sfText = `
           /// <reference path="main.ts"/>
       `;
+      const ngHost = createNgHost({files: {'tmp': {'src': {'index.ts': sfText}}}});
       const sf = ts.createSourceFile('/tmp/src/index.ts', sfText, ts.ScriptTarget.Latest);
       ngHost.getSourceFile = () => sf;
 

--- a/packages/compiler/src/aot/compiler.ts
+++ b/packages/compiler/src/aot/compiler.ts
@@ -113,7 +113,7 @@ export class AotCompiler {
       compMeta.template !.styleUrls.forEach((styleUrl) => {
         const normalizedUrl = this._host.resourceNameToFileName(styleUrl, file.fileName);
         if (!normalizedUrl) {
-          throw new Error(`Couldn't resolve resource ${styleUrl} relative to ${file.fileName}`);
+          throw syntaxError(`Couldn't resolve resource ${styleUrl} relative to ${file.fileName}`);
         }
         const needsShim = (compMeta.template !.encapsulation ||
                            this._config.defaultEncapsulation) === ViewEncapsulation.Emulated;


### PR DESCRIPTION
References to resources (such as .css files) that are generated into
the `outDir` directory outside of `rootDir` would cause a spurious
compiler error about not being able to find a files that ends in
'.ngstyle.ts'.

Also fixed a minor issue in compiler error reporting

Fixes: #19765, #19767

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue Number: #19765 

If .css files are generated into a destination directory outside of the `rootDir` the compiler generate a spurious error message.


## What is the new behavior?

The error message is no longer generated.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
