### PR TITLE
fix(upgrade): need to take base uri into account in setUpLocationSync

### DIFF
--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -84,7 +84,6 @@ module.exports = function(config) {
       'dist/all/@angular/elements/schematics/**',
       'dist/all/@angular/examples/**/e2e_test/*',
       'dist/all/@angular/language-service/**',
-      'dist/all/@angular/router/test/**',
       'dist/all/@angular/router/**/test/**',
       'dist/all/@angular/platform-browser/testing/e2e_util.js',
       'dist/all/angular1_router.js',

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -85,6 +85,7 @@ module.exports = function(config) {
       'dist/all/@angular/examples/**/e2e_test/*',
       'dist/all/@angular/language-service/**',
       'dist/all/@angular/router/test/**',
+      'dist/all/@angular/router/**/test/**',
       'dist/all/@angular/platform-browser/testing/e2e_util.js',
       'dist/all/angular1_router.js',
       'dist/examples/**/e2e_test/**',

--- a/packages/router/BUILD.bazel
+++ b/packages/router/BUILD.bazel
@@ -15,8 +15,8 @@ ng_module(
         "//packages/common",
         "//packages/core",
         "//packages/platform-browser",
-        "//packages/upgrade/static",
         "@rxjs",
+        "@rxjs//operators",
     ],
 )
 

--- a/packages/router/karma-test-shim.js
+++ b/packages/router/karma-test-shim.js
@@ -51,6 +51,8 @@ System.config({
     '@angular/platform-browser': {main: 'index.js', defaultExtension: 'js'},
     '@angular/platform-browser-dynamic/testing': {main: 'index.js', defaultExtension: 'js'},
     '@angular/platform-browser-dynamic': {main: 'index.js', defaultExtension: 'js'},
+    '@angular/upgrade/static': {main: 'index.js', defaultExtension: 'js'},
+    '@angular/router/upgrade': {main: 'index.js', defaultExtension: 'js'},
     '@angular/router/testing': {main: 'index.js', defaultExtension: 'js'},
     '@angular/router': {main: 'index.js', defaultExtension: 'js'},
     'rxjs/ajax': {main: 'index.js', defaultExtension: 'js'},

--- a/packages/router/karma.conf.js
+++ b/packages/router/karma.conf.js
@@ -61,20 +61,23 @@ module.exports = function(config) {
       {
         pattern: 'dist/all/@angular/platform-browser/testing/**/*.js',
         included: false,
-        watched: false,
+        watched: false
       },
 
       {pattern: 'dist/all/@angular/platform-browser-dynamic/*.js', included: false, watched: false},
       {
         pattern: 'dist/all/@angular/platform-browser-dynamic/src/**/*.js',
         included: false,
-        watched: false,
+        watched: false
       },
       {
         pattern: 'dist/all/@angular/platform-browser-dynamic/testing/**/*.js',
         included: false,
-        watched: false,
+        watched: false
       },
+
+      {pattern: 'dist/all/@angular/upgrade/static/*.js', included: false, watched: false},
+      {pattern: 'dist/all/@angular/upgrade/static/src/**/*.js', included: false, watched: false},
 
       // Router
       {pattern: 'dist/all/@angular/router/**/*.js', included: false, watched: true}

--- a/packages/router/upgrade/BUILD.bazel
+++ b/packages/router/upgrade/BUILD.bazel
@@ -6,10 +6,17 @@ load("//tools:defaults.bzl", "ng_module")
 
 ng_module(
     name = "upgrade",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        [
+            "*.ts",
+            "src/**/*.ts",
+        ],
+    ),
     module_name = "@angular/router/upgrade",
     deps = [
+        "//packages/common",
         "//packages/core",
         "//packages/router",
+        "//packages/upgrade/static",
     ],
 )

--- a/packages/router/upgrade/src/upgrade.ts
+++ b/packages/router/upgrade/src/upgrade.ts
@@ -6,11 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Location} from '@angular/common';
 import {APP_BOOTSTRAP_LISTENER, ComponentRef, InjectionToken} from '@angular/core';
 import {Router} from '@angular/router';
 import {UpgradeModule} from '@angular/upgrade/static';
-
-
 
 /**
  * @description
@@ -68,11 +67,13 @@ export function setUpLocationSync(ngUpgrade: UpgradeModule) {
   }
 
   const router: Router = ngUpgrade.injector.get(Router);
+  const location: Location = ngUpgrade.injector.get(Location);
   const url = document.createElement('a');
 
   ngUpgrade.$injector.get('$rootScope')
       .$on('$locationChangeStart', (_: any, next: string, __: string) => {
         url.href = next;
-        router.navigateByUrl(url.pathname + url.search + url.hash);
+        const path: string = location.normalize(url.pathname);
+        router.navigateByUrl(path + url.search + url.hash);
       });
 }

--- a/packages/router/upgrade/test/BUILD.bazel
+++ b/packages/router/upgrade/test/BUILD.bazel
@@ -1,0 +1,37 @@
+load("//tools:defaults.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
+load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
+
+ts_library(
+    name = "test_lib",
+    testonly = 1,
+    srcs = glob(["**/*.ts"]),
+    deps = [
+        "//packages/common",
+        "//packages/core/testing",
+        "//packages/router",
+        "//packages/router/upgrade",
+        "//packages/upgrade/static",
+    ],
+)
+
+jasmine_node_test(
+    name = "test",
+    bootstrap = ["angular/tools/testing/init_node_spec.js"],
+    deps = [
+        ":test_lib",
+        "//tools/testing:node",
+    ],
+)
+
+ts_web_test(
+    name = "test_web",
+    bootstrap = [
+        "//:web_test_bootstrap_scripts",
+    ],
+    # do not sort
+    deps = [
+        "//tools/testing:browser",
+        ":test_lib",
+    ],
+)

--- a/packages/router/upgrade/test/BUILD.bazel
+++ b/packages/router/upgrade/test/BUILD.bazel
@@ -1,6 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
-load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
+load("//tools:defaults.bzl", "ts_library", "ts_web_test_suite")
 
 ts_library(
     name = "test_lib",
@@ -15,23 +13,9 @@ ts_library(
     ],
 )
 
-jasmine_node_test(
-    name = "test",
-    bootstrap = ["angular/tools/testing/init_node_spec.js"],
-    deps = [
-        ":test_lib",
-        "//tools/testing:node",
-    ],
-)
-
-ts_web_test(
+ts_web_test_suite(
     name = "test_web",
-    bootstrap = [
-        "//:web_test_bootstrap_scripts",
-    ],
-    # do not sort
     deps = [
-        "//tools/testing:browser",
         ":test_lib",
     ],
 )

--- a/packages/router/upgrade/test/upgrade.spec.ts
+++ b/packages/router/upgrade/test/upgrade.spec.ts
@@ -78,4 +78,24 @@ describe('setUpLocationSync', () => {
     expect(RouterMock.navigateByUrl).toHaveBeenCalledTimes(1);
     expect(RouterMock.navigateByUrl).toHaveBeenCalledWith(normalizedPathname + query + hash);
   });
+
+  it('should work correctly on browsers that do not start pathname with `/`', () => {
+    const anchorProto = HTMLAnchorElement.prototype;
+    const originalDescriptor = Object.getOwnPropertyDescriptor(anchorProto, 'pathname');
+    Object.defineProperty(anchorProto, 'pathname', {get: () => 'foo/bar'});
+
+    try {
+      const $rootScope = jasmine.createSpyObj('$rootScope', ['$on']);
+      upgradeModule.$injector.get.and.returnValue($rootScope);
+
+      setUpLocationSync(upgradeModule);
+
+      const callback = $rootScope.$on.calls.argsFor(0)[1];
+      callback({}, '', '');
+
+      expect(LocationMock.normalize).toHaveBeenCalledWith('/foo/bar');
+    } finally {
+      Object.defineProperty(anchorProto, 'pathname', originalDescriptor !);
+    }
+  });
 });

