### PR TITLE
perf(ivy): add a proper creationOnly scenario to the tree benchmark

### DIFF
--- a/modules/benchmarks/e2e_test/tree_perf.ts
+++ b/modules/benchmarks/e2e_test/tree_perf.ts
@@ -23,12 +23,22 @@ describe('tree benchmark perf', () => {
 
   Benchmarks.forEach(benchmark => {
     describe(benchmark.id, () => {
+      // This is actually a destroyOnly benchmark
       it('should work for createOnly', (done) => {
         runTreeBenchmark({
           id: 'createOnly',
           benchmark,
           prepare: () => $(CreateBtn).click(),
           work: () => $(DestroyBtn).click()
+        }).then(done, done.fail);
+      });
+
+      it('should work for createOnlyForReal', (done) => {
+        runTreeBenchmark({
+          id: 'createOnlyForReal',
+          benchmark,
+          prepare: () => $(DestroyBtn).click(),
+          work: () => $(CreateBtn).click()
         }).then(done, done.fail);
       });
 


### PR DESCRIPTION
The current `createOnly` scenario of the tree benchmark is actually a `destroyOnly` scenario.

We can either:
- fix it, but loose consistency in years of benchmarks history
- keep it and create a new one which implements correctly the scenario (naming is weird in that case)

This PR is choosing the conservative option, but it can be changed.