### PR TITLE
build(common): export locale data as commonjs instead of es2015

### DIFF
--- a/packages/common/locales/tsconfig-build.json
+++ b/packages/common/locales/tsconfig-build.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "stripInternal": true,
     "experimentalDecorators": true,
-    "module": "es2015",
+    "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "../../../dist/packages/common/locales",
     "paths": {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Build related changes
```

## What is the current behavior?
We build the locale data files as es2015 which won't work in old browsers without recompiling the files first, and it is very annoying when you want to lazy load the files or use them in plunkr


## What is the new behavior?
We build the files as commonjs instead, the change in the generated file is minimal: instead of `export default [ ... ]` it does `export.default = [ ... ]` which will work in old browsers.
At first I wanted to offer both formats, but it makes no sense given that we don't have a package.json per locale file to point to the correct location automatically (es2015 or commonjs), and the difference is so minimal that it doesn't impact treeshacking or bundling.


## Does this PR introduce a breaking change?
```
[x] No
```

@IgorMinar It shouldn't break anything, all tools and browsers support commonjs. If you still think it's risky you can change the target to master instead of "master & patch"