### PR TITLE
doc: document the template compiler options

### DIFF
--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -57,7 +57,7 @@ export interface CompilerOptions extends ts.CompilerOptions {
   // Produce an error if the metadata written for a class would produce an error if used.
   strictMetadataEmit?: boolean;
 
-  // Don't produce .ngfactory.ts or .ngstyle.ts files
+  // Don't produce .ngfactory.js or .ngstyle.js files
   skipTemplateCodegen?: boolean;
 
   // Always report errors when the type of a parameter supplied whose injection type cannot


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Documentation content changes
```

## What is the current behavior?

Issue Number: #20987

The compiler options were not documented.

## What is the new behavior?

The compiler options are documented.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
