### PR TITLE
fix(common): handle JS floating point errors in percent pipe

### DIFF
--- a/packages/common/test/pipes/number_pipe_spec.ts
+++ b/packages/common/test/pipes/number_pipe_spec.ts
@@ -79,6 +79,22 @@ export function main() {
           expect(pipe.transform(1.2, '.2')).toEqual('120.00%');
           expect(pipe.transform(1.2, '4.2')).toEqual('0,120.00%');
           expect(pipe.transform(1.2, '4.2', 'fr')).toEqual('0 120,00 %');
+          // see issue #20136
+          expect(pipe.transform(0.12345674, '0.0-10')).toEqual('12.345674%');
+          expect(pipe.transform(0, '0.0-10')).toEqual('0%');
+          expect(pipe.transform(0.00, '0.0-10')).toEqual('0%');
+          expect(pipe.transform(1, '0.0-10')).toEqual('100%');
+          expect(pipe.transform(0.1, '0.0-10')).toEqual('10%');
+          expect(pipe.transform(0.12, '0.0-10')).toEqual('12%');
+          expect(pipe.transform(0.123, '0.0-10')).toEqual('12.3%');
+          expect(pipe.transform(12.3456, '0.0-10')).toEqual('1,234.56%');
+          expect(pipe.transform(12.345600, '0.0-10')).toEqual('1,234.56%');
+          expect(pipe.transform(12.345699999, '0.0-6')).toEqual('1,234.57%');
+          expect(pipe.transform(12.345699999, '0.4-6')).toEqual('1,234.5700%');
+          expect(pipe.transform(100, '0.4-6')).toEqual('10,000.0000%');
+          expect(pipe.transform(100, '0.0-10')).toEqual('10,000%');
+          expect(pipe.transform(1.5e2)).toEqual('15,000%');
+          expect(pipe.transform(1e100)).toEqual('1E+102%');
         });
 
         it('should not support other objects', () => {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
```

## What is the current behavior?
We multiply the number by 100 in the percent pipe which can lead to floating point errors with float numbers.

Issue Number: #20136


## What is the new behavior?
We now shift the decimal separator without using math, which avoids the js floating point error.
We also remove trailing 0 when rounding if they are not required by the minimal number of fraction (see added tests).


## Does this PR introduce a breaking change?
```
[x] No
```