### PR TITLE
fix(core): should check Zone existance when scheduleMicroTask

### DIFF
--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -21,6 +21,8 @@ const __self = typeof self !== 'undefined' && typeof WorkerGlobalScope !== 'unde
     self instanceof WorkerGlobalScope && self;
 const __global = typeof global !== 'undefined' && global;
 const _global: {[name: string]: any} = __window || __global || __self;
+
+const promise: Promise<any> = Promise.resolve(0);
 /**
  * Attention: whenever providing a new value, be sure to add an
  * entry into the corresponding `....externs.js` file,
@@ -52,7 +54,12 @@ export function getSymbolIterator(): string|symbol {
 }
 
 export function scheduleMicroTask(fn: Function) {
-  Zone.current.scheduleMicroTask('scheduleMicrotask', fn);
+  if (typeof Zone === 'undefined') {
+    // use promise to schedule microTask instead of use Zone
+    promise.then(() => { fn && fn.apply(null, null); });
+  } else {
+    Zone.current.scheduleMicroTask('scheduleMicrotask', fn);
+  }
 }
 
 // JS has NaN !== NaN

--- a/packages/platform-browser/animations/src/animation_renderer.ts
+++ b/packages/platform-browser/animations/src/animation_renderer.ts
@@ -19,6 +19,7 @@ export class AnimationRendererFactory implements RendererFactory2 {
   private _animationCallbacksBuffer: [(e: any) => any, any][] = [];
   private _rendererCache = new Map<Renderer2, BaseAnimationRenderer>();
   private _cdRecurDepth = 0;
+  private promise: Promise<any> = Promise.resolve(0);
 
   constructor(
       private delegate: RendererFactory2, private engine: AnimationEngine, private _zone: NgZone) {
@@ -69,7 +70,8 @@ export class AnimationRendererFactory implements RendererFactory2 {
   }
 
   private _scheduleCountTask() {
-    Zone.current.scheduleMicroTask('incremenet the animation microtask', () => this._microtaskId++);
+    // always use promise to schedule microtask instead of use Zone
+    this.promise.then(() => { this._microtaskId++; });
   }
 
   /* @internal */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When use `noop ngZone` and `not` import `zone.js`, `Zone.current` will throw TypeError,
in current code, there are still several places call `Zone.current.scheduleMicroTask` directly, so 
we need to check `typeof Zone` is undefined or not, if `Zone` not exist, use `Promise.then` instead.

## What is the new behavior?

 if `Zone` not exist, use `Promise.then` instead.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information