### PR TITLE
Use default_tsconfig on ts_repositories

### DIFF
--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -5,16 +5,9 @@ exports_files([
     "tsconfig.json",
 ])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_config", "ts_library")
-
-ts_config(
-    name = "tsconfig",
-    src = ":tsconfig-build.json",
-    deps = [],
-)
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "types",
     srcs = glob(["*.ts"]),
-    tsconfig = ":tsconfig",
 )

--- a/packages/animations/BUILD.bazel
+++ b/packages/animations/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "animations",
@@ -11,7 +11,6 @@ ts_library(
         ],
     ),
     module_name = "@angular/animations",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/core",
     ],

--- a/packages/animations/browser/BUILD.bazel
+++ b/packages/animations/browser/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "browser",
@@ -11,7 +11,6 @@ ts_library(
         ],
     ),
     module_name = "@angular/animations/browser",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/animations",
     ],

--- a/packages/animations/browser/test/BUILD.bazel
+++ b/packages/animations/browser/test/BUILD.bazel
@@ -1,10 +1,9 @@
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "test",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/animations",

--- a/packages/animations/browser/testing/BUILD.bazel
+++ b/packages/animations/browser/testing/BUILD.bazel
@@ -1,13 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "testing",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
     module_name = "@angular/animations/browser/testing",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/animations",
         "//packages/animations/browser",

--- a/packages/animations/test/BUILD.bazel
+++ b/packages/animations/test/BUILD.bazel
@@ -1,10 +1,9 @@
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "test",
     testonly = 1,
     srcs = glob(["test/**/*.ts"]),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/animations",

--- a/packages/common/BUILD.bazel
+++ b/packages/common/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "common",
@@ -11,7 +11,6 @@ ts_library(
         ],
     ),
     module_name = "@angular/common",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/core",
         "@rxjs",

--- a/packages/common/http/BUILD.bazel
+++ b/packages/common/http/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "http",
@@ -11,7 +11,6 @@ ts_library(
         ],
     ),
     module_name = "@angular/common/http",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/common",
         "//packages/core",

--- a/packages/common/http/testing/BUILD.bazel
+++ b/packages/common/http/testing/BUILD.bazel
@@ -1,13 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "testing",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
     module_name = "@angular/common/http/testing",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/common/http",
         "//packages/core",

--- a/packages/common/locales/BUILD.bazel
+++ b/packages/common/locales/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "locales",
@@ -9,7 +9,4 @@ ts_library(
         exclude = ["closure-locale.ts"],
     ),
     module_name = "@angular/common/locales",
-    tsconfig = "//packages:tsconfig",
-    deps = [
-    ],
 )

--- a/packages/common/test/BUILD.bazel
+++ b/packages/common/test/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -8,7 +9,6 @@ ts_library(
         ["**/*.ts"],
         exclude = ["**/*_node_only_spec.ts"],
     ),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/common",
         "//packages/common/locales",

--- a/packages/common/testing/BUILD.bazel
+++ b/packages/common/testing/BUILD.bazel
@@ -1,13 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "testing",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
     module_name = "@angular/common/testing",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/common",
         "//packages/core",

--- a/packages/compiler/BUILD.bazel
+++ b/packages/compiler/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "compiler",
@@ -11,5 +11,4 @@ ts_library(
         ],
     ),
     module_name = "@angular/compiler",
-    tsconfig = "//packages:tsconfig",
 )

--- a/packages/compiler/test/BUILD.bazel
+++ b/packages/compiler/test/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -8,7 +9,6 @@ ts_library(
         ["**/*.ts"],
         exclude = ["**/*_node_only_spec.ts"],
     ),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/common",
