### PR TITLE
fix(forms): mark nested formGroups as submitted on submit (#21263)

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, EventEmitter, Inject, Input, OnChanges, Optional, Output, Self, SimpleChanges, forwardRef} from '@angular/core';
+import {Directive, EventEmitter, Inject, Input, OnChanges, Optional, Output, Self, SimpleChanges, SkipSelf, forwardRef} from '@angular/core';
+
 import {FormArray, FormControl, FormGroup} from '../../model';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from '../../validators';
 import {ControlContainer} from '../control_container';
@@ -76,8 +77,12 @@ export class FormGroupDirective extends ControlContainer implements Form,
 
   constructor(
       @Optional() @Self() @Inject(NG_VALIDATORS) private _validators: any[],
-      @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) private _asyncValidators: any[]) {
+      @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) private _asyncValidators: any[],
+      @Optional() @SkipSelf() private parentFormGroupDir: FormGroupDirective) {
     super();
+    if (parentFormGroupDir) {
+      parentFormGroupDir.ngSubmit.subscribe((event: Event) => { this.onSubmit(event); });
+    }
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -128,7 +128,7 @@ function asyncValidator(expected: any, timeout = 0) {
       let loginControlDir: FormControlName;
 
       beforeEach(() => {
-        form = new FormGroupDirective([], []);
+        form = new FormGroupDirective([], [], null !);
         formModel = new FormGroup({
           'login': new FormControl(),
           'passwords': new FormGroup(
@@ -283,7 +283,7 @@ function asyncValidator(expected: any, timeout = 0) {
 
         it('should set up a sync validator', () => {
           const formValidator = (c: AbstractControl) => ({'custom': true});
-          const f = new FormGroupDirective([formValidator], []);
+          const f = new FormGroupDirective([formValidator], [], null !);
           f.form = formModel;
           f.ngOnChanges({'form': new SimpleChange(null, null, false)});
 
@@ -291,7 +291,7 @@ function asyncValidator(expected: any, timeout = 0) {
         });
 
         it('should set up an async validator', fakeAsync(() => {
-             const f = new FormGroupDirective([], [asyncValidator('expected')]);
+             const f = new FormGroupDirective([], [asyncValidator('expected')], null !);
              f.form = formModel;
              f.ngOnChanges({'form': new SimpleChange(null, null, false)});
 
@@ -402,7 +402,7 @@ function asyncValidator(expected: any, timeout = 0) {
       beforeEach(() => {
         formModel = new FormGroup({'login': new FormControl(null)});
 
-        const parent = new FormGroupDirective([], []);
+        const parent = new FormGroupDirective([], [], null !);
         parent.form = new FormGroup({'group': formModel});
         controlGroupDir = new FormGroupName(parent, [], []);
         controlGroupDir.name = 'group';
@@ -441,7 +441,7 @@ function asyncValidator(expected: any, timeout = 0) {
       let formArrayDir: FormArrayName;
 
       beforeEach(() => {
-        const parent = new FormGroupDirective([], []);
+        const parent = new FormGroupDirective([], [], null !);
         formModel = new FormArray([new FormControl('')]);
         parent.form = new FormGroup({'array': formModel});
         formArrayDir = new FormArrayName(parent, [], []);
@@ -646,7 +646,7 @@ function asyncValidator(expected: any, timeout = 0) {
       beforeEach(() => {
         formModel = new FormControl('name');
 
-        const parent = new FormGroupDirective([], []);
+        const parent = new FormGroupDirective([], [], null !);
         parent.form = new FormGroup({'name': formModel});
         controlNameDir = new FormControlName(parent, [], [], [defaultAccessor]);
         controlNameDir.name = 'name';

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -544,6 +544,28 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         expect(formGroupDir.submitted).toEqual(true);
       });
 
+      it('should mark nested formGroup as submitted on submit event', () => {
+        const fixture = initTest(NestedFormGroupsComp);
+        fixture.componentInstance.form = new FormGroup({
+          'signin': new FormGroup(
+              {'login': new FormControl('loginValue'), 'password': new FormControl('password')})
+        });
+        fixture.detectChanges();
+
+        const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
+        const nestedGroupDir =
+            fixture.debugElement.children[0].children[0].injector.get(FormGroupDirective);
+        expect(formGroupDir.submitted).toBe(false);
+        expect(nestedGroupDir.submitted).toBe(false);
+
+        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        dispatchEvent(formEl, 'submit');
+
+        fixture.detectChanges();
+        expect(formGroupDir.submitted).toEqual(true);
+        expect(nestedGroupDir.submitted).toEqual(true);
+      });
+
       it('should set value in UI when form resets to that value programmatically', () => {
         const fixture = initTest(FormGroupComp);
         const login = new FormControl('some value');
@@ -571,7 +593,6 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         form.reset();
         expect(loginEl.value).toBe('');
       });
-
     });
 
     describe('value changes and status changes', () => {
@@ -2306,6 +2327,20 @@ class FormGroupComp {
     </form>`
 })
 class NestedFormGroupComp {
+  form: FormGroup;
+}
+
+@Component({
+  selector: 'nested-form-groups-comp',
+  template: `
+    <form [formGroup]="form">
+      <div [formGroup]="form.get('signin')" login-is-empty-validator>
+        <input formControlName="login">
+        <input formControlName="password">
+      </div>
+    </form>`
+})
+class NestedFormGroupsComp {
   form: FormGroup;
 }
 

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -316,7 +316,7 @@ export declare class FormGroupDirective extends ControlContainer implements Form
     ngSubmit: EventEmitter<{}>;
     readonly path: string[];
     readonly submitted: boolean;
-    constructor(_validators: any[], _asyncValidators: any[]);
+    constructor(_validators: any[], _asyncValidators: any[], parentFormGroupDir: FormGroupDirective);
     addControl(dir: FormControlName): FormControl;
     addFormArray(dir: FormArrayName): void;
     addFormGroup(dir: FormGroupName): void;


### PR DESCRIPTION
Previously only formGroup on the <form> was marked as submitted, not also nested formGroup are marked.

Fixes #21263

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #21263


## What is the new behavior?
Previously only formGroup on the <form> was marked as submitted, not also nested formGroup are marked.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

  