### PR TITLE
fix(benchpress): Allow ignoring navigationStart events in perflog met…

### DIFF
--- a/packages/benchpress/src/metric/perflog_metric.ts
+++ b/packages/benchpress/src/metric/perflog_metric.ts
@@ -19,18 +19,21 @@ import {PerfLogEvent, PerfLogFeatures, WebDriverExtension} from '../web_driver_e
 @Injectable()
 export class PerflogMetric extends Metric {
   static SET_TIMEOUT = new InjectionToken('PerflogMetric.setTimeout');
+  static IGNORE_NAVIGATION = new InjectionToken('PerflogMetric.ignoreNavigation');
   static PROVIDERS = [
     {
       provide: PerflogMetric,
       deps: [
         WebDriverExtension, PerflogMetric.SET_TIMEOUT, Options.MICRO_METRICS, Options.FORCE_GC,
-        Options.CAPTURE_FRAMES, Options.RECEIVED_DATA, Options.REQUEST_COUNT
+        Options.CAPTURE_FRAMES, Options.RECEIVED_DATA, Options.REQUEST_COUNT,
+        PerflogMetric.IGNORE_NAVIGATION
       ]
     },
     {
       provide: PerflogMetric.SET_TIMEOUT,
       useValue: (fn: Function, millis: number) => <any>setTimeout(fn, millis)
-    }
+    },
+    {provide: PerflogMetric.IGNORE_NAVIGATION, useValue: false}
   ];
 
   private _remainingEvents: PerfLogEvent[];
@@ -41,6 +44,8 @@ export class PerflogMetric extends Metric {
    * @param driverExtension
    * @param setTimeout
    * @param microMetrics Name and description of metrics provided via console.time / console.timeEnd
+   * @param ignoreNavigation If true, don't measure from navigationStart events. These events are
+   *   usually triggered by a page load, but can also be triggered when adding iframes to the DOM.
    **/
   constructor(
       private _driverExtension: WebDriverExtension,
@@ -49,7 +54,8 @@ export class PerflogMetric extends Metric {
       @Inject(Options.FORCE_GC) private _forceGc: boolean,
       @Inject(Options.CAPTURE_FRAMES) private _captureFrames: boolean,
       @Inject(Options.RECEIVED_DATA) private _receivedData: boolean,
-      @Inject(Options.REQUEST_COUNT) private _requestCount: boolean) {
+      @Inject(Options.REQUEST_COUNT) private _requestCount: boolean,
+      @Inject(PerflogMetric.IGNORE_NAVIGATION) private _ignoreNavigation: boolean) {
     super();
 
     this._remainingEvents = [];
@@ -231,7 +237,7 @@ export class PerflogMetric extends Metric {
       const name = event['name'];
       if (ph === 'B' && name === markName) {
         markStartEvent = event;
-      } else if (ph === 'I' && name === 'navigationStart') {
+      } else if (ph === 'I' && name === 'navigationStart' && !this._ignoreNavigation) {
         // if a benchmark measures reload of a page, use the last
         // navigationStart as begin event
         markStartEvent = event;


### PR DESCRIPTION
…ric.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The Benchpress perflog metric will only aggregate perf events after the most recent `navigationStart` event. The assumption is that `navigationStart` only happens on a page load, but our tests include a component that adds an iframe. Adding the iframe to the DOM also logs a `navigationStart` event. This behavior prevents us from testing our components with benchpress.

Issue Number: N/A


## What is the new behavior?
The default behavior is the same, but now users can optionally ignore navigationStart events if they wish.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
