### PR TITLE
build(aio): tighten up code autolinking

### DIFF
--- a/aio/tools/transforms/angular-base-package/index.js
+++ b/aio/tools/transforms/angular-base-package/index.js
@@ -35,6 +35,7 @@ module.exports = new Package('angular-base', [
   .factory('packageInfo', function() { return require(path.resolve(PROJECT_ROOT, 'package.json')); })
   .factory(require('./readers/json'))
   .factory(require('./services/copyFolder'))
+  .factory(require('./services/filterPipes'))
   .factory(require('./services/getImageDimensions'))
 
   .factory(require('./post-processors/add-image-dimensions'))
@@ -126,8 +127,9 @@ module.exports = new Package('angular-base', [
   })
 
 
-  .config(function(postProcessHtml, addImageDimensions, autoLinkCode) {
+  .config(function(postProcessHtml, addImageDimensions, autoLinkCode, filterPipes) {
     addImageDimensions.basePath = path.resolve(AIO_PATH, 'src');
+    autoLinkCode.customFilters = [filterPipes];
     postProcessHtml.plugins = [
       require('./post-processors/autolink-headings'),
       addImageDimensions,

--- a/aio/tools/transforms/angular-base-package/services/filterPipes.js
+++ b/aio/tools/transforms/angular-base-package/services/filterPipes.js
@@ -1,0 +1,12 @@
+
+/**
+ * This service is used by the autoLinkCode post-processors to filter out pipe docs
+ * where the matching word is the pipe name and is not preceded by a pipe
+ */
+module.exports = function filterPipes() {
+  return (docs, words, index) =>
+    docs.filter(doc =>
+      doc.docType !== 'pipe' ||
+      doc.pipeOptions.name !== '\'' + words[index] + '\'' ||
+      index > 0 && words[index - 1].trim() === '|');
+};

--- a/aio/tools/transforms/angular-base-package/services/filterPipes.spec.js
+++ b/aio/tools/transforms/angular-base-package/services/filterPipes.spec.js
@@ -1,0 +1,36 @@
+const filterPipes = require('./filterPipes')();
+
+describe('filterPipes', () => {
+  it('should ignore docs that are not pipes', () => {
+    const docs = [{ docType: 'class', name: 'B', pipeOptions: { name: '\'b\'' } }];
+    const words = ['A', 'b', 'B', 'C'];
+    const filteredDocs = [{ docType: 'class', name: 'B', pipeOptions: { name: '\'b\'' } }];
+    expect(filterPipes(docs, words, 1)).toEqual(filteredDocs);
+    expect(filterPipes(docs, words, 2)).toEqual(filteredDocs);
+  });
+
+  it('should ignore docs that are pipes but do not match the pipe name', () => {
+    const docs = [{ docType: 'pipe', name: 'B', pipeOptions: { name: '\'b\'' } }];
+    const words = ['A', 'B', 'C'];
+    const filteredDocs = [{ docType: 'pipe', name: 'B', pipeOptions: { name: '\'b\'' } }];
+    expect(filterPipes(docs, words, 1)).toEqual(filteredDocs);
+  });
+
+  it('should ignore docs that are pipes, match the pipe name and are preceded by a pipe character', () => {
+    const docs = [{ docType: 'pipe', name: 'B', pipeOptions: { name: '\'b\'' } }];
+    const words = ['A', '|', 'b', 'C'];
+    const filteredDocs = [{ docType: 'pipe', name: 'B', pipeOptions: { name: '\'b\'' } }];
+    expect(filterPipes(docs, words, 2)).toEqual(filteredDocs);
+  });
+
+  it('should filter out docs that are pipes, match the pipe name but are not preceded by a pipe character', () => {
+    const docs = [
+      { docType: 'pipe', name: 'B', pipeOptions: { name: '\'b\'' } },
+      { docType: 'class', name: 'B' }
+    ];
+    const words = ['A', 'b', 'C'];
+    const index = 1;
+    const filteredDocs = [{ docType: 'class', name: 'B' }];
+    expect(filterPipes(docs, words, index)).toEqual(filteredDocs);
+  });
+});


### PR DESCRIPTION
Do not match code "words" that are part of a hyphenated
string of characters: e.g. `platform-browser-dynamic` should
not auto-link `browser`.

Do not match code "words" that correspond to pipe names
but are not preceded by a pipe `|` character. E.g. `package.json` should not auto link `json` to the `JsonPipe`.

Closes #20187
