### PR TITLE
feat(compiler): add a pseudo $any() function to disable type checking

### DIFF
--- a/packages/compiler/src/compiler_util/expression_converter.ts
+++ b/packages/compiler/src/compiler_util/expression_converter.ts
@@ -340,6 +340,15 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
   private _getLocal(name: string): o.Expression|null { return this._localResolver.getLocal(name); }
 
   visitMethodCall(ast: cdAst.MethodCall, mode: _Mode): any {
+    if (ast.receiver instanceof cdAst.ImplicitReceiver && ast.name == '$any') {
+      const args = this.visitAll(ast.args, _Mode.Expression) as any[];
+      if (args.length != 1) {
+        throw new Error(
+            `Invalid call to $any, expected 1 argument but received ${args.length || 'none'}`);
+      }
+      return (args[0] as o.Expression).cast(o.DYNAMIC_TYPE);
+    }
+
     const leftMostSafe = this.leftMostSafeNode(ast);
     if (leftMostSafe) {
       return this.convertSafeAccess(ast, leftMostSafe, mode);


### PR DESCRIPTION
`$any()` can now be used in a binding expression to disable type
checking for the rest of the expression. This similar to `as any` in
TypeScript and allows expression that work at runtime but do not
type-check.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Feature
```

## What is the current behavior?

When "fullTemplateTypeCheck" is enabled, error are reported on some expressions that is very hard to adjust to type check correctly.

## What is the new behavior?

An expression can be surrounded with a call to the pseudo function `$any` that will cast the expression to `any`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
