### PR TITLE
ci: update github bot messages

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -14,8 +14,8 @@ merge:
     failureText: "The following checks are failing:"
 
   # comment that will be added to a PR when there is a conflict, leave empty or set to false to disable
-  mergeConflictComment: "Hello? Don't want to hassle you. Sure you're busy. But this PR has some merge conflicts that you probably ought to resolve.
-\nThat is... if you want it to be merged someday..."
+  mergeConflictComment: "Hi @{{PRAuthor}}! This PR has merge conflicts due to recent upstream merges.
+\nPlease help to unblock it by resolving these conflicts. Thanks!"
 
   # label to monitor
   mergeLabel: "PR action: merge"
@@ -44,9 +44,9 @@ merge:
     # the comment that will be added when the merge label is added despite failing checks, leave empty or set to false to disable
     # {{MERGE_LABEL}} will be replaced by the value of the mergeLabel option
     # {{PLACEHOLDER}} will be replaced by the list of failing checks
-    mergeRemovedComment: "I see that you just added the `{{MERGE_LABEL}}` label. It won't do anything good though, because the following checks are still failing:
-  \n{{PLACEHOLDER}}
-  \n
-  \n**If you want your PR to be merged, it has to pass all the CI checks.**
-  \n
-  \nIf you can't get the PR to a green state due to flakes or broken master, please try rebasing to master and/or restarting the CI job. If that fails and you believe that the issue is not due to your change, please contact the caretaker and ask for help."
+  mergeRemovedComment: "I see that you just added the `{{MERGE_LABEL}}` label, but the following checks are still failing:
+\n{{PLACEHOLDER}}
+\n
+\n**If you want your PR to be merged, it has to pass all the CI checks.**
+\n
+\nIf you can't get the PR to a green state due to flakes or broken master, please try rebasing to master and/or restarting the CI job. If that fails and you believe that the issue is not due to your change, please contact the caretaker and ask for help."


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] CI related changes
```

## What is the current behavior?
Github bot merge conflict messages are a bit too aggressive

Issue Number: #21633


## What is the new behavior?
The message is now neutral

## Does this PR introduce a breaking change?
```
[x] No
```
