### PR TITLE
feat(common): add date pipe for ordinal suffix

### DIFF
--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -70,7 +70,8 @@ export const ISO8601_DATE_REGEX =
  *  |                    | ww          | Numeric: 2 digits + zero padded                               | 01... 53                                                   |
  *  | Week of month      | W           | Numeric: 1 digit                                              | 1... 5                                                     |
  *  | Day of month       | d           | Numeric: minimum digits                                       | 1                                                          |
- *  |                    | dd          | Numeric: 2 digits + zero padded                               | 01                                                          |
+ *  |                    | dd          | Numeric: 2 digits + zero padded                               | 01                                                         |
+ *  |                    | ddd         | Day of month with ordinal suffix                              | 1st, 2nd ... 31st                                          |
  *  | Week day           | E, EE & EEE | Abbreviated                                                   | Tue                                                        |
  *  |                    | EEEE        | Wide                                                          | Tuesday                                                    |
  *  |                    | EEEEE       | Narrow                                                        | T                                                          |

--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -96,6 +96,7 @@ export function main() {
           W: '3',
           d: '15',
           dd: '15',
+          ddd: '15th',
           E: 'Mon',
           EE: 'Mon',
           EEE: 'Mon',
@@ -154,6 +155,7 @@ export function main() {
           W: '1',
           d: '1',
           dd: '01',
+          ddd: '1st',
           E: 'Thu',
           EE: 'Thu',
           EEE: 'Thu',
@@ -259,6 +261,21 @@ export function main() {
 
         Object.keys(dateFixtures).forEach((pattern: string) => {
           expect(pipe.transform(date, pattern)).toMatch(dateFixtures[pattern]);
+        });
+      });
+
+      it('should append proper ordinal suffixes', () => {
+        const dateOrdinals: any = {
+          1: '1st',
+          2: '2nd',
+          3: '3rd',
+          23: '23rd',
+          13: '13th',
+        };
+
+        Object.keys(dateOrdinals).forEach((day: string) => {
+          date = new Date(2015, 5, parseInt(day));
+          expectDateFormatAs(date, 'ddd', dateOrdinals[day]);
         });
       });
 


### PR DESCRIPTION
closes #14448

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 14448


## What is the new behavior?
Added a date pipe 'ddd' which will show date with ordinal suffix eg: 2nd

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
