### PR TITLE
build(aio): fix example protractor config for Travis

### DIFF
--- a/aio/tools/examples/shared/boilerplate/cli/protractor.conf.js
+++ b/aio/tools/examples/shared/boilerplate/cli/protractor.conf.js
@@ -9,7 +9,11 @@ exports.config = {
     './e2e/**/*.e2e-spec.ts'
   ],
   capabilities: {
-    'browserName': 'chrome'
+    'browserName': 'chrome',
+    // For Travis CI only
+    chromeOptions: {
+      binary: process.env.CHROME_BIN
+    }
   },
   directConnect: true,
   baseUrl: 'http://localhost:4200/',


### PR DESCRIPTION
Without setting the CHROME_BIN Travis will not use the correct version
of Chrome for running e2e tests.

Closes #20159

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
