### PR TITLE
docs(aio): update myHighlight references to appHighlight

### DIFF
--- a/aio/content/examples/attribute-directives/src/app/highlight.directive.2.ts
+++ b/aio/content/examples/attribute-directives/src/app/highlight.directive.2.ts
@@ -35,7 +35,7 @@ export class HighlightDirective {
   // #enddocregion color
 
   // #docregion color-2
-  @Input() myHighlight: string;
+  @Input() appHighlight: string;
   // #enddocregion color-2
 }
 

--- a/aio/content/examples/dependency-injection-in-action/src/app/app.component.html
+++ b/aio/content/examples/dependency-injection-in-action/src/app/app.component.html
@@ -11,7 +11,7 @@
 </div>
 
 <!-- #docregion highlight -->
-<div id="highlight"  class="di-component"  appHighlight>
+<div id="highlight" class="di-component" appHighlight>
   <h3>Hero Bios and Contacts</h3>
   <div appHighlight="yellow">
     <app-hero-bios-and-contacts></app-hero-bios-and-contacts>

--- a/aio/content/examples/dependency-injection-in-action/src/assets/sample.css
+++ b/aio/content/examples/dependency-injection-in-action/src/assets/sample.css
@@ -3,7 +3,7 @@
   width:300px;
   margin-bottom: 10px;
 }
