### PR TITLE
fix(language-service): pass compilerOptions.paths to ReflectorHost

### DIFF
--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -376,6 +376,9 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
       if (compilerOptions && compilerOptions.baseUrl) {
         options.baseUrl = compilerOptions.baseUrl;
       }
+      if (compilerOptions && compilerOptions.paths) {
+        options.paths = compilerOptions.paths;
+      }
       result = this._reflectorHost =
           new ReflectorHost(() => this.tsService.getProgram(), this.host, options);
     }

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -160,6 +160,33 @@ export class MyComponent {
 
   });
 
+  it('should respect paths configuration', () => {
+    mockHost.overrideOptions(options => {
+      options.baseUrl = '/app';
+      options.paths = {'bar/*': ['foo/bar/*']};
+      return options;
+    });
+    mockHost.addScript('/app/foo/bar/shared.ts', `
+      export interface Node {
+        children: Node[];
+      }
+    `);
+    mockHost.addScript('/app/my.component.ts', `
+      import { Component } from '@angular/core';
+      import { Node } from 'bar/shared';
+
+      @Component({
+        selector: 'my-component',
+        template: '{{tree.~{tree} }}'
+      })
+      export class MyComponent {
+        tree: Node;
+      }
+    `);
+    ngHost.updateAnalyzedModules();
+    contains('/app/my.component.ts', 'tree', 'children');
+  });
+
   function addCode(code: string, cb: (fileName: string, content?: string) => void) {
     const fileName = '/app/app.component.ts';
     const originalContent = mockHost.getFileContent(fileName);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`paths` defined in tsconfig.json are not used to resolve modules.

Issue Number: N/A

## What is the new behavior?
`paths` in tsconfig.json are now included in module resolution.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
