### PR TITLE
docs(aio): fix word wrap

### DIFF
--- a/aio/content/guide/service-worker-devops.md
+++ b/aio/content/guide/service-worker-devops.md
@@ -200,8 +200,8 @@ versions are safe to use, so existing tabs continue to run from
 cache, but new loads of the app will be served from the network.
 
 * `SAFE_MODE`: the service worker cannot guarantee the safety of 
-using cached data. Either an unexpected error occurred or all c
-ached versions are invalid. All traffic will be served from the 
+using cached data. Either an unexpected error occurred or all 
+cached versions are invalid. All traffic will be served from the 
 network, running as little service worker code as possible.
 
 In both cases, the parenthetical annotation provides the 


### PR DESCRIPTION
The fix removes space between 'c' and 'aches' in docs

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Page https://angular.io/guide/service-worker-devops contains unnecessary space 

> Either an unexpected error occurred or all _c ached_ versions are invalid.

Issue Number: N/A


## What is the new behavior?
The fix removes the space between 'c' and 'ached'

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
