### PR TITLE
fix(platform-browser): support Symbols in custom jasmineToString() method

### DIFF
--- a/packages/platform-browser/testing/src/matchers.ts
+++ b/packages/platform-browser/testing/src/matchers.ts
@@ -107,7 +107,7 @@ export const expect: (actual: any) => NgMatchers = <any>_global.expect;
     return '' + m;
   }
   const res: any[] = [];
-  m.forEach((v: any, k: any) => { res.push(`${k}:${v}`); });
+  m.forEach((v: any, k: any) => { res.push(`${String(k)}:${String(v)}`); });
   return `{ ${res.join(',')} }`;
 };
 


### PR DESCRIPTION
It's illegal to coerce a Symbol to a string, and results in a TypeError:

TypeError: Cannot convert a Symbol value to a string

Previously, the custom jasmineToString() method monkey-patched onto Maps
in platform-browser/testing/src/matchers.ts would coerce keys and values
to strings. A change in a newer version of Jasmine calls this method more
often, resulting in calls against Maps which contain Symbols in some
applications, which causes crashes.

The fix is to explicitly convert keys and values to strings, which does
work on Symbols.