### PR TITLE
build(core): update payload size of hello-world in patch branch

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -1,4 +1,4 @@
 {
-"cli-hello-world":{"master":{"gzip7":{"inline":847,"main":43542,"polyfills":20207},"gzip9":{"inline":847,"main":43471,"polyfills":20204},"uncompressed":{"inline":1447,"main":158096,"polyfills":61254}}},
+"cli-hello-world":{"master":{"gzip7":{"inline":847,"main":42550,"polyfills":20207},"gzip9":{"inline":847,"main":42499,"polyfills":20204},"uncompressed":{"inline":1447,"main":154388,"polyfills":61254}}},
 "hello_world__closure":{"master":{"gzip7":{"bundle":32793},"gzip9":{"bundle":32758},"uncompressed":{"bundle":100661}}}
 }


### PR DESCRIPTION
Fixes payload size on patch branch (needs to be closer to actual size, since patch branch is smaller than master).

