### PR TITLE
fix(common): set correct timezone for ISO8601 dates in Safari

### DIFF
--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -275,6 +275,16 @@ import localeTh from '@angular/common/locales/th';
          () => expect(pipe.transform('2017-05-07T22:14:39', 'dd-MM-yyyy HH:mm'))
                    .toMatch(/07-05-2017 \d{2}:\d{2}/));
 
+      // test for issue https://github.com/angular/angular/issues/21491
+      it('should not assume UTC for iso strings in Safari if the timezone is not defined', () => {
+        // this test only works if the timezone is not in UTC
+        // which is the case for BrowserStack when we test Safari
+        if (new Date().getTimezoneOffset() !== 0) {
+          expect(pipe.transform('2018-01-11T13:00:00', 'HH'))
+              .not.toEqual(pipe.transform('2018-01-11T13:00:00Z', 'HH'));
+        }
+      });
+
       // test for the following bugs:
       // https://github.com/angular/angular/issues/16624
       // https://github.com/angular/angular/issues/17478


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
We have code to handle ISO8601 dates but we never reach the condition, which means that it doesn't behave correctly in Safari

Issue Number: #21491


## What is the new behavior?
We handle ISO8601 dates as expected and it works in Safari as it does in other browsers


## Does this PR introduce a breaking change?
```
[x] No
```