### PR TITLE
export currencies via `getCurrencySymbolElseCode`

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -14,8 +14,7 @@
 export * from './location/index';
 export {NgLocaleLocalization, NgLocalization} from './i18n/localization';
 export {registerLocaleData} from './i18n/locale_data';
-export {Plural, NumberFormatStyle, FormStyle, Time, TranslationWidth, FormatWidth, NumberSymbol, WeekDay, getLocaleDayPeriods, getLocaleDayNames, getLocaleMonthNames, getLocaleId, getLocaleEraNames, getLocaleWeekEndRange, getLocaleFirstDayOfWeek, getLocaleDateFormat, getLocaleDateTimeFormat, getLocaleExtraDayPeriodRules, getLocaleExtraDayPeriods, getLocalePluralCase, getLocaleTimeFormat, getLocaleNumberSymbol, getLocaleNumberFormat, getLocaleCurrencyName, getLocaleCurrencySymbol} from './i18n/locale_data_api';
-export {CURRENCIES} from './i18n/currencies';
+export {Plural, NumberFormatStyle, FormStyle, Time, TranslationWidth, FormatWidth, NumberSymbol, WeekDay, getCurrencySymbol, getLocaleDayPeriods, getLocaleDayNames, getLocaleMonthNames, getLocaleId, getLocaleEraNames, getLocaleWeekEndRange, getLocaleFirstDayOfWeek, getLocaleDateFormat, getLocaleDateTimeFormat, getLocaleExtraDayPeriodRules, getLocaleExtraDayPeriods, getLocalePluralCase, getLocaleTimeFormat, getLocaleNumberSymbol, getLocaleNumberFormat, getLocaleCurrencyName, getLocaleCurrencySymbol} from './i18n/locale_data_api';
 export {parseCookieValue as ɵparseCookieValue} from './cookie';
 export {CommonModule, DeprecatedI18NPipesModule} from './common_module';
 export {NgClass, NgForOf, NgForOfContext, NgIf, NgIfContext, NgPlural, NgPluralCase, NgStyle, NgSwitch, NgSwitchCase, NgSwitchDefault, NgTemplateOutlet, NgComponentOutlet} from './directives/index';

--- a/packages/common/src/i18n/currencies.ts
+++ b/packages/common/src/i18n/currencies.ts
@@ -9,7 +9,7 @@
 // THIS CODE IS GENERATED - DO NOT MODIFY
 // See angular/tools/gulp-tasks/cldr/extract.js
 
