### PR TITLE
docs(aio): Clearing array with [] (#20369)

### DIFF
--- a/aio/content/examples/lifecycle-hooks/src/app/after-content.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/after-content.component.ts
@@ -93,22 +93,20 @@ export class AfterContentComponent implements AfterContentChecked, AfterContentI
 
     <h4>-- AfterContent Logs --</h4>
     <p><button (click)="reset()">Reset</button></p>
-    <div *ngFor="let msg of logs">{{msg}}</div>
+    <div *ngFor="let msg of logger.logs">{{msg}}</div>
   </div>
   `,
   styles: ['.parent {background: burlywood}'],
   providers: [LoggerService]
 })
 export class AfterContentParentComponent {
-  logs: string[];
   show = true;
 
-  constructor(private logger: LoggerService) {
-    this.logs = logger.logs;
+  constructor(public logger: LoggerService) {
   }
 
   reset() {
-    this.logs = [];
+    this.logger.clear();
     // quickly remove and reload AfterContentComponent which recreates it
     this.show = false;
     this.logger.tick_then(() => this.show = true);

--- a/aio/content/examples/lifecycle-hooks/src/app/after-content.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/after-content.component.ts
@@ -108,7 +108,7 @@ export class AfterContentParentComponent {
   }
 
   reset() {
-    this.logs.length = 0;
+    this.logs = [];
     // quickly remove and reload AfterContentComponent which recreates it
     this.show = false;
     this.logger.tick_then(() => this.show = true);

--- a/aio/content/examples/lifecycle-hooks/src/app/after-view.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/after-view.component.ts
@@ -95,22 +95,20 @@ export class AfterViewComponent implements  AfterViewChecked, AfterViewInit {
 
     <h4>-- AfterView Logs --</h4>
     <p><button (click)="reset()">Reset</button></p>
-    <div *ngFor="let msg of logs">{{msg}}</div>
+    <div *ngFor="let msg of logger.logs">{{msg}}</div>
   </div>
   `,
   styles: ['.parent {background: burlywood}'],
   providers: [LoggerService]
 })
 export class AfterViewParentComponent {
-  logs: string[];
   show = true;
 
-  constructor(private logger: LoggerService) {
-    this.logs = logger.logs;
+  constructor(public logger: LoggerService) {
   }
 
   reset() {
-    this.logs = [];
+    this.logger.clear();
     // quickly remove and reload AfterViewComponent which recreates it
     this.show = false;
     this.logger.tick_then(() => this.show = true);

--- a/aio/content/examples/lifecycle-hooks/src/app/after-view.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/after-view.component.ts
@@ -110,7 +110,7 @@ export class AfterViewParentComponent {
   }
 
   reset() {
-    this.logs.length = 0;
+    this.logs = [];
     // quickly remove and reload AfterViewComponent which recreates it
     this.show = false;
     this.logger.tick_then(() => this.show = true);

--- a/aio/content/examples/lifecycle-hooks/src/app/counter.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/counter.component.ts
@@ -27,7 +27,7 @@ export class MyCounterComponent implements OnChanges {
     // Empty the changeLog whenever counter goes to zero
     // hint: this is a way to respond programmatically to external value changes.
     if (this.counter === 0) {
-      this.changeLog.length = 0;
+      this.changeLog = [];
     }
 
     // A change to `counter` is the only change we care about

--- a/aio/content/examples/lifecycle-hooks/src/app/do-check.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/do-check.component.ts
@@ -68,7 +68,7 @@ export class DoCheckComponent implements DoCheck {
 
   reset() {
     this.changeDetected = true;
-    this.changeLog.length = 0;
+    this.changeLog = [];
   }
 }
 

--- a/aio/content/examples/lifecycle-hooks/src/app/logger.service.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/logger.service.ts
@@ -18,7 +18,7 @@ export class LoggerService {
     }
   }
 
-  clear() { this.logs.length = 0; }
+  clear() { this.logs = []; }
 
   // schedules a view refresh to ensure display catches up
   tick() {  this.tick_then(() => { }); }

--- a/aio/content/examples/lifecycle-hooks/src/app/on-changes.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/on-changes.component.ts
@@ -43,7 +43,7 @@ export class OnChangesComponent implements OnChanges {
   }
   // #enddocregion ng-on-changes
 
-  reset() { this.changeLog.length = 0; }
+  reset() { this.changeLog = []; }
 }
 
 /***************************************/

--- a/aio/content/examples/lifecycle-hooks/src/app/spy.component.html
+++ b/aio/content/examples/lifecycle-hooks/src/app/spy.component.html
@@ -12,5 +12,5 @@
   </div>
   <!-- #enddocregion template -->
   <h4>-- Spy Lifecycle Hook Log --</h4>
-  <div *ngFor="let msg of spyLog">{{msg}}</div>
+  <div *ngFor="let msg of logger.logs">{{msg}}</div>
 </div>

--- a/aio/content/examples/lifecycle-hooks/src/app/spy.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/spy.component.ts
@@ -15,10 +15,8 @@ import { LoggerService }  from './logger.service';
 export class SpyParentComponent {
   newName = 'Herbie';
   heroes: string[] = ['Windstorm', 'Magneta'];
-  spyLog: string[];
 
-  constructor(private logger: LoggerService) {
-    this.spyLog = logger.logs;
+  constructor(public logger: LoggerService) {
   }
 
   addHero() {

--- a/aio/content/examples/lifecycle-hooks/src/app/spy.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/spy.component.ts
@@ -34,7 +34,7 @@ export class SpyParentComponent {
   }
   reset() {
     this.logger.log('-- reset --');
-    this.heroes.length = 0;
+    this.heroes = [];
     this.logger.tick();
   }
 }

--- a/aio/content/examples/toh-pt4/src/app/message.service.ts
+++ b/aio/content/examples/toh-pt4/src/app/message.service.ts
@@ -9,6 +9,6 @@ export class MessageService {
   }
 
   clear() {
-    this.messages.length = 0;
+    this.messages = [];
   }
 }

--- a/aio/content/examples/toh-pt5/src/app/message.service.ts
+++ b/aio/content/examples/toh-pt5/src/app/message.service.ts
@@ -9,6 +9,6 @@ export class MessageService {
   }
 
   clear() {
-    this.messages.length = 0;
+    this.messages = [];
   }
 }

--- a/aio/content/examples/toh-pt6/src/app/message.service.ts
+++ b/aio/content/examples/toh-pt6/src/app/message.service.ts
@@ -9,6 +9,6 @@ export class MessageService {
   }
 
   clear() {
-    this.messages.length = 0;
+    this.messages = [];
   }
 }

--- a/aio/content/examples/universal/src/app/message.service.ts
+++ b/aio/content/examples/universal/src/app/message.service.ts
@@ -9,6 +9,6 @@ export class MessageService {
   }
 
   clear() {
-    this.messages.length = 0;
+    this.messages = [];
   }
 }


### PR DESCRIPTION
Clearing array with setting length to 0 replaced with [] for being short
and marginally efficient. For reference: [] is turned into a sequence of
around 15 machine instructions on x64 (if bump pointer allocation succeeds),
whereas a.length=0 is a C++ runtime function call, which requires 10-100x as
many instructions.
Benedikt Meurer

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #20369


## What is the new behavior?
Arrays are being cleared using [] instead of setting it's length to 0

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
