### PR TITLE
fix(common): do not capitalize special characters in TitleCasePipe

### DIFF
--- a/packages/common/src/pipes/case_conversion_pipes.ts
+++ b/packages/common/src/pipes/case_conversion_pipes.ts
@@ -51,7 +51,7 @@ export class TitleCasePipe implements PipeTransform {
       throw invalidPipeArgumentError(TitleCasePipe, value);
     }
 
-    return value.split(/\b/g).map(word => titleCaseWord(word)).join('');
+    return value.replace(/\w\S*/g, (word => titleCaseWord(word)));
   }
 }
 

--- a/packages/common/test/pipes/case_conversion_pipes_spec.ts
+++ b/packages/common/test/pipes/case_conversion_pipes_spec.ts
@@ -45,6 +45,12 @@ export function main() {
       expect(pipe.transform('foo')).toEqual('Foo');
     });
 
+    it('should treat special characters and common characters equally', () => {
+      expect(pipe.transform('føderation')).toEqual('Føderation');
+      expect(pipe.transform('bênção')).toEqual('Bênção');
+      expect(pipe.transform('it\'s complicated')).toEqual('It\'s Complicated');
+    });
+
     it('should not support other objects',
        () => { expect(() => pipe.transform(<any>{})).toThrowError(); });
   });


### PR DESCRIPTION
## PR Checklist

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
```
{{ 'føderation' | titlecase }}
<!-- output: FØDeration -->
{{ 'It's Complicated' | titlecase }}
<!-- output: It'S Complicated -->
```

Issue Number: N/A
Fixes #16586

## What is the new behavior?
```
{{ 'føderation' | titlecase }}
<!-- output: Føderation -->
{{ 'It's Complicated' | titlecase }}
<!-- output: It's Complicated -->
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
This PR fixes a bug introduced by PR #13511.