### PR TITLE
docs(aio): fix TOH inclusion of HeroesService (#20398)

### DIFF
--- a/aio/content/examples/toh-pt4/src/app/app.module.ts
+++ b/aio/content/examples/toh-pt4/src/app/app.module.ts
@@ -21,7 +21,14 @@ import { MessagesComponent } from './messages/messages.component';
     FormsModule
   ],
   // #docregion providers
-  providers: [ HeroService, MessageService ],
+  // #docregion providers-heroservice
+  providers: [
+    HeroService,
+    // #enddocregion providers-heroservice
+    MessageService
+    // #docregion providers-heroservice
+  ],
+  // #enddocregion providers-heroservice
   // #enddocregion providers
   bootstrap: [ AppComponent ]
 })

--- a/aio/content/tutorial/toh-pt4.md
+++ b/aio/content/tutorial/toh-pt4.md
@@ -97,13 +97,19 @@ Since you did not, you'll have to provide it yourself.
 
 Open the `AppModule` class, import the `HeroService`, and add it to the `@NgModule.providers` array.
 
-<code-example path="toh-pt4/src/app/app.module.ts" linenums="false" title="src/app/app.module.ts (providers)" region="providers">
+<code-example path="toh-pt4/src/app/app.module.ts" linenums="false" title="src/app/app.module.ts (providers)" region="providers-heroservice">
 </code-example>
 
 The `providers` array tells Angular to create a single, shared instance of `HeroService`
 and inject into any class that asks for it.
 
 The `HeroService` is now ready to plug into the `HeroesComponent`.
+
+<div class="alert is-important">
+
+This is a interim code sample that will allow you to provide and use the `HeroService`.  At this point, the code will differ from the `HeroService` in the ["final code review"](#final-code-review).
+
+</div>
 
 <div class="alert is-helpful">
 
@@ -421,6 +427,10 @@ Here are the code files discussed on this page and your app should look like thi
 
   <code-pane title="src/app/messages/messages.component.css"
   path="toh-pt4/src/app/messages/messages.component.css">
+  </code-pane>
+
+  <code-pane title="src/app/app.module.ts"
+  path="toh-pt4/src/app/app.module.ts">
   </code-pane>
 
   <code-pane title="src/app/app.component.html"


### PR DESCRIPTION
fix TOH inclusion of HeroesService including MessageService, which doesn't come until further down (#20398)

Change TOH docs where the MessageService is referenced within the Providers array, but it isn't generated until later in the Services tutorial.

Fixes #20398

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Change TOH docs where the MessageService is referenced within the Providers array, but it isn't generated until later in the Services tutorial.

Issue Number: 20398

## What is the new behavior?
Docs now do not show MessageService when working only on the HeroesService,  Warning indicates to reader that "final code review" will differ and that this code is only a "way station" to the final code result for this lesson in the tutorial

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
