### PR TITLE
feat(common): string value support for `options.params` && basic datatypes support for map values

### DIFF
--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -19,6 +19,11 @@ import {HttpParams, HttpParamsOptions} from './params';
 import {HttpRequest} from './request';
 import {HttpEvent, HttpResponse} from './response';
 
+/**
+ * @type HttpRequestQueryParams
+ */
+export type URLQueryParams =
+    HttpParams | {[param: string]: string | number | boolean | null | (string | number)[]} | string;
 
 /**
  * Construct an instance of `HttpRequestOptions<T>` from a source `HttpMethodOptions` and
@@ -28,7 +33,7 @@ function addBody<T>(
     options: {
       headers?: HttpHeaders | {[header: string]: string | string[]},
       observe?: HttpObserve,
-      params?: HttpParams | {[param: string]: string | string[]},
+      params?: URLQueryParams,
       reportProgress?: boolean,
       responseType?: 'arraybuffer' | 'blob' | 'json' | 'text',
       withCredentials?: boolean,
@@ -77,7 +82,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -91,7 +96,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -105,7 +110,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -118,7 +123,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     observe: 'events', reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
@@ -131,9 +136,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -145,9 +148,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -160,10 +161,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     reportProgress?: boolean,
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    responseType?: 'json',
-    withCredentials?: boolean,
+    observe: 'events', params?: URLQueryParams, responseType?: 'json', withCredentials?: boolean,
   }): Observable<HttpEvent<any>>;
 
   /**
@@ -175,10 +173,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     reportProgress?: boolean,
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    responseType?: 'json',
-    withCredentials?: boolean,
+    observe: 'events', params?: URLQueryParams, responseType?: 'json', withCredentials?: boolean,
   }): Observable<HttpEvent<R>>;
 
   /**
@@ -189,9 +184,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -203,9 +196,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -217,9 +208,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -232,10 +221,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     reportProgress?: boolean,
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    responseType?: 'json',
-    withCredentials?: boolean,
+    observe: 'response', params?: URLQueryParams, responseType?: 'json', withCredentials?: boolean,
   }): Observable<HttpResponse<Object>>;
 
   /**
@@ -247,10 +233,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     reportProgress?: boolean,
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    responseType?: 'json',
-    withCredentials?: boolean,
+    observe: 'response', params?: URLQueryParams, responseType?: 'json', withCredentials?: boolean,
   }): Observable<HttpResponse<R>>;
 
   /**
@@ -262,7 +245,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     responseType?: 'json',
     reportProgress?: boolean,
     withCredentials?: boolean,
@@ -277,7 +260,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     responseType?: 'json',
     reportProgress?: boolean,
     withCredentials?: boolean,
@@ -292,7 +275,7 @@ export class HttpClient {
   request(method: string, url: string, options?: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     observe?: HttpObserve,
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
@@ -334,7 +317,7 @@ export class HttpClient {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -363,6 +346,8 @@ export class HttpClient {
       if (!!options.params) {
         if (options.params instanceof HttpParams) {
           params = options.params;
+        } else if (typeof options.params == 'string') {
+          params = new HttpParams({ fromString: options.params } as HttpParamsOptions);
         } else {
           params = new HttpParams({ fromObject: options.params } as HttpParamsOptions);
         }
@@ -454,7 +439,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -468,7 +453,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -481,7 +466,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -493,9 +478,7 @@ export class HttpClient {
    */
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -506,9 +489,7 @@ export class HttpClient {
    */
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -519,9 +500,7 @@ export class HttpClient {
    */
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -533,7 +512,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -547,7 +526,7 @@ export class HttpClient {
   delete<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -560,9 +539,7 @@ export class HttpClient {
    */
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -573,9 +550,7 @@ export class HttpClient {
    */
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -586,9 +561,7 @@ export class HttpClient {
    */
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -600,7 +573,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -614,7 +587,7 @@ export class HttpClient {
   delete<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -628,7 +601,7 @@ export class HttpClient {
   delete (url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -642,7 +615,7 @@ export class HttpClient {
   delete<T>(url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -656,7 +629,7 @@ export class HttpClient {
   delete (url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -673,7 +646,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -686,7 +659,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -699,7 +672,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -711,9 +684,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -724,9 +695,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -737,9 +706,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -751,7 +718,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -765,7 +732,7 @@ export class HttpClient {
   get<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -778,9 +745,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -791,9 +756,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -804,9 +767,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -818,7 +779,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -832,7 +793,7 @@ export class HttpClient {
   get<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -846,7 +807,7 @@ export class HttpClient {
   get(url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -860,7 +821,7 @@ export class HttpClient {
   get<T>(url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -874,7 +835,7 @@ export class HttpClient {
   get(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -891,7 +852,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
 
@@ -904,7 +865,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -917,7 +878,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -929,9 +890,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -942,9 +901,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -955,9 +912,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -969,7 +924,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -983,7 +938,7 @@ export class HttpClient {
   head<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -996,9 +951,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -1009,9 +962,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -1022,9 +973,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -1036,7 +985,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1050,7 +999,7 @@ export class HttpClient {
   head<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1064,7 +1013,7 @@ export class HttpClient {
   head(url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1078,7 +1027,7 @@ export class HttpClient {
   head<T>(url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1092,7 +1041,7 @@ export class HttpClient {
   head(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -1138,7 +1087,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -1151,7 +1100,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -1164,7 +1113,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -1176,9 +1125,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -1189,9 +1136,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -1202,9 +1147,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -1216,7 +1159,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1230,7 +1173,7 @@ export class HttpClient {
   options<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1243,9 +1186,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -1256,9 +1197,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -1269,9 +1208,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -1283,7 +1220,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1297,7 +1234,7 @@ export class HttpClient {
   options<T>(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1311,7 +1248,7 @@ export class HttpClient {
   options(url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1325,7 +1262,7 @@ export class HttpClient {
   options<T>(url: string, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1339,7 +1276,7 @@ export class HttpClient {
   options(url: string, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -1355,7 +1292,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -1368,7 +1305,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -1381,7 +1318,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -1393,9 +1330,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -1406,9 +1341,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -1419,9 +1352,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -1433,7 +1364,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1447,7 +1378,7 @@ export class HttpClient {
   patch<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1460,9 +1391,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -1473,9 +1402,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -1486,9 +1413,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -1500,7 +1425,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1514,7 +1439,7 @@ export class HttpClient {
   patch<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1528,7 +1453,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1542,7 +1467,7 @@ export class HttpClient {
   patch<T>(url: string, body: any|null, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1556,7 +1481,7 @@ export class HttpClient {
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -1572,7 +1497,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -1585,7 +1510,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -1598,7 +1523,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -1610,9 +1535,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -1623,9 +1546,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -1636,9 +1557,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -1650,7 +1569,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1664,7 +1583,7 @@ export class HttpClient {
   post<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1677,9 +1596,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -1690,9 +1607,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -1703,9 +1618,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -1717,7 +1630,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1731,7 +1644,7 @@ export class HttpClient {
   post<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1745,7 +1658,7 @@ export class HttpClient {
   post(url: string, body: any|null, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1759,7 +1672,7 @@ export class HttpClient {
   post<T>(url: string, body: any|null, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1773,7 +1686,7 @@ export class HttpClient {
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
@@ -1789,7 +1702,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<ArrayBuffer>;
@@ -1802,7 +1715,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<Blob>;
@@ -1815,7 +1728,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<string>;
@@ -1827,9 +1740,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpEvent<ArrayBuffer>>;
 
@@ -1840,9 +1751,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpEvent<Blob>>;
 
@@ -1853,9 +1762,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'events', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpEvent<string>>;
 
@@ -1867,7 +1774,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'events',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1890,9 +1797,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'arraybuffer', withCredentials?: boolean,
   }): Observable<HttpResponse<ArrayBuffer>>;
 
@@ -1903,9 +1808,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'blob', withCredentials?: boolean,
   }): Observable<HttpResponse<Blob>>;
 
@@ -1916,9 +1819,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
-    observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
-    reportProgress?: boolean,
+    observe: 'response', params?: URLQueryParams, reportProgress?: boolean,
     responseType: 'text', withCredentials?: boolean,
   }): Observable<HttpResponse<string>>;
 
@@ -1930,7 +1831,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1944,7 +1845,7 @@ export class HttpClient {
   put<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe: 'response',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1958,7 +1859,7 @@ export class HttpClient {
   put(url: string, body: any|null, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1972,7 +1873,7 @@ export class HttpClient {
   put<T>(url: string, body: any|null, options?: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: 'body',
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'json',
     withCredentials?: boolean,
@@ -1986,7 +1887,7 @@ export class HttpClient {
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders | {[header: string]: string | string[]},
     observe?: HttpObserve,
-    params?: HttpParams|{[param: string]: string | string[]},
+    params?: URLQueryParams,
     reportProgress?: boolean,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,

--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -41,6 +41,8 @@ export class HttpUrlEncodingCodec implements HttpParameterCodec {
 function paramParser(rawParams: string, codec: HttpParameterCodec): Map<string, string[]> {
   const map = new Map<string, string[]>();
   if (rawParams.length > 0) {
+    rawParams.charAt(0) == '?' &&
+        (rawParams = rawParams.substr(1));  // safe check to remove '?' prefix, if exists
     const params: string[] = rawParams.split('&');
     params.forEach((param: string) => {
       const eqIdx = param.indexOf('=');
@@ -82,7 +84,7 @@ export interface HttpParamsOptions {
   fromString?: string;
 
   /** Object map of the HTTP params. Mutally exclusive with `fromString`. */
-  fromObject?: {[param: string]: string | string[]};
+  fromObject?: {[param: string]: string | number | boolean | null | (string | number)[]};
 
   /** Encoding codec used to parse and serialize the params. */
   encoder?: HttpParameterCodec;

--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -45,9 +45,24 @@ export function main() {
         expect(req.request.headers.get('X-Option')).toEqual('true');
         req.flush({});
       });
-      it('with params', (done: DoneFn) => {
-        client.get('/test', {params: {'test': 'true'}}).subscribe(() => done());
-        backend.expectOne('/test?test=true').flush({});
+      it('params as object', (done: DoneFn) => {
+        client
+            .get(
+                '/test',
+                {params: {'string': 'string', number: 1, array: [2, 3, '4'], bool: true, a: null}})
+            .subscribe(() => done());
+        backend.expectOne('/test?string=string&number=1&array=2&array=3&array=4&bool=true&a=null')
+            .flush({});
+      });
+      it('params as string', (done: DoneFn) => {
+        client.get('/test', {params: 'angular=awesome&angular5=yes&a=null'})
+            .subscribe(() => done());
+        backend.expectOne('/test?angular=awesome&angular5=yes&a=null').flush({});
+      });
+      it('params as string with `?` prefix', (done: DoneFn) => {
+        client.get('/test', {params: '?angular=awesome&angular5=yes'})
+            .subscribe(() => done());  // With '?' prefix
+        backend.expectOne('/test?angular=awesome&angular5=yes').flush({});
       });
       it('for an arraybuffer', (done: DoneFn) => {
         const body = new ArrayBuffer(4);

--- a/tools/public_api_guard/common/http.d.ts
+++ b/tools/public_api_guard/common/http.d.ts
@@ -14,9 +14,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -26,9 +24,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -38,9 +34,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -50,9 +44,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -62,9 +54,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -74,9 +64,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -86,9 +74,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -98,9 +84,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -110,9 +94,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -122,9 +104,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -134,9 +114,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -146,9 +124,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -158,9 +134,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -170,9 +144,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -182,9 +154,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -194,9 +164,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -206,9 +174,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -218,9 +184,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -230,9 +194,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -242,9 +204,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -254,9 +214,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -266,9 +224,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -278,9 +234,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -290,9 +244,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -302,9 +254,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -314,9 +264,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -326,9 +274,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -338,9 +284,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -350,9 +294,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -362,9 +304,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -374,9 +314,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -386,9 +324,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -398,9 +334,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -410,9 +344,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -422,9 +354,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -434,9 +364,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -446,9 +374,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -458,9 +384,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -470,9 +394,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -482,9 +404,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -494,9 +414,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -506,9 +424,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -518,9 +434,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -530,9 +444,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -542,9 +454,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -556,9 +466,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -568,9 +476,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -580,9 +486,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -592,9 +496,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -604,9 +506,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -616,9 +516,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -628,9 +526,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -640,9 +536,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -652,9 +546,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -664,9 +556,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -676,9 +566,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -688,9 +576,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -700,9 +586,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -712,9 +596,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -724,9 +606,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -736,9 +616,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -748,9 +626,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -760,9 +636,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -772,9 +646,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -784,9 +656,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -796,9 +666,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -808,9 +676,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -820,9 +686,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -832,9 +696,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -844,9 +706,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -856,9 +716,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -868,9 +726,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -880,9 +736,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -892,9 +746,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -904,9 +756,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -916,9 +766,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -928,9 +776,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -940,9 +786,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -952,9 +796,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -964,9 +806,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -976,9 +816,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -988,9 +826,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -1000,9 +836,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -1012,9 +846,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -1024,9 +856,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -1036,9 +866,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -1048,9 +876,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -1060,9 +886,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -1072,9 +896,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -1084,9 +906,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -1096,9 +916,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -1108,9 +926,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -1120,9 +936,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -1132,9 +946,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -1144,9 +956,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -1156,9 +966,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -1176,9 +984,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -1188,9 +994,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -1200,9 +1004,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -1212,9 +1014,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -1224,9 +1024,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -1236,9 +1034,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -1248,9 +1044,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -1260,9 +1054,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType?: 'json';
         withCredentials?: boolean;
@@ -1274,9 +1066,7 @@ export declare class HttpClient {
         };
         reportProgress?: boolean;
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<any>>;
@@ -1286,9 +1076,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         responseType?: 'json';
         reportProgress?: boolean;
         withCredentials?: boolean;
@@ -1299,9 +1087,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -1312,9 +1098,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -1325,9 +1109,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -1337,9 +1119,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         observe: 'events';
         reportProgress?: boolean;
         responseType: 'arraybuffer';
@@ -1351,9 +1131,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -1364,9 +1142,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -1379,9 +1155,7 @@ export declare class HttpClient {
         };
         reportProgress?: boolean;
         observe: 'events';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<R>>;
@@ -1391,9 +1165,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'arraybuffer';
         withCredentials?: boolean;
@@ -1404,9 +1176,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'blob';
         withCredentials?: boolean;
@@ -1417,9 +1187,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         reportProgress?: boolean;
         responseType: 'text';
         withCredentials?: boolean;
@@ -1431,9 +1199,7 @@ export declare class HttpClient {
         };
         reportProgress?: boolean;
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
@@ -1444,9 +1210,7 @@ export declare class HttpClient {
         };
         reportProgress?: boolean;
         observe: 'response';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<R>>;
@@ -1456,9 +1220,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe?: 'body';
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         responseType?: 'json';
         reportProgress?: boolean;
         withCredentials?: boolean;
@@ -1468,9 +1230,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
-        params?: HttpParams | {
-            [param: string]: string | string[];
-        };
+        params?: URLQueryParams;
         observe?: HttpObserve;
         reportProgress?: boolean;
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';


### PR DESCRIPTION
feat(common): string value support for `options.params` && basic datatypes support for map values

The `options.params` paramter of `HttpClient.request` method aceepts only `HttpParams|{[param: 	string]: string | string[]}`, it leads to:

- User can't pass searchParams as string. Ex: angular=awesome&angular5=yes
- User can't set value of an object key to either number (or) boolean (or) null. Ex: {'string': 'string', number: 1, array: [2, 3, "4"], bool: true, a: null}}

Supporting these cases will ease the use of API

Fixes: https://github.com/angular/angular/issues/20316

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/20316


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
