### PR TITLE
fix(forms): allow FormBuilder to create controls with any formState type

### DIFF
--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -54,7 +54,7 @@ export class FormBuilder {
    *
    */
   control(
-      formState: Object, validator?: ValidatorFn|ValidatorFn[]|null,
+      formState: any, validator?: ValidatorFn|ValidatorFn[]|null,
       asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): FormControl {
     return new FormControl(formState, validator, asyncValidator);
   }

--- a/packages/forms/test/form_builder_spec.ts
+++ b/packages/forms/test/form_builder_spec.ts
@@ -41,10 +41,38 @@ export function main() {
       expect(g.controls['password'].asyncValidator).toEqual(asyncValidator);
     });
 
-    it('should use controls', () => {
+    it('should use controls whose form state is a standalone value', () => {
       const g = b.group({'login': b.control('some value', syncValidator, asyncValidator)});
 
       expect(g.controls['login'].value).toEqual('some value');
+      expect(g.controls['login'].validator).toBe(syncValidator);
+      expect(g.controls['login'].asyncValidator).toBe(asyncValidator);
+    });
+
+    it('should support controls with no validators and whose form state is null', () => {
+      const g = b.group({'login': b.control(null)});
+      expect(g.controls['login'].value).toBeNull();
+      expect(g.controls['login'].validator).toBeNull();
+      expect(g.controls['login'].asyncValidator).toBeNull();
+    });
+
+    it('should support controls with validators and whose form state is null', () => {
+      const g = b.group({'login': b.control(null, syncValidator, asyncValidator)});
+      expect(g.controls['login'].value).toBeNull();
+      expect(g.controls['login'].validator).toBe(syncValidator);
+      expect(g.controls['login'].asyncValidator).toBe(asyncValidator);
+    });
+
+    it('should support controls with no validators and whose form state is undefined', () => {
+      const g = b.group({'login': b.control(undefined)});
+      expect(g.controls['login'].value).toBeNull();
+      expect(g.controls['login'].validator).toBeNull();
+      expect(g.controls['login'].asyncValidator).toBeNull();
+    });
+
+    it('should support controls with validators and whose form state is undefined', () => {
+      const g = b.group({'login': b.control(undefined, syncValidator, asyncValidator)});
+      expect(g.controls['login'].value).toBeNull();
       expect(g.controls['login'].validator).toBe(syncValidator);
       expect(g.controls['login'].asyncValidator).toBe(asyncValidator);
     });
@@ -59,10 +87,13 @@ export function main() {
 
     it('should create control arrays', () => {
       const c = b.control('three');
+      const e = b.control(null);
+      const f = b.control(undefined);
       const a = b.array(
-          ['one', ['two', syncValidator], c, b.array(['four'])], syncValidator, asyncValidator);
+          ['one', ['two', syncValidator], c, b.array(['four']), e, f], syncValidator,
+          asyncValidator);
 
-      expect(a.value).toEqual(['one', 'two', 'three', ['four']]);
+      expect(a.value).toEqual(['one', 'two', 'three', ['four'], null, null]);
       expect(a.validator).toBe(syncValidator);
       expect(a.asyncValidator).toBe(asyncValidator);
     });

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -211,7 +211,7 @@ export declare class FormArrayName extends ControlContainer implements OnInit, O
 /** @stable */
 export declare class FormBuilder {
     array(controlsConfig: any[], validator?: ValidatorFn | null, asyncValidator?: AsyncValidatorFn | null): FormArray;
-    control(formState: Object, validator?: ValidatorFn | ValidatorFn[] | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormControl;
+    control(formState: any, validator?: ValidatorFn | ValidatorFn[] | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormControl;
     group(controlsConfig: {
         [key: string]: any;
     }, extra?: {


### PR DESCRIPTION
Align formState type in FormBuilder#control with FormControl#constructor

Fixes #20368

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #20368


## What is the new behavior?
FormBuilder#control takes now a formState of any type instead of Object to align with FormControl#constructor

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information