### PR TITLE
fix(aio): correct DatePipe example format

### DIFF
--- a/packages/examples/common/pipes/ts/date_pipe.ts
+++ b/packages/examples/common/pipes/ts/date_pipe.ts
@@ -34,10 +34,10 @@ registerLocaleData(localeFr);
     <p>The full date/time in french is: {{today | date:'full':'':'fr'}}</p>
 
     <!--output '2015-06-15 05:03 PM GMT+9'-->
-    <p>The custom date is {{today | date:'yyyy-mm-dd HH:mm a z':'+0900'}}</p>
+    <p>The custom date is {{today | date:'yyyy-MM-dd HH:mm a z':'+0900'}}</p>
 
     <!--output '2015-06-15 09:03 AM GMT+9'-->
-    <p>The custom date with fixed timezone is {{fixedTimezone | date:'yyyy-mm-dd HH:mm a z':'+0900'}}</p>
+    <p>The custom date with fixed timezone is {{fixedTimezone | date:'yyyy-MM-dd HH:mm a z':'+0900'}}</p>
   </div>`
 })
 export class DatePipeComponent {
@@ -60,7 +60,7 @@ export class DatePipeComponent {
     <p>The time is {{today | date:'shortTime'}}</p>
 
     <!--output '2010-09-03 12:05 PM'-->
-    <p>The custom date is {{today | date:'yyyy-mm-dd HH:mm a'}}</p>
+    <p>The custom date is {{today | date:'yyyy-MM-dd HH:mm a'}}</p>
   </div>`
 })
 export class DeprecatedDatePipeComponent {


### PR DESCRIPTION
closes #20280

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
date month is formatted with `mm` in examples

Issue Number: #20280


## What is the new behavior?
date month is formatted with `MM` in examples

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```