### PR TITLE
docs(ContentChildren): clarify decendents description

### DIFF
--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -159,7 +159,7 @@ export interface ContentChildrenDecorator {
    * **Metadata Properties**:
    *
    * * **selector** - the directive type or the name used for querying.
-   * * **descendants** - include only direct children or all descendants.
+   * * **descendants** - whether to include all descendants. Defaults to only direct children.
    * * **read** - read a different token from the queried elements.
    *
    * Let's look at an example:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~Tests for the changes have been added (for bug fixes / features)~
- [ ] ~Docs have been added / updated (for bug fixes / features)~


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The current description of the [ContentChildren](https://angular.io/api/core/ContentChildren) metadata properties gives the following description for the `descendants` property:

> descendants - include only direct children or all descendants.

While this describes what it does, it is unclear which strategy is used on `descendents: true`

Issue Number: #20074

## What is the new behavior?
The documentation will indicate that the boolean refers to whether to include all descendants and defaults to only direct children.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```