### PR TITLE
fix(aio): fix code highlight in API docs templates

### DIFF
--- a/aio/tools/transforms/templates/api/includes/annotations.html
+++ b/aio/tools/transforms/templates/api/includes/annotations.html
@@ -2,7 +2,7 @@
 <section class="annotations">
   <h2>Annotations</h2>
   {%- for decorator in doc.decorators %}
-    <code-example hideCopy="true" class="no-box api-heading">@{$ decorator.name $}({$ decorator.arguments $})</code-example>
+    <code-example language="ts" hideCopy="true" class="no-box api-heading">@{$ decorator.name $}({$ decorator.arguments $})</code-example>
     {% if not decorator.notYetDocumented %}{$ decorator.description | marked $}{% endif %}
   {% endfor %}
 </section>

--- a/aio/tools/transforms/templates/api/includes/metadata.html
+++ b/aio/tools/transforms/templates/api/includes/metadata.html
@@ -4,7 +4,7 @@
     {% for metadata in doc.members %}{% if not metadata.internal %}
     <div class="metadata-member">
       <a name="{$ metadata.name $}" class="anchor-offset"></a>
-      <code-example hideCopy="true">{$ metadata.name $}{$ params.paramList(metadata.parameters) | trim $}{$ params.returnType(metadata.type) $}</code-example>
+      <code-example language="ts" hideCopy="true">{$ metadata.name $}{$ params.paramList(metadata.parameters) | trim $}{$ params.returnType(metadata.type) $}</code-example>
       {%- if not metadata.notYetDocumented %}{$ metadata.description | marked $}{% endif -%}
     </div>
     {% if not loop.last %}<hr class="hr-margin">{% endif %}

--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -29,7 +29,7 @@
 {%- macro renderMemberDetail(member, cssClass) -%}
 <div class="{$ cssClass $}">
   <a id="{$ member.anchor $}"></a>
-  <code-example hideCopy="true" class="no-box api-heading">{$ renderMember(member) $}</code-example>
+  <code-example language="ts" hideCopy="true" class="no-box api-heading">{$ renderMember(member) $}</code-example>
   {%- if not member.notYetDocumented %}
   {$ member.description | marked $}
   {% endif -%}


### PR DESCRIPTION
Correctly highlight code in API docs templates.
Fixes #21108.