### PR TITLE
docs(aio): Add v4 doc link to navigation

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -491,6 +491,7 @@
   ],
 
   "docVersions": [
+    { "title": "v4 (LTS)", "url": "https://v4.angular.io" },
     { "title": "v2", "url": "https://v2.angular.io" },
     { "title": "AngularDart", "url": "https://webdev.dartlang.org/angular" }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

angular.io is for v5 and navigation has only v2, dart and next edition.

![image](https://user-images.githubusercontent.com/1529180/32314097-77160814-bfe9-11e7-8e0c-f25b12cdce86.png)

 v4 is marked as *LTS* so it should be kept easy to access.

## What is the new behavior?

v4 in version selector

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Fixes #20090.