### PR TITLE
docs(core): change from deprecated renderer to renderer2

### DIFF
--- a/packages/core/src/linker/element_ref.ts
+++ b/packages/core/src/linker/element_ref.ts
@@ -30,7 +30,7 @@ export class ElementRef {
    *   <header>Use with caution</header>
    *   <p>
    *    Use this API as the last resort when direct access to DOM is needed. Use templating and
-   *    data-binding provided by Angular instead. Alternatively you take a look at {@link Renderer}
+   *    data-binding provided by Angular instead. Alternatively you can take a look at {@link Renderer2}
    *    which provides API that can safely be used even when direct access to native elements is not
    *    supported.
    *   </p>


### PR DESCRIPTION
We now show the proper class instead of the deprecated Renderer

Fixes #19806 ([link](https://github.com/angular/angular/issues/19806))

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
[ElementRef](https://angular.io/api/core/ElementRef) Documentation links to deprecated Renderer class

Issue Number: 19806


## What is the new behavior?
It now links to Renderer2 class instead of the deprecated Renderer class

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
