### PR TITLE
feat(aio): preload the initial content for faster TTI

### DIFF
--- a/aio/src/app/documents/document.service.ts
+++ b/aio/src/app/documents/document.service.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs/Observable';
 import { AsyncSubject } from 'rxjs/AsyncSubject';
 import { of } from 'rxjs/observable/of';
 import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/switchMap';
 
 import { DocumentContents } from './document-contents';
@@ -49,7 +50,7 @@ export class DocumentService {
   private getDocument(url: string) {
     const id = url || 'index';
     this.logger.log('getting document', id);
-    if ( !this.cache.has(id)) {
+    if (!this.cache.has(id)) {
       this.cache.set(id, this.fetchDocument(id));
     }
     return this.cache.get(id);
@@ -92,7 +93,7 @@ export class DocumentService {
   private getErrorDoc(id: string, error: HttpErrorResponse): Observable<DocumentContents> {
     this.logger.error('Error fetching document', error);
     this.cache.delete(id);
-    return Observable.of({
+    return of({
       id: FETCHING_ERROR_ID,
       contents: FETCHING_ERROR_CONTENTS
     });

--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -32,6 +32,19 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="translucent">
 
 
+  <!-- Preload initial content -->
+  <script>
+    var relPath = location.pathname.slice(1) || 'index';
+    var fileUrl = 'generated/docs/' + relPath + '.json';
+    var link = document.createElement('link');
+    link.setAttribute('href', fileUrl);
+    link.setAttribute('rel', 'preload');
+    link.setAttribute('as', 'fetch');
+    link.setAttribute('crossorigin', 'anonymous');
+    document.head.appendChild(link);
+  </script>
+
+
   <!-- Google Analytics -->
   <script>
   // Note this is a customised version of the GA tracking snippet to aid e2e testing


### PR DESCRIPTION
Previously, the main bundle needed to be downloaded and parsed before the request for the file containing the content was made.
As pointed out by @samccone in #20666, since it is trivial to infer the filename from the URL, we can save some time by preloading the file that contains the initial content.

Fixes #20666.

##
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] angular.io application / infrastructure changes
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
