### PR TITLE
fix(router): don't use ParamsInheritanceStrategy in declarations

### DIFF
--- a/packages/router/src/pre_activation.ts
+++ b/packages/router/src/pre_activation.ts
@@ -21,7 +21,7 @@ import {reduce} from 'rxjs/operator/reduce';
 import {LoadedRouterConfig, ResolveData, RunGuardsAndResolvers} from './config';
 import {ActivationStart, ChildActivationStart, Event} from './events';
 import {ChildrenOutletContexts, OutletContext} from './router_outlet_context';
-import {ActivatedRouteSnapshot, ParamsInheritanceStrategy, RouterStateSnapshot, equalParamsAndUrlSegments, inheritedParamsDataResolve} from './router_state';
+import {ActivatedRouteSnapshot, RouterStateSnapshot, equalParamsAndUrlSegments, inheritedParamsDataResolve} from './router_state';
 import {andObservables, forEach, shallowEqual, wrapIntoObservable} from './utils/collection';
 import {TreeNode, nodeChildrenAsMap} from './utils/tree';
 
@@ -63,7 +63,7 @@ export class PreActivation {
         (canDeactivate: boolean) => canDeactivate ? this.runCanActivateChecks() : of (false));
   }
 
-  resolveData(paramsInheritanceStrategy: ParamsInheritanceStrategy): Observable<any> {
+  resolveData(paramsInheritanceStrategy: 'emptyOnly'|'always'): Observable<any> {
     if (!this.isActivating()) return of (null);
     const checks$ = from(this.canActivateChecks);
     const runningChecks$ = concatMap.call(
@@ -308,7 +308,7 @@ export class PreActivation {
 
   private runResolve(
       future: ActivatedRouteSnapshot,
-      paramsInheritanceStrategy: ParamsInheritanceStrategy): Observable<any> {
+      paramsInheritanceStrategy: 'emptyOnly'|'always'): Observable<any> {
     const resolve = future._resolve;
     return map.call(this.resolveNode(resolve, future), (resolvedData: any): any => {
       future._resolvedData = resolvedData;


### PR DESCRIPTION
ParamsInheritanceStrategy is internal, so any references to it from the
published .d.ts files will fail.

Fixes #21456.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Note: I'm not sure how to test this; the fact that the bug was introduced without breaking existing tests indicates to me a fundamental issue with the existing test coverage. See existing discussion on #8819. I don't think the existing tests are running on the .d.ts files that have been stripped of the `@internal`-tagged code. Since fixing that could take substantially more effort than this small regression fix, I am not attempting it in this PR.

/cc @alexeagle

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
See #21456.

## What is the new behavior?
`ParamsInheritanceStrategy` will not be stripped from the .d.ts files.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information