### PR TITLE
refactor(core): create consistent naming scheme across classes

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -14,8 +14,8 @@ import {EmbeddedViewRef as viewEngine_EmbeddedViewRef} from '../linker/view_ref'
 
 import {assertNotNull} from './assert';
 import {ComponentDef, ComponentType} from './definition_interfaces';
-import {NG_HOST_SYMBOL, createError, createViewState, directive, enterView, hostElement, leaveView, locateHostElement, renderComponentOrTemplate} from './instructions';
-import {LElement} from './interfaces';
+import {NG_HOST_SYMBOL, createError, createLView, directive, enterView, hostElement, leaveView, locateHostElement, renderComponentOrTemplate} from './instructions';
+import {LElementNode} from './interfaces';
 import {RElement, Renderer3, RendererFactory3, domRendererFactory3} from './renderer';
 import {notImplemented, stringify} from './util';
 
@@ -170,7 +170,7 @@ export function renderComponent<T>(
   let component: T;
   const hostNode = locateHostElement(rendererFactory, opts.host || componentDef.tag);
   const oldView = enterView(
-      createViewState(-1, rendererFactory.createRenderer(hostNode, componentDef.rendererType), []),
+      createLView(-1, rendererFactory.createRenderer(hostNode, componentDef.rendererType), []),
       null !);
   try {
     // Create element node at index 0 in data array
@@ -188,7 +188,7 @@ export function renderComponent<T>(
 
 export function detectChanges<T>(component: T) {
   ngDevMode && assertNotNull(component, 'component');
-  const hostNode = (component as any)[NG_HOST_SYMBOL] as LElement;
+  const hostNode = (component as any)[NG_HOST_SYMBOL] as LElementNode;
   if (ngDevMode && !hostNode) {
     createError('Not a directive instance', component);
   }
@@ -208,5 +208,5 @@ export function markDirty<T>(
 }
 
 export function getHostElement<T>(component: T): RElement {
-  return ((component as any)[NG_HOST_SYMBOL] as LElement).native;
+  return ((component as any)[NG_HOST_SYMBOL] as LElementNode).native;
 }

--- a/packages/core/src/render3/node_selector_matcher.ts
+++ b/packages/core/src/render3/node_selector_matcher.ts
@@ -10,7 +10,7 @@ import './ng_dev_mode';
 
 import {assertNotNull} from './assert';
 import {CssSelector, CssSelectorWithNegations, SimpleCssSelector} from './interfaces';
-import {LNodeStatic} from './l_node_static';
+import {TNode} from './t_node';
 
 function isCssClassMatching(nodeClassAttrVal: string, cssClassToMatch: string): boolean {
   const nodeClassesLen = nodeClassAttrVal.length;
@@ -33,14 +33,13 @@ function isCssClassMatching(nodeClassAttrVal: string, cssClassToMatch: string): 
  * @param selector
  * @returns true if node matches the selector.
  */
-export function isNodeMatchingSimpleSelector(
-    lNodeStaticData: LNodeStatic, selector: SimpleCssSelector): boolean {
+export function isNodeMatchingSimpleSelector(tNode: TNode, selector: SimpleCssSelector): boolean {
   const noOfSelectorParts = selector.length;
   ngDevMode && assertNotNull(selector[0], 'selector[0]');
   const tagNameInSelector = selector[0];
 
   // check tag tame
-  if (tagNameInSelector !== '' && tagNameInSelector !== lNodeStaticData.tagName) {
+  if (tagNameInSelector !== '' && tagNameInSelector !== tNode.tagName) {
     return false;
   }
 
@@ -50,11 +49,11 @@ export function isNodeMatchingSimpleSelector(
   }
 
   // short-circuit case where an element has no attrs but a selector tries to match some
-  if (noOfSelectorParts > 1 && !lNodeStaticData.attrs) {
+  if (noOfSelectorParts > 1 && !tNode.attrs) {
     return false;
   }
 
-  const attrsInNode = lNodeStaticData.attrs !;
+  const attrsInNode = tNode.attrs !;
 
   for (let i = 1; i < noOfSelectorParts; i += 2) {
     const attrNameInSelector = selector[i];
@@ -84,10 +83,9 @@ export function isNodeMatchingSimpleSelector(
 }
 
 export function isNodeMatchingSelectorWithNegations(
-    lNodeStaticData: LNodeStatic, selector: CssSelectorWithNegations): boolean {
+    tNode: TNode, selector: CssSelectorWithNegations): boolean {
   const positiveSelector = selector[0];
-  if (positiveSelector != null &&
-      !isNodeMatchingSimpleSelector(lNodeStaticData, positiveSelector)) {
+  if (positiveSelector != null && !isNodeMatchingSimpleSelector(tNode, positiveSelector)) {
     return false;
   }
 
@@ -96,7 +94,7 @@ export function isNodeMatchingSelectorWithNegations(
   if (negativeSelectors) {
     for (let i = 0; i < negativeSelectors.length; i++) {
       // if one of negative selectors matched than the whole selector doesn't match
-      if (isNodeMatchingSimpleSelector(lNodeStaticData, negativeSelectors[i])) {
+      if (isNodeMatchingSimpleSelector(tNode, negativeSelectors[i])) {
         return false;
       }
     }
@@ -105,10 +103,9 @@ export function isNodeMatchingSelectorWithNegations(
   return true;
 }
 
-export function isNodeMatchingSelector(
-    lNodeStaticData: LNodeStatic, selector: CssSelector): boolean {
+export function isNodeMatchingSelector(tNode: TNode, selector: CssSelector): boolean {
   for (let i = 0; i < selector.length; i++) {
-    if (isNodeMatchingSelectorWithNegations(lNodeStaticData, selector[i])) {
+    if (isNodeMatchingSelectorWithNegations(tNode, selector[i])) {
       return true;
     }
   }

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -18,9 +18,11 @@ import {Type} from '../type';
 import {assertNotNull} from './assert';
 import {DirectiveDef} from './definition_interfaces';
 import {getOrCreateContainerRef, getOrCreateElementRef, getOrCreateNodeInjectorForNode, getOrCreateTemplateRef} from './di';
-import {LContainer, LElement, LNode, LNodeFlags, LNodeInjector, LView, QueryReadType, QueryState} from './interfaces';
-import {LNodeStatic} from './l_node_static';
+import {LContainerNode, LElementNode, LInjector, LNode, LNodeFlags, LQuery, LViewNode, QueryReadType} from './interfaces';
 import {assertNodeOfPossibleTypes} from './node_assert';
+import {TNode} from './t_node';
+
+
 
 /**
  * A predicate which determines if a given element/directive should be included in the query
@@ -37,7 +39,7 @@ export interface QueryPredicate<T> {
   list: QueryList<T>;
 
   /**
-   * If looking for directives than it contains the directive type.
+   * If looking for directives then it contains the directive type.
    */
   type: Type<T>|null;
 
@@ -59,7 +61,7 @@ export interface QueryPredicate<T> {
   values: any[];
 }
 
-export class QueryState_ implements QueryState {
+export class LQuery_ implements LQuery {
   shallow: QueryPredicate<any>|null = null;
   deep: QueryPredicate<any>|null = null;
 
@@ -78,9 +80,9 @@ export class QueryState_ implements QueryState {
     }
   }
 
-  child(): QueryState|null {
+  child(): LQuery|null {
     if (this.deep === null) {
-      // if we don't have any deep queries than no need to track anything more.
+      // if we don't have any deep queries then no need to track anything more.
       return null;
     }
     if (this.shallow === null) {
@@ -89,7 +91,7 @@ export class QueryState_ implements QueryState {
       return this;
     } else {
       // We need to create new state
-      return new QueryState_(this.deep);
+      return new LQuery_(this.deep);
     }
   }
 
@@ -98,11 +100,11 @@ export class QueryState_ implements QueryState {
     add(this.deep, node);
   }
 
-  insertView(container: LContainer, view: LView, index: number): void {
+  insertView(container: LContainerNode, view: LViewNode, index: number): void {
     throw new Error('Method not implemented.');
   }
 
-  removeView(container: LContainer, view: LView, index: number): void {
+  removeView(container: LContainerNode, view: LViewNode, index: number): void {
     throw new Error('Method not implemented.');
   }
 }
@@ -111,12 +113,12 @@ export class QueryState_ implements QueryState {
  * Iterates over local names for a given node and returns directive index
  * (or -1 if a local name points to an element).
  *
- * @param staticData static data of a node to check
+ * @param tNode static data of a node to check
  * @param selector selector to match
  * @returns directive index, -1 or null if a selector didn't match any of the local names
  */
-function getIdxOfMatchingSelector(staticData: LNodeStatic, selector: string): number|null {
-  const localNames = staticData.localNames;
+function getIdxOfMatchingSelector(tNode: TNode, selector: string): number|null {
+  const localNames = tNode.localNames;
   if (localNames) {
     for (let i = 0; i < localNames.length; i += 2) {
       if (localNames[i] === selector) {
@@ -148,7 +150,7 @@ function geIdxOfMatchingDirective(node: LNode, type: Type<any>): number|null {
   return null;
 }
 
-function readDefaultInjectable(nodeInjector: LNodeInjector, node: LNode): viewEngine_ElementRef|
+function readDefaultInjectable(nodeInjector: LInjector, node: LNode): viewEngine_ElementRef|
     viewEngine_TemplateRef<any>|undefined {
   ngDevMode && assertNodeOfPossibleTypes(node, LNodeFlags.Container, LNodeFlags.Element);
   if ((node.flags & LNodeFlags.TYPE_MASK) === LNodeFlags.Element) {
@@ -159,7 +161,7 @@ function readDefaultInjectable(nodeInjector: LNodeInjector, node: LNode): viewEn
 }
 
 function readFromNodeInjector(
-    nodeInjector: LNodeInjector, node: LNode, read: QueryReadType | Type<any>): any {
+    nodeInjector: LInjector, node: LNode, read: QueryReadType | Type<any>): any {
   if (read === QueryReadType.ElementRef) {
     return getOrCreateElementRef(nodeInjector);
   } else if (read === QueryReadType.ViewContainerRef) {
@@ -176,7 +178,7 @@ function readFromNodeInjector(
 }
 
 function add(predicate: QueryPredicate<any>| null, node: LNode) {
-  const nodeInjector = getOrCreateNodeInjectorForNode(node as LElement | LContainer);
+  const nodeInjector = getOrCreateNodeInjectorForNode(node as LElementNode | LContainerNode);
   while (predicate) {
     const type = predicate.type;
     if (type) {
@@ -194,8 +196,8 @@ function add(predicate: QueryPredicate<any>| null, node: LNode) {
     } else {
       const selector = predicate.selector !;
       for (let i = 0; i < selector.length; i++) {
-        ngDevMode && assertNotNull(node.staticData, 'node.staticData');
-        const directiveIdx = getIdxOfMatchingSelector(node.staticData !, selector[i]);
+        ngDevMode && assertNotNull(node.tNode, 'node.tNode');
+        const directiveIdx = getIdxOfMatchingSelector(node.tNode !, selector[i]);
         // is anything on a node matching a selector?
         if (directiveIdx !== null) {
           if (predicate.read !== null) {

--- a/packages/core/src/render3/t_node.ts
+++ b/packages/core/src/render3/t_node.ts
@@ -9,7 +9,7 @@
 import {DirectiveDef} from './definition_interfaces';
 
 /** The type of the global ngStaticData array. */
-export type NgStaticData = (LNodeStatic | DirectiveDef<any>| null)[];
+export type NgStaticData = (TNode | DirectiveDef<any>| null)[];
 
 /**
  * LNode binding data (flyweight) for a particular node that is shared between all templates
@@ -22,7 +22,7 @@ export type NgStaticData = (LNodeStatic | DirectiveDef<any>| null)[];
  *
  * see: https://en.wikipedia.org/wiki/Flyweight_pattern for more on the Flyweight pattern
  */
-export interface LNodeStatic {
+export interface TNode {
   /** The tag name associated with this node. */
   tagName: string|null;
 
@@ -72,7 +72,7 @@ export interface LNodeStatic {
   outputs: PropertyAliases|null|undefined;
 
   /**
-   * If this LNodeStatic corresponds to an LContainer, the container will
+   * If this TNode corresponds to an LContainerNode, the container will
    * need to have nested static data for each of its embedded views.
    * Otherwise, nodes in embedded views with the same index as nodes
    * in their parent views will overwrite each other, as they are in
@@ -86,14 +86,14 @@ export interface LNodeStatic {
    *   [{tagName: 'button', attrs ...}, null]    // V(1) ngData
    * ]
    */
-  containerStatic: (LNodeStatic|null)[][]|null;
+  containerStatic: (TNode|null)[][]|null;
 }
 
-/** Static data for an LElement */
-export interface LElementStatic extends LNodeStatic { containerStatic: null; }
+/** Static data for an LElementNode */
+export interface TElementNode extends TNode { containerStatic: null; }
 
-/** Static data for an LContainer */
-export interface LContainerStatic extends LNodeStatic { containerStatic: (LNodeStatic|null)[][]; }
+/** Static data for an LContainerNode */
+export interface TContainerNode extends TNode { containerStatic: (TNode|null)[][]; }
 
 /**
  * This mapping is necessary so we can set input properties and output listeners

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -10,8 +10,8 @@ import {ElementRef, TemplateRef, ViewContainerRef} from '@angular/core';
 
 import {bloomAdd, bloomFindPossibleInjector} from '../../src/render3/di';
 import {C, D, E, PublicFeature, T, V, b, b2, c, cR, cr, defineDirective, e, inject, injectElementRef, injectTemplateRef, injectViewContainerRef, t, v} from '../../src/render3/index';
-import {createLNode, createViewState, enterView, getOrCreateNodeInjector, leaveView} from '../../src/render3/instructions';
-import {LNodeFlags, LNodeInjector} from '../../src/render3/interfaces';
+import {createLNode, createLView, enterView, getOrCreateNodeInjector, leaveView} from '../../src/render3/instructions';
+import {LInjector, LNodeFlags} from '../../src/render3/interfaces';
 
 import {renderToHtml} from './render_util';
 
@@ -213,7 +213,7 @@ describe('di', () => {
 
   describe('inject', () => {
     describe('bloom filter', () => {
-      let di: LNodeInjector;
+      let di: LInjector;
       beforeEach(() => {
         di = {} as any;
         di.bf0 = 0;
@@ -318,7 +318,7 @@ describe('di', () => {
 
   describe('getOrCreateNodeInjector', () => {
     it('should handle initial undefined state', () => {
-      const contentView = createViewState(-1, null !, []);
+      const contentView = createLView(-1, null !, []);
       const oldView = enterView(contentView, null !);
       try {
         const parent = createLNode(0, LNodeFlags.Element, null, null);

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -7,10 +7,10 @@
  */
 
 import {CssSelector, CssSelectorWithNegations, SimpleCssSelector} from '../../src/render3/interfaces';
-import {LNodeStatic} from '../../src/render3/l_node_static';
 import {isNodeMatchingSelector, isNodeMatchingSelectorWithNegations, isNodeMatchingSimpleSelector} from '../../src/render3/node_selector_matcher';
+import {TNode} from '../../src/render3/t_node';
 
-function testLStaticData(tagName: string, attrs: string[] | null): LNodeStatic {
+function testLStaticData(tagName: string, attrs: string[] | null): TNode {
   return {
     tagName,
     attrs,

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -8,14 +8,14 @@
 
 import {stringifyElement} from '@angular/platform-browser/testing/src/browser_util';
 import {ComponentTemplate, ComponentType, DirectiveType, PublicFeature, defineComponent, defineDirective, renderComponent as _renderComponent} from '../../src/render3/index';
-import {NG_HOST_SYMBOL, createLNode, createViewState, renderTemplate} from '../../src/render3/instructions';
-import {LElement, LNodeFlags} from '../../src/render3/interfaces';
+import {NG_HOST_SYMBOL, createLNode, createLView, renderTemplate} from '../../src/render3/instructions';
+import {LElementNode, LNodeFlags} from '../../src/render3/interfaces';
 import {RElement, RText, Renderer3, RendererFactory3, domRendererFactory3} from '../../src/render3/renderer';
 import {getRendererFactory2} from './imported_renderer2';
 
 export const document = ((global || window) as any).document;
 export let containerEl: HTMLElement = null !;
-let host: LElement|null;
+let host: LElementNode|null;
 const isRenderer2 =
     typeof process == 'object' && process.argv[3] && process.argv[3] === '--r=renderer2';
 // tslint:disable-next-line:no-console
@@ -63,7 +63,7 @@ export function renderComponent<T>(type: ComponentType<T>, rendererFactory?: Ren
 }
 
 export function toHtml<T>(componentOrElement: T | RElement): string {
-  const node = (componentOrElement as any)[NG_HOST_SYMBOL] as LElement;
+  const node = (componentOrElement as any)[NG_HOST_SYMBOL] as LElementNode;
   if (node) {
     return toHtml(node.native);
   } else {


### PR DESCRIPTION
This PR renames a number of classes so our naming pattern is consistent. We now have three prefixes:

R - Rendered objects (i.e. DOM)
L - Logical objects (one per template instance)
T - Template objects (static data saved on template function, shared across instances)

So for "Node", we have:

- `RNode`: rendered node on the DOM
- `LNode`: instance-specific data for the node
- `TNode`: static data for the node, saved on the template function

This is just a rename PR. In follow-up PRs, we'll be splitting up the code to store more in the `T` objects, so we can avoid re-doing work across instances.

Specific renames: 

- `ViewState` -> `LView`
- `ContainerState` -> `LContainer`
- `ProjectionState` -> `LProjection`
- `QueryState` -> `LQuery`

- `LElement` -> `LElementNode`
- `LText` -> `LTextNode`
- `LContainer` -> `LContainerNode`
- `LView` -> `LViewNode`  (to differentiate from new `LView`)

- `LNodeStatic` -> `TNode`
- `LElementStatic` -> `TElementNode`
- `LContainerStatic` -> `TContainerNode`

- `LNodeInjector` -> `LInjector`

