### PR TITLE
feat(core): add ngOnInit and ngDoCheck support in render3

### DIFF
--- a/modules/benchmarks/src/tree/render3/tree.ts
+++ b/modules/benchmarks/src/tree/render3/tree.ts
@@ -61,6 +61,7 @@ export class TreeComponent {
               e();
             }
             p(0, 'data', b(ctx.data.left));
+            TreeComponent.ngComponentDef.h(1, 0);
             TreeComponent.ngComponentDef.r(1, 0);
           }
           v();
@@ -78,6 +79,7 @@ export class TreeComponent {
               e();
             }
             p(0, 'data', b(ctx.data.right));
+            TreeComponent.ngComponentDef.h(1, 0);
             TreeComponent.ngComponentDef.r(1, 0);
           }
           v();

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -39,6 +39,7 @@ export function defineComponent<T>(componentDefinition: ComponentDefArgs<T>): Co
     template: (componentDefinition as ComponentDefArgs<T>).template || null !,
     r: componentDefinition.refresh ||
         function(d: number, e: number) { componentRefresh(d, e, componentDefinition.template); },
+    h: componentDefinition.hostBindings || noop,
     inputs: invertObject(componentDefinition.inputs),
     outputs: invertObject(componentDefinition.outputs),
     methods: invertObject(componentDefinition.methods),
@@ -58,6 +59,8 @@ export function PublicFeature<T>(definition: DirectiveDef<T>) {
 }
 
 const EMPTY = {};
