### PR TITLE
fix(common): revert changes to generated code

### DIFF
--- a/packages/common/src/i18n/locale_en.ts
+++ b/packages/common/src/i18n/locale_en.ts
@@ -9,13 +9,6 @@
 // THIS CODE IS GENERATED - DO NOT MODIFY
 // See angular/tools/gulp-tasks/cldr/extract.js
 
-function converter(n: number): number {
-  let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
-  if (i === 1 && v === 0) return 1;
-  return 5;
-}
-
-
 export default [
   'en',
   [
@@ -49,5 +42,11 @@ export default [
     '{1} \'at\' {0}',
   ],
   ['.', ',', ';', '%', '+', '-', 'E', '×', '‰', '∞', 'NaN', ':'],
-  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '$', 'US Dollar', converter
+  ['#,##0.###', '#,##0%', '¤#,##0.00', '#E0'], '$', 'US Dollar',
+  function(n: number):
+      number {
+        let i = Math.floor(Math.abs(n)), v = n.toString().replace(/^[^.]*\.?/, '').length;
+        if (i === 1 && v === 0) return 1;
+        return 5;
+      }
 ];


### PR DESCRIPTION
Reverted code should not be changed as in 
`// THIS CODE IS GENERATED - DO NOT MODIFY`

If this needs to be changed the generation script should be updated.

Target is master only because this reverts [a change](https://github.com/angular/angular/pull/21144) that was applied to the master branch only (related to TS2.6 support)

@mprobst could you please approve this PR (see tap/182265725)