### PR TITLE
fix(forms): reflect formControlName to name attribute

### DIFF
--- a/packages/forms/src/directives/radio_control_value_accessor.ts
+++ b/packages/forms/src/directives/radio_control_value_accessor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Injectable, Injector, Input, OnDestroy, OnInit, Renderer2, forwardRef} from '@angular/core';
+import {Directive, ElementRef, Injectable, Injector, Input, OnDestroy, OnInit, Renderer2, SimpleChanges, forwardRef} from '@angular/core';
 
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 import {NgControl} from './ng_control';
@@ -107,6 +107,14 @@ export class RadioControlValueAccessor implements ControlValueAccessor,
   constructor(
       private _renderer: Renderer2, private _elementRef: ElementRef,
       private _registry: RadioControlRegistry, private _injector: Injector) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    const nameChange = changes.formControlName;
+    if (nameChange && !this.name) {
+      this.name = nameChange.currentValue;
+      this._renderer.setProperty(this._elementRef.nativeElement, 'name', this.name);
+    }
+  }
 
   ngOnInit(): void {
     this._control = this._injector.get(NgControl);

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -766,6 +766,20 @@ export function main() {
           expect(inputs[1].nativeElement.checked).toBe(true);
         });
 
+        it('should reflect formControl name to name attribute', () => {
+          const fixture = initTest(FormControlRadioButtons);
+          const foodCtrl = new FormControl('fish');
+          const drinkCtrl = new FormControl('sprite');
+          fixture.componentInstance.form = new FormGroup({'food': foodCtrl, 'drink': drinkCtrl});
+          fixture.detectChanges();
+
+          const inputs = fixture.debugElement.queryAll(By.css('input'));
+          expect(inputs[0].nativeElement.name).toEqual('food');
+          expect(inputs[1].nativeElement.name).toEqual('food');
+          expect(inputs[2].nativeElement.name).toEqual('drink');
+          expect(inputs[3].nativeElement.name).toEqual('drink');
+        });
+
       });
 
       describe('in template-driven forms', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
From #9681, `formControlName` is not reflected back to `name` attribute, which means that browsers cannot group radio buttons together, which leads to strange behavior when navigating through radio buttons with keyboard. As demonstrated [here](https://stackblitz.com/edit/angular-8339wy).

Issue Number: #20529


## What is the new behavior?
`formControlName` is reflected to the `name` attribute so that browsers can group radio buttons properly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Closes #20529