### PR TITLE
ci: fix the payload-size checking scripts

### DIFF
--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -1,3 +1,21 @@
 {
-"aio":{"master":{"change":"application","gzip7":{"inline":925,"main":119519,"polyfills":11863},"gzip9":{"inline":925,"main":119301,"polyfills":11861},"uncompressed":{"inline":1533,"main":486493,"polyfills":37068}}}
+  "aio": {
+    "master": {
+      "gzip7": {
+        "inline": 925,
+        "main": 119519,
+        "polyfills": 11863
+      },
+      "gzip9": {
+        "inline": 925,
+        "main": 119301,
+        "polyfills": 11861
+      },
+      "uncompressed": {
+        "inline": 1533,
+        "main": 486493,
+        "polyfills": 37068
+      }
+    }
+  }
 }

--- a/aio/scripts/payload.sh
+++ b/aio/scripts/payload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/scripts/ci/payload-size.js
+++ b/scripts/ci/payload-size.js
@@ -1,30 +1,32 @@
+'use strict';
 
+// Imports
 const fs = require('fs');
-// Get branch and project name from command line arguments
-const [, , limitFile, project, branch] = process.argv;
 
-const limit = JSON.parse(fs.readFileSync(limitFile, 'utf8'));
-const current = JSON.parse(fs.readFileSync('/tmp/current.log', 'utf8'));
+// Get branch and project name from command line arguments.
+const [, , limitFile, project, branch, commit] = process.argv;
 
+// Load sizes.
+const currentSizes = JSON.parse(fs.readFileSync('/tmp/current.log', 'utf8'));
+const allLimitSizes = JSON.parse(fs.readFileSync(limitFile, 'utf8'));
+const limitSizes = allLimitSizes[project][branch] || allLimitSizes[project]['master'];
 
-const limitData = limit[project][branch] || limit[project]["master"];
-  
-if (!limitData) {
-  console.error(`No limit data found.`);
-  // If no payload limit file found, we don't need to check the size
-  exit(0);
-}
-
+// Check current sizes against limits.
 let failed = false;
-for (let compressionType in limitData) {
-  if (typeof limitData[compressionType] === 'object') {
-    for (let file in limitData[compressionType]) {
-      const name = `${compressionType}/${file}`;
-      const number = limitData[compressionType][file];
-      if (Math.abs(current[name] - number) > number / 100) {
-        console.log(`Commit ${commit} ${compressionType} ${file} changed from ${number} to ${current[name]}.
-            If this is a desired change, please update the payload size limits in file ${limitFile}`);
+for (const compressionType in limitSizes) {
+  if (typeof limitSizes[compressionType] === 'object') {
+    const limitPerFile = limitSizes[compressionType];
+
+    for (const filename in limitPerFile) {
+      const expectedSize = limitPerFile[filename];
+      const actualSize = currentSizes[`${compressionType}/${filename}`];
+
+      if (Math.abs(actualSize - expectedSize) > expectedSize / 100) {
         failed = true;
+        console.log(
+            `Commit ${commit} ${compressionType} ${filename} exceeded expected size by >1% ` +
+            `(expected: ${expectedSize}, actual: ${actualSize}).\n` +
+            `If this is a desired change, please update the size limits in file '${limitFile}'.`);
       }
     }
   }
@@ -33,5 +35,5 @@ for (let compressionType in limitData) {
 if (failed) {
   process.exit(1);
 } else {
-  console.log(`Payload size 1% check okay`);
+  console.log('Payload size <1% change check passed.');
 }


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] CI related changes
```

## What is the current behavior?
When a payload-size limit is exceeded the payload-size checking script breaks while trying to log an error message (due to a missing `commit` variable).
This was accidentally broken in #20524.


## What is the new behavior?
The script doesn't break.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
This commit also does some minor clean-up (improve docs, use more descriptive variable names, remove dead code, etc).