### PR TITLE
fix(core): fix #20582, don't need to wrap zone in location change listener

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -34,8 +34,6 @@ import {UrlSerializer, UrlTree, containsTree, createEmptyUrlTree} from './url_tr
 import {forEach} from './utils/collection';
 import {TreeNode, nodeChildrenAsMap} from './utils/tree';
 
-declare let Zone: any;
-
 /**
  * @whatItDoes Represents the extra options used during navigation.
  *
@@ -306,10 +304,11 @@ export class Router {
    * Sets up the location change listener.
    */
   setUpLocationChangeListener(): void {
-    // Zone.current.wrap is needed because of the issue with RxJS scheduler,
-    // which does not work properly with zone.js in IE and Safari
+    // Don't need to use Zone.wrap any more, because zone.js
+    // already patch onPopState, so location change callback will
+    // run into ngZone
     if (!this.locationSubscription) {
-      this.locationSubscription = <any>this.location.subscribe(Zone.current.wrap((change: any) => {
+      this.locationSubscription = <any>this.location.subscribe((change: any) => {
         const rawUrlTree = this.urlSerializer.parse(change['url']);
         const source: NavigationTrigger = change['type'] === 'popstate' ? 'popstate' : 'hashchange';
         const state = change.state && change.state.navigationId ?
@@ -317,7 +316,7 @@ export class Router {
             null;
         setTimeout(
             () => { this.scheduleNavigation(rawUrlTree, source, state, {replaceUrl: true}); }, 0);
-      }));
+      });
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 20582


## What is the new behavior?
remove `Zone.current.wrap` in `router.ts` when `setUpLocationChangeListener`, because 
`zone.js` already patch `onPopState`, so location change listener will always run in ngZone.
https://github.com/angular/angular/blob/master/packages/common/src/location/location.ts#L55

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information