### PR TITLE
build: remove bazel option --noshow_results

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -29,9 +29,6 @@ build --watchfs
 # Output                      #
 ###############################
 
-# Don't print all the .d.ts output locations after builds
-build --show_result=0
-
 # A more useful default output mode for bazel query
 # Prints eg. "ng_module rule //foo:bar" rather than just "//foo:bar"
 query --output=label_kind


### PR DESCRIPTION
I originally added this when I was trying to build `//packages/core`, which is not what users will do often.
This makes it harder for team members to understand what Bazel is doing. I find myself suggesting to turn it off, so it's better to just remove it.
