### PR TITLE
Fix for issue #19960, parse a path containing # correctly

### DIFF
--- a/packages/compiler/src/aot/lazy_routes.ts
+++ b/packages/compiler/src/aot/lazy_routes.ts
@@ -51,7 +51,9 @@ function _collectLoadChildren(routes: string | Route | Route[], target: string[]
 
 export function parseLazyRoute(
     route: string, reflector: StaticReflector, module?: StaticSymbol): LazyRoute {
-  const [routePath, routeName] = route.split('#');
+  const routeSplit = route.split('#');
+  const routePath  =  routeSplit.slice(0, -1).join('#');
+  const routeName  =  routeSplit.pop() || null;
   const referencedModule = reflector.resolveExternalReference(
       {
         moduleName: routePath,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
This fix allows a # to appear in the path to an Angular project. parseLazuRoute() splitted on '#' and took item 0 and 1 from the result. This fails if there was a '#' in the path itself.

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 19960


## What is the new behavior?
The fix makes it possible to use '#' in the path to an angular project

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I tested it by retrofitting the code into an Angular app. It may need a second pair of eyes to check it out.
The compiler stuff is easier to test in v4 than it is in v5.