### PR TITLE
fix(compiler-cli): output consistent sourcepaths for i18n extracted files

### DIFF
--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -803,9 +803,16 @@ export function i18nSerialize(
     default:
       serializer = new Xliff();
   }
-  return bundle.write(
-      serializer, (sourcePath: string) =>
-                      options.basePath ? path.relative(options.basePath, sourcePath) : sourcePath);
+
+  return bundle.write(serializer, getPathNormalizer(options.basePath));
+}
+
+function getPathNormalizer(basePath?: string) {
+  // normalize sourcepaths by removing the base path and always using "/" as a separator
+  return (sourcePath: string) => {
+    sourcePath = basePath ? path.relative(basePath, sourcePath) : sourcePath;
+    return sourcePath.split(path.sep).join('/');
+  };
 }
 
 export function i18nGetExtension(formatName: string): string {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
Extracted files contain paths that change depending on which OS did the extraction: `\` on windows and `/` on unix
Most of the i18n tests were failing on Windows because of this, but we don't run tests on Windows in our CI...
Issue Number: #20416


## What is the new behavior?
We always use `/` for paths instead of `\` on windows and `/` on unix

## Does this PR introduce a breaking change?
```
[x] No
```