### PR TITLE
docs(compiler-cli): add warning about changing ngtools_api2

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -7,9 +7,12 @@
 #
 # alexeagle - Alex Eagle
 # alxhub - Alex Rickabaugh
+# brocco - Mike Brocchi
 # chuckjaz - Chuck Jazdzewski
+# filipesilva - Filipe Silva
 # Foxandxss - Jesús Rodríguez
 # gkalpak - George Kalpakas
+# hansl - Hans Larsen
 # IgorMinar - Igor Minar
 # jasonaden - Jason Aden
 # juleskremer - Jules Kremer
@@ -144,11 +147,23 @@ groups:
       - mhevery
       - IgorMinar #fallback
 
+  compiler-cli/ngtools:
+    conditions:
+      files:
+        - "packages/compiler-cli/src/ngtools*"
+    users:
+      - hansl
+      - filipesilva #fallback
+      - brocco #fallback
+
   compiler-cli:
     conditions:
       files:
-        - "packages/compiler-cli/*"
-        - "packages/bazel/*"
+        include:
+          - "packages/compiler-cli/*"
+          - "packages/bazel/*"
+        exclude:
+          - "packages/compiler-cli/src/ngtools*"   
     users:
       - alexeagle
       - chuckjaz

--- a/packages/compiler-cli/src/ngtools_api.ts
+++ b/packages/compiler-cli/src/ngtools_api.ts
@@ -13,6 +13,12 @@
  * something else.
  */
 
+/**
+ *********************************************************************
+ * Changes to this file need to be approved by the Angular CLI team. *
+ *********************************************************************
+ */
+
 import {AotCompilerHost, AotSummaryResolver, StaticReflector, StaticSymbolCache, StaticSymbolResolver} from '@angular/compiler';
 import * as ts from 'typescript';
 

--- a/packages/compiler-cli/src/ngtools_api2.ts
+++ b/packages/compiler-cli/src/ngtools_api2.ts
@@ -15,6 +15,12 @@
  * Once the ngc api is public and stable, this can be removed.
  */
 
+/**
+ *********************************************************************
+ * Changes to this file need to be approved by the Angular CLI team. *
+ *********************************************************************
+ */
+
 import {ParseSourceSpan} from '@angular/compiler';
 import * as ts from 'typescript';
 

--- a/packages/compiler-cli/src/ngtools_impl.ts
+++ b/packages/compiler-cli/src/ngtools_impl.ts
@@ -12,6 +12,13 @@
  * This API should be stable for NG 2. It can be removed in NG 4..., but should be replaced by
  * something else.
  */
+
+/**
+ *********************************************************************
+ * Changes to this file need to be approved by the Angular CLI team. *
+ *********************************************************************
+ */
+
 import {AotCompilerHost, StaticReflector, StaticSymbol, core} from '@angular/compiler';
 
 


### PR DESCRIPTION
A recent change (https://github.com/angular/angular/pull/19748) broke the error reporting in Angular CLI. This warning should help coordinate changes to prever situations like that.