### PR TITLE
build(aio): ensure downloadable zip filenames are unique

### DIFF
--- a/aio/tools/example-zipper/exampleZipper.js
+++ b/aio/tools/example-zipper/exampleZipper.js
@@ -62,7 +62,7 @@ class ExampleZipper {
     let exampleZipName;
     const exampleType = this._getExampleType(path.join(sourceDirName, relativeDirName));
     if (relativeDirName.indexOf('/') !== -1) { // Special example
-      exampleZipName = relativeDirName.split('/')[0];
+      exampleZipName = relativeDirName.split('/').join('-');
     } else {
       exampleZipName = jsonFileName.replace(/(plnkr|zipper).json/, relativeDirName);
     }


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] Build related changes
```

## What is the current behavior?
Some examples may result in downloadable ZIP files with the same name (which could be confusing for the user).

Issue Number: #16227


## What is the new behavior?
No two examples will result in downloadable ZIP files with the same name.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
Fixes #16227.