### PR TITLE
uses a loop instead Array.map()

### DIFF
--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -1225,7 +1225,7 @@ export class TransitionAnimationEngine {
     const targetTriggerName: string|undefined =
         instruction.isRemovalTransition ? undefined : triggerName;
 
-    instruction.timelines.map(timelineInstruction => {
+    for (const timelineInstruction of instruction.timelines) {
       const element = timelineInstruction.element;
       const isQueriedElement = element !== rootElement;
       const players = getOrSetAsInMap(allPreviousPlayersMap, element, []);
@@ -1239,7 +1239,7 @@ export class TransitionAnimationEngine {
         player.destroy();
         players.push(player);
       });
-    });
+    }
 
     // this needs to be done so that the PRE/POST styles can be
     // computed properly without interfering with the previous animation


### PR DESCRIPTION
uses a loop instead Array.map() which creates and returns a new array that is discarded.

We're enabling a check in google3 that detects calls to well-known functions and methods that return a value that is discarded. So this pattern will become a compilation error soon. 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