@@ -27,7 +27,6 @@ ts_library(
     name = "test_node_only_lib",
     testonly = 1,
     srcs = glob(["**/*_node_only_spec.ts"]),
-    tsconfig = "//packages:tsconfig",
     deps = [
         ":test_lib",
         "//packages/compiler",

--- a/packages/compiler/testing/BUILD.bazel
+++ b/packages/compiler/testing/BUILD.bazel
@@ -1,13 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "testing",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
     module_name = "@angular/compiler/testing",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/compiler",

--- a/packages/core/BUILD.bazel
+++ b/packages/core/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@angular//:index.bzl", "ng_module")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ng_module")
 
 ng_module(
     name = "core",
@@ -12,7 +11,6 @@ ng_module(
         ],
     ),
     module_name = "@angular/core",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "@rxjs",

--- a/packages/core/test/BUILD.bazel
+++ b/packages/core/test/BUILD.bazel
@@ -1,6 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -13,7 +14,6 @@ ts_library(
             "render3/**/*.ts",
         ],
     ),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/animations",
         "//packages/animations/browser",
@@ -37,7 +37,6 @@ ts_library(
     name = "test_node_only_lib",
     testonly = 1,
     srcs = glob(["**/*_node_only_spec.ts"]),
-    tsconfig = "//packages:tsconfig",
     deps = [
         ":test_lib",
         "//packages/compiler",

--- a/packages/core/test/render3/BUILD.bazel
+++ b/packages/core/test/render3/BUILD.bazel
@@ -1,6 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -14,6 +15,7 @@ ts_library(
             "load_domino.ts",
         ],
     ),
+    # TODO(alexeagle): should not be different tsconfig
     tsconfig = "//packages:tsconfig.json",
     deps = [
         "//packages:types",
@@ -34,7 +36,6 @@ ts_library(
         "domino.d.ts",
         "load_domino.ts",
     ],
-    tsconfig = "//packages:tsconfig",
     deps = [
         ":render3_lib",
         "//packages/platform-browser",

--- a/packages/core/testing/BUILD.bazel
+++ b/packages/core/testing/BUILD.bazel
@@ -1,13 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "testing",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
     module_name = "@angular/core/testing",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/core",

--- a/packages/forms/BUILD.bazel
+++ b/packages/forms/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@angular//:index.bzl", "ng_module")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ng_module")
 
 ng_module(
     name = "forms",
@@ -12,7 +11,6 @@ ng_module(
         ],
     ),
     module_name = "@angular/forms",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/packages/forms/test/BUILD.bazel
+++ b/packages/forms/test/BUILD.bazel
@@ -1,11 +1,11 @@
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
     name = "test_lib",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/core",
         "//packages/core/testing",

--- a/packages/http/BUILD.bazel
+++ b/packages/http/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "http",
@@ -11,7 +11,6 @@ ts_library(
         ],
     ),
     module_name = "@angular/http",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/packages/http/test/BUILD.bazel
+++ b/packages/http/test/BUILD.bazel
@@ -1,11 +1,11 @@
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
     name = "test_lib",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/core",
         "//packages/core/testing",

--- a/packages/http/testing/BUILD.bazel
+++ b/packages/http/testing/BUILD.bazel
@@ -1,13 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "testing",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
     module_name = "@angular/http/testing",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/core",
         "//packages/http",

--- a/packages/language-service/BUILD.bazel
+++ b/packages/language-service/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "language-service",
@@ -11,7 +11,6 @@ ts_library(
         ],
     ),
     module_name = "@angular/language-service",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/compiler",

--- a/packages/language-service/test/BUILD.bazel
+++ b/packages/language-service/test/BUILD.bazel
@@ -1,11 +1,11 @@
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
     name = "test_lib",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/compiler",

--- a/packages/platform-browser-dynamic/BUILD.bazel
+++ b/packages/platform-browser-dynamic/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@angular//:index.bzl", "ng_module")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "platform-browser-dynamic",
@@ -12,7 +11,6 @@ ts_library(
         ],
     ),
     module_name = "@angular/platform-browser-dynamic",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/common",

--- a/packages/platform-browser-dynamic/test/BUILD.bazel
+++ b/packages/platform-browser-dynamic/test/BUILD.bazel
@@ -1,11 +1,11 @@
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
     name = "test_lib",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/compiler",

--- a/packages/platform-browser-dynamic/testing/BUILD.bazel
+++ b/packages/platform-browser-dynamic/testing/BUILD.bazel
@@ -1,13 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "testing",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
     module_name = "@angular/platform-browser-dynamic/testing",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/compiler",
         "//packages/compiler/testing",

--- a/packages/platform-browser/BUILD.bazel
+++ b/packages/platform-browser/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@angular//:index.bzl", "ng_module")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "platform-browser",
@@ -12,7 +11,6 @@ ts_library(
         ],
     ),
     module_name = "@angular/platform-browser",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/common",

--- a/packages/platform-browser/animations/BUILD.bazel
+++ b/packages/platform-browser/animations/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "animations",
@@ -11,7 +11,6 @@ ts_library(
         ],
     ),
     module_name = "@angular/platform-browser/animations",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/animations",
         "//packages/animations/browser",

--- a/packages/platform-browser/test/BUILD.bazel
+++ b/packages/platform-browser/test/BUILD.bazel
@@ -1,11 +1,11 @@
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
     name = "test_lib",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/animations",

--- a/packages/platform-browser/testing/BUILD.bazel
+++ b/packages/platform-browser/testing/BUILD.bazel
@@ -1,13 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "testing",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
     module_name = "@angular/platform-browser/testing",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "platform-server",
@@ -11,7 +11,6 @@ ts_library(
         ],
     ),
     module_name = "@angular/platform-server",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/animations/browser",
         "//packages/common",

--- a/packages/platform-server/test/BUILD.bazel
+++ b/packages/platform-server/test/BUILD.bazel
@@ -1,11 +1,11 @@
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
     name = "test_lib",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/animations",

--- a/packages/platform-server/testing/BUILD.bazel
+++ b/packages/platform-server/testing/BUILD.bazel
@@ -1,13 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "testing",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
     module_name = "@angular/platform-server/testing",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/core",
         "//packages/platform-browser-dynamic/testing",

--- a/packages/platform-webworker-dynamic/BUILD.bazel
+++ b/packages/platform-webworker-dynamic/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@angular//:index.bzl", "ng_module")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "platform-webworker-dynamic",
@@ -12,7 +11,6 @@ ts_library(
         ],
     ),
     module_name = "@angular/platform-webworker-dynamic",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/common",

