### PR TITLE
fix(platform-server): add animations to the UMD global rollup config

### DIFF
--- a/packages/animations/browser/rollup.config.js
+++ b/packages/animations/browser/rollup.config.js
@@ -6,16 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/common': 'ng.common',
-  '@angular/animations': 'ng.animations'
-};
+const globals = require('../../rollup.config').globals('@angular/animations/browser');
 
-export default {
+exports.default = {
   entry: '../../../dist/packages-dist/animations/esm5/browser.js',
   dest: '../../../dist/packages-dist/animations/bundles/animations-browser.umd.js',
   format: 'umd',

--- a/packages/animations/browser/testing/rollup.config.js
+++ b/packages/animations/browser/testing/rollup.config.js
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
 const globals = {
   '@angular/core': 'ng.core',
@@ -16,7 +16,7 @@ const globals = {
   'rxjs/Subject': 'Rx',
 };
 
-export default {
+exports.default = {
   entry: '../../../../dist/packages-dist/animations/esm5/browser/testing.js',
   dest: '../../../../dist/packages-dist/animations/bundles/animations-browser-testing.umd.js',
   format: 'umd',

--- a/packages/animations/rollup.config.js
+++ b/packages/animations/rollup.config.js
@@ -6,17 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/animations': 'ng.animations',
-  'rxjs/Observable': 'Rx',
-  'rxjs/Subject': 'Rx',
-};
+const globals = require('../rollup.config').globals('@angular/animations');
 
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/animations/esm5/animations.js',
   dest: '../../dist/packages-dist/animations/bundles/animations.umd.js',
   format: 'umd',

--- a/packages/common/http/rollup.config.js
+++ b/packages/common/http/rollup.config.js
@@ -6,21 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/platform-browser': 'ng.platformBrowser',
-  '@angular/common': 'ng.common',
-  'rxjs/Observable': 'Rx',
-  'rxjs/Subject': 'Rx',
+const globals = require('../../rollup.config').globals('@angular/common/http');
 
-  'rxjs/observable/of': 'Rx.Observable.prototype',
-
-  'rxjs/operator/concatMap': 'Rx.Observable.prototype',
-  'rxjs/operator/filter': 'Rx.Observable.prototype',
-  'rxjs/operator/map': 'Rx.Observable.prototype',
-};
-
-export default {
+exports.default = {
   entry: '../../../dist/packages-dist/common/esm5/http.js',
   dest: '../../../dist/packages-dist/common/bundles/common-http.umd.js',
   format: 'umd',

--- a/packages/common/http/testing/rollup.config.js
+++ b/packages/common/http/testing/rollup.config.js
@@ -6,20 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/platform-browser': 'ng.platformBrowser',
-  '@angular/common': 'ng.common',
-  '@angular/common/http': 'ng.common.http',
-  'rxjs/Observable': 'Rx',
-  'rxjs/ReplaySubject': 'Rx',
-  'rxjs/Subject': 'Rx',
-};
+const globals = require('../../../rollup.config').globals('@angular/common/http/testing');
 
-export default {
+exports.default = {
   entry: '../../../../dist/packages-dist/common/esm5/http/testing.js',
   dest: '../../../../dist/packages-dist/common/bundles/common-http-testing.umd.js',
   format: 'umd',

--- a/packages/common/rollup.config.js
+++ b/packages/common/rollup.config.js
@@ -6,16 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  'rxjs/Observable': 'Rx',
-  'rxjs/Subject': 'Rx',
-};
+const globals = require('../rollup.config').globals('@angular/common');
 
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/common/esm5/common.js',
   dest: '../../dist/packages-dist/common/bundles/common.umd.js',
   format: 'umd',

--- a/packages/common/testing/rollup.config.js
+++ b/packages/common/testing/rollup.config.js
@@ -6,17 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/common': 'ng.common',
-  'rxjs/Observable': 'Rx',
-  'rxjs/Subject': 'Rx'
-};
+const globals = require('../../rollup.config').globals('@angular/common/testing');
 
-export default {
+exports.default = {
   entry: '../../../dist/packages-dist/common/esm5/testing.js',
   dest: '../../../dist/packages-dist/common/bundles/common-testing.umd.js',
   format: 'umd',

--- a/packages/compiler-cli/browser-rollup.config.js
+++ b/packages/compiler-cli/browser-rollup.config.js
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import commonjs from 'rollup-plugin-commonjs';
-import * as path from 'path';
+const commonjs = require('rollup-plugin-commonjs');
+const path = require('path');
 
-import 'reflect-metadata';
+require('reflect-metadata');
 
 var m = /^\@angular\/((\w|\-)+)(\/(\w|\d|\/|\-)+)?$/;
 var location = normalize('../../dist/packages-dist') + '/';
@@ -49,7 +49,7 @@ function resolve(id, from) {
 // hack to get around issues with default exports
 var banner = `ts['default'] = ts['default'] || ts; fs['default'] = fs['default'] || fs;`;
 
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/compiler-cli/src/ngc.js',
   dest: './browser-bundle.umd.js',
   format: 'umd',
@@ -62,11 +62,7 @@ export default {
     'typescript',
     'reflect-metadata',
   ],
-  globals: {
-    'typescript': 'ts',
-    'path': 'path',
-    'fs': 'fs',
-  },
+  globals: require('../rollup.config').globals('@angular/compiler-cli'),
   banner: banner,
   plugins: [{resolveId: resolve}, commonjs()]
 };

--- a/packages/compiler/rollup.config.js
+++ b/packages/compiler/rollup.config.js
@@ -6,16 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  'rxjs/Observable': 'Rx',
-  'rxjs/Subject': 'Rx',
-};
+const globals = require('../rollup.config').globals('@angular/compiler');
 
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/compiler/esm5/compiler.js',
   dest: '../../dist/packages-dist/compiler/bundles/compiler.umd.js',
   format: 'umd',

--- a/packages/compiler/testing/rollup.config.js
+++ b/packages/compiler/testing/rollup.config.js
@@ -6,18 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/core/testing': 'ng.core.testing',
-  '@angular/compiler': 'ng.compiler',
-  'rxjs/Observable': 'Rx',
-  'rxjs/Subject': 'Rx'
-};
+const globals = require('../../rollup.config').globals('@angular/compiler/testing');
 
-export default {
+exports.default = {
   entry: '../../../dist/packages-dist/compiler/esm5/testing.js',
   dest: '../../../dist/packages-dist/compiler/bundles/compiler-testing.umd.js',
   format: 'umd',

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -6,19 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  'rxjs/Observable': 'Rx',
-  'rxjs/Subject': 'Rx',
-  'rxjs/Observer': 'Rx',
-  'rxjs/Subscription': 'Rx',
-  'rxjs/observable/merge': 'Rx.Observable',
-  'rxjs/operator/share': 'Rx.Observable.prototype'
-};
+const globals = require('../rollup.config').globals('@angular/core');
 
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/core/esm5/core.js',
   dest: '../../dist/packages-dist/core/bundles/core.umd.js',
   format: 'umd',

--- a/packages/core/testing/rollup.config.js
+++ b/packages/core/testing/rollup.config.js
@@ -6,16 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  'rxjs/Observable': 'Rx',
-  'rxjs/Subject': 'Rx',
-};
+const globals = require('../../rollup.config').globals('@angular/core/testing');
 
-export default {
+exports.default = {
   entry: '../../../dist/packages-dist/core/esm5/testing.js',
   dest: '../../../dist/packages-dist/core/bundles/core-testing.umd.js',
   format: 'umd',

--- a/packages/forms/rollup.config.js
+++ b/packages/forms/rollup.config.js
@@ -6,22 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/common': 'ng.common',
-  '@angular/compiler': 'ng.compiler',
-  '@angular/platform-browser': 'ng.platformBrowser',
-  'rxjs/Observable': 'Rx',
-  'rxjs/Subject': 'Rx',
-  'rxjs/observable/fromPromise': 'Rx.Observable',
-  'rxjs/observable/forkJoin': 'Rx.Observable',
-  'rxjs/operator/map': 'Rx.Observable.prototype'
-};
+const globals = require('../rollup.config').globals('@angular/forms');
 
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/forms/esm5/forms.js',
   dest: '../../dist/packages-dist/forms/bundles/forms.umd.js',
   format: 'umd',

--- a/packages/http/rollup.config.js
+++ b/packages/http/rollup.config.js
@@ -6,18 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/compiler': 'ng.compiler',
-  '@angular/platform-browser': 'ng.platformBrowser',
-  'rxjs/Observable': 'Rx',
-  'rxjs/Subject': 'Rx'
-};
+const globals = require('../rollup.config').globals('@angular/http');
 
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/http/esm5/http.js',
   dest: '../../dist/packages-dist/http/bundles/http.umd.js',
   format: 'umd',

--- a/packages/http/testing/rollup.config.js
+++ b/packages/http/testing/rollup.config.js
@@ -6,21 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/compiler': 'ng.compiler',
-  '@angular/platform-browser': 'ng.platformBrowser',
-  '@angular/http': 'ng.http',
-  'rxjs/Observable': 'Rx',
-  'rxjs/ReplaySubject': 'Rx',
-  'rxjs/Subject': 'Rx',
-  'rxjs/operator/take': 'Rx.Observable.prototype'
-};
+const globals = require('../../rollup.config').globals('@angular/http/testing');
 
-export default {
+exports.default = {
   entry: '../../../dist/packages-dist/http/esm5/testing.js',
   dest: '../../../dist/packages-dist/http/bundles/http-testing.umd.js',
   format: 'umd',

--- a/packages/language-service/rollup.config.js
+++ b/packages/language-service/rollup.config.js
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import commonjs from 'rollup-plugin-commonjs';
-import sourcemaps from 'rollup-plugin-sourcemaps';
-import * as path from 'path';
+const commonjs = require('rollup-plugin-commonjs');
+const sourcemaps = require('rollup-plugin-sourcemaps');
+const path = require('path');
 
 var m = /^\@angular\/((\w|\-)+)(\/(\w|\d|\/|\-)+)?$/;
 var location = normalize('../../dist/packages-dist') + '/';
@@ -60,7 +60,7 @@ module.exports = function(provided) {
 }
 `;
 
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/language-service/esm5/language-service.js',
   dest: '../../dist/packages-dist/language-service/bundles/language-service.umd.js',
   format: 'amd',
@@ -77,11 +77,7 @@ export default {
     'path',
     'typescript',
   ],
-  globals: {
-    'typescript': 'ts',
-    'path': 'path',
-    'fs': 'fs',
-  },
+  globals: require('../rollup.config').globals('@angular/language-service'),
   banner: banner,
   plugins: [{resolveId: resolve}, commonjs(), sourcemaps()]
 };

--- a/packages/platform-browser-dynamic/rollup.config.js
+++ b/packages/platform-browser-dynamic/rollup.config.js
@@ -6,17 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/common': 'ng.common',
-  '@angular/compiler': 'ng.compiler',
-  '@angular/platform-browser': 'ng.platformBrowser',
-};
+const globals = require('../rollup.config').globals('@angular/platform-browser-dynamic');
 
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/platform-browser-dynamic/esm5/platform-browser-dynamic.js',
   dest: '../../dist/packages-dist/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js',
   format: 'umd',

--- a/packages/platform-browser-dynamic/testing/rollup.config.js
+++ b/packages/platform-browser-dynamic/testing/rollup.config.js
@@ -6,21 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/core/testing': 'ng.core.testing',
-  '@angular/common': 'ng.common',
-  '@angular/compiler': 'ng.compiler',
-  '@angular/compiler/testing': 'ng.compiler.testing',
-  '@angular/platform-browser': 'ng.platformBrowser',
-  '@angular/platform-browser/testing': 'ng.platformBrowser.testing',
-  '@angular/platform-browser-dynamic': 'ng.platformBrowserDynamic'
-};
+const globals = require('../../rollup.config').globals('@angular/platform-browser-dynamic/testing');
 
-export default {
+exports.default = {
   entry: '../../../dist/packages-dist/platform-browser-dynamic/esm5/testing.js',
   dest:
       '../../../dist/packages-dist/platform-browser-dynamic/bundles/platform-browser-dynamic-testing.umd.js',

--- a/packages/platform-browser/animations/rollup.config.js
+++ b/packages/platform-browser/animations/rollup.config.js
@@ -6,18 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/common': 'ng.common',
-  '@angular/platform-browser': 'ng.platformBrowser',
-  '@angular/animations': 'ng.animations',
-  '@angular/animations/browser': 'ng.animations.browser'
-};
+const globals = require('../../rollup.config').globals('@angular/platform-browser/animations');
 
-export default {
+exports.default = {
   entry: '../../../dist/packages-dist/platform-browser/esm5/animations.js',
   dest: '../../../dist/packages-dist/platform-browser/bundles/platform-browser-animations.umd.js',
   format: 'umd',

--- a/packages/platform-browser/rollup.config.js
+++ b/packages/platform-browser/rollup.config.js
@@ -6,15 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/common': 'ng.common',
-};
+const globals = require('../rollup.config').globals('@angular/platform-browser');
 
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/platform-browser/esm5/platform-browser.js',
   dest: '../../dist/packages-dist/platform-browser/bundles/platform-browser.umd.js',
   format: 'umd',

--- a/packages/platform-browser/testing/rollup.config.js
+++ b/packages/platform-browser/testing/rollup.config.js
@@ -6,16 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/common': 'ng.common',
-  '@angular/platform-browser': 'ng.platformBrowser'
-};
+const globals = require('../../rollup.config').globals('@angular/platform-browser/testing');
 
-export default {
+exports.default = {
   entry: '../../../dist/packages-dist/platform-browser/esm5/testing.js',
   dest: '../../../dist/packages-dist/platform-browser/bundles/platform-browser-testing.umd.js',
   format: 'umd',

--- a/packages/platform-server/rollup.config.js
+++ b/packages/platform-server/rollup.config.js
@@ -10,10 +10,13 @@ import resolve from 'rollup-plugin-node-resolve';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 
 const globals = {
+  '@angular/animations': 'ng.animations',
   '@angular/core': 'ng.core',
   '@angular/common': 'ng.common',
   '@angular/compiler': 'ng.compiler',
+  '@angular/http': 'ng.http',
   '@angular/platform-browser': 'ng.platformBrowser',
+  '@angular/platform-browser-dynamic': 'ng.platformBrowserDynamic',
   'rxjs/Observable': 'Rx',
   'rxjs/Subject': 'Rx',
   'rxjs/operator/toPromise': 'Rx.Observable.prototype',

--- a/packages/platform-server/rollup.config.js
+++ b/packages/platform-server/rollup.config.js
@@ -6,25 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/animations': 'ng.animations',
-  '@angular/core': 'ng.core',
-  '@angular/common': 'ng.common',
-  '@angular/compiler': 'ng.compiler',
-  '@angular/http': 'ng.http',
-  '@angular/platform-browser': 'ng.platformBrowser',
-  '@angular/platform-browser-dynamic': 'ng.platformBrowserDynamic',
-  'rxjs/Observable': 'Rx',
-  'rxjs/Subject': 'Rx',
-  'rxjs/operator/toPromise': 'Rx.Observable.prototype',
-  'rxjs/operator/filter': 'Rx.Observable.prototype',
-  'rxjs/operator/first': 'Rx.Observable.prototype'
-};
+const globals = require('../rollup.config').globals('@angular/platform-server');
 
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/platform-server/esm5/platform-server.js',
   dest: '../../dist/packages-dist/platform-server/bundles/platform-server.umd.js',
   format: 'umd',

--- a/packages/platform-server/testing/rollup.config.js
+++ b/packages/platform-server/testing/rollup.config.js
@@ -6,20 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/common': 'ng.common',
-  '@angular/compiler': 'ng.compiler',
-  '@angular/compiler/testing': 'ng.compiler.testing',
-  '@angular/platform-browser': 'ng.platformBrowser',
-  '@angular/platform-server': 'ng.platformServer',
-  '@angular/platform-browser-dynamic/testing': 'ng.platformBrowserDynamic.testing'
-};
+const globals = require('../../rollup.config').globals('@angular/platform-server/testing');
 
-export default {
+exports.default = {
   entry: '../../../dist/packages-dist/platform-server/esm5/testing.js',
   dest: '../../../dist/packages-dist/platform-server/bundles/platform-server-testing.umd.js',
   format: 'umd',

--- a/packages/platform-webworker-dynamic/rollup.config.js
+++ b/packages/platform-webworker-dynamic/rollup.config.js
@@ -6,19 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/common': 'ng.common',
-  '@angular/compiler': 'ng.compiler',
-  '@angular/platform-browser': 'ng.platformBrowser',
-  '@angular/platform-browser-dynamic': 'ng.platformBrowserDynamic',
-  '@angular/platform-webworker': 'ng.platformWebworker',
-};
+const globals = require('../rollup.config').globals('@angular/platform-webworker-dynamic');
 
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/platform-webworker-dynamic/esm5/platform-webworker-dynamic.js',
   dest:
       '../../dist/packages-dist/platform-webworker-dynamic/bundles/platform-webworker-dynamic.umd.js',

--- a/packages/platform-webworker/rollup.config.js
+++ b/packages/platform-webworker/rollup.config.js
@@ -6,18 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/common': 'ng.common',
-  '@angular/platform-browser': 'ng.platformBrowser',
-  'rxjs/Observable': 'Rx',
-  'rxjs/Subject': 'Rx'
-};
+const globals = require('../rollup.config').globals('@angular/platform-webworker');
 
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/platform-webworker/esm5/platform-webworker.js',
   dest: '../../dist/packages-dist/platform-webworker/bundles/platform-webworker.umd.js',
   format: 'umd',

--- a/packages/rollup.config.js
+++ b/packages/rollup.config.js
@@ -6,6 +6,101 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-export default {plugins: [sourcemaps()]};
+exports.default = {
+  plugins: [sourcemaps()]
+};
+
+
+/**
+ *                  .--.         ______________
+ *  {\             / q {\      / globalGlobal /
+ *  { `\           \ (-(~`   <_______________/
+ * { '.{`\          \ \ )
+ * {'-{ ' \  .-""'-. \ \
+ * {._{'.' \/       '.) \
+ * {_.{.   {`            |
+ * {._{ ' {   ;'-=-.     |
+ *  {-.{.' {  ';-=-.`    /
+ *   {._.{.;    '-=-   .'
+ *    {_.-' `'.__  _,-'
+ *             |||`
+ *            .='==,
+ */
+const globalGlobal = {
+  '@angular/animations': 'ng.animations',
+  '@angular/animations/browser': 'ng.animations.browser',
+  '@angular/animations/browser/testing': 'ng.animations.browser.testing',
+  '@angular/common': 'ng.common',
+  '@angular/common/http': 'ng.common.http',
+  '@angular/common/testing': 'ng.common.testing',
+  '@angular/compiler': 'ng.compiler',
+  '@angular/compiler/testing': 'ng.compiler.testing',
+  '@angular/core': 'ng.core',
+  '@angular/core/testing': 'ng.core.testing',
+  '@angular/http': 'ng.http',
+  '@angular/platform-browser': 'ng.platformBrowser',
+  '@angular/platform-browser/animations': 'ng.platformBrowser.animations',
+  '@angular/platform-browser/testing': 'ng.platformBrowser.testing',
+  '@angular/platform-browser-dynamic': 'ng.platformBrowserDynamic',
+  '@angular/platform-browser-dynamic/testing': 'ng.platformBrowserDynamic.testing',
+  '@angular/platform-server': 'ng.platformServer',
+  '@angular/router': 'ng.router',
+  '@angular/service-worker': 'ng.serviceWorker',
+  '@angular/service-worker/config': 'ng.serviceWorker.config',
+  '@angular/upgrade': 'ng.upgrade',
+  '@angular/upgrade/static': 'ng.upgrade.static',
+  'fs': 'fs',
+  'path': 'path',
+  'rxjs/BehaviorSubject': 'Rx',
+  'rxjs/ConnectableObservable': 'Rx',
+  'rxjs/Observable': 'Rx',
+  'rxjs/Observer': 'Rx',
+  'rxjs/ReplaySubject': 'Rx',
+  'rxjs/Subject': 'Rx',
+  'rxjs/Subscription': 'Rx',
+  'rxjs/observable/ConnectableObservable': 'Rx',
+  'rxjs/observable/PromiseObservable': 'Rx',  // this is wrong, but this stuff has changed in rxjs
+                                              // b.6 so we need to fix it when we update.
+  'rxjs/observable/concat': 'Rx.Observable',
+  'rxjs/observable/defer': 'Rx.Observable',
+  'rxjs/observable/forkJoin': 'Rx.Observable',
+  'rxjs/observable/from': 'Rx.Observable',
+  'rxjs/observable/fromEvent': 'Rx.Observable',
+  'rxjs/observable/fromPromise': 'Rx.Observable',
+  'rxjs/observable/merge': 'Rx.Observable',
+  'rxjs/observable/of': 'Rx.Observable',
+  'rxjs/observable/throw': 'Rx.Observable',
+  'rxjs/operator/catch': 'Rx.Observable.prototype',
+  'rxjs/operator/concatAll': 'Rx.Observable.prototype',
+  'rxjs/operator/concatMap': 'Rx.Observable.prototype',
+  'rxjs/operator/do': 'Rx.Observable.prototype',
+  'rxjs/operator/every': 'Rx.Observable.prototype',
+  'rxjs/operator/filter': 'Rx.Observable.prototype',
+  'rxjs/operator/first': 'Rx.Observable.prototype',
+  'rxjs/operator/last': 'Rx.Observable.prototype',
+  'rxjs/operator/map': 'Rx.Observable.prototype',
+  'rxjs/operator/mergeAll': 'Rx.Observable.prototype',
+  'rxjs/operator/mergeMap': 'Rx.Observable.prototype',
+  'rxjs/operator/publish': 'Rx.Observable.prototype',
+  'rxjs/operator/reduce': 'Rx.Observable.prototype',
+  'rxjs/operator/share': 'Rx.Observable.prototype',
+  'rxjs/operator/startWith': 'Rx.Observable.prototype',
+  'rxjs/operator/switchMap': 'Rx.Observable.prototype',
+  'rxjs/operator/take': 'Rx.Observable.prototype',
+  'rxjs/operator/toPromise': 'Rx.Observable.prototype',
+  'rxjs/util/EmptyError': 'Rx',
+  'typescript': 'ts',
+};
+
+
+exports.globals = function(blacklist) {
+  if (typeof blacklist == 'string') {
+    blacklist = [blacklist];
+  }
+
+  const globalCopy = Object.assign({}, globalGlobal);
+  blacklist.forEach(x => { delete globalCopy[x]; });
+  return globalCopy;
+};

--- a/packages/router/rollup.config.js
+++ b/packages/router/rollup.config.js
@@ -6,40 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/common': 'ng.common',
-  '@angular/platform-browser': 'ng.platformBrowser',
+const globals = require('../rollup.config').globals('@angular/router');
 
-  'rxjs/BehaviorSubject': 'Rx',
-  'rxjs/Observable': 'Rx',
-  'rxjs/Subject': 'Rx',
-  'rxjs/Subscription': 'Rx',
-  'rxjs/util/EmptyError': 'Rx',
-
-  'rxjs/observable/from': 'Rx.Observable',
-  'rxjs/observable/fromPromise': 'Rx.Observable',
-  'rxjs/observable/forkJoin': 'Rx.Observable',
-  'rxjs/observable/of': 'Rx.Observable',
-
-  'rxjs/operator/toPromise': 'Rx.Observable.prototype',
-  'rxjs/operator/map': 'Rx.Observable.prototype',
-  'rxjs/operator/mergeAll': 'Rx.Observable.prototype',
-  'rxjs/operator/concatAll': 'Rx.Observable.prototype',
-  'rxjs/operator/mergeMap': 'Rx.Observable.prototype',
-  'rxjs/operator/reduce': 'Rx.Observable.prototype',
-  'rxjs/operator/every': 'Rx.Observable.prototype',
-  'rxjs/operator/first': 'Rx.Observable.prototype',
-  'rxjs/operator/catch': 'Rx.Observable.prototype',
-  'rxjs/operator/last': 'Rx.Observable.prototype',
-  'rxjs/operator/filter': 'Rx.Observable.prototype',
-  'rxjs/operator/concatMap': 'Rx.Observable.prototype'
-};
-
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/router/esm5/router.js',
   dest: '../../dist/packages-dist/router/bundles/router.umd.js',
   format: 'umd',

--- a/packages/router/testing/rollup.config.js
+++ b/packages/router/testing/rollup.config.js
@@ -6,18 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/common': 'ng.common',
-  '@angular/common/testing': 'ng.common.testing',
-  '@angular/platform-browser': 'ng.platformBrowser',
-  '@angular/router': 'ng.router'
-};
+const globals = require('../../rollup.config').globals('@angular/router/testing');
 
-export default {
+exports.default = {
   entry: '../../../dist/packages-dist/router/esm5/testing.js',
   dest: '../../../dist/packages-dist/router/bundles/router-testing.umd.js',
   format: 'umd',

--- a/packages/router/upgrade/rollup.config.js
+++ b/packages/router/upgrade/rollup.config.js
@@ -6,17 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/common': 'ng.common',
-  '@angular/router': 'ng.router',
-  '@angular/upgrade/static': 'ng.upgrade.static'
-};
+const globals = require('../../rollup.config').globals('@angular/router/upgrade');
 
-export default {
+
+exports.default = {
   entry: '../../../dist/packages-dist/router/esm5/upgrade.js',
   dest: '../../../dist/packages-dist/router/bundles/router-upgrade.umd.js',
   format: 'umd',

--- a/packages/service-worker/cli/rollup-cli.config.js
+++ b/packages/service-worker/cli/rollup-cli.config.js
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
+const resolve = require('rollup-plugin-node-resolve');
 
-export default {
+exports.default = {
   entry: '../../dist/all/@angular/service-worker/cli-custom/main.js',
   dest: '../../dist/packages-dist/service-worker/ngsw-config-tmp.js',
   format: 'iife',

--- a/packages/service-worker/config/rollup.config.js
+++ b/packages/service-worker/config/rollup.config.js
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {};
+const globals = require('../../rollup.config').globals('@angular/service-worker/config');
 
-export default {
+exports.default = {
   entry: '../../../dist/packages-dist/service-worker/esm5/config.js',
   dest: '../../../dist/packages-dist/service-worker/bundles/service-worker-config.umd.js',
   format: 'umd',

--- a/packages/service-worker/rollup.config.js
+++ b/packages/service-worker/rollup.config.js
@@ -6,35 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
+const globals = require('../rollup.config').globals('@angular/service-worker');
 
-  'rxjs/BehaviorSubject': 'Rx',
-  'rxjs/ConnectableObservable': 'Rx',
-  'rxjs/Observable': 'Rx',
-  'rxjs/Subject': 'Rx',
-
-  'rxjs/observable/concat': 'Rx.Observable',
-  'rxjs/observable/defer': 'Rx.Observable',
-  'rxjs/observable/fromEvent': 'Rx.Observable',
-  'rxjs/observable/merge': 'Rx.Observable',
-  'rxjs/observable/of': 'Rx.Observable',
-  'rxjs/observable/throw': 'Rx.Observable',
-
-  'rxjs/operator/do': 'Rx.Observable.prototype',
-  'rxjs/operator/filter': 'Rx.Observable.prototype',
-  'rxjs/operator/map': 'Rx.Observable.prototype',
-  'rxjs/operator/publish': 'Rx.Observable.prototype',
-  'rxjs/operator/startWith': 'Rx.Observable.prototype',
-  'rxjs/operator/switchMap': 'Rx.Observable.prototype',
-  'rxjs/operator/take': 'Rx.Observable.prototype',
-  'rxjs/operator/toPromise': 'Rx.Observable.prototype',
-};
-
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/service-worker/esm5/service-worker.js',
   dest: '../../dist/packages-dist/service-worker/bundles/service-worker.umd.js',
   format: 'umd',

--- a/packages/upgrade/rollup.config.js
+++ b/packages/upgrade/rollup.config.js
@@ -6,23 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core',
-  '@angular/common': 'ng.common',
-  '@angular/compiler': 'ng.compiler',
-  '@angular/platform-browser': 'ng.platformBrowser',
-  '@angular/platform-browser-dynamic': 'ng.platformBrowserDynamic',
-  'rxjs/Subject': 'Rx',
-  'rxjs/observable/PromiseObservable': 'Rx',  // this is wrong, but this stuff has changed in rxjs
-                                              // b.6 so we need to fix it when we update.
-  'rxjs/operator/toPromise': 'Rx.Observable.prototype',
-  'rxjs/Observable': 'Rx',
-};
+const globals = require('../rollup.config').globals('@angular/upgrade');
 
-export default {
+exports.default = {
   entry: '../../dist/packages-dist/upgrade/esm5/upgrade.js',
   dest: '../../dist/packages-dist/upgrade/bundles/upgrade.umd.js',
   format: 'umd',

--- a/packages/upgrade/static/rollup.config.js
+++ b/packages/upgrade/static/rollup.config.js
@@ -6,14 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import resolve from 'rollup-plugin-node-resolve';
-import sourcemaps from 'rollup-plugin-sourcemaps';
+const resolve = require('rollup-plugin-node-resolve');
+const sourcemaps = require('rollup-plugin-sourcemaps');
 
-const globals = {
-  '@angular/core': 'ng.core'
-};
+const globals = require('../../rollup.config').globals('@angular/upgrade/static');
 
-export default {
+exports.default = {
   entry: '../../../dist/packages-dist/upgrade/esm5/static.js',
   dest: '../../../dist/packages-dist/upgrade/bundles/upgrade-static.umd.js',
   format: 'umd',

--- a/tools/tslint/rollupConfigRule.ts
+++ b/tools/tslint/rollupConfigRule.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {RuleFailure} from 'tslint/lib';
+import {AbstractRule} from 'tslint/lib/rules';
+import * as ts from 'typescript';
+
+
+function _isRollupPath(path: string) {
+  return /rollup\.config\.js$/.test(path);
+}
+
+// Regexes to blacklist.
+const sourceFilePathBlacklist = [
+  /_spec\.ts$/,
+  /_perf\.ts$/,
+  /_example\.ts$/,
+  /[/\\]test[/\\]/,
+  /[/\\]testing_internal\.ts$/,
+  /[/\\]integrationtest[/\\]/,
+  /[/\\]packages[/\\]bazel[/\\]/,
+  /[/\\]packages[/\\]benchpress[/\\]/,
+  /[/\\]packages[/\\]examples[/\\]/,
+];
+
+// Import package name whitelist. These will be ignored.
+const importsWhitelist = [
+  '@angular/compiler-cli',                        // Not used in a browser.
+  '@angular/compiler-cli/src/language_services',  // Deep import from language-service.
+  'chokidar',  // Not part of compiler-cli/browser, but still imported.
+  'reflect-metadata',
+  'tsickle',
+  'url',  // Part of node, no need to alias in rollup.
+  'zone.js',
+];
+// Rename blacklist. We rename to get the package name
+const renameBlacklist = [
+  'rxjs',
+];
+
+const packageScopedImportWhitelist: [RegExp, string[]][] = [
+  [/service-worker[/\\]cli/, ['@angular/service-worker']],
+];
+
+
+// Return true if the file should be linted.
+function _pathShouldBeLinted(path: string) {
+  return /[/\\]packages[/\\]/.test(path) && sourceFilePathBlacklist.every(re => !re.test(path));
+}
+
+
+interface RollupMatchInfo {
+  filePath: string;
+  globals: {[packageName: string]: string};
+}
+const rollupConfigMap = new Map<string, RollupMatchInfo>();
+
+
+export class Rule extends AbstractRule {
+  public apply(sourceFile: ts.SourceFile): RuleFailure[] {
+    const allImports = <ts.ImportDeclaration[]>sourceFile.statements.filter(
+        x => x.kind === ts.SyntaxKind.ImportDeclaration);
+
+    // Ignore specs, non-package files, and examples.
+    if (!_pathShouldBeLinted(sourceFile.fileName)) {
+      return [];
+    }
+
+    // Find the rollup.config.js from this location, if it exists.
+    // If rollup cannot be found, this is an error.
+    let p = path.dirname(sourceFile.fileName);
+    let checkedPaths = [];
+    let match: RollupMatchInfo;
+
+    while (p.startsWith(process.cwd())) {
+      if (rollupConfigMap.has(p)) {
+        // We already resolved for this directory, just return it.
+        match = rollupConfigMap.get(p);
+        break;
+      }
+
+      const allFiles = fs.readdirSync(p);
+      const maybeRollupPath = allFiles.find(x => _isRollupPath(path.join(p, x)));
+      if (maybeRollupPath) {
+        const rollupFilePath = path.join(p, maybeRollupPath);
+        const rollupConfig = require(rollupFilePath).default;
+        match = {filePath: rollupFilePath, globals: rollupConfig && rollupConfig.globals};
+
+        // Update all paths that we checked along the way.
+        checkedPaths.forEach(path => rollupConfigMap.set(path, match));
+        rollupConfigMap.set(rollupFilePath, match);
+        break;
+      }
+
+      checkedPaths.push(p);
+      p = path.dirname(p);
+    }
+    if (!match) {
+      throw new Error(
+          `Could not find rollup.config.js for ${JSON.stringify(sourceFile.fileName)}.`);
+    }
+
+    const rollupFilePath = match.filePath;
+    const globalConfig = match.globals || Object.create(null);
+
+    return allImports
+        .map(importStatement => {
+          const modulePath = (importStatement.moduleSpecifier as ts.StringLiteral).text;
+          if (modulePath.startsWith('.')) {
+            return null;
+          }
+
+          if (importsWhitelist.indexOf(modulePath) != -1) {
+            return null;
+          }
+
+          for (const [re, arr] of packageScopedImportWhitelist) {
+            if (re.test(sourceFile.fileName) && arr.indexOf(modulePath) != -1) {
+              return null;
+            }
+          }
+
+          if (!(modulePath in globalConfig)) {
+            return new RuleFailure(
+                sourceFile, importStatement.getStart(), importStatement.getWidth(),
+                `Import ${JSON.stringify(modulePath)} could not be found in the rollup config ` +
+                    `at path ${JSON.stringify(rollupFilePath)}.`,
+                this.ruleName, );
+          }
+
+          return null;
+        })
+        .filter(x => !!x);
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -12,6 +12,7 @@
     "no-jasmine-focus": true,
     "no-var-keyword": true,
     "require-internal-with-underscore": true,
+    "rollup-config": true,
     "semicolon": [true],
     "variable-name": [true, "ban-keywords"],
     "no-inner-declarations": [true, "function"]


### PR DESCRIPTION
This adds the proper bindings for calling animations from platform-server in the UMD.
This was not a problem for universal apps that dont use UMD.

Fixes #19899 

