### PR TITLE
test(aio): wait for Angular to avoid flake in e2e test

### DIFF
--- a/aio/e2e/app.e2e-spec.ts
+++ b/aio/e2e/app.e2e-spec.ts
@@ -58,6 +58,7 @@ describe('site App', function() {
       expect(page.getScrollTop()).toBeGreaterThan(0);
 
       page.getNavItem(/api/i).click();
+      browser.waitForAngular();
       expect(page.locationPath()).toBe('/api');
       expect(page.getScrollTop()).toBe(0);
     });
@@ -69,6 +70,7 @@ describe('site App', function() {
       expect(page.getScrollTop()).toBeGreaterThan(0);
 
       page.getNavItem(/security/i).click();
+      browser.waitForAngular();
       expect(page.locationPath()).toBe('/guide/security');
       expect(page.getScrollTop()).toBe(0);
     });


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] Other... Please describe: Test
```

## What is the current behavior?
Since Protractor does not `waitForAngular` before running `executeScript()`, there is a chance it attempts to get the scroll top, before renderering the new doc (especially on slower machines, such on CI). This can lead to flakes.


## What is the new behavior?
We explcitly wait for Angular before retrieving the scroll top, to ensure the transition (and scrolling) has happened.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
