### PR TITLE
aio(build): do not limit size of gzip7 and gzip 9

### DIFF
--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -1,20 +1,12 @@
 {
   "aio": {
     "master": {
-      "gzip7": {
-        "inline": 961,
-        "main": 116924,
-        "polyfills": 12962
-      },
-      "gzip9": {
-        "inline": 961,
-        "main": 116712,
-        "polyfills": 12958
-      },
       "uncompressed": {
         "inline": 1602,
         "main": 459119,
-        "polyfills": 40264
+        "polyfills": 40264,
+        "embedded": 72537,
+        "prettify": 14888
       }
     }
   }

--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -1,16 +1,6 @@
 {
   "cli-hello-world": {
     "master": {
-      "gzip7": {
-        "inline": 847,
-        "main": 42144,
-        "polyfills": 19838
-      },
-      "gzip9": {
-        "inline": 847,
-        "main": 42083,
-        "polyfills": 19839
-      },
       "uncompressed": {
         "inline": 1447,
         "main": 151639,
@@ -20,12 +10,6 @@
   },
   "hello_world__closure": {
     "master": {
-      "gzip7": {
-        "bundle": 32793
-      },
-      "gzip9": {
-        "bundle": 32758
-      },
       "uncompressed": {
         "bundle": 100661
       }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
We changed the files we want to check the payload sizes.
 - Only check the limit of uncompressed payload size.
 - Removed check for `gzip7` and `gzip9`
 - Check important .chunk.js file sizes: `embedded` and `prettify`

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Current we check the payload size for uncompressed, gzip7, gzip9. We do not check the size for `embedded.*.chunk.js` or `prettify.*.chunk.js`.

Issue Number: #21437


## What is the new behavior?
Only check the limit of uncompressed payload size
 check important .chunk.js file sizes: `embedded` and `prettify`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
