### PR TITLE
perf(ivy): removes generation of comments

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -18,14 +18,14 @@
   "hello_world__render3__closure": {
     "master": {
       "uncompressed": {
-        "bundle": 7674
+        "bundle": 8153
       }
     }
   },
   "hello_world__render3__rollup": {
     "master": {
       "uncompressed": {
-        "bundle": 58662
+        "bundle": 59334
       }
     }
   }

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -392,7 +392,10 @@ export class ReadFromInjectorFn<T> {
  * @returns The ElementRef instance to use
  */
 export function getOrCreateElementRef(di: LInjector): viewEngine_ElementRef {
-  return di.elementRef || (di.elementRef = new ElementRef(di.node.native));
+  return di.elementRef ||
+      (di.elementRef = new ElementRef(
+           ((di.node.flags & LNodeFlags.TYPE_MASK) === LNodeFlags.Container) ? null :
+                                                                               di.node.native));
 }
 
 export const QUERY_READ_TEMPLATE_REF = <QueryReadType<viewEngine_TemplateRef<any>>>(

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -9,7 +9,6 @@
 import {ComponentTemplate} from './definition';
 import {LElementNode, LViewNode} from './node';
 import {LQuery} from './query';
-import {RNode} from './renderer';
 import {LView, TView} from './view';
 
 
@@ -81,15 +80,6 @@ export interface LContainer {
    * this container are reported to queries referenced here.
    */
   query: LQuery|null;
-
-  /*
-   * Caches the reference of the first native node following this container in the same native
-   * parent.
-   * This is reset to undefined in containerRefreshEnd.
-   * When it is undefined, it means the value has not been computed yet.
-   * Otherwise, it contains the result of findBeforeNode(container, null).
-   */
-  nextNative: RNode|null|undefined;
 }
 
 /**

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -9,6 +9,7 @@
 import {ComponentTemplate} from './definition';
 import {LElementNode, LViewNode} from './node';
 import {LQuery} from './query';
+import {RNode} from './renderer';
 import {LView, TView} from './view';
 
 
@@ -80,6 +81,15 @@ export interface LContainer {
    * this container are reported to queries referenced here.
    */
   query: LQuery|null;
+
+  /*
+   * Caches the reference of the first native node following this container in the same native
+   * parent.
+   * This is reset to undefined in containerRefreshEnd.
+   * When it is undefined, it means the value has not been computed yet.
+   * Otherwise, it contains the result of findBeforeNode(container, null).
+   */
+  nextNative: RNode|null|undefined;
 }
 
 /**

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -11,7 +11,7 @@ import {DirectiveDef} from './definition';
 import {LInjector} from './injector';
 import {LProjection} from './projection';
 import {LQuery} from './query';
-import {RComment, RElement, RText} from './renderer';
+import {RElement, RText} from './renderer';
 import {LView, TData, TView} from './view';
 
 
@@ -74,9 +74,8 @@ export interface LNode {
    * The associated DOM node. Storing this allows us to:
    *  - append children to their element parents in the DOM (e.g. `parent.native.appendChild(...)`)
    *  - retrieve the sibling elements of text nodes whose creation / insertion has been delayed
-   *  - mark locations where child views should be inserted (for containers)
    */
-  readonly native: RElement|RText|RComment|null;
+  readonly native: RElement|RText|null;
 
   /**
    * We need a reference to a node's parent so we can append the node to its parent's native
@@ -121,6 +120,14 @@ export interface LNode {
    * If present the node creation/updates are reported to the `QueryState`.
    */
   query: LQuery|null;
+
+  /**
+   * If this node is projected, pointer to the next node in the same projection parent
+   * (which is a container, an element, or a text node), or to the parent projection node
+   * if this is the last node in the projection.
+   * If this node is not projected, this field is null.
+   */
+  pNextOrParent: LNode|null;
 
   /**
    * Pointer to the corresponding TNode object, which stores static
@@ -170,14 +177,7 @@ export interface LViewNode extends LNode {
 
 /** Abstract node container which contains other views. */
 export interface LContainerNode extends LNode {
-  /**
-   * This comment node is appended to the container's parent element to mark where
-   * in the DOM the container's child views should be added.
-   *
-   * If the container is a root node of a view, this comment will not be appended
-   * until the parent view is processed.
-   */
-  readonly native: RComment;
+  readonly native: null;
   readonly data: LContainer;
   child: null;
   next: LContainerNode|LElementNode|LTextNode|LProjectionNode|null;

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -11,8 +11,9 @@ import {DirectiveDef} from './definition';
 import {LInjector} from './injector';
 import {LProjection} from './projection';
 import {LQuery} from './query';
-import {RElement, RText} from './renderer';
+import {RElement, RNode, RText} from './renderer';
 import {LView, TData, TView} from './view';
+
 
 
 /**
@@ -75,7 +76,7 @@ export interface LNode {
    *  - append children to their element parents in the DOM (e.g. `parent.native.appendChild(...)`)
    *  - retrieve the sibling elements of text nodes whose creation / insertion has been delayed
    */
-  readonly native: RElement|RText|null;
+  readonly native: RElement|RText|null|undefined;
 
   /**
    * We need a reference to a node's parent so we can append the node to its parent's native
@@ -177,7 +178,14 @@ export interface LViewNode extends LNode {
 
 /** Abstract node container which contains other views. */
 export interface LContainerNode extends LNode {
-  readonly native: null;
+  /*
+   * Caches the reference of the first native node following this container in the same native
+   * parent.
+   * This is reset to undefined in containerRefreshEnd.
+   * When it is undefined, it means the value has not been computed yet.
+   * Otherwise, it contains the result of findBeforeNode(container, null).
+   */
+  native: RElement|RText|null|undefined;
   readonly data: LContainer;
   child: null;
   next: LContainerNode|LElementNode|LTextNode|LProjectionNode|null;

--- a/packages/core/src/render3/interfaces/projection.ts
+++ b/packages/core/src/render3/interfaces/projection.ts
@@ -9,14 +9,13 @@
 import {LContainerNode, LElementNode, LTextNode} from './node';
 
 /**
- * An LProjection is just an array of projected nodes.
- *
- * It would be nice if we could not need an array, but since a projected node can be
- * re-projected, the same node can be part of more than one LProjectionNode which makes
- * list approach not possible.
+ * An LProjection is a pointer to the first and the last projected nodes.
+ * It is a linked list (using the pNextOrParent property).
  */
-export type LProjection = Array<LElementNode|LTextNode|LContainerNode>;
-
+export interface LProjection {
+  first: LElementNode|LTextNode|LContainerNode|null;
+  last: LElementNode|LTextNode|LContainerNode|null;
+}
 
 /**
  * Parsed selector in the following format:

--- a/packages/core/src/render3/interfaces/projection.ts
+++ b/packages/core/src/render3/interfaces/projection.ts
@@ -13,8 +13,8 @@ import {LContainerNode, LElementNode, LTextNode} from './node';
  * It is a linked list (using the pNextOrParent property).
  */
 export interface LProjection {
-  first: LElementNode|LTextNode|LContainerNode|null;
-  last: LElementNode|LTextNode|LContainerNode|null;
+  head: LElementNode|LTextNode|LContainerNode|null;
+  tail: LElementNode|LTextNode|LContainerNode|null;
 }
 
 /**

--- a/packages/core/src/render3/interfaces/renderer.ts
+++ b/packages/core/src/render3/interfaces/renderer.ts
@@ -35,7 +35,6 @@ export type Renderer3 = ObjectOrientedRenderer3 | ProceduralRenderer3;
  * (reducing payload size).
  * */
 export interface ObjectOrientedRenderer3 {
-  createComment(data: string): RComment;
   createElement(tagName: string): RElement;
   createTextNode(data: string): RText;
 
@@ -52,7 +51,6 @@ export interface ObjectOrientedRenderer3 {
 export interface ProceduralRenderer3 {
   destroy(): void;
   createElement(name: string, namespace?: string|null): RElement;
-  createComment(value: string): RComment;
   createText(value: string): RText;
   /**
    * This property is allowed to be null / undefined,
@@ -137,8 +135,6 @@ export interface RDomTokenList {
 }
 
 export interface RText extends RNode { textContent: string|null; }
-
-export interface RComment extends RNode {}
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency
 // failure based on types.

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -7,11 +7,11 @@
  */
 
 import {ViewEncapsulation} from '../../src/core';
-import {E, T, b, defineComponent, e, markDirty, r, t} from '../../src/render3/index';
+import {C, E, T, V, b, cR, cr, defineComponent, e, markDirty, p, r, t, v} from '../../src/render3/index';
 import {createRendererType2} from '../../src/view/index';
 
 import {getRendererFactory2} from './imported_renderer2';
-import {containerEl, renderComponent, requestAnimationFrame, toHtml} from './render_util';
+import {containerEl, renderComponent, renderToHtml, requestAnimationFrame, toHtml} from './render_util';
 
 describe('component', () => {
   class CounterComponent {
@@ -55,6 +55,70 @@ describe('component', () => {
       expect(toHtml(containerEl)).toEqual('124');
     });
 
+  });
+
+});
+
+describe('component with a container', () => {
+
+  function showItems(ctx: {items: string[]}, cm: boolean) {
+    if (cm) {
+      C(0);
+    }
+    cR(0);
+    {
+      for (const item of ctx.items) {
+        const cm0 = V(0);
+        {
+          if (cm0) {
+            T(0);
+          }
+          t(0, b(item));
+        }
+        v();
+      }
+    }
+    cr();
+  }
+
+  class WrapperComponent {
+    items: string[];
+    static ngComponentDef = defineComponent({
+      type: WrapperComponent,
+      tag: 'wrapper',
+      template: function ChildComponentTemplate(ctx: {items: string[]}, cm: boolean) {
+        if (cm) {
+          C(0);
+        }
+        cR(0);
+        {
+          const cm0 = V(0);
+          { showItems({items: ctx.items}, cm0); }
+          v();
+        }
+        cr();
+      },
+      factory: () => new WrapperComponent,
+      inputs: {items: 'items'}
+    });
+  }
+
+  function template(ctx: {items: string[]}, cm: boolean) {
+    if (cm) {
+      E(0, WrapperComponent);
+      e();
+    }
+    p(0, 'items', b(ctx.items));
+    WrapperComponent.ngComponentDef.h(1, 0);
+    r(1, 0);
+  }
+
+  it('should re-render on input change', () => {
+    const ctx: {items: string[]} = {items: ['a']};
+    expect(renderToHtml(template, ctx)).toEqual('<wrapper>a</wrapper>');
+
+    ctx.items = [...ctx.items, 'b'];
+    expect(renderToHtml(template, ctx)).toEqual('<wrapper>ab</wrapper>');
   });
 
 });

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -377,6 +377,61 @@ describe('content projection', () => {
        expect(toHtml(parent)).toEqual('<child><div></div></child>');
      });
 
+  it('should support projection in embedded views when ng-content is a root node of an embedded view, with other nodes after',
+     () => {
+       let childCmptInstance: any;
+
+       /**
+        * <div>
+        *  % if (!skipContent) {
+        *    before-<ng-content></ng-content>-after
+        *  % }
+        * </div>
+        */
+       const Child = createComponent('child', function(ctx: any, cm: boolean) {
+         if (cm) {
+           pD(0);
+           E(1, 'div');
+           { C(2); }
+           e();
+         }
+         cR(2);
+         {
+           if (!ctx.skipContent) {
+             if (V(0)) {
+               T(0, 'before-');
+               P(1, 0);
+               T(2, '-after');
+             }
+             v();
+           }
+         }
+         cr();
+       });
+
+       /**
+        * <child>content</child>
+        */
+       const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
+         if (cm) {
+           E(0, Child);
+           {
+             childCmptInstance = m(1);
+             T(2, 'content');
+           }
+           e();
+         }
+         Child.ngComponentDef.h(1, 0);
+         r(1, 0);
+       });
+       const parent = renderComponent(Parent);
+       expect(toHtml(parent)).toEqual('<child><div>before-content-after</div></child>');
+
+       childCmptInstance.skipContent = true;
+       detectChanges(parent);
+       expect(toHtml(parent)).toEqual('<child><div></div></child>');
+     });
+
   it('should project nodes into the last ng-content', () => {
     /**
      * <div><ng-content></ng-content></div>

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -296,7 +296,7 @@ describe('query', () => {
       expect(isViewContainerRef(query.first)).toBeTruthy();
     });
 
-    it('should read ElementRef with a native element pointing to comment DOM node from containers',
+    it('should no longer read ElementRef with a native element pointing to comment DOM node from containers',
        () => {
          /**
           * <ng-template #foo></ng-template>
@@ -316,8 +316,7 @@ describe('query', () => {
          const cmptInstance = renderComponent(Cmpt);
          const query = (cmptInstance.query as QueryList<any>);
          expect(query.length).toBe(1);
-         expect(isElementRef(query.first)).toBeTruthy();
-         expect(query.first.nativeElement.nodeType).toBe(8);  // Node.COMMENT_NODE = 8
+         expect(query.first.nativeElement).toBe(null);
        });
 
     it('should read TemplateRef from container nodes by default', () => {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

This PR reduces the time needed to insert elements in the DOM for some use cases such as the one from the [tree_perf benchmark](https://github.com/angular/angular/blob/master/modules/benchmarks/e2e_test/tree_perf.ts).

## What is the current behavior?

An empty HTML comment is inserted in the DOM for each container node (`LContainerNode`) to mark the position where it is, and this is used when calling `insertBefore`.

## What is the new behavior?

Comments are no longer inserted in the DOM. The tree of logical nodes is used to look for the next element, to be passed to the `insertBefore` function. This reduces the time needed to insert elements, as it is less costly to explore the tree of `LNode` elements rather than adding comments in the DOM.

## Does this PR introduce a breaking change?

Yes: queries for `ElementRef` on `ng-template` elements no longer return a pointer to the generated comments, as those comments are no longer generated (cf the test I changed). I discussed a bit with @pkozlowski-opensource, it is debatable whether this edge case should be supported.

## Other information

I will add some tests to more thoroughly check that everything works fine after this change. (Especially, I did not fully consider the case of projected nodes).

As suggested by @marclaval, we could add some optimizations to avoid re-computing the next element when we know it is the same (for example: when adding several views at the end of the same container).
