### PR TITLE
fix(router): NavigatonError and NavigationCancel should always be emi…

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -745,12 +745,14 @@ export class Router {
               },
               (e: any) => {
                 if (isNavigationCancelingError(e)) {
-                  this.resetUrlToCurrentUrlTree();
                   this.navigated = true;
+                  this.resetStateAndUrl(storedState, storedUrl, rawUrl);
                   (this.events as Subject<Event>)
                       .next(new NavigationCancel(id, this.serializeUrl(url), e.message));
+
                   resolvePromise(false);
                 } else {
+                  this.resetStateAndUrl(storedState, storedUrl, rawUrl);
                   (this.events as Subject<Event>)
                       .next(new NavigationError(id, this.serializeUrl(url), e));
                   try {
@@ -759,13 +761,15 @@ export class Router {
                     rejectPromise(ee);
                   }
                 }
-
-                (this as{routerState: RouterState}).routerState = storedState;
-                this.currentUrlTree = storedUrl;
-                this.rawUrlTree = this.urlHandlingStrategy.merge(this.currentUrlTree, rawUrl);
-                this.resetUrlToCurrentUrlTree();
               });
     });
+  }
+
+  private resetStateAndUrl(storedState: RouterState, storedUrl: UrlTree, rawUrl: UrlTree): void {
+    (this as{routerState: RouterState}).routerState = storedState;
+    this.currentUrlTree = storedUrl;
+    this.rawUrlTree = this.urlHandlingStrategy.merge(this.currentUrlTree, rawUrl);
+    this.resetUrlToCurrentUrlTree();
   }
 
   private resetUrlToCurrentUrlTree(): void {


### PR DESCRIPTION
…tted after resetting the URL back

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Sometimes we emit NavigatonCancel before resetting the URL, sometimes after. 

Issue Number: N/A


## What is the new behavior?

We should always emit "final" events (NavigatonError, NavigationCancel, NavigationEnd) after we reset the state of the router.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
