### PR TITLE
feat(common/http): http testing matches url without params as well

### DIFF
--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -49,6 +49,10 @@ export function main() {
         client.get('/test', {params: {'test': 'true'}}).subscribe(() => done());
         backend.expectOne('/test?test=true').flush({});
       });
+      it('with params without matching them, but the URL', (done: DoneFn) => {
+        client.jsonp('/test?output=json&callback=callback', 'callback').subscribe(() => done());
+        backend.expectOne('/test?output=json&callback=callback').flush('hello world!');
+      });
       it('for an arraybuffer', (done: DoneFn) => {
         const body = new ArrayBuffer(4);
         client.get('/test', {responseType: 'arraybuffer'}).subscribe(res => {

--- a/packages/common/http/testing/src/backend.ts
+++ b/packages/common/http/testing/src/backend.ts
@@ -51,7 +51,8 @@ export class HttpClientTestingBackend implements HttpBackend, HttpTestingControl
    */
   private _match(match: string|RequestMatch|((req: HttpRequest<any>) => boolean)): TestRequest[] {
     if (typeof match === 'string') {
-      return this.open.filter(testReq => testReq.request.urlWithParams === match);
+      return this.open.filter(
+          testReq => (testReq.request.urlWithParams === match) || (testReq.request.url === match));
     } else if (typeof match === 'function') {
       return this.open.filter(testReq => match(testReq.request));
     } else {


### PR DESCRIPTION
First try to match by urlWithParams, then just by url

Closes #20878, #19974

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Current the `HttpCientTestingBackend` matches urls with parameters (`urlWithParams`) only. 

Issue Number: #19974 and #20878


## What is the new behavior?
First try to match by the url with params, then without them.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
I thought it would make sense to support matching by the `url` as well, rather than just by `urlWithParams`. If there's a better solution for that please let me know so I can update the PR.