### PR TITLE
feat(core): optional generic type for ElementRef

### DIFF
--- a/packages/core/src/linker/element_ref.ts
+++ b/packages/core/src/linker/element_ref.ts
@@ -21,7 +21,7 @@
 // Note: We don't expose things like `Injector`, `ViewContainer`, ... here,
 // i.e. users have to ask for what they need. With that, we can build better analysis tools
 // and could do better codegen in the future.
-export class ElementRef {
+export class ElementRef<T = any> {
   /**
    * The underlying native element or `null` if direct access to native elements is not supported
    * (e.g. when the application runs in a web worker).
@@ -43,7 +43,7 @@ export class ElementRef {
    * </div>
    * @stable
    */
-  public nativeElement: any;
+  public nativeElement: T;
 
-  constructor(nativeElement: any) { this.nativeElement = nativeElement; }
+  constructor(nativeElement: T) { this.nativeElement = nativeElement; }
 }

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -362,9 +362,9 @@ export interface DoCheck {
 }
 
 /** @stable */
-export declare class ElementRef {
-    /** @stable */ nativeElement: any;
-    constructor(nativeElement: any);
+export declare class ElementRef<T = any> {
+    /** @stable */ nativeElement: T;
+    constructor(nativeElement: T);
 }
 
 /** @experimental */


### PR DESCRIPTION
Add optional, backwards compatible generic type to support typed
`nativeElement`

Fix #13139

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #13139


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
