### PR TITLE
build: update to rxjs@5.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "core-js": "^2.4.1",
     "reflect-metadata": "^0.1.3",
-    "rxjs": "^5.5.0",
+    "rxjs": "^5.5.2",
     "tslib": "^1.7.1",
     "zone.js": "^0.8.12"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6194,9 +6194,9 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-rxjs@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.0.tgz#26d8f3866eb700e247e0728a147c3d628993d812"
+rxjs@^5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.2.tgz#28d403f0071121967f18ad665563255d54236ac3"
   dependencies:
     symbol-observable "^1.0.1"
 


### PR DESCRIPTION
We should push this upgrade as the earlier two point releases have problems with mappings to allow tree shakability. 