### PR TITLE
fix(service-worker): esm2015 points to wrong path

### DIFF
--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -4,7 +4,7 @@
   "description": "Angular - service worker tooling!",
   "main": "./bundles/service-worker.umd.js",
   "module": "./esm5/service-worker.js",
-  "es2015": "./esm15/service-worker.js",
+  "es2015": "./esm2015/service-worker.js",
   "typings": "./service-worker.d.ts",
   "author": "angular",
   "license": "MIT",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The Service Worker package points to a non-existing path for the esm2015 build.
Current value is "esm15"

This makes build with Google Closure Compiler impossible with following settings.
--package_json_entry_names es2015
--process_common_js_modules

Issue Number: N/A


## What is the new behavior?
The esm2015 value should be "esm2015".

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
