### PR TITLE
docs: fix missing code example

### DIFF
--- a/aio/content/examples/ajs-quick-reference/src/app/app.component.html
+++ b/aio/content/examples/ajs-quick-reference/src/app/app.component.html
@@ -34,6 +34,9 @@
 <!-- #docregion href -->
 <a [href]="angularDocsUrl">Angular Docs</a>
 <!-- #enddocregion href -->
+<!-- #docregion routerlink -->
+<a routerLink="#movies">Movies</a>
+<!-- #enddocregion routerlink -->
 
 <p></p>
 <div>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
In the [angularjs cheat sheet bind to href property section](https://angular.io/guide/ajs-quick-reference#bind-to-the-href-property), the code sample is missing for `routerlink`. This PR adds a code sample so that section can properly bring it in.

Issue Number: N/A


## What is the new behavior?
Code example now exists and is properly brought in as referenced

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
