### PR TITLE
style(core): fix typo in error message

### DIFF
--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -118,7 +118,7 @@ export class NgZone {
 
   constructor({enableLongStackTrace = false}) {
     if (typeof Zone == 'undefined') {
-      throw new Error('Angular requires Zone.js prolyfill.');
+      throw new Error('Angular requires Zone.js polyfill.');
     }
 
     Zone.assertZonePatched();


### PR DESCRIPTION
Fix typo in error message when the Zone polyfill is undefined. Fixing this prevents confusion and makes the application look more professional.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Typo in error thrown
Issue Number: N/A


## What is the new behavior?
The typo is fixed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
