### PR TITLE
fix(core/http): allow falsy primitive values in HttpResponse

### DIFF
--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -262,7 +262,7 @@ export class HttpResponse<T> extends HttpResponseBase {
     body?: T | null, headers?: HttpHeaders; status?: number; statusText?: string; url?: string;
   } = {}) {
     super(init);
-    this.body = init.body || null;
+    this.body = typeof init.body === 'undefined' ? null : init.body;
   }
 
   readonly type: HttpEventType.Response = HttpEventType.Response;


### PR DESCRIPTION
Prevent HttpResponse from setting its body to `null` in the case of receiving
`0`, `false`, or `""`. Still prefers `null` to `undefined`.