### PR TITLE
fix(compiler-cli): use the oldProgram option in watch mode

### DIFF
--- a/packages/compiler-cli/src/perform_watch.ts
+++ b/packages/compiler-cli/src/perform_watch.ts
@@ -200,7 +200,7 @@ export function performWatchCompilation(host: PerformWatchHost):
       rootNames: cachedOptions.rootNames,
       options: cachedOptions.options,
       host: cachedCompilerHost,
-      oldProgram: cachedProgram,
+      oldProgram: oldProgram,
       emitCallback: host.createEmitCallback(cachedOptions.options)
     });
 


### PR DESCRIPTION
The performCompilation() is always called with an undefined oldProgram option (even in watch mode).
This was regression introduced in: https://github.com/angular/angular/commit/957be960d28f4f6e8df695d98e2ed117e8451f88

Partial fix, discovered in: #21361

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
``` 