### PR TITLE
feat(router): add "paramsInheritanceStrategy" router configuration option

### DIFF
--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -12,7 +12,7 @@ import {Observer} from 'rxjs/Observer';
 import {of } from 'rxjs/observable/of';
 
 import {Data, ResolveData, Route, Routes} from './config';
-import {ActivatedRouteSnapshot, RouterStateSnapshot, inheritedParamsDataResolve} from './router_state';
+import {ActivatedRouteSnapshot, ParamsInheritanceStrategy, RouterStateSnapshot, inheritedParamsDataResolve} from './router_state';
 import {PRIMARY_OUTLET, defaultUrlMatcher} from './shared';
 import {UrlSegment, UrlSegmentGroup, UrlTree, mapChildrenIntoArray} from './url_tree';
 import {forEach, last} from './utils/collection';
@@ -21,15 +21,17 @@ import {TreeNode} from './utils/tree';
 class NoMatch {}
 
 export function recognize(
-    rootComponentType: Type<any>| null, config: Routes, urlTree: UrlTree,
-    url: string): Observable<RouterStateSnapshot> {
-  return new Recognizer(rootComponentType, config, urlTree, url).recognize();
+    rootComponentType: Type<any>| null, config: Routes, urlTree: UrlTree, url: string,
+    paramsInheritanceStrategy: ParamsInheritanceStrategy =
+        'emptyOnly'): Observable<RouterStateSnapshot> {
+  return new Recognizer(rootComponentType, config, urlTree, url, paramsInheritanceStrategy)
+      .recognize();
 }
 
 class Recognizer {
   constructor(
       private rootComponentType: Type<any>|null, private config: Routes, private urlTree: UrlTree,
-      private url: string) {}
+      private url: string, private paramsInheritanceStrategy: ParamsInheritanceStrategy) {}
 
   recognize(): Observable<RouterStateSnapshot> {
     try {
@@ -55,7 +57,7 @@ class Recognizer {
   inheritParamsAndData(routeNode: TreeNode<ActivatedRouteSnapshot>): void {
     const route = routeNode.value;
 
-    const i = inheritedParamsDataResolve(route);
+    const i = inheritedParamsDataResolve(route, this.paramsInheritanceStrategy);
     route.params = Object.freeze(i.params);
     route.data = Object.freeze(i.data);
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -27,7 +27,7 @@ import {recognize} from './recognize';
 import {DefaultRouteReuseStrategy, DetachedRouteHandleInternal, RouteReuseStrategy} from './route_reuse_strategy';
 import {RouterConfigLoader} from './router_config_loader';
 import {ChildrenOutletContexts} from './router_outlet_context';
-import {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot, advanceActivatedRoute, createEmptyState} from './router_state';
+import {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot, advanceActivatedRoute, createEmptyState, inheritedParamsDataResolve} from './router_state';
 import {Params, isNavigationCancelingError} from './shared';
 import {DefaultUrlHandlingStrategy, UrlHandlingStrategy} from './url_handling_strategy';
 import {UrlSerializer, UrlTree, containsTree, createEmptyUrlTree} from './url_tree';
@@ -248,6 +248,16 @@ export class Router {
    * current URL. Default is 'ignore'.
    */
   onSameUrlNavigation: 'reload'|'ignore' = 'ignore';
+
+  /**
+   * Defines how the router merges params, data and resolved data from parent to child
+   * routes. Available options are:
+   *
+   * - `'emptyOnly'`, the default, only inherits parent params for path-less or component-less
+   *   routes.
+   * - `'always'`, enables unconditional inheritance of parent params.
+   */
+  paramsInheritanceStrategy: 'emptyOnly'|'always' = 'emptyOnly';
 
   /**
    * Creates the router service.
@@ -611,7 +621,8 @@ export class Router {
         urlAndSnapshot$ = mergeMap.call(redirectsApplied$, (appliedUrl: UrlTree) => {
           return map.call(
               recognize(
-                  this.rootComponentType, this.config, appliedUrl, this.serializeUrl(appliedUrl)),
+                  this.rootComponentType, this.config, appliedUrl, this.serializeUrl(appliedUrl),
+                  this.paramsInheritanceStrategy),
               (snapshot: any) => {
 
                 (this.events as Subject<Event>)
@@ -667,7 +678,7 @@ export class Router {
             if (p.shouldActivate && preActivation.isActivating()) {
               this.triggerEvent(
                   new ResolveStart(id, this.serializeUrl(url), p.appliedUrl, p.snapshot));
-              return map.call(preActivation.resolveData(), () => {
+              return map.call(preActivation.resolveData(this.paramsInheritanceStrategy), () => {
                 this.triggerEvent(
                     new ResolveEnd(id, this.serializeUrl(url), p.appliedUrl, p.snapshot));
                 return p;

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -278,6 +278,16 @@ export interface ExtraOptions {
    * current URL. Default is 'ignore'.
    */
   onSameUrlNavigation?: 'reload'|'ignore';
+
+  /**
+   * Defines how the router merges params, data and resolved data from parent to child
+   * routes. Available options are:
+   *
+   * - `'emptyOnly'`, the default, only inherits parent params for path-less or component-less
+   *   routes.
+   * - `'always'`, enables unconditional inheritance of parent params.
+   */
+  paramsInheritanceStrategy?: 'emptyOnly'|'always';
 }
 
 export function setupRouter(
@@ -312,6 +322,10 @@ export function setupRouter(
 
   if (opts.onSameUrlNavigation) {
     router.onSameUrlNavigation = opts.onSameUrlNavigation;
+  }
+
+  if (opts.paramsInheritanceStrategy) {
+    router.paramsInheritanceStrategy = opts.paramsInheritanceStrategy;
   }
 
   return router;

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -3794,6 +3794,19 @@ describe('Integration', () => {
   });
 });
 
+describe('Testing router options', () => {
+  describe('paramsInheritanceStrategy', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule(
+          {imports: [RouterTestingModule.withRoutes([], {paramsInheritanceStrategy: 'always'})]});
+    });
+
+    it('should configure the router', fakeAsync(inject([Router], (router: Router) => {
+         expect(router.paramsInheritanceStrategy).toEqual('always');
+       })));
+  });
+});
+
 function expectEvents(events: Event[], pairs: any[]) {
   expect(events.length).toEqual(pairs.length);
   for (let i = 0; i < events.length; ++i) {

--- a/packages/router/test/router.spec.ts
+++ b/packages/router/test/router.spec.ts
@@ -498,7 +498,7 @@ function checkResolveData(
     future: RouterStateSnapshot, curr: RouterStateSnapshot, injector: any, check: any): void {
   const p = new PreActivation(future, curr, injector);
   p.initialize(new ChildrenOutletContexts());
-  p.resolveData().subscribe(check, (e) => { throw e; });
+  p.resolveData('emptyOnly').subscribe(check, (e) => { throw e; });
 }
 
 function checkGuards(

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -9,7 +9,7 @@
 import {Location, LocationStrategy} from '@angular/common';
 import {MockLocationStrategy, SpyLocation} from '@angular/common/testing';
 import {Compiler, Injectable, Injector, ModuleWithProviders, NgModule, NgModuleFactory, NgModuleFactoryLoader, Optional} from '@angular/core';
-import {ChildrenOutletContexts, NoPreloading, PreloadingStrategy, ROUTES, Route, Router, RouterModule, Routes, UrlHandlingStrategy, UrlSerializer, provideRoutes, ɵROUTER_PROVIDERS as ROUTER_PROVIDERS, ɵflatten as flatten} from '@angular/router';
+import {ChildrenOutletContexts, ExtraOptions, NoPreloading, PreloadingStrategy, ROUTER_CONFIGURATION, ROUTES, Route, Router, RouterModule, Routes, UrlHandlingStrategy, UrlSerializer, provideRoutes, ɵROUTER_PROVIDERS as ROUTER_PROVIDERS, ɵflatten as flatten} from '@angular/router';
 
 
 
@@ -76,6 +76,13 @@ export class SpyNgModuleFactoryLoader implements NgModuleFactoryLoader {
   }
 }
 
+function isUrlHandlingStrategy(opts: ExtraOptions | UrlHandlingStrategy):
+    opts is UrlHandlingStrategy {
+  // This property check is needed because UrlHandlingStrategy is an interface and doesn't exist at
+  // runtime.
+  return 'shouldProcessUrl' in opts;
+}
+
 /**
  * Router setup factory function used for testing.
  *
@@ -84,9 +91,39 @@ export class SpyNgModuleFactoryLoader implements NgModuleFactoryLoader {
 export function setupTestingRouter(
     urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location,
     loader: NgModuleFactoryLoader, compiler: Compiler, injector: Injector, routes: Route[][],
-    urlHandlingStrategy?: UrlHandlingStrategy) {
+    opts?: ExtraOptions, urlHandlingStrategy?: UrlHandlingStrategy): Router;
+
+/**
+ * Router setup factory function used for testing.
+ *
+ * @deprecated As of v5.2. The 2nd-to-last argument should be `ExtraOptions`, not
+ * `UrlHandlingStrategy`
+ */
+export function setupTestingRouter(
+    urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location,
+    loader: NgModuleFactoryLoader, compiler: Compiler, injector: Injector, routes: Route[][],
+    urlHandlingStrategy?: UrlHandlingStrategy): Router;
+
+/**
+ * Router setup factory function used for testing.
+ *
+ * @stable
+ */
+export function setupTestingRouter(
+    urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location,
+    loader: NgModuleFactoryLoader, compiler: Compiler, injector: Injector, routes: Route[][],
+    opts?: ExtraOptions | UrlHandlingStrategy, urlHandlingStrategy?: UrlHandlingStrategy) {
   const router = new Router(
       null !, urlSerializer, contexts, location, injector, loader, compiler, flatten(routes));
+  // Handle deprecated argument ordering.
+  if (opts) {
+    if (isUrlHandlingStrategy(opts)) {
+      router.urlHandlingStrategy = opts;
+    } else if (opts.paramsInheritanceStrategy) {
+      router.paramsInheritanceStrategy = opts.paramsInheritanceStrategy;
+    }
+  }
+
   if (urlHandlingStrategy) {
     router.urlHandlingStrategy = urlHandlingStrategy;
   }
@@ -128,14 +165,20 @@ export function setupTestingRouter(
       useFactory: setupTestingRouter,
       deps: [
         UrlSerializer, ChildrenOutletContexts, Location, NgModuleFactoryLoader, Compiler, Injector,
-        ROUTES, [UrlHandlingStrategy, new Optional()]
+        ROUTES, ROUTER_CONFIGURATION, [UrlHandlingStrategy, new Optional()]
       ]
     },
     {provide: PreloadingStrategy, useExisting: NoPreloading}, provideRoutes([])
   ]
 })
 export class RouterTestingModule {
-  static withRoutes(routes: Routes): ModuleWithProviders {
-    return {ngModule: RouterTestingModule, providers: [provideRoutes(routes)]};
+  static withRoutes(routes: Routes, config?: ExtraOptions): ModuleWithProviders {
+    return {
+      ngModule: RouterTestingModule,
+      providers: [
+        provideRoutes(routes),
+        {provide: ROUTER_CONFIGURATION, useValue: config ? config : {}},
+      ]
+    };
   }
 }

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -127,6 +127,7 @@ export interface ExtraOptions {
     errorHandler?: ErrorHandler;
     initialNavigation?: InitialNavigation;
     onSameUrlNavigation?: 'reload' | 'ignore';
+    paramsInheritanceStrategy?: 'emptyOnly' | 'always';
     preloadingStrategy?: any;
     useHash?: boolean;
 }
@@ -329,6 +330,7 @@ export declare class Router {
     readonly events: Observable<Event>;
     navigated: boolean;
     onSameUrlNavigation: 'reload' | 'ignore';
+    paramsInheritanceStrategy: 'emptyOnly' | 'always';
     routeReuseStrategy: RouteReuseStrategy;
     readonly routerState: RouterState;
     readonly url: string;


### PR DESCRIPTION
Previously, the router would merge path and matrix params, as well as
data/resolve, with special rules (only merging down when the route has
an empty path, or is component-less). This change adds an extra option
"alwaysInheritParams" which makes child routes unconditionally inherit
params from parent routes.

Closes #20572.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #20572


## What is the new behavior?
Adds an `alwaysInheritParams` extra option when configuring the router, which changes parameter inheritance to always merge from parent routes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
