### PR TITLE
feat(aio): update url parameters on search

### DIFF
--- a/aio/src/app/search/search-box/search-box.component.spec.ts
+++ b/aio/src/app/search/search-box/search-box.component.spec.ts
@@ -62,6 +62,17 @@ describe('SearchBoxComponent', () => {
       expect(host.searchHandler).toHaveBeenCalledWith('some query (input)');
     }));
 
+    it('should update the URL with the current search term, after debouncing occurs',
+          fakeAsync(inject([LocationService], (location: MockLocationService) => {
+      const input = fixture.debugElement.query(By.css('input'));
+      input.nativeElement.value = 'clever search term';
+      expect(location.setSearch).not.toHaveBeenCalled();
+      component.doSearch();
+      expect(location.setSearch).not.toHaveBeenCalled();
+      tick(300);
+      expect(location.setSearch).toHaveBeenCalled();
+    })));
+
     it('should only send events if the search value has changed', fakeAsync(() => {
       const input = fixture.debugElement.query(By.css('input'));
 

--- a/aio/src/app/search/search-box/search-box.component.ts
+++ b/aio/src/app/search/search-box/search-box.component.ts
@@ -35,15 +35,25 @@ export class SearchBoxComponent implements OnInit {
 
   constructor(private locationService: LocationService) { }
 
-  /**
-   * When we first show this search box we trigger a search if there is a search query in the URL
-   */
   ngOnInit() {
+    // When we first show this search box we trigger a search if there is a search query in the URL
     const query = this.locationService.search()['search'];
     if (query) {
       this.query = query;
       this.doSearch();
     }
+
+    // Update the URL params after search events
+    this.onSearch.subscribe(searchTerm => {
+      const params = this.locationService.search();
+      if (searchTerm) { params['search'] = searchTerm; }
+      this.locationService.setSearch('', params);
+    });
+
+    // Clear the query value whenever the current path changes.
+    this.locationService.currentPath.subscribe(() => {
+      this.query = '';
+    });
   }
 
   doSearch() {

--- a/aio/src/app/shared/location.service.spec.ts
+++ b/aio/src/app/shared/location.service.spec.ts
@@ -400,6 +400,7 @@ describe('LocationService', () => {
     beforeEach(() => {
       anchor = document.createElement('a');
       spyOn(service, 'go');
+      spyOn(service, 'setSearch');
     });
 
     describe('should try to navigate with go() when anchor clicked for', () => {
@@ -442,6 +443,15 @@ describe('LocationService', () => {
         anchor.href = 'tut.or.ial/toh-p2';
         const result = service.handleAnchorClick(anchor);
         expect(service.go).toHaveBeenCalled();
+        expect(result).toBe(false);
+      });
+
+      it('local url with search params, replacing previous history state', () => {
+        service.go('some/local/url?search=component&something=else');
+        anchor.href = 'some/other/url';
+        const result = service.handleAnchorClick(anchor);
+        expect(service.go).toHaveBeenCalledWith('/some/other/url');
+        expect(service.setSearch).toHaveBeenCalledWith('', {});
         expect(result).toBe(false);
       });
     });

--- a/aio/src/app/shared/location.service.ts
+++ b/aio/src/app/shared/location.service.ts
@@ -142,6 +142,11 @@ export class LocationService {
       return true;
     }
 
+    // clear query parameters for search
+    const params = this.search();
+    delete params['search'];
+    this.setSearch('', params);
+
     // approved for navigation
     this.go(relativeUrl);
     return false;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently searching on aio does not update the URL parameters of the page, which prevents direct linking to the search results. 

## What is the new behavior?
As a user searches in the search box, the URL parameters for the page are updated, replacing the state in history.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```