### PR TITLE
fix(aio): don't use Object.keys on NamedNodeMap to prevent SEO errors

### DIFF
--- a/aio/src/app/shared/attribute-utils.ts
+++ b/aio/src/app/shared/attribute-utils.ts
@@ -11,8 +11,9 @@ interface StringMap { [index: string]: string; }
 export function getAttrs(el:  HTMLElement | ElementRef): StringMap {
   const attrs: NamedNodeMap = el instanceof ElementRef ? el.nativeElement.attributes : el.attributes;
   const attrMap = {};
-  Object.keys(attrs).forEach(key =>
-    attrMap[(attrs[key] as Attr).name.toLowerCase()] = (attrs[key] as Attr).value);
+  for (const attr of attrs as any /* cast due to https://github.com/Microsoft/TypeScript/issues/2695 */) {
+    attrMap[attr.name.toLowerCase()] = attr.value;
+  }
   return attrMap;
 }
 


### PR DESCRIPTION
Apparently Object.keys on NamedNodeMap work differently with googlebot :-(

There are not tests since we don't have a way to write tests for googlebot,
but I did manually verify that after this fix googlebot correctly renders
several of the previously broken pages.

Fixes #21272