### PR TITLE
fix(common): don't convert null to a string when flushing a mock request

### DIFF
--- a/packages/common/http/testing/BUILD.bazel
+++ b/packages/common/http/testing/BUILD.bazel
@@ -5,7 +5,12 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "testing",
     testonly = 1,
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        [
+            "*.ts",
+            "src/**/*.ts",
+        ],
+    ),
     module_name = "@angular/common/http/testing",
     deps = [
         "//packages/common/http",

--- a/packages/common/http/testing/src/request.ts
+++ b/packages/common/http/testing/src/request.ts
@@ -184,26 +184,17 @@ function _maybeConvertBody(
     responseType: string, body: ArrayBuffer | Blob | string | number | Object |
         (string | number | Object | null)[] | null): ArrayBuffer|Blob|string|number|Object|
     (string | number | Object | null)[]|null {
+  if (body === null) {
+    return null;
+  }
   switch (responseType) {
     case 'arraybuffer':
-      if (body === null) {
-        return null;
-      }
       return _toArrayBufferBody(body);
     case 'blob':
-      if (body === null) {
-        return null;
-      }
       return _toBlob(body);
     case 'json':
-      if (body === null) {
-        return 'null';
-      }
       return _toJsonBody(body);
     case 'text':
-      if (body === null) {
-        return null;
-      }
       return _toTextBody(body);
     default:
       throw new Error(`Unsupported responseType: ${responseType}`);

--- a/packages/common/http/testing/test/request_spec.ts
+++ b/packages/common/http/testing/test/request_spec.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ddescribe, describe, iit, it} from '@angular/core/testing/src/testing_internal';
+
+import {HttpClient} from '../../src/client';
+import {HttpClientTestingBackend} from '../src/backend';
+
+describe('HttpClient TestRequest', () => {
+  it('accepts a null body', () => {
+    const mock = new HttpClientTestingBackend();
+    const client = new HttpClient(mock);
+
+    let resp: any;
+    client.post('/some-url', {test: 'test'}).subscribe(body => { resp = body; });
+
+    const req = mock.expectOne('/some-url');
+    req.flush(null);
+
+    expect(resp).toBeNull();
+  });
+});


### PR DESCRIPTION
A bug in TestRequest caused null response bodies to be stringified. This
change causes null to be treated faithfully.

Fixes #20744