-/** @experimental */
+/** @internal */
 export const CURRENCIES: {[code: string]: (string | undefined)[]} = {
   'AOA': [, 'Kz'],
   'ARS': [, '$'],

--- a/packages/common/src/i18n/locale_data_api.ts
+++ b/packages/common/src/i18n/locale_data_api.ts
@@ -527,12 +527,17 @@ export function findLocaleData(locale: string): any {
 
 /**
  * Return the currency symbol for a given currency code, or the code if no symbol available
- * (e.g.: $, US$, or USD)
+ * (e.g.: format narrow = $, format wide = US$, code = USD)
  *
- * @internal
+ * @experimental i18n support is experimental.
  */
-export function findCurrencySymbol(code: string, format: 'wide' | 'narrow') {
-  const currency = CURRENCIES[code] || {};
-  const symbol = currency[0] || code;
-  return format === 'wide' ? symbol : currency[1] || symbol;
+export function getCurrencySymbol(code: string, format: 'wide' | 'narrow'): string {
+  const currency = CURRENCIES[code] || [];
+  const symbolNarrow = currency[1];
+
+  if (format === 'narrow' && typeof symbolNarrow === 'string') {
+    return symbolNarrow;
+  }
+
+  return currency[0] || code;
 }

--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -8,7 +8,7 @@
 
 import {Inject, LOCALE_ID, Pipe, PipeTransform} from '@angular/core';
 import {formatNumber} from '../i18n/format_number';
-import {NumberFormatStyle, findCurrencySymbol, getLocaleCurrencyName, getLocaleCurrencySymbol} from '../i18n/locale_data_api';
+import {NumberFormatStyle, getCurrencySymbol, getLocaleCurrencyName, getLocaleCurrencySymbol} from '../i18n/locale_data_api';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
 /**
@@ -143,7 +143,7 @@ export class CurrencyPipe implements PipeTransform {
 
     let currency = currencyCode || 'USD';
     if (display !== 'code') {
-      currency = findCurrencySymbol(currency, display === 'symbol' ? 'wide' : 'narrow');
+      currency = getCurrencySymbol(currency, display === 'symbol' ? 'wide' : 'narrow');
     }
 
     const {str, error} = formatNumber(value, locale, NumberFormatStyle.Currency, digits, currency);

--- a/packages/common/test/i18n/locale_data_api_spec.ts
+++ b/packages/common/test/i18n/locale_data_api_spec.ts
@@ -11,7 +11,7 @@ import localeEn from '@angular/common/locales/en';
 import localeFr from '@angular/common/locales/fr';
 import localeFrCA from '@angular/common/locales/fr-CA';
 import {registerLocaleData} from '../../src/i18n/locale_data';
-import {findLocaleData} from '../../src/i18n/locale_data_api';
+import {findLocaleData, getCurrencySymbol} from '../../src/i18n/locale_data_api';
 
 {
   describe('locale data api', () => {
@@ -49,6 +49,19 @@ import {findLocaleData} from '../../src/i18n/locale_data_api';
         expect(findLocaleData('fake-id')).toEqual(localeFr);
         expect(findLocaleData('fake_iD')).toEqual(localeFr);
         expect(findLocaleData('fake-id2')).toEqual(localeFrCA);
+      });
+    });
+
+    describe('getCurrencySymbolElseCode', () => {
+      it('should return the correct symbol', () => {
+        expect(getCurrencySymbol('USD', 'wide')).toEqual('$');
+        expect(getCurrencySymbol('USD', 'narrow')).toEqual('$');
+        expect(getCurrencySymbol('AUD', 'wide')).toEqual('A$');
+        expect(getCurrencySymbol('AUD', 'narrow')).toEqual('$');
+        expect(getCurrencySymbol('CRC', 'wide')).toEqual('CRC');
+        expect(getCurrencySymbol('CRC', 'narrow')).toEqual('₡');
+        expect(getCurrencySymbol('FAKE', 'wide')).toEqual('FAKE');
+        expect(getCurrencySymbol('FAKE', 'narrow')).toEqual('FAKE');
       });
     });
   });

--- a/packages/common/test/pipes/number_pipe_spec.ts
+++ b/packages/common/test/pipes/number_pipe_spec.ts
@@ -122,6 +122,7 @@ import {beforeEach, describe, expect, it} from '@angular/core/testing/src/testin
           expect(pipe.transform(5.1234, 'CAD', 'symbol-narrow', '5.2-2')).toEqual('$00,005.12');
           expect(pipe.transform(5.1234, 'CAD', 'symbol-narrow', '5.2-2', 'fr'))
               .toEqual('00 005,12 $');
+          expect(pipe.transform(5.1234, 'FAKE', 'symbol')).toEqual('FAKE5.12');
         });
 
         it('should not support other objects', () => {

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -15,11 +15,6 @@ export declare class AsyncPipe implements OnDestroy, PipeTransform {
 export declare class CommonModule {
 }
 
-/** @experimental */
-export declare const CURRENCIES: {
-    [code: string]: (string | undefined)[];
-};
-
 /** @stable */
 export declare class CurrencyPipe implements PipeTransform {
     constructor(_locale: string);
@@ -82,6 +77,9 @@ export declare enum FormStyle {
     Format = 0,
     Standalone = 1,
 }
+
+/** @experimental */
+export declare function getCurrencySymbol(code: string, format: 'wide' | 'narrow'): string;
 
 /** @experimental */
 export declare function getLocaleCurrencyName(locale: string): string | null;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
We are exporting currencies directly instead of providing an api function for that like we did for all of the other i18n data.
Also we are not exporting `findLocaleData`.

## What is the new behavior?
We export those 2 api functions


## Does this PR introduce a breaking change?
```
[x] No
```