### PR TITLE
fix(testability): fix chained http call

### DIFF
--- a/packages/core/src/testability/testability.ts
+++ b/packages/core/src/testability/testability.ts
@@ -98,13 +98,22 @@ export class Testability implements PublicTestability {
   /** @internal */
   _runCallbacksIfReady(): void {
     if (this.isStable()) {
-      // Schedules the call backs in a new frame so that it is always async.
-      scheduleMicroTask(() => {
-        while (this._callbacks.length !== 0) {
-          (this._callbacks.pop() !)(this._didWork);
-        }
+      if (this._callbacks.length !== 0) {
+        // Schedules the call backs after a macro task run outside of the angular zone to make sure
+        // no new task are added
+        this._ngZone.runOutsideAngular(() => {
+          setTimeout(() => {
+            if (this.isStable()) {
+              while (this._callbacks.length !== 0) {
+                (this._callbacks.pop() !)(this._didWork);
+              }
+              this._didWork = false;
+            }
+          });
+        });
+      } else {
         this._didWork = false;
-      });
+      }
     } else {
       // Not Ready
       this._didWork = true;

--- a/packages/core/test/testability/testability_spec.ts
+++ b/packages/core/test/testability/testability_spec.ts
@@ -16,13 +16,11 @@ import {scheduleMicroTask} from '../../src/util';
 
 
 
-// Schedules a microtasks (using a resolved promise .then())
-function microTask(fn: Function): void {
-  scheduleMicroTask(() => {
-    // We do double dispatch so that we  can wait for scheduleMicrotask in the Testability when
-    // NgZone becomes stable.
-    scheduleMicroTask(fn);
-  });
+// Schedules a task to be run after Testability checks for oustanding tasks. Since Testability
+// uses a 0 second timeout to check for outstanding tasks we add our 0 second timeout after a
+// micro task (which ensures Testability's timeout is run first).
+function afterTestabilityCheck(fn: Function): void {
+  scheduleMicroTask(() => setTimeout(fn));
 }
 
 @Injectable()
@@ -65,7 +63,7 @@ export function main() {
       it('should fire whenstable callbacks if pending count is 0',
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
            testability.whenStable(execute);
-           microTask(() => {
+           afterTestabilityCheck(() => {
              expect(execute).toHaveBeenCalled();
              async.done();
            });
@@ -82,11 +80,11 @@ export function main() {
            testability.increasePendingRequestCount();
            testability.whenStable(execute);
 
-           microTask(() => {
+           afterTestabilityCheck(() => {
              expect(execute).not.toHaveBeenCalled();
              testability.decreasePendingRequestCount();
 
-             microTask(() => {
+             afterTestabilityCheck(() => {
                expect(execute).not.toHaveBeenCalled();
                async.done();
              });
@@ -98,11 +96,11 @@ export function main() {
            testability.increasePendingRequestCount();
            testability.whenStable(execute);
 
-           microTask(() => {
+           afterTestabilityCheck(() => {
              expect(execute).not.toHaveBeenCalled();
              testability.decreasePendingRequestCount();
 
-             microTask(() => {
+             afterTestabilityCheck(() => {
                expect(execute).toHaveBeenCalled();
                async.done();
              });
@@ -120,7 +118,7 @@ export function main() {
       it('should fire whenstable callbacks with didWork if pending count is 0',
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
            testability.whenStable(execute);
-           microTask(() => {
+           afterTestabilityCheck(() => {
              expect(execute).toHaveBeenCalledWith(false);
              async.done();
            });
@@ -131,14 +129,14 @@ export function main() {
            testability.increasePendingRequestCount();
            testability.whenStable(execute);
 
-           microTask(() => {
+           afterTestabilityCheck(() => {
              testability.decreasePendingRequestCount();
 
-             microTask(() => {
+             afterTestabilityCheck(() => {
                expect(execute).toHaveBeenCalledWith(true);
                testability.whenStable(execute2);
 
-               microTask(() => {
+               afterTestabilityCheck(() => {
                  expect(execute2).toHaveBeenCalledWith(false);
                  async.done();
                });
@@ -154,7 +152,7 @@ export function main() {
            ngZone.stable();
            testability.whenStable(execute);
 
-           microTask(() => {
+           afterTestabilityCheck(() => {
              expect(execute).toHaveBeenCalled();
              async.done();
            });
@@ -173,11 +171,11 @@ export function main() {
            ngZone.unstable();
            testability.whenStable(execute);
 
-           microTask(() => {
+           afterTestabilityCheck(() => {
              expect(execute).not.toHaveBeenCalled();
              ngZone.stable();
 
-             microTask(() => {
+             afterTestabilityCheck(() => {
                expect(execute).toHaveBeenCalled();
                async.done();
              });
@@ -198,15 +196,15 @@ export function main() {
            testability.increasePendingRequestCount();
            testability.whenStable(execute);
 
-           microTask(() => {
+           afterTestabilityCheck(() => {
              expect(execute).not.toHaveBeenCalled();
              testability.decreasePendingRequestCount();
 
-             microTask(() => {
+             afterTestabilityCheck(() => {
                expect(execute).not.toHaveBeenCalled();
                ngZone.stable();
 
-               microTask(() => {
+               afterTestabilityCheck(() => {
                  expect(execute).toHaveBeenCalled();
                  async.done();
                });
@@ -221,19 +219,19 @@ export function main() {
            testability.increasePendingRequestCount();
            testability.whenStable(execute);
 
-           microTask(() => {
+           afterTestabilityCheck(() => {
              expect(execute).not.toHaveBeenCalled();
              ngZone.stable();
 
-             microTask(() => {
+             afterTestabilityCheck(() => {
                expect(execute).not.toHaveBeenCalled();
                testability.decreasePendingRequestCount();
 
-               microTask(() => {
+               afterTestabilityCheck(() => {
                  expect(execute).not.toHaveBeenCalled();
                  testability.decreasePendingRequestCount();
 
-                 microTask(() => {
+                 afterTestabilityCheck(() => {
                    expect(execute).toHaveBeenCalled();
                    async.done();
                  });
@@ -248,11 +246,11 @@ export function main() {
            ngZone.stable();
            testability.whenStable(execute);
 
-           microTask(() => {
+           afterTestabilityCheck(() => {
              expect(execute).toHaveBeenCalledWith(true);
              testability.whenStable(execute2);
 
-             microTask(() => {
+             afterTestabilityCheck(() => {
                expect(execute2).toHaveBeenCalledWith(false);
                async.done();
              });
@@ -264,14 +262,14 @@ export function main() {
            ngZone.unstable();
            testability.whenStable(execute);
 
-           microTask(() => {
+           afterTestabilityCheck(() => {
              ngZone.stable();
 
-             microTask(() => {
+             afterTestabilityCheck(() => {
                expect(execute).toHaveBeenCalledWith(true);
                testability.whenStable(execute2);
 
-               microTask(() => {
+               afterTestabilityCheck(() => {
                  expect(execute2).toHaveBeenCalledWith(false);
                  async.done();
                });


### PR DESCRIPTION
Fixes an issue where chained http calls would prematurely call
testability whenStable callbacks after the first http call.

Fixes #209201

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Testability will call the methods queued up with whenStable asynchronously if the macro task queue is empty after an onStable event has fired from ngZone.

This results in the problem described in https://github.com/angular/angular/issues/20921

## What is the new behavior?

Testability will queue an asynchronous check that the macro test queue is empty and then empty the whenStable queue,

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

The reference issue contains a test which is solved with the code fixes, however it is a protractor test dependent on http calls actually being made, currently working on expressing the intended behaviour as a unit test.

Furthermore the change introduces a timer which tests running fakeAsync do not take into consideration, therefore these tests fail. Currently working on disabling testability for those unit tests.