### PR TITLE
fix(animations): renaming issue with DOMAnimation.

### DIFF
--- a/packages/animations/browser/src/render/web_animations/dom_animation.ts
+++ b/packages/animations/browser/src/render/web_animations/dom_animation.ts
@@ -6,7 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export interface DOMAnimation {
+/**
+ * DOMAnimation represents the Animation Web API.
+ *
+ * It is an external API by the browser, and must thus use "declare interface",
+ * to prevent renaming by Closure Compiler.
+ *
+ * @see https://developer.mozilla.org/de/docs/Web/API/Animation
+ */
+export declare interface DOMAnimation {
   cancel(): void;
   play(): void;
   pause(): void;


### PR DESCRIPTION
Closure Compiler renames all properties that are "internal" to the
program. `DOMAnimation` however is external, it is a browser API, so its
fields must not be renamed.

This change marks `DOMAnimation` as external using `declare interface`,
which will cause Closure Compiler to back off and prevent renaming of
any of its fields.


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
```

## What is the current behavior?

Closure Compiler in advanced mode with types will break apps using animations.

Issue Number: N/A

## What is the new behavior?

Apps work :-)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

While we have g3 internal tests for this, we do not have a setup to be able to test this in the open source repository, I'm afraid.