### PR TITLE
docs: replace `my-` with `app-` to conform to CLI selectors

### DIFF
--- a/aio/content/examples/aot-compiler/src/app/app.component.ts
+++ b/aio/content/examples/aot-compiler/src/app/app.component.ts
@@ -2,7 +2,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'my-app',
+  selector: 'app-root',
   templateUrl: './app.component.html'
 })
 export class AppComponent {

--- a/aio/content/examples/aot-compiler/src/index-jit.html
+++ b/aio/content/examples/aot-compiler/src/index-jit.html
@@ -19,6 +19,6 @@
   <!-- #enddocregion jit -->
   </head>
   <body>
-    <my-app>Loading...</my-app>
+    <app-root>Loading...</app-root>
   </body>
 </html>

--- a/aio/content/examples/aot-compiler/src/index.html
+++ b/aio/content/examples/aot-compiler/src/index.html
@@ -12,7 +12,7 @@
     <script src="node_modules/zone.js/dist/zone.js"></script>
   </head>
   <body>
-    <my-app>Loading...</my-app>
+    <app-root>Loading...</app-root>
   </body>
   <!-- #docregion bundle -->
   <script src="build.js"></script>

--- a/aio/content/examples/architecture/src/app/mini-app.ts
+++ b/aio/content/examples/architecture/src/app/mini-app.ts
@@ -12,7 +12,7 @@ import { Component } from '@angular/core';
 // #enddocregion import-core-component
 
 @Component({
- selector: 'my-app',
+ selector: 'app-root',
  template: 'Welcome to Angular'
 })
 export class AppComponent {

--- a/aio/content/examples/deployment/src/app/app.component.ts
+++ b/aio/content/examples/deployment/src/app/app.component.ts
@@ -2,7 +2,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'my-app',
+  selector: 'app-root',
   template: `
     <h1>Simple Deployment</h1>
     <nav>

--- a/aio/content/examples/deployment/src/index.html
+++ b/aio/content/examples/deployment/src/index.html
@@ -32,7 +32,7 @@
   </head>
 
   <body>
-    <my-app></my-app>
+    <app-root></app-root>
   </body>
 
 </html>

--- a/aio/content/examples/http/e2e-spec.ts
+++ b/aio/content/examples/http/e2e-spec.ts
@@ -49,9 +49,9 @@ describe('Server Communication', function () {
   describe('Wikipedia Demo', function () {
 
     it('should initialize the demo with empty result list', function () {
-      let myWikiComp = element(by.tagName('my-wiki'));
-      expect(myWikiComp).toBeDefined('<my-wiki> must exist');
-      let resultList = myWikiComp.all(by.tagName('li'));
+      let wikiComp = element(by.tagName('app-wiki'));
+      expect(wikiComp).toBeDefined('<app-wiki> must exist');
+      let resultList = wikiComp.all(by.tagName('li'));
       expect(resultList.count()).toBe(0, 'result list must be empty');
     });
 
@@ -74,16 +74,16 @@ describe('Server Communication', function () {
     });
 
     function testForRefreshedResult(keyPressed: string, done: () => void) {
-      testForResult('my-wiki', keyPressed, false, done);
+      testForResult('app-wiki', keyPressed, false, done);
     }
   });
 
   describe('Smarter Wikipedia Demo', function () {
 
     it('should initialize the demo with empty result list', function () {
-      let myWikiSmartComp = element(by.tagName('my-wiki-smart'));
-      expect(myWikiSmartComp).toBeDefined('<my-wiki-smart> must exist');
-      let resultList = myWikiSmartComp.all(by.tagName('li'));
+      let wikiSmartComp = element(by.tagName('app-wiki-smart'));
+      expect(wikiSmartComp).toBeDefined('<app-wiki-smart> must exist');
+      let resultList = wikiSmartComp.all(by.tagName('li'));
       expect(resultList.count()).toBe(0, 'result list must be empty');
     });
 
@@ -105,11 +105,11 @@ describe('Server Communication', function () {
 
 
     function testForNewResult(keyPressed: string, done: () => void) {
-      testForResult('my-wiki-smart', keyPressed, false, done);
+      testForResult('app-wiki-smart', keyPressed, false, done);
     }
 
     function testForStaleResult(keyPressed: string, done: () => void) {
-      testForResult('my-wiki-smart', keyPressed, true, done);
+      testForResult('app-wiki-smart', keyPressed, true, done);
     }
 
   });

--- a/aio/content/examples/http/src/app/app.component.ts
+++ b/aio/content/examples/http/src/app/app.component.ts
@@ -2,12 +2,12 @@
 import { Component }         from '@angular/core';
 
 @Component({
-  selector: 'my-app',
+  selector: 'app-root',
   template: `
     <hero-list></hero-list>
     <hero-list-promise></hero-list-promise>
-    <my-wiki></my-wiki>
-    <my-wiki-smart></my-wiki-smart>
+    <app-wiki></app-wiki>
+    <app-wiki-smart></app-wiki-smart>
   `
 })
 export class AppComponent { }

--- a/aio/content/examples/http/src/app/wiki/wiki-smart.component.ts
+++ b/aio/content/examples/http/src/app/wiki/wiki-smart.component.ts
@@ -16,7 +16,7 @@ import { Subject } from 'rxjs/Subject';
 import { WikipediaService } from './wikipedia.service';
 
 @Component({
-  selector: 'my-wiki-smart',
+  selector: 'app-wiki-smart',
   template: `
     <h1>Smarter Wikipedia Demo</h1>
     <p>Search when typing stops</p>

--- a/aio/content/examples/http/src/app/wiki/wiki.component.ts
+++ b/aio/content/examples/http/src/app/wiki/wiki.component.ts
@@ -5,7 +5,7 @@ import { Observable }       from 'rxjs/Observable';
 import { WikipediaService } from './wikipedia.service';
 
 @Component({
-  selector: 'my-wiki',
+  selector: 'app-wiki',
   template: `
     <h1>Wikipedia Demo</h1>
     <p>Search after each keystroke</p>

--- a/aio/content/examples/http/src/index.html
+++ b/aio/content/examples/http/src/index.html
@@ -21,7 +21,7 @@
   </head>
 
   <body>
-      <my-app></my-app>
+      <app-root></app-root>
   </body>
 
 </html>

--- a/aio/content/examples/i18n/e2e-spec.ts
+++ b/aio/content/examples/i18n/e2e-spec.ts
@@ -13,7 +13,7 @@ describe('i18n E2E Tests', () => {
   });
 
   it('should display the node texts without elements', function () {
-    expect(element(by.css('my-app')).getText()).toContain('No genero ningún elemento');
+    expect(element(by.css('app-root')).getText()).toContain('No genero ningún elemento');
   });
 
   it('should display the translated title attribute', function () {

--- a/aio/content/examples/i18n/src/app/app.component.ts
+++ b/aio/content/examples/i18n/src/app/app.component.ts
@@ -2,7 +2,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'my-app',
+  selector: 'app-root',
   templateUrl: './app.component.html'
 })
 export class AppComponent {

--- a/aio/content/examples/i18n/src/index.html
+++ b/aio/content/examples/i18n/src/index.html
@@ -34,6 +34,6 @@
   </head>
 
   <body>
-    <my-app>Loading...</my-app>
+    <app-root>Loading...</app-root>
   </body>
 </html>

--- a/aio/content/examples/ngcontainer/src/app/app.component.ts
+++ b/aio/content/examples/ngcontainer/src/app/app.component.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
 import { heroes } from './hero';
 
 @Component({
-  selector: 'my-app',
+  selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: [ './app.component.css' ]
 })

--- a/aio/content/examples/ngcontainer/src/index.html
+++ b/aio/content/examples/ngcontainer/src/index.html
@@ -6,7 +6,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   <body>
-    <my-app>Loading...</my-apps>
+    <app-root>Loading...</app-roots>
   </body>
 
 </html>

--- a/aio/content/examples/quickstart/src/app/app.component.ts
+++ b/aio/content/examples/quickstart/src/app/app.component.ts
@@ -2,7 +2,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'my-app',
+  selector: 'app-root',
   template: `<h1>Hello {{name}}</h1>`
 })
 export class AppComponent { name = 'Angular'; }

--- a/aio/content/examples/quickstart/src/index.html
+++ b/aio/content/examples/quickstart/src/index.html
@@ -23,9 +23,9 @@
   </head>
 
   <body>
-    <!-- #docregion my-app-->
-    <my-app>Loading AppComponent content here ...</my-app>
-    <!-- #enddocregion my-app-->
+    <!-- #docregion app-root-->
+    <app-root>Loading AppComponent content here ...</app-root>
+    <!-- #enddocregion app-root-->
   </body>
 
 </html>

--- a/aio/content/examples/setup/src/app/app.component.ts
+++ b/aio/content/examples/setup/src/app/app.component.ts
@@ -2,7 +2,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'my-app',
+  selector: 'app-root',
   template: `<h1>Hello {{name}}</h1>`
 })
 export class AppComponent { name = 'Angular'; }

--- a/aio/content/examples/setup/src/index.html
+++ b/aio/content/examples/setup/src/index.html
@@ -20,9 +20,9 @@
   </head>
 
   <body>
-    <!-- #docregion my-app-->
-    <my-app><!-- content managed by Angular --></my-app>
-    <!-- #enddocregion my-app-->
+    <!-- #docregion app-root-->
+    <app-root><!-- content managed by Angular --></app-root>
+    <!-- #enddocregion app-root-->
   </body>
 
 </html>

--- a/aio/content/examples/structural-directives/e2e/app.e2e-spec.ts
+++ b/aio/content/examples/structural-directives/e2e/app.e2e-spec.ts
@@ -37,7 +37,7 @@ describe('Structural Directives', function () {
     expect(paragraph.count()).toEqual(1);
   });
 
-  it('myUnless should show 3 paragraph (A)s and (B)s at the start', function () {
+  it('appUnless should show 3 paragraph (A)s and (B)s at the start', function () {
     const paragraph = element.all(by.css('p.unless'));
     expect(paragraph.count()).toEqual(3);
     for (let i = 0; i < 3; i++) {
@@ -45,7 +45,7 @@ describe('Structural Directives', function () {
     }
   });
 
-  it('myUnless should show 1 paragraph (B) after toggling condition', function () {
+  it('appUnless should show 1 paragraph (B) after toggling condition', function () {
     const toggleConditionButton = element.all(by.cssContainingText('button', 'Toggle condition')).get(0);
     const paragraph = element.all(by.css('p.unless'));
 

--- a/aio/content/examples/structural-directives/src/app/unless.directive.ts
+++ b/aio/content/examples/structural-directives/src/app/unless.directive.ts
@@ -8,7 +8,7 @@ import { Directive, Input, TemplateRef, ViewContainerRef } from '@angular/core';
  * Add the template content to the DOM unless the condition is true.
 // #enddocregion no-docs
  *
- * If the expression assigned to `myUnless` evaluates to a truthy value
+ * If the expression assigned to `appUnless` evaluates to a truthy value
  * then the templated elements are removed removed from the DOM,
  * the templated elements are (re)inserted into the DOM.
  *
@@ -18,8 +18,8 @@ import { Directive, Input, TemplateRef, ViewContainerRef } from '@angular/core';
  *
  * ### Syntax
  *
- * - `<div *myUnless="condition">...</div>`
- * - `<ng-template [myUnless]="condition"><div>...</div></ng-template>`
+ * - `<div *appUnless="condition">...</div>`
+ * - `<ng-template [appUnless]="condition"><div>...</div></ng-template>`
  *
 // #docregion no-docs
  */

--- a/aio/content/examples/styleguide/src/01-01/app/heroes/hero.component.avoid.ts
+++ b/aio/content/examples/styleguide/src/01-01/app/heroes/hero.component.avoid.ts
@@ -11,7 +11,7 @@ class Hero {
 }
 
 @Component({
-  selector: 'my-app',
+  selector: 'app-root',
   template: `
       <h1>{{title}}</h1>
       <pre>{{heroes | json}}</pre>

--- a/aio/content/examples/testing/src/app/bag/bag.spec.ts
+++ b/aio/content/examples/testing/src/app/bag/bag.spec.ts
@@ -425,7 +425,7 @@ describe('TestBed Component Overrides:', () => {
   it('injected provider should not be same as component\'s provider', () => {
 
     // TestComponent is parent of TestProvidersComponent
-    @Component({ template: '<my-service-comp></my-service-comp>' })
+    @Component({ template: '<app-service-comp></app-service-comp>' })
     class TestComponent {}
 
     // 3 levels of FancyService provider: module, TestCompomponent, TestProvidersComponent

--- a/aio/content/examples/testing/src/app/bag/bag.ts
+++ b/aio/content/examples/testing/src/app/bag/bag.ts
@@ -222,7 +222,7 @@ export class IoParentComponent {
 }
 
 @Component({
-  selector: 'my-if-comp',
+  selector: 'app-if-comp',
   template: `MyIf(<span *ngIf="showMore">More</span>)`
 })
 export class MyIfComponent {
@@ -230,7 +230,7 @@ export class MyIfComponent {
 }
 
 @Component({
-  selector: 'my-service-comp',
+  selector: 'app-service-comp',
   template: `injected value: {{fancyService.value}}`,
   providers: [FancyService]
 })
@@ -240,7 +240,7 @@ export class TestProvidersComponent {
 
 
 @Component({
-  selector: 'my-service-comp',
+  selector: 'app-service-comp',
   template: `injected value: {{fancyService.value}}`,
   viewProviders: [FancyService]
 })
@@ -287,7 +287,7 @@ export class NeedsContentComponent {
 
 ///////// MyIfChildComp ////////
 @Component({
-  selector: 'my-if-child-1',
+  selector: 'app-if-child-1',
 
   template: `
     <h4>MyIfChildComp</h4>
@@ -338,7 +338,7 @@ export class MyIfChildComponent implements OnInit, OnChanges, OnDestroy {
 ///////// MyIfParentComp ////////
 
 @Component({
-  selector: 'my-if-parent-comp',
+  selector: 'app-if-parent-comp',
   template: `
     <h3>MyIfParentComp</h3>
     <label>Parent value:
@@ -347,7 +347,7 @@ export class MyIfChildComponent implements OnInit, OnChanges, OnDestroy {
     <button (click)="clicked()">{{toggleLabel}} Child</button><br>
     <div *ngIf="showChild"
          style="margin: 4px; padding: 4px; background-color: aliceblue;">
-      <my-if-child-1  [(value)]="parentValue"></my-if-child-1>
+      <app-if-child-1  [(value)]="parentValue"></app-if-child-1>
     </div>
   `
 })
@@ -387,7 +387,7 @@ export class ShellComponent { }
   selector: 'bag-comp',
   template: `
     <h1>Specs Bag</h1>
-    <my-if-parent-comp></my-if-parent-comp>
+    <app-if-parent-comp></app-if-parent-comp>
     <hr>
     <h3>Input/Output Component</h3>
     <io-parent-comp></io-parent-comp>

--- a/aio/content/examples/universal/src/app/app.component.ts
+++ b/aio/content/examples/universal/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component }          from '@angular/core';
 
 @Component({
-  selector: 'my-app',
+  selector: 'app-root',
   template: `
     <h1>{{title}}</h1>
     <nav>

--- a/aio/content/examples/universal/src/app/dashboard.component.ts
+++ b/aio/content/examples/universal/src/app/dashboard.component.ts
@@ -7,7 +7,7 @@ import 'rxjs/add/operator/map';
 import { Observable } from 'rxjs/Observable';
 
 @Component({
-  selector: 'my-dashboard',
+  selector: 'app-dashboard',
   templateUrl: './dashboard.component.html',
   styleUrls: [ './dashboard.component.css' ]
 })

--- a/aio/content/examples/universal/src/app/hero-detail.component.ts
+++ b/aio/content/examples/universal/src/app/hero-detail.component.ts
@@ -7,7 +7,7 @@ import { Hero }        from './hero';
 import { HeroService } from './hero.service';
 
 @Component({
-  selector: 'my-hero-detail',
+  selector: 'app-hero-detail',
   templateUrl: './hero-detail.component.html',
   styleUrls: [ './hero-detail.component.css' ]
 })

--- a/aio/content/examples/universal/src/app/heroes.component.ts
+++ b/aio/content/examples/universal/src/app/heroes.component.ts
@@ -6,7 +6,7 @@ import { Hero }                from './hero';
 import { HeroService }         from './hero.service';
 
 @Component({
-  selector: 'my-heroes',
+  selector: 'app-heroes',
   templateUrl: './heroes.component.html',
   styleUrls: [ './heroes.component.css' ]
 })

--- a/aio/content/examples/universal/src/index-universal.html
+++ b/aio/content/examples/universal/src/index-universal.html
@@ -14,7 +14,7 @@
   </head>
 
   <body>
-    <my-app>Loading...</my-app>
+    <app-root>Loading...</app-root>
   </body>
   <!-- #docregion client-app-bundle -->
   <script src="client.js"></script>

--- a/aio/content/examples/universal/src/index.html
+++ b/aio/content/examples/universal/src/index.html
@@ -22,6 +22,6 @@
   </head>
 
   <body>
-    <my-app>Loading...</my-app>
+    <app-root>Loading...</app-root>
   </body>
 </html>

--- a/aio/content/examples/upgrade-module/src/app/a-to-ajs-transclusion/container.component.ts
+++ b/aio/content/examples/upgrade-module/src/app/a-to-ajs-transclusion/container.component.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 import { Hero } from '../hero';
 
 @Component({
-  selector: 'my-container',
+  selector: 'app-container',
   template: `
     <hero-detail [hero]="hero">
       <!-- Everything here will get transcluded -->

--- a/aio/content/examples/upgrade-module/src/app/upgrade-io/container.component.ts
+++ b/aio/content/examples/upgrade-module/src/app/upgrade-io/container.component.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 import { Hero } from '../hero';
 
 @Component({
-  selector: 'my-container',
+  selector: 'app-container',
   template: `
     <h1>Tour of Heroes</h1>
     <hero-detail [hero]="hero"

--- a/aio/content/examples/upgrade-module/src/app/upgrade-static/container.component.ts
+++ b/aio/content/examples/upgrade-module/src/app/upgrade-static/container.component.ts
@@ -2,7 +2,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'my-container',
+  selector: 'app-container',
   template: `
     <h1>Tour of Heroes</h1>
     <hero-detail></hero-detail>

--- a/aio/content/examples/upgrade-module/src/index-a-to-ajs-transclusion.html
+++ b/aio/content/examples/upgrade-module/src/index-a-to-ajs-transclusion.html
@@ -24,7 +24,7 @@
 
   <body>
     <hero-app>
-      <my-container></my-container>
+      <app-container></app-container>
     </hero-app>
   </body>
 </html>

--- a/aio/content/examples/upgrade-module/src/index-upgrade-io.html
+++ b/aio/content/examples/upgrade-module/src/index-upgrade-io.html
@@ -24,7 +24,7 @@
 
   <body>
     <hero-app>
-      <my-container></my-container>
+      <app-container></app-container>
     </hero-app>
   </body>
 </html>

--- a/aio/content/examples/upgrade-module/src/index-upgrade-static.html
+++ b/aio/content/examples/upgrade-module/src/index-upgrade-static.html
@@ -24,7 +24,7 @@
 
   <body>
     <hero-app>
-      <my-container></my-container>
+      <app-container></app-container>
     </hero-app>
   </body>
 </html>

--- a/aio/content/examples/webpack/src/app/app.component.ts
+++ b/aio/content/examples/webpack/src/app/app.component.ts
@@ -8,7 +8,7 @@ import '../assets/css/styles.css';
 
 // #docregion component
 @Component({
-  selector: 'my-app',
+  selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })

--- a/aio/content/examples/webpack/src/index.html
+++ b/aio/content/examples/webpack/src/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
-    <my-app>Loading...</my-app>
+    <app-root>Loading...</app-root>
   </body>
 </html>
 <!-- #enddocregion -->

--- a/aio/content/guide/bootstrapping.md
+++ b/aio/content/guide/bootstrapping.md
@@ -151,10 +151,10 @@ The _bootstrapping_ process sets up the execution environment,
 digs the _root_ `AppComponent` out of the module's `bootstrap` array,
 creates an instance of the component and inserts it within the element tag identified by the component's `selector`.
 
-The `AppComponent` selector &mdash; here and in most documentation samples &mdash; is `my-app`
-so Angular looks for a `<my-app>` tag in the `index.html` like this one ...
+The `AppComponent` selector &mdash; here and in most documentation samples &mdash; is `app-root`
+so Angular looks for a `<app-root>` tag in the `index.html` like this one ...
 
-<code-example path="setup/src/index.html" region="my-app" title="setup/src/index.html" linenums="false">
+<code-example path="setup/src/index.html" region="app-root" title="setup/src/index.html" linenums="false">
 
 </code-example>
 

--- a/aio/content/guide/cheatsheet.md
+++ b/aio/content/guide/cheatsheet.md
@@ -85,8 +85,8 @@ is available to <code>declarations</code> of this module.</p>
 <td><p>Binds text content to an interpolated string, for example, "Hello Seabiscuit".</p>
 </td>
 </tr><tr>
-<td><code>&lt;my-cmp <b>[(title)]</b>="name"&gt;</code></td>
-<td><p>Sets up two-way data binding. Equivalent to: <code>&lt;my-cmp [title]="name" (titleChange)="name=$event"&gt;</code></p>
+<td><code>&lt;app-cmp <b>[(title)]</b>="name"&gt;</code></td>
+<td><p>Sets up two-way data binding. Equivalent to: <code>&lt;app-cmp [title]="name" (titleChange)="name=$event"&gt;</code></p>
 </td>
 </tr><tr>
 <td><code>&lt;video <b>#movieplayer</b> ...&gt;<br>  &lt;button <b>(click)</b>="movieplayer.play()"&gt;<br>&lt;/video&gt;</code></td>
@@ -220,11 +220,11 @@ so the <code>@Directive</code> configuration applies to components as well</p>
 <td><p>List of dependency injection providers scoped to this component's view.</p>
 </td>
 </tr><tr>
-<td><code><b>template:</b> 'Hello {{name}}'<br><b>templateUrl:</b> 'my-component.html'</code></td>
+<td><code><b>template:</b> 'Hello {{name}}'<br><b>templateUrl:</b> 'app-component.html'</code></td>
 <td><p>Inline template or external template URL of the component's view.</p>
 </td>
 </tr><tr>
-<td><code><b>styles:</b> ['.primary {color: red}']<br><b>styleUrls:</b> ['my-component.css']</code></td>
+<td><code><b>styles:</b> ['.primary {color: red}']<br><b>styleUrls:</b> ['app-component.css']</code></td>
 <td><p>List of inline CSS styles or external stylesheet URLs for styling the component’s view.</p>
 </td>
 </tr>
@@ -240,11 +240,11 @@ so the <code>@Directive</code> configuration applies to components as well</p>
 <tr>
 <td><code><b>@Input()</b> myProperty;</code></td>
 <td><p>Declares an input property that you can update via property binding (example:
-<code>&lt;my-cmp [myProperty]="someExpression"&gt;</code>).</p>
+<code>&lt;app-cmp [myProperty]="someExpression"&gt;</code>).</p>
 </td>
 </tr><tr>
 <td><code><b>@Output()</b> myEvent = new EventEmitter();</code></td>
-<td><p>Declares an output property that fires events that you can subscribe to with an event binding (example: <code>&lt;my-cmp (myEvent)="doSomething()"&gt;</code>).</p>
+<td><p>Declares an output property that fires events that you can subscribe to with an event binding (example: <code>&lt;app-cmp (myEvent)="doSomething()"&gt;</code>).</p>
 </td>
 </tr><tr>
 <td><code><b>@HostBinding('class.valid')</b> isValid;</code></td>

--- a/aio/content/guide/dependency-injection-in-action.md
+++ b/aio/content/guide/dependency-injection-in-action.md
@@ -480,7 +480,7 @@ Angular sets the constructor's `el` parameter to the injected `ElementRef`, whic
 a wrapper around that DOM element.
 Its `nativeElement` property exposes the DOM element for the directive to manipulate.
 
-The sample code applies the directive's `myHighlight` attribute to two `<div>` tags,
+The sample code applies the directive's `appHighlight` attribute to two `<div>` tags,
 first without a value (yielding the default color) and then with an assigned color value.
 
 <code-example path="dependency-injection-in-action/src/app/app.component.html" region="highlight" title="src/app/app.component.html (highlight)" linenums="false">

--- a/aio/content/guide/displaying-data.md
+++ b/aio/content/guide/displaying-data.md
@@ -92,7 +92,7 @@ the view, such as a keystroke, a timer completion, or a response to an HTTP requ
 Notice that you don't call **new** to create an instance of the `AppComponent` class.
 Angular is creating an instance for you. How?
 
-The CSS `selector` in the `@Component` decorator specifies an element named `<my-app>`.
+The CSS `selector` in the `@Component` decorator specifies an element named `<app-root>`.
 That element is a placeholder in the body of your `index.html` file:
 
 
@@ -102,9 +102,9 @@ That element is a placeholder in the body of your `index.html` file:
 
 
 
-When you bootstrap with the `AppComponent` class (in <code>main.ts</code>), Angular looks for a `<my-app>`
+When you bootstrap with the `AppComponent` class (in <code>main.ts</code>), Angular looks for a `<app-root>`
 in the `index.html`, finds it, instantiates an instance of `AppComponent`, and renders it
-inside the `<my-app>` tag.
+inside the `<app-root>` tag.
 
 Now run the app. It should display the title and hero name:
 

--- a/aio/content/guide/docs-style-guide.md
+++ b/aio/content/guide/docs-style-guide.md
@@ -370,9 +370,9 @@ If you want to include an ignored code file in your project and display it in a 
 The preferred way to un-ignore a file is to update the `content/examples/.gitignore` like this:
 
 <code-example title="content/examples/.gitignore">
-  # my-guide
-  !my-guide/src/something.js
-  !my-guide/more-javascript*.js
+  # app-guide
+  !app-guide/src/something.js
+  !app-guide/more-javascript*.js
 </code-example>
 
 </div>

--- a/aio/content/guide/glossary.md
+++ b/aio/content/guide/glossary.md
@@ -176,7 +176,7 @@ the component in the role of "controller" or "view model".
 The practice of writing compound words or phrases such that each word is separated by a dash or hyphen (`-`).
 This form is also known as kebab-case.
 
-[Directive](guide/glossary#directive) selectors (like `my-app`) and
+[Component](guide/glossary#component) selectors (like `app-heroes`) and
 the root of filenames (such as `hero-list.component.ts`) are often
 spelled in dash-case.
 
@@ -316,7 +316,7 @@ When Angular finds a directive in an HTML template,
 it creates the matching directive class instance
 and gives the instance control over that portion of the browser DOM.
 
-You can invent custom HTML markup (for example, `<my-directive>`) to
+You can invent custom HTML markup (for example, `<app-heroes>`) to
 associate with your custom directives. You add this custom markup to HTML templates
 as if you were writing native HTML. In this way, directives become extensions of
 HTML itself.

--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -233,7 +233,7 @@ One common task is adding an `Authorization` header to outgoing requests. Here's
 ```javascript
 http
   .post('/api/items/add', body, {
-    headers: new HttpHeaders().set('Authorization', 'my-auth-token'),
+    headers: new HttpHeaders().set('Authorization', 'app-auth-token'),
   })
   .subscribe();
 ```
@@ -553,8 +553,8 @@ If your backend service uses different names for the XSRF token cookie or header
 imports: [
   HttpClientModule,
   HttpClientXsrfModule.withConfig({
-    cookieName: 'My-Xsrf-Cookie',
-    headerName: 'My-Xsrf-Header',
+    cookieName: 'app-Xsrf-Cookie',
+    headerName: 'app-Xsrf-Header',
   }),
 ]
 ```

--- a/aio/content/guide/lifecycle-hooks.md
+++ b/aio/content/guide/lifecycle-hooks.md
@@ -571,7 +571,7 @@ the `AfterContentComponent`'s parent. Here's the parent's template:
 
 <code-example path="lifecycle-hooks/src/app/after-content.component.ts" region="parent-template" title="AfterContentParentComponent (template excerpt)" linenums="false"></code-example>
 
-Notice that the `<my-child>` tag is tucked between the `<after-content>` tags.
+Notice that the `<app-child>` tag is tucked between the `<after-content>` tags.
 Never put content between a component's element tags *unless you intend to project that content
 into the component*.
 
@@ -581,7 +581,7 @@ Now look at the component's template:
 
 The `<ng-content>` tag is a *placeholder* for the external content.
 It tells Angular where to insert that content.
-In this case, the projected content is the `<my-child>` from the parent.
+In this case, the projected content is the `<app-child>` from the parent.
 
 <figure>
   <img src='generated/images/guide/lifecycle-hooks/projected-child-view.png' alt="Projected Content">

--- a/aio/content/guide/metadata.md
+++ b/aio/content/guide/metadata.md
@@ -457,7 +457,7 @@ Here's a `provider` example of the problem.
 let foo: number; // neither exported nor initialized
 
 @Component({
-  selector: 'my-component',
+  selector: 'app-component',
   template: ... ,
   providers: [
     { provide: Foo, useValue: foo }
@@ -488,7 +488,7 @@ Alternatively, you can fix it by exporting `foo` with the expectation that `foo`
 export let foo: number; // exported
 
 @Component({
-  selector: 'my-component',
+  selector: 'app-component',
   template: ... ,
   providers: [
     { provide: Foo, useValue: foo }
@@ -508,7 +508,7 @@ For example, it doesn't work for the `template` property.
 export let someTemplate: string; // exported but not initialized
 
 @Component({
-  selector: 'my-component',
+  selector: 'app-component',
   template: someTemplate
 })
 export class MyComponent {}
@@ -540,7 +540,7 @@ the exported `someTemplate` variable which is declared but _unassigned_.
 export let someTemplate: string;
 
 @Component({
-  selector: 'my-component',
+  selector: 'app-component',
   template: someTemplate
 })
 export class MyComponent {}
@@ -553,7 +553,7 @@ You'd also get this error if you imported `someTemplate` from some other module 
 import { someTemplate } from './config';
 
 @Component({
-  selector: 'my-component',
+  selector: 'app-component',
   template: someTemplate
 })
 export class MyComponent {}
@@ -571,7 +571,7 @@ To correct this error, provide the initial value of the variable in an initializ
 export let someTemplate = '<h1>Greetings from Angular</h1>';
 
 @Component({
-  selector: 'my-component',
+  selector: 'app-component',
   template: someTemplate
 })
 export class MyComponent {}

--- a/aio/content/guide/ngmodule.md
+++ b/aio/content/guide/ngmodule.md
@@ -142,7 +142,7 @@ The example `AppComponent` simply displays a data-bound title:
 
 Lastly, the `@NgModule.bootstrap` property identifies this `AppComponent` as the _bootstrap component_.
 When Angular launches the app, it places the HTML rendering of `AppComponent` in the DOM,
-inside the `<my-app>` element tags of the `index.html`.
+inside the `<app-root>` element tags of the `index.html`.
 
 
 {@a bootstrap}

--- a/aio/content/guide/setup-systemjs-anatomy.md
+++ b/aio/content/guide/setup-systemjs-anatomy.md
@@ -152,7 +152,7 @@ If you do, this page can help you understand their purpose.
       The application host page.
       It loads a few essential scripts in a prescribed order.
       Then it boots the application, placing the root `AppComponent`
-      in the custom `<my-app>` body tag.
+      in the custom `<app-root>` body tag.
 
       The same `index.html` satisfies all documentation application samples.
     </td>

--- a/aio/content/guide/upgrade.md
+++ b/aio/content/guide/upgrade.md
@@ -545,7 +545,7 @@ of multiple words. In Angular, you would bind these attributes using camelCase:
 But when using them from AngularJS templates, you must use kebab-case:
 
 <code-example format="">
-  [my-hero]="hero"
+  [app-hero]="hero"
 </code-example>
 
 </div>
@@ -635,7 +635,7 @@ observing the following rules:
 
     <td>
 
-      `<my-component myAttribute="value">`
+      `<app-component myAttribute="value">`
 
     </td>
   </tr>
@@ -650,7 +650,7 @@ observing the following rules:
     </td>
     <td>
 
-      `<my-component (myOutput)="action()">`
+      `<app-component (myOutput)="action()">`
 
     </td>
   </tr>
@@ -665,7 +665,7 @@ observing the following rules:
     </td>
     <td>
 
-      `<my-component [myValue]="anExpression">`
+      `<app-component [myValue]="anExpression">`
 
     </td>
   </tr>
@@ -680,9 +680,9 @@ observing the following rules:
     </td>
     <td>
 
-      As a two-way binding: `<my-component [(myValue)]="anExpression">`.
+      As a two-way binding: `<app-component [(myValue)]="anExpression">`.
       Since most AngularJS two-way bindings actually only need a one-way binding
-      in practice, `<my-component [myValue]="anExpression">` is often enough.
+      in practice, `<app-component [myValue]="anExpression">` is often enough.
 
     </td>
   </tr>


### PR DESCRIPTION
See Issue #19510
Leave some behind for manual attention.
Deliberately do not change “myClick” to “appClick” in TemplateSyntax guide.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```
