### PR TITLE
fix(service-worker): don't collide with TS DOM typings

### DIFF
--- a/packages/bazel/src/ngc-wrapped/BUILD.bazel
+++ b/packages/bazel/src/ngc-wrapped/BUILD.bazel
@@ -11,11 +11,6 @@ ts_library(
     tsconfig = ":tsconfig.json",
     visibility = ["//test/ngc-wrapped:__subpackages__"],
     deps = [
-        # BEGIN-INTERNAL
-        # Only needed when compiling within the Angular repo.
-        # Users will get this dependency from node_modules.
-        "@//packages/compiler-cli",
-        # END-INTERNAL
         "@build_bazel_rules_typescript//internal/tsc_wrapped",
     ],
 )

--- a/packages/bazel/test/ngc-wrapped/BUILD.bazel
+++ b/packages/bazel/test/ngc-wrapped/BUILD.bazel
@@ -10,11 +10,6 @@ ts_library(
     ],
     tsconfig = ":tsconfig.json",
     deps = [
-        # BEGIN-INTERNAL
-        # Only needed when compiling within the Angular repo.
-        # Users will get this dependency from node_modules.
-        "@//packages/compiler-cli",
-        # END-INTERNAL
         "//src/ngc-wrapped:ngc_lib",
     ],
 )

--- a/packages/service-worker/build.sh
+++ b/packages/service-worker/build.sh
@@ -4,7 +4,7 @@ set -u -e -o pipefail
 
 BIN=$(cd .. && npm bin)
 
-$BIN/tsc -p worker/tsconfig.json
+$BIN/tsc -p worker/tsconfig-custom-build.json
 $BIN/rollup -c worker/rollup-worker.config.js
 
 

--- a/packages/service-worker/worker/main.ts
+++ b/packages/service-worker/worker/main.ts
@@ -9,6 +9,7 @@
 import {Adapter} from './src/adapter';
 import {CacheDatabase} from './src/db-cache';
 import {Driver} from './src/driver';
+import {ServiceWorkerGlobalScope} from './src/typings';
 
 const scope = self as any as ServiceWorkerGlobalScope;
 

--- a/packages/service-worker/worker/src/adapter.ts
+++ b/packages/service-worker/worker/src/adapter.ts
@@ -6,6 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {IClient} from './typings';
+
+declare var Client: any;
+
 /**
  * Adapts the service worker to its runtime environment.
  *
@@ -33,7 +37,7 @@ export class Adapter {
   /**
    * Test if a given object is an instance of `Client`.
    */
-  isClient(source: any): source is Client { return (source instanceof Client); }
+  isClient(source: any): source is IClient { return (source instanceof Client); }
 
   /**
    * Read the current UNIX time in milliseconds.

--- a/packages/service-worker/worker/src/app-version.ts
+++ b/packages/service-worker/worker/src/app-version.ts
@@ -13,6 +13,7 @@ import {DataGroup} from './data';
 import {Database} from './database';
 import {IdleScheduler} from './idle';
 import {Manifest} from './manifest';
+import {ServiceWorkerGlobalScope} from './typings';
 import {isNavigationRequest} from './util';
 
 

--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -12,6 +12,7 @@ import {Database, Table} from './database';
 import {IdleScheduler} from './idle';
 import {AssetGroupConfig} from './manifest';
 import {sha1Binary} from './sha1';
+import {Cache, ServiceWorkerGlobalScope} from './typings';
 
 /**
  * A group of assets that are cached in a `Cache` and managed by a given policy.

--- a/packages/service-worker/worker/src/data.ts
+++ b/packages/service-worker/worker/src/data.ts
@@ -9,6 +9,7 @@
 import {Adapter, Context} from './adapter';
 import {Database, Table} from './database';
 import {DataGroupConfig} from './manifest';
+import {Cache, ServiceWorkerGlobalScope} from './typings';
 
 /**
  * A metadata record of how old a particular cached resource is.

--- a/packages/service-worker/worker/src/db-cache.ts
+++ b/packages/service-worker/worker/src/db-cache.ts
@@ -8,6 +8,7 @@
 
 import {Adapter} from './adapter';
 import {Database, NotFound, Table} from './database';
+import {Cache, ServiceWorkerGlobalScope} from './typings';
 
 
 /**

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -14,6 +14,7 @@ import {DebugHandler} from './debug';
 import {IdleScheduler} from './idle';
 import {Manifest, ManifestHash, hashManifest} from './manifest';
 import {MsgAny, isMsgActivateUpdate, isMsgCheckForUpdates} from './msg';
+import {IClient, ExtendableMessageEvent, FetchEvent, InstallEvent, PushEvent, ServiceWorkerGlobalScope} from './typings';
 import {isNavigationRequest} from './util';
 
 type ClientId = string;
@@ -227,7 +228,7 @@ export class Driver implements Debuggable, UpdateSource {
     msg.waitUntil(this.handlePush(msg.data.json()));
   }
 
-  private async handleMessage(msg: MsgAny&{action: string}, from: Client): Promise<void> {
+  private async handleMessage(msg: MsgAny&{action: string}, from: IClient): Promise<void> {
     if (isMsgCheckForUpdates(msg)) {
       const action = (async() => { await this.checkForUpdate(); })();
       await this.reportStatus(from, action, msg.statusNonce);
@@ -251,7 +252,7 @@ export class Driver implements Debuggable, UpdateSource {
     this.scope.registration.showNotification(desc['title'] !, options);
   }
 
-  private async reportStatus(client: Client, promise: Promise<void>, nonce: number): Promise<void> {
+  private async reportStatus(client: IClient, promise: Promise<void>, nonce: number): Promise<void> {
     const response = {type: 'STATUS', nonce, status: true};
     try {
       await promise;
@@ -265,7 +266,7 @@ export class Driver implements Debuggable, UpdateSource {
     }
   }
 
-  async updateClient(client: Client): Promise<void> {
+  async updateClient(client: IClient): Promise<void> {
     // Figure out which version the client is on. If it's not on the latest,
     // it needs to be moved.
     const existing = this.clientVersionMap.get(client.id);

--- a/packages/service-worker/worker/src/typings.ts
+++ b/packages/service-worker/worker/src/typings.ts
@@ -21,13 +21,13 @@
  * @email tiernanc@gmail.com
  * @license: ISC
  */
