### PR TITLE
Allow compilation with TypeScript 2.5

### DIFF
--- a/packages/benchpress/src/runner.ts
+++ b/packages/benchpress/src/runner.ts
@@ -81,7 +81,9 @@ export class Runner {
             {provide: WebDriverAdapter, useValue: adapter}
           ]);
 
-          const sampler = injector.get(Sampler);
+          // TODO: With TypeScript 2.5 injector.get does not infer correctly the
+          // return type. Remove 'any' and investigate the issue.
+          const sampler = injector.get(Sampler) as any;
           return sampler.sample();
         });
   }

--- a/packages/compiler-cli/src/metadata/collector.ts
+++ b/packages/compiler-cli/src/metadata/collector.ts
@@ -116,8 +116,8 @@ export class MetadataCollector {
     function classMetadataOf(classDeclaration: ts.ClassDeclaration): ClassMetadata {
       const result: ClassMetadata = {__symbolic: 'class'};
 
-      function getDecorators(decorators: ts.Decorator[] | undefined): MetadataSymbolicExpression[]|
-          undefined {
+      function getDecorators(decorators: ReadonlyArray<ts.Decorator>| undefined):
+          MetadataSymbolicExpression[]|undefined {
         if (decorators && decorators.length)
           return decorators.map(decorator => objFromDecorator(decorator));
         return undefined;

--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -593,7 +593,8 @@ class AngularCompilerProgram implements Program {
 
   private writeFile(
       outFileName: string, outData: string, writeByteOrderMark: boolean,
-      onError?: (message: string) => void, genFile?: GeneratedFile, sourceFiles?: ts.SourceFile[]) {
+      onError?: (message: string) => void, genFile?: GeneratedFile,
+      sourceFiles?: ReadonlyArray<ts.SourceFile>) {
     // collect emittedLibrarySummaries
     let baseFile: ts.SourceFile|undefined;
     if (genFile) {
@@ -640,7 +641,8 @@ class AngularCompilerProgram implements Program {
     if (baseFile) {
       sourceFiles = sourceFiles ? [...sourceFiles, baseFile] : [baseFile];
     }
-    this.host.writeFile(outFileName, outData, writeByteOrderMark, onError, sourceFiles);
+    // TODO: remove any when TS 2.4 support is removed.
+    this.host.writeFile(outFileName, outData, writeByteOrderMark, onError, sourceFiles as any);
   }
 }
 

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -179,7 +179,13 @@ export function create(info: any /* ts.server.PluginCreateInfo */): ts.LanguageS
   }
 
   function completionToEntry(c: Completion): ts.CompletionEntry {
-    return {kind: c.kind, name: c.name, sortText: c.sort, kindModifiers: ''};
+    return {
+      // TODO: remove any and fix type error.
+      kind: c.kind as any,
+      name: c.name,
+      sortText: c.sort,
+      kindModifiers: ''
+    };
   }
 
   function diagnosticToDiagnostic(d: Diagnostic, file: ts.SourceFile): ts.Diagnostic {
@@ -294,9 +300,10 @@ export function create(info: any /* ts.server.PluginCreateInfo */): ts.LanguageS
                    fileName: loc.fileName,
                    textSpan: {start: loc.span.start, length: loc.span.end - loc.span.start},
                    name: '',
-                   kind: 'definition',
+                   // TODO: remove any and fix type error.
+                   kind: 'definition' as any,
                    containerName: loc.fileName,
-                   containerKind: 'file'
+                   containerKind: 'file' as any,
                  });
                }
              }


### PR DESCRIPTION
A small number of types need to be adjusted. The changes seem to be
backwards compatible with TS 2.4.