### PR TITLE
fix(http): guard against undefined header values

### DIFF
--- a/packages/common/http/src/headers.ts
+++ b/packages/common/http/src/headers.ts
@@ -69,7 +69,7 @@ export class HttpHeaders {
           if (typeof values === 'string') {
             values = [values];
           }
-          if (values.length > 0) {
+          if (values && values.length > 0) {
             this.headers.set(key, values);
             this.maybeSetNormalizedName(name, key);
           }


### PR DESCRIPTION
Headers with undefined values previously caused a TypeError. Now, undefined header values will result in the header value to not be set, but no error will be thrown.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Undefined header values in the Header service constructor would cause a TypeError.
```typescript
headers = new HttpHeaders({foo: undefined});
// TypeError: Cannot read property 'length' of undefined\n
```

Issue Number: N/A


## What is the new behavior?
```typescript
headers = new HttpHeaders({foo: undefined});
headers.get('foo'); // returns null
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
