### PR TITLE
build(aio): move file cleaning to later in the doc gen

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -39,7 +39,6 @@
     "check-env": "yarn ~~check-env",
     "postcheck-env": "yarn aio-check-local",
     "payload-size": "scripts/payload.sh",
-    "predocs": "rimraf src/generated/{docs,*.json}",
     "docs": "dgeni ./tools/transforms/angular.io-package",
     "docs-watch": "node tools/transforms/authors-package/watchr.js",
     "docs-lint": "eslint --ignore-path=\"tools/transforms/.eslintignore\" tools/transforms",

--- a/aio/tools/transforms/angular.io-package/index.js
+++ b/aio/tools/transforms/angular.io-package/index.js
@@ -17,6 +17,7 @@ module.exports = new Package('angular.io', [gitPackage, apiPackage, contentPacka
 
   // This processor relies upon the versionInfo. See below...
   .processor(require('./processors/processNavigationMap'))
+  .processor(require('./processors/cleanGeneratedFiles'))
 
   // We don't include this in the angular-base package because the `versionInfo` stuff
   // accesses the file system and git, which is slow.

--- a/aio/tools/transforms/angular.io-package/processors/cleanGeneratedFiles.js
+++ b/aio/tools/transforms/angular.io-package/processors/cleanGeneratedFiles.js
@@ -1,0 +1,10 @@
+const rimraf = require('rimraf');
+module.exports = function cleanGeneratedFiles() {
+  return {
+    $runAfter: ['writing-files'],
+    $runBefore: ['writeFilesProcessor'],
+    $process: function() {
+      rimraf.sync('src/generated/{docs,*.json}');
+    }
+  };
+};


### PR DESCRIPTION
Previously the generated files were cleaned out before
doc-gen began (via a yarn pre-script). This can cause a
race condition in the CLI server, which prevents the new
generated files from being picked up.

Now we delay the cleaning until the last minute to ensure
that they ar still picked up by the webpack server.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
