### PR TITLE
fix(language-service): Allow empty templates

### DIFF
--- a/packages/language-service/src/diagnostics.ts
+++ b/packages/language-service/src/diagnostics.ts
@@ -71,9 +71,12 @@ export function getDeclarationDiagnostics(
           report(
               `Component '${declaration.type.name}' is not included in a module and will not be available inside a template. Consider adding it to a NgModule declaration`);
         }
-        if (!declaration.metadata.template !.template &&
-            !declaration.metadata.template !.templateUrl) {
-          report(`Component ${declaration.type.name} must have a template or templateUrl`);
+        const {template, templateUrl} = declaration.metadata.template !;
+        if (template === null && !templateUrl) {
+          report(`Component '${declaration.type.name}' must have a template or templateUrl`);
+        } else if (template && templateUrl) {
+          report(
+              `Component '${declaration.type.name}' must not have both template and templateUrl`);
         }
       } else {
         if (!directives) {

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -175,6 +175,22 @@ describe('diagnostics', () => {
       });
     });
 
+    // Issue #19406
+    it('should allow empty template', () => {
+      const appComponent = `
+        import { Component } from '@angular/core';
+
+        @Component({
+          template : '',
+        })
+        export class AppComponent {}
+      `;
+      const fileName = '/app/app.component.ts';
+      mockHost.override(fileName, appComponent);
+      const diagnostics = ngService.getDiagnostics(fileName);
+      expect(diagnostics).toEqual([]);
+    });
+
     // Issue #15460
     it('should be able to find members defined on an ancestor type', () => {
       const app_component = `


### PR DESCRIPTION
Fixes the bug where templates with empty strings show up as error in the editor.

PR Close #19406

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Component with empty template shows up as error.
Issue Number: 19406


## What is the new behavior?
Empty template is now allowed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
