### PR TITLE
fix(compiler-cli): return oldTsProgram in some cases

### DIFF
--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -542,6 +542,8 @@ class AngularCompilerProgram implements Program {
   }
 
   private get tsProgram(): ts.Program {
+    if (this.oldTsProgram)
+      return this.oldTsProgram;  // this sounds weird, however we are in a weird state here
     if (!this._tsProgram) {
       this.initSync();
     }


### PR DESCRIPTION
During a compilation the oldTsProgram can be the actual value and we do not want a new initSync() (and throw away the old one).

Fixes: #21361

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #21361


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
