### PR TITLE
fix(platform-server): support [hidden]="true" on server

### DIFF
--- a/packages/platform-server/src/server_renderer.ts
+++ b/packages/platform-server/src/server_renderer.ts
@@ -148,16 +148,26 @@ class DefaultServerRenderer2 implements Renderer2 {
         this.schema.securityContext(tagName, propertyName, false);
   }
 
+  // Only support boolean value for hidden property
+  private _isValueTypeSupported(name: string, value: any) {
+    return typeof value !== 'boolean' || name === 'hidden';
+  }
+
   setProperty(el: any, name: string, value: any): void {
     checkNoSyntheticProp(name, 'property');
     getDOM().setProperty(el, name, value);
     // Mirror property values for known HTML element properties in the attributes.
     const tagName = (el.tagName as string).toLowerCase();
-    if (value != null && (typeof value === 'number' || typeof value == 'string') &&
+    if (value != null &&
+        (typeof value === 'number' || typeof value == 'string' || typeof value == 'boolean') &&
         this.schema.hasElement(tagName, EMPTY_ARRAY) &&
         this.schema.hasProperty(tagName, name, EMPTY_ARRAY) &&
-        this._isSafeToReflectProperty(tagName, name)) {
-      this.setAttribute(el, name, value.toString());
+        this._isSafeToReflectProperty(tagName, name) && this._isValueTypeSupported(name, value)) {
+      if (typeof value == 'boolean' && value) {
+        this.setAttribute(el, name, '');
+      } else if (typeof value !== 'boolean') {
+        this.setAttribute(el, name, value.toString());
+      }
     }
   }
 

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -254,6 +254,20 @@ class MyInputComponent {
 class NameModule {
 }
 
+@Component({selector: 'app', template: '<input [hidden]="true"><input [hidden]="false">'})
+class MyHiddenComponent {
+  @Input()
+  name = '';
+}
+
+@NgModule({
+  declarations: [MyHiddenComponent],
+  bootstrap: [MyHiddenComponent],
+  imports: [ServerModule, BrowserModule.withServerTransition({appId: 'hidden-attributes'})]
+})
+class HiddenModule {
+}
+
 const TEST_KEY = makeStateKey<number>('test');
 const STRING_KEY = makeStateKey<string>('testString');
 
@@ -548,6 +562,15 @@ class EscapedTransferStoreModule {
              expect(output).toBe(
                  '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
                  '<input name=""></app></body></html>');
+             called = true;
+           });
+         }));
+
+      it('should handle element property "hidden"', async(() => {
+           renderModule(HiddenModule, {document: doc}).then(output => {
+             expect(output).toBe(
+                 '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
+                 '<input hidden=""><input></app></body></html>');
              called = true;
            });
          }));


### PR DESCRIPTION
Closes: #20835

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently when building an angular app on the server (using platform-server), the hidden attribute is not added to the pre-rendered dom node when bound as:
```
[hidden]="true"
```
It looks like this regression was introduced with the DefaultServerRenderer2 class. This bug was previously identified and fixed in the Universal node-renderer: angular/universal#612

Issue Number: 20835


## What is the new behavior?
The hidden attribute is added to the dom node when bound to a true boolean.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
