### PR TITLE
fix(forms): publish missing types

### DIFF
--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -40,7 +40,7 @@ export {NgSelectOption, SelectControlValueAccessor} from './directives/select_co
 export {SelectMultipleControlValueAccessor} from './directives/select_multiple_control_value_accessor';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MinLengthValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {FormBuilder} from './form_builder';
-export {AbstractControl, FormArray, FormControl, FormGroup} from './model';
+export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormGroup} from './model';
 export {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from './validators';
 export {VERSION} from './version';
 

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -80,10 +80,24 @@ function coerceToAsyncValidator(
 
 export type FormHooks = 'change' | 'blur' | 'submit';
 
+/**
+ * @whatItDoes Interface for options provided to an {@link AbstractControl}.
+ *
+ * @experimental
+ */
 export interface AbstractControlOptions {
+  /**
+   * List of validators applied to control.
+   */
   validators?: ValidatorFn|ValidatorFn[]|null;
+  /**
+   * List of async validators applied to control.
+   */
   asyncValidators?: AsyncValidatorFn|AsyncValidatorFn[]|null;
-  updateOn?: FormHooks;
+  /**
+   * The event name for control to update upon.
+   */
+  updateOn?: 'change'|'blur'|'submit';
 }
 
 

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -86,6 +86,13 @@ export declare abstract class AbstractControlDirective {
     reset(value?: any): void;
 }
 
+/** @experimental */
+export interface AbstractControlOptions {
+    asyncValidators?: AsyncValidatorFn | AsyncValidatorFn[] | null;
+    updateOn?: 'change' | 'blur' | 'submit';
+    validators?: ValidatorFn | ValidatorFn[] | null;
+}
+
 /** @stable */
 export declare class AbstractFormGroupDirective extends ControlContainer implements OnInit, OnDestroy {
     readonly asyncValidator: AsyncValidatorFn | null;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Type `AbstractControlOptions` and `FormHooks` are already used in public APIs (like [FormControl](https://next.angular.io/api/forms/FormControl)), but themselves are not part of public API.


## What is the new behavior?

Publish `AbstractControlOptions` and `FormHooks` to public API.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
