### PR TITLE
fix(compiler): don’t store invalid state when using `listLazyRoutes`

### DIFF
--- a/packages/compiler-cli/test/transformers/program_spec.ts
+++ b/packages/compiler-cli/test/transformers/program_spec.ts
@@ -617,6 +617,34 @@ describe('ng program', () => {
       ]);
     });
 
+    it('should emit correctly after listing lazyRoutes', () => {
+      testSupport.writeFiles({
+        'src/main.ts': `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @NgModule({
+            imports: [RouterModule.forRoot([{loadChildren: './lazy/lazy#LazyModule'}])]
+          })
+          export class MainModule {}
+        `,
+        'src/lazy/lazy.ts': `
+          import {NgModule} from '@angular/core';
+
+          @NgModule()
+          export class ChildModule {}
+        `,
+      });
+      const {program, options} = createProgram(['src/main.ts', 'src/lazy/lazy.ts']);
+      expectNoDiagnosticsInProgram(options, program);
+      program.listLazyRoutes();
+      program.emit();
+
+      const lazyNgFactory =
+          fs.readFileSync(path.resolve(testSupport.basePath, 'built/src/lazy/lazy.ngfactory.js'));
+      expect(lazyNgFactory).toContain('import * as i1 from "./lazy";');
+    });
+
     it('should list lazyRoutes given an entryRoute recursively', () => {
       writeSomeRoutes();
       const {program, options} = createProgram(['src/main.ts']);

--- a/packages/compiler/src/aot/static_reflector.ts
+++ b/packages/compiler/src/aot/static_reflector.ts
@@ -80,8 +80,10 @@ export class StaticReflector implements CompileReflector {
     const refSymbol =
         this.symbolResolver.getSymbolByModule(ref.moduleName !, ref.name !, containingFile);
     const declarationSymbol = this.findSymbolDeclaration(refSymbol);
-    this.symbolResolver.recordModuleNameForFileName(refSymbol.filePath, ref.moduleName !);
-    this.symbolResolver.recordImportAs(declarationSymbol, refSymbol);
+    if (!containingFile) {
+      this.symbolResolver.recordModuleNameForFileName(refSymbol.filePath, ref.moduleName !);
+      this.symbolResolver.recordImportAs(declarationSymbol, refSymbol);
+    }
     return declarationSymbol;
   }
 

--- a/packages/compiler/test/aot/static_reflector_spec.ts
+++ b/packages/compiler/test/aot/static_reflector_spec.ts
@@ -1062,6 +1062,22 @@ describe('StaticReflector', () => {
                .useValue)
         .toEqual({path: 'foo', data: {e: 1}});
   });
+
+  describe('resolveExternalReference', () => {
+    it('should register modules names in the StaticSymbolResolver if no containingFile is given',
+       () => {
+         init({
+           '/tmp/root.ts': ``,
+           '/tmp/a.ts': `export const x = 1;`,
+         });
+         let symbol =
+             reflector.resolveExternalReference({moduleName: './a', name: 'x'}, '/tmp/root.ts');
+         expect(symbolResolver.getKnownModuleName(symbol.filePath)).toBeFalsy();
+
+         symbol = reflector.resolveExternalReference({moduleName: 'a', name: 'x'});
+         expect(symbolResolver.getKnownModuleName(symbol.filePath)).toBe('a');
+       });
+  });
 });
 
 const DEFAULT_TEST_DATA: {[key: string]: any} = {


### PR DESCRIPTION
Previously, `listLazyRoute` would store invalid information in a compiler
internal cache, which lead to incorrect paths that were used during emit.
This commit fixes this.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
