### PR TITLE
feat(common): add locale id parameter to `registerLocaleData`

### DIFF
--- a/packages/common/locales/closure-locale.ts
+++ b/packages/common/locales/closure-locale.ts
@@ -4895,6 +4895,5 @@ switch (goog.LOCALE) {
 }
 
 if (l) {
-  l[0] = goog.LOCALE;
-  registerLocaleData(l);
+  registerLocaleData(l, goog.LOCALE);
 }

--- a/packages/common/src/i18n/locale_data.ts
+++ b/packages/common/src/i18n/locale_data.ts
@@ -15,11 +15,27 @@ export const LOCALE_DATA: {[localeId: string]: any} = {};
  * Register global data to be used internally by Angular. See the
  * {@linkDocs guide/i18n#i18n-pipes "I18n guide"} to know how to import additional locale data.
  *
+ * The signature registerLocaleData(data: any, extraData?: any) is deprecated since v5.1
+ * Use registerLocaleData(data: any, localeId?: string, extraData?: any) instead.
+ *
  * @experimental i18n support is experimental.
  */
-export function registerLocaleData(data: any, extraData?: any) {
-  const localeId = data[LocaleDataIndex.LocaleId].toLowerCase().replace(/_/g, '-');
+// we cannot overwrite the function signature like we do with classes because it doesn't
+// generate the correct api file.
+// See: https://github.com/angular/ts-api-guardian/issues/22
+// TODO(ocombe): uncomment the following lines when the bug is fixed
+// export function registerLocaleData(data: any, extraData?: any): void;
+// export function registerLocaleData(data: any, localeId?: string, extraData?: any): void;
+export function registerLocaleData(data: any, localeId?: string | any, extraData?: any): void {
+  if (typeof localeId !== 'string') {
+    extraData = extraData || localeId;
+    localeId = data[LocaleDataIndex.LocaleId];
+  }
+
+  localeId = localeId.toLowerCase().replace(/_/g, '-');
+
   LOCALE_DATA[localeId] = data;
+
   if (extraData) {
     LOCALE_DATA[localeId][LocaleDataIndex.ExtraData] = extraData;
   }

--- a/packages/common/test/i18n/locale_data_api_spec.ts
+++ b/packages/common/test/i18n/locale_data_api_spec.ts
@@ -10,8 +10,12 @@ import localeCaESVALENCIA from '../../locales/ca-ES-VALENCIA';
 import localeEn from '../../locales/en';
 import localeFr from '../../locales/fr';
 import localeFrCA from '../../locales/fr-CA';
-import {findLocaleData} from '../../src/i18n/locale_data_api';
+import localeDeCh from '../../locales/de-CH';
+import localeDeChExtra from '../../locales/extra/de-CH';
+import localeIt from '../../locales/it';
+import localeItExtra from '../../locales/extra/it';
 import {registerLocaleData} from '../../src/i18n/locale_data';
+import {findLocaleData} from '../../src/i18n/locale_data_api';
 
 export function main() {
   describe('locale data api', () => {
@@ -20,6 +24,10 @@ export function main() {
       registerLocaleData(localeEn);
       registerLocaleData(localeFr);
       registerLocaleData(localeFrCA);
+      registerLocaleData(localeDeCh, undefined, localeDeChExtra);
+      registerLocaleData(localeIt, localeItExtra);
+      registerLocaleData(localeFr, 'fake-id');
+      registerLocaleData(localeFrCA, 'fake_Id2');
     });
 
     describe('findLocaleData', () => {
@@ -32,8 +40,11 @@ export function main() {
       it('should return english data if the locale is en-US',
          () => { expect(findLocaleData('en-US')).toEqual(localeEn); });
 
-      it('should return the exact LOCALE_DATA if it is available',
-         () => { expect(findLocaleData('fr-CA')).toEqual(localeFrCA); });
+      it('should return the exact LOCALE_DATA if it is available', () => {
+        expect(findLocaleData('fr-CA')).toEqual(localeFrCA);
+        expect(findLocaleData('de-CH')).toEqual(localeDeCh);
+        expect(findLocaleData('it')).toEqual(localeIt);
+      });
 
       it('should return the parent LOCALE_DATA if it exists and exact locale is not available',
          () => { expect(findLocaleData('fr-BE')).toEqual(localeFr); });
@@ -41,6 +52,12 @@ export function main() {
       it(`should find the LOCALE_DATA even if the locale id is badly formatted`, () => {
         expect(findLocaleData('ca-ES-VALENCIA')).toEqual(localeCaESVALENCIA);
         expect(findLocaleData('CA_es_Valencia')).toEqual(localeCaESVALENCIA);
+      });
+
+      it(`should find the LOCALE_DATA if the locale id was registered`, () => {
+        expect(findLocaleData('fake-id')).toEqual(localeFr);
+        expect(findLocaleData('fake_iD')).toEqual(localeFr);
+        expect(findLocaleData('fake-id2')).toEqual(localeFrCA);
       });
     });
   });

--- a/tools/gulp-tasks/cldr/closure.js
+++ b/tools/gulp-tasks/cldr/closure.js
@@ -143,8 +143,7 @@ switch (goog.LOCALE) {
 ${LOCALES.map(locale => generateCases(locale)).join('')}}
 
 if(l) {
-  l[0] = goog.LOCALE;
-  registerLocaleData(l);
+  registerLocaleData(l, goog.LOCALE);
 }
 `;
   // clang-format on

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -422,7 +422,7 @@ export interface PopStateEvent {
 }
 
 /** @experimental */
-export declare function registerLocaleData(data: any, extraData?: any): void;
+export declare function registerLocaleData(data: any, localeId?: string | any, extraData?: any): void;
 
 /** @stable */
 export declare class SlicePipe implements PipeTransform {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Feature
```

## What is the current behavior?
Registering locale data uses the locale id that it contains, and we then use the value of the token LOCALE_ID to find those data when needed.

Issue Number: Fixes #20340, Fixes https://github.com/angular/material2/issues/8268


## What is the new behavior?
By default it has the same behavior, but you can also use the second parameter from the `registerLocaleData` function to set the locale id that we should use.
This allow people to set LOCALE_ID to the value that they want (e.g.: to use a custom locale id, such as old versions not supported by Angular) and still be able to make i18n pipes work with the locale data that they registered.


## Does this PR introduce a breaking change?
```
[x] No
```

Note: @vicb I couldn't overload the existing signature because this only works with classes, since we only export one of the functions, the api generation was ignoring the other signatures.