### PR TITLE
build: set `preserveWhitespaces` to false by default on Bazel

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -73,7 +73,8 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
           "allowEmptyCodegenFiles": True,
           "enableSummariesForJit": True,
           # FIXME: wrong place to de-dupe
-          "expectedOut": depset([o.path for o in expected_outs]).to_list()
+          "expectedOut": depset([o.path for o in expected_outs]).to_list(),
+          "preserveWhitespaces": False,
       }
   })
 


### PR DESCRIPTION
`preserveWhitespaces: false` will be the default in Angular 6+

You can opt-out at component or element level.

Docs: https://angular.io/api/core/Component#preserveWhitespaces

