### PR TITLE
docs(aio): Fixed typo at AOT compiler documentation

### DIFF
--- a/aio/content/guide/aot-compiler.md
+++ b/aio/content/guide/aot-compiler.md
@@ -103,7 +103,7 @@ You can control your app compilation by providing template compiler options in t
 This option tells the compiler not to produce `.metadata.json` files.
 The option is `false` by default.
 
-`.metadata.json` files contain infomration needed by the template compiler from a `.ts`
+`.metadata.json` files contain information needed by the template compiler from a `.ts`
 file that is not included in the `.d.ts` file produced by the TypeScript compiler. This information contains,
 for example, the content of annotations (such as a component's template) which TypeScript
 emits to the `.js` file but not to the `.d.ts` file.

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -39,7 +39,7 @@ export interface TemplateSource {
 
   /**
    * The version of the source. As files are modified the version should change. That is, if the
-   * `LanguageService` requesting template infomration for a source file and that file has changed
+   * `LanguageService` requesting template information for a source file and that file has changed
    * since the last time the host was asked for the file then this version string should be
    * different. No assumptions are made about the format of this string.
    *
@@ -324,7 +324,7 @@ export interface HoverTextSection {
 }
 
 /**
- * Hover infomration for a symbol at the hover location.
+ * Hover information for a symbol at the hover location.
  */
 export interface Hover {
   /**


### PR DESCRIPTION
fixed 'infomration' at AOT compiler documentation

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```

[x] Documentation content changes

```
fix(typo): 'infomration' typo at AOT Compiler documentation

docs(aio): fix typo on AOT compiler section


## What is the current behavior?
Typo 'infomration' on AOT Compiler documentation.

Issue Number: N/A


## What is the new behavior?

Typo fixed for 'information'

## Does this PR introduce a breaking change?
```
[x ] No
```

## Other information
