### PR TITLE
fix(compiler): don't overwrite missingTranslation's value in JIT

### DIFF
--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -25,7 +25,8 @@ export class CompilerConfig {
 
   constructor(
       {defaultEncapsulation = ViewEncapsulation.Emulated, useJit = true, jitDevMode = false,
-       missingTranslation, enableLegacyTemplate, preserveWhitespaces, strictInjectionParameters}: {
+       missingTranslation = null, enableLegacyTemplate, preserveWhitespaces,
+       strictInjectionParameters}: {
         defaultEncapsulation?: ViewEncapsulation,
         useJit?: boolean,
         jitDevMode?: boolean,
@@ -37,7 +38,7 @@ export class CompilerConfig {
     this.defaultEncapsulation = defaultEncapsulation;
     this.useJit = !!useJit;
     this.jitDevMode = !!jitDevMode;
-    this.missingTranslation = missingTranslation || null;
+    this.missingTranslation = missingTranslation;
     this.enableLegacyTemplate = enableLegacyTemplate === true;
     this.preserveWhitespaces = preserveWhitespacesDefault(noUndefined(preserveWhitespaces));
     this.strictInjectionParameters = strictInjectionParameters === true;

--- a/packages/compiler/test/config_spec.ts
+++ b/packages/compiler/test/config_spec.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {MissingTranslationStrategy} from '@angular/core';
+import {CompilerConfig} from '../src/config';
+
+export function main() {
+  describe('compiler config', () => {
+    it('should set missing translation strategy', () => {
+      const config = new CompilerConfig({missingTranslation: MissingTranslationStrategy.Error});
+      expect(config.missingTranslation).toEqual(MissingTranslationStrategy.Error);
+    });
+  });
+}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
If missing translation strategy value is `MissingTranslationStrategy.Error`, then we replace it with `null` since `MissingTranslationStrategy` is an enum and `Error` has the value 0


## What is the new behavior?
We don't overwrite the value.


## Does this PR introduce a breaking change?
```
[x] No
```