### PR TITLE
fix(router): respect matrix parameters when determining active route

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -19,7 +19,7 @@ export function containsTree(container: UrlTree, containee: UrlTree, exact: bool
         equalSegmentGroups(container.root, containee.root);
   }
 
-  return containsQueryParams(container.queryParams, containee.queryParams) &&
+  return containsParams(container.queryParams, containee.queryParams) &&
       containsSegmentGroup(container.root, containee.root);
 }
 
@@ -29,7 +29,7 @@ function equalQueryParams(
 }
 
 function equalSegmentGroups(container: UrlSegmentGroup, containee: UrlSegmentGroup): boolean {
-  if (!equalPath(container.segments, containee.segments)) return false;
+  if (!equalSegments(container.segments, containee.segments)) return false;
   if (container.numberOfChildren !== containee.numberOfChildren) return false;
   for (const c in containee.children) {
     if (!container.children[c]) return false;
@@ -38,7 +38,7 @@ function equalSegmentGroups(container: UrlSegmentGroup, containee: UrlSegmentGro
   return true;
 }
 
-function containsQueryParams(
+function containsParams(
     container: {[k: string]: string}, containee: {[k: string]: string}): boolean {
   return Object.keys(containee).length <= Object.keys(container).length &&
       Object.keys(containee).every(key => containee[key] === container[key]);
@@ -52,12 +52,12 @@ function containsSegmentGroupHelper(
     container: UrlSegmentGroup, containee: UrlSegmentGroup, containeePaths: UrlSegment[]): boolean {
   if (container.segments.length > containeePaths.length) {
     const current = container.segments.slice(0, containeePaths.length);
-    if (!equalPath(current, containeePaths)) return false;
+    if (!containsSegments(current, containeePaths)) return false;
     if (containee.hasChildren()) return false;
     return true;
 
   } else if (container.segments.length === containeePaths.length) {
-    if (!equalPath(container.segments, containeePaths)) return false;
+    if (!containsSegments(container.segments, containeePaths)) return false;
     for (const c in containee.children) {
       if (!container.children[c]) return false;
       if (!containsSegmentGroup(container.children[c], containee.children[c])) return false;
@@ -67,10 +67,15 @@ function containsSegmentGroupHelper(
   } else {
     const current = containeePaths.slice(0, container.segments.length);
     const next = containeePaths.slice(container.segments.length);
-    if (!equalPath(container.segments, current)) return false;
+    if (!containsSegments(container.segments, current)) return false;
     if (!container.children[PRIMARY_OUTLET]) return false;
     return containsSegmentGroupHelper(container.children[PRIMARY_OUTLET], containee, next);
   }
+}
+
+function containsSegments(container: UrlSegment[], containee: UrlSegment[]): boolean {
+  return equalPath(container, containee) &&
+      containee.every((segment, i) => containsParams(container[i].parameters, segment.parameters));
 }
 
 /**

--- a/packages/router/test/url_tree.spec.ts
+++ b/packages/router/test/url_tree.spec.ts
@@ -41,6 +41,12 @@ describe('UrlTree', () => {
         expect(containsTree(t1, t2, true)).toBe(true);
       });
 
+      it('should return true when matrixParams are the same', () => {
+        const t1 = serializer.parse('/one/two;id=123;param=test');
+        const t2 = serializer.parse('/one/two;id=123;param=test');
+        expect(containsTree(t1, t2, true)).toBe(true);
+      });
+
       it('should return false when queryParams are not the same', () => {
         const t1 = serializer.parse('/one/two?test=1&page=5');
         const t2 = serializer.parse('/one/two?test=1');
@@ -50,6 +56,24 @@ describe('UrlTree', () => {
       it('should return false when containee is missing queryParams', () => {
         const t1 = serializer.parse('/one/two?page=5');
         const t2 = serializer.parse('/one/two');
+        expect(containsTree(t1, t2, true)).toBe(false);
+      });
+
+      it('should return false when matrixParams are not the same', () => {
+        const t1 = serializer.parse('/one/two;id=123');
+        const t2 = serializer.parse('/one/two;id=456');
+        expect(containsTree(t1, t2, true)).toBe(false);
+      });
+
+      it('should return false when the container is missing matrixParams', () => {
+        const t1 = serializer.parse('/one/two');
+        const t2 = serializer.parse('/one/two;id=123');
+        expect(containsTree(t1, t2, true)).toBe(false);
+      });
+
+      it('should return false when the containee is missing matrixParams', () => {
+        const t1 = serializer.parse('/one/two;id=123;param=test');
+        const t2 = serializer.parse('/one/two;id=456');
         expect(containsTree(t1, t2, true)).toBe(false);
       });
 
@@ -121,8 +145,20 @@ describe('UrlTree', () => {
         expect(containsTree(t1, t2, false)).toBe(true);
       });
 
+      it('should return true when container contains containees matrixParams', () => {
+        const t1 = serializer.parse('/one/two;test=1;u=5');
+        const t2 = serializer.parse('/one/two;u=5');
+        expect(containsTree(t1, t2, false)).toBe(true);
+      });
+
       it('should return true when containee does not have queryParams', () => {
         const t1 = serializer.parse('/one/two?page=5');
+        const t2 = serializer.parse('/one/two');
+        expect(containsTree(t1, t2, false)).toBe(true);
+      });
+
+      it('should return true when containee does not have matrixParams', () => {
+        const t1 = serializer.parse('/one/two;page=5');
         const t2 = serializer.parse('/one/two');
         expect(containsTree(t1, t2, false)).toBe(true);
       });
@@ -133,15 +169,33 @@ describe('UrlTree', () => {
         expect(containsTree(t1, t2, false)).toBe(false);
       });
 
+      it('should return false when containee has but container does not have matrixParams', () => {
+        const t1 = serializer.parse('/one/two');
+        const t2 = serializer.parse('/one/two;page=1');
+        expect(containsTree(t1, t2, false)).toBe(false);
+      });
+
       it('should return false when containee has different queryParams', () => {
         const t1 = serializer.parse('/one/two?page=5');
         const t2 = serializer.parse('/one/two?test=1');
         expect(containsTree(t1, t2, false)).toBe(false);
       });
 
+      it('should return false when containee has different matrixParams', () => {
+        const t1 = serializer.parse('/one/two;page=5');
+        const t2 = serializer.parse('/one/two;test=1');
+        expect(containsTree(t1, t2, false)).toBe(false);
+      });
+
       it('should return false when containee has more queryParams than container', () => {
         const t1 = serializer.parse('/one/two?page=5');
         const t2 = serializer.parse('/one/two?page=5&test=1');
+        expect(containsTree(t1, t2, false)).toBe(false);
+      });
+
+      it('should return false when containee has more matrixParams than container', () => {
+        const t1 = serializer.parse('/one/two;page=5');
+        const t2 = serializer.parse('/one/two;page=5;test=1');
         expect(containsTree(t1, t2, false)).toBe(false);
       });
     });


### PR DESCRIPTION
Matrix parameters are treated like query parameters.

Closes #20698.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #20698 


## What is the new behavior?

Matrix parameters will be treated like query parameters.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
