### PR TITLE
build: update rules_typescript

### DIFF
--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -14,7 +14,7 @@ node_repositories(package_json = ["//:package.json"])
 git_repository(
     name = "build_bazel_rules_typescript",
     remote = "https://github.com/bazelbuild/rules_typescript.git",
-    tag = "0.6.0",
+    tag = "0.6.2",
 )
 
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_repositories")


### PR DESCRIPTION
picks up a bugfix to prevent floating versions on install:
https://github.com/bazelbuild/rules_typescript/compare/0.6.1...0.6.2
