### PR TITLE
build(aio): add i18n boilerplate type

### DIFF
--- a/aio/tools/examples/example-boilerplate.js
+++ b/aio/tools/examples/example-boilerplate.js
@@ -45,6 +45,15 @@ const BOILERPLATE_PATHS = {
   ]
 };
 
+// All paths in this tool are relative to the current boilerplate folder, i.e boilerplate/i18n
+// This maps the CLI files that exists in a parent folder
+const cliRelativePath = BOILERPLATE_PATHS.cli.map(file => `../cli/${file}`);
+
+BOILERPLATE_PATHS.i18n = [
+  ...cliRelativePath,
+  'package.json'
+];
+
 const EXAMPLE_CONFIG_FILENAME = 'example-config.json';
 
 class ExampleBoilerPlate {

--- a/aio/tools/examples/example-boilerplate.spec.js
+++ b/aio/tools/examples/example-boilerplate.spec.js
@@ -11,6 +11,7 @@ describe('example-boilerplate tool', () => {
     const sharedNodeModulesDir = path.resolve(sharedDir, 'node_modules');
     const BPFiles = {
       cli: 18,
+      i18n: 1,
       systemjs: 7,
       common: 1
     };
@@ -69,6 +70,21 @@ describe('example-boilerplate tool', () => {
       );
       // for example
       expect(exampleBoilerPlate.copyFile).toHaveBeenCalledWith(`${boilerplateDir}/cli`, 'a/b', 'package.json');
+      expect(exampleBoilerPlate.copyFile).toHaveBeenCalledWith(`${boilerplateDir}/common`, 'c/d', 'src/styles.css');
+    });
+
+    it('should copy all the source boilerplate files for i18n', () => {
+      const boilerplateDir = path.resolve(sharedDir, 'boilerplate');
+      exampleBoilerPlate.loadJsonFile.and.callFake(filePath => filePath.indexOf('a/b') !== -1 ? { projectType: 'i18n' } : {})
+      exampleBoilerPlate.add();
+      expect(exampleBoilerPlate.copyFile).toHaveBeenCalledTimes(
+        (BPFiles.cli + BPFiles.i18n) +
+        (BPFiles.cli) +
+        (BPFiles.common * exampleFolders.length)
+      );
+      // for example
+      expect(exampleBoilerPlate.copyFile).toHaveBeenCalledWith(`${boilerplateDir}/i18n`, 'a/b', '../cli/.angular-cli.json');
+      expect(exampleBoilerPlate.copyFile).toHaveBeenCalledWith(`${boilerplateDir}/i18n`, 'a/b', 'package.json');
       expect(exampleBoilerPlate.copyFile).toHaveBeenCalledWith(`${boilerplateDir}/common`, 'c/d', 'src/styles.css');
     });
 

--- a/aio/tools/examples/shared/boilerplate/i18n/package.json
+++ b/aio/tools/examples/shared/boilerplate/i18n/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "angular.io-example",
+  "version": "0.0.0",
+  "license": "MIT",
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve --aot",
+    "start:fr": "ng serve --aot --i18nFile=src/locale/messages.fr.xlf --i18nFormat=xlf --locale=fr",
+    "build": "ng build --prod",
+    "build:fr": "ng build --prod --i18nFile=src/locale/messages.fr.xlf --i18nFormat=xlf --locale=fr",
+    "test": "ng test",
+    "lint": "ng lint",
+    "e2e": "ng e2e --aot --i18nFile=src/locale/messages.fr.xlf --i18nFormat=xlf --locale=fr",
+    "extract": "ng xi18n --outputPath=src/locale"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/animations": "^5.0.0-rc.7",
+    "@angular/common": "^5.0.0-rc.7",
+    "@angular/compiler": "^5.0.0-rc.7",
+    "@angular/core": "^5.0.0-rc.7",
+    "@angular/forms": "^5.0.0-rc.7",
+    "@angular/http": "^5.0.0-rc.7",
+    "@angular/platform-browser": "^5.0.0-rc.7",
+    "@angular/platform-browser-dynamic": "^5.0.0-rc.7",
+    "@angular/router": "^5.0.0-rc.7",
+    "core-js": "^2.4.1",
+    "rxjs": "^5.5.0",
+    "web-animations-js": "^2.3.1",
+    "zone.js": "^0.8.14"
+  },
+  "devDependencies": {
+    "@angular/cli": "^1.5.0-rc.5",
+    "@angular/compiler-cli": "^5.0.0-rc.7",
+    "@angular/language-service": "^5.0.0-rc.7",
+    "@types/jasmine": "~2.5.53",
+    "@types/jasminewd2": "~2.0.2",
+    "@types/node": "~6.0.60",
+    "codelyzer": "~3.1.1",
+    "jasmine-core": "~2.6.2",
+    "jasmine-spec-reporter": "~4.1.0",
+    "karma": "~1.7.0",
+    "karma-chrome-launcher": "~2.1.1",
+    "karma-cli": "~1.0.1",
+    "karma-coverage-istanbul-reporter": "^1.2.1",
+    "karma-jasmine": "~1.1.0",
+    "karma-jasmine-html-reporter": "^0.2.2",
+    "protractor": "~5.1.2",
+    "ts-node": "~3.2.0",
+    "tslint": "~5.3.2",
+    "typescript": "~2.4.2"
+  }
+}


### PR DESCRIPTION
This is an upgrade to aio boilerplate mechanism. For #19975 @ocombe needs a custom package.json for his guide. Instead of replicating the entire CLI boilerplate to just override one file, it is better to "inherit" from the CLI one and override the needed file. That way we don't have to update the boilerplate twice.

This needs to be reviewed and merged ASAP to release the docs early this week.