### PR TITLE
fix(core): should use native addEventListener in ngZone

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -10,6 +10,12 @@
   },
   "hello_world__closure": {
     "master": {
+      "gzip7": {
+        "bundle": 33190
+      },
+      "gzip9": {
+        "bundle": 33162
+      },
       "uncompressed": {
         "bundle": "TODO(i): temporarily increase the payload size limit from 105779 - this is due to a closure issue related to ESM reexports that still needs to be investigated",
         "bundle": 178101

--- a/packages/platform-browser/test/dom/events/event_manager_spec.ts
+++ b/packages/platform-browser/test/dom/events/event_manager_spec.ts
@@ -284,7 +284,7 @@ import {el} from '../../../testing/src/browser_util';
       });
       getDOM().dispatchEvent(element, dispatchedEvent);
       expect(receivedEvents).toEqual([dispatchedEvent, dispatchedEvent]);
-      expect(receivedZones).toEqual([Zone.root.name, 'fakeAngularZone']);
+      expect(receivedZones).toEqual([Zone.root.name, 'angular']);
 
       receivedEvents = [];
       remover1 && remover1();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 20673
fix #20673

in #18993, there is an optimized version of `addEventListener`, but I used the wrong `addEventListener` when we run in `ngZone`, we should use native `addEventListener` to get better performance when the handler was added in `ngZone`.

And the other issue is in #18993, we support `BLACK_LISTED_EVENTS`, and if an event is blacklisted, it should not run in `angular` zone, but current version it will not work.

## What is the new behavior?
When event handler was added in `angular zone`, use `non patched` addEventListener to get better performance.

And `BLACK_LISTED_EVENTS` should work and run outside of angular zone.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
@mhevery , please review, thank you!