### PR TITLE
refactor(aio): use one argument for `DocViewer` error reporting

### DIFF
--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
@@ -536,7 +536,7 @@ describe('DocViewerComponent', () => {
         expect(swapViewsSpy).not.toHaveBeenCalled();
         expect(docViewer.nextViewContainer.innerHTML).toBe('');
         expect(logger.output.error).toEqual([
-          ['[DocViewer]: Error preparing document \'foo\'.', error],
+          [`[DocViewer] Error preparing document 'foo': ${error.stack}`],
         ]);
       });
 
@@ -555,7 +555,7 @@ describe('DocViewerComponent', () => {
         expect(swapViewsSpy).not.toHaveBeenCalled();
         expect(docViewer.nextViewContainer.innerHTML).toBe('');
         expect(logger.output.error).toEqual([
-          ['[DocViewer]: Error preparing document \'bar\'.', error],
+          [`[DocViewer] Error preparing document 'bar': ${error.stack}`],
         ]);
       });
 
@@ -574,7 +574,7 @@ describe('DocViewerComponent', () => {
         expect(swapViewsSpy).not.toHaveBeenCalled();
         expect(docViewer.nextViewContainer.innerHTML).toBe('');
         expect(logger.output.error).toEqual([
-          ['[DocViewer]: Error preparing document \'baz\'.', error],
+          [`[DocViewer] Error preparing document 'baz': ${error.stack}`],
         ]);
       });
 
@@ -593,7 +593,23 @@ describe('DocViewerComponent', () => {
         expect(swapViewsSpy).toHaveBeenCalledTimes(1);
         expect(docViewer.nextViewContainer.innerHTML).toBe('');
         expect(logger.output.error).toEqual([
-          ['[DocViewer]: Error preparing document \'qux\'.', error],
+          [`[DocViewer] Error preparing document 'qux': ${error.stack}`],
+        ]);
+      });
+
+      it('when something fails with non-Error', async () => {
+        const error = 'Typical string error';
+        swapViewsSpy.and.callFake(() => {
+          expect(docViewer.nextViewContainer.innerHTML).not.toBe('');
+          throw error;
+        });
+
+        await doRender('Some content', 'qux');
+
+        expect(swapViewsSpy).toHaveBeenCalledTimes(1);
+        expect(docViewer.nextViewContainer.innerHTML).toBe('');
+        expect(logger.output.error).toEqual([
+          [`[DocViewer] Error preparing document 'qux': ${error}`],
         ]);
       });
     });

--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.ts
@@ -153,8 +153,9 @@ export class DocViewerComponent implements DoCheck, OnDestroy {
         .switchMap(() => this.swapViews(addTitleAndToc))
         .do(() => this.docRendered.emit())
         .catch(err => {
+          const errorMessage = (err instanceof Error) ? err.stack : err;
+          this.logger.error(`[DocViewer] Error preparing document '${doc.id}': ${errorMessage}`);
           this.nextViewContainer.innerHTML = '';
-          this.logger.error(`[DocViewer]: Error preparing document '${doc.id}'.`, err);
           return this.void$;
         });
   }


### PR DESCRIPTION
Pass one argument to `logger.error()` to improve error reporting in environments that do not handle more than one arguments well (e.g. Googlebot's web rendering service).

Related to #21272.

  