### PR TITLE
docs: RxJS v5.5 for plunkers and systemjs config

### DIFF
--- a/aio/tools/examples/shared/boilerplate/systemjs/src/systemjs.config.web.build.js
+++ b/aio/tools/examples/shared/boilerplate/systemjs/src/systemjs.config.web.build.js
@@ -66,7 +66,7 @@
       '@angular/forms/testing': 'ng:forms-builds/master/bundles/forms-testing.umd.js',
 
       // other libraries
-      'rxjs':                      'npm:rxjs@5.0.1',
+      'rxjs':                      'npm:rxjs@5.5.2',
       'tslib':                     'npm:tslib/tslib.js',
       'angular-in-memory-web-api': 'npm:angular-in-memory-web-api@0.4/bundles/in-memory-web-api.umd.js',
       'ts':                        'npm:plugin-typescript@5.2.7/lib/plugin.js',

--- a/aio/tools/examples/shared/boilerplate/systemjs/src/systemjs.config.web.js
+++ b/aio/tools/examples/shared/boilerplate/systemjs/src/systemjs.config.web.js
@@ -52,7 +52,7 @@
       '@angular/upgrade/static': 'npm:@angular/upgrade/bundles/upgrade-static.umd.js',
 
       // other libraries
-      'rxjs':                      'npm:rxjs@5.0.1',
+      'rxjs':                      'npm:rxjs@5.5.2',
       'tslib':                     'npm:tslib/tslib.js',
       'angular-in-memory-web-api': 'npm:angular-in-memory-web-api@0.4/bundles/in-memory-web-api.umd.js',
       'ts':                        'npm:plugin-typescript@5.2.7/lib/plugin.js',

--- a/aio/tools/plunker-builder/translator/rules/indexHtml.js
+++ b/aio/tools/plunker-builder/translator/rules/indexHtml.js
@@ -72,7 +72,7 @@ var rulesToApply = [
   {
     pattern: 'script',
     from: 'node_modules/rxjs/bundles/Rx.js',
-    to:   'https://unpkg.com/rxjs@5.0.1/bundles/Rx.js'
+    to:   'https://unpkg.com/rxjs@5.5.2/bundles/Rx.js'
   },
   {
     pattern: 'script',


### PR DESCRIPTION
**URGENT - please merge ASAP as we have very little time to update docs before next NG release.**

Should have been companion to PR #19985

**PROBLEM**:  Doesn't work!  Not building plunkers with RxJS v.5.5.2.
Then when I patch it in a plunker,  RxJS v5.2 umd , `import { switchMap } from 'rxjs/operators/switchMap' ` says the umd does NOT have `/operators`. 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```
