### PR TITLE
fix(router): expose ParamsInheritanceType used by other files

### DIFF
--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -175,7 +175,6 @@ export class ActivatedRoute {
   }
 }
 
-/** @internal */
 export type ParamsInheritanceStrategy = 'emptyOnly' | 'always';
 
 /** @internal */


### PR DESCRIPTION
The @internal tag (in conjunction with the 'stripInternal' tsconfig
setting) causes this type to be stripped out of the .d.ts files, but it
still needs to be present in the offline compilation case in order to
avoid errors.

Fixes #21456.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Note: I'm not sure how to test this; the fact that the bug was introduced without breaking existing tests indicates to me a fundamental issue with the existing test coverage. See existing discussion on #8819. I don't think the existing tests are running on the .d.ts files that have been stripped of the `@internal`-tagged code. Since fixing that could take substantially more effort than this small regression fix, I am not attempting it in this PR.

/cc @alexeagle

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
See #21456.

## What is the new behavior?
`ParamsInheritanceStrategy` will not be stripped from the .d.ts files.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
