### PR TITLE
docs(aio): add check for `ProgressEvent` inside `HttpErrorResponse` handler

### DIFF
--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -143,7 +143,7 @@ http
   .subscribe(
     data => {...},
     (err: HttpErrorResponse) => {
-      if (err.error instanceof Error) {
+      if (err.error instanceof Error || err.error instanceof ProgressEvent) {
         // A client-side or network error occurred. Handle it accordingly.
         console.log('An error occurred:', err.error.message);
       } else {


### PR DESCRIPTION
According to the spec (https://xhr.spec.whatwg.org/#event-xhr-error),
XHR errors are instances of ProgressEvent,
so the existing check (e.error instance of Error) won't catch them.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