--- a/packages/platform-webworker/BUILD.bazel
+++ b/packages/platform-webworker/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@angular//:index.bzl", "ng_module")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "platform-webworker",
@@ -12,7 +11,6 @@ ts_library(
         ],
     ),
     module_name = "@angular/platform-webworker",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/common",

--- a/packages/platform-webworker/test/BUILD.1.bazel
+++ b/packages/platform-webworker/test/BUILD.1.bazel
@@ -1,13 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "testing",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
     module_name = "@angular/platform-browser-dynamic/testing",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/compiler",
         "//packages/compiler/testing",

--- a/packages/platform-webworker/test/BUILD.bazel
+++ b/packages/platform-webworker/test/BUILD.bazel
@@ -1,11 +1,11 @@
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
     name = "test_lib",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/compiler",

--- a/packages/router/BUILD.bazel
+++ b/packages/router/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "router",
@@ -11,7 +11,6 @@ ts_library(
         ],
     ),
     module_name = "@angular/router",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/common",
         "//packages/core",

--- a/packages/router/test/BUILD.bazel
+++ b/packages/router/test/BUILD.bazel
@@ -1,11 +1,11 @@
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
     name = "test_lib",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/common",
         "//packages/common/testing",

--- a/packages/router/testing/BUILD.bazel
+++ b/packages/router/testing/BUILD.bazel
@@ -1,13 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "testing",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
     module_name = "@angular/router/testing",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/common",
         "//packages/common/testing",

--- a/packages/service-worker/BUILD.bazel
+++ b/packages/service-worker/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "service-worker",
@@ -11,7 +11,6 @@ ts_library(
         ],
     ),
     module_name = "@angular/service-worker",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/common",
         "//packages/core",

--- a/packages/service-worker/test/BUILD.bazel
+++ b/packages/service-worker/test/BUILD.bazel
@@ -1,11 +1,11 @@
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
     name = "test_lib",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/core",

--- a/packages/service-worker/testing/BUILD.bazel
+++ b/packages/service-worker/testing/BUILD.bazel
@@ -1,13 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "testing",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
     module_name = "@angular/service-worker/testing",
-    tsconfig = "//packages:tsconfig",
-    deps = [
-    ],
 )

--- a/packages/service-worker/worker/test/BUILD.bazel
+++ b/packages/service-worker/worker/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -7,7 +7,6 @@ ts_library(
     srcs = glob(
         ["**/*.ts"],
     ),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/service-worker/worker",

--- a/packages/service-worker/worker/testing/BUILD.bazel
+++ b/packages/service-worker/worker/testing/BUILD.bazel
@@ -1,12 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "testing",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/service-worker/worker",

--- a/packages/upgrade/BUILD.bazel
+++ b/packages/upgrade/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "upgrade",
@@ -11,7 +11,6 @@ ts_library(
         ],
     ),
     module_name = "@angular/upgrade",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/packages/upgrade/static/BUILD.bazel
+++ b/packages/upgrade/static/BUILD.bazel
@@ -1,12 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "static",
     srcs = glob(["**/*.ts"]),
     module_name = "@angular/upgrade/static",
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/packages/upgrade/test/BUILD.bazel
+++ b/packages/upgrade/test/BUILD.bazel
@@ -1,11 +1,11 @@
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
     name = "test_lib",
     testonly = 1,
     srcs = glob(["**/*.ts"]),
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages:types",
         "//packages/core",

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,0 +1,1 @@
+# Marker file indicating this folder is a Bazel package

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -1,0 +1,15 @@
+"""Re-export of some bazel rules with repository-wide defaults."""
+load("@build_bazel_rules_typescript//:defs.bzl", _ts_library = "ts_library")
+load("@angular//:index.bzl", _ng_module = "ng_module")
+
+DEFAULT_TSCONFIG = "//packages:tsconfig-build.json"
+
+def ts_library(tsconfig = None, **kwargs):
+  if not tsconfig:
+    tsconfig = DEFAULT_TSCONFIG
+  _ts_library(tsconfig = tsconfig, **kwargs)
+
+def ng_module(tsconfig = None, **kwargs):
+  if not tsconfig:
+    tsconfig = DEFAULT_TSCONFIG
+  _ng_module(tsconfig = tsconfig, **kwargs)

--- a/tools/testing/BUILD.bazel
+++ b/tools/testing/BUILD.bazel
@@ -1,12 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
     name = "browser",
     testonly = 1,
     srcs = ["init_browser_spec.ts"],
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/core/testing",
         "//packages/platform-browser-dynamic/testing",
@@ -18,7 +17,6 @@ ts_library(
     name = "node",
     testonly = 1,
     srcs = ["init_node_spec.ts"],
-    tsconfig = "//packages:tsconfig",
     deps = [
         "//packages/core/testing",
         "//packages/platform-server",


### PR DESCRIPTION
This prevents us repeating the tsconfig attribute everywhere, and possibly having different tsconfig for different targets