### PR TITLE
fix(common): fallback to last defined value for named date and time formats

### DIFF
--- a/packages/common/src/i18n/locale_data_api.ts
+++ b/packages/common/src/i18n/locale_data_api.ts
@@ -253,7 +253,7 @@ export function getLocaleWeekEndRange(locale: string): [WeekDay, WeekDay] {
  */
 export function getLocaleDateFormat(locale: string, width: FormatWidth): string {
   const data = findLocaleData(locale);
-  return data[LocaleDataIndex.DateFormat][width];
+  return getLastDefinedValue(data[LocaleDataIndex.DateFormat], width);
 }
 
 /**
@@ -278,7 +278,7 @@ export function getLocaleDateFormat(locale: string, width: FormatWidth): string 
  */
 export function getLocaleTimeFormat(locale: string, width: FormatWidth): string {
   const data = findLocaleData(locale);
-  return data[LocaleDataIndex.TimeFormat][width];
+  return getLastDefinedValue(data[LocaleDataIndex.TimeFormat], width);
 }
 
 /**

--- a/packages/common/test/i18n/locale_data_api_spec.ts
+++ b/packages/common/test/i18n/locale_data_api_spec.ts
@@ -9,9 +9,10 @@
 import localeCaESVALENCIA from '@angular/common/locales/ca-ES-VALENCIA';
 import localeEn from '@angular/common/locales/en';
 import localeFr from '@angular/common/locales/fr';
+import localeZh from '@angular/common/locales/zh';
 import localeFrCA from '@angular/common/locales/fr-CA';
 import {registerLocaleData} from '../../src/i18n/locale_data';
-import {findLocaleData, getCurrencySymbol} from '../../src/i18n/locale_data_api';
+import {findLocaleData, getCurrencySymbol, getLocaleDateFormat, FormatWidth} from '../../src/i18n/locale_data_api';
 
 {
   describe('locale data api', () => {
@@ -22,6 +23,7 @@ import {findLocaleData, getCurrencySymbol} from '../../src/i18n/locale_data_api'
       registerLocaleData(localeFrCA);
       registerLocaleData(localeFr, 'fake-id');
       registerLocaleData(localeFrCA, 'fake_Id2');
+      registerLocaleData(localeZh);
     });
 
     describe('findLocaleData', () => {
@@ -63,6 +65,11 @@ import {findLocaleData, getCurrencySymbol} from '../../src/i18n/locale_data_api'
         expect(getCurrencySymbol('FAKE', 'wide')).toEqual('FAKE');
         expect(getCurrencySymbol('FAKE', 'narrow')).toEqual('FAKE');
       });
+    });
+
+    describe('getLastDefinedValue', () => {
+      it('should find the last defined date format when format not defined',
+         () => { expect(getLocaleDateFormat('zh', FormatWidth.Long)).toEqual('y年M月d日'); });
     });
   });
 }


### PR DESCRIPTION
closes #21282

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #21282


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Didn't find a locale which has identical time formats, should we add mock data to test it ?