### PR TITLE
fix(service-worker): don't block initialization on registration

### DIFF
--- a/packages/service-worker/src/module.ts
+++ b/packages/service-worker/src/module.ts
@@ -30,8 +30,10 @@ export function ngswAppInitializer(
         op_filter.call(app.isStable, (stable: boolean) => !!stable) as Observable<boolean>;
     const isStable = op_take.call(onStable, 1) as Observable<boolean>;
     const whenStable = op_toPromise.call(isStable) as Promise<boolean>;
-    return whenStable.then(() => navigator.serviceWorker.register(script, options))
-        .then(() => undefined) as Promise<void>;
+
+    // Don't return the Promise, as that will block the application until the SW is registered, and
+    // cause a crash if the SW registration fails.
+    whenStable.then(() => navigator.serviceWorker.register(script, options));
   };
   return initializer;
 }


### PR DESCRIPTION
Importing ServiceWorkerModule.register() will schedule registration of
the Service Worker inside an APP_INITIALIZER. Previously, the Promise
returned by navigator.serviceWorker.register() was returned from the
initializer function. This has the unwanted side effect of blocking
initialization until the SW is registered. Even worse, if the SW script
fails to load, this can cause the app initialization to fail.

The solution is to not return the registration promise from the
initializer function, essentially decoupling registration from the rest
of the initialization flow.

This change is not unit testable as there are no mocks/adapters yet for
navigator.serviceWorker. A future integration test should cover this case
with better fidelity.