### PR TITLE
fix(compiler-cli): avoid producing source mappings for host views

### DIFF
--- a/packages/compiler-cli/src/transformers/node_emitter.ts
+++ b/packages/compiler-cli/src/transformers/node_emitter.ts
@@ -144,12 +144,14 @@ class _NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
       const span = node.sourceSpan;
       if (span.start.file == span.end.file) {
         const file = span.start.file;
-        let source = this._templateSources.get(file);
-        if (!source) {
-          source = ts.createSourceMapSource(file.url, file.content, pos => pos);
-          this._templateSources.set(file, source);
+        if (file.url) {
+          let source = this._templateSources.get(file);
+          if (!source) {
+            source = ts.createSourceMapSource(file.url, file.content, pos => pos);
+            this._templateSources.set(file, source);
+          }
+          return {pos: span.start.offset, end: span.end.offset, source};
         }
-        return {pos: span.start.offset, end: span.end.offset, source};
       }
     }
     return null;


### PR DESCRIPTION
The host view doesn't map back to user code so the template compiler
produces a blank `url` for them.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The source maps would contain a file mapping "../../" or similar.

## What is the new behavior?

The source maps no longer contain an invalid file name.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
