### PR TITLE
build(common): generate ts declarations for i18n locale files

### DIFF
--- a/packages/common/locales/tsconfig-build.json
+++ b/packages/common/locales/tsconfig-build.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "declaration": false,
+    "declaration": true,
     "stripInternal": true,
     "experimentalDecorators": true,
     "module": "es2015",


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Build
```

## What is the current behavior?
In a previous PR we removed ts declarations generation for i18n locales, and we shouldn't have.

Issue Number: #21120


## What is the new behavior?
Revert this change

## Does this PR introduce a breaking change?
```
[x] No
```