-interface ExtendableEvent extends Event {
+export interface ExtendableEvent extends Event {
   waitUntil(fn: Promise<any>): void;
 }
 
 // CacheStorage API
 
-interface Cache {
+export interface Cache {
   add(request: Request): Promise<void>;
   addAll(requestArray: Array<Request>): Promise<void>;
   'delete'(request: Request, options?: CacheStorageOptions): Promise<boolean>;
@@ -37,7 +37,7 @@ interface Cache {
   put(request: Request|string, response: Response): Promise<void>;
 }
 
-interface CacheStorage {
+export interface CacheStorage {
   'delete'(cacheName: string): Promise<boolean>;
   has(cacheName: string): Promise<boolean>;
   keys(): Promise<Array<string>>;
@@ -45,7 +45,7 @@ interface CacheStorage {
   open(cacheName: string): Promise<Cache>;
 }
 
-interface CacheStorageOptions {
+export interface CacheStorageOptions {
   cacheName?: string;
   ignoreMethod?: boolean;
   ignoreSearch?: boolean;
@@ -54,63 +54,64 @@ interface CacheStorageOptions {
 
 // Client API
 
-declare class Client {
+export interface IClient {
   frameType: ClientFrameType;
   id: string;
   url: string;
   postMessage(message: any): void;
 }
+export declare var Client: any;
 
-interface Clients {
+export interface Clients {
   claim(): Promise<any>;
-  get(id: string): Promise<Client>;
-  matchAll(options?: ClientMatchOptions): Promise<Array<Client>>;
+  get(id: string): Promise<IClient>;
+  matchAll(options?: ClientMatchOptions): Promise<Array<IClient>>;
 }
 
-interface ClientMatchOptions {
+export interface ClientMatchOptions {
   includeUncontrolled?: boolean;
   type?: ClientMatchTypes;
 }
 
-interface WindowClient {
+export interface WindowClient  {
   focused: boolean;
   visibilityState: WindowClientState;
   focus(): Promise<WindowClient>;
   navigate(url: string): Promise<WindowClient>;
 }
 
-type ClientFrameType = 'auxiliary' | 'top-level' | 'nested' | 'none';
-type ClientMatchTypes = 'window' | 'worker' | 'sharedworker' | 'all';
-type WindowClientState = 'hidden' | 'visible' | 'prerender' | 'unloaded';
+export type ClientFrameType = 'auxiliary' | 'top-level' | 'nested' | 'none';
+export type ClientMatchTypes = 'window' | 'worker' | 'sharedworker' | 'all';
+export type WindowClientState = 'hidden' | 'visible' | 'prerender' | 'unloaded';
 
 // Fetch API
 
-interface FetchEvent extends ExtendableEvent {
+export interface FetchEvent extends ExtendableEvent {
   clientId: string|null;
   request: Request;
   respondWith(response: Promise<Response>|Response): Promise<Response>;
 }
 
-interface InstallEvent extends ExtendableEvent {
+export interface InstallEvent extends ExtendableEvent {
   activeWorker: ServiceWorker;
 }
 
-interface ActivateEvent extends ExtendableEvent {}
+export interface ActivateEvent extends ExtendableEvent {}
 
 // Notification API
 
-interface NotificationEvent {
+export interface NotificationEvent {
   action: string;
   notification: Notification;
 }
 
 // Push API
 
-interface PushEvent extends ExtendableEvent {
+export interface PushEvent extends ExtendableEvent {
   data: PushMessageData;
 }
 
-interface PushMessageData {
+export interface PushMessageData {
   arrayBuffer(): ArrayBuffer;
   blob(): Blob;
   json(): any;
@@ -119,19 +120,19 @@ interface PushMessageData {
 
 // Sync API
 
-interface SyncEvent extends ExtendableEvent {
+export interface SyncEvent extends ExtendableEvent {
   lastChance: boolean;
   tag: string;
 }
 
-interface ExtendableMessageEvent extends ExtendableEvent {
+export interface ExtendableMessageEvent extends ExtendableEvent {
   data: any;
-  source: Client|Object;
+  source: IClient|Object;
 }
 
 // ServiceWorkerGlobalScope
 
-interface ServiceWorkerGlobalScope {
+export interface ServiceWorkerGlobalScope {
   caches: CacheStorage;
   clients: Clients;
   registration: ServiceWorkerRegistration;

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -10,6 +10,7 @@ import {CacheDatabase} from '../src/db-cache';
 import {Driver} from '../src/driver';
 import {Manifest} from '../src/manifest';
 import {sha1} from '../src/sha1';
+import {IClient} from '../src/typings';
 import {MockRequest} from '../testing/fetch';
 import {MockFileSystemBuilder, MockServerStateBuilder, tmpHashTableForFs} from '../testing/mock';
 import {SwTestHarness, SwTestHarnessBuilder} from '../testing/scope';
@@ -297,7 +298,7 @@ export function main() {
       scope.updateServerState(serverUpdate);
       expect(await driver.checkForUpdate()).toEqual(true);
       serverUpdate.clearRequests();
-      await driver.updateClient(client as any as Client);
+      await driver.updateClient(client as any as IClient);
 
       expect(client.messages).toEqual([
         {

--- a/packages/service-worker/worker/testing/cache.ts
+++ b/packages/service-worker/worker/testing/cache.ts
@@ -7,6 +7,7 @@
  */
 
 import {MockRequest, MockResponse} from './fetch';
+import {Cache, CacheStorage} from '../src/typings';
 
 export interface DehydratedResponse {
   body: string|null;

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -11,6 +11,7 @@ import {Subject} from 'rxjs/Subject';
 import {Adapter, Context} from '../src/adapter';
 import {AssetGroupConfig, Manifest} from '../src/manifest';
 import {sha1} from '../src/sha1';
+import {Clients, IClient, ServiceWorkerGlobalScope} from '../src/typings';
 
 import {MockCacheStorage} from './cache';
 import {MockHeaders, MockRequest, MockResponse} from './fetch';
@@ -62,15 +63,15 @@ export class MockClients implements Clients {
 
   remove(clientId: string): void { this.clients.delete(clientId); }
 
-  async get(id: string): Promise<Client> {
+  async get(id: string): Promise<IClient> {
     this.add(id);
-    return this.clients.get(id) !as any as Client;
+    return this.clients.get(id) !as any as IClient;
   }
 
   getMock(id: string): MockClient|undefined { return this.clients.get(id); }
 
-  async matchAll(): Promise<Client[]> {
-    return Array.from(this.clients.values()) as any[] as Client[];
+  async matchAll(): Promise<IClient[]> {
+    return Array.from(this.clients.values()) as any[] as IClient[];
   }
 
   async claim(): Promise<any> {}
@@ -245,7 +246,7 @@ export class SwTestHarness implements ServiceWorkerGlobalScope, Adapter, Context
         });
   }
 
-  isClient(obj: any): obj is Client { return obj instanceof MockClient; }
+  isClient(obj: any): obj is IClient { return obj instanceof MockClient; }
 }
 
 interface StaticFile {

--- a/packages/service-worker/worker/tsconfig-custom-build.json
+++ b/packages/service-worker/worker/tsconfig-custom-build.json
@@ -16,7 +16,6 @@
     "typeRoots": []
   },
   "files": [
-    "main.ts",
-    "src/service-worker.d.ts"
+    "main.ts"
   ]
 }


### PR DESCRIPTION
For consistency across TS versions and updates, SW maintains its own
set of typings for some browser APIs. Previously this file was a .d.ts,
which caused those typings to be merged with the TS library versions
of the same types.

This changes the SW to isolate the typings to a .ts file and explicitly
import them everywhere.