### PR TITLE
fix(forms): form container validators re-run on binding changes

### DIFF
--- a/packages/forms/src/directives/ng_model_group.ts
+++ b/packages/forms/src/directives/ng_model_group.ts
@@ -56,8 +56,8 @@ export class NgModelGroup extends AbstractFormGroupDirective implements OnInit, 
       @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) asyncValidators: any[]) {
     super();
     this._parent = parent;
-    this._validators = validators;
-    this._asyncValidators = asyncValidators;
+    this._validators = validators || [];
+    this._asyncValidators = asyncValidators || [];
   }
 
   /** @internal */

--- a/packages/forms/src/directives/reactive_directives/form_group_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_name.ts
@@ -78,8 +78,8 @@ export class FormGroupName extends AbstractFormGroupDirective implements OnInit,
       @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) asyncValidators: any[]) {
     super();
     this._parent = parent;
-    this._validators = validators;
-    this._asyncValidators = asyncValidators;
+    this._validators = validators || [];
+    this._asyncValidators = asyncValidators || [];
   }
 
   /** @internal */
@@ -162,8 +162,8 @@ export class FormArrayName extends ControlContainer implements OnInit, OnDestroy
       @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) asyncValidators: any[]) {
     super();
     this._parent = parent;
-    this._validators = validators;
-    this._asyncValidators = asyncValidators;
+    this._validators = validators || [];
+    this._asyncValidators = asyncValidators || [];
   }
 
   ngOnInit(): void {

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -122,6 +122,17 @@ export function setUpFormContainer(
   if (control == null) _throwError(dir, 'Cannot find control with');
   control.validator = Validators.compose([control.validator, dir.validator]);
   control.asyncValidator = Validators.composeAsync([control.asyncValidator, dir.asyncValidator]);
+
+  // re-run validation when validator binding changes, e.g. minlength=3 -> minlength=4
+  dir._validators.forEach((validator: Validator | ValidatorFn) => {
+    if ((<Validator>validator).registerOnValidatorChange)
+      (<Validator>validator).registerOnValidatorChange !(() => control.updateValueAndValidity());
+  });
+
+  dir._asyncValidators.forEach((validator: AsyncValidator | AsyncValidatorFn) => {
+    if ((<Validator>validator).registerOnValidatorChange)
+      (<Validator>validator).registerOnValidatorChange !(() => control.updateValueAndValidity());
+  });
 }
 
 function _noControlError(dir: NgControl) {


### PR DESCRIPTION
re-run validation when validator binding changes for form containers

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Method registerOnValidatorChange is not called during registration of model group / form container.

Issue Number: #20268

## What is the new behavior?
Method registerOnValidatorChange will be called during registration of model group / form container.
Validators registered on form containers will re-run if their bindings change.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
