### PR TITLE
fix(elements): fixed one way binding issue

### DIFF
--- a/packages/elements/src/ng-element.ts
+++ b/packages/elements/src/ng-element.ts
@@ -101,11 +101,7 @@ export abstract class NgElementImpl<T> extends HTMLElement implements NgElement<
       private readonly outputs: NgElementOutput[]) {
     super();
     
-    this.checkExistingProperties(inputs);
-  }
-  
-  checkExistingProperties(properties: NgElementInput[]) {
-    properties.forEach(({ propName }) => {
+    inputs.forEach(({ propName }) => {
       if (this.hasOwnProperty(propName)) {
         this.setInputValue(propName, this[propName]);
         delete this[propName];

--- a/packages/elements/src/ng-element.ts
+++ b/packages/elements/src/ng-element.ts
@@ -100,6 +100,17 @@ export abstract class NgElementImpl<T> extends HTMLElement implements NgElement<
       private componentFactory: ComponentFactory<T>, private readonly inputs: NgElementInput[],
       private readonly outputs: NgElementOutput[]) {
     super();
+    
+    this.checkExistingProperties(inputs);
+  }
+  
+  checkExistingProperties(properties: NgElementInput[]) {
+    properties.forEach(({ propName }) => {
+      if (this.hasOwnProperty(propName)) {
+        this.setInputValue(propName, this[propName]);
+        delete this[propName];
+      }
+    });
   }
 
   attributeChangedCallback(
@@ -303,12 +314,6 @@ export abstract class NgElementImpl<T> extends HTMLElement implements NgElement<
         // The property does have an initial value.
         // Forward it to the component instance.
         this.setInputValue(propName, initialValue);
-      }
-      
-      if (this.hasOwnProperty(propName)) {
-        let value = this[propName];
-        delete this[propName];
-        this[propName] = value;
       }
     });
 

--- a/packages/elements/src/ng-element.ts
+++ b/packages/elements/src/ng-element.ts
@@ -304,6 +304,12 @@ export abstract class NgElementImpl<T> extends HTMLElement implements NgElement<
         // Forward it to the component instance.
         this.setInputValue(propName, initialValue);
       }
+      
+      if (this.hasOwnProperty(propName)) {
+        let value = this[propName];
+        delete this[propName];
+        this[propName] = value;
+      }
     });
 
     this.initialInputValues.clear();

--- a/packages/elements/src/ng-element.ts
+++ b/packages/elements/src/ng-element.ts
@@ -100,11 +100,12 @@ export abstract class NgElementImpl<T> extends HTMLElement implements NgElement<
       private componentFactory: ComponentFactory<T>, private readonly inputs: NgElementInput[],
       private readonly outputs: NgElementOutput[]) {
     super();
-    
-    inputs.forEach(({ propName }) => {
+
+    inputs.forEach(({propName}) => {
       if (this.hasOwnProperty(propName)) {
-        this.setInputValue(propName, this[propName]);
-        delete this[propName];
+        const pThis = this as (this & {[key: string]: any});
+        pThis.setInputValue(propName, pThis[propName]);
+        delete pThis[propName];
       }
     });
   }


### PR DESCRIPTION
Using angular element inside angular had an issue with one way binding.
[Reason explained here](https://developers.google.com/web/fundamentals/web-components/best-practices#lazy-properties)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
One-way from data source to view target data binding is not working

Issue Number: N/A


## What is the new behavior?
One-way from data source to view target data binding works


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
