### PR TITLE
fix(aio): do not redirect pages on "next" deployment

### DIFF
--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -723,14 +723,14 @@ describe('AppComponent', () => {
         expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
       });
 
-      it('should redirect to `docs` if deployment mode is `next` and not at a docs page', () => {
+      it('should not redirect if deployment mode is `next`', () => {
         createTestingModule('', 'next');
         initializeTest();
-        expect(TestBed.get(LocationService).replace).toHaveBeenCalledWith('docs');
+        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
 
         createTestingModule('resources', 'next');
         initializeTest();
-        expect(TestBed.get(LocationService).replace).toHaveBeenCalledWith('docs');
+        expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
 
         createTestingModule('guide/aot-compiler', 'next');
         initializeTest();
@@ -757,7 +757,7 @@ describe('AppComponent', () => {
         expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();
       });
 
-      it('should not redirect to `docs` if deployment mode is `stable` and not at a docs page', () => {
+      it('should not redirect to `docs` if deployment mode is `stable`', () => {
         createTestingModule('', 'stable');
         initializeTest();
         expect(TestBed.get(LocationService).replace).not.toHaveBeenCalled();

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -121,9 +121,9 @@ export class AppComponent implements OnInit {
     this.documentService.currentDocument.first().subscribe(doc => this.updateHostClassesForDoc(doc));
 
     this.locationService.currentPath.subscribe(path => {
-      // Redirect to docs if we are in not in stable mode and are not hitting a docs page
+      // Redirect to docs if we are in archive mode and are not hitting a docs page
       // (i.e. we have arrived at a marketing page)
-      if (this.deployment.mode !== 'stable' && !/^(docs$|api|guide|tutorial)/.test(path)) {
+      if (this.deployment.mode === 'archive' && !/^(docs$|api|guide|tutorial)/.test(path)) {
         this.locationService.replace('docs');
       }
       if (path === this.currentPath) {


### PR DESCRIPTION
We redirect non-docs pages in the "archive" deployment back to the stable
deployment. We should not redirect pages in the "next" deployment.

Closes #19505

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See #19505


## What is the new behavior?

We no longer redirect "next" deployment pages.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
