### PR TITLE
fix(compiler-cli): report all diagnostic error messages

### DIFF
--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -510,21 +510,25 @@ class AngularCompilerProgram implements Program {
     if (isSyntaxError(e)) {
       const parserErrors = getParseErrors(e);
       if (parserErrors && parserErrors.length) {
-        this._structuralDiagnostics =
-            parserErrors.map<Diagnostic>(e => ({
-                                           messageText: e.contextualMessage(),
-                                           category: ts.DiagnosticCategory.Error,
-                                           span: e.span,
-                                           source: SOURCE,
-                                           code: DEFAULT_ERROR_CODE
-                                         }));
+        this._structuralDiagnostics = [
+          ...(this._structuralDiagnostics || []),
+          ...parserErrors.map<Diagnostic>(e => ({
+                                            messageText: e.contextualMessage(),
+                                            category: ts.DiagnosticCategory.Error,
+                                            span: e.span,
+                                            source: SOURCE,
+                                            code: DEFAULT_ERROR_CODE
+                                          }))
+        ];
       } else {
-        this._structuralDiagnostics = [{
-          messageText: e.message,
-          category: ts.DiagnosticCategory.Error,
-          source: SOURCE,
-          code: DEFAULT_ERROR_CODE
-        }];
+        this._structuralDiagnostics = [
+          ...(this._structuralDiagnostics || []), {
+            messageText: e.message,
+            category: ts.DiagnosticCategory.Error,
+            source: SOURCE,
+            code: DEFAULT_ERROR_CODE
+          }
+        ];
       }
       return null;
     }


### PR DESCRIPTION
This fixes a problem introduced in 8d45fefc313aebd0db7b320a1d324c2d4bebd268
which modified how diagnostic error messages are reported for structural
metadata errors causing some of the diagnostics to be lost.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Not all errors where reported when a structural error causes a cascading metadata validation error.

## What is the new behavior?

All error errors are reported.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
