### PR TITLE
ci: tighten package limits 

### DIFF
--- a/integration/_payload-limits.sh
+++ b/integration/_payload-limits.sh
@@ -8,12 +8,12 @@ payloadLimits["hello_world__closure", "gzip7", "bundle"]=35000
 payloadLimits["hello_world__closure", "gzip9", "bundle"]=35000
 
 payloadLimits["cli-hello-world", "uncompressed", "inline"]=1500
-payloadLimits["cli-hello-world", "uncompressed", "main"]=175000
+payloadLimits["cli-hello-world", "uncompressed", "main"]=160000
 payloadLimits["cli-hello-world", "uncompressed", "polyfills"]=66000
 payloadLimits["cli-hello-world", "gzip7", "inline"]=900
-payloadLimits["cli-hello-world", "gzip7", "main"]=48000
+payloadLimits["cli-hello-world", "gzip7", "main"]=45000
 payloadLimits["cli-hello-world", "gzip7", "polyfills"]=22000
 payloadLimits["cli-hello-world", "gzip9", "inline"]=900
-payloadLimits["cli-hello-world", "gzip9", "main"]=48000
+payloadLimits["cli-hello-world", "gzip9", "main"]=45000
 payloadLimits["cli-hello-world", "gzip9", "polyfills"]=22000
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] CI related changes
```

## What is the new behavior?
With the changes made in v5 and cli v1.5 the packages from a hello world app has now dropped down a bit so we should tighten our limits to account for this.

From testing: 

File | Actual (at the time of testing) | limit before | limit after
--- | --- | --- | ---
main | 154000 | 175000 | 160000
main - gzip7 | 42500 | 48000 | 45000
main - gzip9  |  42500 | 48000 | 45000
