### PR TITLE
fix(forms): disable radio inputs in template driven forms

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -88,9 +88,6 @@ export class FormControlDirective extends NgControl implements OnChanges {
               ngOnChanges(changes: SimpleChanges): void {
                 if (this._isControlChanged(changes)) {
                   setUpControl(this.form, this);
-                  if (this.control.disabled && this.valueAccessor !.setDisabledState) {
-                    this.valueAccessor !.setDisabledState !(true);
-                  }
                   this.form.updateValueAndValidity({emitEvent: false});
                 }
                 if (isPropertyUpdated(changes, this.viewModel)) {

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -148,9 +148,6 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
   private _setUpControl() {
     this._checkParentType();
     (this as{control: FormControl}).control = this.formDirective.addControl(this);
-    if (this.control.disabled && this.valueAccessor !.setDisabledState) {
-      this.valueAccessor !.setDisabledState !(true);
-    }
     this._added = true;
   }
 }

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -836,6 +836,9 @@ export class FormControl extends AbstractControl {
    * Register a listener for disabled events.
    */
   registerOnDisabledChange(fn: (isDisabled: boolean) => void): void {
+    if (this.disabled) {
+      fn(true);
+    }
     this._onDisabledChange.push(fn);
   }
 

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -897,6 +897,18 @@ export function main() {
              expect(inputs[3].nativeElement.disabled).toBe(false);
            }));
 
+        it('should disable all radio buttons when initially disabled', fakeAsync(() => {
+             const fixture = initTest(NgModelDynamicRadioForm);
+
+             fixture.detectChanges();
+             tick();
+
+             const inputs = fixture.debugElement.queryAll(By.css('input'));
+             expect(inputs[0].nativeElement.disabled).toBe(true, 'First radio should be disabled');
+             expect(inputs[1].nativeElement.disabled).toBe(true, 'Second radio should be disabled');
+             expect(inputs[2].nativeElement.disabled).toBe(true, 'Third radio should be disabled');
+           }));
+
       });
 
     });
@@ -1303,6 +1315,22 @@ export class FormControlRadioButtons {
 class NgModelRadioForm {
   food: string;
   drink: string;
+}
+
+@Component({
+  template: `
+    <form>
+      <div *ngFor="let c of cities">
+        <input type="radio" name="city" [value]="c.id" [(ngModel)]="selectedCity" [disabled]="selectionNotAllowed"/>
+        {{ c.name }}
+      </div>
+    </form>
+  `
+})
+class NgModelDynamicRadioForm {
+  selectionNotAllowed = true;
+  selectedCity: string;
+  cities: any[] = [{id: 0, 'name': 'SF'}, {id: 1, 'name': 'NYC'}, {id: 2, 'name': 'Buffalo'}];
 }
 
 @Directive({


### PR DESCRIPTION
In template driven forms, disable radio controls when they are initially disabled using data binding.

closes #18206

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
https://github.com/angular/angular/issues/18206

Issue Number: 18206


## What is the new behavior?
In template driven forms, the radio inputs are correctly disabled when they are initially disabled using data binding.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
