### PR TITLE
[Shadow CSS] Host context fix

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -291,7 +291,7 @@ export class ShadowCss {
       let arrSelector = [m[2]];
       while (match !== null) {
         // Clean the founded selector and save it.
-        const selectorHostContext = match[0].replace('-shadowcsscontext(', '').replace(')','');
+        const selectorHostContext = match[0].replace('-shadowcsscontext(', '').replace(')', '');
         arrSelector.push(selectorHostContext);
         // Remove the current :host-context
         m[3] = m[3].replace(regExprCheckHostContext, '');
@@ -299,11 +299,11 @@ export class ShadowCss {
         match = m[3].match(regExprCheckHostContext);
       }
       // If have more than 1 class, generate all combinations.
-      if(arrSelector.length > 1) {
+      if (arrSelector.length > 1) {
         const listOfCombinations = _this._combineArraySelectors(arrSelector);
         m[2] = '';
         // Add all combination separated by spaces.
-        for(let i = 0; i < listOfCombinations.length; i++) {
+        for (let i = 0; i < listOfCombinations.length; i++) {
           m[2] += listOfCombinations[i].join(' ') + ',';
         }
         // Add one case of all clases without space separator.
@@ -325,18 +325,18 @@ export class ShadowCss {
   }
 
   private _combineArraySelectors(arrSelector: string[]): string[][] {
-   let results: string[][] = [];
-   if (arrSelector.length === 1) return [[arrSelector[0]]];
-   for(let i = 0; i < arrSelector.length; i++) {
-     let copyArr: string[] = arrSelector.slice();
-     let firstItem: string[] = copyArr.splice(i, 1);
-     let childResult: string[][] = this._combineArraySelectors(copyArr);
-     for(let j = 0; j < childResult.length; j++) {
-       results.push([...firstItem, ...childResult[j]]);
-     }
-   }
-   return results;
- }
+    let results: string[][] = [];
+    if (arrSelector.length === 1) return [[arrSelector[0]]];
+    for (let i = 0; i < arrSelector.length; i++) {
+      let copyArr: string[] = arrSelector.slice();
+      let firstItem: string[] = copyArr.splice(i, 1);
+      let childResult: string[][] = this._combineArraySelectors(copyArr);
+      for (let j = 0; j < childResult.length; j++) {
+        results.push([...firstItem, ...childResult[j]]);
+      }
+    }
+    return results;
+  }
 
   private _colonHostContextPartReplacer(host: string, part: string, suffix: string): string {
     if (part.indexOf(_polyfillHost) > -1) {

--- a/packages/compiler/test/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css_spec.ts
@@ -198,7 +198,8 @@ export function main() {
 
       it('should handle multiple host-context', () => {
         expect(s(':host-context(.one) :host-context(.two) {}', 'contenta', 'a-host'))
-          .toEqual('.one[a-host] .two[contenta], .one .two [a-host], .two[a-host] .one[contenta], .two .one [a-host], .one.two[a-host], .one.two [a-host] {}');
+            .toEqual(
+                '.one[a-host] .two[contenta], .one .two [a-host], .two[a-host] .one[contenta], .two .one [a-host], .one.two[a-host], .one.two [a-host] {}');
       });
     });
 

--- a/packages/compiler/test/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css_spec.ts
@@ -195,6 +195,11 @@ export function main() {
         expect(s(':host-context([a=b]) {}', 'contenta', 'a-host'))
             .toEqual('[a=b][a-host], [a="b"] [a-host] {}');
       });
+
+      it('should handle multiple host-context', () => {
+        expect(s(':host-context(.one) :host-context(.two) {}', 'contenta', 'a-host'))
+          .toEqual('.one[a-host] .two[contenta], .one .two [a-host], .two[a-host] .one[contenta], .two .one [a-host], .one.two[a-host], .one.two [a-host] {}');
+      });
     });
 
     it('should support polyfill-next-selector', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When  you use more than one :host-context selector in the same css rule, the compiled css generate a invalid css code "-shadowcsscontext".

Example: 
````scss
// Preprocessed code
:host-context(.one):host-context(.two) {}
````
````css
/* Generated code*/
.one-shadowcsscontext(.two)[nghost],
.one   -shadowcsscontext(.two)[nghost] {}
````

Issue Number: https://github.com/angular/angular/issues/19199

## What is the new behavior?

You can use two or more :host-context selector in the same css rule and generate all css combinations.

Example:

````scss
// Preprocessed code
:host-context(.one) :host-context(.two) {}
````
````css
/* Generated code*/
.one[nghost] .two[ngcontent],
.one .two [a-host], 
.two[nghost] .one[ngcontent], 
.two .one [nghost], 
.one.two[nghost],
.one.two [nghost] {}
````

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
