### PR TITLE
ci: add router/testing to public API guard

### DIFF
--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -38,6 +38,8 @@ module.exports = new Package('angular-api', [basePackage, typeScriptPackage])
     readTypeScriptModules.basePath = API_SOURCE_PATH;
     readTypeScriptModules.ignoreExportsMatching = [/^[_ɵ]|^VERSION$/];
     readTypeScriptModules.hidePrivateMembers = true;
+
+    // NOTE: This list shold be in sync with tools/gulp-tasks/public-api.js
     readTypeScriptModules.sourceFiles = [
       'animations/index.ts',
       'animations/browser/index.ts',

--- a/tools/gulp-tasks/public-api.js
+++ b/tools/gulp-tasks/public-api.js
@@ -6,29 +6,40 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+// NOTE: This list shold be in sync with aio/tools/transforms/angular-api-package/index.js
 const entrypoints = [
-  'dist/packages-dist/core/core.d.ts', 'dist/packages-dist/core/testing.d.ts',
-  'dist/packages-dist/common/common.d.ts', 'dist/packages-dist/common/testing.d.ts',
-  'dist/packages-dist/common/http.d.ts', 'dist/packages-dist/common/http/testing.d.ts',
+  'dist/packages-dist/animations/animations.d.ts',
+  'dist/packages-dist/animations/browser.d.ts',
+  'dist/packages-dist/animations/browser/testing.d.ts',
+  'dist/packages-dist/common/common.d.ts',
+  'dist/packages-dist/common/testing.d.ts',
+  'dist/packages-dist/common/http.d.ts',
+  'dist/packages-dist/common/http/testing.d.ts',
   // The API surface of the compiler is currently unstable - all of the important APIs are exposed
   // via @angular/core, @angular/platform-browser or @angular/platform-browser-dynamic instead.
   //'dist/packages-dist/compiler/index.d.ts',
   //'dist/packages-dist/compiler/testing.d.ts',
-  'dist/packages-dist/upgrade/upgrade.d.ts', 'dist/packages-dist/upgrade/static.d.ts',
+  'dist/packages-dist/core/core.d.ts',
+  'dist/packages-dist/core/testing.d.ts',
+  'dist/packages-dist/forms/forms.d.ts',
+  'dist/packages-dist/http/http.d.ts',
+  'dist/packages-dist/http/testing.d.ts',
   'dist/packages-dist/platform-browser/platform-browser.d.ts',
+  'dist/packages-dist/platform-browser/animations.d.ts',
   'dist/packages-dist/platform-browser/testing.d.ts',
   'dist/packages-dist/platform-browser-dynamic/platform-browser-dynamic.d.ts',
   'dist/packages-dist/platform-browser-dynamic/testing.d.ts',
   'dist/packages-dist/platform-webworker/platform-webworker.d.ts',
   'dist/packages-dist/platform-webworker-dynamic/platform-webworker-dynamic.d.ts',
   'dist/packages-dist/platform-server/platform-server.d.ts',
-  'dist/packages-dist/platform-server/testing.d.ts', 'dist/packages-dist/http/http.d.ts',
-  'dist/packages-dist/http/testing.d.ts', 'dist/packages-dist/forms/forms.d.ts',
-  'dist/packages-dist/router/router.d.ts', 'dist/packages-dist/animations/animations.d.ts',
+  'dist/packages-dist/platform-server/testing.d.ts',
+  'dist/packages-dist/router/router.d.ts',
+  'dist/packages-dist/router/testing.d.ts',
+  'dist/packages-dist/router/upgrade.d.ts',
   'dist/packages-dist/service-worker/service-worker.d.ts',
-  'dist/packages-dist/service-worker/config.d.ts', 'dist/packages-dist/animations/browser.d.ts',
-  'dist/packages-dist/animations/browser/testing.d.ts',
-  'dist/packages-dist/platform-browser/animations.d.ts'
+  'dist/packages-dist/service-worker/config.d.ts',
+  'dist/packages-dist/upgrade/upgrade.d.ts',
+  'dist/packages-dist/upgrade/static.d.ts',
 ];
 
 const publicApiDir = 'tools/public_api_guard';

--- a/tools/public_api_guard/router/testing.d.ts
+++ b/tools/public_api_guard/router/testing.d.ts
@@ -1,0 +1,16 @@
+/** @stable */
+export declare class RouterTestingModule {
+    static withRoutes(routes: Routes): ModuleWithProviders;
+}
+
+/** @stable */
+export declare function setupTestingRouter(urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location, loader: NgModuleFactoryLoader, compiler: Compiler, injector: Injector, routes: Route[][], urlHandlingStrategy?: UrlHandlingStrategy): Router;
+
+/** @stable */
+export declare class SpyNgModuleFactoryLoader implements NgModuleFactoryLoader {
+    stubbedModules: {
+        [path: string]: any;
+    };
+    constructor(compiler: Compiler);
+    load(path: string): Promise<NgModuleFactory<any>>;
+}

--- a/tools/public_api_guard/router/upgrade.d.ts
+++ b/tools/public_api_guard/router/upgrade.d.ts
@@ -1,0 +1,13 @@
+/** @experimental */
+export declare const RouterUpgradeInitializer: {
+    provide: InjectionToken<((compRef: ComponentRef<any>) => void)[]>;
+    multi: boolean;
+    useFactory: (ngUpgrade: UpgradeModule) => () => void;
+    deps: (typeof UpgradeModule)[];
+};
+
+/** @experimental */
+export declare function setUpLocationSync(ngUpgrade: UpgradeModule): void;
+
+/** @experimental */
+export declare function setUpRouterSync(injector: Injector, $injector: any): void;


### PR DESCRIPTION
Also fix the sequence/formatting of entry points listing so it's easier to read. Only meaningful change is adding `'dist/packages-dist/router/testing.d.ts',` to the `entrypoints` list.