### PR TITLE
build(aio): upgrade to zone.js@0.8.19

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -84,7 +84,7 @@
     "rxjs": "^5.5.2",
     "tslib": "^1.7.1",
     "web-animations-js": "^2.2.5",
-    "zone.js": "0.8.16"
+    "zone.js": "^0.8.19"
   },
   "devDependencies": {
     "@angular/cli": "^1.6.0-rc.0",

--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -4,17 +4,17 @@
       "gzip7": {
         "inline": 941,
         "main": 116124,
-        "polyfills": 11860
+        "polyfills": 13102
       },
       "gzip9": {
         "inline": 941,
         "main": 115954,
-        "polyfills": 11858
+        "polyfills": 13104
       },
       "uncompressed": {
         "inline": 1558,
         "main": 456432,
-        "polyfills": 37070
+        "polyfills": 40684
       }
     }
   }

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -9424,10 +9424,10 @@ zip-stream@~0.6.0:
     lodash "~3.10.1"
     readable-stream "~1.0.26"
 
-zone.js@0.8.16:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.16.tgz#ac31b6c418f88c0f918ad6acd8a402aca9313abb"
-
 zone.js@^0.8.14:
   version "0.8.18"
   resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.18.tgz#8cecb3977fcd1b3090562ff4570e2847e752b48d"
+
+zone.js@^0.8.19:
+  version "0.8.19"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.19.tgz#a4b522cd9e8b7b616a638c297d720d4c7f292f71"


### PR DESCRIPTION
This causes a 3.4kb size regressions for polyfills.js. :-(

I filed an issue for this: https://github.com/angular/zone.js/issues/989

-rw-r--r--  1 iminar  eng   73998 Jan  5 17:51 dist/0.5fb611ef423970fd3ba1.chunk.js
-rw-r--r--  1 iminar  eng   14880 Jan  5 17:51 dist/4.c719ac5645940382cdce.chunk.js
-rw-r--r--  1 iminar  eng    1558 Jan  5 17:51 dist/inline.797233300016416206fc.bundle.js
-rw-r--r--  1 iminar  eng  457592 Jan  5 17:51 dist/main.5870135237d5187f1ab6.bundle.js
-rw-r--r--  1 iminar  eng   40684 Jan  5 17:51 dist/polyfills.88f0257676f76560da16.bundle.js
-rw-r--r--  1 iminar  eng   54001 Jan  5 17:51 dist/worker-basic.min.js
