### PR TITLE
Apply unicode flag to pattern

### DIFF
--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -379,6 +379,11 @@ export const PATTERN_VALIDATOR: any = {
  * as the regex to validate Control value against.  Follows pattern attribute
  * semantics; i.e. regex must match entire Control value.
  *
+ * Note: if a string type attribute value is used, the regex will be applied with the
+ * unicode flag on supported browsers. If a unicode-regex is passed, it might break on
+ * unsupported browser. In this case, the user should be responsible to handle the
+ * browser compatibility.
+ *
  * @usageNotes
  * ### Example
  *

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -381,7 +381,7 @@ export const PATTERN_VALIDATOR: any = {
  *
  * Note: if a string type attribute value is used, the regex will be applied with the
  * unicode flag on supported browsers. If a unicode-regex is passed, it might break on
- * unsupported browser. In this case, the user should be responsible to handle the
+ * unsupported browsers. In this case, the application developer should be responsible to handle the
  * browser compatibility.
  *
  * @usageNotes

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -306,7 +306,11 @@ export class Validators {
 
       if (pattern.charAt(pattern.length - 1) !== '$') regexStr += '$';
 
-      regex = new RegExp(regexStr);
+      if (RegExp.prototype.hasOwnProperty('unicode')) {
+        regex = new RegExp(regexStr, 'u');
+      } else {
+        regex = new RegExp(regexStr);
+      }
     } else {
       regexStr = pattern.toString();
       regex = pattern;

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -11,6 +11,7 @@ import {describe, expect, it} from '@angular/core/testing/src/testing_internal';
 import {AbstractControl, AsyncValidatorFn, FormArray, FormControl, Validators} from '@angular/forms';
 import {normalizeAsyncValidator} from '@angular/forms/src/directives/normalize_validator';
 import {AsyncValidator, ValidationErrors, ValidatorFn} from '@angular/forms/src/directives/validators';
+import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
 import {Observable, of , timer} from 'rxjs';
 import {first, map} from 'rxjs/operators';
 
@@ -273,6 +274,13 @@ import {first, map} from 'rxjs/operators';
 
       it('should not error on "undefined" pattern',
          () => expect(Validators.pattern(undefined !)(new FormControl('aaAA'))).toBeNull());
+
+      if (browserDetection.supportsRegExUnicodeFlag) {
+        it('should apply unicode flag to pattern when supported', () => {
+          expect(Validators.pattern('[\u{10000}-\u{10001}]')(new FormControl('\u{10000}')))
+              .toBeNull();
+        });
+      }
 
       it('should work with pattern string containing both boundary symbols',
          () => expect(Validators.pattern('^[aA]*$')(new FormControl('aaAA'))).toBeNull());

--- a/packages/platform-browser/testing/src/browser_util.ts
+++ b/packages/platform-browser/testing/src/browser_util.ts
@@ -75,6 +75,8 @@ export class BrowserDetection {
     return (typeof(document as any).registerElement !== 'undefined');
   }
 
+  get supportsRegExUnicodeFlag(): boolean { return RegExp.prototype.hasOwnProperty('unicode'); }
+
   get supportsShadowDom() {
     const testEl = document.createElement('div');
     return (typeof testEl.attachShadow !== 'undefined');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The pattern validator does not apply unicode flag to string input

## What is the new behavior?
The pattern validator applies unicode flag on string input

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Rationale
> If an input element has a pattern attribute specified, and the attribute's value, when compiled as a JavaScript regular expression with only the "u" flag specified, compiles successfully, then the resulting regular expression is the element's compiled pattern regular expression.

See the [spec](https://html.spec.whatwg.org/multipage/input.html#the-pattern-attribute).

Both Firefox and Chrome have applied unicode flag to the `pattern` content attribute of INPUT element.

See https://www.chromestatus.com/feature/4753420745441280