### PR TITLE
docs(aio): make it clear we are talking about <a> tags

### DIFF
--- a/aio/content/tutorial/toh-pt5.md
+++ b/aio/content/tutorial/toh-pt5.md
@@ -600,7 +600,7 @@ Here are the code files discussed on this page and your app should look like thi
 ## Summary
 
 * You added the Angular router to navigate among different components.
-* You turned the `AppComponent` into a navigation shell with a links and a `<router-outlet>`.
+* You turned the `AppComponent` into a navigation shell with `<a>` links and a `<router-outlet>`.
 * You configured the router in an `AppRoutingModule` 
 * You defined simple routes, a redirect route, and a parameterized route.
 * You used the `routerLink` directive in anchor elements.


### PR DESCRIPTION
As is, it could be seen as a typo at first glance. Wrapping the "a" in carets and backticks for formatting adds some clarity.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Documentation content changes
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The sentence is a bit confusing to read
Issue Number: N/A


## What is the new behavior?
We wrap "a" in carets (to show we are talking about HTML rather than the english word "a") as well as backticks (for formatting) to add some clarity

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
