### PR TITLE
refactor: update Angular to compile cleanly with TypeScript 2.6

### DIFF
--- a/packages/common/src/i18n/locale_en.ts
+++ b/packages/common/src/i18n/locale_en.ts
@@ -9,6 +9,13 @@
 // THIS CODE IS GENERATED - DO NOT MODIFY
 // See angular/tools/gulp-tasks/cldr/extract.js
 
+function converter(n: number): number {
+  let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+  if (i === 1 && v === 0) return 1;
+  return 5;
+}
+
+
 export default [
   'en',
   [
@@ -42,11 +49,5 @@ export default [
     '{1} \'at\' {0}',
   ],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '$', 'US Dollar',
-  function(n: number):
-      number {
-        let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
-        if (i === 1 && v === 0) return 1;
-        return 5;
-      }
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '$', 'US Dollar', converter
 ];

--- a/packages/compiler-cli/src/diagnostics/translate_diagnostics.ts
+++ b/packages/compiler-cli/src/diagnostics/translate_diagnostics.ts
@@ -16,7 +16,8 @@ export interface TypeCheckHost {
   parseSourceSpanOf(fileName: string, line: number, character: number): ParseSourceSpan|null;
 }
 
-export function translateDiagnostics(host: TypeCheckHost, untranslatedDiagnostics: ts.Diagnostic[]):
+export function translateDiagnostics(
+    host: TypeCheckHost, untranslatedDiagnostics: ReadonlyArray<ts.Diagnostic>):
     {ts: ts.Diagnostic[], ng: Diagnostic[]} {
   const ts: ts.Diagnostic[] = [];
   const ng: Diagnostic[] = [];

--- a/packages/compiler-cli/src/metadata/bundle_index_host.ts
+++ b/packages/compiler-cli/src/metadata/bundle_index_host.ts
@@ -44,7 +44,7 @@ function createSyntheticIndexHost<H extends ts.CompilerHost>(
 
   newHost.writeFile =
       (fileName: string, data: string, writeByteOrderMark: boolean,
-       onError?: (message: string) => void, sourceFiles?: ts.SourceFile[]) => {
+       onError: (message: string) => void|undefined, sourceFiles: ReadonlyArray<ts.SourceFile>) => {
         delegate.writeFile(fileName, data, writeByteOrderMark, onError, sourceFiles);
         if (fileName.match(DTS) && sourceFiles && sourceFiles.length == 1 &&
             path.normalize(sourceFiles[0].fileName) == normalSyntheticIndexName) {

--- a/packages/compiler-cli/src/metadata/bundler.ts
+++ b/packages/compiler-cli/src/metadata/bundler.ts
@@ -598,7 +598,7 @@ export class CompilerHostAdapter implements MetadataBundlerHost {
 
   getMetadataFor(fileName: string): ModuleMetadata|undefined {
     const sourceFile = this.host.getSourceFile(fileName + '.ts', ts.ScriptTarget.Latest);
-    return this.collector.getMetadata(sourceFile);
+    if (sourceFile) return this.collector.getMetadata(sourceFile);
   }
 }
 

--- a/packages/compiler-cli/src/metadata/schema.ts
+++ b/packages/compiler-cli/src/metadata/schema.ts
@@ -99,7 +99,11 @@ export function isFunctionMetadata(value: any): value is FunctionMetadata {
 }
 
 export type MetadataValue = string | number | boolean | undefined | null | MetadataObject |
-    MetadataArray | MetadataSymbolicExpression | MetadataError;
+    MetadataArray | MetadataSymbolicExpression | MetadataSymbolicReferenceExpression |
+    MetadataSymbolicBinaryExpression | MetadataSymbolicIndexExpression |
+    MetadataSymbolicCallExpression | MetadataSymbolicPrefixExpression |
+    MetadataSymbolicIfExpression | MetadataSymbolicSpreadExpression |
+    MetadataSymbolicSelectExpression | MetadataError;
 
 export interface MetadataObject { [name: string]: MetadataValue; }
 

--- a/packages/compiler-cli/src/ngtools_api2.ts
+++ b/packages/compiler-cli/src/ngtools_api2.ts
@@ -108,15 +108,15 @@ export interface LazyRoute {
 
 export interface Program {
   getTsProgram(): ts.Program;
-  getTsOptionDiagnostics(cancellationToken?: ts.CancellationToken): ts.Diagnostic[];
-  getNgOptionDiagnostics(cancellationToken?: ts.CancellationToken): Diagnostic[];
+  getTsOptionDiagnostics(cancellationToken?: ts.CancellationToken): ReadonlyArray<ts.Diagnostic>;
+  getNgOptionDiagnostics(cancellationToken?: ts.CancellationToken): ReadonlyArray<Diagnostic>;
   getTsSyntacticDiagnostics(sourceFile?: ts.SourceFile, cancellationToken?: ts.CancellationToken):
-      ts.Diagnostic[];
-  getNgStructuralDiagnostics(cancellationToken?: ts.CancellationToken): Diagnostic[];
+      ReadonlyArray<ts.Diagnostic>;
+  getNgStructuralDiagnostics(cancellationToken?: ts.CancellationToken): ReadonlyArray<Diagnostic>;
   getTsSemanticDiagnostics(sourceFile?: ts.SourceFile, cancellationToken?: ts.CancellationToken):
-      ts.Diagnostic[];
+      ReadonlyArray<ts.Diagnostic>;
   getNgSemanticDiagnostics(fileName?: string, cancellationToken?: ts.CancellationToken):
-      Diagnostic[];
+      ReadonlyArray<Diagnostic>;
   loadNgStructureAsync(): Promise<void>;
   listLazyRoutes(entryRoute?: string): LazyRoute[];
   emit({emitFlags, cancellationToken, customTransformers, emitCallback}: {
@@ -132,7 +132,7 @@ export function createProgram(
     {rootNames, options, host, oldProgram}:
         {rootNames: string[], options: CompilerOptions, host: CompilerHost, oldProgram?: Program}):
     Program {
-  return createProgramOrig({rootNames, options, host, oldProgram: oldProgram as ProgramOrig});
+  return createProgramOrig({rootNames, options, host, oldProgram: oldProgram as any});
 }
 
 // Wrapper for createCompilerHost.

--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -17,7 +17,7 @@ import {createMessageDiagnostic} from './transformers/util';
 
 const TS_EXT = /\.ts$/;
 
-export type Diagnostics = Array<ts.Diagnostic|api.Diagnostic>;
+export type Diagnostics = ReadonlyArray<ts.Diagnostic|api.Diagnostic>;
 
 export function filterErrorsAndWarnings(diagnostics: Diagnostics): Diagnostics {
   return diagnostics.filter(d => d.category !== ts.DiagnosticCategory.Message);
@@ -199,7 +199,7 @@ export function performCompilation({rootNames, options, host, oldProgram, emitCa
 }): PerformCompilationResult {
   let program: api.Program|undefined;
   let emitResult: ts.EmitResult|undefined;
-  let allDiagnostics: Diagnostics = [];
+  let allDiagnostics: Array<ts.Diagnostic|api.Diagnostic> = [];
   try {
     if (!host) {
       host = ng.createCompilerHost({options});
@@ -240,7 +240,7 @@ export function performCompilation({rootNames, options, host, oldProgram, emitCa
   }
 }
 function defaultGatherDiagnostics(program: api.Program): Diagnostics {
-  const allDiagnostics: Diagnostics = [];
+  const allDiagnostics: Array<ts.Diagnostic|api.Diagnostic> = [];
 
   function checkDiagnostics(diags: Diagnostics | undefined) {
     if (diags) {

--- a/packages/compiler-cli/src/perform_watch.ts
+++ b/packages/compiler-cli/src/perform_watch.ts
@@ -161,7 +161,7 @@ export function performWatchCompilation(host: PerformWatchHost):
       const originalWriteFileCallback = cachedCompilerHost.writeFile;
       cachedCompilerHost.writeFile = function(
           fileName: string, data: string, writeByteOrderMark: boolean,
-          onError?: (message: string) => void, sourceFiles?: ts.SourceFile[]) {
+          onError: (message: string) => void|undefined, sourceFiles: ReadonlyArray<ts.SourceFile>) {
         ingoreFilesForWatch.add(path.normalize(fileName));
         return originalWriteFileCallback(fileName, data, writeByteOrderMark, onError, sourceFiles);
       };

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -266,12 +266,12 @@ export interface Program {
    * faster than calling `getTsProgram().getOptionsDiagnostics()` since it does not need to
    * collect Angular structural information to produce the errors.
    */
-  getTsOptionDiagnostics(cancellationToken?: ts.CancellationToken): ts.Diagnostic[];
+  getTsOptionDiagnostics(cancellationToken?: ts.CancellationToken): ReadonlyArray<ts.Diagnostic>;
 
   /**
    * Retrieve options diagnostics for the Angular options used to create the program.
    */
-  getNgOptionDiagnostics(cancellationToken?: ts.CancellationToken): Diagnostic[];
+  getNgOptionDiagnostics(cancellationToken?: ts.CancellationToken): ReadonlyArray<Diagnostic>;
 
   /**
    * Retrieve the syntax diagnostics from TypeScript. This is faster than calling
@@ -279,7 +279,7 @@ export interface Program {
    * information to produce the errors.
    */
   getTsSyntacticDiagnostics(sourceFile?: ts.SourceFile, cancellationToken?: ts.CancellationToken):
-      ts.Diagnostic[];
+      ReadonlyArray<ts.Diagnostic>;
 
   /**
    * Retrieve the diagnostics for the structure of an Angular application is correctly formed.
@@ -292,14 +292,14 @@ export interface Program {
    *
    * Angular structural information is required to produce these diagnostics.
    */
-  getNgStructuralDiagnostics(cancellationToken?: ts.CancellationToken): Diagnostic[];
+  getNgStructuralDiagnostics(cancellationToken?: ts.CancellationToken): ReadonlyArray<Diagnostic>;
 
   /**
    * Retrieve the semantic diagnostics from TypeScript. This is equivilent to calling
    * `getTsProgram().getSemanticDiagnostics()` directly and is included for completeness.
    */
   getTsSemanticDiagnostics(sourceFile?: ts.SourceFile, cancellationToken?: ts.CancellationToken):
-      ts.Diagnostic[];
+      ReadonlyArray<ts.Diagnostic>;
 
   /**
    * Retrieve the Angular semantic diagnostics.
@@ -307,7 +307,7 @@ export interface Program {
    * Angular structural information is required to produce these diagnostics.
    */
   getNgSemanticDiagnostics(fileName?: string, cancellationToken?: ts.CancellationToken):
-      Diagnostic[];
+      ReadonlyArray<Diagnostic>;
 
   /**
    * Load Angular structural information asynchronously. If this method is not called then the

--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -266,9 +266,9 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
     }
     // Note: This can also return undefined,
     // as the TS typings are not correct!
-    const sf = this.context.getSourceFile(filePath, languageVersion, onError) || null;
+    const sf = this.context.getSourceFile(filePath, languageVersion, onError);
     this.originalSourceFiles.set(filePath, sf);
-    return sf;
+    return sf || null;
   }
 
   updateGeneratedFile(genFile: GeneratedFile): ts.SourceFile {
@@ -565,7 +565,8 @@ function addReferencesToSourceFile(sf: ts.SourceFile, genFileNames: string[]) {
   // value for `referencedFiles` around in cache the original host is caching ts.SourceFiles.
   // Note: cloning the ts.SourceFile is expensive as the nodes in have parent pointers,
   // i.e. we would also need to clone and adjust all nodes.
-  let originalReferencedFiles: ts.FileReference[]|undefined = (sf as any).originalReferencedFiles;
+  let originalReferencedFiles: ReadonlyArray<ts.FileReference>|undefined =
+      (sf as any).originalReferencedFiles;
   if (!originalReferencedFiles) {
     originalReferencedFiles = sf.referencedFiles;
     (sf as any).originalReferencedFiles = originalReferencedFiles;

--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -40,6 +40,7 @@ const defaultEmitCallback: TsEmitCallback =
             targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers);
 
 class AngularCompilerProgram implements Program {
+  private rootNames: string[];
   private metadataCache: LowerMetadataCache;
   private oldProgramLibrarySummaries: Map<string, LibrarySummary>|undefined;
   private oldProgramEmittedGeneratedFiles: Map<string, GeneratedFile>|undefined;
@@ -60,8 +61,9 @@ class AngularCompilerProgram implements Program {
   private _optionsDiagnostics: Diagnostic[] = [];
 
   constructor(
-      private rootNames: string[], private options: CompilerOptions, private host: CompilerHost,
-      oldProgram?: Program) {
+      rootNames: ReadonlyArray<string>, private options: CompilerOptions,
+      private host: CompilerHost, oldProgram?: Program) {
+    this.rootNames = [...rootNames];
     const [major, minor] = ts.version.split('.');
     if (Number(major) < 2 || (Number(major) === 2 && Number(minor) < 4)) {
       throw new Error('The Angular Compiler requires TypeScript >= 2.4.');
@@ -74,7 +76,8 @@ class AngularCompilerProgram implements Program {
     }
 
     if (options.flatModuleOutFile) {
-      const {host: bundleHost, indexName, errors} = createBundleIndexHost(options, rootNames, host);
+      const {host: bundleHost, indexName, errors} =
+          createBundleIndexHost(options, this.rootNames, host);
       if (errors) {
         // TODO(tbosch): once we move MetadataBundler from tsc_wrapped into compiler_cli,
         // directly create ng.Diagnostic instead of using ts.Diagnostic here.
@@ -85,7 +88,7 @@ class AngularCompilerProgram implements Program {
                                                       code: DEFAULT_ERROR_CODE
                                                     })));
       } else {
-        rootNames.push(indexName !);
+        this.rootNames.push(indexName !);
         this.host = bundleHost;
       }
     }
@@ -133,16 +136,16 @@ class AngularCompilerProgram implements Program {
     return this.tsProgram.getOptionsDiagnostics(cancellationToken);
   }
 
-  getNgOptionDiagnostics(cancellationToken?: ts.CancellationToken): Diagnostic[] {
+  getNgOptionDiagnostics(cancellationToken?: ts.CancellationToken): ReadonlyArray<Diagnostic> {
     return [...this._optionsDiagnostics, ...getNgOptionDiagnostics(this.options)];
   }
 
   getTsSyntacticDiagnostics(sourceFile?: ts.SourceFile, cancellationToken?: ts.CancellationToken):
-      ts.Diagnostic[] {
+      ReadonlyArray<ts.Diagnostic> {
     return this.tsProgram.getSyntacticDiagnostics(sourceFile, cancellationToken);
   }
 
-  getNgStructuralDiagnostics(cancellationToken?: ts.CancellationToken): Diagnostic[] {
+  getNgStructuralDiagnostics(cancellationToken?: ts.CancellationToken): ReadonlyArray<Diagnostic> {
     return this.structuralDiagnostics;
   }
 
@@ -159,7 +162,7 @@ class AngularCompilerProgram implements Program {
   }
 
   getNgSemanticDiagnostics(fileName?: string, cancellationToken?: ts.CancellationToken):
-      Diagnostic[] {
+      ReadonlyArray<Diagnostic> {
     let diags: ts.Diagnostic[] = [];
     this.tsProgram.getSourceFiles().forEach(sf => {
       if (GENERATED_FILES.test(sf.fileName) && !sf.isDeclarationFile) {
@@ -245,7 +248,7 @@ class AngularCompilerProgram implements Program {
     const emitOnlyDtsFiles = (emitFlags & (EmitFlags.DTS | EmitFlags.JS)) == EmitFlags.DTS;
     // Restore the original references before we emit so TypeScript doesn't emit
     // a reference to the .d.ts file.
-    const augmentedReferences = new Map<ts.SourceFile, ts.FileReference[]>();
+    const augmentedReferences = new Map<ts.SourceFile, ReadonlyArray<ts.FileReference>>();
     for (const sourceFile of this.tsProgram.getSourceFiles()) {
       const originalReferences = getOriginalReferences(sourceFile);
       if (originalReferences) {
@@ -295,7 +298,8 @@ class AngularCompilerProgram implements Program {
       // Restore the references back to the augmented value to ensure that the
       // checks that TypeScript makes for project structure reuse will succeed.
       for (const [sourceFile, references] of Array.from(augmentedReferences)) {
-        sourceFile.referencedFiles = references;
+        // TODO(chuckj): Remove any cast after updating build to 2.6
+        (sourceFile as any).referencedFiles = references;
       }
     }
     this.emittedSourceFiles = emittedSourceFiles;
@@ -312,7 +316,8 @@ class AngularCompilerProgram implements Program {
 
     if (!outSrcMapping.length) {
       // if no files were emitted by TypeScript, also don't emit .json files
-      emitResult.diagnostics.push(createMessageDiagnostic(`Emitted no files.`));
+      emitResult.diagnostics =
+          emitResult.diagnostics.concat([createMessageDiagnostic(`Emitted no files.`)]);
       return emitResult;
     }
 
@@ -344,12 +349,12 @@ class AngularCompilerProgram implements Program {
     }
     const emitEnd = Date.now();
     if (this.options.diagnostics) {
-      emitResult.diagnostics.push(createMessageDiagnostic([
+      emitResult.diagnostics = emitResult.diagnostics.concat([createMessageDiagnostic([
         `Emitted in ${emitEnd - emitStart}ms`,
         `- ${emittedUserTsCount} user ts files`,
         `- ${genTsFiles.length} generated ts files`,
         `- ${genJsonFiles.length + metadataJsonCount} generated json files`,
-      ].join('\n')));
+      ].join('\n'))]);
     }
     return emitResult;
   }
@@ -376,7 +381,7 @@ class AngularCompilerProgram implements Program {
     return this._analyzedModules !;
   }
 
-  private get structuralDiagnostics(): Diagnostic[] {
+  private get structuralDiagnostics(): ReadonlyArray<Diagnostic> {
     let diagnostics = this._structuralDiagnostics;
     if (!diagnostics) {
       this.initSync();
@@ -643,10 +648,11 @@ class AngularCompilerProgram implements Program {
   }
 }
 
-export function createProgram(
-    {rootNames, options, host, oldProgram}:
-        {rootNames: string[], options: CompilerOptions, host: CompilerHost, oldProgram?: Program}):
-    Program {
+export function createProgram({rootNames, options, host, oldProgram}: {
+  rootNames: ReadonlyArray<string>,
+  options: CompilerOptions,
+  host: CompilerHost, oldProgram?: Program
+}): Program {
   return new AngularCompilerProgram(rootNames, options, host, oldProgram);
 }
 
@@ -687,7 +693,7 @@ function getAotCompilerOptions(options: CompilerOptions): AotCompilerOptions {
   };
 }
 
-function getNgOptionDiagnostics(options: CompilerOptions): Diagnostic[] {
+function getNgOptionDiagnostics(options: CompilerOptions): ReadonlyArray<Diagnostic> {
   if (options.annotationsAs) {
     switch (options.annotationsAs) {
       case 'decorators':
@@ -765,7 +771,7 @@ export function i18nExtract(
   const content = i18nSerialize(bundle, formatName, options);
   const dstFile = outFile || `messages.${ext}`;
   const dstPath = path.resolve(options.outDir || options.basePath, dstFile);
-  host.writeFile(dstPath, content, false);
+  host.writeFile(dstPath, content, false, undefined, []);
   return [dstPath];
 }
 

--- a/packages/compiler-cli/test/diagnostics/check_types_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/check_types_spec.ts
@@ -84,7 +84,7 @@ describe('ng type checker', () => {
   });
 
   describe('type narrowing', () => {
-    const a = (files: MockFiles, options: object = {}) => {
+    const a = (files: MockFiles, options: ng.AngularCompilerOptions = {}) => {
       accept(files, {fullTemplateTypeCheck: true, ...options});
     };
 
@@ -219,7 +219,7 @@ describe('ng type checker', () => {
   });
 
   describe('casting $any', () => {
-    const a = (files: MockFiles, options: object = {}) => {
+    const a = (files: MockFiles, options: ng.AngularCompilerOptions = {}) => {
       accept(
           {'src/app.component.ts': '', 'src/lib.ts': '', ...files},
           {fullTemplateTypeCheck: true, ...options});
@@ -227,7 +227,7 @@ describe('ng type checker', () => {
 
     const r =
         (message: string | RegExp, location: RegExp | null, files: MockFiles,
-         options: object = {}) => {
+         options: ng.AngularCompilerOptions = {}) => {
           reject(
               message, location, {'src/app.component.ts': '', 'src/lib.ts': '', ...files},
               {fullTemplateTypeCheck: true, ...options});
@@ -323,7 +323,7 @@ describe('ng type checker', () => {
   });
 
   describe('regressions ', () => {
-    const a = (files: MockFiles, options: object = {}) => {
+    const a = (files: MockFiles, options: ng.AngularCompilerOptions = {}) => {
       accept(files, {fullTemplateTypeCheck: true, ...options});
     };
 

--- a/packages/compiler-cli/test/metadata/symbols_spec.ts
+++ b/packages/compiler-cli/test/metadata/symbols_spec.ts
@@ -91,7 +91,8 @@ describe('Symbols', () => {
   });
 
   it('should be able to resolve any symbol in core global scope', () => {
-    const core = program.getSourceFiles().find(source => source.fileName.endsWith('lib.d.ts'));
+    const core = (program.getSourceFiles() as ts.SourceFile[])
+                     .find(source => source.fileName.endsWith('lib.d.ts'));
     expect(core).toBeDefined();
     const visit = (node: ts.Node): boolean => {
       switch (node.kind) {

--- a/packages/compiler-cli/test/perform_watch_spec.ts
+++ b/packages/compiler-cli/test/perform_watch_spec.ts
@@ -166,10 +166,10 @@ class MockWatchHost {
   nextTimeoutListenerId = 1;
   timeoutListeners: {[id: string]: (() => void)} = {};
   fileChangeListeners: Array<((event: FileChangeEvent, fileName: string) => void)|null> = [];
-  diagnostics: ng.Diagnostics = [];
+  diagnostics: ng.Diagnostic[] = [];
   constructor(public config: ng.ParsedConfiguration) {}
 
-  reportDiagnostics(diags: ng.Diagnostics) { this.diagnostics.push(...diags); }
+  reportDiagnostics(diags: ng.Diagnostics) { this.diagnostics.push(...(diags as ng.Diagnostic[])); }
   readConfiguration() { return this.config; }
   createCompilerHost(options: ng.CompilerOptions) { return ng.createCompilerHost({options}); }
   createEmitCallback() { return undefined; }

--- a/packages/compiler-cli/test/transformers/program_spec.ts
+++ b/packages/compiler-cli/test/transformers/program_spec.ts
@@ -415,14 +415,15 @@ describe('ng program', () => {
     });
     const host = ng.createCompilerHost({options});
     const written = new Map < string, {
-      original: ts.SourceFile[]|undefined;
+      original: ReadonlyArray<ts.SourceFile>|undefined;
       data: string;
     }
     > ();
 
     host.writeFile =
         (fileName: string, data: string, writeByteOrderMark: boolean,
-         onError?: (message: string) => void, sourceFiles?: ts.SourceFile[]) => {
+         onError: (message: string) => void|undefined,
+         sourceFiles: ReadonlyArray<ts.SourceFile>) => {
           written.set(fileName, {original: sourceFiles, data});
         };
     const program = ng.createProgram(
@@ -494,9 +495,9 @@ describe('ng program', () => {
     const host = ng.createCompilerHost({options});
     const writtenFileNames: string[] = [];
     const oldWriteFile = host.writeFile;
-    host.writeFile = (fileName, data, writeByteOrderMark) => {
+    host.writeFile = (fileName, data, writeByteOrderMark, onError, sourceFiles) => {
       writtenFileNames.push(fileName);
-      oldWriteFile(fileName, data, writeByteOrderMark);
+      oldWriteFile(fileName, data, writeByteOrderMark, onError, sourceFiles);
     };
 
     compile(/*oldProgram*/ undefined, options, /*rootNames*/ undefined, host);

--- a/packages/compiler/test/aot/test_util.ts
+++ b/packages/compiler/test/aot/test_util.ts
@@ -172,7 +172,8 @@ export class EmittingCompilerHost implements ts.CompilerHost {
 
   writeFile: ts.WriteFileCallback =
       (fileName: string, data: string, writeByteOrderMark: boolean,
-       onError?: (message: string) => void, sourceFiles?: ts.SourceFile[]) => {
+       onError: ((message: string) => void)|undefined,
+       sourceFiles: ReadonlyArray<ts.SourceFile>) => {
         this.addWrittenFile(fileName, data);
         if (this.options.emitMetadata && sourceFiles && sourceFiles.length && DTS.test(fileName)) {
           const metadataFilePath = fileName.replace(DTS, '.metadata.json');
@@ -430,7 +431,7 @@ export class MockMetadataBundlerHost implements MetadataBundlerHost {
 
   getMetadataFor(moduleName: string): ModuleMetadata|undefined {
     const source = this.host.getSourceFile(moduleName + '.ts', ts.ScriptTarget.Latest);
-    return this.collector.getMetadata(source);
+    if (source) return this.collector.getMetadata(source);
   }
 }
 
@@ -603,7 +604,7 @@ export function expectNoDiagnostics(program: ts.Program) {
     return '';
   }
 
-  function expectNoDiagnostics(diagnostics: ts.Diagnostic[]) {
+  function expectNoDiagnostics(diagnostics: ReadonlyArray<ts.Diagnostic>) {
     if (diagnostics && diagnostics.length) {
       throw new Error(
           'Errors from TypeScript:\n' +


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Refactoring (no functional changes, no api changes)
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Angular an only use 2.5 of TypeScript to compile.

## What is the new behavior?

Angular can use either 2.5 or 2.6 of TypeScript to compile everything except the language service which needs to be updated with the upgrad as the language service API has breaking changes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