-div[myHighlight] {
+div[appHighlight] {
   padding: 2px 8px;
 }
 

--- a/aio/content/guide/attribute-directives.md
+++ b/aio/content/guide/attribute-directives.md
@@ -33,7 +33,7 @@ An attribute directive minimally requires building a controller class annotated 
 the attribute.
 The controller class implements the desired directive behavior.
 
-This page demonstrates building a simple _myHighlight_ attribute
+This page demonstrates building a simple _appHighlight_ attribute
 directive to set an element's background color
 when the user hovers over that element. You can apply it like this:
 
@@ -64,21 +64,21 @@ as an argument.
 the HTML in the template that is associated with the directive.
 The [CSS selector for an attribute](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors)
 is the attribute name in square brackets.
-Here, the directive's selector is `[myHighlight]`.
-Angular locates all elements in the template that have an attribute named `myHighlight`.
+Here, the directive's selector is `[appHighlight]`.
+Angular locates all elements in the template that have an attribute named `appHighlight`.
 
 <div class="l-sub-section">
 
 ### Why not call it "highlight"?
 
-Though *highlight* is a more concise name than *myHighlight* and would work,
+Though *highlight* is a more concise name than *appHighlight* and would work,
 a best practice is to prefix selector names to ensure
 they don't conflict with standard HTML attributes.
 This also reduces the risk of colliding with third-party directive names.
 
 Make sure you do **not** prefix the `highlight` directive name with **`ng`** because
 that prefix is reserved for Angular and using it could cause bugs that are difficult to diagnose.
-For a simple demo, the short prefix, `my`, helps distinguish your custom directive.
+For a simple demo, the short prefix, `app`, helps distinguish your custom directive.
 
 </div>
 
@@ -112,11 +112,11 @@ Now reference this template in the `AppComponent`:
 
 Next, add an `import` statement to fetch the `Highlight` directive and
 add that class to the `declarations` NgModule metadata. This way Angular
-recognizes the directive when it encounters `myHighlight` in the template.
+recognizes the directive when it encounters `appHighlight` in the template.
 
 <code-example path="attribute-directives/src/app/app.module.ts" title="src/app/app.module.ts"></code-example>
 
-Now when the app runs, the `myHighlight` directive highlights the paragraph text.
+Now when the app runs, the `appHighlight` directive highlights the paragraph text.
 
 <figure>
   <img src="generated/images/guide/attribute-directives/first-highlight.png" alt="First Highlight">
@@ -132,7 +132,7 @@ Open the console in the browser tools and look for an error like this:
 
 <code-example format="nocode">
   EXCEPTION: Template parse errors:
-    Can't bind to 'myHighlight' since it isn't a known property of 'p'.
+    Can't bind to 'appHighlight' since it isn't a known property of 'p'.
 </code-example>
 
 Angular detects that you're trying to bind to *something* but it can't find this directive
@@ -142,7 +142,7 @@ Angular knows it can apply the directive to components declared in this module.
 
 </div>
 
-To summarize, Angular found the `myHighlight` attribute on the `<p>` element.
+To summarize, Angular found the `appHighlight` attribute on the `<p>` element.
 It created an instance of the `HighlightDirective` class and
 injected a reference to the `<p>` element into the directive's constructor
 which sets the `<p>` element's background style to yellow.
@@ -151,7 +151,7 @@ which sets the `<p>` element's background style to yellow.
 
 ## Respond to user-initiated events
 
-Currently, `myHighlight` simply sets an element color.
+Currently, `appHighlight` simply sets an element color.
 The directive could be more dynamic.
 It could detect when the user mouses into or out of the element
 and respond by setting or clearing the highlight color.
@@ -232,16 +232,16 @@ That's good, but it would be nice to _simultaneously_ apply the directive and se
 
 <code-example path="attribute-directives/src/app/app.component.html" linenums="false" title="src/app/app.component.html (color)" region="color"></code-example>
 
-The `[myHighlight]` attribute binding both applies the highlighting directive to the `<p>` element
+The `[appHighlight]` attribute binding both applies the highlighting directive to the `<p>` element
 and sets the directive's highlight color with a property binding.
-You're re-using the directive's attribute selector (`[myHighlight]`) to do both jobs.
+You're re-using the directive's attribute selector (`[appHighlight]`) to do both jobs.
 That's a crisp, compact syntax.
 
-You'll have to rename the directive's `highlightColor` property to `myHighlight` because that's now the color property binding name.
+You'll have to rename the directive's `highlightColor` property to `appHighlight` because that's now the color property binding name.
 
 <code-example path="attribute-directives/src/app/highlight.directive.2.ts" linenums="false" title="src/app/highlight.directive.ts (renamed to match directive selector)" region="color-2"></code-example>
 
-This is disagreeable. The word, `myHighlight`, is a terrible property name and it doesn't convey the property's intent.
+This is disagreeable. The word, `appHighlight`, is a terrible property name and it doesn't convey the property's intent.
 
 {@a input-alias}
 
@@ -254,7 +254,7 @@ Restore the original property name and specify the selector as the alias in the 
 <code-example path="attribute-directives/src/app/highlight.directive.ts" linenums="false" title="src/app/highlight.directive.ts (color property with alias)" region="color"></code-example>
 
 _Inside_ the directive the property is known as `highlightColor`.
-_Outside_ the directive, where you bind to it, it's known as `myHighlight`.
+_Outside_ the directive, where you bind to it, it's known as `appHighlight`.
 
 You get the best of both worlds: the property name you want and the binding syntax you want:
 
@@ -308,7 +308,7 @@ then with the `defaultColor`, and falls back to "red" if both properties are und
 
 <code-example path="attribute-directives/src/app/highlight.directive.ts" linenums="false" title="src/app/highlight.directive.ts (mouse-enter)" region="mouse-enter"></code-example>
 
-How do you bind to a second property when you're already binding to the `myHighlight` attribute name?
+How do you bind to a second property when you're already binding to the `appHighlight` attribute name?
 
 As with components, you can add as many directive property bindings as you need by stringing them along in the template.
 The developer should be able to write the following template HTML to both bind to the `AppComponent.color`
@@ -398,6 +398,6 @@ Now apply that reasoning to the following example:
   The template and its component trust each other.
   The `color` property doesn't require the `@Input` decorator.
 
-* The `myHighlight` property on the left refers to an _aliased_ property of the `HighlightDirective`,
+* The `appHighlight` property on the left refers to an _aliased_ property of the `HighlightDirective`,
   not a property of the template's component. There are trust issues.
   Therefore, the directive property must carry the `@Input` decorator.

--- a/aio/content/guide/dependency-injection-in-action.md
+++ b/aio/content/guide/dependency-injection-in-action.md
@@ -435,7 +435,7 @@ Angular sets the constructor's `el` parameter to the injected `ElementRef`, whic
 a wrapper around that DOM element.
 Its `nativeElement` property exposes the DOM element for the directive to manipulate.
 
-The sample code applies the directive's `myHighlight` attribute to two `<div>` tags,
+The sample code applies the directive's `appHighlight` attribute to two `<div>` tags,
 first without a value (yielding the default color) and then with an assigned color value.
 
 <code-example path="dependency-injection-in-action/src/app/app.component.html" region="highlight" title="src/app/app.component.html (highlight)" linenums="false">

--- a/aio/content/guide/dependency-injection-in-action.md
+++ b/aio/content/guide/dependency-injection-in-action.md
@@ -480,7 +480,7 @@ Angular sets the constructor's `el` parameter to the injected `ElementRef`, whic
 a wrapper around that DOM element.
 Its `nativeElement` property exposes the DOM element for the directive to manipulate.
 
-The sample code applies the directive's `myHighlight` attribute to two `<div>` tags,
+The sample code applies the directive's `appHighlight` attribute to two `<div>` tags,
 first without a value (yielding the default color) and then with an assigned color value.
 
 <code-example path="dependency-injection-in-action/src/app/app.component.html" region="highlight" title="src/app/app.component.html (highlight)" linenums="false">


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Fix documentation on referenced attribute directive _appHighlight_

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
In Angular.io docs, _myHighlight_ is referenced in Attribute Directives and Dependency Injection In Action. In the code snippets, _appHighlight_ is mentioned.

Issue Number: N/A


## What is the new behavior?
_appHighlight_ is mentioned where myHighlight was.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```


## Other information
