### PR TITLE
fix(compiler-cli): only use error collector when needed.

### DIFF
--- a/packages/compiler-cli/src/ngtools_api.ts
+++ b/packages/compiler-cli/src/ngtools_api.ts
@@ -89,7 +89,7 @@ export class NgTools_InternalApi_NG_2 {
     // as we only needed this to support Angular CLI 1.5.0 rc.*
     const ngProgram = createProgram({
       rootNames: options.program.getRootFileNames(),
-      options: options.angularCompilerOptions,
+      options: {...options.angularCompilerOptions, collectAllErrors: true},
       host: options.host
     });
     const lazyRoutes = ngProgram.listLazyRoutes(options.entryModule);

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -150,6 +150,9 @@ export interface CompilerOptions extends ts.CompilerOptions {
    * in JIT mode. This is off by default.
    */
   enableSummariesForJit?: boolean;
+
+  /** @internal */
+  collectAllErrors?: boolean;
 }
 
 export interface CompilerHost extends ts.CompilerHost {

--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -422,14 +422,15 @@ class AngularCompilerProgram implements Program {
         this.oldProgramLibrarySummaries);
     const aotOptions = getAotCompilerOptions(this.options);
     this._structuralDiagnostics = [];
-    const errorCollector = (err: any) => {
-      this._structuralDiagnostics !.push({
-        messageText: err.toString(),
-        category: ts.DiagnosticCategory.Error,
-        source: SOURCE,
-        code: DEFAULT_ERROR_CODE
-      });
-    };
+    const errorCollector =
+        (this.options.collectAllErrors || this.options.fullTemplateTypeCheck) ? (err: any) => {
+          this._structuralDiagnostics !.push({
+            messageText: err.toString(),
+            category: ts.DiagnosticCategory.Error,
+            source: SOURCE,
+            code: DEFAULT_ERROR_CODE
+          });
+        } : undefined;
     this._compiler = createAotCompiler(this._hostAdapter, aotOptions, errorCollector).compiler;
   }
 

--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -1424,11 +1424,8 @@ describe('ngc transformer command-line', () => {
       const messages: string[] = [];
       const exitCode =
           main(['-p', path.join(basePath, 'src/tsconfig.json')], message => messages.push(message));
-      expect(exitCode).toBe(1, 'Compile was expected to fail');
-      expect(messages).toEqual([
-        'Error: Error: Error encountered resolving symbol values statically. Tagged template expressions are not supported in metadata (position 3:27 in the original .ts file)\n' +
-        'Error: No template specified for component TestComponent\n'
-      ]);
+      expect(exitCode).toBe(2, 'Compile was expected to fail');
+      expect(messages[0]).toContain(['Tagged template expressions are not supported in metadata']);
     });
   });
 });

--- a/packages/compiler-cli/test/transformers/program_spec.ts
+++ b/packages/compiler-cli/test/transformers/program_spec.ts
@@ -554,8 +554,8 @@ describe('ng program', () => {
       });
     }
 
-    function createProgram(rootNames: string[]) {
-      const options = testSupport.createCompilerOptions();
+    function createProgram(rootNames: string[], overrideOptions: ng.CompilerOptions = {}) {
+      const options = testSupport.createCompilerOptions(overrideOptions);
       const host = ng.createCompilerHost({options});
       const program = ng.createProgram(
           {rootNames: rootNames.map(p => path.resolve(testSupport.basePath, p)), options, host});
@@ -797,7 +797,7 @@ describe('ng program', () => {
           export class ChildModule {}
         `,
       });
-      const program = createProgram(['src/main.ts']).program;
+      const program = createProgram(['src/main.ts'], {collectAllErrors: true}).program;
       expect(normalizeRoutes(program.listLazyRoutes('src/main#MainModule'))).toEqual([{
         module: {name: 'MainModule', filePath: path.resolve(testSupport.basePath, 'src/main.ts')},
         referencedModule:

--- a/packages/compiler/src/aot/compiler_factory.ts
+++ b/packages/compiler/src/aot/compiler_factory.ts
@@ -54,7 +54,7 @@ export function createAotUrlResolver(host: {
  */
 export function createAotCompiler(
     compilerHost: AotCompilerHost, options: AotCompilerOptions,
-    errorCollector: (error: any, type?: any) =>
+    errorCollector?: (error: any, type?: any) =>
         void): {compiler: AotCompiler, reflector: StaticReflector} {
   let translations: string = options.translations || '';
 


### PR DESCRIPTION
The error collector changes behavior of the metadata resolver
in ways that haven't been fully hardened. This changes limits
its use to the lazy route detection and the language service.

Issue: #19906

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue Number: #19906 

Part of issue 19906 demonstrates that the compiler was loosing error messages. 

## What is the new behavior?

Reverted the error collector for use in the primary `ngc` code path, switching back to a single error reporting mechanism used prior to the change.

The multiple error reporting is deferred now till 5.1 which will allow us time to harden the compiler against the changes to the metadata collector implied by using the error collector.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
