### PR TITLE
ci: allow me to approve circleCI changes

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -44,6 +44,7 @@ groups:
         include:
           - "*"
         exclude:
+          - ".circleci/*"
           - "aio/*"
           - "integration/*"
           - "modules/*"


### PR DESCRIPTION
Removes the root group from the pullapprove settings for .circleci/*