### PR TITLE
docs(aio): Fix typo in Reactive Forms guide. Rename formControlName to formControl

### DIFF
--- a/aio/content/guide/reactive-forms.md
+++ b/aio/content/guide/reactive-forms.md
@@ -254,7 +254,7 @@ It _styles_ the form but in no way impacts the logic of the form.
 
 ## Import the _ReactiveFormsModule_
 
-The HeroDetailComponent template uses `formControlName`
+The HeroDetailComponent template uses `formControl`
 directive from the `ReactiveFormsModule`.
 
 Do the following two things in `app.module.ts`:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Fix typo in "Reactive Forms" guide. Rename formControlName to formControl. FormControlName directive used as well but later in documentation.