### PR TITLE
refactor(forms): match getError and hasError to get method signature

### DIFF
--- a/packages/forms/src/directives/abstract_control_directive.ts
+++ b/packages/forms/src/directives/abstract_control_directive.ts
@@ -153,7 +153,7 @@ export abstract class AbstractControlDirective {
    * If no path is given, it checks for the error on the present control.
    * If the control is not present, false is returned.
    */
-  hasError(errorCode: string, path?: string[]): boolean {
+  hasError(errorCode: string, path?: Array<string|number>|string): boolean {
     return this.control ? this.control.hasError(errorCode, path) : false;
   }
 
@@ -162,7 +162,7 @@ export abstract class AbstractControlDirective {
    * Reports error data for the control with the given path.
    * If the control is not present, null is returned.
    */
-  getError(errorCode: string, path?: string[]): any {
+  getError(errorCode: string, path?: Array<string|number>|string): any {
     return this.control ? this.control.getError(errorCode, path) : null;
   }
 }

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -654,7 +654,7 @@ export abstract class AbstractControl {
    * @returns The error data if the control with the given path has the given error, otherwise null
    * or undefined.
    */
-  getError(errorCode: string, path?: string[]): any {
+  getError(errorCode: string, path?: Array<string|number>|string): any {
     const control = path ? this.get(path) : this;
     return control && control.errors ? control.errors[errorCode] : null;
   }
@@ -667,7 +667,9 @@ export abstract class AbstractControl {
    * control.
    * @returns True when the control with the given path has the error, otherwise false.
    */
-  hasError(errorCode: string, path?: string[]): boolean { return !!this.getError(errorCode, path); }
+  hasError(errorCode: string, path?: Array<string|number>|string): boolean {
+    return !!this.getError(errorCode, path);
+  }
 
   /**
    * Retrieves the top-level ancestor of this control.

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -684,6 +684,70 @@ import {of } from 'rxjs';
         expect(g.getError('required', ['one'])).toEqual(null);
         expect(g.getError('required', ['invalid'])).toEqual(null);
       });
+
+      it('should be able to traverse group with single string', () => {
+        const c = new FormControl('', Validators.required);
+        const g = new FormGroup({'one': c});
+        expect(c.getError('required')).toEqual(true);
+        expect(g.getError('required', 'one')).toEqual(true);
+      });
+
+      it('should be able to traverse group with string delimited by dots', () => {
+        const c = new FormControl('', Validators.required);
+        const g2 = new FormGroup({'two': c});
+        const g1 = new FormGroup({'one': g2});
+        expect(c.getError('required')).toEqual(true);
+        expect(g1.getError('required', 'one.two')).toEqual(true);
+      });
+
+      it('should traverse group with form array using string and numbers', () => {
+        const c = new FormControl('', Validators.required);
+        const g2 = new FormGroup({'two': c});
+        const a = new FormArray([g2]);
+        const g1 = new FormGroup({'one': a});
+        expect(c.getError('required')).toEqual(true);
+        expect(g1.getError('required', ['one', 0, 'two'])).toEqual(true);
+      });
+    });
+
+    describe('hasError', () => {
+      it('should return true when it is present', () => {
+        const c = new FormControl('', Validators.required);
+        const g = new FormGroup({'one': c});
+        expect(c.hasError('required')).toEqual(true);
+        expect(g.hasError('required', ['one'])).toEqual(true);
+      });
+
+      it('should return false otherwise', () => {
+        const c = new FormControl('not empty', Validators.required);
+        const g = new FormGroup({'one': c});
+        expect(c.hasError('invalid')).toEqual(false);
+        expect(g.hasError('required', ['one'])).toEqual(false);
+        expect(g.hasError('required', ['invalid'])).toEqual(false);
+      });
+
+      it('should be able to traverse group with single string', () => {
+        const c = new FormControl('', Validators.required);
+        const g = new FormGroup({'one': c});
+        expect(c.hasError('required')).toEqual(true);
+        expect(g.hasError('required', 'one')).toEqual(true);
+      });
+
+      it('should be able to traverse group with string delimited by dots', () => {
+        const c = new FormControl('', Validators.required);
+        const g2 = new FormGroup({'two': c});
+        const g1 = new FormGroup({'one': g2});
+        expect(c.hasError('required')).toEqual(true);
+        expect(g1.hasError('required', 'one.two')).toEqual(true);
+      });
+      it('should traverse group with form array using string and numbers', () => {
+        const c = new FormControl('', Validators.required);
+        const g2 = new FormGroup({'two': c});
+        const a = new FormArray([g2]);
+        const g1 = new FormGroup({'one': a});
+        expect(c.getError('required')).toEqual(true);
+        expect(g1.getError('required', ['one', 0, 'two'])).toEqual(true);
+      });
     });
 
     describe('validator', () => {

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -30,8 +30,8 @@ export declare abstract class AbstractControl {
         emitEvent?: boolean;
     }): void;
     get(path: Array<string | number> | string): AbstractControl | null;
-    getError(errorCode: string, path?: string[]): any;
-    hasError(errorCode: string, path?: string[]): boolean;
+    getError(errorCode: string, path?: Array<string | number> | string): any;
+    hasError(errorCode: string, path?: Array<string | number> | string): boolean;
     markAsDirty(opts?: {
         onlySelf?: boolean;
     }): void;
@@ -80,8 +80,8 @@ export declare abstract class AbstractControlDirective {
     readonly valid: boolean | null;
     readonly value: any;
     readonly valueChanges: Observable<any> | null;
-    getError(errorCode: string, path?: string[]): any;
-    hasError(errorCode: string, path?: string[]): boolean;
+    getError(errorCode: string, path?: Array<string | number> | string): any;
+    hasError(errorCode: string, path?: Array<string | number> | string): boolean;
     reset(value?: any): void;
 }
 


### PR DESCRIPTION
closes #19734

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Feature
```

## What is the current behavior?
`getError` and `hasError` mismatch the api of `get`

Issue Number: #19734


## What is the new behavior?
apis match


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
