### PR TITLE
fix: tsconfig.app.json excludes all testing files

### DIFF
--- a/aio/tools/examples/shared/boilerplate/cli/src/tsconfig.app.json
+++ b/aio/tools/examples/shared/boilerplate/cli/src/tsconfig.app.json
@@ -9,7 +9,6 @@
   "exclude": [
     "test.ts",
     "**/*.spec.ts",
-    "testing/**",
-    "**/*.1.*"
+    "**/testing/*"
   ]
 }


### PR DESCRIPTION
Fixes app build error in testing guide which has testing folder at multiple levels,
with files in them referring to files in the root `testing` folder.
Also removed the exclusion of files with `.1` in the name because
all app `.ts` files must be buildable per aio policy.
must build

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

**AIO tooling only**

Fixes build error in revised `aio/testing` guide (#20697) which has `testing` folders at multiple levels.
By aio convention, all files in a `testing` folder should be excluded from the application build as they are devoted exclusively to unit testing the app.

Also removed exclusion of files with `.1` in the name. By aio rule, all app sample files must be buildable. If anything breaks as a result of this exclusion, we will fix it in an update to this PR.

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```
