### PR TITLE
fix(benchpress): should still support selenium_webdriver < 3.6.0

### DIFF
--- a/packages/benchpress/src/webdriver/selenium_webdriver_adapter.ts
+++ b/packages/benchpress/src/webdriver/selenium_webdriver_adapter.ts
@@ -34,7 +34,7 @@ export class SeleniumWebDriverAdapter extends WebDriverAdapter {
   capabilities(): Promise<{[key: string]: any}> {
     return this._driver.getCapabilities().then((capsObject: any) => {
       const localData: {[key: string]: any} = {};
-      for (const key of capsObject.keys()) {
+      for (const key of Array.from((<Map<string, any>>capsObject).keys())) {
         localData[key] = capsObject.get(key);
       }
       return localData;


### PR DESCRIPTION
Since https://github.com/angular/angular/pull/21399, benchmarks fail to run locally.
The reason root cause is how TS transpiles this new code. It is a known issue which was fixed in https://github.com/Microsoft/TypeScript/pull/12346 with a new option: `downlevelIteration`.

As discussed with @alexeagle, instead of changing our compiler options right now, we can also work around it.