### PR TITLE
fix(service-worker): ensure initialised in browser only

### DIFF
--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -12,7 +12,8 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@angular/core": "0.0.0-PLACEHOLDER"
+    "@angular/core": "0.0.0-PLACEHOLDER",
+    "@angular/common": "0.0.0-PLACEHOLDER"
   },
   "repository": {
     "type": "git",

--- a/packages/service-worker/rollup.config.js
+++ b/packages/service-worker/rollup.config.js
@@ -11,6 +11,7 @@ const sourcemaps = require('rollup-plugin-sourcemaps');
 
 const globals = {
   '@angular/core': 'ng.core',
+  '@angular/common': 'ng.common',
 
   'rxjs/BehaviorSubject': 'Rx',
   'rxjs/ConnectableObservable': 'Rx',

--- a/packages/service-worker/src/module.ts
+++ b/packages/service-worker/src/module.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_INITIALIZER, ApplicationRef, Inject, InjectionToken, Injector, ModuleWithProviders, NgModule} from '@angular/core';
+import {isPlatformBrowser} from '@angular/common';
+import {APP_INITIALIZER, ApplicationRef, Inject, InjectionToken, Injector, ModuleWithProviders, NgModule, PLATFORM_ID} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {filter as op_filter} from 'rxjs/operator/filter';
 import {take as op_take} from 'rxjs/operator/take';
@@ -20,10 +21,11 @@ export const SCRIPT = new InjectionToken<string>('NGSW_REGISTER_SCRIPT');
 export const OPTS = new InjectionToken<Object>('NGSW_REGISTER_OPTIONS');
 
 export function ngswAppInitializer(
-    injector: Injector, script: string, options: RegistrationOptions): Function {
+    injector: Injector, script: string, options: RegistrationOptions,
+    platformId: string): Function {
   const initializer = () => {
     const app = injector.get<ApplicationRef>(ApplicationRef);
-    if (!('serviceWorker' in navigator)) {
+    if (!(isPlatformBrowser(platformId) && ('serviceWorker' in navigator))) {
       return;
     }
     const onStable =
@@ -59,7 +61,7 @@ export class ServiceWorkerModule {
         {
           provide: APP_INITIALIZER,
           useFactory: ngswAppInitializer,
-          deps: [Injector, SCRIPT, OPTS],
+          deps: [Injector, SCRIPT, OPTS, PLATFORM_ID],
           multi: true,
         },
       ],

--- a/packages/service-worker/tsconfig-build.json
+++ b/packages/service-worker/tsconfig-build.json
@@ -5,7 +5,8 @@
     "baseUrl": ".",
     "rootDir": ".",
     "paths": {
-      "@angular/core": ["../../dist/packages/core"]
+      "@angular/core": ["../../dist/packages/core"],
+      "@angular/common": ["../../dist/packages/common"]
     },
     "outDir": "../../dist/packages/service-worker"
   },


### PR DESCRIPTION
closes #20360 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
```

## What is the current behavior?
Using ServiceWorkerModule on the server would cause an error due to `navigator` being undefined

Issue Number: 20360

## What is the new behavior?
Only runs the initialisation function if running on browser


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other
Not really sure how to test this since it would require a platform-server integration test and I cant find any existing ones for the SW
