### PR TITLE
build: Make ng_module bazel rule emit ngfactory files.

### DIFF
--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "build_bazel_rules_nodejs",
     remote = "https://github.com/bazelbuild/rules_nodejs.git",
-    tag = "0.2.1",
+    tag = "0.3.0",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")

--- a/integration/bazel/package.json
+++ b/integration/bazel/package.json
@@ -9,14 +9,19 @@
     "@angular/compiler": "file:../../dist/packages-dist/compiler",
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
+    "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
+    "@angular/platform-server": "file:../../dist/packages-dist/platform-server",
+    "@angular/http": "file:../../dist/packages-dist/http",
+    "jasmine": "^2.8.0",
     "rxjs": "file:../../node_modules/rxjs",
     "zone.js": "file:../../node_modules/zone.js"
   },
   "devDependencies": {
     "@angular/bazel": "file:../../dist/packages-dist/bazel",
     "@angular/compiler-cli": "file:../../dist/packages-dist/compiler-cli",
-    "typescript": "file:../../node_modules/typescript",
-    "@types/source-map": "0.5.1"
+    "@types/jasmine": "^2.8.2",
+    "@types/source-map": "0.5.1",
+    "typescript": "file:../../node_modules/typescript"
   },
   "scripts": {
     "postinstall": "ngc -p angular.tsconfig.json",

--- a/integration/bazel/src/BUILD.bazel
+++ b/integration/bazel/src/BUILD.bazel
@@ -1,11 +1,35 @@
 load("@angular//:index.bzl", "ng_module")
+load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 
 # Allow targets under sub-packages to reference the tsconfig.json file
 exports_files(["tsconfig.json"])
 
 ng_module(
-    name = "src",
-    srcs = glob(["*.ts"]),
+    name = "app",
+    srcs = ["app.module.ts"],
     deps = ["//src/hello-world"],
     tsconfig = ":tsconfig.json",
+)
+
+ng_module(
+    name = "main",
+    srcs = ["main.ts"],
+    deps = [":app"],
+    tsconfig = ":tsconfig.json",
+)
+
+ts_library(
+    name = "test_lib",
+    srcs = [
+        "init-tests.ts", 
+        "ngsummary.spec.ts", 
+        "ngfactory.spec.ts",
+    ],
+    deps = [":app"],
+)
+
+jasmine_node_test(
+    name = "test",
+    srcs = [":test_lib"],
 )

--- a/integration/bazel/src/app.module.ts
+++ b/integration/bazel/src/app.module.ts
@@ -1,9 +1,9 @@
-import {HelloWorldModule} from './hello-world/hello-world.module';
-
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 
-@NgModule({
-  imports: [BrowserModule, HelloWorldModule]
-})
-export class AppModule {}
+import {HelloWorldModule} from './hello-world/hello-world.module';
+
+@NgModule({imports: [BrowserModule, HelloWorldModule]})
+export class AppModule {
+  ngDoBootstrap() {}
+}

--- a/integration/bazel/src/init-tests.ts
+++ b/integration/bazel/src/init-tests.ts
@@ -1,0 +1,6 @@
+require('reflect-metadata');
+require('zone.js/dist/zone-node.js');
+require('zone.js/dist/long-stack-trace-zone.js');
+require('zone.js/dist/sync-test.js');
+require('zone.js/dist/proxy.js');
+require('zone.js/dist/jasmine-patch.js');

--- a/integration/bazel/src/ngfactory.spec.ts
+++ b/integration/bazel/src/ngfactory.spec.ts
@@ -1,0 +1,10 @@
+import {Component} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {platformServerTesting, ServerTestingModule} from '@angular/platform-server/testing';
+
+import {AppModuleNgFactory} from './app.module.ngfactory';
+
+describe('ngfactory generation', () => {
+  it('should be able to create a component',
+     (done) => platformServerTesting().bootstrapModuleFactory(AppModuleNgFactory).then(done));
+});

--- a/integration/bazel/src/ngsummary.spec.ts
+++ b/integration/bazel/src/ngsummary.spec.ts
@@ -1,0 +1,25 @@
+import {Component} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {platformServerTesting, ServerTestingModule} from '@angular/platform-server/testing';
+
+import {HelloWorldComponent} from './hello-world/hello-world.component';
+import {HelloWorldModule} from './hello-world/hello-world.module';
+import {HelloWorldModuleNgSummary} from './hello-world/hello-world.module.ngsummary';
+
+describe('Jit Summaries', () => {
+  beforeEach(() => {
+    TestBed.initTestEnvironment(
+        ServerTestingModule, platformServerTesting(), HelloWorldModuleNgSummary);
+  });
+
+  afterEach(() => {
+    TestBed.resetTestEnvironment();
+  });
+
+  it('should be able to create a component', () => {
+    const helloWorldComponent = TestBed.configureTestingModule({imports: [HelloWorldModule]})
+                                    .createComponent(HelloWorldComponent);
+
+    expect(helloWorldComponent).toBeDefined();
+  });
+});

--- a/integration/bazel/src/tsconfig.json
+++ b/integration/bazel/src/tsconfig.json
@@ -8,5 +8,11 @@
       "es2015.iterable",
       "es2015.promise"
     ]
-  }
+  },
+  "types": [
+    "jasmine"
+  ],
+  "typeRoots": [
+    "node_modules/@types"
+  ]
 }

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -69,6 +69,7 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
 
   return dict(tsc_wrapped_tsconfig(ctx, files, srcs, **kwargs), **{
       "angularCompilerOptions": {
+          "skipMetadataEmit": False, # Needed to generate ngfactory files.
           "generateCodeForLibraries": False,
           "allowEmptyCodegenFiles": True,
           "enableSummariesForJit": True,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently the ng_module rule emits empty ngfactory and ngsummary files. 

Issue Number: N/A


## What is the new behavior?
Before empty ngfactory.ts files were emited by ng_module. Now they aren't empty!

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
