### PR TITLE
test(common): make date pipe tests work in more timezones

### DIFF
--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -263,10 +263,10 @@ import localeTh from '@angular/common/locales/th';
       });
 
       it('should format invalid in IE ISO date',
-         () => expect(pipe.transform('2017-01-11T09:25:14.014-0500')).toEqual('Jan 11, 2017'));
+         () => expect(pipe.transform('2017-01-11T12:00:00.014-0500')).toEqual('Jan 11, 2017'));
 
       it('should format invalid in Safari ISO date',
-         () => expect(pipe.transform('2017-01-20T19:00:00+0000')).toEqual('Jan 20, 2017'));
+         () => expect(pipe.transform('2017-01-20T12:00:00+0000')).toEqual('Jan 20, 2017'));
 
       // test for the following bugs:
       // https://github.com/angular/angular/issues/9524


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Other... Please describe: tests
```

## What is the current behavior?
Some date pipe tests use a time that will return a different date depending on the timezone of the machine running the tests

Issue Number: #21112


## What is the new behavior?
We set the time to 12h00 so that the test passes in all timezones

## Does this PR introduce a breaking change?
```
[x] No
```