### PR TITLE
fix(compiler-cli): do not lower expressions in non-modules

### DIFF
--- a/packages/compiler-cli/src/transformers/lower_expressions.ts
+++ b/packages/compiler-cli/src/transformers/lower_expressions.ts
@@ -325,13 +325,14 @@ export class LowerMetadataCache implements RequestsMap {
     };
 
     // Do not validate or lower metadata in a declaration file. Declaration files are requested
-    // when we need to update the version of the metadata to add informatoin that might be missing
+    // when we need to update the version of the metadata to add information that might be missing
     // in the out-of-date version that can be recovered from the .d.ts file.
     const declarationFile = sourceFile.isDeclarationFile;
+    const moduleFile = ts.isExternalModule(sourceFile);
 
     const metadata = this.collector.getMetadata(
         sourceFile, this.strict && !declarationFile,
-        declarationFile ? undefined : substituteExpression);
+        moduleFile && !declarationFile ? substituteExpression : undefined);
 
     return {metadata, requests};
   }

--- a/packages/compiler-cli/test/transformers/lower_expressions_spec.ts
+++ b/packages/compiler-cli/test/transformers/lower_expressions_spec.ts
@@ -99,7 +99,17 @@ describe('Expression lowering', () => {
           .toBeTruthy('did not find the data field');
     });
 
-    it('should throw a validation execption for invalid files', () => {
+    it('should not lower a non-module', () => {
+      const collected = collect(`
+          declare const global: any;
+          const ngDevMode: boolean = (function(global: any) {
+            return global.ngDevMode = true;
+          })(typeof window != 'undefined' && window || typeof self != 'undefined' && self || typeof global != 'undefined' && global);
+       `);
+      expect(collected.requests.size).toBe(0, 'unexpected rewriting');
+    });
+
+    it('should throw a validation exception for invalid files', () => {
       const cache = new LowerMetadataCache({}, /* strict */ true);
       const sourceFile = ts.createSourceFile(
           'foo.ts', `


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue: #21651

If a compilation contains a non-module `ngc` might convert it into a module if it contains a expression that might be rewritten.


## What is the new behavior?

Only modules are rewritten.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