+
+function noop() {}
 
 /** Swaps the keys and values of an object. */
 function invertObject(obj: any): any {

--- a/packages/core/src/render3/definition_interfaces.ts
+++ b/packages/core/src/render3/definition_interfaces.ts
@@ -68,24 +68,32 @@ export interface DirectiveDef<T> {
   n(): T;
 
   /**
-   * Refresh method. Used by the containing component to signal
-   * to the directive that it should be refreshed. (Directives
-   * usually call life cycle methods at this point.)
+   * Refreshes the view of the component. Also calls lifecycle hooks like
+   * ngAfterViewInit, if they are defined on the component.
    *
-   * NOTE: this property is short (1 char) because it is used in
-   * component templates which is sensitive to size.
+   * NOTE: this property is short (1 char) because it is used in component
+   * templates which is sensitive to size.
    *
    * @param directiveIndex index of the directive in the containing template
    * @param elementIndex index of an host element for a given directive.
    */
   r(directiveIndex: number, elementIndex: number): void;
+
+  /**
+   * Refreshes host bindings on the associated directive. Also calls lifecycle hooks
+   * like ngOnInit and ngDoCheck, if they are defined on the directive.
+   */
+  // Note: This call must be separate from r() because hooks like ngOnInit need to
+  // be called breadth-first across a view before processing onInits in children
+  // (for backwards compatibility). Child template processing thus needs to be
+  // delayed until all inputs and host bindings in a view have been checked.
+  h(directiveIndex: number, elementIndex: number): void;
 }
 
 export interface ComponentDef<T> extends DirectiveDef<T> {
   /**
-   * Refresh method. Used by the containing component to signal
-   * to the directive that it should be refreshed. (Directives
-   * usually call life cycle methods at this point.)
+   * Refreshes the view of the component. Also calls lifecycle hooks like
+   * ngAfterViewInit, if they are defined on the component.
    *
    * NOTE: this property is short (1 char) because it is used in
    * component templates which is sensitive to size.
@@ -131,6 +139,7 @@ export interface ComponentDefArgs<T> extends DirectiveDefArgs<T> {
   tag: string;
   template: ComponentTemplate<T>;
   refresh?: (directiveIndex: number, elementIndex: number) => void;
+  hostBindings?: (directiveIndex: number, elementIndex: number) => void;
   features?: ComponentDefFeature[];
   rendererType?: RendererType2;
 }

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -72,6 +72,7 @@ describe('encapsulation', () => {
           { D(1, EncapsulatedComponent.ngComponentDef.n(), EncapsulatedComponent.ngComponentDef); }
           e();
         }
+        EncapsulatedComponent.ngComponentDef.h(1, 0);
         EncapsulatedComponent.ngComponentDef.r(1, 0);
       },
       factory: () => new WrapperComponent,
@@ -89,6 +90,7 @@ describe('encapsulation', () => {
           { D(2, LeafComponent.ngComponentDef.n(), LeafComponent.ngComponentDef); }
           e();
         }
+        LeafComponent.ngComponentDef.h(2, 1);
         LeafComponent.ngComponentDef.r(2, 1);
       },
       factory: () => new EncapsulatedComponent,
@@ -137,6 +139,7 @@ describe('encapsulation', () => {
             { D(1, LeafComponentwith.ngComponentDef.n(), LeafComponentwith.ngComponentDef); }
             e();
           }
+          LeafComponentwith.ngComponentDef.h(1, 0);
           LeafComponentwith.ngComponentDef.r(1, 0);
         },
         factory: () => new WrapperComponentWith,

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -37,6 +37,7 @@ describe('content projection', () => {
         }
         e();
       }
+      Child.ngComponentDef.h(1, 0);
       Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
@@ -59,6 +60,7 @@ describe('content projection', () => {
         }
         e();
       }
+      Child.ngComponentDef.h(1, 0);
       Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
@@ -83,6 +85,7 @@ describe('content projection', () => {
           P(3, 0);
         }
         e();
+        GrandChild.ngComponentDef.h(2, 1);
         GrandChild.ngComponentDef.r(2, 1);
       }
     });
@@ -98,6 +101,7 @@ describe('content projection', () => {
         }
         e();
       }
+      Child.ngComponentDef.h(1, 0);
       Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
@@ -136,6 +140,7 @@ describe('content projection', () => {
         }
       }
       cr();
+      Child.ngComponentDef.h(1, 0);
       Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
@@ -175,6 +180,7 @@ describe('content projection', () => {
         }
       }
       cr();
+      Child.ngComponentDef.h(1, 0);
       Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
@@ -225,6 +231,7 @@ describe('content projection', () => {
         }
       }
       cr();
+      Child.ngComponentDef.h(1, 0);
       Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
@@ -285,6 +292,7 @@ describe('content projection', () => {
         }
         e();
       }
+      Child.ngComponentDef.h(1, 0);
       Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
@@ -340,6 +348,7 @@ describe('content projection', () => {
            }
            e();
          }
+         Child.ngComponentDef.h(1, 0);
          Child.ngComponentDef.r(1, 0);
        });
        const parent = renderComponent(Parent);
@@ -379,6 +388,7 @@ describe('content projection', () => {
         }
         e();
       }
+      Child.ngComponentDef.h(1, 0);
       Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
@@ -439,6 +449,7 @@ describe('content projection', () => {
         }
         e();
       }
+      Child.ngComponentDef.h(1, 0);
       Child.ngComponentDef.r(1, 0);
     });
     const parent = renderComponent(Parent);
@@ -489,6 +500,7 @@ describe('content projection', () => {
           }
           e();
         }
+        Child.ngComponentDef.h(1, 0);
         Child.ngComponentDef.r(1, 0);
       });
 
@@ -536,6 +548,7 @@ describe('content projection', () => {
           }
           e();
         }
+        Child.ngComponentDef.h(1, 0);
         Child.ngComponentDef.r(1, 0);
       });
 
@@ -583,6 +596,7 @@ describe('content projection', () => {
           }
           e();
         }
+        Child.ngComponentDef.h(1, 0);
         Child.ngComponentDef.r(1, 0);
       });
 
@@ -629,6 +643,7 @@ describe('content projection', () => {
           }
           e();
         }
+        Child.ngComponentDef.h(1, 0);
         Child.ngComponentDef.r(1, 0);
       });
 
@@ -676,6 +691,7 @@ describe('content projection', () => {
           }
           e();
         }
+        Child.ngComponentDef.h(1, 0);
         Child.ngComponentDef.r(1, 0);
       });
 
@@ -724,6 +740,7 @@ describe('content projection', () => {
           }
           e();
         }
+        Child.ngComponentDef.h(0, 0);
         Child.ngComponentDef.r(0, 0);
       });
 
@@ -772,6 +789,7 @@ describe('content projection', () => {
             e();
           }
           e();
+          GrandChild.ngComponentDef.h(2, 1);
           GrandChild.ngComponentDef.r(2, 1);
         }
       });
@@ -794,6 +812,7 @@ describe('content projection', () => {
           }
           e();
         }
+        Child.ngComponentDef.h(1, 0);
         Child.ngComponentDef.r(1, 0);
       });
 
@@ -846,6 +865,7 @@ describe('content projection', () => {
           }
         }
         cr();
+        Child.ngComponentDef.h(1, 0);
         Child.ngComponentDef.r(1, 0);
       });
       const parent = renderComponent(Parent);

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -234,6 +234,7 @@ describe('iv integration test', () => {
           { D(1, TodoComponent.ngComponentDef.n(), TodoComponent.ngComponentDef); }
           e();
         }
+        TodoComponent.ngComponentDef.h(1, 0);
         TodoComponent.ngComponentDef.r(1, 0);
       }
 
@@ -248,6 +249,7 @@ describe('iv integration test', () => {
           e();
           T(2, 'two');
         }
+        TodoComponent.ngComponentDef.h(1, 0);
         TodoComponent.ngComponentDef.r(1, 0);
       }
       expect(renderToHtml(Template, null)).toEqual('<todo><p>Todo one</p></todo>two');
@@ -267,6 +269,8 @@ describe('iv integration test', () => {
           { D(3, TodoComponent.ngComponentDef.n(), TodoComponent.ngComponentDef); }
           e();
         }
+        TodoComponent.ngComponentDef.h(1, 0);
+        TodoComponent.ngComponentDef.h(3, 2);
         TodoComponent.ngComponentDef.r(1, 0);
         TodoComponent.ngComponentDef.r(3, 2);
       }
@@ -290,11 +294,9 @@ describe('iv integration test', () => {
             t(0, b(ctx.title));
           },
           factory: () => cmptInstance = new TodoComponentHostBinding,
-          refresh: function(directiveIndex: number, elementIndex: number): void {
+          hostBindings: function(directiveIndex: number, elementIndex: number): void {
             // host bindings
             p(elementIndex, 'title', b(D<TodoComponentHostBinding>(directiveIndex).title));
-            // refresh component's template
-            r(directiveIndex, elementIndex, this.template);
           }
         });
       }
@@ -308,6 +310,7 @@ describe('iv integration test', () => {
           }
           e();
         }
+        TodoComponentHostBinding.ngComponentDef.h(1, 0);
         TodoComponentHostBinding.ngComponentDef.r(1, 0);
       }
 
@@ -341,6 +344,7 @@ describe('iv integration test', () => {
           { D(1, MyComp.ngComponentDef.n(), MyComp.ngComponentDef); }
           e();
         }
+        MyComp.ngComponentDef.h(1, 0);
         MyComp.ngComponentDef.r(1, 0);
       }
 
@@ -389,6 +393,7 @@ describe('iv integration test', () => {
           e();
         }
         p(0, 'condition', b(ctx.condition));
+        MyComp.ngComponentDef.h(1, 0);
         MyComp.ngComponentDef.r(1, 0);
       }
 

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -211,6 +211,8 @@ describe('event listeners', () => {
             { D(4, MyComp.ngComponentDef.n(), MyComp.ngComponentDef); }
             e();
           }
+          MyComp.ngComponentDef.h(2, 1);
+          MyComp.ngComponentDef.h(4, 3);
           MyComp.ngComponentDef.r(2, 1);
           MyComp.ngComponentDef.r(4, 3);
           v();

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -51,6 +51,7 @@ describe('outputs', () => {
         }
         e();
       }
+      ButtonToggle.ngComponentDef.h(1, 0);
       ButtonToggle.ngComponentDef.r(1, 0);
     }
 
@@ -77,6 +78,7 @@ describe('outputs', () => {
         }
         e();
       }
+      ButtonToggle.ngComponentDef.h(1, 0);
       ButtonToggle.ngComponentDef.r(1, 0);
     }
 
@@ -103,6 +105,7 @@ describe('outputs', () => {
         }
         e();
       }
+      ButtonToggle.ngComponentDef.h(1, 0);
       ButtonToggle.ngComponentDef.r(1, 0);
     }
 
@@ -140,6 +143,7 @@ describe('outputs', () => {
             }
             e();
           }
+          ButtonToggle.ngComponentDef.h(1, 0);
           ButtonToggle.ngComponentDef.r(1, 0);
           v();
         }
@@ -194,6 +198,7 @@ describe('outputs', () => {
                 }
                 e();
               }
+              ButtonToggle.ngComponentDef.h(1, 0);
               ButtonToggle.ngComponentDef.r(1, 0);
               v();
             }
@@ -270,6 +275,8 @@ describe('outputs', () => {
             { D(5, DestroyComp.ngComponentDef.n(), DestroyComp.ngComponentDef); }
             e();
           }
+          ButtonToggle.ngComponentDef.h(3, 2);
+          DestroyComp.ngComponentDef.h(5, 4);
           ButtonToggle.ngComponentDef.r(3, 2);
           DestroyComp.ngComponentDef.r(5, 4);
           v();
@@ -350,6 +357,7 @@ describe('outputs', () => {
         }
         e();
       }
+      ButtonToggle.ngComponentDef.h(1, 0);
       ButtonToggle.ngComponentDef.r(1, 0);
     }
 
@@ -385,6 +393,7 @@ describe('outputs', () => {
         e();
       }
       p(0, 'change', b(ctx.change));
+      ButtonToggle.ngComponentDef.h(1, 0);
       ButtonToggle.ngComponentDef.r(1, 0);
     }
 
@@ -431,6 +440,7 @@ describe('outputs', () => {
             }
             e();
           }
+          ButtonToggle.ngComponentDef.h(1, 0);
           ButtonToggle.ngComponentDef.r(1, 0);
           v();
         } else {

--- a/packages/core/test/render3/properties_spec.ts
+++ b/packages/core/test/render3/properties_spec.ts
@@ -164,6 +164,7 @@ describe('elementProperty', () => {
           e();
         }
         p(0, 'id', b(ctx.id));
+        Comp.ngComponentDef.h(1, 0);
         Comp.ngComponentDef.r(1, 0);
       }
 
@@ -538,6 +539,7 @@ describe('elementProperty', () => {
               { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
               e();
             }
+            Comp.ngComponentDef.h(1, 0);
             Comp.ngComponentDef.r(1, 0);
             v();
           }

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -67,6 +67,7 @@ describe('renderer factory lifecycle', () => {
       { D(2, SomeComponent.ngComponentDef.n(), SomeComponent.ngComponentDef); }
       e();
     }
+    SomeComponent.ngComponentDef.h(2, 1);
     SomeComponent.ngComponentDef.r(2, 1);
   }
 


### PR DESCRIPTION
Adds support and testing for the `ngOnInit` and `ngDoCheck` lifecycle hooks.

The `ngOnInit` hook should always be called breadth-first across components in a view before being called in child views (see example order [here)](https://goo.gl/D6J9VW). Calling `ngOnInit` in the `ngComponentDef.r()` method as originally planned is thus problematic because that method also contains the instruction to process child view templates. As a result, child view `ngOnInit` calls would happen before the calls for sibling components in the parent view. 

To resolve this, refresh is now split into two parts:
- `hostRefresh` (for host bindings, `ngOnInit`, and `ngDoCheck`)
- and `refresh` (component template processing, `ngAfterViewInit`, and `ngAfterViewChecked`) 

This way, we can delay child view processing until later, ensuring that *all* `ngOnInit` hooks in the current view execute first.

cc @jelbourn @chuckjaz 
 