### PR TITLE
feat(compiler-cli): improve error messages produced during structural errors

### DIFF
--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -20,7 +20,6 @@ import {GENERATED_FILES} from './transformers/util';
 
 import {exitCodeFromResult, performCompilation, readConfiguration, formatDiagnostics, Diagnostics, ParsedConfiguration, PerformCompilationResult, filterErrorsAndWarnings} from './perform_compile';
 import {performWatchCompilation, createPerformWatchHost} from './perform_watch';
-import {isSyntaxError} from '@angular/compiler';
 
 export function main(
     args: string[], consoleError: (s: string) => void = console.error,

--- a/packages/compiler-cli/src/metadata/collector.ts
+++ b/packages/compiler-cli/src/metadata/collector.ts
@@ -8,8 +8,8 @@
 
 import * as ts from 'typescript';
 
-import {Evaluator, errorSymbol} from './evaluator';
-import {ClassMetadata, ConstructorMetadata, FunctionMetadata, InterfaceMetadata, METADATA_VERSION, MemberMetadata, MetadataEntry, MetadataError, MetadataMap, MetadataSymbolicBinaryExpression, MetadataSymbolicCallExpression, MetadataSymbolicExpression, MetadataSymbolicIfExpression, MetadataSymbolicIndexExpression, MetadataSymbolicPrefixExpression, MetadataSymbolicReferenceExpression, MetadataSymbolicSelectExpression, MetadataSymbolicSpreadExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataSymbolicExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSelectExpression, isMethodMetadata} from './schema';
+import {Evaluator, errorSymbol, recordMapEntry} from './evaluator';
+import {ClassMetadata, ConstructorMetadata, FunctionMetadata, InterfaceMetadata, METADATA_VERSION, MemberMetadata, MetadataEntry, MetadataError, MetadataMap, MetadataSymbolicBinaryExpression, MetadataSymbolicCallExpression, MetadataSymbolicExpression, MetadataSymbolicIfExpression, MetadataSymbolicIndexExpression, MetadataSymbolicPrefixExpression, MetadataSymbolicReferenceExpression, MetadataSymbolicSelectExpression, MetadataSymbolicSpreadExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataImportDefaultReference, isMetadataImportedSymbolReferenceExpression, isMetadataSymbolicExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSelectExpression, isMethodMetadata} from './schema';
 import {Symbols} from './symbols';
 
 const isStatic = (node: ts.Node) => ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Static;
@@ -76,8 +76,7 @@ export class MetadataCollector {
     }
 
     function recordEntry<T extends MetadataEntry>(entry: T, node: ts.Node): T {
-      nodeMap.set(entry, node);
-      return entry;
+      return recordMapEntry(entry, node, nodeMap, sourceFile);
     }
 
     function errorSym(

--- a/packages/compiler-cli/src/metadata/schema.ts
+++ b/packages/compiler-cli/src/metadata/schema.ts
@@ -178,7 +178,20 @@ export function isMetadataSymbolicIfExpression(value: any): value is MetadataSym
   return value && value.__symbolic === 'if';
 }
 
-export interface MetadataGlobalReferenceExpression extends MetadataSymbolicExpression {
+export interface MetadataSourceLocationInfo {
+  /**
+   * The line number of the error in the .ts file the metadata was created for.
+   */
+  line?: number;
+
+  /**
+   * The number of utf8 code-units from the beginning of the file of the error.
+   */
+  character?: number;
+}
+
+export interface MetadataGlobalReferenceExpression extends MetadataSymbolicExpression,
+    MetadataSourceLocationInfo {
   __symbolic: 'reference';
   name: string;
   arguments?: MetadataValue[];
@@ -188,7 +201,8 @@ export function isMetadataGlobalReferenceExpression(value: any):
   return value && value.name && !value.module && isMetadataSymbolicReferenceExpression(value);
 }
 
-export interface MetadataModuleReferenceExpression extends MetadataSymbolicExpression {
+export interface MetadataModuleReferenceExpression extends MetadataSymbolicExpression,
+    MetadataSourceLocationInfo {
   __symbolic: 'reference';
   module: string;
 }
@@ -198,7 +212,8 @@ export function isMetadataModuleReferenceExpression(value: any):
       isMetadataSymbolicReferenceExpression(value);
 }
 
-export interface MetadataImportedSymbolReferenceExpression extends MetadataSymbolicExpression {
+export interface MetadataImportedSymbolReferenceExpression extends MetadataSymbolicExpression,
+    MetadataSourceLocationInfo {
   __symbolic: 'reference';
   module: string;
   name: string;
@@ -209,7 +224,8 @@ export function isMetadataImportedSymbolReferenceExpression(value: any):
   return value && value.module && !!value.name && isMetadataSymbolicReferenceExpression(value);
 }
 
-export interface MetadataImportedDefaultReferenceExpression extends MetadataSymbolicExpression {
+export interface MetadataImportedDefaultReferenceExpression extends MetadataSymbolicExpression,
+    MetadataSourceLocationInfo {
   __symbolic: 'reference';
   module: string;
   default:
@@ -218,7 +234,7 @@ export interface MetadataImportedDefaultReferenceExpression extends MetadataSymb
 }
 export function isMetadataImportDefaultReference(value: any):
     value is MetadataImportedDefaultReferenceExpression {
-  return value.module && value.default && isMetadataSymbolicReferenceExpression(value);
+  return value && value.module && value.default && isMetadataSymbolicReferenceExpression(value);
 }
 
 export type MetadataSymbolicReferenceExpression = MetadataGlobalReferenceExpression |
@@ -248,7 +264,7 @@ export function isMetadataSymbolicSpreadExpression(value: any):
   return value && value.__symbolic === 'spread';
 }
 
-export interface MetadataError {
+export interface MetadataError extends MetadataSourceLocationInfo {
   __symbolic: 'error';
 
   /**
@@ -258,16 +274,6 @@ export interface MetadataError {
    * descriptive and/or localized.
    */
   message: string;
-
-  /**
-   * The line number of the error in the .ts file the metadata was created for.
-   */
-  line?: number;
-
-  /**
-   * The number of utf8 code-units from the beginning of the file of the error.
-   */
-  character?: number;
 
   /**
    * The module of the error (only used in bundled metadata)
@@ -280,6 +286,7 @@ export interface MetadataError {
    */
   context?: {[name: string]: string};
 }
+
 export function isMetadataError(value: any): value is MetadataError {
   return value && value.__symbolic === 'error';
 }

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -6,16 +6,24 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {GeneratedFile, ParseSourceSpan} from '@angular/compiler';
+import {GeneratedFile, ParseSourceSpan, Position} from '@angular/compiler';
 import * as ts from 'typescript';
 
 export const DEFAULT_ERROR_CODE = 100;
 export const UNKNOWN_ERROR_CODE = 500;
 export const SOURCE = 'angular' as 'angular';
 
+export interface DiagnosticMessageChain {
+  messageText: string;
+  position?: Position;
+  next?: DiagnosticMessageChain;
+}
+
 export interface Diagnostic {
   messageText: string;
   span?: ParseSourceSpan;
+  position?: Position;
+  chain?: DiagnosticMessageChain;
   category: ts.DiagnosticCategory;
   code: number;
   source: 'angular';

--- a/packages/compiler-cli/test/metadata/collector_spec.ts
+++ b/packages/compiler-cli/test/metadata/collector_spec.ts
@@ -112,7 +112,13 @@ describe('Collector', () => {
           __symbolic: 'class',
           decorators: [{
             __symbolic: 'call',
-            expression: {__symbolic: 'reference', module: 'angular2/core', name: 'Component'},
+            expression: {
+              __symbolic: 'reference',
+              module: 'angular2/core',
+              name: 'Component',
+              line: 4,
+              character: 7
+            },
             arguments: [{
               selector: 'my-hero-detail',
               template: `
@@ -132,8 +138,13 @@ describe('Collector', () => {
               __symbolic: 'property',
               decorators: [{
                 __symbolic: 'call',
-                expression:
-                    {__symbolic: 'reference', module: 'angular2/core', name: 'Input'}
+                expression: {
+                  __symbolic: 'reference',
+                  module: 'angular2/core',
+                  name: 'Input',
+                  line: 18,
+                  character: 9
+                }
               }]
             }]
           }
@@ -153,7 +164,13 @@ describe('Collector', () => {
           __symbolic: 'class',
           decorators: [{
             __symbolic: 'call',
-            expression: {__symbolic: 'reference', module: 'angular2/core', name: 'Component'},
+            expression: {
+              __symbolic: 'reference',
+              module: 'angular2/core',
+              name: 'Component',
+              line: 9,
+              character: 7
+            },
             arguments: [{
               selector: 'my-app',
               template: `
@@ -172,20 +189,52 @@ describe('Collector', () => {
                   __symbolic: 'reference',
                   module: './hero-detail.component',
                   name: 'HeroDetailComponent',
+                  line: 22,
+                  character: 21
                 },
-                {__symbolic: 'reference', module: 'angular2/common', name: 'NgFor'}
+                {
+                  __symbolic: 'reference',
+                  module: 'angular2/common',
+                  name: 'NgFor',
+                  line: 22,
+                  character: 42
+                }
               ],
-              providers: [{__symbolic: 'reference', module: './hero.service', default: true}],
+              providers: [{
+                __symbolic: 'reference',
+                module: './hero.service',
+                default: true,
+                line: 23,
+                character: 20
+              }],
               pipes: [
-                {__symbolic: 'reference', module: 'angular2/common', name: 'LowerCasePipe'},
-                {__symbolic: 'reference', module: 'angular2/common', name: 'UpperCasePipe'}
+                {
+                  __symbolic: 'reference',
+                  module: 'angular2/common',
+                  name: 'LowerCasePipe',
+                  line: 24,
+                  character: 16
+                },
+                {
+                  __symbolic: 'reference',
+                  module: 'angular2/common',
+                  name: 'UpperCasePipe',
+                  line: 24,
+                  character: 38
+                }
               ]
             }]
           }],
           members: {
             __ctor__: [{
               __symbolic: 'constructor',
-              parameters: [{__symbolic: 'reference', module: './hero.service', default: true}]
+              parameters: [{
+                __symbolic: 'reference',
+                module: './hero.service',
+                default: true,
+                line: 31,
+                character: 42
+              }]
             }],
             onSelect: [{__symbolic: 'method'}],
             ngOnInit: [{__symbolic: 'method'}],
@@ -236,22 +285,23 @@ describe('Collector', () => {
   });
 
   it('should record annotations on set and get declarations', () => {
-    const propertyData = {
+    const propertyData = (line: number) => ({
       name: [{
         __symbolic: 'property',
         decorators: [{
           __symbolic: 'call',
-          expression: {__symbolic: 'reference', module: 'angular2/core', name: 'Input'},
+          expression:
+              {__symbolic: 'reference', module: 'angular2/core', name: 'Input', line, character: 9},
           arguments: ['firstName']
         }]
       }]
-    };
+    });
     const caseGetProp = <ClassMetadata>casesMetadata.metadata['GetProp'];
-    expect(caseGetProp.members).toEqual(propertyData);
+    expect(caseGetProp.members).toEqual(propertyData(11));
     const caseSetProp = <ClassMetadata>casesMetadata.metadata['SetProp'];
-    expect(caseSetProp.members).toEqual(propertyData);
+    expect(caseSetProp.members).toEqual(propertyData(19));
     const caseFullProp = <ClassMetadata>casesMetadata.metadata['FullProp'];
-    expect(caseFullProp.members).toEqual(propertyData);
+    expect(caseFullProp.members).toEqual(propertyData(27));
   });
 
   it('should record references to parameterized types', () => {
@@ -260,7 +310,13 @@ describe('Collector', () => {
       __symbolic: 'class',
       decorators: [{
         __symbolic: 'call',
-        expression: {__symbolic: 'reference', module: 'angular2/core', name: 'Injectable'}
+        expression: {
+          __symbolic: 'reference',
+          module: 'angular2/core',
+          name: 'Injectable',
+          line: 40,
+          character: 7
+        }
       }],
       members: {
         __ctor__: [{
@@ -313,7 +369,7 @@ describe('Collector', () => {
     const ctor = <ConstructorMetadata>someClass.members !['__ctor__'][0];
     const parameters = ctor.parameters;
     expect(parameters).toEqual([
-      {__symbolic: 'reference', module: 'angular2/common', name: 'NgFor'}
+      {__symbolic: 'reference', module: 'angular2/common', name: 'NgFor', line: 6, character: 29}
     ]);
   });
 
@@ -398,7 +454,7 @@ describe('Collector', () => {
     const ctor = <ConstructorMetadata>someClass.members !['__ctor__'][0];
     const parameters = ctor.parameters;
     expect(parameters).toEqual([
-      {__symbolic: 'reference', module: 'angular2/common', name: 'NgFor'}
+      {__symbolic: 'reference', module: 'angular2/common', name: 'NgFor', line: 6, character: 29}
     ]);
   });
 
@@ -427,7 +483,13 @@ describe('Collector', () => {
       B: 1,
       C: 30,
       D: 40,
-      E: {__symbolic: 'reference', module: './exported-consts', name: 'constValue'}
+      E: {
+        __symbolic: 'reference',
+        module: './exported-consts',
+        name: 'constValue',
+        line: 5,
+        character: 75
+      }
     });
   });
 
@@ -457,13 +519,25 @@ describe('Collector', () => {
     expect(classData).toBeDefined();
     expect(classData.decorators).toEqual([{
       __symbolic: 'call',
-      expression: {__symbolic: 'reference', module: 'angular2/core', name: 'Component'},
+      expression: {
+        __symbolic: 'reference',
+        module: 'angular2/core',
+        name: 'Component',
+        line: 4,
+        character: 5
+      },
       arguments: [{
         providers: {
           __symbolic: 'call',
           expression: {
             __symbolic: 'select',
-            expression: {__symbolic: 'reference', module: './static-method', name: 'MyModule'},
+            expression: {
+              __symbolic: 'reference',
+              module: './static-method',
+              name: 'MyModule',
+              line: 5,
+              character: 17
+            },
             member: 'with'
           },
           arguments: ['a']
@@ -489,13 +563,25 @@ describe('Collector', () => {
     expect(classData).toBeDefined();
     expect(classData.decorators).toEqual([{
       __symbolic: 'call',
-      expression: {__symbolic: 'reference', module: 'angular2/core', name: 'Component'},
+      expression: {
+        __symbolic: 'reference',
+        module: 'angular2/core',
+        name: 'Component',
+        line: 4,
+        character: 5
+      },
       arguments: [{
         providers: [{
           provide: 'a',
           useValue: {
             __symbolic: 'select',
-            expression: {__symbolic: 'reference', module: './static-field', name: 'MyModule'},
+            expression: {
+              __symbolic: 'reference',
+              module: './static-field',
+              name: 'MyModule',
+              line: 5,
+              character: 45
+            },
             member: 'VALUE'
           }
         }]
@@ -578,8 +664,20 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(source) !;
     expect(metadata.metadata).toEqual({
       MyClass: Object({__symbolic: 'class'}),
-      OtherModule: {__symbolic: 'reference', module: './static-field-reference', name: 'Foo'},
-      MyOtherModule: {__symbolic: 'reference', module: './static-field', name: 'MyModule'}
+      OtherModule: {
+        __symbolic: 'reference',
+        module: './static-field-reference',
+        name: 'Foo',
+        line: 4,
+        character: 12
+      },
+      MyOtherModule: {
+        __symbolic: 'reference',
+        module: './static-field',
+        name: 'MyModule',
+        line: 4,
+        character: 25
+      }
     });
   });
 
@@ -598,7 +696,13 @@ describe('Collector', () => {
         __symbolic: 'class',
         decorators: [{
           __symbolic: 'call',
-          expression: {__symbolic: 'reference', module: 'angular2/core', name: 'Component'},
+          expression: {
+            __symbolic: 'reference',
+            module: 'angular2/core',
+            name: 'Component',
+            line: 11,
+            character: 5
+          },
           arguments: [{providers: [{__symbolic: 'reference', name: 'REQUIRED_VALIDATOR'}]}]
         }]
       }
@@ -620,7 +724,13 @@ describe('Collector', () => {
         __symbolic: 'class',
         decorators: [{
           __symbolic: 'call',
-          expression: {__symbolic: 'reference', module: 'angular2/core', name: 'Component'},
+          expression: {
+            __symbolic: 'reference',
+            module: 'angular2/core',
+            name: 'Component',
+            line: 11,
+            character: 5
+          },
           arguments: [{providers: [{__symbolic: 'reference', name: 'REQUIRED_VALIDATOR'}]}]
         }]
       }
@@ -653,7 +763,13 @@ describe('Collector', () => {
         __symbolic: 'constructor',
         parameterDecorators: [[{
           __symbolic: 'call',
-          expression: {__symbolic: 'reference', module: 'angular2/core', name: 'Inject'},
+          expression: {
+            __symbolic: 'reference',
+            module: 'angular2/core',
+            name: 'Inject',
+            line: 6,
+            character: 19
+          },
           arguments: ['a']
         }]],
         parameters: [{__symbolic: 'reference', name: 'any'}]
@@ -687,13 +803,20 @@ describe('Collector', () => {
           __symbolic: 'reference',
           module: './external',
           name: 'external',
+          line: 0,
+          character: 68,
         }
       });
     });
 
     it('should simplify a redundant template', () => {
-      e('`${external}`', 'import {external} from "./external";')
-          .toEqual({__symbolic: 'reference', module: './external', name: 'external'});
+      e('`${external}`', 'import {external} from "./external";').toEqual({
+        __symbolic: 'reference',
+        module: './external',
+        name: 'external',
+        line: 0,
+        character: 59
+      });
     });
 
     it('should be able to collect complex template with imported references', () => {
@@ -710,11 +833,18 @@ describe('Collector', () => {
               __symbolic: 'binop',
               operator: '+',
               left: 'foo:',
-              right: {__symbolic: 'reference', module: './external', name: 'foo'}
+              right: {
+                __symbolic: 'reference',
+                module: './external',
+                name: 'foo',
+                line: 0,
+                character: 63
+              }
             },
             right: ', bar:'
           },
-          right: {__symbolic: 'reference', module: './external', name: 'bar'}
+          right:
+              {__symbolic: 'reference', module: './external', name: 'bar', line: 0, character: 75}
         },
         right: ', end'
       });
@@ -741,11 +871,11 @@ describe('Collector', () => {
       __ctor__: [{
         __symbolic: 'constructor',
         parameters: [
-          {__symbolic: 'reference', module: './foo', name: 'Foo'},
-          {__symbolic: 'reference', module: './foo', name: 'Foo'},
-          {__symbolic: 'reference', module: './foo', name: 'Foo'},
-          {__symbolic: 'reference', module: './foo', name: 'Foo'},
-          {__symbolic: 'reference', module: './foo', name: 'Foo'}
+          {__symbolic: 'reference', module: './foo', name: 'Foo', line: 3, character: 24},
+          {__symbolic: 'reference', module: './foo', name: 'Foo', line: 3, character: 24},
+          {__symbolic: 'reference', module: './foo', name: 'Foo', line: 3, character: 24},
+          {__symbolic: 'reference', module: './foo', name: 'Foo', line: 3, character: 24},
+          {__symbolic: 'reference', module: './foo', name: 'Foo', line: 3, character: 24}
         ]
       }]
     });
@@ -825,7 +955,9 @@ describe('Collector', () => {
         extends: {
           __symbolic: 'reference',
           module: './class-inheritance-parent',
-          name: 'ParentClassFromOtherFile'
+          name: 'ParentClassFromOtherFile',
+          line: 9,
+          character: 45,
         }
       });
     });

--- a/packages/compiler-cli/test/metadata/evaluator_spec.ts
+++ b/packages/compiler-cli/test/metadata/evaluator_spec.ts
@@ -149,12 +149,14 @@ describe('Evaluator', () => {
     const newExpression = program.getSourceFile('newExpression.ts');
     expect(evaluator.evaluateNode(findVarInitializer(newExpression, 'someValue'))).toEqual({
       __symbolic: 'new',
-      expression: {__symbolic: 'reference', name: 'Value', module: './classes'},
+      expression:
+          {__symbolic: 'reference', name: 'Value', module: './classes', line: 4, character: 33},
       arguments: ['name', 12]
     });
     expect(evaluator.evaluateNode(findVarInitializer(newExpression, 'complex'))).toEqual({
       __symbolic: 'new',
-      expression: {__symbolic: 'reference', name: 'Value', module: './classes'},
+      expression:
+          {__symbolic: 'reference', name: 'Value', module: './classes', line: 5, character: 42},
       arguments: ['name', 12]
     });
   });
@@ -173,8 +175,7 @@ describe('Evaluator', () => {
     const errors = program.getSourceFile('errors.ts');
     const fDecl = findVar(errors, 'f') !;
     expect(evaluator.evaluateNode(fDecl.initializer !))
-        .toEqual(
-            {__symbolic: 'error', message: 'Function call not supported', line: 1, character: 12});
+        .toEqual({__symbolic: 'error', message: 'Lambda not supported', line: 1, character: 12});
     const eDecl = findVar(errors, 'e') !;
     expect(evaluator.evaluateNode(eDecl.type !)).toEqual({
       __symbolic: 'error',

--- a/packages/compiler-cli/test/perform_watch_spec.ts
+++ b/packages/compiler-cli/test/perform_watch_spec.ts
@@ -143,7 +143,7 @@ describe('perform watch', () => {
 
       const errDiags = host.diagnostics.filter(d => d.category === ts.DiagnosticCategory.Error);
       expect(errDiags.length).toBe(1);
-      expect(errDiags[0].messageText).toContain('Function calls are not supported.');
+      expect(errDiags[0].messageText).toContain('Function expressions are not supported');
     }
   });
 });

--- a/packages/compiler-cli/test/transformers/program_spec.ts
+++ b/packages/compiler-cli/test/transformers/program_spec.ts
@@ -930,7 +930,7 @@ describe('ng program', () => {
 
       const structuralErrors = program.getNgStructuralDiagnostics();
       expect(structuralErrors.length).toBe(1);
-      expect(structuralErrors[0].messageText).toContain('Function calls are not supported.');
+      expect(structuralErrors[0].messageText).toContain('Function expressions are not supported');
     });
 
     it('should not throw on structural errors but collect them (loadNgStructureAsync)', (done) => {
@@ -943,7 +943,7 @@ describe('ng program', () => {
       program.loadNgStructureAsync().then(() => {
         const structuralErrors = program.getNgStructuralDiagnostics();
         expect(structuralErrors.length).toBe(1);
-        expect(structuralErrors[0].messageText).toContain('Function calls are not supported.');
+        expect(structuralErrors[0].messageText).toContain('Function expressions are not supported');
         done();
       });
     });
@@ -982,7 +982,8 @@ describe('ng program', () => {
          const program = ng.createProgram({rootNames: allRootNames, options, host});
          const structuralErrors = program.getNgStructuralDiagnostics();
          expect(structuralErrors.length).toBe(1);
-         expect(structuralErrors[0].messageText).toContain('Function calls are not supported.');
+         expect(structuralErrors[0].messageText)
+             .toContain('Function expressions are not supported');
        });
   });
 });

--- a/packages/compiler/src/aot/formatted_error.ts
+++ b/packages/compiler/src/aot/formatted_error.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {syntaxError} from '../util';
+
+export interface Position {
+  fileName: string;
+  line: number;
+  column: number;
+}
+
+export interface FormattedMessageChain {
+  message: string;
+  position?: Position;
+  next?: FormattedMessageChain;
+}
+
+export type FormattedError = Error & {
+  chain: FormattedMessageChain;
+  position?: Position;
+};
+
+const FORMATTED_MESSAGE = 'ngFormattedMessage';
+
+function indentStr(level: number): string {
+  if (level <= 0) return '';
+  if (level < 6) return ['', ' ', '  ', '   ', '    ', '     '][level];
+  const half = indentStr(Math.floor(level / 2));
+  return half + half + (level % 2 === 1 ? ' ' : '');
+}
+
+function formatChain(chain: FormattedMessageChain | undefined, indent: number = 0): string {
+  if (!chain) return '';
+  const position = chain.position ?
+      `${chain.position.fileName}(${chain.position.line+1},${chain.position.column+1})` :
+      '';
+  const prefix = position && indent === 0 ? `${position}: ` : '';
+  const postfix = position && indent !== 0 ? ` at ${position}` : '';
+  const message = `${prefix}${chain.message}${postfix}`;
+
+  return `${indentStr(indent)}${message}${(chain.next && ('\n' + formatChain(chain.next, indent + 2))) || ''}`;
+}
+
+export function formattedError(chain: FormattedMessageChain): FormattedError {
+  const message = formatChain(chain) + '.';
+  const error = syntaxError(message) as FormattedError;
+  (error as any)[FORMATTED_MESSAGE] = true;
+  error.chain = chain;
+  error.position = chain.position;
+  return error;
+}
+
+export function isFormattedError(error: Error): error is FormattedError {
+  return !!(error as any)[FORMATTED_MESSAGE];
+}

--- a/packages/compiler/src/aot/static_symbol_resolver.ts
+++ b/packages/compiler/src/aot/static_symbol_resolver.ts
@@ -146,9 +146,9 @@ export class StaticSymbolResolver {
     if (isGeneratedFile(staticSymbol.filePath)) {
       return null;
     }
-    let resolvedSymbol = this.resolveSymbol(staticSymbol);
+    let resolvedSymbol = unwrapResolvedMetadata(this.resolveSymbol(staticSymbol));
     while (resolvedSymbol && resolvedSymbol.metadata instanceof StaticSymbol) {
-      resolvedSymbol = this.resolveSymbol(resolvedSymbol.metadata);
+      resolvedSymbol = unwrapResolvedMetadata(this.resolveSymbol(resolvedSymbol.metadata));
     }
     return (resolvedSymbol && resolvedSymbol.metadata && resolvedSymbol.metadata.arity) || null;
   }
@@ -204,7 +204,7 @@ export class StaticSymbolResolver {
     if (!baseResolvedSymbol) {
       return null;
     }
-    const baseMetadata = baseResolvedSymbol.metadata;
+    let baseMetadata = unwrapResolvedMetadata(baseResolvedSymbol.metadata);
     if (baseMetadata instanceof StaticSymbol) {
       return new ResolvedStaticSymbol(
           staticSymbol, this.getStaticSymbol(baseMetadata.filePath, baseMetadata.name, members));
@@ -374,6 +374,19 @@ export class StaticSymbolResolver {
       return new ResolvedStaticSymbol(sourceSymbol, transformedMeta);
     }
 
+    let _originalFileMemo: string|undefined;
+    const getOriginalName: () => string = () => {
+      if (!_originalFileMemo) {
+        // Guess what hte original file name is from the reference. If it has a `.d.ts` extension
+        // replace it with `.ts`. If it already has `.ts` just leave it in place. If it doesn't have
+        // .ts or .d.ts, append `.ts'. Also, if it is in `node_modules`, trim the `node_module`
+        // location as it is not important to finding the file.
+        _originalFileMemo =
+            topLevelPath.replace(/((\.ts)|(\.d\.ts)|)$/, '.ts').replace(/^.*node_modules[/\\]/, '');
+      }
+      return _originalFileMemo;
+    };
+
     const self = this;
 
     class ReferenceTransformer extends ValueTransformer {
@@ -397,10 +410,19 @@ export class StaticSymbolResolver {
             if (!filePath) {
               return {
                 __symbolic: 'error',
-                message: `Could not resolve ${module} relative to ${sourceSymbol.filePath}.`
+                message: `Could not resolve ${module} relative to ${sourceSymbol.filePath}.`,
+                line: map.line,
+                character: map.character,
+                fileName: getOriginalName()
               };
             }
-            return self.getStaticSymbol(filePath, name);
+            return {
+              __symbolic: 'resolved',
+              symbol: self.getStaticSymbol(filePath, name),
+              line: map.line,
+              character: map.character,
+              fileName: getOriginalName()
+            };
           } else if (functionParams.indexOf(name) >= 0) {
             // reference to a function parameter
             return {__symbolic: 'reference', name: name};
@@ -411,14 +433,17 @@ export class StaticSymbolResolver {
             // ambient value
             null;
           }
+        } else if (symbolic === 'error') {
+          return {...map, fileName: getOriginalName()};
         } else {
           return super.visitStringMap(map, functionParams);
         }
       }
     }
     const transformedMeta = visitValue(metadata, new ReferenceTransformer(), []);
-    if (transformedMeta instanceof StaticSymbol) {
-      return this.createExport(sourceSymbol, transformedMeta);
+    let unwrappedTransformedMeta = unwrapResolvedMetadata(transformedMeta);
+    if (unwrappedTransformedMeta instanceof StaticSymbol) {
+      return this.createExport(sourceSymbol, unwrappedTransformedMeta);
     }
     return new ResolvedStaticSymbol(sourceSymbol, transformedMeta);
   }
@@ -504,4 +529,11 @@ export class StaticSymbolResolver {
 // See https://github.com/Microsoft/TypeScript/blob/master/src/compiler/utilities.ts
 export function unescapeIdentifier(identifier: string): string {
   return identifier.startsWith('___') ? identifier.substr(1) : identifier;
+}
+
+export function unwrapResolvedMetadata(metadata: any): any {
+  if (metadata && metadata.__symbolic === 'resolved') {
+    return metadata.symbol;
+  }
+  return metadata;
 }

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -35,6 +35,7 @@ export * from './aot/compiler';
 export * from './aot/generated_file';
 export * from './aot/compiler_options';
 export * from './aot/compiler_host';
+export * from './aot/formatted_error';
 export * from './aot/static_reflector';
 export * from './aot/static_symbol';
 export * from './aot/static_symbol_resolver';

--- a/packages/compiler/test/aot/compiler_spec.ts
+++ b/packages/compiler/test/aot/compiler_spec.ts
@@ -768,9 +768,9 @@ describe('compiler (unbundled Angular)', () => {
                  childClassDecorator: '',
                  childModuleDecorator: '@NgModule({providers: [Extends]})',
                }))
-            .toThrowError(
-                'Class Extends in /app/main.ts extends from a Injectable in another compilation unit without duplicating the decorator. ' +
-                'Please add a Injectable or Pipe or Directive or Component or NgModule decorator to the class.');
+            .toThrowError(`Error during template compile of 'Extends'
+  Class Extends in /app/main.ts extends from a Injectable in another compilation unit without duplicating the decorator
+    Please add a Injectable or Pipe or Directive or Component or NgModule decorator to the class.`);
       });
     });
 
@@ -792,9 +792,9 @@ describe('compiler (unbundled Angular)', () => {
                  childClassDecorator: '',
                  childModuleDecorator: '@NgModule({declarations: [Extends]})',
                }))
-            .toThrowError(
-                'Class Extends in /app/main.ts extends from a Directive in another compilation unit without duplicating the decorator. ' +
-                'Please add a Directive or Component decorator to the class.');
+            .toThrowError(`Error during template compile of 'Extends'
+  Class Extends in /app/main.ts extends from a Directive in another compilation unit without duplicating the decorator
+    Please add a Directive or Component decorator to the class.`);
       });
     });
 
@@ -816,9 +816,9 @@ describe('compiler (unbundled Angular)', () => {
                  childClassDecorator: '',
                  childModuleDecorator: '@NgModule({declarations: [Extends]})',
                }))
-            .toThrowError(
-                'Class Extends in /app/main.ts extends from a Directive in another compilation unit without duplicating the decorator. ' +
-                'Please add a Directive or Component decorator to the class.');
+            .toThrowError(`Error during template compile of 'Extends'
+  Class Extends in /app/main.ts extends from a Directive in another compilation unit without duplicating the decorator
+    Please add a Directive or Component decorator to the class.`);
       });
     });
 
@@ -840,9 +840,9 @@ describe('compiler (unbundled Angular)', () => {
                  childClassDecorator: '',
                  childModuleDecorator: '@NgModule({declarations: [Extends]})',
                }))
-            .toThrowError(
-                'Class Extends in /app/main.ts extends from a Pipe in another compilation unit without duplicating the decorator. ' +
-                'Please add a Pipe decorator to the class.');
+            .toThrowError(`Error during template compile of 'Extends'
+  Class Extends in /app/main.ts extends from a Pipe in another compilation unit without duplicating the decorator
+    Please add a Pipe decorator to the class.`);
       });
     });
 
@@ -864,9 +864,9 @@ describe('compiler (unbundled Angular)', () => {
                  childClassDecorator: '',
                  childModuleDecorator: '',
                }))
-            .toThrowError(
-                'Class Extends in /app/main.ts extends from a NgModule in another compilation unit without duplicating the decorator. ' +
-                'Please add a NgModule decorator to the class.');
+            .toThrowError(`Error during template compile of 'Extends'
+  Class Extends in /app/main.ts extends from a NgModule in another compilation unit without duplicating the decorator
+    Please add a NgModule decorator to the class.`);
       });
     });
   }

