### PR TITLE
docs(aio): remove trailing underscore from provide_

### DIFF
--- a/aio/content/tutorial/toh-pt4.md
+++ b/aio/content/tutorial/toh-pt4.md
@@ -80,7 +80,7 @@ You must _provide_ the `HeroService` in the _dependency injection system_
 before Angular can _inject_ it into the `HeroesComponent`, 
 as you will do [below](#inject).
 
-There are several ways to provide_ the `HeroService`: 
+There are several ways to provide the `HeroService`: 
 in the `HeroesComponent`, in the `AppComponent`, in the `AppModule`.
 Each option has pros and cons. 
 


### PR DESCRIPTION


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There was a dangling `_` on the word "provide". The word was _emphasized_ in the previous paragraph so I don't think it is necessary here.
Issue Number: N/A


## What is the new behavior?

The dangling `_` is removed

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
