### PR TITLE
build(aio): make plunker works with rxjs operators

### DIFF
--- a/aio/tools/examples/shared/boilerplate/systemjs/src/systemjs.config.web.build.js
+++ b/aio/tools/examples/shared/boilerplate/systemjs/src/systemjs.config.web.build.js
@@ -67,10 +67,11 @@
 
       // other libraries
       'rxjs':                      'npm:rxjs@5.5.2',
+      'rxjs/operators':            'npm:rxjs@5.5.2/operators/index.js',
       'tslib':                     'npm:tslib/tslib.js',
       'angular-in-memory-web-api': 'npm:angular-in-memory-web-api@0.4/bundles/in-memory-web-api.umd.js',
       'ts':                        'npm:plugin-typescript@5.2.7/lib/plugin.js',
-      'typescript':                'npm:typescript@2.3.2/lib/typescript.js',
+      'typescript':                'npm:typescript@2.4.2/lib/typescript.js',
 
     },
     // packages tells the System loader how to load when no filename and/or no extension

--- a/aio/tools/examples/shared/boilerplate/systemjs/src/systemjs.config.web.js
+++ b/aio/tools/examples/shared/boilerplate/systemjs/src/systemjs.config.web.js
@@ -53,10 +53,11 @@
 
       // other libraries
       'rxjs':                      'npm:rxjs@5.5.2',
+      'rxjs/operators':            'npm:rxjs@5.5.2/operators/index.js',
       'tslib':                     'npm:tslib/tslib.js',
       'angular-in-memory-web-api': 'npm:angular-in-memory-web-api@0.4/bundles/in-memory-web-api.umd.js',
       'ts':                        'npm:plugin-typescript@5.2.7/lib/plugin.js',
-      'typescript':                'npm:typescript@2.3.2/lib/typescript.js',
+      'typescript':                'npm:typescript@2.4.2/lib/typescript.js',
 
     },
     // packages tells the System loader how to load when no filename and/or no extension


### PR DESCRIPTION
Interestingly it was working on my demos, now it can't find that operators. Luckily, an easy fix.

Also updated TS to 2.4.2 for plunkers.