### PR TITLE
build: update polyfill size

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -4,17 +4,17 @@
       "gzip7": {
         "inline": 847,
         "main": 42144,
-        "polyfills": 20207
+        "polyfills": 19838
       },
       "gzip9": {
         "inline": 847,
         "main": 42083,
-        "polyfills": 20204
+        "polyfills": 19839
       },
       "uncompressed": {
         "inline": 1447,
         "main": 151639,
-        "polyfills": 61254
+        "polyfills": 59179
       }
     }
   },


### PR DESCRIPTION
[Master is failing](https://travis-ci.org/angular/angular/jobs/327479868) because the polyfills bundle has reduced in size. Probably because of zone.js release this morning?
