### PR TITLE
fix(service-worker): include versionedFiles in the manifest hashTable

### DIFF
--- a/packages/service-worker/config/src/generator.ts
+++ b/packages/service-worker/config/src/generator.ts
@@ -46,7 +46,7 @@ export class Generator {
       plainFiles.forEach(file => seenMap.add(file));
 
       // Add the hashes.
-      await plainFiles.reduce(async(previous, file) => {
+      await[...versionedFiles, ...plainFiles].reduce(async(previous, file) => {
         await previous;
         const hash = await this.fs.hash(file);
         hashTable[joinUrls(this.baseHref, file)] = hash;

--- a/packages/service-worker/config/test/generator_spec.ts
+++ b/packages/service-worker/config/test/generator_spec.ts
@@ -14,6 +14,7 @@ export function main() {
     it('generates a correct config', (done: DoneFn) => {
       const fs = new MockFilesystem({
         '/index.html': 'This is a test',
+        '/test.txt': 'Another test',
         '/foo/test.html': 'Another test',
         '/ignored/x.html': 'should be ignored',
       });
@@ -30,7 +31,9 @@ export function main() {
               '/**/*.html', '!/ignored/**',
               //                '/*.html',
             ],
-            versionedFiles: [],
+            versionedFiles: [
+              '/**/*.txt',
+            ],
             urls: [
               '/absolute/**',
               '/some/url?with+escaped+chars',
@@ -62,7 +65,11 @@ export function main() {
                'name': 'test',
                'installMode': 'prefetch',
                'updateMode': 'prefetch',
-               'urls': ['/test/index.html', '/test/foo/test.html'],
+               'urls': [
+                 '/test/index.html',
+                 '/test/foo/test.html',
+                 '/test/test.txt',
+               ],
                'patterns': [
                  '\\/absolute\\/.*',
                  '\\/some\\/url\\?with\\+escaped\\+chars',
@@ -79,6 +86,7 @@ export function main() {
                'version': 1,
              }],
              'hashTable': {
+               '/test/test.txt': '18f6f8eb7b1c23d2bb61bff028b83d867a9e4643',
                '/test/index.html': 'a54d88e06612d820bc3be72877c74f257b561b19',
                '/test/foo/test.html': '18f6f8eb7b1c23d2bb61bff028b83d867a9e4643'
              }


### PR DESCRIPTION
There is no difference in runtime (yet) between versioned and unversioned
files. Theoretically, the SW does not have to cache-bust versioned files,
but the SW doesn't cache bust files on the first request anyway, so in the
common case it doesn't matter. If the hash doesn't match, the SW will cache
bust the file to be sure, which is technically unnecessary, but since the
file itself is versioned, the likelihood of this happening is rare.

This fixes a critical bug where versioned files were erroneously not included
in the hashTable in the generated manifest. This could lead to applications
not updating if only versioned files changed in between versions.
