### PR TITLE
fix(language-service): Fix crash when no script files are found

### DIFF
--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -146,11 +146,19 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
   private ensureAnalyzedModules(): NgAnalyzedModules {
     let analyzedModules = this.analyzedModules;
     if (!analyzedModules) {
-      const analyzeHost = {isSourceFile(filePath: string) { return true; }};
-      const programFiles = this.program.getSourceFiles().map(sf => sf.fileName);
-
-      analyzedModules = this.analyzedModules =
-          analyzeNgModules(programFiles, analyzeHost, this.staticSymbolResolver, this.resolver);
+      if (this.host.getScriptFileNames().length === 0) {
+        analyzedModules = {
+          files: [],
+          ngModuleByPipeOrDirective: new Map(),
+          ngModules: [],
+        };
+      } else {
+        const analyzeHost = {isSourceFile(filePath: string) { return true; }};
+        const programFiles = this.program.getSourceFiles().map(sf => sf.fileName);
+        analyzedModules =
+            analyzeNgModules(programFiles, analyzeHost, this.staticSymbolResolver, this.resolver);
+      }
+      this.analyzedModules = analyzedModules;
     }
     return analyzedModules;
   }
@@ -357,7 +365,11 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
     if (!result) {
       if (!this.context) {
         // Make up a context by finding the first script and using that as the base dir.
-        this.context = this.host.getScriptFileNames()[0];
+        const scriptFileNames = this.host.getScriptFileNames();
+        if (0 === scriptFileNames.length) {
+          throw new Error('Internal error: no script file names found');
+        }
+        this.context = scriptFileNames[0];
       }
 
       // Use the file context's directory as the base directory.

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -39,4 +39,11 @@ describe('completions', () => {
     ngHost = new TypeScriptServiceHost(host, service);
     expect(ngHost.getAnalyzedModules()).toBeDefined();
   });
+
+  it('should not throw if there is no script names', () => {
+    host = new MockTypescriptHost([], toh);
+    service = ts.createLanguageService(host);
+    ngHost = new TypeScriptServiceHost(host, service);
+    expect(() => ngHost.getAnalyzedModules()).not.toThrow();
+  });
 });


### PR DESCRIPTION
Fixes the crash in typescript host when getScriptFileNames() returns an
empty array.

PR Close #19325

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Exception when trying to instantiate ReflectorHost when files are empty.

Issue Number: 19325


## What is the new behavior?
Return an empty list.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
