### PR TITLE
fix(language-service): Clear caches when program changes

### DIFF
--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -140,7 +140,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
   }
 
   getAnalyzedModules(): NgAnalyzedModules {
-    this.validate();
+    this.updateAnalyzedModules();
     return this.ensureAnalyzedModules();
   }
 
@@ -240,7 +240,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
 
   private validate() {
     const program = this.program;
-    if (this._staticSymbolResolver && this.lastProgram != program) {
+    if (this.lastProgram !== program) {
       // Invalidate file that have changed in the static symbol resolver
       const invalidateFile = (fileName: string) =>
           this._staticSymbolResolver.invalidateFile(fileName);
@@ -253,14 +253,18 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
         const lastVersion = this.fileVersions.get(fileName);
         if (version != lastVersion) {
           this.fileVersions.set(fileName, version);
-          invalidateFile(fileName);
+          if (this._staticSymbolResolver) {
+            invalidateFile(fileName);
+          }
         }
       }
 
       // Remove file versions that are no longer in the file and invalidate them.
       const missing = Array.from(this.fileVersions.keys()).filter(f => !seen.has(f));
       missing.forEach(f => this.fileVersions.delete(f));
-      missing.forEach(invalidateFile);
+      if (this._staticSymbolResolver) {
+        missing.forEach(invalidateFile);
+      }
 
       this.lastProgram = program;
     }

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -248,7 +248,7 @@ describe('diagnostics', () => {
           template: \`
             <div *ngIf="comps | async; let comps; else loading">
             </div>
-            <ng-template #loading>Loading comps...</ng-template>            
+            <ng-template #loading>Loading comps...</ng-template>
           \`
         })
         export class MyComponent {}

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -46,4 +46,20 @@ describe('completions', () => {
     ngHost = new TypeScriptServiceHost(host, service);
     expect(() => ngHost.getAnalyzedModules()).not.toThrow();
   });
+
+  it('should clear the caches if program changes', () => {
+    // First create a TypescriptHost with empty script names
+    host = new MockTypescriptHost([], toh);
+    service = ts.createLanguageService(host);
+    ngHost = new TypeScriptServiceHost(host, service);
+    expect(ngHost.getAnalyzedModules().ngModules).toEqual([]);
+    // Now add a script, this would change the program
+    const fileName = '/app/main.ts';
+    const content = (host as MockTypescriptHost).getFileContent(fileName) !;
+    (host as MockTypescriptHost).addScript(fileName, content);
+    // If the caches are not cleared, we would get back an empty array.
+    // But if the caches are cleared then the analyzed modules will be non-empty.
+    expect(ngHost.getAnalyzedModules().ngModules.length).not.toEqual(0);
+  });
+
 });


### PR DESCRIPTION
This commit fixes a bug whereby the empty set of analyzed modules is
cached and subsequently produces the incorrect error 'Component ... is
not included in a module...'

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Error message 'Component ... is not included in a module...' is incorrectly shown.

Issue Number: 19405

## What is the new behavior?
Language service no longer shows incorrect error message.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
