### PR TITLE
fix(compiler): report a reasonable error with invalid metadata

### DIFF
--- a/packages/compiler/src/metadata_resolver.ts
+++ b/packages/compiler/src/metadata_resolver.ts
@@ -664,16 +664,18 @@ export class CompileMetadataResolver {
   }
 
   private _getTypeDescriptor(type: Type): string {
-    if (this.isDirective(type)) {
-      return 'directive';
-    }
+    if (isValidType(type)) {
+      if (this.isDirective(type)) {
+        return 'directive';
+      }
 
-    if (this.isPipe(type)) {
-      return 'pipe';
-    }
+      if (this.isPipe(type)) {
+        return 'pipe';
+      }
 
-    if (this.isNgModule(type)) {
-      return 'module';
+      if (this.isNgModule(type)) {
+        return 'module';
+      }
     }
 
     if ((type as any).provide) {

--- a/packages/compiler/test/metadata_resolver_spec.ts
+++ b/packages/compiler/test/metadata_resolver_spec.ts
@@ -399,6 +399,18 @@ export function main() {
 
          expect(() => resolver.getNgModuleMetadata(ModuleWithComponentInBootstrap)).not.toThrow();
        }));
+
+    // #20049
+    it('should throw a reasonable message when an invalid import is given',
+       inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
+         @NgModule({imports: [{ngModule: true as any}]})
+         class InvalidModule {
+         }
+
+         expect(() => { resolver.getNgModuleMetadata(InvalidModule); })
+             .toThrowError(
+                 `Unexpected value '[object Object]' imported by the module 'InvalidModule'. Please add a @NgModule annotation.`);
+       }));
   });
 
   it('should dedupe declarations in NgModule',


### PR DESCRIPTION
The compiler would throw an internal exception if an import using
the `ngModule` syntax and the module as not a resolvable symbol.

Fixes: #20049

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue Number: #20049

The compiler would throw an internal exception when importing a module that could not be resolved.

## What is the new behavior?

The compiler produces more reasonable error message.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
