### PR TITLE
refactor(ivy): add TView and TContainer

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -171,7 +171,8 @@ export function renderComponent<T>(
   let component: T;
   const hostNode = locateHostElement(rendererFactory, opts.host || componentDef.tag);
   const oldView = enterView(
-      createLView(-1, rendererFactory.createRenderer(hostNode, componentDef.rendererType), []),
+      createLView(
+          -1, rendererFactory.createRenderer(hostNode, componentDef.rendererType), {data: []}),
       null !);
   try {
     // Create element node at index 0 in data array

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -207,11 +207,11 @@ export function getOrCreateInjectable<T>(di: LInjector, token: Type<T>, flags?: 
         // nothing to the "left" of it so it doesn't need a mask.
         const start = flags >> LNodeFlags.INDX_SHIFT;
 
-        const ngStaticData = node.view.ngStaticData;
+        const tData = node.view.tView.data;
         for (let i = start, ii = start + size; i < ii; i++) {
           // Get the definition for the directive at this index and, if it is injectable (diPublic),
           // and matches the given token, return the directive instance.
-          const directiveDef = ngStaticData[i] as TypedDirectiveDef<any>;
+          const directiveDef = tData[i] as TypedDirectiveDef<any>;
           if (directiveDef.diPublic && directiveDef.type == token) {
             return node.view.data[i];
           }

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -8,7 +8,7 @@
 
 import {ComponentTemplate} from './definition';
 import {LElementNode, LViewNode} from './node';
-import {LView} from './view';
+import {LView, TView} from './view';
 
 
 /** The state associated with an LContainer */
@@ -67,6 +67,24 @@ export interface LContainer {
    */
   readonly template: ComponentTemplate<any>|null;
 }
+
+/**
+ * The static equivalent of LContainer, used in TContainerNode.
+ *
+ * The container needs to store static data for each of its embedded views
+ * (TViews). Otherwise, nodes in embedded views with the same index as nodes
+ * in their parent views will overwrite each other, as they are in
+ * the same template.
+ *
+ * Each index in this array corresponds to the static data for a certain
+ * view. So if you had V(0) and V(1) in a container, you might have:
+ *
+ * [
+ *   [{tagName: 'div', attrs: ...}, null],     // V(0) TView
+ *   [{tagName: 'button', attrs ...}, null]    // V(1) TView
+ * ]
+ */
+export type TContainer = TView[];
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency
 // failure based on types.

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -14,7 +14,7 @@ import {resolveRendererType2} from '../../view/util';
  * Definition of what a template rendering function should look like.
  */
 export type ComponentTemplate<T> = {
-  (ctx: T, creationMode: boolean): void; ngStaticData?: never;
+  (ctx: T, creationMode: boolean): void; ngPrivateData?: never;
 };
 export type EmbeddedTemplate<T> = (ctx: T) => void;
 

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {LContainer} from './container';
+import {LContainer, TContainer} from './container';
 import {DirectiveDef} from './definition';
 import {LInjector} from './injector';
 import {LProjection} from './projection';
 import {LQuery} from './query';
 import {RComment, RElement, RText} from './renderer';
-import {LView} from './view';
+import {LView, TData, TView} from './view';
 
 
 /**
@@ -198,10 +198,6 @@ export interface LProjectionNode extends LNode {
   readonly parent: LElementNode|LViewNode;
 }
 
-
-/** The type of the global ngStaticData array. */
-export type NgStaticData = (TNode | DirectiveDef<any>| null)[];
-
 /**
  * LNode binding data (flyweight) for a particular node that is shared between all templates
  * of a specific type.
@@ -263,28 +259,21 @@ export interface TNode {
   outputs: PropertyAliases|null|undefined;
 
   /**
+   * The static data equivalent of LNode.data.
+   *
    * If this TNode corresponds to an LContainerNode, the container will
-   * need to have nested static data for each of its embedded views.
-   * Otherwise, nodes in embedded views with the same index as nodes
-   * in their parent views will overwrite each other, as they are in
-   * the same template.
+   * need to store separate static data for each of its views (TContainer).
    *
-   * Each index in this array corresponds to the static data for a certain
-   * view. So if you had V(0) and V(1) in a container, you might have:
-   *
-   * [
-   *   [{tagName: 'div', attrs: ...}, null],     // V(0) ngData
-   *   [{tagName: 'button', attrs ...}, null]    // V(1) ngData
-   * ]
+   * If this TNode corresponds to an LElementNode, data will be null.
    */
-  containerStatic: (TNode|null)[][]|null;
+  data: TContainer|null;
 }
 
-/** Static data for an LElementNode */
-export interface TElementNode extends TNode { containerStatic: null; }
+/** Static data for an LElementNode  */
+export interface TElementNode extends TNode { data: null; }
 
 /** Static data for an LContainerNode */
-export interface TContainerNode extends TNode { containerStatic: (TNode|null)[][]; }
+export interface TContainerNode extends TNode { data: TContainer; }
 
 /**
  * This mapping is necessary so we can set input properties and output listeners

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -129,19 +129,15 @@ export interface LView {
    * appear in the template, starting with `bindingStartIndex`.
    * We use `bindingIndex` to internally keep track of which binding
    * is currently active.
-   *
-   * NOTE: We also use data == null as a marker for creationMode. We
-   * do this by creating ViewState in incomplete state with nodes == null
-   * and we initialize it on first run.
    */
   readonly data: any[];
 
   /**
-   * The static data array for the current view. We need a reference to this so we
-   * can easily walk up the node tree in DI and get the ngStaticData array associated
-   * with a node (where the directive defs are stored).
+   * The static data for this view. We need a reference to this so we can easily walk up the
+   * node tree in DI and get the TView.data array associated with a node (where the
+   * directive defs are stored).
    */
-  ngStaticData: (TNode|DirectiveDef<any>|null)[];
+  tView: TView;
 }
 
 /** Interface necessary to work with view tree traversal */
@@ -151,6 +147,24 @@ export interface LViewOrLContainer {
   views?: LViewNode[];
   parent: LView|null;
 }
+
+/**
+ * The static data for an LView (shared between all templates of a
+ * given type).
+ *
+ * Stored on the template function as ngPrivateData.
+ */
+export interface TView { data: TData; }
+
+/**
+ * Static data that corresponds to the instance-specific data array on an LView.
+ *
+ * Each node's static data is stored in tData at the same index that it's stored
+ * in the data array. Each directive's definition is stored here at the same index
+ * as its directive instance in the data array. Any nodes that do not have static
+ * data store a null value in tData to avoid a sparse array.
+ */
+export type TData = (TNode | DirectiveDef<any>| null)[];
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency
 // failure based on types.

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -138,12 +138,12 @@ function getIdxOfMatchingSelector(tNode: TNode, selector: string): number|null {
  * @returns Index of a found directive or null when none found.
  */
 function geIdxOfMatchingDirective(node: LNode, type: Type<any>): number|null {
-  const ngStaticData = node.view.ngStaticData;
+  const tData = node.view.tView.data;
   const flags = node.flags;
   for (let i = flags >> LNodeFlags.INDX_SHIFT,
            ii = i + ((flags & LNodeFlags.SIZE_MASK) >> LNodeFlags.SIZE_SHIFT);
        i < ii; i++) {
-    const def = ngStaticData[i] as TypedDirectiveDef<any>;
+    const def = tData[i] as TypedDirectiveDef<any>;
     if (def.diPublic && def.type === type) {
       return i;
     }

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -272,7 +272,7 @@ describe('di', () => {
 
   describe('getOrCreateNodeInjector', () => {
     it('should handle initial undefined state', () => {
-      const contentView = createLView(-1, null !, []);
+      const contentView = createLView(-1, null !, {data: []});
       const oldView = enterView(contentView, null !);
       try {
         const parent = createLNode(0, LNodeFlags.Element, null, null);

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -604,22 +604,22 @@ describe('render3 integration test', () => {
         cr();
       }
 
-      expect((Template as any).ngStaticData).toBeUndefined();
+      expect((Template as any).ngPrivateData).toBeUndefined();
 
       renderToHtml(Template, {condition: true});
 
-      const oldTemplateData = (Template as any).ngStaticData;
-      const oldContainerData = (oldTemplateData as any)[0];
-      const oldElementData = oldContainerData.containerStatic[0][0];
+      const oldTemplateData = (Template as any).ngPrivateData;
+      const oldContainerData = (oldTemplateData as any).data[0];
+      const oldElementData = oldContainerData.data[0][0];
       expect(oldContainerData).not.toBeNull();
       expect(oldElementData).not.toBeNull();
 
       renderToHtml(Template, {condition: false});
       renderToHtml(Template, {condition: true});
 
-      const newTemplateData = (Template as any).ngStaticData;
-      const newContainerData = (oldTemplateData as any)[0];
-      const newElementData = oldContainerData.containerStatic[0][0];
+      const newTemplateData = (Template as any).ngPrivateData;
+      const newContainerData = (oldTemplateData as any).data[0];
+      const newElementData = oldContainerData.data[0][0];
       expect(newTemplateData === oldTemplateData).toBe(true);
       expect(newContainerData === oldContainerData).toBe(true);
       expect(newElementData === oldElementData).toBe(true);

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -18,7 +18,7 @@ function testLStaticData(tagName: string, attrs: string[] | null): TNode {
     initialInputs: undefined,
     inputs: undefined,
     outputs: undefined,
-    containerStatic: null,
+    data: null,
   };
 }
 


### PR DESCRIPTION
This PR adds `TView` and `TContainer`, which will pave the way for other planned changes like saving static data for providers.

Notes:

- We were previously storing each template's static data in an array called `ngStaticData` (`template.ngStaticData`), but this was limiting because it required all static data to be organized by node index. To support storing other properties statically, the static data on the template is now an object, `TView`, that wraps the original data array.
- `LView` used to have an `ngStaticData` property, but it now has a reference to its corresponding `TView`. 
- The data array on `LView` corresponds to the data array on `TView` (e.g. a node's instance-specific data will be stored at an index in `LView.data` and its static data will be stored at the same index in `TView.data`).
