### PR TITLE
release: widen peerDeps to allow TypeScript 2.5

### DIFF
--- a/integration/typings_test_ts25/include-all.ts
+++ b/integration/typings_test_ts25/include-all.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as compiler from '@angular/compiler';
+import * as compilerTesting from '@angular/compiler/testing';
+import * as core from '@angular/core';
+import * as coreTesting from '@angular/core/testing';
+import * as forms from '@angular/forms';
+import * as http from '@angular/http';
+import * as httpTesting from '@angular/http/testing';
+import * as platformBrowserDynamic from '@angular/platform-browser-dynamic';
+import * as platformBrowser from '@angular/platform-browser';
+import * as platformBrowserTesting from '@angular/platform-browser/testing';
+import * as platformServer from '@angular/platform-server';
+import * as platformServerTesting from '@angular/platform-server/testing';
+import * as router from '@angular/router';
+import * as routerTesting from '@angular/router/testing';
+import * as upgrade from '@angular/upgrade';
+
+export default {
+  compiler,
+  compilerTesting,
+  core,
+  coreTesting,
+  forms,
+  http,
+  httpTesting,
+  platformBrowser,
+  platformBrowserTesting,
+  platformBrowserDynamic,
+  platformServer,
+  platformServerTesting,
+  router,
+  routerTesting,
+  upgrade
+};

--- a/integration/typings_test_ts25/package.json
+++ b/integration/typings_test_ts25/package.json
@@ -18,7 +18,7 @@
     "@angular/upgrade": "file:../../dist/packages-dist/upgrade",
     "@types/jasmine": "2.5.41",
     "rxjs": "file:../../node_modules/rxjs",
-    "typescript": "2.4.x",
+    "typescript": "2.5.x",
     "zone.js": "file:../../node_modules/zone.js"
   },
   "scripts": {

--- a/integration/typings_test_ts25/tsconfig.json
+++ b/integration/typings_test_ts25/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "../../dist/typing-test/",
+    "rootDir": ".",
+    "target": "es5",
+    "lib": [
+      "es5",
+      "dom",
+      "es2015.collection",
+      "es2015.iterable",
+      "es2015.promise"
+    ],
+    "types": [],
+    "strictNullChecks": true
+  },
+  "files": [
+    "include-all.ts",
+    "node_modules/@types/jasmine/index.d.ts"
+  ]
+}

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@angular/compiler-cli": "0.0.0-PLACEHOLDER",
-    "typescript": ">=2.4.2 <2.5"
+    "typescript": ">=2.4.2 <2.6"
   },
   "dependencies": {
     "@bazel/typescript": "0.2.x",

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "reflect-metadata": "^0.1.2",
     "minimist": "^1.2.0",
-    "tsickle": "^0.24.0",
+    "tsickle": "^0.25.5",
     "chokidar": "^1.4.2"
   },
   "peerDependencies": {
-    "typescript": ">=2.4.2 <2.5",
+    "typescript": ">=2.4.2 <2.6",
     "@angular/compiler": "0.0.0-PLACEHOLDER"
   },
   "repository": {


### PR DESCRIPTION
this is a much simpler subset of https://github.com/angular/angular/pull/20175 which might be easier to land