### PR TITLE
fix(http): rework HttpParams to always be immutable (#20430)

### DIFF
--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -66,6 +66,15 @@ import {HttpParams} from '../src/params';
         const body = new HttpParams({fromString: 'a=1&b=2&c=3&d=4'});
         expect(body.keys()).toEqual(['a', 'b', 'c', 'd']);
       });
+
+      it('should not duplicate parameters after multiple reads', () => {
+        let body = new HttpParams();
+        body = body.append('a', 'b');
+        body.toString();
+        body = body.append('c', 'd');
+        body.toString();
+        expect(body.toString()).toEqual('a=b&c=d');
+      });
     });
   });
 }


### PR DESCRIPTION
I reworked the HttpParams object so that it's a simpler immutable object.  It used to track it's current map and then it's pending updates in separate Maps.  This might make sense if the object wasn't immutable, but since it is, why not just return the updated map every time?  

The object looked immutable from the outside as the modification operations (append, set, delete) would return a new object, however as soon as you called a read operation (get, keys, toString) it would actually modify the object in order to spit out the correct values. Due to a bug in this logic it would create duplicate parameters in certain cases (the issue referenced)

The rework simplifies everything by removing the tracked `clonefrom` and `updates` and just keeping the existing `map` updated right when you do an operation that results in a clone.  This way read operations are already working with a fully up to date map and can just return the values requested

PR Close #20430 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently when you make a read operation on a HttpParam object, it modifies the object.  This is contrary to the documentation that says the object is immutable.

Issue Number: #20430 


## What is the new behavior?
All change operations now correctly return a new completed object, and all reads return values from this object without modifying it

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```