### PR TITLE
fix(router): set tabindex only if link is not null

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -9,13 +9,13 @@
 import {LocationStrategy} from '@angular/common';
 import {Attribute, Directive, ElementRef, HostBinding, HostListener, Input, OnChanges, OnDestroy, Renderer2, SimpleChanges} from '@angular/core';
 import {Subject, Subscription} from 'rxjs';
-
 import {QueryParamsHandling} from '../config';
 import {Event, NavigationEnd} from '../events';
 import {Router} from '../router';
 import {ActivatedRoute} from '../router_state';
 import {Params} from '../shared';
 import {UrlTree} from '../url_tree';
+
 
 
 /**
@@ -188,17 +188,20 @@ export class RouterLink implements OnChanges {
 
   constructor(
       private router: Router, private route: ActivatedRoute,
-      @Attribute('tabindex') tabIndex: string, renderer: Renderer2, el: ElementRef) {
-    if (tabIndex == null) {
-      renderer.setAttribute(el.nativeElement, 'tabindex', '0');
-    }
-  }
+      @Attribute('tabindex') private tabIndex: string, private renderer: Renderer2,
+      private el: ElementRef) {}
 
   /** @nodoc */
   ngOnChanges(changes: SimpleChanges) {
     // This is subscribed to by `RouterLinkActive` so that it knows to update when there are changes
     // to the RouterLinks it's tracking.
     this.onChanges.next(this);
+    const routerLinkChange = changes['routerLink'];
+    if (routerLinkChange) {
+      if (this.tabIndex == null && routerLinkChange.currentValue != null) {
+        this.renderer.setAttribute(this.el.nativeElement, 'tabindex', '0');
+      }
+    }
   }
 
   /**

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -2119,6 +2119,7 @@ describe('Integration', () => {
          expect(() => anchors[1].click()).not.toThrow();
          expect(() => buttons[0].click()).not.toThrow();
          expect(() => buttons[1].click()).not.toThrow();
+         expect(buttons[0].getAttribute('tabindex')).toBeNull();
        }));
 
     it('should not throw when some command is null', fakeAsync(() => {


### PR DESCRIPTION
* Sets tabindex of non anchor routerLink host only if routerLink is not
null

Fixes #17616

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #17616 


## What is the new behavior?

It doesn't set `tabindex` for non anchor elements with `[routerLink]="null"`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
