### PR TITLE
ci(aio): run e2e tests in `production` mode

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -19,6 +19,7 @@
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn ~~update-webdriver",
     "e2e": "ng e2e --no-webdriver-update",
+    "e2e-prod": "yarn e2e --environment=dev --target=production",
     "preinstall": "node ../tools/yarn/check-yarn.js",
     "presetup": "yarn install --frozen-lockfile && yarn ~~check-env && yarn boilerplate:remove",
     "setup": "yarn aio-use-npm && yarn example-use-npm",

--- a/scripts/ci/test-aio.sh
+++ b/scripts/ci/test-aio.sh
@@ -33,7 +33,8 @@ source ${thisDir}/_travis-fold.sh
 
   # Run e2e tests
   travisFoldStart "test.aio.e2e"
-    yarn e2e
+    # Use `production` mode to catch issues introduced by build optimizations.
+    yarn e2e-prod
   travisFoldEnd "test.aio.e2e"
 
 


### PR DESCRIPTION
This will enable catching errors introduced by build optimizations that do not appear in `development` mode.

Fixes #21446.