### PR TITLE
build(common): don't generate .d.ts & .metadata.json files for i18n locales

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -476,7 +476,7 @@ do
 
       if [[ ${PACKAGE} == "common" ]]; then
         echo "======      Copy i18n locale data"
-        rsync -a --exclude=*.d.ts --exclude=*.metadata.json ${OUT_DIR}/locales/ ${NPM_DIR}/locales
+        rsync -a ${OUT_DIR}/locales/ ${NPM_DIR}/locales
       fi
     else
       echo "======        Copy ${PACKAGE} node tool"

--- a/packages/common/locales/tsconfig-build.json
+++ b/packages/common/locales/tsconfig-build.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declaration": true,
+    "declaration": false,
     "stripInternal": true,
     "experimentalDecorators": true,
     "module": "es2015",
@@ -21,6 +21,7 @@
     "./closure-locale.ts"
   ],
   "angularCompilerOptions": {
-    "skipTemplateCodegen": true
+    "skipTemplateCodegen": true,
+    "skipMetadataEmit": true
   }
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Build related changes
```

## What is the current behavior?
.d.ts & .metadata.json files are generated for i18n locales

Issue Number: fixes #20880 #20260 #20207 #20502 #20961


## What is the new behavior?
We don't generate those files that are not needed and can cause issues


## Does this PR introduce a breaking change?
```
[x] No
```