### PR TITLE
refactor(animations): instantiate Set-matching code with values in constructor

### DIFF
--- a/packages/animations/browser/src/dsl/animation_transition_expr.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_expr.ts
@@ -65,13 +65,12 @@ function parseAnimationAlias(alias: string, errors: string[]): string|Transition
   }
 }
 
-const TRUE_BOOLEAN_VALUES = new Set<string>();
-TRUE_BOOLEAN_VALUES.add('true');
-TRUE_BOOLEAN_VALUES.add('1');
-
-const FALSE_BOOLEAN_VALUES = new Set<string>();
-FALSE_BOOLEAN_VALUES.add('false');
-FALSE_BOOLEAN_VALUES.add('0');
+// DO NOT REFACTOR ... keep the follow set instantiations
+// with the values intact (closure compiler for some reason
+// removes follow-up lines that add the values outside of
+// the constructor...
+const TRUE_BOOLEAN_VALUES = new Set<string>(['true', '1']);
+const FALSE_BOOLEAN_VALUES = new Set<string>(['false', '0']);
 
 function makeLambdaFromStates(lhs: string, rhs: string): TransitionMatcherFn {
   const LHS_MATCH_BOOLEAN = TRUE_BOOLEAN_VALUES.has(lhs) || FALSE_BOOLEAN_VALUES.has(lhs);


### PR DESCRIPTION
For some reason, prior to this fix, the boolean set matching
code (within `animation_transition_expr.ts`) failed to remain
the same when compiled with closure. This refactor makes sure
that the code stays in tact.

Reproduction Details:
Passes without `ng build --prod`: https://burger.stackblitz.io/
Fails with `ng build --prod`: http://burger.fxck.cz/

Closes #20374