### PR TITLE
ci(aio): move e2e tests to optional job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ env:
     - CI_MODE=browserstack_optional
     - CI_MODE=aio_tools_test
     - CI_MODE=aio
+    - CI_MODE=aio_optional
     - CI_MODE=aio_e2e AIO_SHARD=0
     - CI_MODE=aio_e2e AIO_SHARD=1
     - CI_MODE=bazel
@@ -63,6 +64,7 @@ matrix:
   allow_failures:
     - env: "CI_MODE=saucelabs_optional"
     - env: "CI_MODE=browserstack_optional"
+    - env: "CI_MODE=aio_optional"
 
 before_install:
   # source the env.sh script so that the exported variables are available to other scripts later on

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -47,7 +47,12 @@ travisFoldStart "bower-install"
 travisFoldEnd "bower-install"
 
 
-if [[ ${TRAVIS} && (${CI_MODE} == "aio" || ${CI_MODE} == "aio_e2e" || ${CI_MODE} == "aio_tools_test") ]]; then
+if [[ ${TRAVIS} &&
+  ${CI_MODE} == "aio" ||
+  ${CI_MODE} == "aio_e2e" ||
+  ${CI_MODE} == "aio_tools_test" ||
+  ${CI_MODE} == "aio_optional"
+]]; then
   # angular.io: Install all yarn dependencies according to angular.io/yarn.lock
   travisFoldStart "yarn-install.aio"
     (
@@ -74,7 +79,14 @@ fi
 
 
 # Install Chromium
-if [[ ${TRAVIS} && ${CI_MODE} == "js" || ${CI_MODE} == "e2e" || ${CI_MODE} == "e2e_2" || ${CI_MODE} == "aio" || ${CI_MODE} == "aio_e2e" ]]; then
+if [[ ${TRAVIS} &&
+  ${CI_MODE} == "js" ||
+  ${CI_MODE} == "e2e" ||
+  ${CI_MODE} == "e2e_2" ||
+  ${CI_MODE} == "aio" ||
+  ${CI_MODE} == "aio_e2e" ||
+  ${CI_MODE} == "aio_optional"
+]]; then
   travisFoldStart "install-chromium"
     (
       ${thisDir}/install-chromium.sh

--- a/scripts/ci/test-aio-optional.sh
+++ b/scripts/ci/test-aio-optional.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -u -e -o pipefail
+
+# Setup environment
+readonly thisDir=$(cd $(dirname $0); pwd)
+source ${thisDir}/_travis-fold.sh
+
+# run in subshell to avoid polluting cwd
+(
+  cd ${PROJECT_ROOT}/aio
+  # Run e2e tests
+  travisFoldStart "test.aio.e2e"
+    yarn setup
+    yarn e2e
+  travisFoldEnd "test.aio.e2e"
+
+)

--- a/scripts/ci/test-aio.sh
+++ b/scripts/ci/test-aio.sh
@@ -31,12 +31,6 @@ source ${thisDir}/_travis-fold.sh
   travisFoldEnd "test.aio.unit"
 
 
-  # Run e2e tests
-  travisFoldStart "test.aio.e2e"
-    yarn e2e
-  travisFoldEnd "test.aio.e2e"
-
-
   # Run unit tests for aio/aio-builds-setup
   travisFoldStart "test.aio.aio-builds-setup"
     ./aio-builds-setup/scripts/test.sh

--- a/scripts/ci/test.sh
+++ b/scripts/ci/test.sh
@@ -46,6 +46,9 @@ case ${CI_MODE} in
   aio_e2e)
     ${thisDir}/test-aio-e2e.sh
     ;;
+  aio_optional)
+    ${thisDir}/test-aio-optional.sh
+    ;;
   bazel)
     ${thisDir}/test-bazel.sh
     ;;


### PR DESCRIPTION
The AIO e2e tests are failing randomly.
This PR moves those tests to an optional Travis job while we investigate.
See https://github.com/angular/angular/issues/20159#issuecomment-341832801