### PR TITLE
Add canonical compiler examples

### DIFF
--- a/modules/benchmarks/src/largetable/render3/table.ts
+++ b/modules/benchmarks/src/largetable/render3/table.ts
@@ -16,16 +16,13 @@ export class LargeTableComponent {
 
   /** @nocollapse */
   static ngComponentDef: ComponentDef<LargeTableComponent> = defineComponent({
-    type: LargeTableComponent,
     tag: 'largetable',
     template: function(ctx: LargeTableComponent, cm: boolean) {
       if (cm) {
         E(0, 'table');
         {
           E(1, 'tbody');
-          {
-            C(2);
-          }
+          { C(2); }
           e();
         }
         e();

--- a/modules/benchmarks/src/largetable/render3/table.ts
+++ b/modules/benchmarks/src/largetable/render3/table.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵC as C, ɵE as E, ɵT as T, ɵV as V, ɵb as b, ɵc as c, ɵcR as cR, ɵcr as cr, ɵdefineComponent as defineComponent, ɵdetectChanges as detectChanges, ɵe as e, ɵs as s, ɵt as t, ɵv as v} from '@angular/core';
+import {ɵC as C, ɵE as E, ɵT as T, ɵV as V, ɵb as b, ɵcR as cR, ɵcr as cr, ɵdefineComponent as defineComponent, ɵdetectChanges as detectChanges, ɵe as e, ɵs as s, ɵt as t, ɵv as v} from '@angular/core';
 import {ComponentDef} from '@angular/core/src/render3/interfaces/definition';
 
 import {TableCell, buildTable, emptyTable} from '../util';
@@ -25,7 +25,6 @@ export class LargeTableComponent {
           E(1, 'tbody');
           {
             C(2);
-            c();
           }
           e();
         }
@@ -39,7 +38,6 @@ export class LargeTableComponent {
             if (cm1) {
               E(0, 'tr');
               C(1);
-              c();
               e();
             }
             cR(1);

--- a/modules/benchmarks/src/tree/render3/tree.ts
+++ b/modules/benchmarks/src/tree/render3/tree.ts
@@ -36,7 +36,6 @@ export class TreeComponent {
 
   /** @nocollapse */
   static ngComponentDef: ComponentDef<TreeComponent> = defineComponent({
-    type: TreeComponent,
     tag: 'tree',
     template: function(ctx: TreeComponent, cm: boolean) {
       if (cm) {
@@ -93,7 +92,6 @@ export class TreeFunction extends TreeComponent {
 
   /** @nocollapse */
   static ngComponentDef: ComponentDef<TreeFunction> = defineComponent({
-    type: TreeFunction,
     tag: 'tree',
     template: function(ctx: TreeFunction, cm: boolean) {
       // bit of a hack

--- a/modules/benchmarks/src/tree/render3/tree.ts
+++ b/modules/benchmarks/src/tree/render3/tree.ts
@@ -56,8 +56,7 @@ export class TreeComponent {
           let cm0 = V(0);
           {
             if (cm0) {
-              E(0, TreeComponent.ngComponentDef);
-              { D(1, TreeComponent.ngComponentDef.n(), TreeComponent.ngComponentDef); }
+              E(0, TreeComponent);
               e();
             }
             p(0, 'data', b(ctx.data.left));
@@ -74,8 +73,7 @@ export class TreeComponent {
           let cm0 = V(0);
           {
             if (cm0) {
-              E(0, TreeComponent.ngComponentDef);
-              { D(1, TreeComponent.ngComponentDef.n(), TreeComponent.ngComponentDef); }
+              E(0, TreeComponent);
               e();
             }
             p(0, 'data', b(ctx.data.right));

--- a/modules/benchmarks/src/tree/render3/tree.ts
+++ b/modules/benchmarks/src/tree/render3/tree.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵC as C, ɵD as D, ɵE as E, ɵT as T, ɵV as V, ɵb as b, ɵb1 as b1, ɵc as c, ɵcR as cR, ɵcr as cr, ɵdefineComponent as defineComponent, ɵdetectChanges as _detectChanges, ɵe as e, ɵp as p, ɵs as s, ɵt as t, ɵv as v} from '@angular/core';
+import {ɵC as C, ɵD as D, ɵE as E, ɵT as T, ɵV as V, ɵb as b, ɵb1 as b1, ɵcR as cR, ɵcr as cr, ɵdefineComponent as defineComponent, ɵdetectChanges as _detectChanges, ɵe as e, ɵp as p, ɵs as s, ɵt as t, ɵv as v} from '@angular/core';
 import {ComponentDef} from '@angular/core/src/render3/interfaces/definition';
 
 import {TreeNode, buildTree, emptyTree} from '../util';
@@ -44,9 +44,7 @@ export class TreeComponent {
         { T(1); }
         e();
         C(2);
-        c();
         C(3);
-        c();
       }
       s(0, 'background-color', b(ctx.data.depth % 2 ? '' : 'grey'));
       t(1, b1(' ', ctx.data.value, ' '));
@@ -112,9 +110,7 @@ export function TreeTpl(ctx: TreeNode, cm: boolean) {
     { T(1); }
     e();
     C(2);
-    c();
     C(3);
-    c();
   }
   s(0, 'background-color', b(ctx.depth % 2 ? '' : 'grey'));
   t(1, b1(' ', ctx.value, ' '));

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -18,7 +18,6 @@ export {
   V as ɵV,
   b as ɵb,
   b1 as ɵb1,
-  c as ɵc,
   cR as ɵcR,
   cr as ɵcr,
   e as ɵe,

--- a/packages/core/src/render3/assert.ts
+++ b/packages/core/src/render3/assert.ts
@@ -21,7 +21,10 @@
  * @returns The stringified value
  */
 function stringifyValueForError(value: any): string {
-  return typeof value === 'string' ? `"${value}"` : '' + value;
+  if (value && value.native && value.native.outerHTML) {
+    return value.native.outerHTML;
+  }
+  return typeof value === 'string' ? `"${value}"` : value;
 }
 
 export function assertNumber(actual: any, name: string) {
@@ -57,6 +60,8 @@ export function assertNotEqual<T>(actual: T, expected: T, name: string) {
 export function assertThrow<T>(
     actual: T, expected: T, name: string, operator: string,
     serializer: ((v: T) => string) = stringifyValueForError): never {
-  throw new Error(
-      `ASSERT: expected ${name} ${operator} ${serializer(expected)} but was ${serializer(actual)}!`);
+  const error =
+      `ASSERT: expected ${name} ${operator} ${serializer(expected)} but was ${serializer(actual)}!`;
+  debugger;  // leave `debugger` here to aid in debugging.
+  throw new Error(error);
 }

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -13,11 +13,12 @@ import {ComponentRef as viewEngine_ComponentRef} from '../linker/component_facto
 import {EmbeddedViewRef as viewEngine_EmbeddedViewRef} from '../linker/view_ref';
 
 import {assertNotNull} from './assert';
-import {NG_HOST_SYMBOL, createError, createLView, directive, enterView, hostElement, leaveView, locateHostElement, renderComponentOrTemplate, directiveCreate} from './instructions';
-import {ComponentDef, ComponentType} from './interfaces/definition';
+import {NG_HOST_SYMBOL, createError, createLView, directive, directiveCreate, enterView, hostElement, leaveView, locateHostElement, renderComponentOrTemplate} from './instructions';
+import {ComponentDef, ComponentType, TypedComponentDef} from './interfaces/definition';
 import {LElementNode} from './interfaces/node';
-import {RElement, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
+import {RElement, Renderer3, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
 import {notImplemented, stringify} from './util';
+
 
 
 /** Options that control how the component should be bootstrapped. */
@@ -165,7 +166,8 @@ export const NULL_INJECTOR: Injector = {
 export function renderComponent<T>(
     componentType: ComponentType<T>, opts: CreateComponentOptions = {}): T {
   const rendererFactory = opts.rendererFactory || domRendererFactory3;
-  const componentDef = componentType.ngComponentDef;
+  const componentDef = componentType.ngComponentDef as TypedComponentDef<T>;
+  if (componentDef.type != componentType) componentDef.type = componentType;
   let component: T;
   const hostNode = locateHostElement(rendererFactory, opts.host || componentDef.tag);
   const oldView = enterView(

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -13,12 +13,11 @@ import {ComponentRef as viewEngine_ComponentRef} from '../linker/component_facto
 import {EmbeddedViewRef as viewEngine_EmbeddedViewRef} from '../linker/view_ref';
 
 import {assertNotNull} from './assert';
-import {NG_HOST_SYMBOL, createError, createLView, directive, enterView, hostElement, leaveView, locateHostElement, renderComponentOrTemplate} from './instructions';
+import {NG_HOST_SYMBOL, createError, createLView, directive, enterView, hostElement, leaveView, locateHostElement, renderComponentOrTemplate, directiveCreate} from './instructions';
 import {ComponentDef, ComponentType} from './interfaces/definition';
 import {LElementNode} from './interfaces/node';
 import {RElement, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
 import {notImplemented, stringify} from './util';
-
 
 
 /** Options that control how the component should be bootstrapped. */
@@ -176,7 +175,7 @@ export function renderComponent<T>(
     // Create element node at index 0 in data array
     hostElement(hostNode, componentDef);
     // Create directive instance with n() and store at index 1 in data array (el is 0)
-    component = directive(1, componentDef.n(), componentDef);
+    component = directiveCreate(1, componentDef.n(), componentDef);
   } finally {
     leaveView(oldView);
   }

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -32,7 +32,6 @@ import {ComponentDef, ComponentDefArgs, DirectiveDef, DirectiveDefArgs} from './
  */
 export function defineComponent<T>(componentDefinition: ComponentDefArgs<T>): ComponentDef<T> {
   const def = <ComponentDef<any>>{
-    type: componentDefinition.type,
     diPublic: null,
     n: componentDefinition.factory,
     tag: (componentDefinition as ComponentDefArgs<T>).tag || null !,

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -44,6 +44,7 @@ export function defineComponent<T>(componentDefinition: ComponentDefArgs<T>): Co
     outputs: invertObject(componentDefinition.outputs),
     methods: invertObject(componentDefinition.methods),
     rendererType: resolveRendererType2(componentDefinition.rendererType) || null,
+    exportAs: componentDefinition.exportAs,
   };
   const feature = componentDefinition.features;
   feature && feature.forEach((fn) => fn(def));

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -17,7 +17,7 @@ import {ViewContainerRef as viewEngine_ViewContainerRef} from '../linker/view_co
 import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, ViewRef as viewEngine_ViewRef} from '../linker/view_ref';
 import {Type} from '../type';
 
-import {ComponentTemplate, DirectiveDef} from './interfaces/definition';
+import {ComponentTemplate, DirectiveDef, TypedDirectiveDef} from './interfaces/definition';
 import {LInjector} from './interfaces/injector';
 import {LContainerNode, LElementNode, LNodeFlags} from './interfaces/node';
 import {assertNodeType} from './node_assert';
@@ -147,7 +147,7 @@ function createInjectionError(text: string, token: any) {
  * @param di The node injector in which a directive will be added
  * @param def The definition of the directive to be made public
  */
-export function diPublicInInjector(di: LInjector, def: DirectiveDef<any>): void {
+export function diPublicInInjector(di: LInjector, def: TypedDirectiveDef<any>): void {
   bloomAdd(di, def.type);
 }
 
@@ -211,7 +211,7 @@ export function getOrCreateInjectable<T>(di: LInjector, token: Type<T>, flags?: 
         for (let i = start, ii = start + size; i < ii; i++) {
           // Get the definition for the directive at this index and, if it is injectable (diPublic),
           // and matches the given token, return the directive instance.
-          const directiveDef = ngStaticData[i] as DirectiveDef<any>;
+          const directiveDef = ngStaticData[i] as TypedDirectiveDef<any>;
           if (directiveDef.diPublic && directiveDef.type == token) {
             return node.view.data[i];
           }

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -84,3 +84,4 @@ export {
   defineDirective,
 };
 export {createComponentRef, detectChanges, getHostElement, markDirty, renderComponent};
+export {InjectFlags} from './di';

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -39,8 +39,7 @@ export {
 
   componentRefresh as r,
 
-  containerStart as C,
-  containerEnd as c,
+  container as C,
   containerRefreshStart as cR,
   containerRefreshEnd as cr,
 

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1107,7 +1107,7 @@ export function executeViewHooks(): void {
  * @param attrs The attrs attached to the container, if applicable
  * @param localRefs A set of local reference bindings on the element.
  */
-export function containerStart(
+export function container(
     index: number, directiveTypes?: DirectiveType<any>[], template?: ComponentTemplate<any>,
     tagName?: string, attrs?: string[], localRefs?: string[] | null): void {
   ngDevMode && assertEqual(currentView.bindingStartIndex, null, 'bindingStartIndex');
@@ -1145,15 +1145,8 @@ export function containerStart(
   // because views can be removed and re-inserted.
   addToViewTree(node.data);
   hack_declareDirectives(index, directiveTypes, localRefs);
-}
 
-export function containerEnd() {
-  if (isParent) {
-    isParent = false;
-  } else {
-    ngDevMode && assertHasParent();
-    previousOrParentNode = previousOrParentNode.parent !;
-  }
+  isParent = false;
   ngDevMode && assertNodeType(previousOrParentNode, LNodeFlags.Container);
   const query = previousOrParentNode.query;
   query && query.addNode(previousOrParentNode);

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -28,11 +28,6 @@ export const enum DirectiveDefFlags {ContentQuery = 0b10}
  * `DirectiveDef` is a compiled version of the Directive used by the renderer instructions.
  */
 export interface DirectiveDef<T> {
-  /**
-   * Token representing the directive. Used by DI.
-   */
-  type: Type<T>;
-
   /** Function that makes a directive public to the DI system. */
   diPublic: ((def: DirectiveDef<any>) => void)|null;
 
@@ -41,26 +36,26 @@ export interface DirectiveDef<T> {
    *
    * The key is minified property name whereas the value is the original unminified name.
    */
-  inputs: {[P in keyof T]: P};
+  readonly inputs: {[P in keyof T]: P};
 
   /**
    * List of outputs which are part of the components public API.
    *
    * The key is minified property name whereas the value is the original unminified name.=
    */
-  outputs: {[P in keyof T]: P};
+  readonly outputs: {[P in keyof T]: P};
 
   /**
    * List of methods which are part of the components public API.
    *
    * The key is minified property name whereas the value is the original unminified name.
    */
-  methods: {[P in keyof T]: P};
+  readonly methods: {[P in keyof T]: P};
 
   /**
    * Name under which the directive is exported (for use with local references in template)
    */
-  exportAs: string|null;
+  readonly exportAs: string|null;
 
   /**
    * factory function used to create a new directive instance.
@@ -111,25 +106,34 @@ export interface ComponentDef<T> extends DirectiveDef<T> {
    *
    * NOTE: only used with component directives.
    */
-  tag: string;
+  readonly tag: string;
 
   /**
    * The View template of the component.
    *
    * NOTE: only used with component directives.
    */
-  template: ComponentTemplate<T>;
+  readonly template: ComponentTemplate<T>;
 
   /**
    * Renderer type data of the component.
    *
    * NOTE: only used with component directives.
    */
-  rendererType: RendererType2|null;
+  readonly rendererType: RendererType2|null;
 }
 
+/**
+ * Private: do not export
+ */
+export interface TypedDirectiveDef<T> extends DirectiveDef<T> { type: DirectiveType<T>; }
+
+/**
+ * Private: do not export
+ */
+export interface TypedComponentDef<T> extends ComponentDef<T> { type: ComponentType<T>; }
+
 export interface DirectiveDefArgs<T> {
-  type: Type<T>;
   factory: () => T;
   refresh?: (directiveIndex: number, elementIndex: number) => void;
   inputs?: {[P in keyof T]?: string};

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -58,6 +58,11 @@ export interface DirectiveDef<T> {
   methods: {[P in keyof T]: P};
 
   /**
+   * Name under which the directive is exported (for use with local references in template)
+   */
+  exportAs: string|null;
+
+  /**
    * factory function used to create a new directive instance.
    *
    * NOTE: this property is short (1 char) because it is used in
@@ -131,6 +136,7 @@ export interface DirectiveDefArgs<T> {
   outputs?: {[P in keyof T]?: string};
   methods?: {[P in keyof T]?: string};
   features?: DirectiveDefFeature[];
+  exportAs?: string;
 }
 
 export interface ComponentDefArgs<T> extends DirectiveDefArgs<T> {

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -17,11 +17,12 @@ import {Type} from '../type';
 
 import {assertNotNull} from './assert';
 import {getOrCreateContainerRef, getOrCreateElementRef, getOrCreateNodeInjectorForNode, getOrCreateTemplateRef} from './di';
-import {DirectiveDef} from './interfaces/definition';
+import {DirectiveDef, TypedDirectiveDef} from './interfaces/definition';
 import {LInjector} from './interfaces/injector';
 import {LContainerNode, LElementNode, LNode, LNodeFlags, LViewNode, TNode} from './interfaces/node';
 import {LQuery, QueryReadType} from './interfaces/query';
 import {assertNodeOfPossibleTypes} from './node_assert';
+
 
 
 /**
@@ -142,7 +143,7 @@ function geIdxOfMatchingDirective(node: LNode, type: Type<any>): number|null {
   for (let i = flags >> LNodeFlags.INDX_SHIFT,
            ii = i + ((flags & LNodeFlags.SIZE_MASK) >> LNodeFlags.SIZE_SHIFT);
        i < ii; i++) {
-    const def = ngStaticData[i] as DirectiveDef<any>;
+    const def = ngStaticData[i] as TypedDirectiveDef<any>;
     if (def.diPublic && def.type === type) {
       return i;
     }

--- a/packages/core/test/render3/basic_perf.ts
+++ b/packages/core/test/render3/basic_perf.ts
@@ -32,7 +32,6 @@ describe('iv perf test', () => {
       it(`${iteration}. create ${count} divs in Render3`, () => {
         class Component {
           static ngComponentDef = defineComponent({
-            type: Component,
             tag: 'div',
             template: function Template(ctx: any, cm: any) {
               if (cm) {

--- a/packages/core/test/render3/basic_perf.ts
+++ b/packages/core/test/render3/basic_perf.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, E, T, V, c, cR, cr, defineComponent, e, v} from '../../src/render3/index';
+import {C, E, T, V, cR, cr, defineComponent, e, v} from '../../src/render3/index';
 
 import {document, renderComponent} from './render_util';
 
@@ -37,7 +37,6 @@ describe('iv perf test', () => {
             template: function Template(ctx: any, cm: any) {
               if (cm) {
                 C(0);
-                c();
               }
               cR(0);
               {

--- a/packages/core/test/render3/compiler_canonical_spec.ts
+++ b/packages/core/test/render3/compiler_canonical_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, Type, NgModule, Injectable, Optional, TemplateRef} from '../../src/core';
+import {Component, Directive, Injectable, NgModule, Optional, TemplateRef, Type} from '../../src/core';
 import * as r3 from '../../src/render3/index';
 
 import {containerEl, renderComponent, requestAnimationFrame, toHtml} from './render_util';
@@ -27,7 +27,6 @@ describe('compiler specification', () => {
       class MyComponent {
         // NORMATIVE
         static ngComponentDef = r3.defineComponent({
-          type: MyComponent,
           tag: 'my-component',
           factory: () => new MyComponent(),
           template: function(ctx: MyComponent, cm: boolean) {
@@ -60,7 +59,6 @@ describe('compiler specification', () => {
         constructor() { log.push('ChildComponent'); }
         // NORMATIVE
         static ngComponentDef = r3.defineComponent({
-          type: ChildComponent,
           tag: `child`,
           factory: () => new ChildComponent(),
           template: function(ctx: ChildComponent, cm: boolean) {
@@ -79,7 +77,6 @@ describe('compiler specification', () => {
         constructor() { log.push('SomeDirective'); }
         // NORMATIVE
         static ngDirectiveDef = r3.defineDirective({
-          type: ChildComponent,
           factory: () => new SomeDirective(),
         });
         // /NORMATIVE
@@ -121,13 +118,13 @@ describe('compiler specification', () => {
         constructor(template: TemplateRef<any>) { log.push('ifDirective'); }
         // NORMATIVE
         static ngDirectiveDef = r3.defineDirective({
-          type: IfDirective,
           factory: () => new IfDirective(r3.injectTemplateRef()),
         });
         // /NORMATIVE
       }
 
-      @Component({selector: 'my-component', template: `<ul #foo><li *if>{{salutation}} {{foo}}</li></ul>`})
+      @Component(
+          {selector: 'my-component', template: `<ul #foo><li *if>{{salutation}} {{foo}}</li></ul>`})
       class MyComponent {
         salutation = 'Hello';
         // NORMATIVE
@@ -198,7 +195,7 @@ describe('compiler specification', () => {
 
 xdescribe('NgModule', () => {
   interface Injectable {
-    scope?: /*InjectorDefType<any>*/any;
+    scope?: /*InjectorDefType<any>*/ any;
     factory: Function;
   }
 
@@ -237,8 +234,8 @@ xdescribe('NgModule', () => {
       static ngInjectorDef = defineInjector({
         factory: () => new MyModule(inject(Toast)),
         provider: [
-          {provide: Toast, deps: [String]}, // If Toast has matadata generate this line
-          Toast, // If toast has not metadata generate this line.
+          {provide: Toast, deps: [String]},  // If Toast has matadata generate this line
+          Toast,                             // If toast has not metadata generate this line.
           {provide: String, useValue: 'Hello'}
         ],
         imports: [CommonModule]
@@ -247,7 +244,7 @@ xdescribe('NgModule', () => {
     }
 
     @Injectable(/*{MyModule}*/)
-    class BurntToast{
+    class BurntToast {
       constructor(@Optional() toast: Toast|null, name: String) {}
       // NORMATIVE
       static ngInjectableDef = defineInjectable({

--- a/packages/core/test/render3/compiler_canonical_spec.ts
+++ b/packages/core/test/render3/compiler_canonical_spec.ts
@@ -1,0 +1,265 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, Directive, Type, NgModule, Injectable, Optional, TemplateRef} from '../../src/core';
+import * as r3 from '../../src/render3/index';
+
+import {containerEl, renderComponent, requestAnimationFrame, toHtml} from './render_util';
+
+/**
+ * NORMATIVE => /NORMATIVE: Designates what the compiler is expected to generate.
+ *
+ * All local variable names are considered non-normative (informative).
+ */
+
+describe('compiler specification', () => {
+  describe('elements', () => {
+    it('should translate DOM structure', () => {
+      @Component({
+        selector: 'my-component',
+        template: `<div class="my-app" title="Hello">Hello <b>World</b>!</div>`
+      })
+      class MyComponent {
+        // NORMATIVE
+        static ngComponentDef = r3.defineComponent({
+          type: MyComponent,
+          tag: 'my-component',
+          factory: () => new MyComponent(),
+          template: function(ctx: MyComponent, cm: boolean) {
+            if (cm) {
+              r3.E(0, 'div', e0_attrs);
+              r3.T(1, 'Hello ');
+              r3.E(2, 'b');
+              r3.T(3, 'World');
+              r3.e();
+              r3.T(4, '!');
+              r3.e();
+            }
+          }
+        });
+        // /NORMATIVE
+      }
+      // Important: keep arrays outside of function to not create new instances.
+      const e0_attrs = ['class', 'my-app', 'title', 'Hello'];
+
+      expect(renderComp(MyComponent))
+          .toEqual('<div class="my-app" title="Hello">Hello <b>World</b>!</div>');
+    });
+  });
+
+  describe('components & directives', () => {
+    it('should instantiate directives', () => {
+      const log: string[] = [];
+      @Component({selector: 'child', template: 'child-view'})
+      class ChildComponent {
+        constructor() { log.push('ChildComponent'); }
+        // NORMATIVE
+        static ngComponentDef = r3.defineComponent({
+          type: ChildComponent,
+          tag: `child`,
+          factory: () => new ChildComponent(),
+          template: function(ctx: ChildComponent, cm: boolean) {
+            if (cm) {
+              r3.T(0, 'child-view');
+            }
+          }
+        });
+        // /NORMATIVE
+      }
+
+      @Directive({
+        selector: 'some-directive',
+      })
+      class SomeDirective {
+        constructor() { log.push('SomeDirective'); }
+        // NORMATIVE
+        static ngDirectiveDef = r3.defineDirective({
+          type: ChildComponent,
+          factory: () => new SomeDirective(),
+        });
+        // /NORMATIVE
+      }
+
+      @Component({selector: 'my-component', template: `<child some-directive></child>!`})
+      class MyComponent {
+        // NORMATIVE
+        static ngComponentDef = r3.defineComponent({
+          tag: 'my-component',
+          factory: () => new MyComponent(),
+          template: function(ctx: MyComponent, cm: boolean) {
+            if (cm) {
+              r3.E(0, ChildComponent, e0_attrs, e0_dirs);
+              r3.e();
+              r3.T(3, '!');
+            }
+            ChildComponent.ngComponentDef.r(1, 0);
+          }
+        });
+        // /NORMATIVE
+      }
+      // Important: keep arrays outside of function to not create new instances.
+      // NORMATIVE
+      const e0_attrs = ['some-directive', ''];
+      const e0_dirs = [SomeDirective];
+      // /NORMATIVE
+
+      expect(renderComp(MyComponent)).toEqual('<child some-directive="">child-view</child>!');
+      expect(log).toEqual(['ChildComponent', 'SomeDirective']);
+    });
+
+    xit('should support structural directives', () => {
+      const log: string[] = [];
+      @Directive({
+        selector: 'if',
+      })
+      class IfDirective {
+        constructor(template: TemplateRef<any>) { log.push('ifDirective'); }
+        // NORMATIVE
+        static ngDirectiveDef = r3.defineDirective({
+          type: IfDirective,
+          factory: () => new IfDirective(r3.injectTemplateRef()),
+        });
+        // /NORMATIVE
+      }
+
+      @Component({selector: 'my-component', template: `<ul #foo><li *if>{{salutation}} {{foo}}</li></ul>`})
+      class MyComponent {
+        salutation = 'Hello';
+        // NORMATIVE
+        static ngComponentDef = r3.defineComponent({
+          tag: 'my-component',
+          factory: () => new MyComponent(),
+          template: function(ctx: MyComponent, cm: boolean) {
+            if (cm) {
+              r3.E(0, 'ul', null, null, e0_locals);
+              r3.C(2, c1_dirs, C1);
+              r3.e();
+            }
+            let foo = r3.m<any>(1);
+            r3.cR(2);
+            IfDirective.ngDirectiveDef.r(3, 2);
+            r3.cr();
+
+            function C1(ctx1: any, cm: boolean) {
+              if (cm) {
+                r3.E(0, 'li');
+                r3.T(1);
+                r3.e();
+              }
+              r3.t(1, r3.b2('', ctx.salutation, ' ', foo, ''));
+            }
+          }
+        });
+        // /NORMATIVE
+      }
+      // Important: keep arrays outside of function to not create new instances.
+      // NORMATIVE
+      const e0_locals = ['foo', ''];
+      const c1_dirs = [IfDirective];
+      // /NORMATIVE
+
+      expect(renderComp(MyComponent)).toEqual('<child some-directive="">child-view</child>!');
+      expect(log).toEqual(['ChildComponent', 'SomeDirective']);
+    });
+  });
+
+  describe('local references', () => {
+    // TODO(misko): currently disabled until local refs are working
+    xit('should translate DOM structure', () => {
+      @Component({selector: 'my-component', template: `<input #user>Hello {{user.value}}!`})
+      class MyComponent {
+        // NORMATIVE
+        static ngComponentDef = r3.defineComponent({
+          tag: 'my-component',
+          factory: () => new MyComponent,
+          template: function(ctx: MyComponent, cm: boolean) {
+            if (cm) {
+              r3.E(0, 'input', null, null, ['user', '']);
+              r3.e();
+              r3.T(2);
+            }
+            r3.t(2, r3.b1('Hello ', r3.m<any>(1).value, '!'));
+          }
+        });
+        // NORMATIVE
+      }
+
+      expect(renderComp(MyComponent))
+          .toEqual('<div class="my-app" title="Hello">Hello <b>World</b>!</div>');
+    });
+  });
+
+});
+
+xdescribe('NgModule', () => {
+  interface Injectable {
+    scope?: /*InjectorDefType<any>*/any;
+    factory: Function;
+  }
+
+  function defineInjectable(opts: Injectable): Injectable {
+    // This class should be imported from https://github.com/angular/angular/pull/20850
+    return opts;
+  }
+  function defineInjector(opts: any): any {
+    // This class should be imported from https://github.com/angular/angular/pull/20850
+    return opts;
+  }
+  it('should convert module', () => {
+    @Injectable()
+    class Toast {
+      constructor(name: String) {}
+      // NORMATIVE
+      static ngInjectableDef = defineInjectable({
+        factory: () => new Toast(inject(String)),
+      });
+      // /NORMATIVE
+    }
+
+    class CommonModule {
+      // NORMATIVE
+      static ngInjectorDef = defineInjector({});
+      // /NORMATIVE
+    }
+
+    @NgModule({
+      providers: [Toast, {provide: String, useValue: 'Hello'}],
+      imports: [CommonModule],
+    })
+    class MyModule {
+      constructor(toast: Toast) {}
+      // NORMATIVE
+      static ngInjectorDef = defineInjector({
+        factory: () => new MyModule(inject(Toast)),
+        provider: [
+          {provide: Toast, deps: [String]}, // If Toast has matadata generate this line
+          Toast, // If toast has not metadata generate this line.
+          {provide: String, useValue: 'Hello'}
+        ],
+        imports: [CommonModule]
+      });
+      // /NORMATIVE
+    }
+
+    @Injectable(/*{MyModule}*/)
+    class BurntToast{
+      constructor(@Optional() toast: Toast|null, name: String) {}
+      // NORMATIVE
+      static ngInjectableDef = defineInjectable({
+        scope: MyModule,
+        factory: () => new BurntToast(inject(Toast, r3.InjectFlags.Optional), inject(String)),
+      });
+      // /NORMATIVE
+    }
+
+  });
+});
+
+function renderComp<T>(type: r3.ComponentType<T>): string {
+  return toHtml(renderComponent(type));
+}

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -68,8 +68,7 @@ describe('encapsulation', () => {
       tag: 'wrapper',
       template: function(ctx: WrapperComponent, cm: boolean) {
         if (cm) {
-          E(0, EncapsulatedComponent.ngComponentDef);
-          { D(1, EncapsulatedComponent.ngComponentDef.n(), EncapsulatedComponent.ngComponentDef); }
+          E(0, EncapsulatedComponent);
           e();
         }
         EncapsulatedComponent.ngComponentDef.h(1, 0);
@@ -86,8 +85,7 @@ describe('encapsulation', () => {
       template: function(ctx: EncapsulatedComponent, cm: boolean) {
         if (cm) {
           T(0, 'foo');
-          E(1, LeafComponent.ngComponentDef);
-          { D(2, LeafComponent.ngComponentDef.n(), LeafComponent.ngComponentDef); }
+          E(1, LeafComponent);
           e();
         }
         LeafComponent.ngComponentDef.h(2, 1);
@@ -135,8 +133,7 @@ describe('encapsulation', () => {
         tag: 'wrapper',
         template: function(ctx: WrapperComponentWith, cm: boolean) {
           if (cm) {
-            E(0, LeafComponentwith.ngComponentDef);
-            { D(1, LeafComponentwith.ngComponentDef.n(), LeafComponentwith.ngComponentDef); }
+            E(0, LeafComponentwith);
             e();
           }
           LeafComponentwith.ngComponentDef.h(1, 0);

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -20,7 +20,6 @@ describe('component', () => {
     increment() { this.count++; }
 
     static ngComponentDef = defineComponent({
-      type: CounterComponent,
       tag: 'counter',
       template: function(ctx: CounterComponent, cm: boolean) {
         if (cm) {
@@ -64,7 +63,6 @@ describe('component', () => {
 describe('encapsulation', () => {
   class WrapperComponent {
     static ngComponentDef = defineComponent({
-      type: WrapperComponent,
       tag: 'wrapper',
       template: function(ctx: WrapperComponent, cm: boolean) {
         if (cm) {
@@ -80,7 +78,6 @@ describe('encapsulation', () => {
 
   class EncapsulatedComponent {
     static ngComponentDef = defineComponent({
-      type: EncapsulatedComponent,
       tag: 'encapsulated',
       template: function(ctx: EncapsulatedComponent, cm: boolean) {
         if (cm) {
@@ -99,7 +96,6 @@ describe('encapsulation', () => {
 
   class LeafComponent {
     static ngComponentDef = defineComponent({
-      type: LeafComponent,
       tag: 'leaf',
       template: function(ctx: LeafComponent, cm: boolean) {
         if (cm) {
@@ -129,7 +125,6 @@ describe('encapsulation', () => {
   it('should encapsulate host and children with different attributes', () => {
     class WrapperComponentWith {
       static ngComponentDef = defineComponent({
-        type: WrapperComponent,
         tag: 'wrapper',
         template: function(ctx: WrapperComponentWith, cm: boolean) {
           if (cm) {
@@ -147,7 +142,6 @@ describe('encapsulation', () => {
 
     class LeafComponentwith {
       static ngComponentDef = defineComponent({
-        type: LeafComponentwith,
         tag: 'leaf',
         template: function(ctx: LeafComponentwith, cm: boolean) {
           if (cm) {

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, P, T, V, c, cR, cr, detectChanges, e, m, pD, v} from '../../src/render3/index';
+import {C, D, E, P, T, V, cR, cr, detectChanges, e, m, pD, v} from '../../src/render3/index';
 
 import {createComponent, renderComponent, toHtml} from './render_util';
 
@@ -114,7 +114,6 @@ describe('content projection', () => {
         {
           T(2, '(');
           C(3);
-          c();
           T(4, ')');
         }
         e();
@@ -154,7 +153,6 @@ describe('content projection', () => {
         E(0, Child);
         {
           C(2);
-          c();
         }
         e();
       }
@@ -198,7 +196,6 @@ describe('content projection', () => {
         {
           T(2, '(');
           C(3);
-          c();
           T(4, ')');
         }
         e();
@@ -249,7 +246,6 @@ describe('content projection', () => {
         E(1, 'div');
         {
           C(2);
-          c();
         }
         e();
       }
@@ -307,7 +303,6 @@ describe('content projection', () => {
            E(1, 'div');
            {
              C(2);
-             c();
            }
            e();
          }
@@ -405,7 +400,6 @@ describe('content projection', () => {
         E(2, 'div');
         {
           C(3);
-          c();
         }
         e();
       }
@@ -824,7 +818,6 @@ describe('content projection', () => {
           E(0, Child);
           {
             C(2, undefined, undefined, 'div');
-            c();
           }
           e();
         }

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -151,9 +151,7 @@ describe('content projection', () => {
     const Parent = createComponent('parent', function(ctx: {value: any}, cm: boolean) {
       if (cm) {
         E(0, Child);
-        {
-          C(2);
-        }
+        { C(2); }
         e();
       }
       cR(2);
@@ -244,9 +242,7 @@ describe('content projection', () => {
       if (cm) {
         m(0, pD());
         E(1, 'div');
-        {
-          C(2);
-        }
+        { C(2); }
         e();
       }
       cR(2);
@@ -301,9 +297,7 @@ describe('content projection', () => {
          if (cm) {
            m(0, pD());
            E(1, 'div');
-           {
-             C(2);
-           }
+           { C(2); }
            e();
          }
          cR(2);
@@ -398,9 +392,7 @@ describe('content projection', () => {
         m(0, pD());
         P(1, 0);
         E(2, 'div');
-        {
-          C(3);
-        }
+        { C(3); }
         e();
       }
       cR(3);
@@ -816,9 +808,7 @@ describe('content projection', () => {
       const Parent = createComponent('parent', function(ctx: {value: any}, cm: boolean) {
         if (cm) {
           E(0, Child);
-          {
-            C(2, undefined, undefined, 'div');
-          }
+          { C(2, undefined, undefined, 'div'); }
           e();
         }
         cR(2);

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -30,11 +30,8 @@ describe('content projection', () => {
      */
     const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
       if (cm) {
-        E(0, Child.ngComponentDef);
-        {
-          D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
-          T(2, 'content');
-        }
+        E(0, Child);
+        { T(2, 'content'); }
         e();
       }
       Child.ngComponentDef.h(1, 0);
@@ -53,11 +50,8 @@ describe('content projection', () => {
     });
     const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
       if (cm) {
-        E(0, Child.ngComponentDef);
-        {
-          D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
-          T(2, 'content');
-        }
+        E(0, Child);
+        { T(2, 'content'); }
         e();
       }
       Child.ngComponentDef.h(1, 0);
@@ -79,11 +73,8 @@ describe('content projection', () => {
     const Child = createComponent('child', function(ctx: any, cm: boolean) {
       if (cm) {
         m(0, pD());
-        E(1, GrandChild.ngComponentDef);
-        {
-          D(2, GrandChild.ngComponentDef.n(), GrandChild.ngComponentDef);
-          P(3, 0);
-        }
+        E(1, GrandChild);
+        { P(3, 0); }
         e();
         GrandChild.ngComponentDef.h(2, 1);
         GrandChild.ngComponentDef.r(2, 1);
@@ -91,9 +82,8 @@ describe('content projection', () => {
     });
     const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
       if (cm) {
-        E(0, Child.ngComponentDef);
+        E(0, Child);
         {
-          D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
           E(2, 'b');
           T(3, 'Hello');
           e();
@@ -120,9 +110,8 @@ describe('content projection', () => {
     });
     const Parent = createComponent('parent', function(ctx: {value: any}, cm: boolean) {
       if (cm) {
-        E(0, Child.ngComponentDef);
+        E(0, Child);
         {
-          D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
           T(2, '(');
           C(3);
           c();
@@ -162,9 +151,8 @@ describe('content projection', () => {
     });
     const Parent = createComponent('parent', function(ctx: {value: any}, cm: boolean) {
       if (cm) {
-        E(0, Child.ngComponentDef);
+        E(0, Child);
         {
-          D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
           C(2);
           c();
         }
@@ -206,9 +194,8 @@ describe('content projection', () => {
     });
     const Parent = createComponent('parent', function(ctx: {value: any}, cm: boolean) {
       if (cm) {
-        E(0, Child.ngComponentDef);
+        E(0, Child);
         {
-          D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
           T(2, '(');
           C(3);
           c();
@@ -285,9 +272,9 @@ describe('content projection', () => {
      */
     const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
       if (cm) {
-        E(0, Child.ngComponentDef);
+        E(0, Child);
         {
-          D(1, childCmptInstance = Child.ngComponentDef.n(), Child.ngComponentDef);
+          childCmptInstance = D(1);
           T(2, 'content');
         }
         e();
@@ -341,9 +328,9 @@ describe('content projection', () => {
         */
        const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
          if (cm) {
-           E(0, Child.ngComponentDef);
+           E(0, Child);
            {
-             D(1, childCmptInstance = Child.ngComponentDef.n(), Child.ngComponentDef);
+             childCmptInstance = D(1);
              T(2, 'content');
            }
            e();
@@ -381,11 +368,8 @@ describe('content projection', () => {
      */
     const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
       if (cm) {
-        E(0, Child.ngComponentDef);
-        {
-          D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
-          T(2, 'content');
-        }
+        E(0, Child);
+        { T(2, 'content'); }
         e();
       }
       Child.ngComponentDef.h(1, 0);
@@ -442,9 +426,9 @@ describe('content projection', () => {
      */
     const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
       if (cm) {
-        E(0, Child.ngComponentDef);
+        E(0, Child);
         {
-          D(1, childCmptInstance = Child.ngComponentDef.n(), Child.ngComponentDef);
+          childCmptInstance = D(1);
           T(2, 'content');
         }
         e();
@@ -488,9 +472,8 @@ describe('content projection', () => {
        */
       const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Child.ngComponentDef);
+          E(0, Child);
           {
-            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
             E(2, 'span', ['title', 'toFirst']);
             { T(3, '1'); }
             e();
@@ -536,9 +519,8 @@ describe('content projection', () => {
        */
       const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Child.ngComponentDef);
+          E(0, Child);
           {
-            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
             E(2, 'span', ['class', 'toFirst']);
             { T(3, '1'); }
             e();
@@ -584,9 +566,8 @@ describe('content projection', () => {
        */
       const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Child.ngComponentDef);
+          E(0, Child);
           {
-            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
             E(2, 'span', ['class', 'other toFirst']);
             { T(3, '1'); }
             e();
@@ -631,9 +612,8 @@ describe('content projection', () => {
        */
       const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Child.ngComponentDef);
+          E(0, Child);
           {
-            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
             E(2, 'span', ['class', 'toFirst']);
             { T(3, '1'); }
             e();
@@ -678,9 +658,8 @@ describe('content projection', () => {
        */
       const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Child.ngComponentDef);
+          E(0, Child);
           {
-            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
             E(2, 'span', ['class', 'toFirst']);
             { T(3, '1'); }
             e();
@@ -727,9 +706,8 @@ describe('content projection', () => {
        */
       const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Child.ngComponentDef);
+          E(0, Child);
           {
-            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
             E(2, 'span');
             { T(3, '1'); }
             e();
@@ -780,9 +758,8 @@ describe('content projection', () => {
       const Child = createComponent('child', function(ctx: any, cm: boolean) {
         if (cm) {
           m(0, pD());
-          E(1, GrandChild.ngComponentDef);
+          E(1, GrandChild);
           {
-            D(2, GrandChild.ngComponentDef.n(), GrandChild.ngComponentDef);
             P(3, 0);
             E(4, 'span');
             { T(5, 'in child template'); }
@@ -803,9 +780,8 @@ describe('content projection', () => {
        */
       const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Child.ngComponentDef);
+          E(0, Child);
           {
-            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
             E(2, 'span');
             { T(3, 'parent content'); }
             e();
@@ -845,10 +821,9 @@ describe('content projection', () => {
        */
       const Parent = createComponent('parent', function(ctx: {value: any}, cm: boolean) {
         if (cm) {
-          E(0, Child.ngComponentDef);
+          E(0, Child);
           {
-            D(1, Child.ngComponentDef.n(), Child.ngComponentDef);
-            C(2, undefined, 'div');
+            C(2, undefined, undefined, 'div');
             c();
           }
           e();

--- a/packages/core/test/render3/control_flow_spec.ts
+++ b/packages/core/test/render3/control_flow_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, E, T, V, b, c, cR, cr, e, t, v} from '../../src/render3/index';
+import {C, E, T, V, b, cR, cr, e, t, v} from '../../src/render3/index';
 
 import {renderToHtml} from './render_util';
 
@@ -19,7 +19,6 @@ describe('JS control flow', () => {
         E(0, 'div');
         {
           C(1);
-          c();
         }
         e();
       }
@@ -70,7 +69,6 @@ describe('JS control flow', () => {
         E(0, 'div');
         {
           C(1);
-          c();
         }
         e();
       }
@@ -83,7 +81,6 @@ describe('JS control flow', () => {
               E(0, 'span');
               {
                 C(1);
-                c();
               }
               e();
             }
@@ -141,7 +138,6 @@ describe('JS control flow', () => {
         { T(1, 'hello'); }
         e();
         C(2);
-        c();
       }
       cR(2);
       {
@@ -150,7 +146,6 @@ describe('JS control flow', () => {
           {
             if (cm0) {
               C(0);
-              c();
             }
             cR(0);
             {
@@ -187,7 +182,6 @@ describe('JS control flow', () => {
         E(0, 'ul');
         {
           C(1);
-          c();
         }
         e();
       }
@@ -236,7 +230,6 @@ describe('JS control flow', () => {
         E(0, 'ul');
         {
           C(1);
-          c();
         }
         e();
       }
@@ -249,7 +242,6 @@ describe('JS control flow', () => {
               E(0, 'li');
               {
                 C(1);
-                c();
               }
               e();
             }
@@ -298,7 +290,6 @@ describe('JS control flow', () => {
         {
           T(1, 'Before');
           C(2);
-          c();
           T(3, 'After');
         }
         e();
@@ -313,7 +304,6 @@ describe('JS control flow', () => {
               { T(1); }
               e();
               C(2);
-              c();
               T(3, '-');
             }
             t(1, b(ctx.cafes[i].name));
@@ -380,7 +370,6 @@ describe('JS control flow', () => {
         {
           T(1, 'Before');
           C(2);
-          c();
           T(3, 'After');
         }
         e();
@@ -395,7 +384,6 @@ describe('JS control flow', () => {
               { T(1); }
               e();
               C(2);
-              c();
               T(3, '-');
             }
             t(1, b(ctx.cafes[i].name));
@@ -409,7 +397,6 @@ describe('JS control flow', () => {
                     { T(1); }
                     e();
                     C(2);
-                    c();
                   }
                   t(1, b(ctx.cafes[i].entrees[j].name));
                   cR(2);
@@ -472,7 +459,6 @@ describe('JS control flow', () => {
         E(0, 'div');
         {
           C(1);
-          c();
         }
         e();
       }
@@ -523,7 +509,6 @@ describe('JS for loop', () => {
         E(0, 'div');
         {
           C(1);
-          c();
         }
         e();
       }
@@ -580,9 +565,7 @@ describe('function calls', () => {
         {
           T(1, 'Before');
           C(2);
-          c();
           C(3);
-          c();
           T(4, 'After');
         }
         e();

--- a/packages/core/test/render3/control_flow_spec.ts
+++ b/packages/core/test/render3/control_flow_spec.ts
@@ -17,9 +17,7 @@ describe('JS control flow', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         E(0, 'div');
-        {
-          C(1);
-        }
+        { C(1); }
         e();
       }
       cR(1);
@@ -67,9 +65,7 @@ describe('JS control flow', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         E(0, 'div');
-        {
-          C(1);
-        }
+        { C(1); }
         e();
       }
       cR(1);
@@ -79,9 +75,7 @@ describe('JS control flow', () => {
           {
             if (cm1) {
               E(0, 'span');
-              {
-                C(1);
-              }
+              { C(1); }
               e();
             }
             cR(1);
@@ -180,9 +174,7 @@ describe('JS control flow', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         E(0, 'ul');
-        {
-          C(1);
-        }
+        { C(1); }
         e();
       }
       cR(1);
@@ -228,9 +220,7 @@ describe('JS control flow', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         E(0, 'ul');
-        {
-          C(1);
-        }
+        { C(1); }
         e();
       }
       cR(1);
@@ -240,9 +230,7 @@ describe('JS control flow', () => {
           {
             if (cm1) {
               E(0, 'li');
-              {
-                C(1);
-              }
+              { C(1); }
               e();
             }
             cR(1);
@@ -457,9 +445,7 @@ describe('JS control flow', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         E(0, 'div');
-        {
-          C(1);
-        }
+        { C(1); }
         e();
       }
       cR(1);
@@ -507,9 +493,7 @@ describe('JS for loop', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         E(0, 'div');
-        {
-          C(1);
-        }
+        { C(1); }
         e();
       }
       cR(1);

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -21,16 +21,13 @@ describe('di', () => {
     it('should create directive with no deps', () => {
       class Directive {
         value: string = 'Created';
+        static ngDirectiveDef = defineDirective({type: Directive, factory: () => new Directive});
       }
-      const DirectiveDef = defineDirective({type: Directive, factory: () => new Directive});
 
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'div');
-          {
-            D(1, DirectiveDef.n(), DirectiveDef);
-            T(2);
-          }
+          E(0, 'div', null, [Directive]);
+          { T(2); }
           e();
         }
         t(2, b(D<Directive>(1).value));
@@ -44,36 +41,31 @@ describe('di', () => {
     it('should create directive with inter view dependencies', () => {
       class DirectiveA {
         value: string = 'A';
+        static ngDirectiveDef = defineDirective(
+            {type: DirectiveA, factory: () => new DirectiveA, features: [PublicFeature]});
       }
-      const DirectiveADef = defineDirective(
-          {type: DirectiveA, factory: () => new DirectiveA, features: [PublicFeature]});
 
       class DirectiveB {
         value: string = 'B';
+        static ngDirectiveDef = defineDirective(
+            {type: DirectiveB, factory: () => new DirectiveB, features: [PublicFeature]});
       }
-      const DirectiveBDef = defineDirective(
-          {type: DirectiveB, factory: () => new DirectiveB, features: [PublicFeature]});
 
       class DirectiveC {
         value: string;
         constructor(a: DirectiveA, b: DirectiveB) { this.value = a.value + b.value; }
+        static ngDirectiveDef = defineDirective({
+          type: DirectiveC,
+          factory: () => new DirectiveC(inject(DirectiveA), inject(DirectiveB))
+        });
       }
-      const DirectiveCDef = defineDirective({
-        type: DirectiveC,
-        factory: () => new DirectiveC(inject(DirectiveA), inject(DirectiveB))
-      });
 
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'div');
+          E(0, 'div', null, [DirectiveA]);
           {
-            D(1, DirectiveADef.n(), DirectiveADef);
-            E(2, 'span');
-            {
-              D(3, DirectiveBDef.n(), DirectiveBDef);
-              D(4, DirectiveCDef.n(), DirectiveCDef);
-              T(5);
-            }
+            E(2, 'span', null, [DirectiveB, DirectiveC]);
+            { T(5); }
             e();
           }
           e();
@@ -92,32 +84,28 @@ describe('di', () => {
         constructor(public elementRef: ElementRef) {
           this.value = (elementRef.constructor as any).name;
         }
+        static ngDirectiveDef = defineDirective({
+          type: Directive,
+          factory: () => new Directive(injectElementRef()),
+          features: [PublicFeature]
+        });
       }
-      const DirectiveDef = defineDirective({
-        type: Directive,
-        factory: () => new Directive(injectElementRef()),
-        features: [PublicFeature]
-      });
 
       class DirectiveSameInstance {
         value: boolean;
         constructor(elementRef: ElementRef, directive: Directive) {
           this.value = elementRef === directive.elementRef;
         }
+        static ngDirectiveDef = defineDirective({
+          type: DirectiveSameInstance,
+          factory: () => new DirectiveSameInstance(injectElementRef(), inject(Directive))
+        });
       }
-      const DirectiveSameInstanceDef = defineDirective({
-        type: DirectiveSameInstance,
-        factory: () => new DirectiveSameInstance(injectElementRef(), inject(Directive))
-      });
 
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'div');
-          {
-            D(1, DirectiveDef.n(), DirectiveDef);
-            D(2, DirectiveSameInstanceDef.n(), DirectiveSameInstanceDef);
-            T(3);
-          }
+          E(0, 'div', null, [Directive, DirectiveSameInstance]);
+          { T(3); }
           e();
         }
         t(3, b2('', D<Directive>(1).value, '-', D<DirectiveSameInstance>(2).value, ''));
@@ -134,32 +122,28 @@ describe('di', () => {
         constructor(public templateRef: TemplateRef<any>) {
           this.value = (templateRef.constructor as any).name;
         }
+        static ngDirectiveDef = defineDirective({
+          type: Directive,
+          factory: () => new Directive(injectTemplateRef()),
+          features: [PublicFeature]
+        });
       }
-      const DirectiveDef = defineDirective({
-        type: Directive,
-        factory: () => new Directive(injectTemplateRef()),
-        features: [PublicFeature]
-      });
 
       class DirectiveSameInstance {
         value: boolean;
         constructor(templateRef: TemplateRef<any>, directive: Directive) {
           this.value = templateRef === directive.templateRef;
         }
+        static ngDirectiveDef = defineDirective({
+          type: DirectiveSameInstance,
+          factory: () => new DirectiveSameInstance(injectTemplateRef(), inject(Directive))
+        });
       }
-      const DirectiveSameInstanceDef = defineDirective({
-        type: DirectiveSameInstance,
-        factory: () => new DirectiveSameInstance(injectTemplateRef(), inject(Directive))
-      });
 
 
       function Template(ctx: any, cm: any) {
         if (cm) {
-          C(0, function() {});
-          {
-            D(1, DirectiveDef.n(), DirectiveDef);
-            D(2, DirectiveSameInstanceDef.n(), DirectiveSameInstanceDef);
-          }
+          C(0, [Directive, DirectiveSameInstance], function() {});
           c();
           T(3);
         }
@@ -177,32 +161,28 @@ describe('di', () => {
         constructor(public viewContainerRef: ViewContainerRef) {
           this.value = (viewContainerRef.constructor as any).name;
         }
+        static ngDirectiveDef = defineDirective({
+          type: Directive,
+          factory: () => new Directive(injectViewContainerRef()),
+          features: [PublicFeature]
+        });
       }
-      const DirectiveDef = defineDirective({
-        type: Directive,
-        factory: () => new Directive(injectViewContainerRef()),
-        features: [PublicFeature]
-      });
 
       class DirectiveSameInstance {
         value: boolean;
         constructor(viewContainerRef: ViewContainerRef, directive: Directive) {
           this.value = viewContainerRef === directive.viewContainerRef;
         }
+        static ngDirectiveDef = defineDirective({
+          type: DirectiveSameInstance,
+          factory: () => new DirectiveSameInstance(injectViewContainerRef(), inject(Directive))
+        });
       }
-      const DirectiveSameInstanceDef = defineDirective({
-        type: DirectiveSameInstance,
-        factory: () => new DirectiveSameInstance(injectViewContainerRef(), inject(Directive))
-      });
 
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'div');
-          {
-            D(1, DirectiveDef.n(), DirectiveDef);
-            D(2, DirectiveSameInstanceDef.n(), DirectiveSameInstanceDef);
-            T(3);
-          }
+          E(0, 'div', null, [Directive, DirectiveSameInstance]);
+          { T(3); }
           e();
         }
         t(3, b2('', D<Directive>(1).value, '-', D<DirectiveSameInstance>(2).value, ''));
@@ -255,38 +235,41 @@ describe('di', () => {
     });
 
     it('should inject from parent view', () => {
-      class ParentDirective {}
-      const ParentDirectiveDef = defineDirective(
-          {type: ParentDirective, factory: () => new ParentDirective(), features: [PublicFeature]});
+      class ParentDirective {
+        static ngDirectiveDef = defineDirective({
+          type: ParentDirective,
+          factory: () => new ParentDirective(),
+          features: [PublicFeature]
+        });
+      }
 
       class ChildDirective {
         value: string;
         constructor(public parent: ParentDirective) {
           this.value = (parent.constructor as any).name;
         }
+        static ngDirectiveDef = defineDirective({
+          type: ChildDirective,
+          factory: () => new ChildDirective(inject(ParentDirective)),
+          features: [PublicFeature]
+        });
       }
-      const ChildDirectiveDef = defineDirective({
-        type: ChildDirective,
-        factory: () => new ChildDirective(inject(ParentDirective)),
-        features: [PublicFeature]
-      });
 
       class Child2Directive {
         value: boolean;
         constructor(parent: ParentDirective, child: ChildDirective) {
           this.value = parent === child.parent;
         }
+        static ngDirectiveDef = defineDirective({
+          type: Child2Directive,
+          factory: () => new Child2Directive(inject(ParentDirective), inject(ChildDirective))
+        });
       }
-      const Child2DirectiveDef = defineDirective({
-        type: Child2Directive,
-        factory: () => new Child2Directive(inject(ParentDirective), inject(ChildDirective))
-      });
 
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'div');
+          E(0, 'div', null, [ParentDirective]);
           {
-            D(1, ParentDirectiveDef.n(), ParentDirectiveDef);
             C(2);
             c();
           }
@@ -295,12 +278,8 @@ describe('di', () => {
         cR(2);
         {
           if (V(0)) {
-            E(0, 'span');
-            {
-              D(1, ChildDirectiveDef.n(), ChildDirectiveDef);
-              D(2, Child2DirectiveDef.n(), Child2DirectiveDef);
-              T(3);
-            }
+            E(0, 'span', null, [ChildDirective, Child2Directive]);
+            { T(3); }
             e();
           }
           t(3, b2('', D<ChildDirective>(1).value, '-', D<Child2Directive>(2).value, ''));

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -9,7 +9,7 @@
 import {ElementRef, TemplateRef, ViewContainerRef} from '@angular/core';
 
 import {bloomAdd, bloomFindPossibleInjector} from '../../src/render3/di';
-import {C, D, E, PublicFeature, T, V, b, b2, c, cR, cr, defineDirective, e, inject, injectElementRef, injectTemplateRef, injectViewContainerRef, t, v} from '../../src/render3/index';
+import {C, D, E, PublicFeature, T, V, b, b2, cR, cr, defineDirective, e, inject, injectElementRef, injectTemplateRef, injectViewContainerRef, t, v} from '../../src/render3/index';
 import {createLNode, createLView, enterView, getOrCreateNodeInjector, leaveView} from '../../src/render3/instructions';
 import {LInjector} from '../../src/render3/interfaces/injector';
 import {LNodeFlags} from '../../src/render3/interfaces/node';
@@ -21,7 +21,7 @@ describe('di', () => {
     it('should create directive with no deps', () => {
       class Directive {
         value: string = 'Created';
-        static ngDirectiveDef = defineDirective({type: Directive, factory: () => new Directive});
+        static ngDirectiveDef = defineDirective({factory: () => new Directive});
       }
 
       function Template(ctx: any, cm: boolean) {
@@ -41,23 +41,21 @@ describe('di', () => {
     it('should create directive with inter view dependencies', () => {
       class DirectiveA {
         value: string = 'A';
-        static ngDirectiveDef = defineDirective(
-            {type: DirectiveA, factory: () => new DirectiveA, features: [PublicFeature]});
+        static ngDirectiveDef =
+            defineDirective({factory: () => new DirectiveA, features: [PublicFeature]});
       }
 
       class DirectiveB {
         value: string = 'B';
-        static ngDirectiveDef = defineDirective(
-            {type: DirectiveB, factory: () => new DirectiveB, features: [PublicFeature]});
+        static ngDirectiveDef =
+            defineDirective({factory: () => new DirectiveB, features: [PublicFeature]});
       }
 
       class DirectiveC {
         value: string;
         constructor(a: DirectiveA, b: DirectiveB) { this.value = a.value + b.value; }
-        static ngDirectiveDef = defineDirective({
-          type: DirectiveC,
-          factory: () => new DirectiveC(inject(DirectiveA), inject(DirectiveB))
-        });
+        static ngDirectiveDef = defineDirective(
+            {factory: () => new DirectiveC(inject(DirectiveA), inject(DirectiveB))});
       }
 
       function Template(ctx: any, cm: boolean) {
@@ -84,11 +82,8 @@ describe('di', () => {
         constructor(public elementRef: ElementRef) {
           this.value = (elementRef.constructor as any).name;
         }
-        static ngDirectiveDef = defineDirective({
-          type: Directive,
-          factory: () => new Directive(injectElementRef()),
-          features: [PublicFeature]
-        });
+        static ngDirectiveDef = defineDirective(
+            {factory: () => new Directive(injectElementRef()), features: [PublicFeature]});
       }
 
       class DirectiveSameInstance {
@@ -96,10 +91,8 @@ describe('di', () => {
         constructor(elementRef: ElementRef, directive: Directive) {
           this.value = elementRef === directive.elementRef;
         }
-        static ngDirectiveDef = defineDirective({
-          type: DirectiveSameInstance,
-          factory: () => new DirectiveSameInstance(injectElementRef(), inject(Directive))
-        });
+        static ngDirectiveDef = defineDirective(
+            {factory: () => new DirectiveSameInstance(injectElementRef(), inject(Directive))});
       }
 
       function Template(ctx: any, cm: boolean) {
@@ -122,11 +115,8 @@ describe('di', () => {
         constructor(public templateRef: TemplateRef<any>) {
           this.value = (templateRef.constructor as any).name;
         }
-        static ngDirectiveDef = defineDirective({
-          type: Directive,
-          factory: () => new Directive(injectTemplateRef()),
-          features: [PublicFeature]
-        });
+        static ngDirectiveDef = defineDirective(
+            {factory: () => new Directive(injectTemplateRef()), features: [PublicFeature]});
       }
 
       class DirectiveSameInstance {
@@ -134,10 +124,8 @@ describe('di', () => {
         constructor(templateRef: TemplateRef<any>, directive: Directive) {
           this.value = templateRef === directive.templateRef;
         }
-        static ngDirectiveDef = defineDirective({
-          type: DirectiveSameInstance,
-          factory: () => new DirectiveSameInstance(injectTemplateRef(), inject(Directive))
-        });
+        static ngDirectiveDef = defineDirective(
+            {factory: () => new DirectiveSameInstance(injectTemplateRef(), inject(Directive))});
       }
 
 
@@ -160,11 +148,8 @@ describe('di', () => {
         constructor(public viewContainerRef: ViewContainerRef) {
           this.value = (viewContainerRef.constructor as any).name;
         }
-        static ngDirectiveDef = defineDirective({
-          type: Directive,
-          factory: () => new Directive(injectViewContainerRef()),
-          features: [PublicFeature]
-        });
+        static ngDirectiveDef = defineDirective(
+            {factory: () => new Directive(injectViewContainerRef()), features: [PublicFeature]});
       }
 
       class DirectiveSameInstance {
@@ -173,7 +158,6 @@ describe('di', () => {
           this.value = viewContainerRef === directive.viewContainerRef;
         }
         static ngDirectiveDef = defineDirective({
-          type: DirectiveSameInstance,
           factory: () => new DirectiveSameInstance(injectViewContainerRef(), inject(Directive))
         });
       }
@@ -235,11 +219,8 @@ describe('di', () => {
 
     it('should inject from parent view', () => {
       class ParentDirective {
-        static ngDirectiveDef = defineDirective({
-          type: ParentDirective,
-          factory: () => new ParentDirective(),
-          features: [PublicFeature]
-        });
+        static ngDirectiveDef =
+            defineDirective({factory: () => new ParentDirective(), features: [PublicFeature]});
       }
 
       class ChildDirective {
@@ -248,7 +229,6 @@ describe('di', () => {
           this.value = (parent.constructor as any).name;
         }
         static ngDirectiveDef = defineDirective({
-          type: ChildDirective,
           factory: () => new ChildDirective(inject(ParentDirective)),
           features: [PublicFeature]
         });
@@ -259,18 +239,14 @@ describe('di', () => {
         constructor(parent: ParentDirective, child: ChildDirective) {
           this.value = parent === child.parent;
         }
-        static ngDirectiveDef = defineDirective({
-          type: Child2Directive,
-          factory: () => new Child2Directive(inject(ParentDirective), inject(ChildDirective))
-        });
+        static ngDirectiveDef = defineDirective(
+            {factory: () => new Child2Directive(inject(ParentDirective), inject(ChildDirective))});
       }
 
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, 'div', null, [ParentDirective]);
-          {
-            C(2);
-          }
+          { C(2); }
           e();
         }
         cR(2);

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -144,7 +144,6 @@ describe('di', () => {
       function Template(ctx: any, cm: any) {
         if (cm) {
           C(0, [Directive, DirectiveSameInstance], function() {});
-          c();
           T(3);
         }
         t(3, b2('', D<Directive>(1).value, '-', D<DirectiveSameInstance>(2).value, ''));
@@ -271,7 +270,6 @@ describe('di', () => {
           E(0, 'div', null, [ParentDirective]);
           {
             C(2);
-            c();
           }
           e();
         }

--- a/packages/core/test/render3/directive_spec.ts
+++ b/packages/core/test/render3/directive_spec.ts
@@ -20,7 +20,6 @@ describe('directive', () => {
       class Directive {
         klass = 'foo';
         static ngDirectiveDef = defineDirective({
-          type: Directive,
           factory: () => directiveInstance = new Directive,
           refresh: (directiveIndex: number, elementIndex: number) => {
             p(elementIndex, 'className', b(D<Directive>(directiveIndex).klass));

--- a/packages/core/test/render3/directive_spec.ts
+++ b/packages/core/test/render3/directive_spec.ts
@@ -19,22 +19,21 @@ describe('directive', () => {
 
       class Directive {
         klass = 'foo';
+        static ngDirectiveDef = defineDirective({
+          type: Directive,
+          factory: () => directiveInstance = new Directive,
+          refresh: (directiveIndex: number, elementIndex: number) => {
+            p(elementIndex, 'className', b(D<Directive>(directiveIndex).klass));
+          }
+        });
       }
-      const DirectiveDef = defineDirective({
-        type: Directive,
-        factory: () => directiveInstance = new Directive,
-        refresh: (directiveIndex: number, elementIndex: number) => {
-          p(elementIndex, 'className', b(D<Directive>(directiveIndex).klass));
-        }
-      });
 
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'span');
-          { D(1, DirectiveDef.n(), DirectiveDef); }
+          E(0, 'span', null, [Directive]);
           e();
         }
-        DirectiveDef.r(1, 0);
+        Directive.ngDirectiveDef.r(1, 0);
       }
 
       expect(renderToHtml(Template, {})).toEqual('<span class="foo"></span>');

--- a/packages/core/test/render3/exports_spec.ts
+++ b/packages/core/test/render3/exports_spec.ts
@@ -42,12 +42,8 @@ describe('exports', () => {
     class MyComponent {
       name = 'Nancy';
 
-      static ngComponentDef = defineComponent({
-        type: MyComponent,
-        tag: 'comp',
-        template: function() {},
-        factory: () => new MyComponent
-      });
+      static ngComponentDef =
+          defineComponent({tag: 'comp', template: function() {}, factory: () => new MyComponent});
     }
 
     expect(renderToHtml(Template, {})).toEqual('<comp></comp>Nancy');
@@ -59,19 +55,14 @@ describe('exports', () => {
     let myDir: MyDir;
     class MyComponent {
       constructor() { myComponent = this; }
-      static ngComponentDef = defineComponent({
-        type: MyComponent,
-        tag: 'comp',
-        template: function() {},
-        factory: () => new MyComponent
-      });
+      static ngComponentDef =
+          defineComponent({tag: 'comp', template: function() {}, factory: () => new MyComponent});
     }
 
     class MyDir {
       myDir: MyComponent;
       constructor() { myDir = this; }
-      static ngDirectiveDef =
-          defineDirective({type: MyDir, factory: () => new MyDir, inputs: {myDir: 'myDir'}});
+      static ngDirectiveDef = defineDirective({factory: () => new MyDir, inputs: {myDir: 'myDir'}});
     }
 
     /** <comp #myComp></comp> <div [myDir]="myComp"></div> */
@@ -103,7 +94,7 @@ describe('exports', () => {
 
     class SomeDir {
       name = 'Drew';
-      static ngDirectiveDef = defineDirective({type: SomeDir, factory: () => new SomeDir});
+      static ngDirectiveDef = defineDirective({factory: () => new SomeDir});
     }
 
     expect(renderToHtml(Template, {})).toEqual('<div></div>Drew');
@@ -184,7 +175,6 @@ describe('exports', () => {
         constructor() { myComponent = this; }
 
         static ngComponentDef = defineComponent({
-          type: MyComponent,
           tag: 'comp',
           template: function(ctx: MyComponent, cm: boolean) {},
           factory: () => new MyComponent
@@ -197,7 +187,7 @@ describe('exports', () => {
         constructor() { myDir = this; }
 
         static ngDirectiveDef =
-            defineDirective({type: MyDir, factory: () => new MyDir, inputs: {myDir: 'myDir'}});
+            defineDirective({factory: () => new MyDir, inputs: {myDir: 'myDir'}});
       }
 
       /** <div [myDir]="myComp"></div><comp #myComp></comp> */
@@ -240,12 +230,8 @@ describe('exports', () => {
 
         constructor() { myComponent = this; }
 
-        static ngComponentDef = defineComponent({
-          type: MyComponent,
-          tag: 'comp',
-          template: function() {},
-          factory: () => new MyComponent
-        });
+        static ngComponentDef =
+            defineComponent({tag: 'comp', template: function() {}, factory: () => new MyComponent});
       }
       expect(renderToHtml(Template, {})).toEqual('oneNancy<comp></comp><input value="one">');
     });
@@ -254,9 +240,7 @@ describe('exports', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, 'div');
-          {
-            C(1);
-          }
+          { C(1); }
           e();
         }
         cR(1);

--- a/packages/core/test/render3/exports_spec.ts
+++ b/packages/core/test/render3/exports_spec.ts
@@ -32,8 +32,7 @@ describe('exports', () => {
     /** <comp #myComp></comp> {{ myComp.name }} */
     function Template(ctx: any, cm: boolean) {
       if (cm) {
-        E(0, MyComponent.ngComponentDef);
-        { D(1, MyComponent.ngComponentDef.n(), MyComponent.ngComponentDef); }
+        E(0, MyComponent);
         e();
         T(2);
       }
@@ -78,11 +77,9 @@ describe('exports', () => {
     /** <comp #myComp></comp> <div [myDir]="myComp"></div> */
     function Template(ctx: any, cm: boolean) {
       if (cm) {
-        E(0, MyComponent.ngComponentDef);
-        { D(1, MyComponent.ngComponentDef.n(), MyComponent.ngComponentDef); }
+        E(0, MyComponent);
         e();
-        E(2, 'div');
-        { D(3, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+        E(2, 'div', null, [MyDir]);
         e();
       }
       p(2, 'myDir', b(D<MyComponent>(1)));
@@ -97,8 +94,7 @@ describe('exports', () => {
     /** <div someDir #myDir="someDir"></div> {{ myDir.name }} */
     function Template(ctx: any, cm: boolean) {
       if (cm) {
-        E(0, 'div');
-        D(1, SomeDirDef.n(), SomeDirDef);
+        E(0, 'div', null, [SomeDir]);
         e();
         T(2);
       }
@@ -107,8 +103,8 @@ describe('exports', () => {
 
     class SomeDir {
       name = 'Drew';
+      static ngDirectiveDef = defineDirective({type: SomeDir, factory: () => new SomeDir});
     }
-    const SomeDirDef = defineDirective({type: SomeDir, factory: () => new SomeDir});
 
     expect(renderToHtml(Template, {})).toEqual('<div></div>Drew');
   });
@@ -207,11 +203,9 @@ describe('exports', () => {
       /** <div [myDir]="myComp"></div><comp #myComp></comp> */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'div');
-          { D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+          E(0, 'div', null, [MyDir]);
           e();
-          E(2, MyComponent.ngComponentDef);
-          { D(3, MyComponent.ngComponentDef.n(), MyComponent.ngComponentDef); }
+          E(2, MyComponent);
           e();
         }
         p(0, 'myDir', b(D<MyComponent>(3)));
@@ -228,8 +222,7 @@ describe('exports', () => {
         if (cm) {
           T(0);
           T(1);
-          E(2, 'comp');
-          { D(3, MyComponent.ngComponentDef.n(), MyComponent.ngComponentDef); }
+          E(2, MyComponent);
           e();
           E(4, 'input', ['value', 'one']);
           e();

--- a/packages/core/test/render3/exports_spec.ts
+++ b/packages/core/test/render3/exports_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, T, V, a, b, c, cR, cr, defineComponent, defineDirective, e, k, p, t, v} from '../../src/render3/index';
+import {C, D, E, T, V, a, b, cR, cr, defineComponent, defineDirective, e, k, p, t, v} from '../../src/render3/index';
 
 import {renderToHtml} from './render_util';
 
@@ -256,7 +256,6 @@ describe('exports', () => {
           E(0, 'div');
           {
             C(1);
-            c();
           }
           e();
         }

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -230,8 +230,7 @@ describe('render3 integration test', () => {
     it('should support a basic component template', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, TodoComponent.ngComponentDef);
-          { D(1, TodoComponent.ngComponentDef.n(), TodoComponent.ngComponentDef); }
+          E(0, TodoComponent);
           e();
         }
         TodoComponent.ngComponentDef.h(1, 0);
@@ -244,8 +243,7 @@ describe('render3 integration test', () => {
     it('should support a component template with sibling', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, TodoComponent.ngComponentDef);
-          { D(1, TodoComponent.ngComponentDef.n(), TodoComponent.ngComponentDef); }
+          E(0, TodoComponent);
           e();
           T(2, 'two');
         }
@@ -262,11 +260,9 @@ describe('render3 integration test', () => {
        */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, TodoComponent.ngComponentDef);
-          { D(1, TodoComponent.ngComponentDef.n(), TodoComponent.ngComponentDef); }
+          E(0, TodoComponent);
           e();
-          E(2, TodoComponent.ngComponentDef);
-          { D(3, TodoComponent.ngComponentDef.n(), TodoComponent.ngComponentDef); }
+          E(2, TodoComponent);
           e();
         }
         TodoComponent.ngComponentDef.h(1, 0);
@@ -303,11 +299,7 @@ describe('render3 integration test', () => {
 
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, TodoComponentHostBinding.ngComponentDef);
-          {
-            D(1, TodoComponentHostBinding.ngComponentDef.n(),
-              TodoComponentHostBinding.ngComponentDef);
-          }
+          E(0, TodoComponentHostBinding);
           e();
         }
         TodoComponentHostBinding.ngComponentDef.h(1, 0);
@@ -340,8 +332,7 @@ describe('render3 integration test', () => {
 
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, MyComp.ngComponentDef);
-          { D(1, MyComp.ngComponentDef.n(), MyComp.ngComponentDef); }
+          E(0, MyComp);
           e();
         }
         MyComp.ngComponentDef.h(1, 0);
@@ -388,8 +379,7 @@ describe('render3 integration test', () => {
       /** <comp [condition]="condition"></comp> */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, MyComp.ngComponentDef);
-          { D(1, MyComp.ngComponentDef.n(), MyComp.ngComponentDef); }
+          E(0, MyComp);
           e();
         }
         p(0, 'condition', b(ctx.condition));

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -210,7 +210,6 @@ describe('render3 integration test', () => {
       value = ' one';
 
       static ngComponentDef = defineComponent({
-        type: TodoComponent,
         tag: 'todo',
         template: function TodoTemplate(ctx: any, cm: boolean) {
           if (cm) {
@@ -280,7 +279,6 @@ describe('render3 integration test', () => {
       class TodoComponentHostBinding {
         title = 'one';
         static ngComponentDef = defineComponent({
-          type: TodoComponentHostBinding,
           tag: 'todo',
           template: function TodoComponentHostBindingTemplate(
               ctx: TodoComponentHostBinding, cm: boolean) {
@@ -316,7 +314,6 @@ describe('render3 integration test', () => {
       class MyComp {
         name = 'Bess';
         static ngComponentDef = defineComponent({
-          type: MyComp,
           tag: 'comp',
           template: function MyCompTemplate(ctx: any, cm: boolean) {
             if (cm) {
@@ -351,7 +348,6 @@ describe('render3 integration test', () => {
       class MyComp {
         condition: boolean;
         static ngComponentDef = defineComponent({
-          type: MyComp,
           tag: 'comp',
           template: function MyCompTemplate(ctx: any, cm: boolean) {
             if (cm) {

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, NC, T, V, a, b, b1, b2, b3, b4, b5, b6, b7, b8, bV, c, cR, cr, defineComponent, e, k, p, r, s, t, v} from '../../src/render3/index';
+import {C, D, E, NC, T, V, a, b, b1, b2, b3, b4, b5, b6, b7, b8, bV, cR, cr, defineComponent, e, k, p, r, s, t, v} from '../../src/render3/index';
 import {NO_CHANGE} from '../../src/render3/instructions';
 
 import {containerEl, renderToHtml} from './render_util';
@@ -356,7 +356,6 @@ describe('render3 integration test', () => {
           template: function MyCompTemplate(ctx: any, cm: boolean) {
             if (cm) {
               C(0);
-              c();
             }
             cR(0);
             {
@@ -478,7 +477,6 @@ describe('render3 integration test', () => {
           if (cm) {
             E(0, 'span');
             C(1);
-            c();
             e();
           }
           a(0, 'title', b(ctx.title));
@@ -595,7 +593,6 @@ describe('render3 integration test', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           C(0);
-          c();
         }
         cR(0);
         {

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -38,7 +38,6 @@ describe('lifecycles', () => {
         ngOnInit() { events.push(`${name}${this.val}`); }
 
         static ngComponentDef = defineComponent({
-          type: Component,
           tag: name,
           factory: () => new Component(),
           hostBindings: function(directiveIndex: number, elementIndex: number):
@@ -271,7 +270,6 @@ describe('lifecycles', () => {
         ngOnInit() { allEvents.push('ngOnInit ' + name); }
 
         static ngComponentDef = defineComponent({
-          type: Component,
           tag: name,
           factory: () => new Component(),
           hostBindings: function(
@@ -363,7 +361,6 @@ describe('lifecycles', () => {
         ngAfterViewChecked() { allEvents.push(`${name}${this.val} check`); }
 
         static ngComponentDef = defineComponent({
-          type: Component,
           tag: name,
           factory: () => new Component(),
           refresh: (directiveIndex: number, elementIndex: number) => {
@@ -405,7 +402,6 @@ describe('lifecycles', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           C(0);
-          c();
         }
         cR(0);
         {
@@ -492,7 +488,6 @@ describe('lifecycles', () => {
           E(0, Comp);
           e();
           C(2);
-          c();
           E(3, Comp);
           e();
         }
@@ -536,7 +531,6 @@ describe('lifecycles', () => {
           E(0, Parent);
           e();
           C(2);
-          c();
           E(3, Parent);
           e();
         }
@@ -621,7 +615,6 @@ describe('lifecycles', () => {
             E(0, Parent);
             e();
             C(2);
-            c();
             E(3, Parent);
             e();
           }
@@ -674,7 +667,6 @@ describe('lifecycles', () => {
         ngOnDestroy() { events.push(`${name}${this.val}`); }
 
         static ngComponentDef = defineComponent({
-          type: Component,
           tag: name,
           factory: () => {
             const comp = new Component();

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -15,8 +15,7 @@ describe('lifecycles', () => {
   function getParentTemplate(type: any) {
     return (ctx: any, cm: boolean) => {
       if (cm) {
-        E(0, type.ngComponentDef);
-        { D(1, type.ngComponentDef.n(), type.ngComponentDef); }
+        E(0, type);
         e();
       }
       p(0, 'val', b(ctx.val));
@@ -54,8 +53,7 @@ describe('lifecycles', () => {
          /** <comp [val]="val"></comp> */
          function Template(ctx: any, cm: boolean) {
            if (cm) {
-             E(0, Comp.ngComponentDef);
-             { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+             E(0, Comp);
              e();
            }
            p(0, 'val', b(ctx.val));
@@ -78,8 +76,7 @@ describe('lifecycles', () => {
 
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Parent.ngComponentDef);
-          { D(1, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+          E(0, Parent);
           e();
         }
         Parent.ngComponentDef.h(1, 0);
@@ -100,11 +97,9 @@ describe('lifecycles', () => {
 
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Parent.ngComponentDef);
-          { D(1, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+          E(0, Parent);
           e();
-          E(2, Parent.ngComponentDef);
-          { D(3, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+          E(2, Parent);
           e();
         }
         p(0, 'val', 1);
@@ -136,8 +131,7 @@ describe('lifecycles', () => {
         {
           if (ctx.condition) {
             if (V(0)) {
-              E(0, Comp.ngComponentDef);
-              { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              E(0, Comp);
               e();
             }
             Comp.ngComponentDef.h(1, 0);
@@ -169,13 +163,11 @@ describe('lifecycles', () => {
 
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Comp.ngComponentDef);
-          { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+          E(0, Comp);
           e();
           C(2);
           c();
-          E(3, Comp.ngComponentDef);
-          { D(4, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+          E(3, Comp);
           e();
         }
         p(0, 'val', 1);
@@ -186,8 +178,7 @@ describe('lifecycles', () => {
         {
           for (let j = 2; j < 5; j++) {
             if (V(0)) {
-              E(0, Comp.ngComponentDef);
-              { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              E(0, Comp);
               e();
             }
             p(0, 'val', j);
@@ -219,13 +210,11 @@ describe('lifecycles', () => {
 
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Parent.ngComponentDef);
-          { D(1, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+          E(0, Parent);
           e();
           C(2);
           c();
-          E(3, Parent.ngComponentDef);
-          { D(4, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+          E(3, Parent);
           e();
         }
         p(0, 'val', 1);
@@ -236,8 +225,7 @@ describe('lifecycles', () => {
         {
           for (let j = 2; j < 5; j++) {
             if (V(0)) {
-              E(0, Parent.ngComponentDef);
-              { D(1, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+              E(0, Parent);
               e();
             }
             p(0, 'val', j);
@@ -303,8 +291,7 @@ describe('lifecycles', () => {
       /** <comp></comp> */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Comp.ngComponentDef);
-          { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+          E(0, Comp);
           e();
         }
         Comp.ngComponentDef.h(1, 0);
@@ -326,8 +313,7 @@ describe('lifecycles', () => {
 
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Parent.ngComponentDef);
-          { D(1, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+          E(0, Parent);
           e();
         }
         Parent.ngComponentDef.h(1, 0);
@@ -342,8 +328,7 @@ describe('lifecycles', () => {
       /** <comp></comp> */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Comp.ngComponentDef);
-          { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+          E(0, Comp);
           e();
         }
         Comp.ngComponentDef.h(1, 0);
@@ -400,8 +385,7 @@ describe('lifecycles', () => {
       /** <comp></comp> */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Comp.ngComponentDef);
-          { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+          E(0, Comp);
           e();
         }
         Comp.ngComponentDef.h(1, 0);
@@ -430,8 +414,7 @@ describe('lifecycles', () => {
         {
           if (ctx.condition) {
             if (V(0)) {
-              E(0, Comp.ngComponentDef);
-              { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              E(0, Comp);
               e();
             }
             Comp.ngComponentDef.h(1, 0);
@@ -461,8 +444,7 @@ describe('lifecycles', () => {
        */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Parent.ngComponentDef);
-          { D(1, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+          E(0, Parent);
           e();
         }
         Parent.ngComponentDef.h(1, 0);
@@ -483,11 +465,9 @@ describe('lifecycles', () => {
        */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Parent.ngComponentDef);
-          { D(1, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+          E(0, Parent);
           e();
-          E(2, Parent.ngComponentDef);
-          { D(3, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+          E(2, Parent);
           e();
         }
         p(0, 'val', 1);
@@ -512,13 +492,11 @@ describe('lifecycles', () => {
        */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Comp.ngComponentDef);
-          { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+          E(0, Comp);
           e();
           C(2);
           c();
-          E(3, Comp.ngComponentDef);
-          { D(4, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+          E(3, Comp);
           e();
         }
         p(0, 'val', 1);
@@ -529,8 +507,7 @@ describe('lifecycles', () => {
         {
           for (let i = 2; i < 4; i++) {
             if (V(0)) {
-              E(0, Comp.ngComponentDef);
-              { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              E(0, Comp);
               e();
             }
             p(0, 'val', i);
@@ -559,13 +536,11 @@ describe('lifecycles', () => {
        */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Parent.ngComponentDef);
-          { D(1, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+          E(0, Parent);
           e();
           C(2);
           c();
-          E(3, Parent.ngComponentDef);
-          { D(4, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+          E(3, Parent);
           e();
         }
         p(0, 'val', 1);
@@ -576,8 +551,7 @@ describe('lifecycles', () => {
         {
           for (let i = 2; i < 4; i++) {
             if (V(0)) {
-              E(0, Parent.ngComponentDef);
-              { D(1, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+              E(0, Parent);
               e();
             }
             p(0, 'val', i);
@@ -604,8 +578,7 @@ describe('lifecycles', () => {
         /** <comp></comp> */
         function Template(ctx: any, cm: boolean) {
           if (cm) {
-            E(0, Comp.ngComponentDef);
-            { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+            E(0, Comp);
             e();
           }
           Comp.ngComponentDef.h(1, 0);
@@ -623,8 +596,7 @@ describe('lifecycles', () => {
         /** <comp [val]="myVal"></comp> */
         function Template(ctx: any, cm: boolean) {
           if (cm) {
-            E(0, Comp.ngComponentDef);
-            { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+            E(0, Comp);
             e();
           }
           p(0, 'val', b(ctx.myVal));
@@ -649,13 +621,11 @@ describe('lifecycles', () => {
          */
         function Template(ctx: any, cm: boolean) {
           if (cm) {
-            E(0, Parent.ngComponentDef);
-            { D(1, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+            E(0, Parent);
             e();
             C(2);
             c();
-            E(3, Parent.ngComponentDef);
-            { D(4, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+            E(3, Parent);
             e();
           }
           p(0, 'val', 1);
@@ -666,8 +636,7 @@ describe('lifecycles', () => {
           {
             for (let i = 2; i < 4; i++) {
               if (V(0)) {
-                E(0, Parent.ngComponentDef);
-                { D(1, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+                E(0, Parent);
                 e();
               }
               p(0, 'val', i);
@@ -737,8 +706,7 @@ describe('lifecycles', () => {
         {
           if (ctx.condition) {
             if (V(0)) {
-              E(0, Comp.ngComponentDef);
-              { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              E(0, Comp);
               e();
             }
             Comp.ngComponentDef.h(1, 0);
@@ -771,11 +739,9 @@ describe('lifecycles', () => {
         {
           if (ctx.condition) {
             if (V(0)) {
-              E(0, Comp.ngComponentDef);
-              { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              E(0, Comp);
               e();
-              E(2, Comp.ngComponentDef);
-              { D(3, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              E(2, Comp);
               e();
             }
             p(0, 'val', b('1'));
@@ -813,8 +779,7 @@ describe('lifecycles', () => {
         {
           if (ctx.condition) {
             if (V(0)) {
-              E(0, Parent.ngComponentDef);
-              { D(1, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+              E(0, Parent);
               e();
             }
             Parent.ngComponentDef.h(1, 0);
@@ -842,8 +807,7 @@ describe('lifecycles', () => {
 
       let Grandparent = createOnDestroyComponent('grandparent', function(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Parent.ngComponentDef);
-          { D(1, Parent.ngComponentDef.n(), Parent.ngComponentDef); }
+          E(0, Parent);
           e();
         }
         Parent.ngComponentDef.h(1, 0);
@@ -859,8 +823,7 @@ describe('lifecycles', () => {
         {
           if (ctx.condition) {
             if (V(0)) {
-              E(0, Grandparent.ngComponentDef);
-              { D(1, Grandparent.ngComponentDef.n(), Grandparent.ngComponentDef); }
+              E(0, Grandparent);
               e();
             }
             Grandparent.ngComponentDef.h(1, 0);
@@ -897,13 +860,11 @@ describe('lifecycles', () => {
         {
           if (ctx.condition) {
             if (V(0)) {
-              E(0, Comp.ngComponentDef);
-              { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              E(0, Comp);
               e();
               C(2);
               c();
-              E(3, Comp.ngComponentDef);
-              { D(4, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              E(3, Comp);
               e();
             }
             p(0, 'val', b('1'));
@@ -914,8 +875,7 @@ describe('lifecycles', () => {
             {
               if (ctx.condition2) {
                 if (V(0)) {
-                  E(0, Comp.ngComponentDef);
-                  { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+                  E(0, Comp);
                   e();
                 }
                 p(0, 'val', b('2'));
@@ -978,13 +938,11 @@ describe('lifecycles', () => {
         {
           if (ctx.condition) {
             if (V(0)) {
-              E(0, Comp.ngComponentDef);
-              { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              E(0, Comp);
               e();
               C(2);
               c();
-              E(3, Comp.ngComponentDef);
-              { D(4, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              E(3, Comp);
               e();
             }
             p(0, 'val', b('1'));
@@ -995,8 +953,7 @@ describe('lifecycles', () => {
             {
               for (let j = 2; j < ctx.len; j++) {
                 if (V(0)) {
-                  E(0, Comp.ngComponentDef);
-                  { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+                  E(0, Comp);
                   e();
                 }
                 p(0, 'val', b(j));
@@ -1067,8 +1024,7 @@ describe('lifecycles', () => {
                 T(1, 'Click me');
               }
               e();
-              E(2, Comp.ngComponentDef);
-              { D(3, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              E(2, Comp);
               e();
               E(4, 'button');
               {

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, ComponentDef, ComponentTemplate, D, E, L, LifecycleHook, T, V, b, c, cR, cr, defineComponent, e, l, p, r, v} from '../../src/render3/index';
+import {C, ComponentDef, ComponentTemplate, D, E, L, LifecycleHook, T, V, b, cR, cr, defineComponent, e, l, p, r, v} from '../../src/render3/index';
 
 import {containerEl, renderToHtml} from './render_util';
 
@@ -125,7 +125,6 @@ describe('lifecycles', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           C(0);
-          c();
         }
         cR(0);
         {
@@ -166,7 +165,6 @@ describe('lifecycles', () => {
           E(0, Comp);
           e();
           C(2);
-          c();
           E(3, Comp);
           e();
         }
@@ -213,7 +211,6 @@ describe('lifecycles', () => {
           E(0, Parent);
           e();
           C(2);
-          c();
           E(3, Parent);
           e();
         }
@@ -700,7 +697,6 @@ describe('lifecycles', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           C(0);
-          c();
         }
         cR(0);
         {
@@ -733,7 +729,6 @@ describe('lifecycles', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           C(0);
-          c();
         }
         cR(0);
         {
@@ -773,7 +768,6 @@ describe('lifecycles', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           C(0);
-          c();
         }
         cR(0);
         {
@@ -817,7 +811,6 @@ describe('lifecycles', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           C(0);
-          c();
         }
         cR(0);
         {
@@ -854,7 +847,6 @@ describe('lifecycles', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           C(0);
-          c();
         }
         cR(0);
         {
@@ -863,7 +855,6 @@ describe('lifecycles', () => {
               E(0, Comp);
               e();
               C(2);
-              c();
               E(3, Comp);
               e();
             }
@@ -932,7 +923,6 @@ describe('lifecycles', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           C(0);
-          c();
         }
         cR(0);
         {
@@ -941,7 +931,6 @@ describe('lifecycles', () => {
               E(0, Comp);
               e();
               C(2);
-              c();
               E(3, Comp);
               e();
             }
@@ -1012,7 +1001,6 @@ describe('lifecycles', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           C(0);
-          c();
         }
         cR(0);
         {

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, L, T, V, c, cR, cr, defineComponent, e, v} from '../../src/render3/index';
+import {C, D, E, L, T, V, cR, cr, defineComponent, e, v} from '../../src/render3/index';
 
 import {containerEl, renderComponent, renderToHtml} from './render_util';
 
@@ -137,7 +137,6 @@ describe('event listeners', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         C(0);
-        c();
       }
       cR(0);
       {
@@ -145,7 +144,6 @@ describe('event listeners', () => {
           if (V(0)) {
             T(0, 'Hello');
             C(1);
-            c();
           }
           cR(1);
           {
@@ -197,7 +195,6 @@ describe('event listeners', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         C(0);
-        c();
       }
       cR(0);
       {
@@ -254,7 +251,6 @@ describe('event listeners', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         C(0);
-        c();
       }
       cR(0);
       {
@@ -262,9 +258,7 @@ describe('event listeners', () => {
           if (V(0)) {
             T(0, 'Hello');
             C(1);
-            c();
             C(2);
-            c();
           }
           cR(1);
           {

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -204,11 +204,9 @@ describe('event listeners', () => {
         if (ctx.showing) {
           if (V(0)) {
             T(0, 'Hello');
-            E(1, MyComp.ngComponentDef);
-            { D(2, MyComp.ngComponentDef.n(), MyComp.ngComponentDef); }
+            E(1, MyComp);
             e();
-            E(3, MyComp.ngComponentDef);
-            { D(4, MyComp.ngComponentDef.n(), MyComp.ngComponentDef); }
+            E(3, MyComp);
             e();
           }
           MyComp.ngComponentDef.h(2, 1);

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -21,7 +21,6 @@ describe('event listeners', () => {
     onClick() { this.counter++; }
 
     static ngComponentDef = defineComponent({
-      type: MyComp,
       tag: 'comp',
       /** <button (click)="onClick()"> Click me </button> */
       template: function CompTemplate(ctx: any, cm: boolean) {

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -21,7 +21,6 @@ describe('outputs', () => {
 
     static ngComponentDef = defineComponent({
       tag: 'button-toggle',
-      type: ButtonToggle,
       template: function(ctx: any, cm: boolean) {},
       factory: () => buttonToggle = new ButtonToggle(),
       outputs: {change: 'change', resetStream: 'reset'}
@@ -33,11 +32,8 @@ describe('outputs', () => {
   class OtherDir {
     changeStream = new EventEmitter();
 
-    static ngDirectiveDef = defineDirective({
-      type: OtherDir,
-      factory: () => otherDir = new OtherDir,
-      outputs: {changeStream: 'change'}
-    });
+    static ngDirectiveDef = defineDirective(
+        {factory: () => otherDir = new OtherDir, outputs: {changeStream: 'change'}});
   }
 
   it('should call component output function when event is emitted', () => {
@@ -217,7 +213,6 @@ describe('outputs', () => {
 
       static ngComponentDef = defineComponent({
         tag: 'destroy-comp',
-        type: DestroyComp,
         template: function(ctx: any, cm: boolean) {},
         factory: () => {
           destroyComp = new DestroyComp();
@@ -296,8 +291,8 @@ describe('outputs', () => {
     class MyButton {
       click = new EventEmitter();
 
-      static ngDirectiveDef = defineDirective(
-          {type: MyButton, factory: () => buttonDir = new MyButton, outputs: {click: 'click'}});
+      static ngDirectiveDef =
+          defineDirective({factory: () => buttonDir = new MyButton, outputs: {click: 'click'}});
     }
 
     function Template(ctx: any, cm: boolean) {
@@ -349,8 +344,8 @@ describe('outputs', () => {
     class OtherDir {
       change: boolean;
 
-      static ngDirectiveDef = defineDirective(
-          {type: OtherDir, factory: () => otherDir = new OtherDir, inputs: {change: 'change'}});
+      static ngDirectiveDef =
+          defineDirective({factory: () => otherDir = new OtherDir, inputs: {change: 'change'}});
     }
 
     /** <button-toggle (change)="onChange()" otherDir [change]="change"></button-toggle> */

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -8,7 +8,7 @@
 
 import {EventEmitter} from '@angular/core';
 
-import {C, D, E, L, LifecycleHook, T, V, b, c, cR, cr, defineComponent, defineDirective, e, l, p, v} from '../../src/render3/index';
+import {C, D, E, L, LifecycleHook, T, V, b, cR, cr, defineComponent, defineDirective, e, l, p, v} from '../../src/render3/index';
 
 import {containerEl, renderToHtml} from './render_util';
 
@@ -123,7 +123,6 @@ describe('outputs', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         C(0);
-        c();
       }
       cR(0);
       {
@@ -168,14 +167,12 @@ describe('outputs', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         C(0);
-        c();
       }
       cR(0);
       {
         if (ctx.condition) {
           if (V(0)) {
             C(0);
-            c();
           }
           cR(0);
           {
@@ -240,7 +237,6 @@ describe('outputs', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         C(0);
-        c();
       }
       cR(0);
       {
@@ -399,7 +395,6 @@ describe('outputs', () => {
         }
         e();
         C(2);
-        c();
       }
       cR(2);
       {

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -44,11 +44,8 @@ describe('outputs', () => {
     /** <button-toggle (change)="onChange()"></button-toggle> */
     function Template(ctx: any, cm: boolean) {
       if (cm) {
-        E(0, ButtonToggle.ngComponentDef);
-        {
-          D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
-          L('change', ctx.onChange.bind(ctx));
-        }
+        E(0, ButtonToggle);
+        { L('change', ctx.onChange.bind(ctx)); }
         e();
       }
       ButtonToggle.ngComponentDef.h(1, 0);
@@ -70,9 +67,8 @@ describe('outputs', () => {
     /** <button-toggle (change)="onChange()" (reset)="onReset()"></button-toggle> */
     function Template(ctx: any, cm: boolean) {
       if (cm) {
-        E(0, ButtonToggle.ngComponentDef);
+        E(0, ButtonToggle);
         {
-          D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
           L('change', ctx.onChange.bind(ctx));
           L('reset', ctx.onReset.bind(ctx));
         }
@@ -98,11 +94,8 @@ describe('outputs', () => {
     /** <button-toggle (change)="counter++"></button-toggle> */
     function Template(ctx: any, cm: boolean) {
       if (cm) {
-        E(0, ButtonToggle.ngComponentDef);
-        {
-          D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
-          L('change', () => ctx.counter++);
-        }
+        E(0, ButtonToggle);
+        { L('change', () => ctx.counter++); }
         e();
       }
       ButtonToggle.ngComponentDef.h(1, 0);
@@ -136,11 +129,8 @@ describe('outputs', () => {
       {
         if (ctx.condition) {
           if (V(0)) {
-            E(0, ButtonToggle.ngComponentDef);
-            {
-              D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
-              L('change', ctx.onChange.bind(ctx));
-            }
+            E(0, ButtonToggle);
+            { L('change', ctx.onChange.bind(ctx)); }
             e();
           }
           ButtonToggle.ngComponentDef.h(1, 0);
@@ -191,11 +181,8 @@ describe('outputs', () => {
           {
             if (ctx.condition2) {
               if (V(0)) {
-                E(0, ButtonToggle.ngComponentDef);
-                {
-                  D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
-                  L('change', ctx.onChange.bind(ctx));
-                }
+                E(0, ButtonToggle);
+                { L('change', ctx.onChange.bind(ctx)); }
                 e();
               }
               ButtonToggle.ngComponentDef.h(1, 0);
@@ -265,14 +252,10 @@ describe('outputs', () => {
               T(1, 'Click me');
             }
             e();
-            E(2, ButtonToggle.ngComponentDef);
-            {
-              D(3, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
-              L('change', ctx.onChange.bind(ctx));
-            }
+            E(2, ButtonToggle);
+            { L('change', ctx.onChange.bind(ctx)); }
             e();
-            E(4, DestroyComp.ngComponentDef);
-            { D(5, DestroyComp.ngComponentDef.n(), DestroyComp.ngComponentDef); }
+            E(4, DestroyComp);
             e();
           }
           ButtonToggle.ngComponentDef.h(3, 2);
@@ -323,11 +306,8 @@ describe('outputs', () => {
 
     function Template(ctx: any, cm: boolean) {
       if (cm) {
-        E(0, 'button');
-        {
-          D(1, MyButton.ngDirectiveDef.n(), MyButton.ngDirectiveDef);
-          L('click', ctx.onClick.bind(ctx));
-        }
+        E(0, 'button', null, [MyButton]);
+        { L('click', ctx.onClick.bind(ctx)); }
         e();
       }
     }
@@ -349,12 +329,8 @@ describe('outputs', () => {
     /** <button-toggle (change)="onChange()" otherDir></button-toggle> */
     function Template(ctx: any, cm: boolean) {
       if (cm) {
-        E(0, ButtonToggle.ngComponentDef);
-        {
-          D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
-          D(2, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
-          L('change', ctx.onChange.bind(ctx));
-        }
+        E(0, ButtonToggle, null, [OtherDir]);
+        { L('change', ctx.onChange.bind(ctx)); }
         e();
       }
       ButtonToggle.ngComponentDef.h(1, 0);
@@ -384,12 +360,8 @@ describe('outputs', () => {
     /** <button-toggle (change)="onChange()" otherDir [change]="change"></button-toggle> */
     function Template(ctx: any, cm: boolean) {
       if (cm) {
-        E(0, ButtonToggle.ngComponentDef);
-        {
-          D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
-          D(2, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
-          L('change', ctx.onChange.bind(ctx));
-        }
+        E(0, ButtonToggle, null, [OtherDir]);
+        { L('change', ctx.onChange.bind(ctx)); }
         e();
       }
       p(0, 'change', b(ctx.change));
@@ -433,11 +405,8 @@ describe('outputs', () => {
       {
         if (ctx.condition) {
           if (V(0)) {
-            E(0, ButtonToggle.ngComponentDef);
-            {
-              D(1, ButtonToggle.ngComponentDef.n(), ButtonToggle.ngComponentDef);
-              L('change', ctx.onChange.bind(ctx));
-            }
+            E(0, ButtonToggle);
+            { L('change', ctx.onChange.bind(ctx)); }
             e();
           }
           ButtonToggle.ngComponentDef.h(1, 0);
@@ -445,11 +414,8 @@ describe('outputs', () => {
           v();
         } else {
           if (V(1)) {
-            E(0, 'div');
-            {
-              D(1, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
-              L('change', ctx.onChange.bind(ctx));
-            }
+            E(0, 'div', null, [OtherDir]);
+            { L('change', ctx.onChange.bind(ctx)); }
             e();
           }
           v();

--- a/packages/core/test/render3/properties_spec.ts
+++ b/packages/core/test/render3/properties_spec.ts
@@ -8,7 +8,7 @@
 
 import {EventEmitter} from '@angular/core';
 
-import {C, D, E, L, T, V, b, b1, c, cR, cr, defineComponent, defineDirective, e, p, t, v} from '../../src/render3/index';
+import {C, D, E, L, T, V, b, b1, cR, cr, defineComponent, defineDirective, e, p, t, v} from '../../src/render3/index';
 import {NO_CHANGE} from '../../src/render3/instructions';
 
 import {renderToHtml} from './render_util';
@@ -252,7 +252,6 @@ describe('elementProperty', () => {
           { T(2, 'Click me'); }
           e();
           C(3);
-          c();
         }
         p(0, 'id', b(ctx.id1));
         cR(3);
@@ -434,7 +433,6 @@ describe('elementProperty', () => {
           E(0, 'div', ['role', 'listbox'], [MyDir]);
           e();
           C(2);
-          c();
         }
         cR(2);
         {
@@ -495,7 +493,6 @@ describe('elementProperty', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           C(0);
-          c();
         }
         cR(0);
         {

--- a/packages/core/test/render3/properties_spec.ts
+++ b/packages/core/test/render3/properties_spec.ts
@@ -69,8 +69,8 @@ describe('elementProperty', () => {
     class MyButton {
       disabled: boolean;
 
-      static ngDirectiveDef = defineDirective(
-          {type: MyButton, factory: () => button = new MyButton(), inputs: {disabled: 'disabled'}});
+      static ngDirectiveDef =
+          defineDirective({factory: () => button = new MyButton(), inputs: {disabled: 'disabled'}});
     }
 
     class OtherDir {
@@ -78,7 +78,6 @@ describe('elementProperty', () => {
       clickStream = new EventEmitter();
 
       static ngDirectiveDef = defineDirective({
-        type: OtherDir,
         factory: () => otherDir = new OtherDir(),
         inputs: {id: 'id'},
         outputs: {clickStream: 'click'}
@@ -142,7 +141,6 @@ describe('elementProperty', () => {
 
         static ngComponentDef = defineComponent({
           tag: 'comp',
-          type: Comp,
           template: function(ctx: any, cm: boolean) {},
           factory: () => comp = new Comp(),
           inputs: {id: 'id'}
@@ -174,7 +172,6 @@ describe('elementProperty', () => {
         disabled: boolean;
 
         static ngDirectiveDef = defineDirective({
-          type: OtherDisabledDir,
           factory: () => otherDisabledDir = new OtherDisabledDir(),
           inputs: {disabled: 'disabled'}
         });
@@ -234,8 +231,8 @@ describe('elementProperty', () => {
       class IdDir {
         idNumber: number;
 
-        static ngDirectiveDef = defineDirective(
-            {type: IdDir, factory: () => idDir = new IdDir(), inputs: {idNumber: 'id'}});
+        static ngDirectiveDef =
+            defineDirective({factory: () => idDir = new IdDir(), inputs: {idNumber: 'id'}});
       }
 
       /**
@@ -297,7 +294,6 @@ describe('elementProperty', () => {
       changeStream = new EventEmitter();
 
       static ngDirectiveDef = defineDirective({
-        type: MyDir,
         factory: () => myDir = new MyDir(),
         inputs: {role: 'role', direction: 'dir'},
         outputs: {changeStream: 'change'}
@@ -308,8 +304,8 @@ describe('elementProperty', () => {
     class MyDirB {
       roleB: string;
 
-      static ngDirectiveDef = defineDirective(
-          {type: MyDirB, factory: () => dirB = new MyDirB(), inputs: {roleB: 'role'}});
+      static ngDirectiveDef =
+          defineDirective({factory: () => dirB = new MyDirB(), inputs: {roleB: 'role'}});
     }
 
     it('should set input property based on attribute if existing', () => {
@@ -472,7 +468,6 @@ describe('elementProperty', () => {
       class Comp {
         static ngComponentDef = defineComponent({
           tag: 'comp',
-          type: Comp,
           template: function(ctx: any, cm: boolean) {
             if (cm) {
               E(0, 'div', ['role', 'button'], [MyDir]);

--- a/packages/core/test/render3/properties_spec.ts
+++ b/packages/core/test/render3/properties_spec.ts
@@ -90,12 +90,8 @@ describe('elementProperty', () => {
       /** <button myButton [id]="id" [disabled]="isDisabled">Click me</button> */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'button');
-          {
-            D(1, MyButton.ngDirectiveDef.n(), MyButton.ngDirectiveDef);
-            D(2, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
-            T(3, 'Click me');
-          }
+          E(0, 'button', null, [MyButton, OtherDir]);
+          { T(3, 'Click me'); }
           e();
         }
 
@@ -120,11 +116,8 @@ describe('elementProperty', () => {
       /** <button myButton [id]="id" [disabled]="isDisabled">Click me</button> */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'button');
-          {
-            D(1, MyButton.ngDirectiveDef.n(), MyButton.ngDirectiveDef);
-            T(2, 'Click me');
-          }
+          E(0, 'button', null, [MyButton]);
+          { T(2, 'Click me'); }
           e();
         }
 
@@ -159,8 +152,7 @@ describe('elementProperty', () => {
       /** <comp [id]="id"></comp> */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, Comp.ngComponentDef);
-          { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+          E(0, Comp);
           e();
         }
         p(0, 'id', b(ctx.id));
@@ -191,12 +183,8 @@ describe('elementProperty', () => {
       /** <button myButton otherDisabledDir [disabled]="isDisabled">Click me</button> */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'button');
-          {
-            D(1, MyButton.ngDirectiveDef.n(), MyButton.ngDirectiveDef);
-            D(2, OtherDisabledDir.ngDirectiveDef.n(), OtherDisabledDir.ngDirectiveDef);
-            T(3, 'Click me');
-          }
+          E(0, 'button', null, [MyButton, OtherDisabledDir]);
+          { T(3, 'Click me'); }
           e();
         }
         p(0, 'disabled', b(ctx.isDisabled));
@@ -217,9 +205,8 @@ describe('elementProperty', () => {
       /** <button otherDir [id]="id" (click)="onClick()">Click me</button> */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'button');
+          E(0, 'button', null, [OtherDir]);
           {
-            D(1, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
             L('click', ctx.onClick.bind(ctx));
             T(2, 'Click me');
           }
@@ -261,11 +248,8 @@ describe('elementProperty', () => {
        */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'button');
-          {
-            D(1, IdDir.ngDirectiveDef.n(), IdDir.ngDirectiveDef);
-            T(2, 'Click me');
-          }
+          E(0, 'button', null, [IdDir]);
+          { T(2, 'Click me'); }
           e();
           C(3);
           c();
@@ -283,11 +267,8 @@ describe('elementProperty', () => {
             v();
           } else {
             if (V(1)) {
-              E(0, 'button');
-              {
-                D(1, OtherDir.ngDirectiveDef.n(), OtherDir.ngDirectiveDef);
-                T(2, 'Click me too');
-              }
+              E(0, 'button', null, [OtherDir]);
+              { T(2, 'Click me too'); }
               e();
             }
             p(0, 'id', b(ctx.id3));
@@ -337,8 +318,7 @@ describe('elementProperty', () => {
       /** <div role="button" myDir></div> */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'div', ['role', 'button']);
-          { D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+          E(0, 'div', ['role', 'button'], [MyDir]);
           e();
         }
       }
@@ -352,8 +332,7 @@ describe('elementProperty', () => {
       /** <div role="button" [role]="role" myDir></div> */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'div', ['role', 'button']);
-          { D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+          E(0, 'div', ['role', 'button'], [MyDir]);
           e();
         }
         p(0, 'role', b(ctx.role));
@@ -371,11 +350,7 @@ describe('elementProperty', () => {
       /** <div role="button" myDir myDirB></div> */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'div', ['role', 'button']);
-          {
-            D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef);
-            D(2, MyDirB.ngDirectiveDef.n(), MyDirB.ngDirectiveDef);
-          }
+          E(0, 'div', ['role', 'button'], [MyDir, MyDirB]);
           e();
         }
       }
@@ -390,8 +365,7 @@ describe('elementProperty', () => {
       /** <div role="button" dir="rtl" myDir></div> */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'div', ['role', 'button', 'dir', 'rtl']);
-          { D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+          E(0, 'div', ['role', 'button', 'dir', 'rtl'], [MyDir]);
           e();
         }
       }
@@ -406,11 +380,8 @@ describe('elementProperty', () => {
       /** <div role="button" (change)="onChange()" myDir></div> */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'div', ['role', 'button']);
-          {
-            D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef);
-            L('change', ctx.onChange.bind(ctx));
-          }
+          E(0, 'div', ['role', 'button'], [MyDir]);
+          { L('change', ctx.onChange.bind(ctx)); }
           e();
         }
       }
@@ -434,11 +405,9 @@ describe('elementProperty', () => {
        */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'div', ['role', 'button', 'dir', 'rtl']);
-          { D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+          E(0, 'div', ['role', 'button', 'dir', 'rtl'], [MyDir]);
           e();
-          E(2, 'div', ['role', 'listbox']);
-          { D(3, MyDirB.ngDirectiveDef.n(), MyDirB.ngDirectiveDef); }
+          E(2, 'div', ['role', 'listbox'], [MyDirB]);
           e();
         }
       }
@@ -462,8 +431,7 @@ describe('elementProperty', () => {
        */
       function Template(ctx: any, cm: boolean) {
         if (cm) {
-          E(0, 'div', ['role', 'listbox']);
-          { D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+          E(0, 'div', ['role', 'listbox'], [MyDir]);
           e();
           C(2);
           c();
@@ -472,8 +440,7 @@ describe('elementProperty', () => {
         {
           if (ctx.condition) {
             if (V(0)) {
-              E(0, 'div', ['role', 'button']);
-              { D(1, MyDirB.ngDirectiveDef.n(), MyDirB.ngDirectiveDef); }
+              E(0, 'div', ['role', 'button'], [MyDirB]);
               e();
             }
             v();
@@ -510,8 +477,7 @@ describe('elementProperty', () => {
           type: Comp,
           template: function(ctx: any, cm: boolean) {
             if (cm) {
-              E(0, 'div', ['role', 'button']);
-              { D(1, MyDir.ngDirectiveDef.n(), MyDir.ngDirectiveDef); }
+              E(0, 'div', ['role', 'button'], [MyDir]);
               e();
               T(2);
             }
@@ -535,8 +501,7 @@ describe('elementProperty', () => {
         {
           for (let i = 0; i < 2; i++) {
             if (V(0)) {
-              E(0, Comp.ngComponentDef);
-              { D(1, Comp.ngComponentDef.n(), Comp.ngComponentDef); }
+              E(0, Comp);
               e();
             }
             Comp.ngComponentDef.h(1, 0);

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -59,11 +59,11 @@ describe('query', () => {
       if (cm) {
         m(0, Q(Child, false));
         m(1, Q(Child, true));
-        E(2, Child.ngComponentDef);
+        E(2, Child);
         {
-          child1 = D(3, Child.ngComponentDef.n(), Child.ngComponentDef);
-          E(4, Child.ngComponentDef);
-          { child2 = D(5, Child.ngComponentDef.n(), Child.ngComponentDef); }
+          child1 = D(3);
+          E(4, Child);
+          { child2 = D(5); }
           e();
         }
         e();
@@ -92,8 +92,7 @@ describe('query', () => {
         let tmp: any;
         if (cm) {
           m(0, Q(Child, false, QueryReadType.ElementRef));
-          elToQuery = E(1, 'div');
-          { D(2, Child.ngDirectiveDef.n(), Child.ngDirectiveDef); }
+          elToQuery = E(1, 'div', null, [Child]);
           e();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -121,11 +120,8 @@ describe('query', () => {
         let tmp: any;
         if (cm) {
           m(0, Q(Child, false, OtherChild));
-          E(1, 'div');
-          {
-            D(2, Child.ngDirectiveDef.n(), Child.ngDirectiveDef);
-            D(3, otherChildInstance = OtherChild.ngDirectiveDef.n(), OtherChild.ngDirectiveDef);
-          }
+          E(1, 'div', null, [Child, OtherChild]);
+          { otherChildInstance = D(3); }
           e();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -150,8 +146,7 @@ describe('query', () => {
         let tmp: any;
         if (cm) {
           m(0, Q(Child, false, OtherChild));
-          E(1, 'div');
-          { D(2, Child.ngDirectiveDef.n(), Child.ngDirectiveDef); }
+          E(1, 'div', null, [Child]);
           e();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -179,7 +174,7 @@ describe('query', () => {
         let tmp: any;
         if (cm) {
           m(0, Q(['foo']));
-          elToQuery = E(1, 'div', [], 'foo');
+          elToQuery = E(1, 'div', null, null, ['foo', '']);
           e();
           E(2, 'div');
           e();
@@ -209,11 +204,11 @@ describe('query', () => {
         let tmp: any;
         if (cm) {
           m(0, Q(['foo', 'bar']));
-          el1ToQuery = E(1, 'div', null, 'foo');
+          el1ToQuery = E(1, 'div', null, null, ['foo', '']);
           e();
           E(2, 'div');
           e();
-          el2ToQuery = E(3, 'div', null, 'bar');
+          el2ToQuery = E(3, 'div', null, null, ['bar', '']);
           e();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -240,7 +235,7 @@ describe('query', () => {
         let tmp: any;
         if (cm) {
           m(0, Q(['foo'], false, QueryReadType.ElementRef));
-          elToQuery = E(1, 'div', [], 'foo');
+          elToQuery = E(1, 'div', null, null, ['foo', '']);
           e();
           E(2, 'div');
           e();
@@ -266,7 +261,7 @@ describe('query', () => {
         let tmp: any;
         if (cm) {
           m(0, Q(['foo'], false, QueryReadType.ViewContainerRef));
-          E(1, 'div', [], 'foo');
+          E(1, 'div', null, null, ['foo', '']);
           e();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -289,7 +284,7 @@ describe('query', () => {
         let tmp: any;
         if (cm) {
           m(0, Q(['foo'], false, QueryReadType.ViewContainerRef));
-          C(1, undefined, undefined, undefined, 'foo');
+          C(1, undefined, undefined, undefined, undefined, ['foo', '']);
           c();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -313,7 +308,7 @@ describe('query', () => {
            let tmp: any;
            if (cm) {
              m(0, Q(['foo'], false, QueryReadType.ElementRef));
-             C(1, undefined, undefined, undefined, 'foo');
+             C(1, undefined, undefined, undefined, undefined, ['foo', '']);
              c();
            }
            qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -338,7 +333,7 @@ describe('query', () => {
         let tmp: any;
         if (cm) {
           m(0, Q(['foo']));
-          C(1, undefined, undefined, undefined, 'foo');
+          C(1, undefined, undefined, undefined, undefined, ['foo', '']);
           c();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -362,7 +357,7 @@ describe('query', () => {
         let tmp: any;
         if (cm) {
           m(0, Q(['foo'], false, QueryReadType.TemplateRef));
-          C(1, undefined, undefined, undefined, 'foo');
+          C(1, undefined, undefined, undefined, undefined, ['foo', '']);
           c();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -388,8 +383,8 @@ describe('query', () => {
         let tmp: any;
         if (cm) {
           m(0, Q(['foo']));
-          E(1, Child.ngComponentDef, []);
-          { childInstance = D(2, Child.ngComponentDef.n(), Child.ngComponentDef, 'foo'); }
+          E(1, Child, null, null, ['foo', '']);
+          { childInstance = D(2); }
           e();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -403,7 +398,7 @@ describe('query', () => {
 
     it('should read directive instance if element queried for has an exported directive with a matching name',
        () => {
-         const Child = createDirective();
+         const Child = createDirective({exportAs: 'child'});
 
          let childInstance;
          /**
@@ -416,8 +411,8 @@ describe('query', () => {
            let tmp: any;
            if (cm) {
              m(0, Q(['foo']));
-             E(1, 'div');
-             { childInstance = D(2, Child.ngDirectiveDef.n(), Child.ngDirectiveDef, 'foo'); }
+             E(1, 'div', null, [Child], ['foo', 'child']);
+             childInstance = D(2);
              e();
            }
            qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -430,8 +425,8 @@ describe('query', () => {
        });
 
     it('should read all matching directive instances from a given element', () => {
-      const Child1 = createDirective();
-      const Child2 = createDirective();
+      const Child1 = createDirective({exportAs: 'child1'});
+      const Child2 = createDirective({exportAs: 'child2'});
 
       let child1Instance, child2Instance;
       /**
@@ -444,10 +439,10 @@ describe('query', () => {
         let tmp: any;
         if (cm) {
           m(0, Q(['foo', 'bar']));
-          E(1, 'div');
+          E(1, 'div', null, [Child1, Child2], ['foo', 'child1', 'bar', 'child2']);
           {
-            child1Instance = D(2, Child1.ngDirectiveDef.n(), Child1.ngDirectiveDef, 'foo');
-            child2Instance = D(3, Child2.ngDirectiveDef.n(), Child2.ngDirectiveDef, 'bar');
+            child1Instance = D(2);
+            child2Instance = D(3);
           }
           e();
         }
@@ -462,7 +457,7 @@ describe('query', () => {
     });
 
     it('should match match on exported directive name and read a requested token', () => {
-      const Child = createDirective();
+      const Child = createDirective({exportAs: 'child'});
 
       let div;
       /**
@@ -475,8 +470,7 @@ describe('query', () => {
         let tmp: any;
         if (cm) {
           m(0, Q(['foo'], undefined, QueryReadType.ElementRef));
-          div = E(1, 'div');
-          { D(2, Child.ngDirectiveDef.n(), Child.ngDirectiveDef, 'foo'); }
+          div = E(1, 'div', null, [Child], ['foo', 'child']);
           e();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -489,7 +483,7 @@ describe('query', () => {
     });
 
     it('should support reading a mix of ElementRef and directive instances', () => {
-      const Child = createDirective();
+      const Child = createDirective({exportAs: 'child'});
 
       let childInstance, div;
       /**
@@ -502,8 +496,8 @@ describe('query', () => {
         let tmp: any;
         if (cm) {
           m(0, Q(['foo', 'bar']));
-          div = E(1, 'div', [], 'foo');
-          { childInstance = D(2, Child.ngDirectiveDef.n(), Child.ngDirectiveDef, 'bar'); }
+          div = E(1, 'div', null, [Child], ['foo', '', 'bar', 'child']);
+          { childInstance = D(2); }
           e();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -530,7 +524,7 @@ describe('query', () => {
         let tmp: any;
         if (cm) {
           m(0, Q(['foo'], false, Child));
-          div = E(1, 'div', [], 'foo');
+          div = E(1, 'div', null, null, ['foo', '']);
           e();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {C, D, E, Q, QueryList, c, e, m, qR} from '../../src/render3/index';
+import {C, D, E, Q, QueryList, e, m, qR} from '../../src/render3/index';
 import {QueryReadType} from '../../src/render3/interfaces/query';
 
 import {createComponent, createDirective, renderComponent} from './render_util';
@@ -285,7 +285,6 @@ describe('query', () => {
         if (cm) {
           m(0, Q(['foo'], false, QueryReadType.ViewContainerRef));
           C(1, undefined, undefined, undefined, undefined, ['foo', '']);
-          c();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
       });
@@ -309,7 +308,6 @@ describe('query', () => {
            if (cm) {
              m(0, Q(['foo'], false, QueryReadType.ElementRef));
              C(1, undefined, undefined, undefined, undefined, ['foo', '']);
-             c();
            }
            qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
          });
@@ -334,7 +332,6 @@ describe('query', () => {
         if (cm) {
           m(0, Q(['foo']));
           C(1, undefined, undefined, undefined, undefined, ['foo', '']);
-          c();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
       });
@@ -358,7 +355,6 @@ describe('query', () => {
         if (cm) {
           m(0, Q(['foo'], false, QueryReadType.TemplateRef));
           C(1, undefined, undefined, undefined, undefined, ['foo', '']);
-          c();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
       });

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -7,6 +7,7 @@
  */
 
 import {stringifyElement} from '@angular/platform-browser/testing/src/browser_util';
+import {DirectiveDefArgs} from '../../src/render3/definition_interfaces';
 import {ComponentTemplate, ComponentType, DirectiveType, PublicFeature, defineComponent, defineDirective, renderComponent as _renderComponent} from '../../src/render3/index';
 import {NG_HOST_SYMBOL, createLNode, createLView, renderTemplate} from '../../src/render3/instructions';
 import {LElementNode, LNodeFlags} from '../../src/render3/interfaces/node';
@@ -89,12 +90,13 @@ export function createComponent(
   };
 }
 
-export function createDirective(): DirectiveType<any> {
+export function createDirective({exportAs}: {exportAs?: string} = {}): DirectiveType<any> {
   return class Directive {
     static ngDirectiveDef = defineDirective({
       type: Directive,
       factory: () => new Directive(),
       features: [PublicFeature],
+      exportAs: exportAs,
     });
   };
 }

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -7,11 +7,13 @@
  */
 
 import {stringifyElement} from '@angular/platform-browser/testing/src/browser_util';
-import {DirectiveDefArgs} from '../../src/render3/definition_interfaces';
+
 import {ComponentTemplate, ComponentType, DirectiveType, PublicFeature, defineComponent, defineDirective, renderComponent as _renderComponent} from '../../src/render3/index';
 import {NG_HOST_SYMBOL, createLNode, createLView, renderTemplate} from '../../src/render3/instructions';
+import {DirectiveDefArgs} from '../../src/render3/interfaces/definition';
 import {LElementNode, LNodeFlags} from '../../src/render3/interfaces/node';
 import {RElement, RText, Renderer3, RendererFactory3, domRendererFactory3} from '../../src/render3/interfaces/renderer';
+
 import {getRendererFactory2} from './imported_renderer2';
 
 export const document = ((global || window) as any).document;
@@ -80,20 +82,14 @@ export function createComponent(
     name: string, template: ComponentTemplate<any>): ComponentType<any> {
   return class Component {
     value: any;
-    static ngComponentDef = defineComponent({
-      type: Component,
-      tag: name,
-      factory: () => new Component,
-      template: template,
-      features: [PublicFeature]
-    });
+    static ngComponentDef = defineComponent(
+        {tag: name, factory: () => new Component, template: template, features: [PublicFeature]});
   };
 }
 
 export function createDirective({exportAs}: {exportAs?: string} = {}): DirectiveType<any> {
   return class Directive {
     static ngDirectiveDef = defineDirective({
-      type: Directive,
       factory: () => new Directive(),
       features: [PublicFeature],
       exportAs: exportAs,

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -29,7 +29,6 @@ describe('renderer factory lifecycle', () => {
 
   class SomeComponent {
     static ngComponentDef = defineComponent({
-      type: SomeComponent,
       tag: 'some-component',
       template: function(ctx: SomeComponent, cm: boolean) {
         logs.push('component');
@@ -43,7 +42,6 @@ describe('renderer factory lifecycle', () => {
 
   class SomeComponentWhichThrows {
     static ngComponentDef = defineComponent({
-      type: SomeComponentWhichThrows,
       tag: 'some-component-with-Error',
       template: function(ctx: SomeComponentWhichThrows, cm: boolean) {
         throw(new Error('SomeComponentWhichThrows threw'));
@@ -122,7 +120,6 @@ describe('animation renderer factory', () => {
 
   class SomeComponent {
     static ngComponentDef = defineComponent({
-      type: SomeComponent,
       tag: 'some-component',
       template: function(ctx: SomeComponent, cm: boolean) {
         if (cm) {
@@ -139,7 +136,6 @@ describe('animation renderer factory', () => {
       eventLogs.push(`${event.fromState ? event.fromState : event.toState} - ${event.phaseName}`);
     }
     static ngComponentDef = defineComponent({
-      type: SomeComponentWithAnimation,
       tag: 'some-component',
       template: function(ctx: SomeComponentWithAnimation, cm: boolean) {
         if (cm) {

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -63,8 +63,7 @@ describe('renderer factory lifecycle', () => {
     logs.push('function_with_component');
     if (cm) {
       T(0, 'bar');
-      E(1, SomeComponent.ngComponentDef);
-      { D(2, SomeComponent.ngComponentDef.n(), SomeComponent.ngComponentDef); }
+      E(1, SomeComponent);
       e();
     }
     SomeComponent.ngComponentDef.h(2, 1);


### PR DESCRIPTION

This PR is a beginning of canonical compiler examples (What do we expect the compiler to generate).

While doing this PR I ran into some issue and was forced to refactor:

1. Directives need to be passed into the `E` instructions since instantiation order can't be determined without breaking locality principle. Current implementation is a bit of a hack, follow on PR will create proper implementation.

2. The way queries register the local names is not consistent with the locality rule. In process of making new API, currently all of the query tests are broken. The local name `#local-name` on the element and the `exportAs` have to be resolved at runtime. /cc @pkozlowski-opensource 
  