--- a/packages/compiler/test/aot/static_reflector_spec.ts
+++ b/packages/compiler/test/aot/static_reflector_spec.ts
@@ -107,8 +107,11 @@ describe('StaticReflector', () => {
   it('should provide context for errors reported by the collector', () => {
     const SomeClass = reflector.findDeclaration('src/error-reporting', 'SomeClass');
     expect(() => reflector.annotations(SomeClass))
-        .toThrow(new Error(
-            'Error encountered resolving symbol values statically. A reasonable error message (position 13:34 in the original .ts file), resolving symbol ErrorSym in /tmp/src/error-references.d.ts, resolving symbol Link2 in /tmp/src/error-references.d.ts, resolving symbol Link1 in /tmp/src/error-references.d.ts, resolving symbol SomeClass in /tmp/src/error-reporting.d.ts, resolving symbol SomeClass in /tmp/src/error-reporting.d.ts'));
+        .toThrow(new Error(`Error during template compile of 'SomeClass'
+  A reasonable error message in 'Link1'
+    'Link1' references 'Link2'
+      'Link2' references 'ErrorSym'
+        'ErrorSym' contains the error at /tmp/src/error-references.ts(13,34).`));
   });
 
   it('should simplify primitive into itself', () => {
@@ -330,10 +333,12 @@ describe('StaticReflector', () => {
   it('should error on direct recursive calls', () => {
     expect(
         () => simplify(
-            reflector.getStaticSymbol('/tmp/src/function-reference.ts', ''),
+            reflector.getStaticSymbol('/tmp/src/function-reference.ts', 'MyComp'),
             reflector.getStaticSymbol('/tmp/src/function-reference.ts', 'recursion')))
-        .toThrow(new Error(
-            'Recursion not supported, resolving symbol recursive in /tmp/src/function-recursive.d.ts, resolving symbol recursion in /tmp/src/function-reference.ts, resolving symbol  in /tmp/src/function-reference.ts'));
+        .toThrow(new Error(`Error during template compile of 'MyComp'
+  Recursion is not supported in 'recursion'
+    'recursion' references 'recursive'
+      'recursive' called 'recursive' recursively.`));
   });
 
   it('should throw a SyntaxError without stack trace when the required resource cannot be resolved',
@@ -345,8 +350,8 @@ describe('StaticReflector', () => {
                  message:
                      'Could not resolve ./does-not-exist.component relative to /tmp/src/function-reference.ts'
                })))
-           .toThrowError(
-               'Error encountered resolving symbol values statically. Could not resolve ./does-not-exist.component relative to /tmp/src/function-reference.ts, resolving symbol AppModule in /tmp/src/function-reference.ts');
+           .toThrowError(`Error during template compile of 'AppModule'
+  Could not resolve ./does-not-exist.component relative to /tmp/src/function-reference.ts.`);
      });
 
   it('should record data about the error in the exception', () => {
@@ -361,7 +366,7 @@ describe('StaticReflector', () => {
       simplify(
           reflector.getStaticSymbol('/tmp/src/invalid-metadata.ts', ''), classData.decorators[0]);
     } catch (e) {
-      expect(e.fileName).toBe('/tmp/src/invalid-metadata.ts');
+      expect(e.position).toBeDefined();
       threw = true;
     }
     expect(threw).toBe(true);
@@ -370,10 +375,13 @@ describe('StaticReflector', () => {
   it('should error on indirect recursive calls', () => {
     expect(
         () => simplify(
-            reflector.getStaticSymbol('/tmp/src/function-reference.ts', ''),
+            reflector.getStaticSymbol('/tmp/src/function-reference.ts', 'MyComp'),
             reflector.getStaticSymbol('/tmp/src/function-reference.ts', 'indirectRecursion')))
-        .toThrow(new Error(
-            'Recursion not supported, resolving symbol indirectRecursion2 in /tmp/src/function-recursive.d.ts, resolving symbol indirectRecursion1 in /tmp/src/function-recursive.d.ts, resolving symbol indirectRecursion in /tmp/src/function-reference.ts, resolving symbol  in /tmp/src/function-reference.ts'));
+        .toThrow(new Error(`Error during template compile of 'MyComp'
+  Recursion is not supported in 'indirectRecursion'
+    'indirectRecursion' references 'indirectRecursion1'
+      'indirectRecursion1' references 'indirectRecursion2'
+        'indirectRecursion2' called 'indirectRecursion1' recursively.`));
   });
 
   it('should simplify a spread expression', () => {
@@ -401,7 +409,8 @@ describe('StaticReflector', () => {
         () => reflector.annotations(
             reflector.getStaticSymbol('/tmp/src/invalid-calls.ts', 'MyComponent')))
         .toThrow(new Error(
-            `Error encountered resolving symbol values statically. Calling function 'someFunction', function calls are not supported. Consider replacing the function or lambda with a reference to an exported function, resolving symbol MyComponent in /tmp/src/invalid-calls.ts, resolving symbol MyComponent in /tmp/src/invalid-calls.ts`));
+            `/tmp/src/invalid-calls.ts(8,29): Error during template compile of 'MyComponent'
+  Function calls are not supported in decorators but 'someFunction' was called.`));
   });
 
   it('should be able to get metadata for a class containing a static method call', () => {
@@ -962,7 +971,7 @@ describe('StaticReflector', () => {
   });
 
   // Regression #18170
-  it('should agressively evaluate enums selects', () => {
+  it('should eagerly evaluate enums selects', () => {
     const data = Object.create(DEFAULT_TEST_DATA);
     const file = '/tmp/src/my_component.ts';
     data[file] = `
@@ -1077,6 +1086,228 @@ describe('StaticReflector', () => {
          symbol = reflector.resolveExternalReference({moduleName: 'a', name: 'x'});
          expect(symbolResolver.getKnownModuleName(symbol.filePath)).toBe('a');
        });
+  });
+
+  describe('formatted error reporting', () => {
+    describe('function calls', () => {
+      const fileName = '/tmp/src/invalid/components.ts';
+      beforeEach(() => {
+        const localData = {
+          '/tmp/src/invalid/function-call.ts': `
+        import {functionToCall} from 'some-module';
+        export const CALL_FUNCTION = functionToCall();
+    `,
+          '/tmp/src/invalid/indirect.ts': `
+        import {CALL_FUNCTION} from './function-call';
+
+        export const INDIRECT_CALL_FUNCTION = CALL_FUNCTION + 1;
+    `,
+          '/tmp/src/invalid/two-levels-indirect.ts': `
+        import {INDIRECT_CALL_FUNCTION} from './indirect';
+
+        export const TWO_LEVELS_INDIRECT_CALL_FUNCTION = INDIRECT_CALL_FUNCTION + 1;
+    `,
+          '/tmp/src/invalid/components.ts': `
+        import {functionToCall} from 'some-module';
+        import {Component} from '@angular/core';
+        import {CALL_FUNCTION} from './function-call';
+        import {INDIRECT_CALL_FUNCTION} from './indirect';
+        import {TWO_LEVELS_INDIRECT_CALL_FUNCTION} from './two-levels-indirect';
+
+        @Component({
+          value: functionToCall()
+        })
+        export class CallImportedFunction {}
+
+        @Component({
+          value: CALL_FUNCTION
+        })
+        export class ReferenceCalledFunction {}
+
+        @Component({
+          value: INDIRECT_CALL_FUNCTION
+        })
+        export class IndirectReferenceCalledFunction {}
+
+        @Component({
+          value: TWO_LEVELS_INDIRECT_CALL_FUNCTION
+        })
+        export class TwoLevelsIndirectReferenceCalledFunction {}
+    `
+        };
+        init({...DEFAULT_TEST_DATA, ...localData});
+      });
+
+      it('should report a formatted error for a direct function call', () => {
+        expect(() => {
+          return reflector.annotations(reflector.getStaticSymbol(fileName, 'CallImportedFunction'));
+        })
+            .toThrowError(
+                `/tmp/src/invalid/components.ts(9,18): Error during template compile of 'CallImportedFunction'
+  Function calls are not supported in decorators but 'functionToCall' was called.`);
+      });
+
+      it('should report a formatted error for a refernce to a function call', () => {
+        expect(() => {
+          return reflector.annotations(
+              reflector.getStaticSymbol(fileName, 'ReferenceCalledFunction'));
+        })
+            .toThrowError(
+                `/tmp/src/invalid/components.ts(14,18): Error during template compile of 'ReferenceCalledFunction'
+  Function calls are not supported in decorators but 'functionToCall' was called in 'CALL_FUNCTION'
+    'CALL_FUNCTION' calls 'functionToCall' at /tmp/src/invalid/function-call.ts(3,38).`);
+      });
+
+      it('should report a formatted error for an indirect reference to a function call', () => {
+        expect(() => {
+          return reflector.annotations(
+              reflector.getStaticSymbol(fileName, 'IndirectReferenceCalledFunction'));
+        })
+            .toThrowError(
+                `/tmp/src/invalid/components.ts(19,18): Error during template compile of 'IndirectReferenceCalledFunction'
+  Function calls are not supported in decorators but 'functionToCall' was called in 'INDIRECT_CALL_FUNCTION'
+    'INDIRECT_CALL_FUNCTION' references 'CALL_FUNCTION' at /tmp/src/invalid/indirect.ts(4,47)
+      'CALL_FUNCTION' calls 'functionToCall' at /tmp/src/invalid/function-call.ts(3,38).`);
+      });
+
+      it('should report a formatted error for a double-indirect refernce to a function call', () => {
+        expect(() => {
+          return reflector.annotations(
+              reflector.getStaticSymbol(fileName, 'TwoLevelsIndirectReferenceCalledFunction'));
+        })
+            .toThrowError(
+                `/tmp/src/invalid/components.ts(24,18): Error during template compile of 'TwoLevelsIndirectReferenceCalledFunction'
+  Function calls are not supported in decorators but 'functionToCall' was called in 'TWO_LEVELS_INDIRECT_CALL_FUNCTION'
+    'TWO_LEVELS_INDIRECT_CALL_FUNCTION' references 'INDIRECT_CALL_FUNCTION' at /tmp/src/invalid/two-levels-indirect.ts(4,58)
+      'INDIRECT_CALL_FUNCTION' references 'CALL_FUNCTION' at /tmp/src/invalid/indirect.ts(4,47)
+        'CALL_FUNCTION' calls 'functionToCall' at /tmp/src/invalid/function-call.ts(3,38).`);
+      });
+    });
+
+    describe('macro functions', () => {
+      const fileName = '/tmp/src/invalid/components.ts';
+      beforeEach(() => {
+        const localData = {
+          '/tmp/src/invalid/function-call.ts': `
+        import {functionToCall} from 'some-module';
+        export const CALL_FUNCTION = functionToCall();
+    `,
+          '/tmp/src/invalid/indirect.ts': `
+        import {CALL_FUNCTION} from './function-call';
+
+        export const INDIRECT_CALL_FUNCTION = CALL_FUNCTION + 1;
+    `,
+          '/tmp/src/invalid/macros.ts': `
+        export function someMacro(value: any) {
+          return [ { provide: 'key', value: value } ];
+        }
+    `,
+          '/tmp/src/invalid/components.ts': `
+        import {Component} from '@angular/core';
+        import {functionToCall} from 'some-module';
+        import {someMacro} from './macros';
+        import {CALL_FUNCTION} from './function-call';
+        import {INDIRECT_CALL_FUNCTION} from './indirect';
+
+        @Component({
+          template: someMacro(functionToCall())
+        })
+        export class DirectCall {}
+
+        @Component({
+          template: someMacro(CALL_FUNCTION)
+        })
+        export class IndirectCall {}
+
+        @Component({
+          template: someMacro(INDIRECT_CALL_FUNCTION)
+        })
+        export class DoubleIndirectCall {}
+    `
+        };
+        init({...DEFAULT_TEST_DATA, ...localData});
+      });
+
+      it('should report a formatted error for a direct function call', () => {
+        expect(() => {
+          return reflector.annotations(reflector.getStaticSymbol(fileName, 'DirectCall'));
+        })
+            .toThrowError(
+                `/tmp/src/invalid/components.ts(9,31): Error during template compile of 'DirectCall'
+  Function calls are not supported in decorators but 'functionToCall' was called.`);
+      });
+
+      it('should report a formatted error for a reference to a function call', () => {
+        expect(() => {
+          return reflector.annotations(reflector.getStaticSymbol(fileName, 'IndirectCall'));
+        })
+            .toThrowError(
+                `/tmp/src/invalid/components.ts(14,31): Error during template compile of 'IndirectCall'
+  Function calls are not supported in decorators but 'functionToCall' was called in 'CALL_FUNCTION'
+    'CALL_FUNCTION' calls 'functionToCall' at /tmp/src/invalid/function-call.ts(3,38).`);
+      });
+
+      it('should report a formatted error for an indirect refernece to a function call', () => {
+        expect(() => {
+          return reflector.annotations(reflector.getStaticSymbol(fileName, 'DoubleIndirectCall'));
+        })
+            .toThrowError(
+                `/tmp/src/invalid/components.ts(19,31): Error during template compile of 'DoubleIndirectCall'
+  Function calls are not supported in decorators but 'functionToCall' was called in 'INDIRECT_CALL_FUNCTION'
+    'INDIRECT_CALL_FUNCTION' references 'CALL_FUNCTION' at /tmp/src/invalid/indirect.ts(4,47)
+      'CALL_FUNCTION' calls 'functionToCall' at /tmp/src/invalid/function-call.ts(3,38).`);
+      });
+    });
+
+    describe('and give advice', () => {
+      // If in a reference expression, advice the user to replace with a reference.
+      const fileName = '/tmp/src/invalid/components.ts';
+
+      function collectError(symbol: string): string {
+        try {
+          reflector.annotations(reflector.getStaticSymbol(fileName, symbol));
+        } catch (e) {
+          return e.message;
+        }
+        fail('Expected an exception to be thrown');
+        return '';
+      }
+
+      function initWith(content: string) {
+        init({
+          ...DEFAULT_TEST_DATA,
+          [fileName]: `import {Component} from '@angular/core';\n${content}`
+        });
+      }
+
+      it('should advise exorting a local', () => {
+        initWith(`const f: string; @Component({value: f}) export class MyComp {}`);
+        expect(collectError('MyComp')).toContain(`Consider exporting 'f'`);
+      });
+
+      it('should advise export a class', () => {
+        initWith('class Foo {} @Component({value: Foo}) export class MyComp {}');
+        expect(collectError('MyComp')).toContain(`Consider exporting 'Foo'`);
+      });
+
+      it('should advise avoiding destructuring', () => {
+        initWith(
+            'export const {foo, bar} = {foo: 1, bar: 2}; @Component({value: foo}) export class MyComp {}');
+        expect(collectError('MyComp')).toContain(`Consider simplifying to avoid destructuring`);
+      });
+
+      it('should advise converting an arrow function into an exported function', () => {
+        initWith('@Component({value: () => true}) export class MyComp {}');
+        expect(collectError('MyComp'))
+            .toContain(`Consider changing the function expression into an exported function`);
+      });
+
+      it('should advise converting a function expression into an exported function', () => {
+        initWith('@Component({value: function () { return true; }}) export class MyComp {}');
+        expect(collectError('MyComp'))
+            .toContain(`Consider changing the function expression into an exported function`);
+      });
+    });
   });
 });
 
@@ -1467,5 +1698,5 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
         export class Dep {
           @Input f: Forward;
         }
-      `
+      `,
 };

--- a/packages/compiler/test/aot/static_symbol_resolver_spec.ts
+++ b/packages/compiler/test/aot/static_symbol_resolver_spec.ts
@@ -234,15 +234,25 @@ describe('StaticSymbolResolver', () => {
     });
     expect(symbolResolver.resolveSymbol(symbolCache.get('/test.ts', 'a')).metadata)
         .toEqual(symbolCache.get('/test2.ts', 'b'));
-    expect(symbolResolver.resolveSymbol(symbolCache.get('/test.ts', 'x')).metadata).toEqual([
-      symbolCache.get('/test2.ts', 'y')
-    ]);
+    expect(symbolResolver.resolveSymbol(symbolCache.get('/test.ts', 'x')).metadata).toEqual([{
+      __symbolic: 'resolved',
+      symbol: symbolCache.get('/test2.ts', 'y'),
+      line: 3,
+      character: 24,
+      fileName: '/test.ts'
+    }]);
     expect(symbolResolver.resolveSymbol(symbolCache.get('/test.ts', 'simpleFn')).metadata).toEqual({
       __symbolic: 'function',
       parameters: ['fnArg'],
       value: [
-        symbolCache.get('/test.ts', 'a'), symbolCache.get('/test2.ts', 'y'),
-        Object({__symbolic: 'reference', name: 'fnArg'})
+        symbolCache.get('/test.ts', 'a'), {
+          __symbolic: 'resolved',
+          symbol: symbolCache.get('/test2.ts', 'y'),
+          line: 6,
+          character: 21,
+          fileName: '/test.ts'
+        },
+        {__symbolic: 'reference', name: 'fnArg'}
       ]
     });
   });

--- a/packages/language-service/src/diagnostics.ts
+++ b/packages/language-service/src/diagnostics.ts
@@ -10,7 +10,7 @@ import {NgAnalyzedModules, StaticSymbol} from '@angular/compiler';
 import {DiagnosticTemplateInfo, getTemplateExpressionDiagnostics} from '@angular/compiler-cli/src/language_services';
 
 import {AstResult} from './common';
-import {Declarations, Diagnostic, DiagnosticKind, Diagnostics, Span, TemplateSource} from './types';
+import {Declarations, Diagnostic, DiagnosticKind, DiagnosticMessageChain, Diagnostics, Span, TemplateSource} from './types';
 import {offsetSpan, spanOf} from './utils';
 
 export interface AstProvider {
@@ -56,7 +56,7 @@ export function getDeclarationDiagnostics(
 
   let directives: Set<StaticSymbol>|undefined = undefined;
   for (const declaration of declarations) {
-    const report = (message: string, span?: Span) => {
+    const report = (message: string | DiagnosticMessageChain, span?: Span) => {
       results.push(<Diagnostic>{
         kind: DiagnosticKind.Error,
         span: span || declaration.declarationSpan, message

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -81,7 +81,7 @@ export type TemplateSources = TemplateSource[] | undefined;
 /**
  * Error information found getting declaration information
  *
- * A host type; see `LanagueServiceHost`.
+ * A host type; see `LanguageServiceHost`.
  *
  * @experimental
  */
@@ -92,9 +92,10 @@ export interface DeclarationError {
   readonly span: Span;
 
   /**
-   * The message to display describing the error.
+   * The message to display describing the error or a chain
+   * of messages.
    */
-  readonly message: string;
+  readonly message: string|DiagnosticMessageChain;
 }
 
 /**
@@ -256,6 +257,28 @@ export enum DiagnosticKind {
 }
 
 /**
+ * A template diagnostics message chain. This is similar to the TypeScript
+ * DiagnosticMessageChain. The messages are intended to be formatted as separate
+ * sentence fragments and indented.
+ *
+ * For compatiblity previous implementation, the values are expected to override
+ * toString() to return a formatted message.
+ *
+ * @experimental
+ */
+export interface DiagnosticMessageChain {
+  /**
+   * The text of the diagnostic message to display.
+   */
+  message: string;
+
+  /**
+   * The next message in the chain.
+   */
+  next?: DiagnosticMessageChain;
+}
+
+/**
  * An template diagnostic message to display.
  *
  * @experimental
@@ -272,9 +295,9 @@ export interface Diagnostic {
   span: Span;
 
   /**
-   * The text of the diagnostic message to display.
+   * The text of the diagnostic message to display or a chain of messages.
    */
-  message: string;
+  message: string|DiagnosticMessageChain;
 }
 
 /**

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -13,7 +13,7 @@ import {Diagnostics} from '../src/types';
 import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {toh} from './test_data';
-import {MockTypescriptHost, includeDiagnostic, noDiagnostics} from './test_utils';
+import {MockTypescriptHost, diagnosticMessageContains, findDiagnostic, includeDiagnostic, noDiagnostics} from './test_utils';
 
 describe('diagnostics', () => {
   let documentRegistry = ts.createDocumentRegistry();
@@ -123,7 +123,8 @@ describe('diagnostics', () => {
       addCode(code, (fileName, content) => {
         const diagnostics = ngService.getDiagnostics(fileName);
         includeDiagnostic(
-            diagnostics !, 'Function calls are not supported.', '() => \'foo\'', content);
+            diagnostics !, 'Function expressions are not supported in decorators', '() => \'foo\'',
+            content);
       });
     });
 
@@ -168,8 +169,7 @@ describe('diagnostics', () => {
       const code =
           ` @Component({template: '<p> Using an invalid pipe {{data | dat}} </p>'}) export class MyComponent { data = 'some data'; }`;
       addCode(code, fileName => {
-        const diagnostic =
-            ngService.getDiagnostics(fileName) !.filter(d => d.message.indexOf('pipe') > 0)[0];
+        const diagnostic = findDiagnostic(ngService.getDiagnostics(fileName) !, 'pipe') !;
         expect(diagnostic).not.toBeUndefined();
         expect(diagnostic.span.end - diagnostic.span.start).toBeLessThan(11);
       });
@@ -216,8 +216,8 @@ describe('diagnostics', () => {
       `,
           fileName => {
             const diagnostics = ngService.getDiagnostics(fileName) !;
-            const expected = diagnostics.find(d => d.message.startsWith('Invalid providers for'));
-            const notExpected = diagnostics.find(d => d.message.startsWith('Cannot read property'));
+            const expected = findDiagnostic(diagnostics, 'Invalid providers for');
+            const notExpected = findDiagnostic(diagnostics, 'Cannot read property');
             expect(expected).toBeDefined();
             expect(notExpected).toBeUndefined();
           });
@@ -355,12 +355,12 @@ describe('diagnostics', () => {
       expect(diagnostics.length).toBe(1);
       if (diagnostics.length > 1) {
         for (const diagnostic of diagnostics) {
-          if (diagnostic.message.indexOf('MyComponent') >= 0) continue;
+          if (diagnosticMessageContains(diagnostic.message, 'MyComponent')) continue;
           fail(`(${diagnostic.span.start}:${diagnostic.span.end}): ${diagnostic.message}`);
         }
         return;
       }
-      expect(diagnostics[0].message.indexOf('MyComponent') >= 0).toBeTruthy();
+      expect(diagnosticMessageContains(diagnostics[0].message, 'MyComponent')).toBeTruthy();
     }
   });
 });


### PR DESCRIPTION
The errors produced when error were encountered while interpreting the
content of a directive was often incomprehencible. With this change
these kind of error messages should be easier to understand and diagnose.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Feature
```

## What is the current behavior?

The errors reported by static reflector are often incomprehensible.


## What is the new behavior?

The errors are now somewhat more comprehensible.

Part of #19700

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
