### PR TITLE
refactor(bazel): pass around tsconfig as a file, not a path

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,12 +15,15 @@ node_repositories(package_json = ["//:package.json"])
 
 git_repository(
     name = "build_bazel_rules_typescript",
-    remote = "https://github.com/bazelbuild/rules_typescript.git",
-#    tag = "0.7.1+",
-    commit = "89d2c75066bea3d9c942f29dd1d2ea543c58d6d5"
+    # Use alexeagle's branch temporarily to allow a green build in the middle of
+    # the tsconfig refactoring.
+    # TODO(alexeagle): after the change lands in google3, push it to bazelbuild
+    # mirror and point this back to upstream.
+    remote = "https://github.com/alexeagle/rules_typescript.git",
+    commit = "5ccf967a393d94f53b5b1a97760eb1e18367faa3"
 )
 
-load("@build_bazel_rules_typescript//:setup.bzl", "ts_setup_workspace")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")
 
 ts_setup_workspace()
 

--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -13,12 +13,15 @@ node_repositories(package_json = ["//:package.json"])
 
 git_repository(
     name = "build_bazel_rules_typescript",
-    remote = "https://github.com/bazelbuild/rules_typescript.git",
-#    tag = "0.6.0",
-    commit = "89d2c75066bea3d9c942f29dd1d2ea543c58d6d5"
+    # Use alexeagle's branch temporarily to allow a green build in the middle of
+    # the tsconfig refactoring.
+    # TODO(alexeagle): after the change lands in google3, push it to bazelbuild
+    # mirror and point this back to upstream.
+    remote = "https://github.com/alexeagle/rules_typescript.git",
+    commit = "5ccf967a393d94f53b5b1a97760eb1e18367faa3"
 )
 
-load("@build_bazel_rules_typescript//:setup.bzl", "ts_setup_workspace")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")
 
 ts_setup_workspace()
 


### PR DESCRIPTION
this unlocks the ability to replay ts compilations with different settings
