### PR TITLE
fix(compiler): always use relative paths to refer to generated code

### DIFF
--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -192,7 +192,8 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
     const containingFilePackageName = getPackageName(containingFile);
 
     let moduleName: string;
-    if (importedFilePackagName === containingFilePackageName) {
+    if (importedFilePackagName === containingFilePackageName ||
+        GENERATED_FILES.test(originalImportedFile)) {
       const rootedContainingFile = relativeToRootDirs(containingFile, this.rootDirs);
       const rootedImportedFile = relativeToRootDirs(importedFile, this.rootDirs);
 

--- a/packages/compiler-cli/test/transformers/compiler_host_spec.ts
+++ b/packages/compiler-cli/test/transformers/compiler_host_spec.ts
@@ -90,6 +90,14 @@ describe('NgCompilerHost', () => {
           .toBe('./a/child');
     });
 
+    it('should use a relative import when accessing generated files, even if crossing packages',
+       () => {
+         expect(host.fileNameToModuleName(
+                    '/tmp/node_modules/mod2/b.ngfactory.d.ts',
+                    '/tmp/node_modules/mod1/a.ngfactory.d.ts'))
+             .toBe('../mod2/b.ngfactory');
+       });
+
     it('should support multiple rootDirs when accessing a source file form a source file', () => {
       const hostWithMultipleRoots = createHost({
         options: {


### PR DESCRIPTION
Previously we generated imports like `@angular/material/index.ngfactory`,
which doesn’t make sense as we don’t ship generated code on npm

Closes #20031

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
