### PR TITLE
ci: use `sudo: false` on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
-# Work-around for https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524.
-# (Restore `sudo: false` once that is resolved.)
-sudo: required
+sudo: false
 dist: trusty
 node_js:
   - '8.9.1'

--- a/aio/karma.conf.js
+++ b/aio/karma.conf.js
@@ -30,8 +30,14 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['CustomChrome'],
     browserNoActivityTimeout: 60000,
-    singleRun: false
+    singleRun: false,
+    customLaunchers: {
+      CustomChrome: {
+        base: 'Chrome',
+        flags: process.env.TRAVIS && ['--no-sandbox']
+      }
+    }
   });
 };

--- a/aio/protractor.conf.js
+++ b/aio/protractor.conf.js
@@ -12,7 +12,8 @@ exports.config = {
     browserName: 'chrome',
     // For Travis
     chromeOptions: {
-      binary: process.env.CHROME_BIN
+      binary: process.env.CHROME_BIN,
+      args: ['--no-sandbox']
     }
   },
   directConnect: true,

--- a/aio/tools/examples/shared/boilerplate/cli/protractor.conf.js
+++ b/aio/tools/examples/shared/boilerplate/cli/protractor.conf.js
@@ -12,7 +12,8 @@ exports.config = {
     'browserName': 'chrome',
     // For Travis CI only
     chromeOptions: {
-      binary: process.env.CHROME_BIN
+      binary: process.env.CHROME_BIN,
+      args: ['--no-sandbox']
     }
   },
   directConnect: true,

--- a/aio/tools/examples/shared/protractor.config.js
+++ b/aio/tools/examples/shared/protractor.config.js
@@ -23,7 +23,8 @@ exports.config = {
     'browserName': 'chrome',
     // For Travis
     chromeOptions: {
-      binary: process.env.CHROME_BIN
+      binary: process.env.CHROME_BIN,
+      args: ['--no-sandbox']
     }
   },
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] CI related changes
```

## What is the current behavior?
`sude: required`: Travis jobs run on non-container-based infrastructure (on VMs from the open source pool).


## What is the new behavior?
`sudo: false`: Travis jobs run on the container-based infrastructure (on VMs from our pre-paid pool).


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
In order to switch back to `sude: false` (and take advantage of our paid poolof VMs), we need to run Chrome/Chromium with the `--no-sandbox` flag.
Related to #21422.

Relevant discussion: travis-ci/travis-ci#8836