### PR TITLE
fix(service-worker): fix improper call of Observable.merge

### DIFF
--- a/packages/service-worker/src/push.ts
+++ b/packages/service-worker/src/push.ts
@@ -43,7 +43,7 @@ export class SwPush {
 
     const workerDrivenSubscriptions = <Observable<PushSubscription|null>>(op_switchMap.call(
         this.pushManager, (pm: PushManager) => pm.getSubscription().then(sub => { return sub; })));
-    this.subscription = obs_merge.call(workerDrivenSubscriptions, this.subscriptionChanges);
+    this.subscription = obs_merge(workerDrivenSubscriptions, this.subscriptionChanges);
   }
 
   requestSubscription(options: {serverPublicKey: string}): Promise<PushSubscription> {


### PR DESCRIPTION
Observable.merge was called using .call() as if it were an operator
and not an Observable factory. This removes the .call() and uses
the factory properly.