### PR TITLE
feat(forms): introduce initialValue to AbstractControl

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -121,6 +121,7 @@ export abstract class AbstractControl {
   private _parent: FormGroup|FormArray;
   private _asyncValidationSubscription: any;
   public readonly value: any;
+  public readonly initialValue: any;
 
   constructor(public validator: ValidatorFn|null, public asyncValidator: AsyncValidatorFn|null) {}
 
@@ -632,6 +633,9 @@ export abstract class AbstractControl {
       this._updateOn = (opts as AbstractControlOptions).updateOn !;
     }
   }
+
+  /** @internal */
+  _setInitialValue(value: any) { (this as{initialValue: any}).initialValue = value; }
 }
 
 /**
@@ -718,6 +722,7 @@ export class FormControl extends AbstractControl {
     this._applyFormState(formState);
     this._setUpdateStrategy(validatorOrOpts);
     this.updateValueAndValidity({onlySelf: true, emitEvent: false});
+    this._setInitialValue(this.value);
     this._initObservables();
   }
 
@@ -801,6 +806,7 @@ export class FormControl extends AbstractControl {
     this.markAsPristine(options);
     this.markAsUntouched(options);
     this.setValue(this.value, options);
+    this._setInitialValue(this.value);
   }
 
   /**
@@ -951,6 +957,7 @@ export class FormGroup extends AbstractControl {
     this._setUpdateStrategy(validatorOrOpts);
     this._setUpControls();
     this.updateValueAndValidity({onlySelf: true, emitEvent: false});
+    this._setInitialValue(this.value);
   }
 
   /**
@@ -1107,6 +1114,7 @@ export class FormGroup extends AbstractControl {
       control.reset(value[name], {onlySelf: true, emitEvent: options.emitEvent});
     });
     this.updateValueAndValidity(options);
+    this._setInitialValue(this.value);
     this._updatePristine(options);
     this._updateTouched(options);
   }
@@ -1288,6 +1296,7 @@ export class FormArray extends AbstractControl {
     this._setUpdateStrategy(validatorOrOpts);
     this._setUpControls();
     this.updateValueAndValidity({onlySelf: true, emitEvent: false});
+    this._setInitialValue(this.value);
   }
 
   /**
@@ -1442,6 +1451,7 @@ export class FormArray extends AbstractControl {
       control.reset(value[index], {onlySelf: true, emitEvent: options.emitEvent});
     });
     this.updateValueAndValidity(options);
+    this._setInitialValue(this.value);
     this._updatePristine(options);
     this._updateTouched(options);
   }

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -1099,5 +1099,34 @@ export function main() {
       });
 
     });
+
+    describe('initialValue', () => {
+      let c: FormControl;
+      let a: FormArray;
+
+      beforeEach(() => {
+        c = new FormControl('initial value');
+        a = new FormArray([c]);
+      });
+
+      it('should be the value passed into constructor',
+         () => { expect(a.initialValue).toEqual(['initial value']); });
+
+      it('should not change when value changes via setValue', () => {
+        a.setValue(['different value']);
+        expect(a.initialValue).toEqual(['initial value']);
+      });
+
+      it('should not change when value changes via patchValue', () => {
+        a.patchValue(['different value']);
+        expect(a.initialValue).toEqual(['initial value']);
+      });
+
+      it('should change when control is reset', () => {
+        a.reset(['new value']);
+        expect(a.initialValue).toEqual(['new value']);
+      });
+    });
+
   });
 }

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -1141,5 +1141,29 @@ export function main() {
 
       });
     });
+
+    describe('initialValue', () => {
+      let c: FormControl;
+
+      beforeEach(() => c = new FormControl('initial value'));
+
+      it('should be the value passed into constructor',
+         () => { expect(c.initialValue).toEqual('initial value'); });
+
+      it('should not change when value changes via setValue', () => {
+        c.setValue('different value');
+        expect(c.initialValue).toEqual('initial value');
+      });
+
+      it('should not change when value changes via patchValue', () => {
+        c.patchValue('different value');
+        expect(c.initialValue).toEqual('initial value');
+      });
+
+      it('should change when control is reset', () => {
+        c.reset('new value');
+        expect(c.initialValue).toEqual('new value');
+      });
+    });
   });
 }

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -1124,6 +1124,33 @@ export function main() {
 
     });
 
+    describe('initialValue', () => {
+      let c: FormControl;
+      let g: FormGroup;
+
+      beforeEach(() => {
+        c = new FormControl('initial value');
+        g = new FormGroup({'one': c});
+      });
+
+      it('should be the value passed into constructor',
+         () => { expect(g.initialValue).toEqual({'one': 'initial value'}); });
+
+      it('should not change when value changes via setValue', () => {
+        g.setValue({'one': 'different value'});
+        expect(g.initialValue).toEqual({'one': 'initial value'});
+      });
+
+      it('should not change when value changes via patchValue', () => {
+        g.patchValue({'one': 'different value'});
+        expect(g.initialValue).toEqual({'one': 'initial value'});
+      });
+
+      it('should change when control is reset', () => {
+        g.reset({'one': 'new value'});
+        expect(g.initialValue).toEqual({'one': 'new value'});
+      });
+    });
 
   });
 }

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -5,6 +5,7 @@ export declare abstract class AbstractControl {
     readonly disabled: boolean;
     readonly enabled: boolean;
     readonly errors: ValidationErrors | null;
+    readonly initialValue: any;
     readonly invalid: boolean;
     readonly parent: FormGroup | FormArray;
     readonly pending: boolean;


### PR DESCRIPTION
closes #19747
adds `initialValue` as a readonly property on `AbstractControl` which holds the value passed during construction and is never change except on calling `reset`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
```
[x] Feature
```

## What is the current behavior?
There is no simple way to save a forms inital/original value/state
Issue Number: #19747

## What is the new behavior?
a new property that stores the orginal value

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```