### PR TITLE
fix(animations): avoid infinite loop with multiple blocked sub triggers

### DIFF
--- a/packages/animations/src/players/animation_group_player.ts
+++ b/packages/animations/src/players/animation_group_player.ts
@@ -33,17 +33,17 @@ export class AnimationGroupPlayer implements AnimationPlayer {
     } else {
       this.players.forEach(player => {
         player.onDone(() => {
-          if (++doneCount >= total) {
+          if (++doneCount == total) {
             this._onFinish();
           }
         });
         player.onDestroy(() => {
-          if (++destroyCount >= total) {
+          if (++destroyCount == total) {
             this._onDestroy();
           }
         });
         player.onStart(() => {
-          if (++startCount >= total) {
+          if (++startCount == total) {
             this._onStart();
           }
         });
@@ -67,9 +67,9 @@ export class AnimationGroupPlayer implements AnimationPlayer {
 
   private _onStart() {
     if (!this.hasStarted()) {
+      this._started = true;
       this._onStartFns.forEach(fn => fn());
       this._onStartFns = [];
-      this._started = true;
     }
   }
 


### PR DESCRIPTION
This patch fixes animations so that if multiple sub @triggers are used
and are blocked by a parent animation then the engine will not lead
itself into an infinite loop.