### PR TITLE
fix(compiler): make `.ngsummary.json` files idempotent

### DIFF
--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -488,6 +488,10 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
     return assert(this.context.readFile(filePath));
   }
 
+  getOutputName(filePath: string): string {
+    return path.relative(this.getCurrentDirectory(), filePath);
+  }
+
   private hasBundleIndex(filePath: string): boolean {
     const checkBundleIndex = (directory: string): boolean => {
       let result = this.flatModuleIndexCache.get(directory);

--- a/packages/compiler/src/aot/static_symbol_resolver.ts
+++ b/packages/compiler/src/aot/static_symbol_resolver.ts
@@ -39,6 +39,12 @@ export interface StaticSymbolResolverHost {
    * `path/to/containingFile.ts` containing `import {...} from 'module-name'`.
    */
   moduleNameToFileName(moduleName: string, containingFile?: string): string|null;
+
+  /**
+   * Get a file suitable for display to the user that should be relative to the project directory
+   * or the current directory.
+   */
+  getOutputName(filePath: string): string;
 }
 
 const SUPPORTED_SCHEMA_VERSION = 4;
@@ -382,7 +388,8 @@ export class StaticSymbolResolver {
         // .ts or .d.ts, append `.ts'. Also, if it is in `node_modules`, trim the `node_module`
         // location as it is not important to finding the file.
         _originalFileMemo =
-            topLevelPath.replace(/((\.ts)|(\.d\.ts)|)$/, '.ts').replace(/^.*node_modules[/\\]/, '');
+            this.host.getOutputName(topLevelPath.replace(/((\.ts)|(\.d\.ts)|)$/, '.ts')
+                                        .replace(/^.*node_modules[/\\]/, ''));
       }
       return _originalFileMemo;
     };

--- a/packages/compiler/test/aot/static_symbol_resolver_spec.ts
+++ b/packages/compiler/test/aot/static_symbol_resolver_spec.ts
@@ -496,6 +496,8 @@ export class MockStaticSymbolResolverHost implements StaticSymbolResolverHost {
 
   getMetadataFor(moduleId: string): any { return this._getMetadataFor(moduleId); }
 
+  getOutputName(filePath: string): string { return filePath; }
+
   private _getMetadataFor(filePath: string): any {
     if (this.data[filePath] && filePath.match(TS_EXT)) {
       const text = this.data[filePath];

--- a/packages/compiler/test/aot/test_util.ts
+++ b/packages/compiler/test/aot/test_util.ts
@@ -386,6 +386,8 @@ export class MockAotCompilerHost implements AotCompilerHost {
     return resolved ? resolved.resolvedFileName : null;
   }
 
+  getOutputName(filePath: string) { return filePath; }
+
   resourceNameToFileName(resourceName: string, containingFile: string) {
     // Note: we convert package paths into relative paths to be compatible with the the
     // previous implementation of UrlResolver.

--- a/packages/language-service/src/reflector_host.ts
+++ b/packages/language-service/src/reflector_host.ts
@@ -76,4 +76,6 @@ export class ReflectorHost implements StaticSymbolResolverHost {
             .resolvedModule;
     return resolved ? resolved.resolvedFileName : null;
   }
+
+  getOutputName(filePath: string) { return filePath; }
 }


### PR DESCRIPTION
Fixes: #21432

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue Number: #21432

Full path names are written to the `.ngsummary.json` file.

## What is the new behavior?

Relative path names are written to the `.ngsummary.json` file.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
