### PR TITLE
feat(bazel): allow ng_module rules to control whether type checking is enabled

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -74,6 +74,7 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
           "generateCodeForLibraries": False,
           "allowEmptyCodegenFiles": True,
           "enableSummariesForJit": True,
+          "fullTemplateTypeCheck": ctx.attr.type_check,
           # FIXME: wrong place to de-dupe
           "expectedOut": depset([o.path for o in expected_outs]).to_list(),
           "preserveWhitespaces": False,
@@ -261,6 +262,8 @@ NG_MODULE_ATTRIBUTES = {
       # TODO(alexeagle): change this to ".ng.html" when usages updated
       ".html",
     ]),
+
+    "type_check": attr.bool(default = True),
 
     "no_i18n": attr.bool(default = False),
 


### PR DESCRIPTION
Defaults to true which is different than `ngc` which defaults to false.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Feature
```

## What is the current behavior?

ng_module's do not type check the templates.

## What is the new behavior?

ng_module's type check the templates by default be type checking can be disabled by adding `type_check: False` in the rule.
