### PR TITLE
[wip] feat(core): introduce ComponentLifecycle

### DIFF
--- a/packages/compiler/src/identifiers.ts
+++ b/packages/compiler/src/identifiers.ts
@@ -28,6 +28,7 @@ export class Identifiers {
   };
   static QueryList: o.ExternalReference = {name: 'QueryList', moduleName: CORE};
   static TemplateRef: o.ExternalReference = {name: 'TemplateRef', moduleName: CORE};
+  static ComponentLifecycle: o.ExternalReference = {name: 'ComponentLifecycle', moduleName: CORE};
   static CodegenComponentFactoryResolver: o.ExternalReference = {
     name: 'ɵCodegenComponentFactoryResolver',
     moduleName: CORE,

--- a/packages/compiler/src/provider_analyzer.ts
+++ b/packages/compiler/src/provider_analyzer.ts
@@ -243,7 +243,10 @@ export class ProviderElementContext {
                 this.viewContext.reflector.resolveExternalReference(
                     Identifiers.ChangeDetectorRef) ||
             tokenReference(dep.token) ===
-                this.viewContext.reflector.resolveExternalReference(Identifiers.TemplateRef)) {
+                this.viewContext.reflector.resolveExternalReference(Identifiers.TemplateRef) ||
+            tokenReference(dep.token) ===
+                this.viewContext.reflector.resolveExternalReference(
+                    Identifiers.ComponentLifecycle)) {
           return dep;
         }
         if (tokenReference(dep.token) ===

--- a/packages/core/src/linker.ts
+++ b/packages/core/src/linker.ts
@@ -10,6 +10,7 @@
 export {COMPILER_OPTIONS, Compiler, CompilerFactory, CompilerOptions, ModuleWithComponentFactories} from './linker/compiler';
 export {ComponentFactory, ComponentRef} from './linker/component_factory';
 export {ComponentFactoryResolver} from './linker/component_factory_resolver';
+export {ComponentLifecycle} from './linker/component_lifecycle';
 export {ElementRef} from './linker/element_ref';
 export {NgModuleFactory, NgModuleRef} from './linker/ng_module_factory';
 export {NgModuleFactoryLoader, getModuleFactory} from './linker/ng_module_factory_loader';

--- a/packages/core/src/linker/component_lifecycle.ts
+++ b/packages/core/src/linker/component_lifecycle.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Subject} from 'rxjs/Subject';
+
+import {SimpleChanges} from '../change_detection/change_detection';
+
+
+/**
+ * An accessor to a component's lifecycle events as observables.
+ *
+ * ```
+ * @Component({
+ *   selector: 'some-cmp',
+ *   template: `
+ *   <div *ngIf="init$ | async">...</div>
+ *   `})
+ * export class SomeCmp {
+ *   init$: Observable<void>;
+ *   constructor(private lifecycle: ComponentLifecycle, private someService: any) {
+ *     // Get an observable that emits an event when the component is created.
+ *     this.init$ = this.lifecycle.onInit;
+ *   }
+ *
+ *   ngOnInit() {
+ *     this.someService.events$
+ *      .pipe(
+ *        // Unsubscribe the observable automatically when the component is destroyed.
+ *        takeUntil(this.lifecycle.onDestroy),
+ *      )
+ *      .subscribe(event => {});
+ *   }
+ * }
+ * ```
+ *
+ * @experimental
+ */
+export class ComponentLifecycle {
+  /**
+   * An observable form of ngOnInit lifecycle event
+   * @experimental
+   */
+  readonly onInit = new Subject<void>();
+  /**
+   * An observable form of ngOnChanges lifecycle event
+   * @experimental
+   */
+  readonly onChanges = new Subject<SimpleChanges>();
+  /**
+   * An observable form of ngAfterContentInit lifecycle event
+   * @experimental
+   */
+  readonly afterContentInit = new Subject<void>();
+  /**
+   * An observable form of ngAfterContentChecked lifecycle event
+   * @experimental
+   */
+  readonly afterContentChecked = new Subject<void>();
+  /**
+   * An observable form of ngAfterViewInit lifecycle event
+   * @experimental
+   */
+  readonly afterViewInit = new Subject<void>();
+  /**
+   * An observable form of ngAfterViewChecked lifecycle event
+   * @experimental
+   */
+  readonly afterViewChecked = new Subject<void>();
+  /**
+   * An observable form of ngOnDestroy lifecycle event
+   * @experimental
+   */
+  readonly onDestroy = new Subject<void>();
+}

--- a/packages/core/src/view/provider.ts
+++ b/packages/core/src/view/provider.ts
@@ -8,6 +8,7 @@
 
 import {ChangeDetectorRef, SimpleChange, SimpleChanges, WrappedValue} from '../change_detection/change_detection';
 import {Injector, resolveForwardRef} from '../di';
+import {ComponentLifecycle} from '../linker/component_lifecycle';
 import {ElementRef} from '../linker/element_ref';
 import {TemplateRef} from '../linker/template_ref';
 import {ViewContainerRef} from '../linker/view_container_ref';
@@ -24,6 +25,7 @@ const ViewContainerRefTokenKey = tokenKey(ViewContainerRef);
 const TemplateRefTokenKey = tokenKey(TemplateRef);
 const ChangeDetectorRefTokenKey = tokenKey(ChangeDetectorRef);
 const InjectorRefTokenKey = tokenKey(Injector);
+const ComponentLifecycleTokenKey = tokenKey(ComponentLifecycle);
 
 export function directiveDef(
     checkIndex: number, flags: NodeFlags,
@@ -197,10 +199,17 @@ export function checkAndUpdateDirectiveInline(
   }
   if (changes) {
     directive.ngOnChanges(changes);
+    if (view.lifecycle) {
+      view.lifecycle.onChanges.next(changes);
+    }
   }
-  if ((def.flags & NodeFlags.OnInit) &&
-      shouldCallLifecycleInitHook(view, ViewState.InitState_CallingOnInit, def.nodeIndex)) {
-    directive.ngOnInit();
+  if (shouldCallLifecycleInitHook(view, ViewState.InitState_CallingOnInit, def.nodeIndex)) {
+    if ((def.flags & NodeFlags.OnInit)) {
+      directive.ngOnInit();
+    }
+    if (view.lifecycle) {
+      view.lifecycle.onInit.next();
+    }
   }
   if (def.flags & NodeFlags.DoCheck) {
     directive.ngDoCheck();
@@ -222,10 +231,17 @@ export function checkAndUpdateDirectiveDynamic(
   }
   if (changes) {
     directive.ngOnChanges(changes);
+    if (view.lifecycle) {
+      view.lifecycle.onChanges.next(changes);
+    }
   }
-  if ((def.flags & NodeFlags.OnInit) &&
-      shouldCallLifecycleInitHook(view, ViewState.InitState_CallingOnInit, def.nodeIndex)) {
-    directive.ngOnInit();
+  if (shouldCallLifecycleInitHook(view, ViewState.InitState_CallingOnInit, def.nodeIndex)) {
+    if ((def.flags & NodeFlags.OnInit)) {
+      directive.ngOnInit();
+    }
+    if (view.lifecycle) {
+      view.lifecycle.onInit.next();
+    }
   }
   if (def.flags & NodeFlags.DoCheck) {
     directive.ngDoCheck();
@@ -373,6 +389,9 @@ export function resolveDep(
         }
         case InjectorRefTokenKey:
           return createInjector(view, elDef);
+        case ComponentLifecycleTokenKey:
+          const compView = findCompView(view, elDef, allowPrivateServices);
+          return compView.lifecycle;
         default:
           const providerDef =
               (allowPrivateServices ? elDef.element !.allProviders :
@@ -547,18 +566,33 @@ function callProviderLifecycles(
   if (lifecycles & NodeFlags.AfterContentInit &&
       shouldCallLifecycleInitHook(view, ViewState.InitState_CallingAfterContentInit, initIndex)) {
     provider.ngAfterContentInit();
+    if (view.lifecycle) {
+      view.lifecycle.afterContentInit.next();
+    }
   }
   if (lifecycles & NodeFlags.AfterContentChecked) {
     provider.ngAfterContentChecked();
+    if (view.lifecycle) {
+      view.lifecycle.afterContentChecked.next();
+    }
   }
   if (lifecycles & NodeFlags.AfterViewInit &&
       shouldCallLifecycleInitHook(view, ViewState.InitState_CallingAfterViewInit, initIndex)) {
     provider.ngAfterViewInit();
+    if (view.lifecycle) {
+      view.lifecycle.afterViewInit.next();
+    }
   }
   if (lifecycles & NodeFlags.AfterViewChecked) {
     provider.ngAfterViewChecked();
+    if (view.lifecycle) {
+      view.lifecycle.afterViewChecked.next();
+    }
   }
   if (lifecycles & NodeFlags.OnDestroy) {
     provider.ngOnDestroy();
+    if (view.lifecycle) {
+      view.lifecycle.onDestroy.next();
+    }
   }
 }

--- a/packages/core/src/view/types.ts
+++ b/packages/core/src/view/types.ts
@@ -9,6 +9,7 @@
 import {Injector} from '../di';
 import {ErrorHandler} from '../error_handler';
 import {ComponentFactory} from '../linker/component_factory';
+import {ComponentLifecycle} from '../linker/component_lifecycle';
 import {NgModuleRef} from '../linker/ng_module_factory';
 import {QueryList} from '../linker/query_list';
 import {TemplateRef} from '../linker/template_ref';
@@ -355,6 +356,7 @@ export interface ViewData {
   oldValues: any[];
   disposables: DisposableFn[]|null;
   initIndex: number;
+  lifecycle: ComponentLifecycle|null;
 }
 
 /**


### PR DESCRIPTION
Close #10185

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

This feature is inspired by #10185, "Provide Component Lifecycle Hooks as Observables". 
New `ComponentLifecycle` can bring many benefits. For example...

- Can get `initialized` flag without local boolean property (more async friendly).
- Can avoid memory leaks with `takeUntil` operator (to unsubscribe automatically).
- More reactive Angular

This feature doesn't affect any current behaviors. It's just a new API. 

```ts
@Component({
  selector: 'some-cmp',
  template: `
  <div *ngIf="init$ | async">...</div>
  `})
export class SomeCmp {
  init$: Observable<void>;
  constructor(private lifecycle: ComponentLifecycle, private someService: any) {
    // Get an observable that emits an event when the component is created.
    this.init$ = this.lifecycle.onInit;
  }
  ngOnInit() {
    this.someService.events$
     .pipe(
       // Unsubscribe the observable automatically when the component is destroyed.
       takeUntil(this.lifecycle.onDestroy),
     )
     .subscribe(event => {});
  }
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
