### PR TITLE
fix(compiler-cli): correct error message

### DIFF
--- a/packages/compiler-cli/src/metadata/bundle_index_host.ts
+++ b/packages/compiler-cli/src/metadata/bundle_index_host.ts
@@ -68,7 +68,7 @@ export function createBundleIndexHost<H extends ts.CompilerHost>(
         start: null as any as number,
         length: null as any as number,
         messageText:
-            'Angular compiler option "flatModuleIndex" requires one and only one .ts file in the "files" field.',
+            'Angular compiler option "flatModuleOutFile" requires one and only one .ts file in the "files" field.',
         category: ts.DiagnosticCategory.Error,
         code: 0
       }]


### PR DESCRIPTION
When **files** in `tsconfig` are <> 1
show `Angular compiler option "flatModuleOutFile" requires one and only one .ts file in the "files" field.`

instead of `Angular compiler option "flatModuleIndex" requires one and only one .ts file in the "files" field.`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