--- a/packages/router/upgrade/test/upgrade.spec.ts
+++ b/packages/router/upgrade/test/upgrade.spec.ts
@@ -16,21 +16,22 @@ describe('setUpLocationSync', () => {
   let upgradeModule: UpgradeModule;
   let RouterMock: any;
   let LocationMock: any;
+
   beforeEach(() => {
     RouterMock = jasmine.createSpyObj('Router', ['navigateByUrl']);
     LocationMock = jasmine.createSpyObj('Location', ['normalize']);
+
     TestBed.configureTestingModule({
       providers: [
         UpgradeModule, {provide: Router, useValue: RouterMock},
         {provide: Location, useValue: LocationMock}
       ],
     });
-    upgradeModule = TestBed.get(UpgradeModule);
 
+    upgradeModule = TestBed.get(UpgradeModule);
     upgradeModule.$injector = {
       get: jasmine.createSpy('$injector.get').and.returnValue({'$on': () => undefined})
     };
-
   });
 
   it('should throw an error if the UpgradeModule.bootstrap has not been called', () => {
@@ -44,7 +45,6 @@ describe('setUpLocationSync', () => {
 
   it('should get the $rootScope from AngularJS and set an $on watch on $locationChangeStart',
      () => {
-
        const $rootScope = jasmine.createSpyObj('$rootScope', ['$on']);
 
        upgradeModule.$injector.get.and.callFake(
@@ -54,31 +54,28 @@ describe('setUpLocationSync', () => {
 
        expect($rootScope.$on).toHaveBeenCalledTimes(1);
        expect($rootScope.$on).toHaveBeenCalledWith('$locationChangeStart', jasmine.any(Function));
-
      });
 
   it('should navigate by url every time $locationChangeStart is broadcasted', () => {
-
+    const url = 'https://google.com';
+    const pathname = '/custom/route';
+    const normalizedPathname = 'foo';
+    const query = '?query=1&query2=3';
+    const hash = '#new/hash';
     const $rootScope = jasmine.createSpyObj('$rootScope', ['$on']);
+
     upgradeModule.$injector.get.and.returnValue($rootScope);
+    LocationMock.normalize.and.returnValue(normalizedPathname);
 
     setUpLocationSync(upgradeModule);
 
-    const url = 'https://google.com';
-    const pathname = '/custom/route';
-    const query = '?query=1&query2=3';
-    const hash = '#new/hash';
     const callback = $rootScope.$on.calls.argsFor(0)[1];
-
-    LocationMock.normalize.and.returnValue(pathname);
-
     callback({}, url + pathname + query + hash, '');
 
     expect(LocationMock.normalize).toHaveBeenCalledTimes(1);
     expect(LocationMock.normalize).toHaveBeenCalledWith(pathname);
 
     expect(RouterMock.navigateByUrl).toHaveBeenCalledTimes(1);
-    expect(RouterMock.navigateByUrl).toHaveBeenCalledWith(pathname + query + hash);
+    expect(RouterMock.navigateByUrl).toHaveBeenCalledWith(normalizedPathname + query + hash);
   });
-
 });

--- a/packages/router/upgrade/test/upgrade.spec.ts
+++ b/packages/router/upgrade/test/upgrade.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Location} from '@angular/common';
+import {TestBed} from '@angular/core/testing';
+import {Router} from '@angular/router';
+import {setUpLocationSync} from '@angular/router/upgrade';
+import {UpgradeModule} from '@angular/upgrade/static';
+
+describe('setUpLocationSync', () => {
+  let upgradeModule: UpgradeModule;
+  let RouterMock: any;
+  let LocationMock: any;
+  beforeEach(() => {
+    RouterMock = jasmine.createSpyObj('Router', ['navigateByUrl']);
+    LocationMock = jasmine.createSpyObj('Location', ['normalize']);
+    TestBed.configureTestingModule({
+      providers: [
+        UpgradeModule, {provide: Router, useValue: RouterMock},
+        {provide: Location, useValue: LocationMock}
+      ],
+    });
+    upgradeModule = TestBed.get(UpgradeModule);
+
+    upgradeModule.$injector = {
+      get: jasmine.createSpy('$injector.get').and.returnValue({'$on': () => undefined})
+    };
+
+  });
+
+  it('should throw an error if the UpgradeModule.bootstrap has not been called', () => {
+    upgradeModule.$injector = null;
+
+    expect(() => setUpLocationSync(upgradeModule)).toThrowError(`
+        RouterUpgradeInitializer can be used only after UpgradeModule.bootstrap has been called.
+        Remove RouterUpgradeInitializer and call setUpLocationSync after UpgradeModule.bootstrap.
+      `);
+  });
+
+  it('should get the $rootScope from AngularJS and set an $on watch on $locationChangeStart',
+     () => {
+
+       const $rootScope = jasmine.createSpyObj('$rootScope', ['$on']);
+
+       upgradeModule.$injector.get.and.callFake(
+           (name: string) => (name === '$rootScope') && $rootScope);
+
+       setUpLocationSync(upgradeModule);
+
+       expect($rootScope.$on).toHaveBeenCalledTimes(1);
+       expect($rootScope.$on).toHaveBeenCalledWith('$locationChangeStart', jasmine.any(Function));
+
+     });
+
+  it('should navigate by url every time $locationChangeStart is broadcasted', () => {
+
+    const $rootScope = jasmine.createSpyObj('$rootScope', ['$on']);
+    upgradeModule.$injector.get.and.returnValue($rootScope);
+
+    setUpLocationSync(upgradeModule);
+
+    const url = 'https://google.com';
+    const pathname = '/custom/route';
+    const query = '?query=1&query2=3';
+    const hash = '#new/hash';
+    const callback = $rootScope.$on.calls.argsFor(0)[1];
+
+    LocationMock.normalize.and.returnValue(pathname);
+
+    callback({}, url + pathname + query + hash, '');
+
+    expect(LocationMock.normalize).toHaveBeenCalledTimes(1);
+    expect(LocationMock.normalize).toHaveBeenCalledWith(pathname);
+
+    expect(RouterMock.navigateByUrl).toHaveBeenCalledTimes(1);
+    expect(RouterMock.navigateByUrl).toHaveBeenCalledWith(pathname + query + hash);
+  });
+
+});


### PR DESCRIPTION
The url.pathname passes the base uri as part of the url instead of removing it

Fixes angular/angular#20061

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
I am modifying the setUpLocationSync in packages/router/upgrade/src/upgrade.ts to take the base tag into account when navigating by url

Issue Number: 20061


## What is the new behavior?
The base tag is removed from the pathname before the router navigates to the specified url. This stops an infinite loop from occurring when navigating between Angular and AngularJS.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
