### PR TITLE
fix(compiler): correctly detect when to serialze summary metadata

### DIFF
--- a/packages/compiler/src/aot/summary_serializer.ts
+++ b/packages/compiler/src/aot/summary_serializer.ts
@@ -11,7 +11,7 @@ import {Summary, SummaryResolver} from '../summary_resolver';
 import {OutputContext, ValueTransformer, ValueVisitor, visitValue} from '../util';
 
 import {StaticSymbol, StaticSymbolCache} from './static_symbol';
-import {ResolvedStaticSymbol, StaticSymbolResolver} from './static_symbol_resolver';
+import {ResolvedStaticSymbol, StaticSymbolResolver, unwrapResolvedMetadata} from './static_symbol_resolver';
 import {isLoweredSymbol, ngfactoryFilePath, summaryForJitFileName, summaryForJitName} from './util';
 
 export function serializeSummaries(
@@ -453,10 +453,10 @@ function isCall(metadata: any): boolean {
 }
 
 function isFunctionCall(metadata: any): boolean {
-  return isCall(metadata) && metadata.expression instanceof StaticSymbol;
+  return isCall(metadata) && unwrapResolvedMetadata(metadata.expression) instanceof StaticSymbol;
 }
 
 function isMethodCallOnVariable(metadata: any): boolean {
   return isCall(metadata) && metadata.expression && metadata.expression.__symbolic === 'select' &&
-      metadata.expression.expression instanceof StaticSymbol;
+      unwrapResolvedMetadata(metadata.expression.expression) instanceof StaticSymbol;
 }

--- a/packages/compiler/test/aot/summary_serializer_spec.ts
+++ b/packages/compiler/test/aot/summary_serializer_spec.ts
@@ -430,5 +430,41 @@ export function main() {
         importAs: symbolCache.get('someFile.ngfactory.d.ts', 'lib_1')
       }]);
     });
+
+    describe('with resolved symbols', () => {
+      it('should be able to serialize a call', () => {
+        init();
+        const serialized = serializeSummaries(
+            'someFile.ts', createMockOutputContext(), summaryResolver, symbolResolver, [{
+              symbol: symbolCache.get('/tmp/test.ts', 'main'),
+              metadata: {
+                __symbolic: 'call',
+                expression:
+                    {__symbolic: 'resolved', symbol: symbolCache.get('/tmp/test2.ts', 'ref')}
+              }
+            }],
+            []);
+        expect(serialized.json).not.toContain('error');
+      });
+
+      it('should be able to serialize a call to a method', () => {
+        init();
+        const serialized = serializeSummaries(
+            'someFile.ts', createMockOutputContext(), summaryResolver, symbolResolver, [{
+              symbol: symbolCache.get('/tmp/test.ts', 'main'),
+              metadata: {
+                __symbolic: 'call',
+                expression: {
+                  __symbolic: 'select',
+                  expression:
+                      {__symbolic: 'resolved', symbol: symbolCache.get('/tmp/test2.ts', 'ref')},
+                  name: 'foo'
+                }
+              }
+            }],
+            []);
+        expect(serialized.json).not.toContain('error');
+      });
+    });
   });
 }


### PR DESCRIPTION
The change to improve error messages broke the summary serialization
of summaries.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Serialization of summaries was broken by change to improve reflector errors. It incorrectly dropped calls that were previously supported.

## What is the new behavior?

The calls previously dropped are now correctly serialized.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
