### PR TITLE
feat(aio): support multibyte character in heading

### DIFF
--- a/aio/src/app/shared/scroll.service.spec.ts
+++ b/aio/src/app/shared/scroll.service.spec.ts
@@ -136,6 +136,17 @@ describe('ScrollService', () => {
       expect(element.scrollIntoView).toHaveBeenCalled();
       expect(window.scrollBy).toHaveBeenCalled();
     });
+
+    it('should scroll to the element whose id matches the hash with encoded characters', () => {
+      const element = new MockElement();
+      location.hash = '%F0%9F%91%8D'; // 👍
+      document.getElementById.and.returnValue(element);
+
+      scrollService.scroll();
+      expect(document.getElementById).toHaveBeenCalledWith('👍');
+      expect(element.scrollIntoView).toHaveBeenCalled();
+      expect(window.scrollBy).toHaveBeenCalled();
+    });
   });
 
   describe('#scrollToElement', () => {

--- a/aio/src/app/shared/scroll.service.ts
+++ b/aio/src/app/shared/scroll.service.ts
@@ -83,6 +83,6 @@ export class ScrollService {
    * Return the hash fragment from the `PlatformLocation`, minus the leading `#`.
    */
   private getCurrentHash() {
-    return this.location.hash.replace(/^#/, '');
+    return decodeURIComponent(this.location.hash.replace(/^#/, ''));
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, Auto-generated `id` of heading element is preserve multibyte charactors set. (`ルートフォルダ`  below)
But Auto-generated **links** are using URI encoded hash. (`%E3%83%AB%E3%83%BC%E3%83%88%E3%83%95%E3%82%A9%E3%83%AB%E3%83%80`  below)

This behavior becomes a problem in the localization of aio. The ToC links for the page doesn't work well.

For example: https://angular.jp/tutorial/toh-pt0 (localization in Japanese)

![image](https://user-images.githubusercontent.com/1529180/34724777-75dae22e-f592-11e7-8ddf-aaba26d39779.png)


Issue Number: N/A


## What is the new behavior?

Decoding the URL hash before scrolling. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
