### PR TITLE
fix(compiler): add support for marker tags in xliff serializers

### DIFF
--- a/packages/compiler/src/i18n/serializers/xliff2.ts
+++ b/packages/compiler/src/i18n/serializers/xliff2.ts
@@ -21,6 +21,7 @@ const _XMLNS = 'urn:oasis:names:tc:xliff:document:2.0';
 const _DEFAULT_SOURCE_LANG = 'en';
 const _PLACEHOLDER_TAG = 'ph';
 const _PLACEHOLDER_SPANNING_TAG = 'pc';
+const _MARKER_TAG = 'mrk';
 
 const _XLIFF_TAG = 'xliff';
 const _SOURCE_TAG = 'source';
@@ -332,6 +333,8 @@ class XmlToI18n implements ml.Visitor {
               new i18n.Placeholder('', endId, el.sourceSpan));
         }
         break;
+      case _MARKER_TAG:
+        return [].concat(...ml.visitAll(this, el.children));
       default:
         this._addError(el, `Unexpected tag`);
     }

--- a/packages/compiler/test/i18n/serializers/xliff2_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xliff2_spec.ts
@@ -238,6 +238,24 @@ lines</source>
 lignes</target>
       </segment>
     </unit>
+    <unit id="mrk-test">
+     <notes>
+      <note id="n1" appliesTo="target">Please check the translation for 'namespace'. On also can use 'espace de nom',but I think most technical manuals use the English term.</note>
+     </notes>
+     <segment>
+      <source>You use your own namespace.</source>
+      <target>Vous pouvez utiliser votre propre <mrk id="m1" type="comment" ref="#n1">namespace</mrk>.</target>
+     </segment>
+    </unit>
+    <unit id="mrk-test2">
+     <notes>
+      <note id="n1" appliesTo="target">Please check the translation for 'namespace'. On also can use 'espace de nom',but I think most technical manuals use the English term.</note>
+     </notes>
+     <segment>
+      <source>You use your own namespace.</source>
+      <target>Vous pouvez utiliser <mrk id="m1" type="comment" ref="#n1">votre propre <mrk id="m2" type="comment" ref="#n1">namespace</mrk></mrk>.</target>
+     </segment>
+    </unit>
   </file>
 </xliff>
 `;
@@ -289,7 +307,9 @@ lignes</target>
           '5229984852258993423': '{VAR_PLURAL, plural, =0 {[{VAR_SELECT, select, other {[<ph' +
               ' name="START_PARAGRAPH"/>, profondément imbriqué, <ph name="CLOSE_PARAGRAPH"/>]}},  ]}, =other {[beaucoup]}}',
           '2340165783990709777': `multi
-lignes`
+lignes`,
+          'mrk-test': 'Vous pouvez utiliser votre propre namespace.',
+          'mrk-test2': 'Vous pouvez utiliser votre propre namespace.'
         });
       });
 

--- a/packages/compiler/test/i18n/serializers/xliff_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xliff_spec.ts
@@ -221,6 +221,20 @@ lignes</target>
           <context context-type="linenumber">12</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="mrk-test">
+        <source>First sentence.</source>
+        <seg-source>
+          <invalid-tag>Should not be parsed</invalid-tag>
+        </seg-source>
+        <target>Translated <mrk mtype="seg" mid="1">first sentence</mrk>.</target>
+      </trans-unit>
+      <trans-unit id="mrk-test2">
+        <source>First sentence. Second sentence.</source>
+        <seg-source>
+          <invalid-tag>Should not be parsed</invalid-tag>
+        </seg-source>
+        <target>Translated <mrk mtype="seg" mid="1"><mrk mtype="seg" mid="2">first</mrk> sentence</mrk>.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>
@@ -273,7 +287,9 @@ lignes</target>
               '{VAR_PLURAL, plural, =0 {[{VAR_SELECT, select, other {[<ph' +
               ' name="START_PARAGRAPH"/>, profondément imbriqué, <ph name="CLOSE_PARAGRAPH"/>]}},  ]}, =other {[beaucoup]}}',
           'fcfa109b0e152d4c217dbc02530be0bcb8123ad1': `multi
-lignes`
+lignes`,
+          'mrk-test': 'Translated first sentence.',
+          'mrk-test2': 'Translated first sentence.'
         });
       });
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
```

## What is the current behavior?
We do not support marker tags that are specified in the XLIFF spec

Issue Number: #21078


## What is the new behavior?
We support those tags (those are "inert" tags used by translation tools, we just need to ignore them and parse their contents)

## Does this PR introduce a breaking change?
```
[x] No
```