### PR TITLE
fix(compiler): emit correct type-check-blocks with TemplateRef's

### DIFF
--- a/packages/compiler-cli/test/diagnostics/check_types_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/check_types_spec.ts
@@ -87,6 +87,23 @@ describe('ng type checker', () => {
     addTests({fullTemplateTypeCheck: true});
   });
 
+  describe('regressions', () => {
+    // #19485
+    it('should accept if else (TemplateRef)', () => {
+      accept(
+          {
+            'src/app.component.html': `
+              <div class="text-center" *ngIf="!person; else e">
+                No person supplied.
+              </div>
+              <ng-template #e>
+                Welcome {{person.name}}!
+              <ng-template>`
+          },
+          {fullTemplateTypeCheck: true});
+    });
+  });
+
   function addTests(config: {fullTemplateTypeCheck: boolean}) {
     function a(template: string) { accept({'src/app.component.html': template}, config); }
 
@@ -234,6 +251,7 @@ const QUICKSTART = {
   `,
   'src/app.module.ts': `
     import { NgModule }      from '@angular/core';
+    import { CommonModule }  from '@angular/common';
     import { AppComponent, APipe, ADirective }  from './app.component';
     import { LibDirective, LibPipe } from './lib';
 
@@ -246,7 +264,7 @@ const QUICKSTART = {
     @NgModule({
       declarations: [ AppComponent, APipe, ADirective ],
       bootstrap:    [ AppComponent ],
-      imports:      [ LibModule ]
+      imports:      [ LibModule, CommonModule ]
     })
     export class AppModule { }
   `


### PR DESCRIPTION
The type-check block generated with `"fullTemplateTypeCheck"` was
invalid if the it contained a template ref as would be generated
using the `else` micro-syntax of `NgIf`.

Fixes: #19485

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue Number: #19485

## What is the new behavior?

The type-check blocks are now valid if they contain a generated template ref.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
