### PR TITLE
feat(forms): expose updateTreeValidity method

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -158,7 +158,7 @@ export class FormGroupDirective extends ControlContainer implements Form,
       }
     });
 
-    this.form._updateTreeValidity({emitEvent: false});
+    this.form.updateTreeValidity({emitEvent: false});
   }
 
   private _updateRegistrations() {

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -434,9 +434,13 @@ export abstract class AbstractControl {
     }
   }
 
-  /** @internal */
-  _updateTreeValidity(opts: {emitEvent?: boolean} = {emitEvent: true}) {
-    this._forEachChild((ctrl: AbstractControl) => ctrl._updateTreeValidity(opts));
+  /**
+   * Re-calculates the value and validation status of the entire controls tree.
+   *
+   * @experimental
+   */
+  updateTreeValidity(opts: {emitEvent?: boolean} = {emitEvent: true}): void {
+    this._forEachChild((ctrl: AbstractControl) => ctrl.updateTreeValidity(opts));
     this.updateValueAndValidity({onlySelf: true, emitEvent: opts.emitEvent});
   }
 

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -1070,12 +1070,12 @@ export function main() {
       });
 
       it('should update tree validity', () => {
-        form._updateTreeValidity();
+        form.updateTreeValidity();
         expect(logger).toEqual(['one', 'two', 'nested', 'three', 'form']);
       });
 
       it('should not emit events when turned off', () => {
-        form._updateTreeValidity({emitEvent: false});
+        form.updateTreeValidity({emitEvent: false});
         expect(logger).toEqual([]);
       });
 

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -57,6 +57,9 @@ export declare abstract class AbstractControl {
     setParent(parent: FormGroup | FormArray): void;
     setValidators(newValidator: ValidatorFn | ValidatorFn[] | null): void;
     abstract setValue(value: any, options?: Object): void;
+    /** @experimental */ updateTreeValidity(opts?: {
+        emitEvent?: boolean;
+    }): void;
     updateValueAndValidity(opts?: {
         onlySelf?: boolean;
         emitEvent?: boolean;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #6170, closes #19820.


## What is the new behavior?

Expose `AbstractControl#updateValueAndValidity()` to allow user force re-validate a `FormGroup`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
