### PR TITLE
fix(compiler): show explanatory text in template errors

### DIFF
--- a/packages/compiler/src/parse_util.ts
+++ b/packages/compiler/src/parse_util.ts
@@ -120,12 +120,13 @@ export class ParseError {
 
   contextualMessage(): string {
     const ctx = this.span.start.getContext(100, 3);
-    return ctx ? ` ("${ctx.before}[${ParseErrorLevel[this.level]} ->]${ctx.after}")` : '';
+    return ctx ? `${this.msg} ("${ctx.before}[${ParseErrorLevel[this.level]} ->]${ctx.after}")` :
+                 this.msg;
   }
 
   toString(): string {
     const details = this.span.details ? `, ${this.span.details}` : '';
-    return `${this.msg}${this.contextualMessage()}: ${this.span.start}${details}`;
+    return `${this.contextualMessage()}: ${this.span.start}${details}`;
   }
 }
 


### PR DESCRIPTION
Fixes: #20076

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue Number: #20076

## What is the new behavior?

The explanatory text is included in template error messages.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
