### PR TITLE
fix(core): use SystemJS global instead of System

### DIFF
--- a/packages/core/src/linker/system_js_ng_module_factory_loader.ts
+++ b/packages/core/src/linker/system_js_ng_module_factory_loader.ts
@@ -16,7 +16,7 @@ import {NgModuleFactoryLoader} from './ng_module_factory_loader';
 const _SEPARATOR = '#';
 
 const FACTORY_CLASS_SUFFIX = 'NgFactory';
-declare var System: any;
+declare var SystemJS: any;
 
 /**
  * Configuration for SystemJsNgModuleLoader.
@@ -64,7 +64,7 @@ export class SystemJsNgModuleLoader implements NgModuleFactoryLoader {
       exportName = 'default';
     }
 
-    return System.import(module)
+    return SystemJS.import(module)
         .then((module: any) => module[exportName])
         .then((type: any) => checkNotEmpty(type, module, exportName))
         .then((type: any) => this._compiler.compileModuleAsync(type));
@@ -78,7 +78,7 @@ export class SystemJsNgModuleLoader implements NgModuleFactoryLoader {
       factoryClassSuffix = '';
     }
 
-    return System.import(this._config.factoryPathPrefix + module + this._config.factoryPathSuffix)
+    return SystemJS.import(this._config.factoryPathPrefix + module + this._config.factoryPathSuffix)
         .then((module: any) => module[exportName + factoryClassSuffix])
         .then((factory: any) => checkNotEmpty(factory, module, exportName));
   }

--- a/packages/core/test/linker/system_ng_module_factory_loader_spec.ts
+++ b/packages/core/test/linker/system_ng_module_factory_loader_spec.ts
@@ -24,14 +24,14 @@ export function main() {
   describe('SystemJsNgModuleLoader', () => {
     let oldSystem: any = null;
     beforeEach(() => {
-      oldSystem = global['System'];
-      global['System'] = mockSystem({
+      oldSystem = global['SystemJS'];
+      global['SystemJS'] = mockSystem({
         'test.ngfactory':
             {'default': 'test module factory', 'NamedNgFactory': 'test NamedNgFactory'},
         'prefixed/test/suffixed': {'NamedNgFactory': 'test module factory'}
       });
     });
-    afterEach(() => { global['System'] = oldSystem; });
+    afterEach(() => { global['SystemJS'] = oldSystem; });
 
     it('loads a default factory by appending the factory suffix', async(() => {
          const loader = new SystemJsNgModuleLoader(new Compiler());


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fixes #11580


## What is the new behavior?

Use `SystemJS` global to avoid incorrect recognition in Webpack.

SystemJS always provides two globals `SystemJS` and `System`, since SystemJS is no longer a polyfill of loader API, `SystemJS` global is more specific to refer to the SysmteJS library.

And `SystemJS` global [is officially preferred](https://github.com/systemjs/systemjs/commit/1aeb69d7fab371e1c2725273b10c80316f05ae8e#diff-04c6e90faac2675aa89e2176d2eec7d8R46) instead of `System` as well for a long time.



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Question: should the usage in testing & aio be changed as well? In separated PR?