### PR TITLE
refactor(ivy): remove unnecessary D instruction

### DIFF
--- a/modules/benchmarks/src/tree/render3/tree.ts
+++ b/modules/benchmarks/src/tree/render3/tree.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵC as C, ɵD as D, ɵE as E, ɵT as T, ɵV as V, ɵb as b, ɵb1 as b1, ɵcR as cR, ɵcr as cr, ɵdefineComponent as defineComponent, ɵdetectChanges as _detectChanges, ɵe as e, ɵp as p, ɵs as s, ɵt as t, ɵv as v} from '@angular/core';
+import {ɵC as C, ɵE as E, ɵT as T, ɵV as V, ɵb as b, ɵb1 as b1, ɵcR as cR, ɵcr as cr, ɵdefineComponent as defineComponent, ɵdetectChanges as _detectChanges, ɵe as e, ɵp as p, ɵs as s, ɵt as t, ɵv as v} from '@angular/core';
 import {ComponentDef} from '@angular/core/src/render3/interfaces/definition';
 
 import {TreeNode, buildTree, emptyTree} from '../util';

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -12,7 +12,6 @@ export {
   detectChanges as ɵdetectChanges,
   renderComponent as ɵrenderComponent,
   C as ɵC,
-  D as ɵD,
   E as ɵE,
   T as ɵT,
   V as ɵV,

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -13,7 +13,7 @@ import {ComponentRef as viewEngine_ComponentRef} from '../linker/component_facto
 import {EmbeddedViewRef as viewEngine_EmbeddedViewRef} from '../linker/view_ref';
 
 import {assertNotNull} from './assert';
-import {NG_HOST_SYMBOL, createError, createLView, directive, directiveCreate, enterView, hostElement, leaveView, locateHostElement, renderComponentOrTemplate} from './instructions';
+import {NG_HOST_SYMBOL, createError, createLView, directiveCreate, enterView, hostElement, leaveView, locateHostElement, renderComponentOrTemplate} from './instructions';
 import {ComponentDef, ComponentType, TypedComponentDef} from './interfaces/definition';
 import {LElementNode} from './interfaces/node';
 import {RElement, Renderer3, RendererFactory3, domRendererFactory3} from './interfaces/renderer';

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -43,8 +43,6 @@ export {
   containerRefreshStart as cR,
   containerRefreshEnd as cr,
 
-  directive as D,
-
   elementAttribute as a,
   elementClass as k,
   elementEnd as e,

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -901,20 +901,6 @@ export function textBinding<T>(index: number, value: T | NO_CHANGE): void {
 //////////////////////////
 
 /**
- * Retrieve a directive.
- *
- * NOTE: directives can be created in order other than the index order. They can also
- *       be retrieved before they are created in which case the value will be null.
- *
- * @param index Each directive in a `View` will have a unique index. Directives can
- *        be created or retrieved out of order.
- */
-export function directive<T>(index: number): T {
-  ngDevMode && assertDataInRange(index);
-  return data[index];
-}
-
-/**
  * Create a directive.
  *
  * NOTE: directives can be created in order other than the index order. They can also

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ViewEncapsulation} from '../../src/core';
-import {D, E, T, b, defineComponent, e, markDirty, t} from '../../src/render3/index';
+import {E, T, b, defineComponent, e, markDirty, t} from '../../src/render3/index';
 import {createRendererType2} from '../../src/view/index';
 
 import {getRendererFactory2} from './imported_renderer2';

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, P, T, V, cR, cr, detectChanges, e, m, pD, v} from '../../src/render3/index';
+import {C, E, P, T, V, cR, cr, detectChanges, e, m, pD, v} from '../../src/render3/index';
 
 import {createComponent, renderComponent, toHtml} from './render_util';
 
@@ -266,7 +266,7 @@ describe('content projection', () => {
       if (cm) {
         E(0, Child);
         {
-          childCmptInstance = D(1);
+          childCmptInstance = m(1);
           T(2, 'content');
         }
         e();
@@ -319,7 +319,7 @@ describe('content projection', () => {
          if (cm) {
            E(0, Child);
            {
-             childCmptInstance = D(1);
+             childCmptInstance = m(1);
              T(2, 'content');
            }
            e();
@@ -414,7 +414,7 @@ describe('content projection', () => {
       if (cm) {
         E(0, Child);
         {
-          childCmptInstance = D(1);
+          childCmptInstance = m(1);
           T(2, 'content');
         }
         e();

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -9,7 +9,7 @@
 import {ElementRef, TemplateRef, ViewContainerRef} from '@angular/core';
 
 import {bloomAdd, bloomFindPossibleInjector} from '../../src/render3/di';
-import {C, D, E, PublicFeature, T, V, b, b2, cR, cr, defineDirective, e, inject, injectElementRef, injectTemplateRef, injectViewContainerRef, t, v} from '../../src/render3/index';
+import {C, E, PublicFeature, T, V, b, b2, cR, cr, defineDirective, e, inject, injectElementRef, injectTemplateRef, injectViewContainerRef, m, t, v} from '../../src/render3/index';
 import {createLNode, createLView, enterView, getOrCreateNodeInjector, leaveView} from '../../src/render3/instructions';
 import {LInjector} from '../../src/render3/interfaces/injector';
 import {LNodeFlags} from '../../src/render3/interfaces/node';
@@ -30,7 +30,7 @@ describe('di', () => {
           { T(2); }
           e();
         }
-        t(2, b(D<Directive>(1).value));
+        t(2, b(m<Directive>(1).value));
       }
 
       expect(renderToHtml(Template, {})).toEqual('<div>Created</div>');
@@ -68,7 +68,7 @@ describe('di', () => {
           }
           e();
         }
-        t(5, b(D<DirectiveC>(4).value));
+        t(5, b(m<DirectiveC>(4).value));
       }
 
       expect(renderToHtml(Template, {})).toEqual('<div><span>AB</span></div>');
@@ -101,7 +101,7 @@ describe('di', () => {
           { T(3); }
           e();
         }
-        t(3, b2('', D<Directive>(1).value, '-', D<DirectiveSameInstance>(2).value, ''));
+        t(3, b2('', m<Directive>(1).value, '-', m<DirectiveSameInstance>(2).value, ''));
       }
 
       expect(renderToHtml(Template, {})).toEqual('<div>ElementRef-true</div>');
@@ -134,7 +134,7 @@ describe('di', () => {
           C(0, [Directive, DirectiveSameInstance], function() {});
           T(3);
         }
-        t(3, b2('', D<Directive>(1).value, '-', D<DirectiveSameInstance>(2).value, ''));
+        t(3, b2('', m<Directive>(1).value, '-', m<DirectiveSameInstance>(2).value, ''));
       }
 
       expect(renderToHtml(Template, {})).toEqual('TemplateRef-true');
@@ -168,7 +168,7 @@ describe('di', () => {
           { T(3); }
           e();
         }
-        t(3, b2('', D<Directive>(1).value, '-', D<DirectiveSameInstance>(2).value, ''));
+        t(3, b2('', m<Directive>(1).value, '-', m<DirectiveSameInstance>(2).value, ''));
       }
 
       expect(renderToHtml(Template, {})).toEqual('<div>ViewContainerRef-true</div>');
@@ -256,7 +256,7 @@ describe('di', () => {
             { T(3); }
             e();
           }
-          t(3, b2('', D<ChildDirective>(1).value, '-', D<Child2Directive>(2).value, ''));
+          t(3, b2('', m<ChildDirective>(1).value, '-', m<Child2Directive>(2).value, ''));
           v();
         }
         cr();

--- a/packages/core/test/render3/directive_spec.ts
+++ b/packages/core/test/render3/directive_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {D, E, b, defineDirective, e, p} from '../../src/render3/index';
+import {E, b, defineDirective, e, m, p} from '../../src/render3/index';
 
 import {renderToHtml} from './render_util';
 
@@ -22,7 +22,7 @@ describe('directive', () => {
         static ngDirectiveDef = defineDirective({
           factory: () => directiveInstance = new Directive,
           refresh: (directiveIndex: number, elementIndex: number) => {
-            p(elementIndex, 'className', b(D<Directive>(directiveIndex).klass));
+            p(elementIndex, 'className', b(m<Directive>(directiveIndex).klass));
           }
         });
       }

--- a/packages/core/test/render3/exports_spec.ts
+++ b/packages/core/test/render3/exports_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, T, V, a, b, cR, cr, defineComponent, defineDirective, e, k, p, t, v} from '../../src/render3/index';
+import {C, E, T, V, a, b, cR, cr, defineComponent, defineDirective, e, k, m, p, t, v} from '../../src/render3/index';
 
 import {renderToHtml} from './render_util';
 
@@ -36,7 +36,7 @@ describe('exports', () => {
         e();
         T(2);
       }
-      t(2, D<MyComponent>(1).name);
+      t(2, m<MyComponent>(1).name);
     }
 
     class MyComponent {
@@ -73,7 +73,7 @@ describe('exports', () => {
         E(2, 'div', null, [MyDir]);
         e();
       }
-      p(2, 'myDir', b(D<MyComponent>(1)));
+      p(2, 'myDir', b(m<MyComponent>(1)));
     }
 
     renderToHtml(Template, {});
@@ -89,7 +89,7 @@ describe('exports', () => {
         e();
         T(2);
       }
-      t(2, D<SomeDir>(1).name);
+      t(2, m<SomeDir>(1).name);
     }
 
     class SomeDir {
@@ -198,7 +198,7 @@ describe('exports', () => {
           E(2, MyComponent);
           e();
         }
-        p(0, 'myDir', b(D<MyComponent>(3)));
+        p(0, 'myDir', b(m<MyComponent>(3)));
       }
 
       renderToHtml(Template, {});
@@ -218,7 +218,7 @@ describe('exports', () => {
           e();
         }
         let myInput = E(4);
-        let myComp = D(3) as MyComponent;
+        let myComp = m(3) as MyComponent;
         t(0, b(myInput && (myInput as any).value));
         t(1, b(myComp && myComp.name));
       }

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, NC, T, V, a, b, b1, b2, b3, b4, b5, b6, b7, b8, bV, cR, cr, defineComponent, e, k, p, r, s, t, v} from '../../src/render3/index';
+import {C, E, NC, T, V, a, b, b1, b2, b3, b4, b5, b6, b7, b8, bV, cR, cr, defineComponent, e, k, m, p, r, s, t, v} from '../../src/render3/index';
 import {NO_CHANGE} from '../../src/render3/instructions';
 
 import {containerEl, renderToHtml} from './render_util';
@@ -290,7 +290,7 @@ describe('render3 integration test', () => {
           factory: () => cmptInstance = new TodoComponentHostBinding,
           hostBindings: function(directiveIndex: number, elementIndex: number): void {
             // host bindings
-            p(elementIndex, 'title', b(D<TodoComponentHostBinding>(directiveIndex).title));
+            p(elementIndex, 'title', b(m<TodoComponentHostBinding>(directiveIndex).title));
           }
         });
       }

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, ComponentDef, ComponentTemplate, D, E, L, LifecycleHook, T, V, b, cR, cr, defineComponent, e, l, p, r, v} from '../../src/render3/index';
+import {C, ComponentDef, ComponentTemplate, E, L, LifecycleHook, T, V, b, cR, cr, defineComponent, e, l, m, p, r, v} from '../../src/render3/index';
 
 import {containerEl, renderToHtml} from './render_util';
 
@@ -41,7 +41,7 @@ describe('lifecycles', () => {
           tag: name,
           factory: () => new Component(),
           hostBindings: function(directiveIndex: number, elementIndex: number):
-              void { l(LifecycleHook.ON_INIT) && D<Component>(directiveIndex).ngOnInit(); },
+              void { l(LifecycleHook.ON_INIT) && m<Component>(directiveIndex).ngOnInit(); },
           inputs: {val: 'val'}, template
         });
       };
@@ -274,8 +274,8 @@ describe('lifecycles', () => {
           factory: () => new Component(),
           hostBindings: function(
               this: ComponentDef<Component>, directiveIndex: number, elementIndex: number): void {
-            l(LifecycleHook.ON_INIT) && D<Component>(directiveIndex).ngOnInit();
-            D<Component>(directiveIndex).ngDoCheck();
+            l(LifecycleHook.ON_INIT) && m<Component>(directiveIndex).ngOnInit();
+            m<Component>(directiveIndex).ngDoCheck();
           },
           template
         });
@@ -365,7 +365,7 @@ describe('lifecycles', () => {
           factory: () => new Component(),
           refresh: (directiveIndex: number, elementIndex: number) => {
             r(directiveIndex, elementIndex, template);
-            const comp = D(directiveIndex) as Component;
+            const comp = m(directiveIndex) as Component;
             l(LifecycleHook.AFTER_VIEW_INIT, comp, comp.ngAfterViewInit);
             l(LifecycleHook.AFTER_VIEW_CHECKED, comp, comp.ngAfterViewChecked);
           },

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, D, E, L, T, V, cR, cr, defineComponent, e, v} from '../../src/render3/index';
+import {C, E, L, T, V, cR, cr, defineComponent, e, v} from '../../src/render3/index';
 
 import {containerEl, renderComponent, renderToHtml} from './render_util';
 

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -8,7 +8,7 @@
 
 import {EventEmitter} from '@angular/core';
 
-import {C, D, E, L, LifecycleHook, T, V, b, cR, cr, defineComponent, defineDirective, e, l, p, v} from '../../src/render3/index';
+import {C, E, L, LifecycleHook, T, V, b, cR, cr, defineComponent, defineDirective, e, l, p, v} from '../../src/render3/index';
 
 import {containerEl, renderToHtml} from './render_util';
 

--- a/packages/core/test/render3/properties_spec.ts
+++ b/packages/core/test/render3/properties_spec.ts
@@ -8,7 +8,7 @@
 
 import {EventEmitter} from '@angular/core';
 
-import {C, D, E, L, T, V, b, b1, cR, cr, defineComponent, defineDirective, e, p, t, v} from '../../src/render3/index';
+import {C, E, L, T, V, b, b1, cR, cr, defineComponent, defineDirective, e, m, p, t, v} from '../../src/render3/index';
 import {NO_CHANGE} from '../../src/render3/instructions';
 
 import {renderToHtml} from './render_util';
@@ -474,7 +474,7 @@ describe('elementProperty', () => {
               e();
               T(2);
             }
-            t(2, b(D<MyDir>(1).role));
+            t(2, b(m<MyDir>(1).role));
           },
           factory: () => new Comp()
         });

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {C, D, E, Q, QueryList, e, m, qR} from '../../src/render3/index';
+import {C, E, Q, QueryList, e, m, qR} from '../../src/render3/index';
 import {QueryReadType} from '../../src/render3/interfaces/query';
 
 import {createComponent, createDirective, renderComponent} from './render_util';
@@ -61,9 +61,9 @@ describe('query', () => {
         m(1, Q(Child, true));
         E(2, Child);
         {
-          child1 = D(3);
+          child1 = m(3);
           E(4, Child);
-          { child2 = D(5); }
+          { child2 = m(5); }
           e();
         }
         e();
@@ -121,7 +121,7 @@ describe('query', () => {
         if (cm) {
           m(0, Q(Child, false, OtherChild));
           E(1, 'div', null, [Child, OtherChild]);
-          { otherChildInstance = D(3); }
+          { otherChildInstance = m(3); }
           e();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -380,7 +380,7 @@ describe('query', () => {
         if (cm) {
           m(0, Q(['foo']));
           E(1, Child, null, null, ['foo', '']);
-          { childInstance = D(2); }
+          { childInstance = m(2); }
           e();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -408,7 +408,7 @@ describe('query', () => {
            if (cm) {
              m(0, Q(['foo']));
              E(1, 'div', null, [Child], ['foo', 'child']);
-             childInstance = D(2);
+             childInstance = m(2);
              e();
            }
            qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -437,8 +437,8 @@ describe('query', () => {
           m(0, Q(['foo', 'bar']));
           E(1, 'div', null, [Child1, Child2], ['foo', 'child1', 'bar', 'child2']);
           {
-            child1Instance = D(2);
-            child2Instance = D(3);
+            child1Instance = m(2);
+            child2Instance = m(3);
           }
           e();
         }
@@ -493,7 +493,7 @@ describe('query', () => {
         if (cm) {
           m(0, Q(['foo', 'bar']));
           div = E(1, 'div', null, [Child], ['foo', '', 'bar', 'child']);
-          { childInstance = D(2); }
+          { childInstance = m(2); }
           e();
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -10,7 +10,7 @@ import {AnimationEvent} from '@angular/animations';
 import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/browser/testing';
 
 import {RendererType2, ViewEncapsulation} from '../../src/core';
-import {D, E, L, T, b, defineComponent, detectChanges, e, p} from '../../src/render3/index';
+import {E, L, T, b, defineComponent, detectChanges, e, p} from '../../src/render3/index';
 import {createRendererType2} from '../../src/view/index';
 
 import {getAnimationRendererFactory2, getRendererFactory2} from './imported_renderer2';


### PR DESCRIPTION
This PR removes the `D()` instruction. Now that it simply retrieves the directive instance from the data array, it's functionally equivalent to the existing `m()` instruction. All `D` usages have been changed to `m`.