### PR TITLE
build(aio): add `@nodoc` alias to the `@internal` tag

### DIFF
--- a/aio/tools/transforms/angular-api-package/tag-defs/internal.js
+++ b/aio/tools/transforms/angular-api-package/tag-defs/internal.js
@@ -1,5 +1,16 @@
+/**
+ * Use this tag to ensure that dgeni does not include this code item
+ * in the rendered docs.
+ *
+ * The `@internal` tag indicates to the compiler not to include the
+ * item in the public typings file.
+ * Use the `@nodoc` alias if you only want to hide the item from the
+ * docs but not from the typings file.
+ */
 module.exports = function() {
   return {
-    name: 'internal', transforms: function() { return true; }
+    name: 'internal',
+    aliases: ['nodoc'],
+    transforms: function() { return true; }
   };
 };


### PR DESCRIPTION
The `@internal` tag prevents code items from appearing in the docs and the
typings files. You can now use `@nodoc` if you only want it to be excluded
from the docs and not the typings files.

Closes #20990

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
