### PR TITLE
Another approach for formatting

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -138,7 +138,7 @@ is not properly formatted, the CI will fail and the PR can not be merged.
 You can automatically format your code by running:
 
 ``` shell
-$ gulp format
+$ yarn format
 ```
 
 ## Linting/verifying your source code

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,7 +28,10 @@ function loadTask(fileName, taskName) {
 }
 
 gulp.task('format:enforce', loadTask('format', 'enforce'));
-gulp.task('format', loadTask('format', 'format'));
+gulp.task('format', () => {
+  console.error('\nERROR: Run `yarn format` instead');
+  process.exit(1);
+});
 gulp.task('build.sh', loadTask('build', 'all'));
 gulp.task('build.sh:no-bundle', loadTask('build', 'no-bundle'));
 gulp.task('public-api:enforce', loadTask('public-api', 'enforce'));

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "fs-extra": "4.0.2",
     "glob": "7.1.2",
     "gulp": "3.9.1",
-    "gulp-clang-format": "1.0.23",
     "gulp-connect": "5.0.0",
     "gulp-conventional-changelog": "1.1.0",
     "gulp-tslint": "8.1.2",

--- a/tools/gulp-tasks/cldr/closure.js
+++ b/tools/gulp-tasks/cldr/closure.js
@@ -12,7 +12,7 @@ const {I18N_DATA_FOLDER, RELATIVE_I18N_DATA_FOLDER, HEADER} = require('./extract
 const OUTPUT_NAME = `closure-locale.ts`;
 
 // tslint:disable:no-console
-module.exports = (gulp, done) => {
+module.exports = () => {
   // the locales used by closure that will be used to generate the closure-locale file
   // extracted from:
   // https://github.com/google/closure-library/blob/master/closure/goog/i18n/datetimepatterns.js#L2136
@@ -55,13 +55,6 @@ module.exports = (gulp, done) => {
   console.log(`Writing file ${I18N_DATA_FOLDER}/${OUTPUT_NAME}`);
   fs.writeFileSync(
       `${RELATIVE_I18N_DATA_FOLDER}/${OUTPUT_NAME}`, generateAllLocalesFile(GOOG_LOCALES, ALIASES));
-
-  console.log(`Formatting ${I18N_DATA_FOLDER}/${OUTPUT_NAME}..."`);
-  const format = require('gulp-clang-format');
-  const clangFormat = require('clang-format');
-  return gulp.src([`${I18N_DATA_FOLDER}/${OUTPUT_NAME}`], {base: '.'})
-      .pipe(format.format('file', clangFormat))
-      .pipe(gulp.dest('.'));
 };
 
 /**

--- a/tools/gulp-tasks/cldr/extract.js
+++ b/tools/gulp-tasks/cldr/extract.js
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+ // clang-format off
 const fs = require('fs');
 const path = require('path');
 const util = require('util');
@@ -37,7 +38,7 @@ const HEADER = `/**
 `;
 
 // tslint:disable:no-console
-module.exports = (gulp, done) => {
+module.exports = () => {
   const cldrData = require('./cldr-data');
   const LOCALES = cldrData.availableLocales;
 
@@ -72,17 +73,7 @@ module.exports = (gulp, done) => {
   console.log(`Writing file ${I18N_FOLDER}/currencies.ts`);
   fs.writeFileSync(`${RELATIVE_I18N_FOLDER}/currencies.ts`, generateCurrencies());
 
-  console.log(`All i18n cldr files have been generated, formatting files..."`);
-  const format = require('gulp-clang-format');
-  const clangFormat = require('clang-format');
-  return gulp
-    .src([
-        `${I18N_DATA_FOLDER}/**/*.ts`,
-        `${I18N_FOLDER}/currencies.ts`,
-        `${I18N_FOLDER}/locale_en.ts`
-      ], {base: '.'})
-    .pipe(format.format('file', clangFormat))
-    .pipe(gulp.dest('.'));
+  console.log(`All i18n cldr files have been generated`);
 };
 
 /**

--- a/tools/gulp-tasks/format.js
+++ b/tools/gulp-tasks/format.js
@@ -6,43 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-const {I18N_FOLDER, I18N_DATA_FOLDER} = require('./cldr/extract');
-
-// clang-format entry points
-const srcsToFmt = [
-  'packages/**/*.{js,ts}',
-  'modules/benchmarks/**/*.{js,ts}',
-  'modules/e2e_util/**/*.{js,ts}',
-  'modules/playground/**/*.{js,ts}',
-  'tools/**/*.{js,ts}',
-  '!tools/public_api_guard/**/*.d.ts',
-  './*.{js,ts}',
-  '!**/node_modules/**',
-  '!**/dist/**',
-  '!**/built/**',
-  '!shims_for_IE.js',
-  `!${I18N_DATA_FOLDER}/**/*.{js,ts}`,
-  `!${I18N_FOLDER}/available_locales.ts`,
-  `!${I18N_FOLDER}/currencies.ts`,
-  `!${I18N_FOLDER}/locale_en.ts`,
-  '!tools/gulp-tasks/cldr/extract.js',
-];
+const shell = require("shelljs");
 
 module.exports = {
   // Check source code for formatting errors (clang-format)
   enforce: (gulp) => () => {
-    const format = require('gulp-clang-format');
-    const clangFormat = require('clang-format');
-    return gulp.src(srcsToFmt).pipe(
-        format.checkFormat('file', clangFormat, {verbose: true, fail: true}));
+    const result = shell.exec("./node_modules/.bin/git-clang-format");
+    if (result.code !== 0) {
+      console.error('git-clang-format found unformatted changes');
+      process.exit(1);
+    }
   },
-
-  // Format the source code with clang-format (see .clang-format)
-  format: (gulp) => () => {
-    const format = require('gulp-clang-format');
-    const clangFormat = require('clang-format');
-    return gulp.src(srcsToFmt, {base: '.'})
-        .pipe(format.format('file', clangFormat))
-        .pipe(gulp.dest('.'));
-  }
 };

--- a/tools/gulp-tasks/format.js
+++ b/tools/gulp-tasks/format.js
@@ -14,7 +14,7 @@ module.exports = {
     const result = shell.exec("./node_modules/.bin/git-clang-format");
     if (result.code !== 0) {
       console.error('git-clang-format found unformatted changes');
-      process.exit(1);
+      process.exit(1) ;
     }
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,7 +249,7 @@ ansi-escapes@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
-ansi-regex@^2.0.0, ansi-regex@^2.1.1:
+ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
@@ -1011,14 +1011,6 @@ clang-format@1.0.41:
     glob "^7.0.0"
     resolve "^1.1.6"
 
-clang-format@^1.0.32:
-  version "1.0.55"
-  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.0.55.tgz#8031271329e27a779a5d08fc5dce24d7c52c14d5"
-  dependencies:
-    async "^1.5.2"
-    glob "^7.0.0"
-    resolve "^1.1.6"
-
 cldr-data-downloader@0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cldr-data-downloader/-/cldr-data-downloader-0.3.2.tgz#8d0c98346d16486252fdc9afa36a46542fe4652f"
@@ -1053,17 +1045,6 @@ cldrjs@0.5.0:
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
-
-cli-color@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-1.2.0.tgz#3a5ae74fd76b6267af666e69e2afbbd01def34d1"
-  dependencies:
-    ansi-regex "^2.1.1"
-    d "1"
-    es5-ext "^0.10.12"
-    es6-iterator "2"
-    memoizee "^0.4.3"
-    timers-ext "0.1"
 
 cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
@@ -1916,7 +1897,7 @@ didyoumean@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.1.tgz#e92edfdada6537d484d73c0172fd1eba0c4976ff"
 
-diff@^2.0.2, diff@^2.2.3:
+diff@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/diff/-/diff-2.2.3.tgz#60eafd0d28ee906e4e8ff0a52c1229521033bf99"
 
@@ -1966,7 +1947,7 @@ duplexer2@0.0.2:
   dependencies:
     readable-stream "~1.1.9"
 
-duplexer2@^0.1.4, duplexer2@~0.1.0:
+duplexer2@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
   dependencies:
@@ -2124,7 +2105,7 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
-es5-ext@^0.10.12, es5-ext@^0.10.14, es5-ext@^0.10.30, es5-ext@^0.10.9, es5-ext@~0.10.14, es5-ext@~0.10.2:
+es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.30"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.30.tgz#7141a16836697dbabfaaaeee41495ce29f52c939"
   dependencies:
@@ -2135,7 +2116,7 @@ es6-error@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.0.0.tgz#f094c7041f662599bb12720da059d6b9c7ff0f40"
 
-es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
+es6-iterator@2, es6-iterator@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.1.tgz#8e319c9f0453bf575d374940a655920e59ca5512"
   dependencies:
@@ -2173,21 +2154,12 @@ es6-set@^0.1.4:
     es6-symbol "3.1.1"
     event-emitter "~0.3.5"
 
-es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1:
+es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@~3.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
   dependencies:
     d "1"
     es5-ext "~0.10.14"
-
-es6-weak-map@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.14"
-    es6-iterator "^2.0.1"
-    es6-symbol "^3.1.1"
 
 escape-html@1.0.2:
   version "1.0.2"
@@ -2237,14 +2209,14 @@ etag@~1.8.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
-event-emitter@^0.3.5, event-emitter@~0.3.5:
+event-emitter@~0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
   dependencies:
     d "1"
     es5-ext "~0.10.14"
 
-event-stream@^3.1.5, event-stream@^3.3.2:
+event-stream@^3.3.2:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
   dependencies:
@@ -3176,18 +3148,6 @@ gtoken@^1.2.1:
     mime "^1.2.11"
     request "^2.72.0"
 
-gulp-clang-format@1.0.23:
-  version "1.0.23"
-  resolved "https://registry.yarnpkg.com/gulp-clang-format/-/gulp-clang-format-1.0.23.tgz#fe258586b83998491e632fc0c4fc0ecdfa10c89f"
-  dependencies:
-    clang-format "^1.0.32"
-    gulp-diff "^1.0.0"
-    gulp-util "^3.0.4"
-    pkginfo "^0.3.0"
-    stream-combiner2 "^1.1.1"
-    stream-equal "0.1.6"
-    through2 "^0.6.3"
-
 gulp-connect@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/gulp-connect/-/gulp-connect-5.0.0.tgz#f2fdf306ae911468368c2285f2d782f13eddaf4e"
@@ -3209,16 +3169,6 @@ gulp-conventional-changelog@1.1.0:
     object-assign "^4.0.1"
     through2 "^2.0.0"
 
-gulp-diff@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gulp-diff/-/gulp-diff-1.0.0.tgz#101b23712dd6b107bd07d05ab88ea3ac485fed77"
-  dependencies:
-    cli-color "^1.0.0"
-    diff "^2.0.2"
-    event-stream "^3.1.5"
-    gulp-util "^3.0.6"
-    through2 "^2.0.0"
-
 gulp-tslint@8.1.2:
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/gulp-tslint/-/gulp-tslint-8.1.2.tgz#e0f43194b473d7e76bb45a58fe8c60e7dfe3beb2"
@@ -3227,7 +3177,7 @@ gulp-tslint@8.1.2:
     map-stream "~0.0.7"
     through "~2.3.8"
 
-gulp-util@^3.0.0, gulp-util@^3.0.4, gulp-util@^3.0.6, gulp-util@~3.0.8:
+gulp-util@^3.0.0, gulp-util@^3.0.6, gulp-util@~3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:
@@ -3760,10 +3710,6 @@ is-posix-bracket@^0.1.0:
 is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
-
-is-promise@^2.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
 is-property@^1.0.0:
   version "1.0.2"
@@ -4548,12 +4494,6 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-lru-queue@0.1:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
-  dependencies:
-    es5-ext "~0.10.2"
-
 madge@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/madge/-/madge-0.5.0.tgz#4da1ba55ccde09bd7642a8e721fe6cbcea32c60f"
@@ -4622,19 +4562,6 @@ memoizeasync@1.0.0:
   dependencies:
     lru-cache "2.5.0"
     passerror "1.1.1"
-
-memoizee@^0.4.3:
-  version "0.4.11"
-  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.11.tgz#bde9817663c9e40fdb2a4ea1c367296087ae8c8f"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.30"
-    es6-weak-map "^2.0.2"
-    event-emitter "^0.3.5"
-    is-promise "^2.1"
-    lru-queue "0.1"
-    next-tick "1"
-    timers-ext "^0.1.2"
 
 memory-fs@^0.2.0:
   version "0.2.0"
@@ -4928,10 +4855,6 @@ nested-error-stacks@^1.0.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz#19f619591519f096769a5ba9a86e6eeec823c3cf"
   dependencies:
     inherits "~2.0.1"
-
-next-tick@1:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
 
 node-forge@^0.7.1:
   version "0.7.1"
@@ -5443,7 +5366,7 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
-pkginfo@0.3.x, pkginfo@^0.3.0:
+pkginfo@0.3.x:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
 
@@ -6618,13 +6541,6 @@ stream-browserify@^1.0.0:
     inherits "~2.0.1"
     readable-stream "^1.0.27-1"
 
-stream-combiner2@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stream-combiner2/-/stream-combiner2-1.1.1.tgz#fb4d8a1420ea362764e21ad4780397bebcb41cbe"
-  dependencies:
-    duplexer2 "~0.1.0"
-    readable-stream "^2.0.2"
-
 stream-combiner@~0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
@@ -6640,10 +6556,6 @@ stream-counter@~0.2.0:
   resolved "https://registry.yarnpkg.com/stream-counter/-/stream-counter-0.2.0.tgz#ded266556319c8b0e222812b9cf3b26fa7d947de"
   dependencies:
     readable-stream "~1.1.8"
-
-stream-equal@0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/stream-equal/-/stream-equal-0.1.6.tgz#cc522fab38516012e4d4ee47513b147b72359019"
 
 stream-events@^1.0.1:
   version "1.0.2"
@@ -6934,7 +6846,7 @@ through2@2.0.1:
     readable-stream "~2.0.0"
     xtend "~4.0.0"
 
-through2@^0.6.1, through2@^0.6.3:
+through2@^0.6.1:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
   dependencies:
@@ -6979,13 +6891,6 @@ timers-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-1.4.2.tgz#c9c58b575be8407375cb5e2462dacee74359f41d"
   dependencies:
     process "~0.11.0"
-
-timers-ext@0.1, timers-ext@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/timers-ext/-/timers-ext-0.1.2.tgz#61cc47a76c1abd3195f14527f978d58ae94c5204"
-  dependencies:
-    es5-ext "~0.10.14"
-    next-tick "1"
 
 tiny-lr@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
Keep current version of clang format, don't introduce a hook.
Continue to verify formatting on CircleCI, but only look at changes.
Give users a faster command to run locally that only re-formats changes.

This is an alternative starting point for https://github.com/angular/angular/pull/20884

let's keep discussion on that PR?