### PR TITLE
fix(forms): avoid producing an error with hostBindingTypeCheck

### DIFF
--- a/packages/forms/src/directives/default_value_accessor.ts
+++ b/packages/forms/src/directives/default_value_accessor.ts
@@ -49,10 +49,10 @@ export const COMPOSITION_BUFFER_MODE = new InjectionToken<boolean>('CompositionE
   // https://github.com/angular/angular/issues/3011 is implemented
   // selector: '[ngModel],[formControl],[formControlName]',
   host: {
-    '(input)': '_handleInput($event.target.value)',
+    '(input)': '$any(this)._handleInput($event.target.value)',
     '(blur)': 'onTouched()',
-    '(compositionstart)': '_compositionStart()',
-    '(compositionend)': '_compositionEnd($event.target.value)'
+    '(compositionstart)': '$any(this)._compositionStart()',
+    '(compositionend)': '$any(this)._compositionEnd($event.target.value)'
   },
   providers: [DEFAULT_VALUE_ACCESSOR]
 })


### PR DESCRIPTION
Using the default value accessor no longer produces errors when
used in combination with fullTemplateTypeCheck and hostBindingTypeCheck.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Using the default value accessor causes an error to be produced when both `fullTemplateTypeCheck` and `hostBindingTypeCheck` are enabled.

## What is the new behavior?

No errors are produced.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```