### PR TITLE
fix(compiler): support referencing enums in namespaces

### DIFF
--- a/packages/compiler/src/aot/summary_resolver.ts
+++ b/packages/compiler/src/aot/summary_resolver.ts
@@ -65,13 +65,15 @@ export class AotSummaryResolver implements SummaryResolver<StaticSymbol> {
   }
 
   resolveSummary(staticSymbol: StaticSymbol): Summary<StaticSymbol>|null {
-    staticSymbol.assertNoMembers();
-    let summary = this.summaryCache.get(staticSymbol);
+    const rootSymbol = staticSymbol.members.length ?
+        this.staticSymbolCache.get(staticSymbol.filePath, staticSymbol.name) :
+        staticSymbol;
+    let summary = this.summaryCache.get(rootSymbol);
     if (!summary) {
       this._loadSummaryFile(staticSymbol.filePath);
       summary = this.summaryCache.get(staticSymbol) !;
     }
-    return summary || null;
+    return (rootSymbol === staticSymbol && summary) || null;
   }
 
   getSymbolsOf(filePath: string): StaticSymbol[]|null {

--- a/packages/compiler/test/aot/summary_resolver_spec.ts
+++ b/packages/compiler/test/aot/summary_resolver_spec.ts
@@ -95,6 +95,15 @@ export function main() {
            expect(host.isSourceFile).toHaveBeenCalledWith('someFile.ts');
          });
     });
+
+    describe('regression', () => {
+      // #18170
+      it('should support resolving symbol with members ', () => {
+        init();
+        expect(summaryResolver.resolveSummary(symbolCache.get('/src.d.ts', 'Src', ['One', 'Two'])))
+            .toBeNull();
+      });
+    });
   });
 }
 


### PR DESCRIPTION
Due to an overly agressive assert the compiler would generate
an internal error when referencing an enum declared in
namspace.

Fixes #18170

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue Number: #18170


## What is the new behavior?

The assert is removed and change to remove the members before loading the summary for a enum reference. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
