### PR TITLE
perf(ivy): set ngDevMode to false in render3 benchmarks

### DIFF
--- a/modules/benchmarks/src/largetable/render3/index.html
+++ b/modules/benchmarks/src/largetable/render3/index.html
@@ -26,6 +26,8 @@
   </div>
 
   <script>
+    // TODO(mlaval): remove once we have a proper solution
+    ngDevMode = false;
     var mainUrl = window.location.search.split(/[?&]main=([^&]+)/)[1]
       || '../../bootstrap_ng2.js';
     document.write('<script src="' + mainUrl + '">\u003c/script>');

--- a/modules/benchmarks/src/tree/render3/index.html
+++ b/modules/benchmarks/src/tree/render3/index.html
@@ -28,6 +28,8 @@
   </div>
 
   <script>
+    // TODO(mlaval): remove once we have a proper solution
+    ngDevMode = false;
     var mainUrl = window.location.search.split(/[?&]main=([^&]+)/)[1]
       || '../../bootstrap_ng2.js';
     document.write('<script src="' + mainUrl + '">\u003c/script>');

--- a/modules/benchmarks/src/tree/render3_function/index.html
+++ b/modules/benchmarks/src/tree/render3_function/index.html
@@ -28,6 +28,8 @@
   </div>
 
   <script>
+    // TODO(mlaval): remove once we have a proper solution
+    ngDevMode = false;
     var mainUrl = window.location.search.split(/[?&]main=([^&]+)/)[1]
       || '../../bootstrap_ng2.js';
     document.write('<script src="' + mainUrl + '">\u003c/script>');


### PR DESCRIPTION
This is a temporary solution to run `render3` benchmarks with dev mode deactivated.

It should be properly managed at build time. But knowing that, at least locally, we run the benchmarks on not minified and not bundled code, it may mean to revisit the full process. 
