### PR TITLE
fix(router): deactivate outlet if already activated when calling acti…

### DIFF
--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -124,7 +124,7 @@ export class RouterOutlet implements OnDestroy, OnInit {
 
   activateWith(activatedRoute: ActivatedRoute, resolver: ComponentFactoryResolver|null) {
     if (this.isActivated) {
-      throw new Error('Cannot activate an already activated outlet');
+      this.deactivate();
     }
     this._activatedRoute = activatedRoute;
     const snapshot = activatedRoute._futureSnapshot;


### PR DESCRIPTION
fix(router): deactivate outlet if already activated when calling activateWith

Instead of throwing an error, we are now able to deactivate the outlet before activating it again with a new route. This makes routing configuration more flexible when we have named outlets we want to re-use on different routes with nested child routes

Closes #20694

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
I described the current behavior in the issue #20694, the router throws an error when the user tries to navigate from one route `/home` to another `/about` and the routing config is defined as follows:

```
export const routes = [
{
    path: '',
    component: IndexComponent, 
    children: [
        {
            path: 'home',
            children: [
                { path: '', component: FirstComponent, outlet: 'first', data: { state: 'a' } },
                { path: '', component: SecondComponent, outlet: 'second', data: { state: 'b' } }
            ]
        },
        {
            path: 'about', 
            children: [
                { path: '', component: FirstComponent, outlet: 'first', data: { state: 'b' } },
                { path: '', component: SecondComponent, outlet: 'second', data: { state: 'a' } }
            ]
        }
    ]
}
```

Issue Number: #20694 


## What is the new behavior?
With the new behavior, instead of throwing an error, it simply deactivates the current outlet route, before activating the new one.  

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
