### PR TITLE
fix(upgrade): account for baseHref when calling navigateByUrl

### DIFF
--- a/packages/router/upgrade/src/upgrade.ts
+++ b/packages/router/upgrade/src/upgrade.ts
@@ -9,7 +9,7 @@
 import {APP_BOOTSTRAP_LISTENER, ComponentRef, InjectionToken} from '@angular/core';
 import {Router} from '@angular/router';
 import {UpgradeModule} from '@angular/upgrade/static';
-import {LocationStrategy} from '@angular/common';
+import { LocationStrategy } from '@angular/common';
 
 
 

--- a/packages/router/upgrade/src/upgrade.ts
+++ b/packages/router/upgrade/src/upgrade.ts
@@ -9,6 +9,7 @@
 import {APP_BOOTSTRAP_LISTENER, ComponentRef, InjectionToken} from '@angular/core';
 import {Router} from '@angular/router';
 import {UpgradeModule} from '@angular/upgrade/static';
+import { LocationStrategy } from '@angular/common';
 
 
 
@@ -66,11 +67,12 @@ export function setUpLocationSync(ngUpgrade: UpgradeModule) {
   }
 
   const router: Router = ngUpgrade.injector.get(Router);
+  const baseHref: string = ngUpgrade.injector.get(LocationStrategy).getBaseHref();
   const url = document.createElement('a');
 
   ngUpgrade.$injector.get('$rootScope')
       .$on('$locationChangeStart', (_: any, next: string, __: string) => {
         url.href = next;
-        router.navigateByUrl(url.pathname + url.search + url.hash);
+        router.navigateByUrl(url.pathname.replace(baseHref, '') + url.search + url.hash);
       });
 }

--- a/packages/router/upgrade/src/upgrade.ts
+++ b/packages/router/upgrade/src/upgrade.ts
@@ -9,7 +9,7 @@
 import {APP_BOOTSTRAP_LISTENER, ComponentRef, InjectionToken} from '@angular/core';
 import {Router} from '@angular/router';
 import {UpgradeModule} from '@angular/upgrade/static';
-import { LocationStrategy } from '@angular/common';
+import {LocationStrategy} from '@angular/common';
 
 
 


### PR DESCRIPTION
url.pathname needs to remove baseHref otherwise it repeatedly gets added causing numerous redirects

Fixes angular/angular#20061

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently the baseHref is not being removed when syncing the URL from AngularJS to Angular.

Issue Number: [20061](https://github.com/angular/angular/issues/20061)


## What is the new behavior?
The baseHref is now removed before calling navigateByUrl which fixes navigation problems / seemingly infinite redirects.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I know there is a commit against this issue already but I feel this is a more robust way to address the issue. This change, rather than parsing and splicing url fragments and inferring the baseHref, uses ```LocationStrategy```'s ```getBaseHref()``` and simply removes it before navigating. Seems less fragile **AND** more importantly will also work in the case where somebody manually sets ```APP_BASE_HREF```.

Another item of note is there was no spec file covering this method. I attempted to add one but get odd results when trying to call ```setupLocationSync``` from within my test. When calling ```setupLocationSync``` from within a test my assertion would not be reached whereas without the call to ```setupLocationSync``` it does.  Perhaps this is why there is no test? In any case, I am willing to add one but might need some guidance.