### PR TITLE
fix(compiler-cli): Fix swallowed Error messages

### DIFF
--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -869,17 +869,21 @@ function syntaxErrorToDiagnostics(error: Error): Diagnostic[] {
                                           source: SOURCE,
                                           code: DEFAULT_ERROR_CODE
                                         }));
-  } else {
-    if (isFormattedError(error)) {
-      return [{
-        messageText: error.message,
-        chain: error.chain && diagnosticChainFromFormattedDiagnosticChain(error.chain),
-        category: ts.DiagnosticCategory.Error,
-        source: SOURCE,
-        code: DEFAULT_ERROR_CODE,
-        position: error.position
-      }];
-    }
+  } else if (isFormattedError(error)) {
+    return [{
+      messageText: error.message,
+      chain: error.chain && diagnosticChainFromFormattedDiagnosticChain(error.chain),
+      category: ts.DiagnosticCategory.Error,
+      source: SOURCE,
+      code: DEFAULT_ERROR_CODE,
+      position: error.position
+    }];
   }
-  return [];
+  // Produce a Diagnostic anyway since we know for sure `error` is a SyntaxError
+  return [{
+    messageText: error.message,
+    category: ts.DiagnosticCategory.Error,
+    code: DEFAULT_ERROR_CODE,
+    source: SOURCE,
+  }];
 }

--- a/packages/compiler-cli/test/transformers/program_spec.ts
+++ b/packages/compiler-cli/test/transformers/program_spec.ts
@@ -948,6 +948,35 @@ describe('ng program', () => {
       });
     });
 
+    it('should include non-formatted errors (e.g. invalid templateUrl)', () => {
+      testSupport.write('src/index.ts', `
+        import {Component, NgModule} from '@angular/core';
+
+        @Component({
+          selector: 'my-component',
+          templateUrl: 'template.html',   // invalid template url
+        })
+        export class MyComponent {}
+
+        @NgModule({
+          declarations: [MyComponent]
+        })
+        export class MyModule {}
+      `);
+
+      const options = testSupport.createCompilerOptions();
+      const host = ng.createCompilerHost({options});
+      const program = ng.createProgram({
+        rootNames: [path.resolve(testSupport.basePath, 'src/index.ts')],
+        options,
+        host,
+      });
+
+      const structuralErrors = program.getNgStructuralDiagnostics();
+      expect(structuralErrors.length).toBe(1);
+      expect(structuralErrors[0].messageText).toContain('Couldn\'t resolve resource template.html');
+    });
+
     it('should be able report structural errors with noResolve:true and generateCodeForLibraries:false ' +
            'even if getSourceFile throws for non existent files',
        () => {


### PR DESCRIPTION
This commit fixes a bug in which non-formatted errors are silently
dropped.

Internal issue: b/67739418

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Non-formatted errors are silently dropped.
For example, compiler complained about empty ngfactory when the actual error message should be
about invalid templateUrl ot styleUrl.

## What is the new behavior?
Errors are no longer silently dropped.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
