### PR TITLE
fix(aio): add appForbiddenName directive in hero form template

### DIFF
--- a/aio/content/examples/form-validation/src/app/template/hero-form-template.component.html
+++ b/aio/content/examples/form-validation/src/app/template/hero-form-template.component.html
@@ -12,7 +12,7 @@
         <!-- #docregion name-with-error-msg -->
         <!-- #docregion name-input -->
         <input id="name" name="name" class="form-control"
-               required minlength="4" forbiddenName="bob"
+               required minlength="4" appForbiddenName forbiddenName="bob"
                [(ngModel)]="hero.name" #name="ngModel" >
         <!-- #enddocregion name-input -->
 


### PR DESCRIPTION
add appForbiddenName to validate the input field. currently validation is not taking effect due to absence of the directive

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently example in section "Fundamentals > Forms > Form Validation"  is not validating forbidden name because appForbiddenName is not being applied on input field which accepts name. with this commit I have applied  appForbiddenName to solve the issue.

Issue Number: #20206


## What is the new behavior?
Validation is currently working as expected.
https://plnkr.co/edit/1sws9qy7rNrDGFDpvhUd?p=preview



## Does this PR introduce a breaking change?
[ ] Yes
[ x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
