### PR TITLE
fix(forms): no longers marks fields neede by templates as internal

### DIFF
--- a/packages/compiler-cli/test/diagnostics/check_types_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/check_types_spec.ts
@@ -114,6 +114,30 @@ describe('ng type checker', () => {
         export class MainModule {}`
       });
     });
+
+    // #19905
+    it('should accept references the default module', () => {
+      a({
+        'src/app.component.ts': '',
+        'src/lib.ts': '',
+        'src/app.module.ts': `
+        import {NgModule, Component} from '@angular/core';
+        import {CommonModule} from '@angular/common';
+        import {FormsModule} from '@angular/forms';
+
+        @Component({
+          selector: 'test-comp',
+          template: '<form> <input name="first" ngModel required #first="ngModel"> </form>'
+        })
+        export class TestComponent { }
+
+        @NgModule({
+          declarations: [TestComponent],
+          imports: [CommonModule, FormsModule]
+        })
+        export class MainModule {}`
+      });
+    });
   });
 
   describe('with modified quickstart (fullTemplateTypeCheck: false)', () => {

--- a/packages/forms/src/directives/default_value_accessor.ts
+++ b/packages/forms/src/directives/default_value_accessor.ts
@@ -83,17 +83,17 @@ export class DefaultValueAccessor implements ControlValueAccessor {
     this._renderer.setProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
   }
 
-  /** @internal */
+  /* tslint:disable-next-line */
   _handleInput(value: any): void {
     if (!this._compositionMode || (this._compositionMode && !this._composing)) {
       this.onChange(value);
     }
   }
 
-  /** @internal */
+  /* tslint:disable-next-line */
   _compositionStart(): void { this._composing = true; }
 
-  /** @internal */
+  /* tslint:disable-next-line */
   _compositionEnd(value: any): void {
     this._composing = false;
     this._compositionMode && this.onChange(value);

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -146,6 +146,9 @@ export declare class DefaultValueAccessor implements ControlValueAccessor {
     onChange: (_: any) => void;
     onTouched: () => void;
     constructor(_renderer: Renderer2, _elementRef: ElementRef, _compositionMode: boolean);
+    _compositionEnd(value: any): void;
+    _compositionStart(): void;
+    _handleInput(value: any): void;
     registerOnChange(fn: (_: any) => void): void;
     registerOnTouched(fn: () => void): void;
     setDisabledState(isDisabled: boolean): void;


### PR DESCRIPTION
Marking fields referenced by decorators  as internal causes
them to be reported as undefined when using `fullTemplateTypCheck`.


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue Number: 19905

When `fullTemplateTypeCheck` is enabled, using the `DefaultValueAccessor` causes errors.

## What is the new behavior?

Using `DefaultValueAccessor` no longer produces errors.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
