### PR TITLE
feat(ivy): add afterContentInit and afterContentChecked to render3

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -18,14 +18,14 @@
   "hello_world__render3__closure": {
     "master": {
       "uncompressed": {
-        "bundle": 7065
+        "bundle": 7674
       }
     }
   },
   "hello_world__render3__rollup": {
     "master": {
       "uncompressed": {
-        "bundle": 56550
+        "bundle": 58662
       }
     }
   }

--- a/integration/hello_world__render3__closure/src/index.ts
+++ b/integration/hello_world__render3__closure/src/index.ts
@@ -14,6 +14,7 @@ export class HelloWorld {
 
   /** @nocollapse */
   static ngComponentDef: ComponentDef<HelloWorld> = defineComponent({
+    type: HelloWorld,
     tag: 'hello-world',
     template: function (ctx: HelloWorld, cm: boolean) {
       if (cm) {

--- a/integration/hello_world__render3__rollup/src/index.ts
+++ b/integration/hello_world__render3__rollup/src/index.ts
@@ -14,6 +14,7 @@ export class HelloWorld {
 
   /** @nocollapse */
   static ngComponentDef: ComponentDef<HelloWorld> = defineComponent({
+    type: HelloWorld,
     tag: 'hello-world',
     template: function (ctx: HelloWorld, cm: boolean) {
       if (cm) {

--- a/modules/benchmarks/src/largetable/render3/table.ts
+++ b/modules/benchmarks/src/largetable/render3/table.ts
@@ -16,6 +16,7 @@ export class LargeTableComponent {
 
   /** @nocollapse */
   static ngComponentDef: ComponentDef<LargeTableComponent> = defineComponent({
+    type: LargeTableComponent,
     tag: 'largetable',
     template: function(ctx: LargeTableComponent, cm: boolean) {
       if (cm) {

--- a/modules/benchmarks/src/tree/render3/tree.ts
+++ b/modules/benchmarks/src/tree/render3/tree.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵC as C, ɵE as E, ɵT as T, ɵV as V, ɵb as b, ɵb1 as b1, ɵcR as cR, ɵcr as cr, ɵdefineComponent as defineComponent, ɵdetectChanges as _detectChanges, ɵe as e, ɵp as p, ɵs as s, ɵt as t, ɵv as v} from '@angular/core';
+import {ɵC as C, ɵE as E, ɵT as T, ɵV as V, ɵb as b, ɵb1 as b1, ɵcR as cR, ɵcr as cr, ɵdefineComponent as defineComponent, ɵdetectChanges as _detectChanges, ɵe as e, ɵp as p, ɵr as r, ɵs as s, ɵt as t, ɵv as v} from '@angular/core';
 import {ComponentDef} from '@angular/core/src/render3/interfaces/definition';
 
 import {TreeNode, buildTree, emptyTree} from '../util';
@@ -59,7 +59,7 @@ export class TreeComponent {
             }
             p(0, 'data', b(ctx.data.left));
             TreeComponent.ngComponentDef.h(1, 0);
-            TreeComponent.ngComponentDef.r(1, 0);
+            r(1, 0);
           }
           v();
         }
@@ -76,7 +76,7 @@ export class TreeComponent {
             }
             p(0, 'data', b(ctx.data.right));
             TreeComponent.ngComponentDef.h(1, 0);
-            TreeComponent.ngComponentDef.r(1, 0);
+            r(1, 0);
           }
           v();
         }

--- a/modules/benchmarks/src/tree/render3/tree.ts
+++ b/modules/benchmarks/src/tree/render3/tree.ts
@@ -36,6 +36,7 @@ export class TreeComponent {
 
   /** @nocollapse */
   static ngComponentDef: ComponentDef<TreeComponent> = defineComponent({
+    type: TreeComponent,
     tag: 'tree',
     template: function(ctx: TreeComponent, cm: boolean) {
       if (cm) {
@@ -92,6 +93,7 @@ export class TreeFunction {
 
   /** @nocollapse */
   static ngComponentDef: ComponentDef<TreeFunction> = defineComponent({
+    type: TreeFunction,
     tag: 'tree',
     template: function(ctx: TreeFunction, cm: boolean) {
       // bit of a hack

--- a/packages/compiler/test/render3/r3_view_compiler_spec.ts
+++ b/packages/compiler/test/render3/r3_view_compiler_spec.ts
@@ -205,8 +205,8 @@ describe('r3_view_compiler', () => {
               IDENT.ɵe();
               IDENT.ɵT(3, '!');
             }
-            ChildComponent.ngComponentDef.r(1, 0);
-            SomeDirective.ngDirectiveDef.r(2, 0);
+            r(1, 0);
+            r(2, 0);
           }
         });
       `;
@@ -267,7 +267,7 @@ describe('r3_view_compiler', () => {
             }
             const IDENT = IDENT.ɵm(1);
             IDENT.ɵcR(2);
-            IfDirective.ngDirectiveDef.r(3,2);
+            r(3,2);
             IDENT.ɵcr();
 
             function MyComponent_IfDirective_Template_2(ctx0: IDENT, cm: IDENT) {

--- a/packages/compiler/test/render3/r3_view_compiler_spec.ts
+++ b/packages/compiler/test/render3/r3_view_compiler_spec.ts
@@ -205,8 +205,8 @@ describe('r3_view_compiler', () => {
               IDENT.ɵe();
               IDENT.ɵT(3, '!');
             }
-            r(1, 0);
-            r(2, 0);
+            ChildComponent.ngComponentDef.r(1, 0);
+            SomeDirective.ngDirectiveDef.r(2, 0);
           }
         });
       `;
@@ -267,7 +267,7 @@ describe('r3_view_compiler', () => {
             }
             const IDENT = IDENT.ɵm(1);
             IDENT.ɵcR(2);
-            r(3,2);
+            IfDirective.ngDirectiveDef.r(3,2);
             IDENT.ɵcr();
 
             function MyComponent_IfDirective_Template_2(ctx0: IDENT, cm: IDENT) {

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -34,5 +34,6 @@ export {
   s as ɵs,
   t as ɵt,
   v as ɵv,
+  r as ɵr,
 } from './render3/index';
 // clang-format on

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -13,8 +13,7 @@ import {ComponentRef as viewEngine_ComponentRef} from '../linker/component_facto
 import {EmbeddedViewRef as viewEngine_EmbeddedViewRef} from '../linker/view_ref';
 
 import {assertNotNull} from './assert';
-
-import {NG_HOST_SYMBOL, createError, createLView, directiveCreate, enterView, hostElement, leaveView, locateHostElement, renderComponentOrTemplate} from './instructions';
+import {NG_HOST_SYMBOL, createError, createLView, createTView, directiveCreate, enterView, hostElement, leaveView, locateHostElement, renderComponentOrTemplate} from './instructions';
 import {ComponentDef, ComponentType} from './interfaces/definition';
 import {LElementNode} from './interfaces/node';
 import {RElement, Renderer3, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
@@ -173,7 +172,7 @@ export function renderComponent<T>(
   const hostNode = locateHostElement(rendererFactory, opts.host || componentDef.tag);
   const oldView = enterView(
       createLView(
-          -1, rendererFactory.createRenderer(hostNode, componentDef.rendererType), {data: []}),
+          -1, rendererFactory.createRenderer(hostNode, componentDef.rendererType), createTView()),
       null !);
   try {
     // Create element node at index 0 in data array

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -13,8 +13,9 @@ import {ComponentRef as viewEngine_ComponentRef} from '../linker/component_facto
 import {EmbeddedViewRef as viewEngine_EmbeddedViewRef} from '../linker/view_ref';
 
 import {assertNotNull} from './assert';
+
 import {NG_HOST_SYMBOL, createError, createLView, directiveCreate, enterView, hostElement, leaveView, locateHostElement, renderComponentOrTemplate} from './instructions';
-import {ComponentDef, ComponentType, TypedComponentDef} from './interfaces/definition';
+import {ComponentDef, ComponentType} from './interfaces/definition';
 import {LElementNode} from './interfaces/node';
 import {RElement, Renderer3, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
 import {notImplemented, stringify} from './util';
@@ -166,7 +167,7 @@ export const NULL_INJECTOR: Injector = {
 export function renderComponent<T>(
     componentType: ComponentType<T>, opts: CreateComponentOptions = {}): T {
   const rendererFactory = opts.rendererFactory || domRendererFactory3;
-  const componentDef = componentType.ngComponentDef as TypedComponentDef<T>;
+  const componentDef = componentType.ngComponentDef as ComponentDef<T>;
   if (componentDef.type != componentType) componentDef.type = componentType;
   let component: T;
   const hostNode = locateHostElement(rendererFactory, opts.host || componentDef.tag);

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -40,11 +40,6 @@ export function defineComponent<T>(componentDefinition: ComponentDefArgs<T>): Co
     n: componentDefinition.factory,
     tag: (componentDefinition as ComponentDefArgs<T>).tag || null !,
     template: (componentDefinition as ComponentDefArgs<T>).template || null !,
-    r: componentDefinition.refresh || (componentDefinition.template ?
-                                           function(d: number, e: number) {
-                                             componentRefresh(d, e, componentDefinition.template);
-                                           } :
-                                           noop),
     h: componentDefinition.hostBindings || noop,
     inputs: invertObject(componentDefinition.inputs),
     outputs: invertObject(componentDefinition.outputs),

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -167,7 +167,7 @@ export function diPublicInInjector(di: LInjector, def: DirectiveDef<any>): void 
  *
  * @param def The definition of the directive to be made public
  */
-export function diPublic(def: TypedDirectiveDef<any>): void {
+export function diPublic(def: DirectiveDef<any>): void {
   diPublicInInjector(getOrCreateNodeInjector(), def);
 }
 

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -19,7 +19,7 @@ import {Type} from '../type';
 
 import {assertLessThan} from './assert';
 import {assertPreviousIsParent, getPreviousOrParentNode, getRenderer, renderEmbeddedTemplate} from './instructions';
-import {ComponentTemplate, DirectiveDef, TypedDirectiveDef} from './interfaces/definition';
+import {ComponentTemplate, DirectiveDef} from './interfaces/definition';
 import {LInjector} from './interfaces/injector';
 import {LContainerNode, LElementNode, LNode, LNodeFlags, LViewNode} from './interfaces/node';
 import {QueryReadType} from './interfaces/query';
@@ -158,7 +158,7 @@ function createInjectionError(text: string, token: any) {
  * @param di The node injector in which a directive will be added
  * @param def The definition of the directive to be made public
  */
-export function diPublicInInjector(di: LInjector, def: TypedDirectiveDef<any>): void {
+export function diPublicInInjector(di: LInjector, def: DirectiveDef<any>): void {
   bloomAdd(di, def.type);
 }
 
@@ -291,7 +291,7 @@ export function getOrCreateInjectable<T>(
         for (let i = start, ii = start + size; i < ii; i++) {
           // Get the definition for the directive at this index and, if it is injectable (diPublic),
           // and matches the given token, return the directive instance.
-          const directiveDef = tData[i] as TypedDirectiveDef<any>;
+          const directiveDef = tData[i] as DirectiveDef<any>;
           if (directiveDef.diPublic && directiveDef.type == token) {
             return node.view.data[i];
           }

--- a/packages/core/src/render3/hooks.ts
+++ b/packages/core/src/render3/hooks.ts
@@ -1,0 +1,153 @@
+
+import {LifecycleHooksMap} from './interfaces/definition';
+import {LNodeFlags} from './interfaces/node';
+import {HookData, LView, TView} from './interfaces/view';
+
+
+/**
+ * Enum used by the lifecycle (l) instruction to determine which lifecycle hook is requesting
+ * processing.
+ */
+export const enum LifecycleHook {
+  ON_INIT = 0b00,
+  ON_CHECK = 0b01,
+  ON_CHANGES = 0b10
+}
+
+/** Constants used by lifecycle hooks to determine when and how a hook should be called. */
+export const enum LifecycleHookUtils {
+  /* Mask used to get the type of the lifecycle hook from flags in hook queue */
+  TYPE_MASK = 0b00000000000000000000000000000001,
+
+  /* Shift needed to get directive index from flags in hook queue */
+  INDX_SHIFT = 1
+}
+
+/**
+ * Loops through the directives on a node and queues their afterContentInit,
+ * afterContentChecked, and onDestroy hooks, if they exist.
+ */
+export function queueLifecycleHooks(flags: number, currentView: LView): void {
+  // It's necessary to loop through the directives at elementEnd() (rather than storing
+  // the hooks at creation time) so we can preserve the current hook order. All hooks
+  // for projected components and directives must be called *before* their hosts.
+  const size = (flags & LNodeFlags.SIZE_MASK) >> LNodeFlags.SIZE_SHIFT;
+  const start = flags >> LNodeFlags.INDX_SHIFT;
+  let contentHooks = currentView.contentHooks;
+  let cleanup = currentView.cleanup;
+
+  for (let i = start, end = start + size; i < end; i++) {
+    const instance = currentView.data[i];
+    if (instance.ngAfterContentInit != null) {
+      (contentHooks || (currentView.contentHooks = contentHooks = [
+       ])).push(LifecycleHook.ON_INIT, instance.ngAfterContentInit, instance);
+    }
+    if (instance.ngAfterContentChecked != null) {
+      (contentHooks || (currentView.contentHooks = contentHooks = [
+       ])).push(LifecycleHook.ON_CHECK, instance.ngAfterContentChecked, instance);
+    }
+    if (instance.ngOnDestroy != null) {
+      (cleanup || (currentView.cleanup = cleanup = [])).push(instance.ngOnDestroy, instance);
+    }
+  }
+}
+
+/**
+ * If this is the first template pass, any ngOnInit or ngDoCheck hooks on the current directive
+ * will be queued on TView.initHooks.
+ *
+ * The directive index and hook type are encoded into one number (1st bit: type, remaining bits:
+ * directive index), then saved in the even indices of the initHooks array. The odd indices
+ * hold the hook functions themselves.
+ *
+ * @param index The index of the directive in LView.data
+ * @param hooks The static hooks map on the directive def
+ * @param tView The current TView
+ */
+export function queueInitHooks(index: number, hooks: LifecycleHooksMap, tView: TView): void {
+  if (tView.firstTemplatePass && hooks.onInit != null) {
+    const hookFlags = index << LifecycleHookUtils.INDX_SHIFT;
+    (tView.initHooks || (tView.initHooks = [])).push(hookFlags, hooks.onInit);
+  }
+
+  if (tView.firstTemplatePass && hooks.doCheck != null) {
+    const hookFlags = (index << LifecycleHookUtils.INDX_SHIFT) | LifecycleHook.ON_CHECK;
+    (tView.initHooks || (tView.initHooks = [])).push(hookFlags, hooks.doCheck);
+  }
+}
+
+/**
+ * Calls onInit and doCheck calls if they haven't already been called.
+ *
+ * @param currentView The current view
+ * @param initHooks The init hooks for this view
+ */
+export function executeInitHooks(currentView: LView): void {
+  const initHooks = currentView.tView.initHooks;
+
+  if (currentView.initHooksCalled === false && initHooks != null) {
+    const data = currentView.data;
+    const creationMode = currentView.creationMode;
+
+    for (let i = 0; i < initHooks.length; i += 2) {
+      const flags = initHooks[i] as number;
+      const hook = initHooks[i | 1] as() => void;
+      const onInit = (flags & LifecycleHookUtils.TYPE_MASK) === LifecycleHook.ON_INIT;
+      const instance = data[flags >> LifecycleHookUtils.INDX_SHIFT];
+      if (onInit === false || creationMode) {
+        hook.call(instance);
+      }
+    }
+    currentView.initHooksCalled = true;
+  }
+}
+
+/** Iterates over view hook functions and calls them. */
+export function executeViewHooks(data: any[], viewHookStartIndex: number | null): void {
+  if (viewHookStartIndex == null) return;
+  executeHooksAndRemoveInits(data, viewHookStartIndex);
+}
+
+/**
+ * Calls all afterContentInit and afterContentChecked hooks for the view, then splices
+ * out afterContentInit hooks to prep for the next run in update mode.
+ */
+export function executeContentHooks(currentView: LView): void {
+  if (currentView.contentHooks != null && currentView.contentHooksCalled === false) {
+    executeHooksAndRemoveInits(currentView.contentHooks, 0);
+    currentView.contentHooksCalled = true;
+  }
+}
+
+/**
+ * Calls lifecycle hooks with their contexts, then splices out any init-only hooks
+ * to prep for the next run in update mode.
+ *
+ * @param arr The array in which the hooks are found
+ * @param startIndex The index at which to start calling hooks
+ */
+function executeHooksAndRemoveInits(arr: any[], startIndex: number): void {
+  // Instead of using splice to remove init hooks after their first run (expensive), we
+  // shift over the AFTER_CHECKED hooks as we call them and truncate once at the end.
+  let checkIndex = startIndex;
+  let writeIndex = startIndex;
+  while (checkIndex < arr.length) {
+    // Call lifecycle hook with its context
+    arr[checkIndex + 1].call(arr[checkIndex + 2]);
+
+    if (arr[checkIndex] === LifecycleHook.ON_CHECK) {
+      // We know if the writeIndex falls behind that there is an init that needs to
+      // be overwritten.
+      if (writeIndex < checkIndex) {
+        arr[writeIndex] = arr[checkIndex];
+        arr[writeIndex + 1] = arr[checkIndex + 1];
+        arr[writeIndex + 2] = arr[checkIndex + 2];
+      }
+      writeIndex += 3;
+    }
+    checkIndex += 3;
+  }
+
+  // Truncate once at the writeIndex
+  arr.length = writeIndex;
+}

--- a/packages/core/src/render3/hooks.ts
+++ b/packages/core/src/render3/hooks.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 
 import {DirectiveDef, LifecycleHooksMap} from './interfaces/definition';
 import {LNodeFlags} from './interfaces/node';
@@ -5,14 +12,12 @@ import {HookData, LView, TView} from './interfaces/view';
 
 
 
-/**
- * Enum used by the lifecycle (l) instruction to determine which lifecycle hook is requesting
- * processing.
- */
-export const enum LifecycleHook {ON_INIT = 0b00, ON_CHECK = 0b01, ON_CHANGES = 0b10}
-
 /** Constants used by lifecycle hooks to determine when and how a hook should be called. */
-export const enum LifecycleHookUtils {
+export const enum LifecycleHook {
+  ON_INIT = 0b00,
+  ON_CHECK = 0b01,
+  ON_CHANGES = 0b10,
+
   /* Mask used to get the type of the lifecycle hook from flags in hook queue */
   TYPE_MASK = 0b00000000000000000000000000000001,
 
@@ -21,70 +26,8 @@ export const enum LifecycleHookUtils {
 }
 
 /**
- * Loops through the directives on a node and queues their all hooks except ngOnInit
- * and ngDoCheck, which are queued separately in E.
- */
-export function queueLifecycleHooks(flags: number, currentView: LView): void {
-  const tView = currentView.tView;
-  if (tView.firstTemplatePass === true) {
-    const size = (flags & LNodeFlags.SIZE_MASK) >> LNodeFlags.SIZE_SHIFT;
-    const start = flags >> LNodeFlags.INDX_SHIFT;
-
-    // It's necessary to loop through the directives at elementEnd() (rather than storing
-    // the hooks at creation time) so we can preserve the current hook order. All hooks
-    // for projected components and directives must be called *before* their hosts.
-    for (let i = start, end = start + size; i < end; i++) {
-      const hooks = (tView.data[i] as DirectiveDef<any>).lifecycleHooks;
-      queueContentHooks(hooks, tView, i);
-      queueViewHooks(hooks, tView, i);
-    }
-  }
-
-  const size = (flags & LNodeFlags.SIZE_MASK) >> LNodeFlags.SIZE_SHIFT;
-  const start = flags >> LNodeFlags.INDX_SHIFT;
-  let cleanup = currentView.cleanup;
-
-  for (let i = start, end = start + size; i < end; i++) {
-    const instance = currentView.data[i];
-    if (instance.ngOnDestroy != null) {
-      (cleanup || (currentView.cleanup = cleanup = [])).push(instance.ngOnDestroy, instance);
-    }
-  }
-}
-
-function queueContentHooks(hooks: LifecycleHooksMap, tView: TView, i: number): void {
-  if (hooks.afterContentInit != null) {
-    (tView.contentHooks || (tView.contentHooks = [])).push(getInitFlags(i), hooks.afterContentInit);
-  }
-
-  if (hooks.afterContentChecked != null) {
-    (tView.contentHooks || (tView.contentHooks = [
-     ])).push(getCheckFlags(i), hooks.afterContentChecked);
-  }
-}
-function queueViewHooks(hooks: LifecycleHooksMap, tView: TView, i: number): void {
-  if (hooks.afterViewInit != null) {
-    (tView.viewHooks || (tView.viewHooks = [])).push(getInitFlags(i), hooks.afterViewInit);
-  }
-
-  if (hooks.afterViewChecked != null) {
-    (tView.viewHooks || (tView.viewHooks = [])).push(getCheckFlags(i), hooks.afterViewChecked);
-  }
-}
-
-/** Generates flags for init-only hooks */
-function getInitFlags(index: number): number {
-  return index << LifecycleHookUtils.INDX_SHIFT;
-}
-
-/** Generates flags for hooks called every change detection run */
-function getCheckFlags(index: number): number {
-  return (index << LifecycleHookUtils.INDX_SHIFT) | LifecycleHook.ON_CHECK;
-}
-
-/**
- * If this is the first template pass, any ngOnInit or ngDoCheck hooks on the current directive
- * will be queued on TView.initHooks.
+ * If this is the first template pass, any ngOnInit or ngDoCheck hooks will be queued into
+ * TView.initHooks during directiveCreate.
  *
  * The directive index and hook type are encoded into one number (1st bit: type, remaining bits:
  * directive index), then saved in the even indices of the initHooks array. The odd indices
@@ -95,22 +38,82 @@ function getCheckFlags(index: number): number {
  * @param tView The current TView
  */
 export function queueInitHooks(index: number, hooks: LifecycleHooksMap, tView: TView): void {
-  if (tView.firstTemplatePass === true && hooks.onInit != null) {
-    const hookFlags = index << LifecycleHookUtils.INDX_SHIFT;
-    (tView.initHooks || (tView.initHooks = [])).push(hookFlags, hooks.onInit);
+  const firstTemplatePass = tView.firstTemplatePass;
+  if (firstTemplatePass === true && hooks.onInit != null) {
+    (tView.initHooks || (tView.initHooks = [])).push(getInitFlags(index), hooks.onInit);
   }
 
-  if (tView.firstTemplatePass === true && hooks.doCheck != null) {
-    const hookFlags = (index << LifecycleHookUtils.INDX_SHIFT) | LifecycleHook.ON_CHECK;
-    (tView.initHooks || (tView.initHooks = [])).push(hookFlags, hooks.doCheck);
+  if (firstTemplatePass === true && hooks.doCheck != null) {
+    (tView.initHooks || (tView.initHooks = [])).push(getCheckFlags(index), hooks.doCheck);
   }
+}
+
+/**
+ * Loops through the directives on a node and queues all their hooks except ngOnInit
+ * and ngDoCheck, which are queued separately in directiveCreate.
+ */
+export function queueLifecycleHooks(flags: number, currentView: LView): void {
+  const tView = currentView.tView;
+  if (tView.firstTemplatePass === true) {
+    const size = (flags & LNodeFlags.SIZE_MASK) >> LNodeFlags.SIZE_SHIFT;
+    const start = flags >> LNodeFlags.INDX_SHIFT;
+
+    // It's necessary to loop through the directives at elementEnd() (rather than processing in
+    // directiveCreate) so we can preserve the current hook order. Content, view, and destroy
+    // hooks for projected components and directives must be called *before* their hosts.
+    for (let i = start, end = start + size; i < end; i++) {
+      const hooks = (tView.data[i] as DirectiveDef<any>).lifecycleHooks;
+      queueContentHooks(hooks, tView, i);
+      queueViewHooks(hooks, tView, i);
+      queueDestroyHooks(hooks, tView, i);
+    }
+  }
+}
+
+/** Queues afterContentInit and afterContentChecked hooks on TView */
+function queueContentHooks(hooks: LifecycleHooksMap, tView: TView, i: number): void {
+  if (hooks.afterContentInit != null) {
+    (tView.contentHooks || (tView.contentHooks = [])).push(getInitFlags(i), hooks.afterContentInit);
+  }
+
+  if (hooks.afterContentChecked != null) {
+    (tView.contentHooks || (tView.contentHooks = [
+     ])).push(getCheckFlags(i), hooks.afterContentChecked);
+  }
+}
+
+/** Queues afterViewInit and afterViewChecked hooks on TView */
+function queueViewHooks(hooks: LifecycleHooksMap, tView: TView, i: number): void {
+  if (hooks.afterViewInit != null) {
+    (tView.viewHooks || (tView.viewHooks = [])).push(getInitFlags(i), hooks.afterViewInit);
+  }
+
+  if (hooks.afterViewChecked != null) {
+    (tView.viewHooks || (tView.viewHooks = [])).push(getCheckFlags(i), hooks.afterViewChecked);
+  }
+}
+
+/** Queues onDestroy hooks on TView */
+function queueDestroyHooks(hooks: LifecycleHooksMap, tView: TView, i: number): void {
+  if (hooks.onDestroy != null) {
+    (tView.destroyHooks || (tView.destroyHooks = [])).push(i, hooks.onDestroy);
+  }
+}
+
+/** Generates flags for init-only hooks */
+function getInitFlags(index: number): number {
+  return index << LifecycleHook.INDX_SHIFT;
+}
+
+/** Generates flags for hooks called every change detection run */
+function getCheckFlags(index: number): number {
+  return (index << LifecycleHook.INDX_SHIFT) | LifecycleHook.ON_CHECK;
 }
 
 /**
  * Calls onInit and doCheck calls if they haven't already been called.
  *
  * @param currentView The current view
- * @param initHooks The init hooks for this view
  */
 export function executeInitHooks(currentView: LView): void {
   const initHooks = currentView.tView.initHooks;
@@ -121,7 +124,11 @@ export function executeInitHooks(currentView: LView): void {
   }
 }
 
-/** Iterates over view hook functions and calls them. */
+/**
+ * Iterates over afterViewInit and afterViewChecked functions and calls them.
+ *
+ * @param currentView The current view
+ */
 export function executeViewHooks(currentView: LView): void {
   const viewHooks = currentView.tView.viewHooks;
 
@@ -133,6 +140,8 @@ export function executeViewHooks(currentView: LView): void {
 /**
  * Calls all afterContentInit and afterContentChecked hooks for the view, then splices
  * out afterContentInit hooks to prep for the next run in update mode.
+ *
+ * @param currentView The current view
  */
 export function executeContentHooks(currentView: LView): void {
   const contentHooks = currentView.tView.contentHooks;
@@ -157,8 +166,8 @@ function executeLifecycleHooks(currentView: LView, arr: HookData): void {
   for (let i = 0; i < arr.length; i += 2) {
     const flags = arr[i] as number;
     const hook = arr[i | 1] as() => void;
-    const initOnly = (flags & LifecycleHookUtils.TYPE_MASK) === LifecycleHook.ON_INIT;
-    const instance = data[flags >> LifecycleHookUtils.INDX_SHIFT];
+    const initOnly = (flags & LifecycleHook.TYPE_MASK) === LifecycleHook.ON_INIT;
+    const instance = data[flags >> LifecycleHook.INDX_SHIFT];
     if (initOnly === false || creationMode) {
       hook.call(instance);
     }

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -50,7 +50,6 @@ export {
   elementStart as E,
   elementStyle as s,
 
-  lifecycle as l,
   listener as L,
   memory as m,
 

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -24,8 +24,6 @@ export {InjectFlags, QUERY_READ_CONTAINER_REF, QUERY_READ_ELEMENT_REF, QUERY_REA
 // clang-format off
 export {
 
-  LifecycleHook,
-
   NO_CHANGE as NC,
 
   bind as b,
@@ -68,10 +66,13 @@ export {
 
 export {
   QueryList,
-  
+
   query as Q,
   queryRefresh as qR,
 } from './query';
+
+export {LifecycleHook} from './hooks';
+
 // clang-format on
 
 export {

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -24,7 +24,7 @@ import {LContainerNode, LElementNode, LNode, LNodeFlags, LProjectionNode, LTextN
 import {assertNodeType, assertNodeOfPossibleTypes} from './node_assert';
 import {appendChild, insertChild, insertView, processProjectedNode, removeView} from './node_manipulation';
 import {isNodeMatchingSelector} from './node_selector_matcher';
-import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveType, TypedDirectiveDef, TypedComponentDef} from './interfaces/definition';
+import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveType} from './interfaces/definition';
 import {RComment, RElement, RText, Renderer3, RendererFactory3, ProceduralRenderer3, ObjectOrientedRenderer3, RendererStyleFlags3} from './interfaces/renderer';
 import {isDifferent, stringify} from './util';
 
@@ -447,8 +447,6 @@ export function elementStart(
       if (hostComponentDef) {
         // TODO(mhevery): This assumes that the directives come in correct order, which
         // is not guaranteed. Must be refactored to take it into account.
-        (hostComponentDef as TypedComponentDef<any>).type =
-            nameOrComponentType as ComponentType<any>;
         directiveCreate(++index, hostComponentDef.n(), hostComponentDef, queryName);
       }
       hack_declareDirectives(index, directiveTypes, localRefs);
@@ -476,7 +474,6 @@ function hack_declareDirectives(
       // TODO(misko): refactor this to store the `DirectiveDef` in `TView.data`.
       const directiveType = directiveTypes[i];
       const directiveDef = directiveType.ngDirectiveDef;
-      (directiveDef as TypedDirectiveDef<any>).type = directiveType;
       directiveCreate(
           ++index, directiveDef.n(), directiveDef, hack_findQueryName(directiveDef, localRefs));
     }

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -71,14 +71,16 @@ export interface DirectiveDef<T> {
    * Refreshes host bindings on the associated directive. Also calls lifecycle hooks
    * like ngOnInit and ngDoCheck, if they are defined on the directive.
    */
-  // Note: This call must be separate from r() because hooks like ngOnInit need to
-  // be called breadth-first across a view before processing onInits in children
-  // (for backwards compatibility). Child template processing thus needs to be
-  // delayed until all inputs and host bindings in a view have been checked.
   h(directiveIndex: number, elementIndex: number): void;
 
-  /* A map of the lifecycle hooks defined on this directive (key: name, value: fn) */
-  lifecycleHooks: LifecycleHooksMap;
+  /* The following are lifecycle hooks for this component */
+  onInit: (() => void)|null;
+  doCheck: (() => void)|null;
+  afterContentInit: (() => void)|null;
+  afterContentChecked: (() => void)|null;
+  afterViewInit: (() => void)|null;
+  afterViewChecked: (() => void)|null;
+  onDestroy: (() => void)|null;
 }
 
 export interface ComponentDef<T> extends DirectiveDef<T> {
@@ -102,17 +104,6 @@ export interface ComponentDef<T> extends DirectiveDef<T> {
    * NOTE: only used with component directives.
    */
   readonly rendererType: RendererType2|null;
-}
-
-/* A map of the lifecycle hooks defined on a directive (key: name, value: fn) */
-export interface LifecycleHooksMap {
-  onInit: () => void | null;
-  doCheck: () => void | null;
-  afterContentInit: () => void | null;
-  afterContentChecked: () => void | null;
-  afterViewInit: () => void | null;
-  afterViewChecked: () => void | null;
-  onDestroy: () => void | null;
 }
 
 export interface DirectiveDefArgs<T> {

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -68,18 +68,6 @@ export interface DirectiveDef<T> {
   n(): T;
 
   /**
-   * Refreshes the view of the component. Also calls lifecycle hooks like
-   * ngAfterViewInit, if they are defined on the component.
-   *
-   * NOTE: this property is short (1 char) because it is used in component
-   * templates which is sensitive to size.
-   *
-   * @param directiveIndex index of the directive in the containing template
-   * @param elementIndex index of an host element for a given directive.
-   */
-  r(directiveIndex: number, elementIndex: number): void;
-
-  /**
    * Refreshes host bindings on the associated directive. Also calls lifecycle hooks
    * like ngOnInit and ngDoCheck, if they are defined on the directive.
    */
@@ -94,18 +82,6 @@ export interface DirectiveDef<T> {
 }
 
 export interface ComponentDef<T> extends DirectiveDef<T> {
-  /**
-   * Refreshes the view of the component. Also calls lifecycle hooks like
-   * ngAfterViewInit, if they are defined on the component.
-   *
-   * NOTE: this property is short (1 char) because it is used in
-   * component templates which is sensitive to size.
-   *
-   * @param directiveIndex index of the directive in the containing template
-   * @param elementIndex index of an host element for a given component.
-   */
-  r(directiveIndex: number, elementIndex: number): void;
-
   /**
    * The tag name which should be used by the component.
    *
@@ -142,19 +118,17 @@ export interface LifecycleHooksMap {
 export interface DirectiveDefArgs<T> {
   type: Type<T>;
   factory: () => T;
-  refresh?: (directiveIndex: number, elementIndex: number) => void;
   inputs?: {[P in keyof T]?: string};
   outputs?: {[P in keyof T]?: string};
   methods?: {[P in keyof T]?: string};
   features?: DirectiveDefFeature[];
+  hostBindings?: (directiveIndex: number, elementIndex: number) => void;
   exportAs?: string;
 }
 
 export interface ComponentDefArgs<T> extends DirectiveDefArgs<T> {
   tag: string;
   template: ComponentTemplate<T>;
-  refresh?: (directiveIndex: number, elementIndex: number) => void;
-  hostBindings?: (directiveIndex: number, elementIndex: number) => void;
   features?: ComponentDefFeature[];
   rendererType?: RendererType2;
 }

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -27,6 +27,9 @@ export const enum DirectiveDefFlags {ContentQuery = 0b10}
  * `DirectiveDef` is a compiled version of the Directive used by the renderer instructions.
  */
 export interface DirectiveDef<T> {
+  /** Token representing the directive. Used by DI. */
+  type: Type<T>;
+
   /** Function that makes a directive public to the DI system. */
   diPublic: ((def: DirectiveDef<any>) => void)|null;
 
@@ -85,6 +88,9 @@ export interface DirectiveDef<T> {
   // (for backwards compatibility). Child template processing thus needs to be
   // delayed until all inputs and host bindings in a view have been checked.
   h(directiveIndex: number, elementIndex: number): void;
+
+  /* A map of the lifecycle hooks defined on this directive (key: name, value: fn) */
+  lifecycleHooks: LifecycleHooksMap;
 }
 
 export interface ComponentDef<T> extends DirectiveDef<T> {
@@ -122,17 +128,19 @@ export interface ComponentDef<T> extends DirectiveDef<T> {
   readonly rendererType: RendererType2|null;
 }
 
-/**
- * Private: do not export
- */
-export interface TypedDirectiveDef<T> extends DirectiveDef<T> { type: DirectiveType<T>; }
-
-/**
- * Private: do not export
- */
-export interface TypedComponentDef<T> extends ComponentDef<T> { type: ComponentType<T>; }
+/* A map of the lifecycle hooks defined on a directive (key: name, value: fn) */
+export interface LifecycleHooksMap {
+  onInit: () => void | null;
+  doCheck: () => void | null;
+  afterContentInit: () => void | null;
+  afterContentChecked: () => void | null;
+  afterViewInit: () => void | null;
+  afterViewChecked: () => void | null;
+  onDestroy: () => void | null;
+}
 
 export interface DirectiveDefArgs<T> {
+  type: Type<T>;
   factory: () => T;
   refresh?: (directiveIndex: number, elementIndex: number) => void;
   inputs?: {[P in keyof T]?: string};

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -91,6 +91,28 @@ export interface LView {
   cleanup: any[]|null;
 
   /**
+   * Array of ngAfterContentInit and ngAfterContentChecked hooks.
+   *
+   * These need to be queued so they can be called all at once after init hooks
+   * and any embedded views are finished processing (to maintain backwards-compatible
+   * order).
+   *
+   * 1st index is: type of hook (afterContentInit or afterContentChecked)
+   * 2nd index is: method to call
+   * 3rd index is: context
+   */
+  contentHooks: any[]|null;
+
+  /**
+   * Whether or not the content hooks have been called in this change detection run.
+   *
+   * Content hooks are executed by the first Comp.r() instruction that runs (to avoid
+   * adding to the code size), so it needs to be able to check whether or not they should
+   * be called.
+   */
+  contentHooksCalled: boolean;
+
+  /**
    * The first LView or LContainer beneath this LView in the hierarchy.
    *
    * Necessary to store this so views can traverse through their nested views

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -104,6 +104,16 @@ export interface LView {
   contentHooks: any[]|null;
 
   /**
+   * Whether or not the ngOnInit and ngDoCheck hooks have been called in this change
+   * detection run.
+   *
+   * These two hooks are executed by the first Comp.r() instruction that runs OR the
+   * first cR instruction that runs (so inits are run for the top level view before
+   * any embedded views). For this reason, the call must be tracked.
+   */
+  initHooksCalled: boolean;
+
+  /**
    * Whether or not the content hooks have been called in this change detection run.
    *
    * Content hooks are executed by the first Comp.r() instruction that runs (to avoid
@@ -194,7 +204,29 @@ export interface LViewOrLContainer {
  *
  * Stored on the template function as ngPrivateData.
  */
-export interface TView { data: TData; }
+export interface TView {
+  /** Static data equivalent of LView.data[]. Contains TNodes and directive defs. */
+  data: TData;
+
+  /** Whether or not this template has been processed. */
+  firstTemplatePass: boolean;
+
+  /**
+   * Array of init hooks that should be executed for this view.
+   *
+   * Even indices: Flags (1st bit: hook type, remaining: directive index)
+   * Odd indices: Hook function
+   */
+  initHooks: HookData|null;
+}
+
+/**
+ * Array of init hooks that should be executed for a view.
+ *
+ * Even indices: Flags (1st bit: hook type, remaining: directive index)
+ * Odd indices: Hook function
+ */
+export type HookData = (number | (() => void))[];
 
 /**
  * Static data that corresponds to the instance-specific data array on an LView.

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -33,9 +33,6 @@ export interface LView {
    */
   creationMode: boolean;
 
-  /** The index in the data array at which view hooks begin to be stored. */
-  viewHookStartIndex: number|null;
-
   /**
    * The parent view is needed when we exit the view and must restore the previous
    * `LView`. Without this, the render method would have to keep a stack of
@@ -89,19 +86,6 @@ export interface LView {
    * 2nd index is; context for function
    */
   cleanup: any[]|null;
-
-  /**
-   * Array of ngAfterContentInit and ngAfterContentChecked hooks.
-   *
-   * These need to be queued so they can be called all at once after init hooks
-   * and any embedded views are finished processing (to maintain backwards-compatible
-   * order).
-   *
-   * 1st index is: type of hook (afterContentInit or afterContentChecked)
-   * 2nd index is: method to call
-   * 3rd index is: context
-   */
-  contentHooks: any[]|null;
 
   /**
    * Whether or not the ngOnInit and ngDoCheck hooks have been called in this change
@@ -212,12 +196,30 @@ export interface TView {
   firstTemplatePass: boolean;
 
   /**
-   * Array of init hooks that should be executed for this view.
+   * Array of ngOnInit and ngDoCheck hooks that should be executed for this view.
    *
    * Even indices: Flags (1st bit: hook type, remaining: directive index)
    * Odd indices: Hook function
    */
   initHooks: HookData|null;
+
+  /**
+   * Array of ngAfterContentInit and ngAfterContentChecked hooks that should be executed for
+   * this view.
+   *
+   * Even indices: Flags (1st bit: hook type, remaining: directive index)
+   * Odd indices: Hook function
+   */
+  contentHooks: HookData|null;
+
+  /**
+   * Array of ngAfterViewInit and ngAfterViewChecked hooks that should be executed for
+   * this view.
+   *
+   * Even indices: Flags (1st bit: hook type, remaining: directive index)
+   * Odd indices: Hook function
+   */
+  viewHooks: HookData|null;
 }
 
 /**

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -88,24 +88,21 @@ export interface LView {
   cleanup: any[]|null;
 
   /**
-   * Whether or not the ngOnInit and ngDoCheck hooks have been called in this change
-   * detection run.
+   * This number tracks the next lifecycle hook that needs to be run.
    *
-   * These two hooks are executed by the first Comp.r() instruction that runs OR the
-   * first cR() instruction that runs (so inits are run for the top level view before
-   * any embedded views). For this reason, the call must be tracked.
-   */
-  initHooksCalled: boolean;
-
-  /**
-   * Whether or not the afterContentInit and afterContentChecked hooks have been called
-   * in this change detection run.
+   * If lifecycleStage === LifecycleStage.ON_INIT, the init hooks haven't yet been run
+   * and should be executed by the first r() instruction that runs OR the first
+   * cR() instruction that runs (so inits are run for the top level view before any
+   * embedded views).
    *
-   * Content hooks are executed by the first Comp.r() instruction that runs (to avoid
-   * adding to the code size), so it needs to be able to check whether or not they should
-   * be called.
+   * If lifecycleStage === LifecycleStage.CONTENT_INIT, the init hooks have been run, but
+   * the content hooks have not yet been run. They should be executed on the first
+   * r() instruction that runs.
+   *
+   * If lifecycleStage === LifecycleStage.VIEW_INIT, both the init hooks and content hooks
+   * have already been run.
    */
-  contentHooksCalled: boolean;
+  lifecycleStage: LifecycleStage;
 
   /**
    * The first LView or LContainer beneath this LView in the hierarchy.
@@ -238,6 +235,18 @@ export interface TView {
  * Odd indices: Hook function
  */
 export type HookData = (number | (() => void))[];
+
+/** Possible values of LView.lifecycleStage, used to determine which hooks to run.  */
+export const enum LifecycleStage {
+  /* Init hooks need to be run, if any. */
+  INIT = 1,
+
+  /* Content hooks need to be run, if any. Init hooks have already run. */
+  CONTENT_INIT = 2,
+
+  /* View hooks need to be run, if any. Any init hooks/content hooks have ran. */
+  VIEW_INIT = 3
+}
 
 /**
  * Static data that corresponds to the instance-specific data array on an LView.

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -69,9 +69,9 @@ export interface LView {
   bindingStartIndex: number|null;
 
   /**
-   * When a view is destroyed, listeners need to be released and onDestroy callbacks
-   * need to be called. This cleanup array stores both listener data (in chunks of 4)
-   * and onDestroy data (in chunks of 2) for a particular view. Combining the arrays
+   * When a view is destroyed, listeners need to be released and outputs need to be
+   * unsubscribed. This cleanup array stores both listener data (in chunks of 4)
+   * and output data (in chunks of 2) for a particular view. Combining the arrays
    * saves on memory (70 bytes per array) and on a few bytes of code size (for two
    * separate for loops).
    *
@@ -81,9 +81,9 @@ export interface LView {
    * 3rd index is: listener function
    * 4th index is: useCapture boolean
    *
-   * If it's an onDestroy function:
-   * 1st index is: onDestroy function
-   * 2nd index is; context for function
+   * If it's an output subscription:
+   * 1st index is: unsubscribe function
+   * 2nd index is: context for function
    */
   cleanup: any[]|null;
 
@@ -92,13 +92,14 @@ export interface LView {
    * detection run.
    *
    * These two hooks are executed by the first Comp.r() instruction that runs OR the
-   * first cR instruction that runs (so inits are run for the top level view before
+   * first cR() instruction that runs (so inits are run for the top level view before
    * any embedded views). For this reason, the call must be tracked.
    */
   initHooksCalled: boolean;
 
   /**
-   * Whether or not the content hooks have been called in this change detection run.
+   * Whether or not the afterContentInit and afterContentChecked hooks have been called
+   * in this change detection run.
    *
    * Content hooks are executed by the first Comp.r() instruction that runs (to avoid
    * adding to the code size), so it needs to be able to check whether or not they should
@@ -220,10 +221,18 @@ export interface TView {
    * Odd indices: Hook function
    */
   viewHooks: HookData|null;
+
+  /**
+   * Array of ngOnDestroy hooks that should be executed when this view is destroyed.
+   *
+   * Even indices: Directive index
+   * Odd indices: Hook function
+   */
+  destroyHooks: HookData|null;
 }
 
 /**
- * Array of init hooks that should be executed for a view.
+ * Array of hooks that should be executed for a view and their directive indices.
  *
  * Even indices: Flags (1st bit: hook type, remaining: directive index)
  * Odd indices: Hook function

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -11,7 +11,7 @@ import {LContainer, unusedValueExportToPlacateAjd as unused1} from './interfaces
 import {LContainerNode, LElementNode, LNode, LNodeFlags, LProjectionNode, LTextNode, LViewNode, unusedValueExportToPlacateAjd as unused2} from './interfaces/node';
 import {LProjection, unusedValueExportToPlacateAjd as unused3} from './interfaces/projection';
 import {ProceduralRenderer3, RComment, RElement, RNode, RText, unusedValueExportToPlacateAjd as unused4} from './interfaces/renderer';
-import {LView, LViewOrLContainer, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
+import {HookData, LView, LViewOrLContainer, TView, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
 import {assertNodeType} from './node_assert';
 
 const unusedValueToPlacateAjd = unused1 + unused2 + unused3 + unused4 + unused5;
@@ -295,17 +295,36 @@ export function getParentState(state: LViewOrLContainer, rootView: LView): LView
  * @param view The LView to clean up
  */
 function cleanUpView(view: LView): void {
-  if (!view.cleanup) return;
+  removeListeners(view);
+  executeOnDestroys(view);
+}
+
+/** Removes listeners and unsubscribes from output subscriptions */
+function removeListeners(view: LView): void {
   const cleanup = view.cleanup !;
-  for (let i = 0; i < cleanup.length - 1; i += 2) {
-    if (typeof cleanup[i] === 'string') {
-      cleanup ![i + 1].removeEventListener(cleanup[i], cleanup[i + 2], cleanup[i + 3]);
-      i += 2;
-    } else {
-      cleanup[i].call(cleanup[i + 1]);
+  if (cleanup != null) {
+    for (let i = 0; i < cleanup.length - 1; i += 2) {
+      if (typeof cleanup[i] === 'string') {
+        cleanup ![i + 1].removeEventListener(cleanup[i], cleanup[i + 2], cleanup[i + 3]);
+        i += 2;
+      } else {
+        cleanup[i].call(cleanup[i + 1]);
+      }
+    }
+    view.cleanup = null;
+  }
+}
+
+/** Calls onDestroy hooks for this view */
+function executeOnDestroys(view: LView): void {
+  const tView = view.tView;
+  let destroyHooks: HookData|null;
+  if (tView != null && (destroyHooks = tView.destroyHooks) != null) {
+    for (let i = 0; i < destroyHooks.length; i += 2) {
+      const instance = view.data[destroyHooks[i] as number];
+      (destroyHooks[i | 1] as() => void).call(instance);
     }
   }
-  view.cleanup = null;
 }
 
 /**

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -18,7 +18,7 @@ import {Type} from '../type';
 import {assertNotNull} from './assert';
 import {ReadFromInjectorFn, getOrCreateNodeInjectorForNode} from './di';
 import {assertPreviousIsParent, getCurrentQuery} from './instructions';
-import {DirectiveDef, TypedDirectiveDef, unusedValueExportToPlacateAjd as unused1} from './interfaces/definition';
+import {DirectiveDef, unusedValueExportToPlacateAjd as unused1} from './interfaces/definition';
 import {LInjector, unusedValueExportToPlacateAjd as unused2} from './interfaces/injector';
 import {LContainerNode, LElementNode, LNode, LNodeFlags, LViewNode, TNode, unusedValueExportToPlacateAjd as unused3} from './interfaces/node';
 import {LQuery, QueryReadType, unusedValueExportToPlacateAjd as unused4} from './interfaces/query';
@@ -159,7 +159,7 @@ function geIdxOfMatchingDirective(node: LNode, type: Type<any>): number|null {
   for (let i = flags >> LNodeFlags.INDX_SHIFT,
            ii = i + ((flags & LNodeFlags.SIZE_MASK) >> LNodeFlags.SIZE_SHIFT);
        i < ii; i++) {
-    const def = tData[i] as TypedDirectiveDef<any>;
+    const def = tData[i] as DirectiveDef<any>;
     if (def.diPublic && def.type === type) {
       return i;
     }

--- a/packages/core/test/render3/basic_perf.ts
+++ b/packages/core/test/render3/basic_perf.ts
@@ -32,6 +32,7 @@ describe('iv perf test', () => {
       it(`${iteration}. create ${count} divs in Render3`, () => {
         class Component {
           static ngComponentDef = defineComponent({
+            type: Component,
             tag: 'div',
             template: function Template(ctx: any, cm: any) {
               if (cm) {

--- a/packages/core/test/render3/common_integration_spec.ts
+++ b/packages/core/test/render3/common_integration_spec.ts
@@ -8,7 +8,7 @@
 
 import {NgForOfContext} from '@angular/common';
 
-import {C, E, T, b, cR, cr, defineComponent, e, p, t} from '../../src/render3/index';
+import {C, E, T, b, cR, cr, defineComponent, e, p, r, t} from '../../src/render3/index';
 
 import {NgForOf} from './common_with_def';
 import {renderComponent, toHtml} from './render_util';
@@ -20,6 +20,7 @@ describe('@angular/common integration', () => {
         items: string[] = ['first', 'second'];
 
         static ngComponentDef = defineComponent({
+          type: MyApp,
           factory: () => new MyApp(),
           tag: 'my-app',
           // <ul>
@@ -33,7 +34,7 @@ describe('@angular/common integration', () => {
             }
             p(1, 'ngForOf', b(myApp.items));
             cR(1);
-            NgForOf.ngDirectiveDef.r(2, 0);
+            r(2, 0);
             cr();
 
             function liTemplate(row: NgForOfContext<string>, cm: boolean) {

--- a/packages/core/test/render3/common_with_def.ts
+++ b/packages/core/test/render3/common_with_def.ts
@@ -15,13 +15,11 @@ import {DirectiveType, InjectFlags, NgOnChangesFeature, defineDirective, inject,
 export const NgForOf: DirectiveType<NgForOfDef<any>> = NgForOfDef as any;
 
 NgForOf.ngDirectiveDef = defineDirective({
+  type: NgForOfDef,
   factory: () => new NgForOfDef(
                injectViewContainerRef(), injectTemplateRef(),
                inject(IterableDiffers, InjectFlags.Default, defaultIterableDiffers)),
   features: [NgOnChangesFeature(NgForOf)],
-  refresh: (directiveIndex: number, elementIndex: number) => {
-    m<NgForOfDef<any>>(directiveIndex).ngDoCheck();
-  },
   inputs: {
     ngForOf: 'ngForOf',
     ngForTrackBy: 'ngForTrackBy',

--- a/packages/core/test/render3/compiler_canonical_spec.ts
+++ b/packages/core/test/render3/compiler_canonical_spec.ts
@@ -311,14 +311,12 @@ describe('compiler specification', () => {
 
       // NORMATIVE
       static ngDirectiveDef = r3.defineDirective({
+        type: ForOfDirective,
         factory: function ForOfDirective_Factory() {
           return new ForOfDirective(r3.injectViewContainerRef(), r3.injectTemplateRef());
         },
         // TODO(chuckj): Enable when ngForOf enabling lands.
         // features: [NgOnChangesFeature(NgForOf)],
-        refresh: function ForOfDirective_Refresh(directiveIndex: number, elementIndex: number) {
-          r3.m<ForOfDirective>(directiveIndex).ngDoCheck();
-        },
         inputs: {forOf: 'forOf'}
       });
       // /NORMATIVE
@@ -340,6 +338,7 @@ describe('compiler specification', () => {
 
         // NORMATIVE
         static ngComponentDef = r3.defineComponent({
+          type: MyComponent,
           tag: 'my-component',
           factory: function MyComponent_Factory() { return new MyComponent(); },
           template: function MyComponentTemplate(ctx: MyComponent, cm: boolean) {
@@ -350,7 +349,7 @@ describe('compiler specification', () => {
             }
             r3.p(1, 'forOf', r3.b(ctx.items));
             r3.cR(1);
-            ForOfDirective.ngDirectiveDef.r(2, 1);
+            r3.r(2, 1);
             r3.cr();
 
             function MyComponent_ForOfDirective_Template_1(ctx1: any, cm: boolean) {
@@ -404,6 +403,7 @@ describe('compiler specification', () => {
 
         // NORMATIVE
         static ngComponentDef = r3.defineComponent({
+          type: MyComponent,
           tag: 'my-component',
           factory: function MyComponent_Factory() { return new MyComponent(); },
           template: function MyComponent_Template(ctx: MyComponent, cm: boolean) {
@@ -414,7 +414,7 @@ describe('compiler specification', () => {
             }
             r3.p(1, 'forOf', r3.b(ctx.items));
             r3.cR(1);
-            ForOfDirective.ngDirectiveDef.r(2, 1);
+            r3.r(2, 1);
             r3.cr();
 
             function MyComponent_ForOfDirective_Template_1(ctx1: any, cm: boolean) {
@@ -430,7 +430,7 @@ describe('compiler specification', () => {
               r3.t(1, r3.b1('', l0_item.name, ''));
               r3.p(4, 'forOf', r3.b(ctx.items));
               r3.cR(3);
-              ForOfDirective.ngDirectiveDef.r(4, 3);
+              r3.r(4, 3);
               r3.cr();
 
               function MyComponent_ForOfDirective_ForOfDirective_Template_3(

--- a/packages/core/test/render3/compiler_canonical_spec.ts
+++ b/packages/core/test/render3/compiler_canonical_spec.ts
@@ -27,6 +27,7 @@ describe('compiler specification', () => {
       class MyComponent {
         // NORMATIVE
         static ngComponentDef = r3.defineComponent({
+          type: MyComponent,
           tag: 'my-component',
           factory: () => new MyComponent(),
           template: function(ctx: MyComponent, cm: boolean) {
@@ -59,6 +60,7 @@ describe('compiler specification', () => {
         constructor() { log.push('ChildComponent'); }
         // NORMATIVE
         static ngComponentDef = r3.defineComponent({
+          type: ChildComponent,
           tag: `child`,
           factory: () => new ChildComponent(),
           template: function(ctx: ChildComponent, cm: boolean) {
@@ -77,6 +79,7 @@ describe('compiler specification', () => {
         constructor() { log.push('SomeDirective'); }
         // NORMATIVE
         static ngDirectiveDef = r3.defineDirective({
+          type: SomeDirective,
           factory: () => new SomeDirective(),
         });
         // /NORMATIVE
@@ -86,6 +89,7 @@ describe('compiler specification', () => {
       class MyComponent {
         // NORMATIVE
         static ngComponentDef = r3.defineComponent({
+          type: MyComponent,
           tag: 'my-component',
           factory: () => new MyComponent(),
           template: function(ctx: MyComponent, cm: boolean) {
@@ -119,6 +123,7 @@ describe('compiler specification', () => {
         constructor(template: TemplateRef<any>) { log.push('ifDirective'); }
         // NORMATIVE
         static ngDirectiveDef = r3.defineDirective({
+          type: IfDirective,
           factory: () => new IfDirective(r3.injectTemplateRef()),
         });
         // /NORMATIVE
@@ -130,6 +135,7 @@ describe('compiler specification', () => {
         salutation = 'Hello';
         // NORMATIVE
         static ngComponentDef = r3.defineComponent({
+          type: MyComponent,
           tag: 'my-component',
           factory: () => new MyComponent(),
           template: function(ctx: MyComponent, cm: boolean) {
@@ -236,6 +242,7 @@ describe('compiler specification', () => {
       class MyComponent {
         // NORMATIVE
         static ngComponentDef = r3.defineComponent({
+          type: MyComponent,
           tag: 'my-component',
           factory: () => new MyComponent,
           template: function(ctx: MyComponent, cm: boolean) {

--- a/packages/core/test/render3/compiler_canonical_spec.ts
+++ b/packages/core/test/render3/compiler_canonical_spec.ts
@@ -98,8 +98,8 @@ describe('compiler specification', () => {
               r3.e();
               r3.T(3, '!');
             }
-            ChildComponent.ngComponentDef.r(1, 0);
-            SomeDirective.ngDirectiveDef.r(2, 0);
+            r3.r(1, 0);
+            r3.r(2, 0);
           }
         });
         // /NORMATIVE
@@ -146,7 +146,7 @@ describe('compiler specification', () => {
             }
             let foo = r3.m<any>(1);
             r3.cR(2);
-            IfDirective.ngDirectiveDef.r(3, 2);
+            r3.r(3, 2);
             r3.cr();
 
             function C1(ctx1: any, cm: boolean) {

--- a/packages/core/test/render3/compiler_canonical_spec.ts
+++ b/packages/core/test/render3/compiler_canonical_spec.ts
@@ -175,6 +175,7 @@ describe('compiler specification', () => {
       @Component({selector: 'simple', template: `<div><ng-content></ng-content></div>`})
       class SimpleComponent {
         static ngComponentDef = r3.defineComponent({
+          type: SimpleComponent,
           tag: 'simple',
           factory: () => new SimpleComponent(),
           template: function(ctx: SimpleComponent, cm: boolean) {
@@ -196,6 +197,7 @@ describe('compiler specification', () => {
       })
       class ComplexComponent {
         static ngComponentDef = r3.defineComponent({
+          type: ComplexComponent,
           tag: 'complex',
           factory: () => new ComplexComponent(),
           template: function(ctx: ComplexComponent, cm: boolean) {
@@ -221,6 +223,7 @@ describe('compiler specification', () => {
       })
       class MyApp {
         static ngComponentDef = r3.defineComponent({
+          type: MyApp,
           tag: 'my-app',
           factory: () => new MyApp(),
           template: function(ctx: MyApp, cm: boolean) {

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -20,6 +20,7 @@ describe('component', () => {
     increment() { this.count++; }
 
     static ngComponentDef = defineComponent({
+      type: CounterComponent,
       tag: 'counter',
       template: function(ctx: CounterComponent, cm: boolean) {
         if (cm) {
@@ -63,6 +64,7 @@ describe('component', () => {
 describe('encapsulation', () => {
   class WrapperComponent {
     static ngComponentDef = defineComponent({
+      type: WrapperComponent,
       tag: 'wrapper',
       template: function(ctx: WrapperComponent, cm: boolean) {
         if (cm) {
@@ -78,6 +80,7 @@ describe('encapsulation', () => {
 
   class EncapsulatedComponent {
     static ngComponentDef = defineComponent({
+      type: EncapsulatedComponent,
       tag: 'encapsulated',
       template: function(ctx: EncapsulatedComponent, cm: boolean) {
         if (cm) {
@@ -96,6 +99,7 @@ describe('encapsulation', () => {
 
   class LeafComponent {
     static ngComponentDef = defineComponent({
+      type: LeafComponent,
       tag: 'leaf',
       template: function(ctx: LeafComponent, cm: boolean) {
         if (cm) {
@@ -125,6 +129,7 @@ describe('encapsulation', () => {
   it('should encapsulate host and children with different attributes', () => {
     class WrapperComponentWith {
       static ngComponentDef = defineComponent({
+        type: WrapperComponentWith,
         tag: 'wrapper',
         template: function(ctx: WrapperComponentWith, cm: boolean) {
           if (cm) {
@@ -142,6 +147,7 @@ describe('encapsulation', () => {
 
     class LeafComponentwith {
       static ngComponentDef = defineComponent({
+        type: LeafComponentwith,
         tag: 'leaf',
         template: function(ctx: LeafComponentwith, cm: boolean) {
           if (cm) {

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ViewEncapsulation} from '../../src/core';
-import {E, T, b, defineComponent, e, markDirty, t} from '../../src/render3/index';
+import {E, T, b, defineComponent, e, markDirty, r, t} from '../../src/render3/index';
 import {createRendererType2} from '../../src/view/index';
 
 import {getRendererFactory2} from './imported_renderer2';
@@ -72,7 +72,7 @@ describe('encapsulation', () => {
           e();
         }
         EncapsulatedComponent.ngComponentDef.h(1, 0);
-        EncapsulatedComponent.ngComponentDef.r(1, 0);
+        r(1, 0);
       },
       factory: () => new WrapperComponent,
     });
@@ -89,7 +89,7 @@ describe('encapsulation', () => {
           e();
         }
         LeafComponent.ngComponentDef.h(2, 1);
-        LeafComponent.ngComponentDef.r(2, 1);
+        r(2, 1);
       },
       factory: () => new EncapsulatedComponent,
       rendererType:
@@ -137,7 +137,7 @@ describe('encapsulation', () => {
             e();
           }
           LeafComponentwith.ngComponentDef.h(1, 0);
-          LeafComponentwith.ngComponentDef.r(1, 0);
+          r(1, 0);
         },
         factory: () => new WrapperComponentWith,
         rendererType:

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -138,7 +138,7 @@ describe('content projection', () => {
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent))
-      .toEqual('<child><div><projected-comp>content</projected-comp></div></child>');
+        .toEqual('<child><div><projected-comp>content</projected-comp></div></child>');
   });
 
   it('should project content with container.', () => {

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -104,7 +104,7 @@ describe('content projection', () => {
     /** <div><ng-content></ng-content></div> */
     const Child = createComponent('child', (ctx: any, cm: boolean) => {
       if (cm) {
-        m(0, pD());
+        pD(0);
         E(1, 'div');
         { P(2, 0); }
         e();

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, E, P, T, V, cR, cr, detectChanges, e, m, pD, v} from '../../src/render3/index';
+import {C, E, P, T, V, cR, cr, detectChanges, e, m, pD, r, v} from '../../src/render3/index';
 
 import {createComponent, renderComponent, toHtml} from './render_util';
 
@@ -35,7 +35,7 @@ describe('content projection', () => {
         e();
       }
       Child.ngComponentDef.h(1, 0);
-      Child.ngComponentDef.r(1, 0);
+      r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div>content</div></child>');
@@ -55,7 +55,7 @@ describe('content projection', () => {
         e();
       }
       Child.ngComponentDef.h(1, 0);
-      Child.ngComponentDef.r(1, 0);
+      r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child>content</child>');
@@ -77,7 +77,7 @@ describe('content projection', () => {
         { P(3, 0); }
         e();
         GrandChild.ngComponentDef.h(2, 1);
-        GrandChild.ngComponentDef.r(2, 1);
+        r(2, 1);
       }
     });
     const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
@@ -92,7 +92,7 @@ describe('content projection', () => {
         e();
       }
       Child.ngComponentDef.h(1, 0);
-      Child.ngComponentDef.r(1, 0);
+      r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent))
@@ -133,8 +133,8 @@ describe('content projection', () => {
       }
       Child.ngComponentDef.h(1, 0);
       ProjectedComp.ngComponentDef.h(3, 2);
-      ProjectedComp.ngComponentDef.r(3, 2);
-      Child.ngComponentDef.r(1, 0);
+      r(3, 2);
+      r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent))
@@ -171,7 +171,7 @@ describe('content projection', () => {
       }
       cr();
       Child.ngComponentDef.h(1, 0);
-      Child.ngComponentDef.r(1, 0);
+      r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div>()</div></child>');
@@ -207,7 +207,7 @@ describe('content projection', () => {
       }
       cr();
       Child.ngComponentDef.h(1, 0);
-      Child.ngComponentDef.r(1, 0);
+      r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child></child>');
@@ -256,7 +256,7 @@ describe('content projection', () => {
       }
       cr();
       Child.ngComponentDef.h(1, 0);
-      Child.ngComponentDef.r(1, 0);
+      r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div>(else)</div></child>');
@@ -314,7 +314,7 @@ describe('content projection', () => {
         e();
       }
       Child.ngComponentDef.h(1, 0);
-      Child.ngComponentDef.r(1, 0);
+      r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div><span>content</span></div></child>');
@@ -367,7 +367,7 @@ describe('content projection', () => {
            e();
          }
          Child.ngComponentDef.h(1, 0);
-         Child.ngComponentDef.r(1, 0);
+         r(1, 0);
        });
        const parent = renderComponent(Parent);
        expect(toHtml(parent)).toEqual('<child><div>content</div></child>');
@@ -404,7 +404,7 @@ describe('content projection', () => {
         e();
       }
       Child.ngComponentDef.h(1, 0);
-      Child.ngComponentDef.r(1, 0);
+      r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div></div><span>content</span></child>');
@@ -462,7 +462,7 @@ describe('content projection', () => {
         e();
       }
       Child.ngComponentDef.h(1, 0);
-      Child.ngComponentDef.r(1, 0);
+      r(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child>content<div></div></child>');
@@ -511,7 +511,7 @@ describe('content projection', () => {
           e();
         }
         Child.ngComponentDef.h(1, 0);
-        Child.ngComponentDef.r(1, 0);
+        r(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -557,7 +557,7 @@ describe('content projection', () => {
           e();
         }
         Child.ngComponentDef.h(1, 0);
-        Child.ngComponentDef.r(1, 0);
+        r(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -603,7 +603,7 @@ describe('content projection', () => {
           e();
         }
         Child.ngComponentDef.h(1, 0);
-        Child.ngComponentDef.r(1, 0);
+        r(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -649,7 +649,7 @@ describe('content projection', () => {
           e();
         }
         Child.ngComponentDef.h(1, 0);
-        Child.ngComponentDef.r(1, 0);
+        r(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -696,7 +696,7 @@ describe('content projection', () => {
           e();
         }
         Child.ngComponentDef.h(1, 0);
-        Child.ngComponentDef.r(1, 0);
+        r(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -743,8 +743,8 @@ describe('content projection', () => {
           }
           e();
         }
-        Child.ngComponentDef.h(0, 0);
-        Child.ngComponentDef.r(0, 0);
+        Child.ngComponentDef.h(1, 0);
+        r(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -792,7 +792,7 @@ describe('content projection', () => {
           }
           e();
           GrandChild.ngComponentDef.h(2, 1);
-          GrandChild.ngComponentDef.r(2, 1);
+          r(2, 1);
         }
       });
 
@@ -814,7 +814,7 @@ describe('content projection', () => {
           e();
         }
         Child.ngComponentDef.h(1, 0);
-        Child.ngComponentDef.r(1, 0);
+        r(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -863,7 +863,7 @@ describe('content projection', () => {
         }
         cr();
         Child.ngComponentDef.h(1, 0);
-        Child.ngComponentDef.r(1, 0);
+        r(1, 0);
       });
       const parent = renderComponent(Parent);
       expect(toHtml(parent)).toEqual('<child><span><div>content</div></span></child>');

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -99,6 +99,48 @@ describe('content projection', () => {
         .toEqual('<child><grand-child><div><b>Hello</b>World!</div></grand-child></child>');
   });
 
+  it('should project components', () => {
+
+    /** <div><ng-content></ng-content></div> */
+    const Child = createComponent('child', (ctx: any, cm: boolean) => {
+      if (cm) {
+        m(0, pD());
+        E(1, 'div');
+        { P(2, 0); }
+        e();
+      }
+    });
+
+    const ProjectedComp = createComponent('projected-comp', (ctx: any, cm: boolean) => {
+      if (cm) {
+        T(0, 'content');
+      }
+    });
+
+    /**
+     * <child>
+     *   <projected-comp></projected-comp>
+     * </child>
+     */
+    const Parent = createComponent('parent', (ctx: any, cm: boolean) => {
+      if (cm) {
+        E(0, Child);
+        {
+          E(2, ProjectedComp);
+          e();
+        }
+        e();
+      }
+      Child.ngComponentDef.h(1, 0);
+      ProjectedComp.ngComponentDef.h(3, 2);
+      ProjectedComp.ngComponentDef.r(3, 2);
+      Child.ngComponentDef.r(1, 0);
+    });
+    const parent = renderComponent(Parent);
+    expect(toHtml(parent))
+      .toEqual('<child><div><projected-comp>content</projected-comp></div></child>');
+  });
+
   it('should project content with container.', () => {
     const Child = createComponent('child', function(ctx: any, cm: boolean) {
       if (cm) {

--- a/packages/core/test/render3/define_spec.ts
+++ b/packages/core/test/render3/define_spec.ts
@@ -42,7 +42,7 @@ describe('define', () => {
         expect(myDir.log).toEqual(['second']);
         expect(myDir.valB).toEqual('works');
         myDir.log.length = 0;
-        myDir.ngDoCheck();
+        MyDirective.ngDirectiveDef.doCheck !.call(myDir);
         expect(myDir.log).toEqual([
           'ngOnChanges', 'valA', 'initValue', 'first', 'valB', undefined, 'second', 'ngDoCheck'
         ]);

--- a/packages/core/test/render3/define_spec.ts
+++ b/packages/core/test/render3/define_spec.ts
@@ -28,6 +28,7 @@ describe('define', () => {
           }
 
           static ngDirectiveDef = defineDirective({
+            type: MyDirective,
             factory: () => new MyDirective(),
             features: [NgOnChangesFeature(MyDirective)],
             inputs: {valA: 'valA', valB: 'valB'}

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -22,7 +22,7 @@ describe('di', () => {
     it('should create directive with no deps', () => {
       class Directive {
         value: string = 'Created';
-        static ngDirectiveDef = defineDirective({factory: () => new Directive});
+        static ngDirectiveDef = defineDirective({type: Directive, factory: () => new Directive});
       }
 
       function Template(ctx: any, cm: boolean) {
@@ -42,21 +42,23 @@ describe('di', () => {
     it('should create directive with inter view dependencies', () => {
       class DirectiveA {
         value: string = 'A';
-        static ngDirectiveDef =
-            defineDirective({factory: () => new DirectiveA, features: [PublicFeature]});
+        static ngDirectiveDef = defineDirective(
+            {type: DirectiveA, factory: () => new DirectiveA, features: [PublicFeature]});
       }
 
       class DirectiveB {
         value: string = 'B';
-        static ngDirectiveDef =
-            defineDirective({factory: () => new DirectiveB, features: [PublicFeature]});
+        static ngDirectiveDef = defineDirective(
+            {type: DirectiveB, factory: () => new DirectiveB, features: [PublicFeature]});
       }
 
       class DirectiveC {
         value: string;
         constructor(a: DirectiveA, b: DirectiveB) { this.value = a.value + b.value; }
-        static ngDirectiveDef = defineDirective(
-            {factory: () => new DirectiveC(inject(DirectiveA), inject(DirectiveB))});
+        static ngDirectiveDef = defineDirective({
+          type: DirectiveC,
+          factory: () => new DirectiveC(inject(DirectiveA), inject(DirectiveB))
+        });
       }
 
       function Template(ctx: any, cm: boolean) {
@@ -83,8 +85,11 @@ describe('di', () => {
         constructor(public elementRef: ElementRef) {
           this.value = (elementRef.constructor as any).name;
         }
-        static ngDirectiveDef = defineDirective(
-            {factory: () => new Directive(injectElementRef()), features: [PublicFeature]});
+        static ngDirectiveDef = defineDirective({
+          type: Directive,
+          factory: () => new Directive(injectElementRef()),
+          features: [PublicFeature]
+        });
       }
 
       class DirectiveSameInstance {
@@ -92,8 +97,10 @@ describe('di', () => {
         constructor(elementRef: ElementRef, directive: Directive) {
           this.value = elementRef === directive.elementRef;
         }
-        static ngDirectiveDef = defineDirective(
-            {factory: () => new DirectiveSameInstance(injectElementRef(), inject(Directive))});
+        static ngDirectiveDef = defineDirective({
+          type: DirectiveSameInstance,
+          factory: () => new DirectiveSameInstance(injectElementRef(), inject(Directive))
+        });
       }
 
       function Template(ctx: any, cm: boolean) {
@@ -116,8 +123,11 @@ describe('di', () => {
         constructor(public templateRef: TemplateRef<any>) {
           this.value = (templateRef.constructor as any).name;
         }
-        static ngDirectiveDef = defineDirective(
-            {factory: () => new Directive(injectTemplateRef()), features: [PublicFeature]});
+        static ngDirectiveDef = defineDirective({
+          type: Directive,
+          factory: () => new Directive(injectTemplateRef()),
+          features: [PublicFeature]
+        });
       }
 
       class DirectiveSameInstance {
@@ -125,8 +135,10 @@ describe('di', () => {
         constructor(templateRef: TemplateRef<any>, directive: Directive) {
           this.value = templateRef === directive.templateRef;
         }
-        static ngDirectiveDef = defineDirective(
-            {factory: () => new DirectiveSameInstance(injectTemplateRef(), inject(Directive))});
+        static ngDirectiveDef = defineDirective({
+          type: DirectiveSameInstance,
+          factory: () => new DirectiveSameInstance(injectTemplateRef(), inject(Directive))
+        });
       }
 
 
@@ -149,8 +161,11 @@ describe('di', () => {
         constructor(public viewContainerRef: ViewContainerRef) {
           this.value = (viewContainerRef.constructor as any).name;
         }
-        static ngDirectiveDef = defineDirective(
-            {factory: () => new Directive(injectViewContainerRef()), features: [PublicFeature]});
+        static ngDirectiveDef = defineDirective({
+          type: Directive,
+          factory: () => new Directive(injectViewContainerRef()),
+          features: [PublicFeature]
+        });
       }
 
       class DirectiveSameInstance {
@@ -159,6 +174,7 @@ describe('di', () => {
           this.value = viewContainerRef === directive.viewContainerRef;
         }
         static ngDirectiveDef = defineDirective({
+          type: DirectiveSameInstance,
           factory: () => new DirectiveSameInstance(injectViewContainerRef(), inject(Directive))
         });
       }
@@ -237,8 +253,11 @@ describe('di', () => {
 
     it('should inject from parent view', () => {
       class ParentDirective {
-        static ngDirectiveDef =
-            defineDirective({factory: () => new ParentDirective(), features: [PublicFeature]});
+        static ngDirectiveDef = defineDirective({
+          type: ParentDirective,
+          factory: () => new ParentDirective(),
+          features: [PublicFeature]
+        });
       }
 
       class ChildDirective {
@@ -247,6 +266,7 @@ describe('di', () => {
           this.value = (parent.constructor as any).name;
         }
         static ngDirectiveDef = defineDirective({
+          type: ChildDirective,
           factory: () => new ChildDirective(inject(ParentDirective)),
           features: [PublicFeature]
         });
@@ -257,8 +277,10 @@ describe('di', () => {
         constructor(parent: ParentDirective, child: ChildDirective) {
           this.value = parent === child.parent;
         }
-        static ngDirectiveDef = defineDirective(
-            {factory: () => new Child2Directive(inject(ParentDirective), inject(ChildDirective))});
+        static ngDirectiveDef = defineDirective({
+          type: Child2Directive,
+          factory: () => new Child2Directive(inject(ParentDirective), inject(ChildDirective))
+        });
       }
 
       function Template(ctx: any, cm: boolean) {

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -240,7 +240,7 @@ describe('di', () => {
           constructor(public value: string) {}
 
           static ngComponentDef = defineComponent({
-            // type: MyApp,
+            type: MyApp,
             tag: 'my-app',
             factory: () => new MyApp(inject(String as any, InjectFlags.Default, 'DefaultValue')),
             template: () => null

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -11,7 +11,7 @@ import {ElementRef, TemplateRef, ViewContainerRef} from '@angular/core';
 import {defineComponent} from '../../src/render3/definition';
 import {InjectFlags, bloomAdd, bloomFindPossibleInjector, getOrCreateNodeInjector} from '../../src/render3/di';
 import {C, E, PublicFeature, T, V, b, b2, cR, cr, defineDirective, e, inject, injectElementRef, injectTemplateRef, injectViewContainerRef, m, t, v} from '../../src/render3/index';
-import {createLNode, createLView, enterView, leaveView} from '../../src/render3/instructions';
+import {createLNode, createLView, createTView, enterView, leaveView} from '../../src/render3/instructions';
 import {LInjector} from '../../src/render3/interfaces/injector';
 import {LNodeFlags} from '../../src/render3/interfaces/node';
 
@@ -312,7 +312,7 @@ describe('di', () => {
 
   describe('getOrCreateNodeInjector', () => {
     it('should handle initial undefined state', () => {
-      const contentView = createLView(-1, null !, {data: []});
+      const contentView = createLView(-1, null !, createTView());
       const oldView = enterView(contentView, null !);
       try {
         const parent = createLNode(0, LNodeFlags.Element, null, null);

--- a/packages/core/test/render3/directive_spec.ts
+++ b/packages/core/test/render3/directive_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {E, b, defineDirective, e, m, p} from '../../src/render3/index';
+import {E, b, defineDirective, e, m, p, r} from '../../src/render3/index';
 
 import {renderToHtml} from './render_util';
 
@@ -22,7 +22,7 @@ describe('directive', () => {
         static ngDirectiveDef = defineDirective({
           type: Directive,
           factory: () => directiveInstance = new Directive,
-          refresh: (directiveIndex: number, elementIndex: number) => {
+          hostBindings: (directiveIndex: number, elementIndex: number) => {
             p(elementIndex, 'className', b(m<Directive>(directiveIndex).klass));
           }
         });
@@ -33,7 +33,8 @@ describe('directive', () => {
           E(0, 'span', null, [Directive]);
           e();
         }
-        Directive.ngDirectiveDef.r(1, 0);
+        Directive.ngDirectiveDef.h(1, 0);
+        r(1, 0);
       }
 
       expect(renderToHtml(Template, {})).toEqual('<span class="foo"></span>');

--- a/packages/core/test/render3/directive_spec.ts
+++ b/packages/core/test/render3/directive_spec.ts
@@ -20,6 +20,7 @@ describe('directive', () => {
       class Directive {
         klass = 'foo';
         static ngDirectiveDef = defineDirective({
+          type: Directive,
           factory: () => directiveInstance = new Directive,
           refresh: (directiveIndex: number, elementIndex: number) => {
             p(elementIndex, 'className', b(m<Directive>(directiveIndex).klass));

--- a/packages/core/test/render3/exports_spec.ts
+++ b/packages/core/test/render3/exports_spec.ts
@@ -42,8 +42,12 @@ describe('exports', () => {
     class MyComponent {
       name = 'Nancy';
 
-      static ngComponentDef =
-          defineComponent({tag: 'comp', template: function() {}, factory: () => new MyComponent});
+      static ngComponentDef = defineComponent({
+        type: MyComponent,
+        tag: 'comp',
+        template: function() {},
+        factory: () => new MyComponent
+      });
     }
 
     expect(renderToHtml(Template, {})).toEqual('<comp></comp>Nancy');
@@ -55,14 +59,19 @@ describe('exports', () => {
     let myDir: MyDir;
     class MyComponent {
       constructor() { myComponent = this; }
-      static ngComponentDef =
-          defineComponent({tag: 'comp', template: function() {}, factory: () => new MyComponent});
+      static ngComponentDef = defineComponent({
+        type: MyComponent,
+        tag: 'comp',
+        template: function() {},
+        factory: () => new MyComponent
+      });
     }
 
     class MyDir {
       myDir: MyComponent;
       constructor() { myDir = this; }
-      static ngDirectiveDef = defineDirective({factory: () => new MyDir, inputs: {myDir: 'myDir'}});
+      static ngDirectiveDef =
+          defineDirective({type: MyDir, factory: () => new MyDir, inputs: {myDir: 'myDir'}});
     }
 
     /** <comp #myComp></comp> <div [myDir]="myComp"></div> */
@@ -94,7 +103,7 @@ describe('exports', () => {
 
     class SomeDir {
       name = 'Drew';
-      static ngDirectiveDef = defineDirective({factory: () => new SomeDir});
+      static ngDirectiveDef = defineDirective({type: SomeDir, factory: () => new SomeDir});
     }
 
     expect(renderToHtml(Template, {})).toEqual('<div></div>Drew');
@@ -175,6 +184,7 @@ describe('exports', () => {
         constructor() { myComponent = this; }
 
         static ngComponentDef = defineComponent({
+          type: MyComponent,
           tag: 'comp',
           template: function(ctx: MyComponent, cm: boolean) {},
           factory: () => new MyComponent
@@ -187,7 +197,7 @@ describe('exports', () => {
         constructor() { myDir = this; }
 
         static ngDirectiveDef =
-            defineDirective({factory: () => new MyDir, inputs: {myDir: 'myDir'}});
+            defineDirective({type: MyDir, factory: () => new MyDir, inputs: {myDir: 'myDir'}});
       }
 
       /** <div [myDir]="myComp"></div><comp #myComp></comp> */
@@ -230,8 +240,12 @@ describe('exports', () => {
 
         constructor() { myComponent = this; }
 
-        static ngComponentDef =
-            defineComponent({tag: 'comp', template: function() {}, factory: () => new MyComponent});
+        static ngComponentDef = defineComponent({
+          type: MyComponent,
+          tag: 'comp',
+          template: function() {},
+          factory: () => new MyComponent
+        });
       }
       expect(renderToHtml(Template, {})).toEqual('oneNancy<comp></comp><input value="one">');
     });

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -234,7 +234,7 @@ describe('render3 integration test', () => {
           e();
         }
         TodoComponent.ngComponentDef.h(1, 0);
-        TodoComponent.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
 
       expect(renderToHtml(Template, null)).toEqual('<todo><p>Todo one</p></todo>');
@@ -248,7 +248,7 @@ describe('render3 integration test', () => {
           T(2, 'two');
         }
         TodoComponent.ngComponentDef.h(1, 0);
-        TodoComponent.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
       expect(renderToHtml(Template, null)).toEqual('<todo><p>Todo one</p></todo>two');
     });
@@ -267,8 +267,8 @@ describe('render3 integration test', () => {
         }
         TodoComponent.ngComponentDef.h(1, 0);
         TodoComponent.ngComponentDef.h(3, 2);
-        TodoComponent.ngComponentDef.r(1, 0);
-        TodoComponent.ngComponentDef.r(3, 2);
+        r(1, 0);
+        r(3, 2);
       }
       expect(renderToHtml(Template, null))
           .toEqual('<todo><p>Todo one</p></todo><todo><p>Todo one</p></todo>');
@@ -303,7 +303,7 @@ describe('render3 integration test', () => {
           e();
         }
         TodoComponentHostBinding.ngComponentDef.h(1, 0);
-        TodoComponentHostBinding.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
 
       expect(renderToHtml(Template, {})).toEqual('<todo title="one">one</todo>');
@@ -336,7 +336,7 @@ describe('render3 integration test', () => {
           e();
         }
         MyComp.ngComponentDef.h(1, 0);
-        MyComp.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
 
       expect(renderToHtml(Template, null)).toEqual('<comp><p>Bess</p></comp>');
@@ -383,7 +383,7 @@ describe('render3 integration test', () => {
         }
         p(0, 'condition', b(ctx.condition));
         MyComp.ngComponentDef.h(1, 0);
-        MyComp.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
 
       expect(renderToHtml(Template, {condition: true})).toEqual('<comp><div>text</div></comp>');

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -210,6 +210,7 @@ describe('render3 integration test', () => {
       value = ' one';
 
       static ngComponentDef = defineComponent({
+        type: TodoComponent,
         tag: 'todo',
         template: function TodoTemplate(ctx: any, cm: boolean) {
           if (cm) {
@@ -279,6 +280,7 @@ describe('render3 integration test', () => {
       class TodoComponentHostBinding {
         title = 'one';
         static ngComponentDef = defineComponent({
+          type: TodoComponentHostBinding,
           tag: 'todo',
           template: function TodoComponentHostBindingTemplate(
               ctx: TodoComponentHostBinding, cm: boolean) {
@@ -314,6 +316,7 @@ describe('render3 integration test', () => {
       class MyComp {
         name = 'Bess';
         static ngComponentDef = defineComponent({
+          type: MyComp,
           tag: 'comp',
           template: function MyCompTemplate(ctx: any, cm: boolean) {
             if (cm) {
@@ -348,6 +351,7 @@ describe('render3 integration test', () => {
       class MyComp {
         condition: boolean;
         static ngComponentDef = defineComponent({
+          type: MyComp,
           tag: 'comp',
           template: function MyCompTemplate(ctx: any, cm: boolean) {
             if (cm) {

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -31,14 +31,13 @@ describe('lifecycles', () => {
     let Comp = createOnInitComponent('comp', (ctx: any, cm: boolean) => {
       if (cm) {
         m(0, pD());
-        E(1, 'div'); {
-          P(2, 0);
-        }
+        E(1, 'div');
+        { P(2, 0); }
         e();
       }
     });
     let Parent = createOnInitComponent('parent', getParentTemplate(Comp));
-    let ProjectedComp = createOnInitComponent('projected', (ctx: any, cm: boolean)=> {
+    let ProjectedComp = createOnInitComponent('projected', (ctx: any, cm: boolean) => {
       if (cm) {
         T(0, 'content');
       }
@@ -429,9 +428,7 @@ describe('lifecycles', () => {
       if (cm) {
         m(0, pD());
         E(1, Comp);
-        {
-          P(3, 0);
-        }
+        { P(3, 0); }
         e();
       }
       p(1, 'val', b(ctx.val));
@@ -455,12 +452,8 @@ describe('lifecycles', () => {
         }
         ngAfterContentChecked() { allEvents.push(`${name}${this.val} check`); }
 
-        static ngComponentDef = defineComponent({
-          tag: name,
-          factory: () => new Component(),
-          inputs: {val: 'val'},
-          template: template
-        });
+        static ngComponentDef = defineComponent(
+            {tag: name, factory: () => new Component(), inputs: {val: 'val'}, template: template});
       };
     }
 
@@ -469,9 +462,7 @@ describe('lifecycles', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, Comp);
-          {
-            T(2, 'content');
-          }
+          { T(2, 'content'); }
           e();
         }
         Comp.ngComponentDef.h(1, 0);
@@ -495,20 +486,20 @@ describe('lifecycles', () => {
         if (cm) {
           C(0);
         }
-        cR(0); {
+        cR(0);
+        {
           if (ctx.condition) {
             if (V(0)) {
               E(0, Comp);
-              {
-                T(2, 'content');
-              }
+              { T(2, 'content'); }
               e();
             }
             Comp.ngComponentDef.h(1, 0);
             Comp.ngComponentDef.r(1, 0);
             v();
           }
-        } cr();
+        }
+        cr();
       }
 
       renderToHtml(Template, {condition: true});
@@ -523,13 +514,9 @@ describe('lifecycles', () => {
 
     it('should be called on directives after component', () => {
       class Directive {
-        ngAfterContentInit() {
-          events.push('dir');
-        }
+        ngAfterContentInit() { events.push('dir'); }
 
-        static ngDirectiveDef = defineDirective({
-          factory: () => new Directive()
-        });
+        static ngDirectiveDef = defineDirective({factory: () => new Directive()});
       }
 
       function Template(ctx: any, cm: boolean) {
@@ -558,9 +545,7 @@ describe('lifecycles', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, Parent);
-          {
-            T(2, 'content');
-          }
+          { T(2, 'content'); }
           e();
         }
         Parent.ngComponentDef.h(1, 0);
@@ -581,14 +566,10 @@ describe('lifecycles', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, Parent);
-          {
-            T(2, 'content');
-          }
+          { T(2, 'content'); }
           e();
           E(3, Parent);
-          {
-            T(5, 'content');
-          }
+          { T(5, 'content'); }
           e();
         }
         p(0, 'val', 1);
@@ -619,16 +600,14 @@ describe('lifecycles', () => {
           E(0, Parent);
           {
             E(2, ProjectedComp);
-            {
-              T(4, 'content');
-            }
+            { T(4, 'content'); }
             e();
           }
           e();
         }
         Parent.ngComponentDef.h(1, 0);
         ProjectedComp.ngComponentDef.h(3, 2);
-        ProjectedComp.ngComponentDef.r(3,2);
+        ProjectedComp.ngComponentDef.r(3, 2);
         Parent.ngComponentDef.r(1, 0);
       }
 
@@ -655,18 +634,14 @@ describe('lifecycles', () => {
           E(0, Parent);
           {
             E(2, ProjectedComp);
-            {
-              T(4, 'content');
-            }
+            { T(4, 'content'); }
             e();
           }
           e();
           E(5, Parent);
           {
             E(7, ProjectedComp);
-            {
-              T(9, 'content');
-            }
+            { T(9, 'content'); }
             e();
           }
           e();
@@ -700,28 +675,23 @@ describe('lifecycles', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, Comp);
-          {
-            T(2, 'content');
-          }
+          { T(2, 'content'); }
           e();
           C(3);
           E(4, Comp);
-          {
-            T(6, 'content');
-          }
+          { T(6, 'content'); }
           e();
         }
         p(0, 'val', 1);
         p(4, 'val', 4);
         Comp.ngComponentDef.h(1, 0);
         Comp.ngComponentDef.h(5, 4);
-        cR(3); {
+        cR(3);
+        {
           for (let i = 2; i < 4; i++) {
             if (V(0)) {
               E(0, Comp);
-              {
-                T(2, 'content');
-              }
+              { T(2, 'content'); }
               e();
             }
             p(0, 'val', i);
@@ -729,7 +699,8 @@ describe('lifecycles', () => {
             Comp.ngComponentDef.r(1, 0);
             v();
           }
-        } cr();
+        }
+        cr();
         Comp.ngComponentDef.r(1, 0);
         Comp.ngComponentDef.r(5, 4);
       }
@@ -741,28 +712,23 @@ describe('lifecycles', () => {
     function ForLoopWithChildrenTemplate(ctx: any, cm: boolean) {
       if (cm) {
         E(0, Parent);
-        {
-          T(2, 'content');
-        }
+        { T(2, 'content'); }
         e();
         C(3);
         E(4, Parent);
-        {
-          T(6, 'content');
-        }
+        { T(6, 'content'); }
         e();
       }
       p(0, 'val', 1);
       p(4, 'val', 4);
       Parent.ngComponentDef.h(1, 0);
       Parent.ngComponentDef.h(5, 4);
-      cR(3); {
+      cR(3);
+      {
         for (let i = 2; i < 4; i++) {
           if (V(0)) {
             E(0, Parent);
-            {
-              T(2, 'content');
-            }
+            { T(2, 'content'); }
             e();
           }
           p(0, 'val', i);
@@ -770,12 +736,13 @@ describe('lifecycles', () => {
           Parent.ngComponentDef.r(1, 0);
           v();
         }
-      } cr();
+      }
+      cr();
       Parent.ngComponentDef.r(1, 0);
       Parent.ngComponentDef.r(5, 4);
     }
 
-    it('should be called in correct order in a for loop with children', () =>{
+    it('should be called in correct order in a for loop with children', () => {
       /**
        * <parent [val]="1">content</parent>
        * % for(let i = 2; i < 4; i++) {
@@ -785,8 +752,8 @@ describe('lifecycles', () => {
        */
 
       renderToHtml(ForLoopWithChildrenTemplate, {});
-      expect(events)
-        .toEqual(['parent2', 'comp2', 'parent3', 'comp3', 'parent1', 'parent4', 'comp1', 'comp4']);
+      expect(events).toEqual(
+          ['parent2', 'comp2', 'parent3', 'comp3', 'parent1', 'parent4', 'comp1', 'comp4']);
     });
 
     describe('ngAfterContentChecked', () => {
@@ -796,9 +763,7 @@ describe('lifecycles', () => {
         function Template(ctx: any, cm: boolean) {
           if (cm) {
             E(0, Comp);
-            {
-              T(2, 'content');
-            }
+            { T(2, 'content'); }
             e();
           }
           Comp.ngComponentDef.h(1, 0);
@@ -828,15 +793,14 @@ describe('lifecycles', () => {
     let Comp = createAfterViewInitComponent('comp', (ctx: any, cm: boolean) => {
       if (cm) {
         m(0, pD());
-        E(1, 'div'); {
-          P(2, 0);
-        }
+        E(1, 'div');
+        { P(2, 0); }
         e();
       }
     });
     let Parent = createAfterViewInitComponent('parent', getParentTemplate(Comp));
 
-    let ProjectedComp = createAfterViewInitComponent('projected', (ctx: any, cm: boolean)=> {
+    let ProjectedComp = createAfterViewInitComponent('projected', (ctx: any, cm: boolean) => {
       if (cm) {
         T(0, 'content');
       }
@@ -1250,7 +1214,12 @@ describe('lifecycles', () => {
 
     beforeEach(() => { events = []; });
 
-    let Comp = createOnDestroyComponent('comp', function(ctx: any, cm: boolean) {});
+    let Comp = createOnDestroyComponent('comp', (ctx: any, cm: boolean) => {
+      if (cm) {
+        m(0, pD());
+        P(1, 0);
+      }
+    });
     let Parent = createOnDestroyComponent('parent', getParentTemplate(Comp));
 
     function createOnDestroyComponent(name: string, template: ComponentTemplate<any>) {
@@ -1258,16 +1227,8 @@ describe('lifecycles', () => {
         val: string = '';
         ngOnDestroy() { events.push(`${name}${this.val}`); }
 
-        static ngComponentDef = defineComponent({
-          tag: name,
-          factory: () => {
-            const comp = new Component();
-            l(LifecycleHook.ON_DESTROY, comp, comp.ngOnDestroy);
-            return comp;
-          },
-          inputs: {val: 'val'},
-          template: template
-        });
+        static ngComponentDef = defineComponent(
+            {tag: name, factory: () => new Component(), inputs: {val: 'val'}, template: template});
       };
     }
 
@@ -1414,6 +1375,64 @@ describe('lifecycles', () => {
       renderToHtml(Template, {condition: true});
       renderToHtml(Template, {condition: false});
       expect(events).toEqual(['comp', 'parent', 'grandparent']);
+    });
+
+    it('should be called in projected components before their hosts', () => {
+      const ProjectedComp = createOnDestroyComponent('projected', (ctx: any, cm: boolean) => {});
+
+      /**
+       * % if (showing) {
+       *   <comp [val]="1">
+       *     <projected-comp [val]="1"></projected-comp>
+       *   </comp>
+       *   <comp [val]="2">
+       *     <projected-comp [val]="2"></projected-comp>
+       *   </comp>
+       * }
+       */
+      function Template(ctx: any, cm: boolean) {
+        if (cm) {
+          C(0);
+        }
+        cR(0);
+        {
+          if (ctx.showing) {
+            if (V(0)) {
+              E(0, Comp);
+              {
+                E(2, ProjectedComp);
+                e();
+              }
+              e();
+              E(4, Comp);
+              {
+                E(6, ProjectedComp);
+                e();
+              }
+              e();
+            }
+            p(0, 'val', 1);
+            p(2, 'val', 1);
+            p(4, 'val', 2);
+            p(6, 'val', 2);
+            Comp.ngComponentDef.h(1, 0);
+            ProjectedComp.ngComponentDef.h(3, 2);
+            Comp.ngComponentDef.h(5, 4);
+            ProjectedComp.ngComponentDef.h(7, 6);
+            ProjectedComp.ngComponentDef.r(3, 2);
+            Comp.ngComponentDef.r(1, 0);
+            ProjectedComp.ngComponentDef.r(7, 6);
+            Comp.ngComponentDef.r(5, 4);
+            v();
+          }
+        }
+        cr();
+      }
+
+      renderToHtml(Template, {showing: true});
+      renderToHtml(Template, {showing: false});
+
+      expect(events).toEqual(['projected1', 'comp1', 'projected2', 'comp2']);
     });
 
 
@@ -1636,6 +1655,138 @@ describe('lifecycles', () => {
       expect(ctx.counter).toEqual(2);
     });
 
+
+  });
+
+  describe('hook order', () => {
+    let events: string[];
+
+    beforeEach(() => { events = []; });
+
+    function createAllHooksComponent(name: string, template: ComponentTemplate<any>) {
+      return class Component {
+        val: string = '';
+
+        ngOnInit() { events.push(`init ${name}${this.val}`); }
+        ngDoCheck() { events.push(`check ${name}${this.val}`); }
+
+        ngAfterContentInit() { events.push(`contentInit ${name}${this.val}`); }
+        ngAfterContentChecked() { events.push(`contentCheck ${name}${this.val}`); }
+
+        ngAfterViewInit() { events.push(`viewInit ${name}${this.val}`); }
+        ngAfterViewChecked() { events.push(`viewCheck ${name}${this.val}`); }
+
+        static ngComponentDef = defineComponent({
+          tag: name,
+          factory: () => new Component(),
+          hostBindings: function(directiveIndex: number, elementIndex: number): void {
+            const comp = D(directiveIndex) as Component;
+            l(LifecycleHook.ON_INIT) && comp.ngOnInit();
+            comp.ngDoCheck();
+          },
+          refresh: function(directiveIndex: number, elementIndex: number): void {
+            r(directiveIndex, elementIndex, template);
+            const comp = D(directiveIndex) as Component;
+            l(LifecycleHook.AFTER_INIT, comp, comp.ngAfterViewInit);
+            l(LifecycleHook.AFTER_CHECKED, comp, comp.ngAfterViewChecked);
+          },
+          inputs: {val: 'val'}, template
+        });
+      };
+    }
+
+    it('should call all hooks in correct order', () => {
+      const Comp = createAllHooksComponent('comp', (ctx: any, cm: boolean) => {});
+
+
+      /**
+       * <comp [val]="1"></comp>
+       * <comp [val]="2"></comp>
+       */
+      function Template(ctx: any, cm: boolean) {
+        if (cm) {
+          E(0, Comp);
+          e();
+          E(2, Comp);
+          e();
+        }
+        p(0, 'val', 1);
+        p(2, 'val', 2);
+        Comp.ngComponentDef.h(1, 0);
+        Comp.ngComponentDef.h(3, 2);
+        Comp.ngComponentDef.r(1, 0);
+        Comp.ngComponentDef.r(3, 2);
+      }
+
+      renderToHtml(Template, {});
+      expect(events).toEqual([
+        'init comp1', 'check comp1', 'init comp2', 'check comp2', 'contentInit comp1',
+        'contentCheck comp1', 'contentInit comp2', 'contentCheck comp2', 'viewInit comp1',
+        'viewCheck comp1', 'viewInit comp2', 'viewCheck comp2'
+      ]);
+
+      events = [];
+      renderToHtml(Template, {});
+      expect(events).toEqual([
+        'check comp1', 'check comp2', 'contentCheck comp1', 'contentCheck comp2', 'viewCheck comp1',
+        'viewCheck comp2'
+      ]);
+    });
+
+    it('should call all hooks in correct order with children', () => {
+      const Comp = createAllHooksComponent('comp', (ctx: any, cm: boolean) => {});
+
+      /** <comp [val]="val"></comp> */
+      const Parent = createAllHooksComponent('parent', (ctx: any, cm: boolean) => {
+        if (cm) {
+          E(0, Comp);
+          e();
+        }
+        p(0, 'val', b(ctx.val));
+        Comp.ngComponentDef.h(1, 0);
+        Comp.ngComponentDef.r(1, 0);
+      });
+
+      /**
+       * <parent [val]="1"></parent>
+       * <parent [val]="2"></parent>
+       */
+      function Template(ctx: any, cm: boolean) {
+        if (cm) {
+          E(0, Parent);
+          e();
+          E(2, Parent);
+          e();
+        }
+        p(0, 'val', 1);
+        p(2, 'val', 2);
+        Parent.ngComponentDef.h(1, 0);
+        Parent.ngComponentDef.h(3, 2);
+        Parent.ngComponentDef.r(1, 0);
+        Parent.ngComponentDef.r(3, 2);
+      }
+
+      renderToHtml(Template, {});
+      expect(events).toEqual([
+        'init parent1',        'check parent1',        'init parent2',
+        'check parent2',       'contentInit parent1',  'contentCheck parent1',
+        'contentInit parent2', 'contentCheck parent2', 'init comp1',
+        'check comp1',         'contentInit comp1',    'contentCheck comp1',
+        'viewInit comp1',      'viewCheck comp1',      'init comp2',
+        'check comp2',         'contentInit comp2',    'contentCheck comp2',
+        'viewInit comp2',      'viewCheck comp2',      'viewInit parent1',
+        'viewCheck parent1',   'viewInit parent2',     'viewCheck parent2'
+      ]);
+
+      events = [];
+      renderToHtml(Template, {});
+      expect(events).toEqual([
+        'check parent1', 'check parent2', 'contentCheck parent1', 'contentCheck parent2',
+        'check comp1', 'contentCheck comp1', 'viewCheck comp1', 'check comp2', 'contentCheck comp2',
+        'viewCheck comp2', 'viewCheck parent1', 'viewCheck parent2'
+      ]);
+
+    });
 
   });
 

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -31,7 +31,7 @@ describe('lifecycles', () => {
 
     let Comp = createOnInitComponent('comp', (ctx: any, cm: boolean) => {
       if (cm) {
-        m(0, pD());
+        pD(0);
         E(1, 'div');
         { P(2, 0); }
         e();
@@ -435,14 +435,14 @@ describe('lifecycles', () => {
 
     let Comp = createAfterContentInitComp('comp', function(ctx: any, cm: boolean) {
       if (cm) {
-        m(0, pD());
+        pD(0);
         P(1, 0);
       }
     });
 
     let Parent = createAfterContentInitComp('parent', function(ctx: any, cm: boolean) {
       if (cm) {
-        m(0, pD());
+        pD(0);
         E(1, Comp);
         { P(3, 0); }
         e();
@@ -454,7 +454,7 @@ describe('lifecycles', () => {
 
     let ProjectedComp = createAfterContentInitComp('projected', (ctx: any, cm: boolean) => {
       if (cm) {
-        m(0, pD());
+        pD(0);
         P(1, 0);
       }
     });
@@ -813,7 +813,7 @@ describe('lifecycles', () => {
 
     let Comp = createAfterViewInitComponent('comp', (ctx: any, cm: boolean) => {
       if (cm) {
-        m(0, pD());
+        pD(0);
         E(1, 'div');
         { P(2, 0); }
         e();
@@ -1244,7 +1244,7 @@ describe('lifecycles', () => {
 
     let Comp = createOnDestroyComponent('comp', (ctx: any, cm: boolean) => {
       if (cm) {
-        m(0, pD());
+        pD(0);
         P(1, 0);
       }
     });

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -20,7 +20,7 @@ describe('lifecycles', () => {
       }
       p(0, 'val', b(ctx.val));
       type.ngComponentDef.h(1, 0);
-      type.ngComponentDef.r(1, 0);
+      r(1, 0);
     };
   }
 
@@ -68,7 +68,7 @@ describe('lifecycles', () => {
            }
            p(0, 'val', b(ctx.val));
            Comp.ngComponentDef.h(1, 0);
-           Comp.ngComponentDef.r(1, 0);
+           r(1, 0);
          }
 
          renderToHtml(Template, {val: '1'});
@@ -90,7 +90,7 @@ describe('lifecycles', () => {
           e();
         }
         Parent.ngComponentDef.h(1, 0);
-        Parent.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -116,8 +116,8 @@ describe('lifecycles', () => {
         p(2, 'val', 2);
         Parent.ngComponentDef.h(1, 0);
         Parent.ngComponentDef.h(3, 2);
-        Parent.ngComponentDef.r(1, 0);
-        Parent.ngComponentDef.r(3, 2);
+        r(1, 0);
+        r(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -144,7 +144,7 @@ describe('lifecycles', () => {
               e();
             }
             Comp.ngComponentDef.h(1, 0);
-            Comp.ngComponentDef.r(1, 0);
+            r(1, 0);
             v();
           }
         }
@@ -175,8 +175,8 @@ describe('lifecycles', () => {
         }
         Comp.ngComponentDef.h(1, 0);
         ProjectedComp.ngComponentDef.h(3, 2);
-        ProjectedComp.ngComponentDef.r(3, 2);
-        Comp.ngComponentDef.r(1, 0);
+        r(3, 2);
+        r(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -209,10 +209,10 @@ describe('lifecycles', () => {
         ProjectedComp.ngComponentDef.h(3, 2);
         Comp.ngComponentDef.h(5, 4);
         ProjectedComp.ngComponentDef.h(7, 6);
-        ProjectedComp.ngComponentDef.r(3, 2);
-        Comp.ngComponentDef.r(1, 0);
-        ProjectedComp.ngComponentDef.r(7, 6);
-        Comp.ngComponentDef.r(5, 4);
+        r(3, 2);
+        r(1, 0);
+        r(7, 6);
+        r(5, 4);
       }
 
       renderToHtml(Template, {});
@@ -232,7 +232,7 @@ describe('lifecycles', () => {
           e();
         }
         Comp.ngComponentDef.h(1, 0);
-        Comp.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -273,13 +273,13 @@ describe('lifecycles', () => {
             }
             p(0, 'val', j);
             Comp.ngComponentDef.h(1, 0);
-            Comp.ngComponentDef.r(1, 0);
+            r(1, 0);
             v();
           }
         }
         cr();
-        Comp.ngComponentDef.r(1, 0);
-        Comp.ngComponentDef.r(4, 3);
+        r(1, 0);
+        r(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -319,13 +319,13 @@ describe('lifecycles', () => {
             }
             p(0, 'val', j);
             Parent.ngComponentDef.h(1, 0);
-            Parent.ngComponentDef.r(1, 0);
+            r(1, 0);
             v();
           }
         }
         cr();
-        Parent.ngComponentDef.r(1, 0);
-        Parent.ngComponentDef.r(4, 3);
+        r(1, 0);
+        r(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -375,7 +375,7 @@ describe('lifecycles', () => {
           e();
         }
         Comp.ngComponentDef.h(1, 0);
-        Comp.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -397,7 +397,7 @@ describe('lifecycles', () => {
           e();
         }
         Parent.ngComponentDef.h(1, 0);
-        Parent.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -412,7 +412,7 @@ describe('lifecycles', () => {
           e();
         }
         Comp.ngComponentDef.h(1, 0);
-        Comp.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -449,7 +449,7 @@ describe('lifecycles', () => {
       }
       p(1, 'val', b(ctx.val));
       Comp.ngComponentDef.h(2, 1);
-      Comp.ngComponentDef.r(2, 1);
+      r(2, 1);
     });
 
     let ProjectedComp = createAfterContentInitComp('projected', (ctx: any, cm: boolean) => {
@@ -487,7 +487,7 @@ describe('lifecycles', () => {
           e();
         }
         Comp.ngComponentDef.h(1, 0);
-        Comp.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -516,7 +516,7 @@ describe('lifecycles', () => {
               e();
             }
             Comp.ngComponentDef.h(1, 0);
-            Comp.ngComponentDef.r(1, 0);
+            r(1, 0);
             v();
           }
         }
@@ -546,7 +546,7 @@ describe('lifecycles', () => {
           e();
         }
         Comp.ngComponentDef.h(1, 0);
-        Comp.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -570,7 +570,7 @@ describe('lifecycles', () => {
           e();
         }
         Parent.ngComponentDef.h(1, 0);
-        Parent.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -597,8 +597,8 @@ describe('lifecycles', () => {
         p(3, 'val', 2);
         Parent.ngComponentDef.h(1, 0);
         Parent.ngComponentDef.h(4, 3);
-        Parent.ngComponentDef.r(1, 0);
-        Parent.ngComponentDef.r(4, 3);
+        r(1, 0);
+        r(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -628,8 +628,8 @@ describe('lifecycles', () => {
         }
         Parent.ngComponentDef.h(1, 0);
         ProjectedComp.ngComponentDef.h(3, 2);
-        ProjectedComp.ngComponentDef.r(3, 2);
-        Parent.ngComponentDef.r(1, 0);
+        r(3, 2);
+        r(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -675,10 +675,10 @@ describe('lifecycles', () => {
         ProjectedComp.ngComponentDef.h(3, 2);
         Parent.ngComponentDef.h(6, 5);
         ProjectedComp.ngComponentDef.h(8, 7);
-        ProjectedComp.ngComponentDef.r(3, 2);
-        Parent.ngComponentDef.r(1, 0);
-        ProjectedComp.ngComponentDef.r(8, 7);
-        Parent.ngComponentDef.r(6, 5);
+        r(3, 2);
+        r(1, 0);
+        r(8, 7);
+        r(6, 5);
       }
 
       renderToHtml(Template, {});
@@ -717,13 +717,13 @@ describe('lifecycles', () => {
             }
             p(0, 'val', i);
             Comp.ngComponentDef.h(1, 0);
-            Comp.ngComponentDef.r(1, 0);
+            r(1, 0);
             v();
           }
         }
         cr();
-        Comp.ngComponentDef.r(1, 0);
-        Comp.ngComponentDef.r(5, 4);
+        r(1, 0);
+        r(5, 4);
       }
 
       renderToHtml(Template, {});
@@ -754,13 +754,13 @@ describe('lifecycles', () => {
           }
           p(0, 'val', i);
           Parent.ngComponentDef.h(1, 0);
-          Parent.ngComponentDef.r(1, 0);
+          r(1, 0);
           v();
         }
       }
       cr();
-      Parent.ngComponentDef.r(1, 0);
-      Parent.ngComponentDef.r(5, 4);
+      r(1, 0);
+      r(5, 4);
     }
 
     it('should be called in correct order in a for loop with children', () => {
@@ -788,7 +788,7 @@ describe('lifecycles', () => {
             e();
           }
           Comp.ngComponentDef.h(1, 0);
-          Comp.ngComponentDef.r(1, 0);
+          r(1, 0);
         }
 
         renderToHtml(Template, {});
@@ -854,7 +854,7 @@ describe('lifecycles', () => {
           e();
         }
         Comp.ngComponentDef.h(1, 0);
-        Comp.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -882,7 +882,7 @@ describe('lifecycles', () => {
               e();
             }
             Comp.ngComponentDef.h(1, 0);
-            Comp.ngComponentDef.r(1, 0);
+            r(1, 0);
             v();
           }
         }
@@ -912,7 +912,7 @@ describe('lifecycles', () => {
           e();
         }
         Parent.ngComponentDef.h(1, 0);
-        Parent.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -938,8 +938,8 @@ describe('lifecycles', () => {
         p(2, 'val', 2);
         Parent.ngComponentDef.h(1, 0);
         Parent.ngComponentDef.h(3, 2);
-        Parent.ngComponentDef.r(1, 0);
-        Parent.ngComponentDef.r(3, 2);
+        r(1, 0);
+        r(3, 2);
       }
       renderToHtml(Template, {});
       expect(events).toEqual(['comp1', 'comp2', 'parent1', 'parent2']);
@@ -963,8 +963,8 @@ describe('lifecycles', () => {
         }
         Comp.ngComponentDef.h(1, 0);
         ProjectedComp.ngComponentDef.h(3, 2);
-        ProjectedComp.ngComponentDef.r(3, 2);
-        Comp.ngComponentDef.r(1, 0);
+        r(3, 2);
+        r(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -1003,10 +1003,10 @@ describe('lifecycles', () => {
         ProjectedComp.ngComponentDef.h(3, 2);
         Comp.ngComponentDef.h(5, 4);
         ProjectedComp.ngComponentDef.h(7, 6);
-        ProjectedComp.ngComponentDef.r(3, 2);
-        Comp.ngComponentDef.r(1, 0);
-        ProjectedComp.ngComponentDef.r(7, 6);
-        Comp.ngComponentDef.r(5, 4);
+        r(3, 2);
+        r(1, 0);
+        r(7, 6);
+        r(5, 4);
       }
 
       renderToHtml(Template, {});
@@ -1032,8 +1032,8 @@ describe('lifecycles', () => {
         p(2, 'val', b(ctx.val));
         Comp.ngComponentDef.h(1, 0);
         ProjectedComp.ngComponentDef.h(3, 2);
-        ProjectedComp.ngComponentDef.r(3, 2);
-        Comp.ngComponentDef.r(1, 0);
+        r(3, 2);
+        r(1, 0);
       });
 
       /**
@@ -1051,8 +1051,8 @@ describe('lifecycles', () => {
         p(2, 'val', 2);
         ParentComp.ngComponentDef.h(1, 0);
         ParentComp.ngComponentDef.h(3, 2);
-        ParentComp.ngComponentDef.r(1, 0);
-        ParentComp.ngComponentDef.r(3, 2);
+        r(1, 0);
+        r(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -1088,13 +1088,13 @@ describe('lifecycles', () => {
             }
             p(0, 'val', i);
             Comp.ngComponentDef.h(1, 0);
-            Comp.ngComponentDef.r(1, 0);
+            r(1, 0);
             v();
           }
         }
         cr();
-        Comp.ngComponentDef.r(1, 0);
-        Comp.ngComponentDef.r(4, 3);
+        r(1, 0);
+        r(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -1131,13 +1131,13 @@ describe('lifecycles', () => {
             }
             p(0, 'val', i);
             Parent.ngComponentDef.h(1, 0);
-            Parent.ngComponentDef.r(1, 0);
+            r(1, 0);
             v();
           }
         }
         cr();
-        Parent.ngComponentDef.r(1, 0);
-        Parent.ngComponentDef.r(4, 3);
+        r(1, 0);
+        r(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -1157,7 +1157,7 @@ describe('lifecycles', () => {
             e();
           }
           Comp.ngComponentDef.h(1, 0);
-          Comp.ngComponentDef.r(1, 0);
+          r(1, 0);
         }
 
         renderToHtml(Template, {});
@@ -1176,7 +1176,7 @@ describe('lifecycles', () => {
           }
           p(0, 'val', b(ctx.myVal));
           Comp.ngComponentDef.h(1, 0);
-          Comp.ngComponentDef.r(1, 0);
+          r(1, 0);
         }
 
         renderToHtml(Template, {myVal: 5});
@@ -1215,13 +1215,13 @@ describe('lifecycles', () => {
               }
               p(0, 'val', i);
               Parent.ngComponentDef.h(1, 0);
-              Parent.ngComponentDef.r(1, 0);
+              r(1, 0);
               v();
             }
           }
           cr();
-          Parent.ngComponentDef.r(1, 0);
-          Parent.ngComponentDef.r(4, 3);
+          r(1, 0);
+          r(4, 3);
         }
 
         renderToHtml(Template, {});
@@ -1284,7 +1284,7 @@ describe('lifecycles', () => {
               e();
             }
             Comp.ngComponentDef.h(1, 0);
-            Comp.ngComponentDef.r(1, 0);
+            r(1, 0);
             v();
           }
         }
@@ -1321,8 +1321,8 @@ describe('lifecycles', () => {
             p(2, 'val', b('2'));
             Comp.ngComponentDef.h(1, 0);
             Comp.ngComponentDef.h(3, 2);
-            Comp.ngComponentDef.r(1, 0);
-            Comp.ngComponentDef.r(3, 2);
+            r(1, 0);
+            r(3, 2);
             v();
           }
         }
@@ -1355,7 +1355,7 @@ describe('lifecycles', () => {
               e();
             }
             Parent.ngComponentDef.h(1, 0);
-            Parent.ngComponentDef.r(1, 0);
+            r(1, 0);
             v();
           }
         }
@@ -1383,7 +1383,7 @@ describe('lifecycles', () => {
           e();
         }
         Parent.ngComponentDef.h(1, 0);
-        Parent.ngComponentDef.r(1, 0);
+        r(1, 0);
       });
 
       function Template(ctx: any, cm: boolean) {
@@ -1398,7 +1398,7 @@ describe('lifecycles', () => {
               e();
             }
             Grandparent.ngComponentDef.h(1, 0);
-            Grandparent.ngComponentDef.r(1, 0);
+            r(1, 0);
             v();
           }
         }
@@ -1452,10 +1452,10 @@ describe('lifecycles', () => {
             ProjectedComp.ngComponentDef.h(3, 2);
             Comp.ngComponentDef.h(5, 4);
             ProjectedComp.ngComponentDef.h(7, 6);
-            ProjectedComp.ngComponentDef.r(3, 2);
-            Comp.ngComponentDef.r(1, 0);
-            ProjectedComp.ngComponentDef.r(7, 6);
-            Comp.ngComponentDef.r(5, 4);
+            r(3, 2);
+            r(1, 0);
+            r(7, 6);
+            r(5, 4);
             v();
           }
         }
@@ -1507,13 +1507,13 @@ describe('lifecycles', () => {
                 }
                 p(0, 'val', b('2'));
                 Comp.ngComponentDef.h(1, 0);
-                Comp.ngComponentDef.r(1, 0);
+                r(1, 0);
                 v();
               }
             }
             cr();
-            Comp.ngComponentDef.r(1, 0);
-            Comp.ngComponentDef.r(4, 3);
+            r(1, 0);
+            r(4, 3);
             v();
           }
         }
@@ -1583,13 +1583,13 @@ describe('lifecycles', () => {
                 }
                 p(0, 'val', b(j));
                 Comp.ngComponentDef.h(1, 0);
-                Comp.ngComponentDef.r(1, 0);
+                r(1, 0);
                 v();
               }
             }
             cr();
-            Comp.ngComponentDef.r(1, 0);
-            Comp.ngComponentDef.r(4, 3);
+            r(1, 0);
+            r(4, 3);
             v();
           }
         }
@@ -1658,7 +1658,7 @@ describe('lifecycles', () => {
               e();
             }
             Comp.ngComponentDef.h(3, 2);
-            Comp.ngComponentDef.r(3, 2);
+            r(3, 2);
             v();
           }
         }
@@ -1737,8 +1737,8 @@ describe('lifecycles', () => {
         p(2, 'val', 2);
         Comp.ngComponentDef.h(1, 0);
         Comp.ngComponentDef.h(3, 2);
-        Comp.ngComponentDef.r(1, 0);
-        Comp.ngComponentDef.r(3, 2);
+        r(1, 0);
+        r(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -1767,7 +1767,7 @@ describe('lifecycles', () => {
         }
         p(0, 'val', b(ctx.val));
         Comp.ngComponentDef.h(1, 0);
-        Comp.ngComponentDef.r(1, 0);
+        r(1, 0);
       });
 
       /**
@@ -1785,8 +1785,8 @@ describe('lifecycles', () => {
         p(2, 'val', 2);
         Parent.ngComponentDef.h(1, 0);
         Parent.ngComponentDef.h(3, 2);
-        Parent.ngComponentDef.r(1, 0);
-        Parent.ngComponentDef.r(3, 2);
+        r(1, 0);
+        r(3, 2);
       }
 
       renderToHtml(Template, {});

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, ComponentDef, ComponentTemplate, E, L, LifecycleHook, P, T, V, b, cR, cr, defineComponent, defineDirective, e, l, m, p, pD, r, v} from '../../src/render3/index';
+import {C, ComponentTemplate, E, L, P, T, V, b, cR, cr, defineComponent, defineDirective, e, m, p, pD, r, v} from '../../src/render3/index';
 
 import {containerEl, renderToHtml} from './render_util';
 
@@ -840,12 +840,6 @@ describe('lifecycles', () => {
           type: Component,
           tag: name,
           factory: () => new Component(),
-          refresh: (directiveIndex: number, elementIndex: number) => {
-            r(directiveIndex, elementIndex, template);
-            const comp = m(directiveIndex) as Component;
-            l(LifecycleHook.ON_INIT, comp, comp.ngAfterViewInit);
-            l(LifecycleHook.ON_CHECK, comp, comp.ngAfterViewChecked);
-          },
           inputs: {val: 'val'},
           template: template
         });
@@ -961,7 +955,10 @@ describe('lifecycles', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, Comp);
-          { E(2, ProjectedComp); }
+          {
+            E(2, ProjectedComp);
+            e();
+          }
           e();
         }
         Comp.ngComponentDef.h(1, 0);
@@ -986,10 +983,16 @@ describe('lifecycles', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           E(0, Comp);
-          { E(2, ProjectedComp); }
+          {
+            E(2, ProjectedComp);
+            e();
+          }
           e();
           E(4, Comp);
-          { E(6, ProjectedComp); }
+          {
+            E(6, ProjectedComp);
+            e();
+          }
           e();
         }
         p(0, 'val', 1);
@@ -1019,7 +1022,10 @@ describe('lifecycles', () => {
       const ParentComp = createAfterViewInitComponent('parent', (ctx: any, cm: boolean) => {
         if (cm) {
           E(0, Comp);
-          { E(2, ProjectedComp); }
+          {
+            E(2, ProjectedComp);
+            e();
+          }
           e();
         }
         p(0, 'val', b(ctx.val));
@@ -1707,12 +1713,6 @@ describe('lifecycles', () => {
           type: Component,
           tag: name,
           factory: () => new Component(),
-          refresh: function(directiveIndex: number, elementIndex: number): void {
-            r(directiveIndex, elementIndex, template);
-            const comp = m(directiveIndex) as Component;
-            l(LifecycleHook.ON_INIT, comp, comp.ngAfterViewInit);
-            l(LifecycleHook.ON_CHECK, comp, comp.ngAfterViewChecked);
-          },
           inputs: {val: 'val'}, template
         });
       };

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -49,6 +49,7 @@ describe('lifecycles', () => {
         ngOnInit() { events.push(`${name}${this.val}`); }
 
         static ngComponentDef = defineComponent({
+          type: Component,
           tag: name,
           factory: () => new Component(),
           hostBindings: function(directiveIndex: number, elementIndex: number):
@@ -339,6 +340,7 @@ describe('lifecycles', () => {
         ngOnInit() { allEvents.push('ngOnInit ' + name); }
 
         static ngComponentDef = defineComponent({
+          type: Component,
           tag: name,
           factory: () => new Component(),
           hostBindings: function(
@@ -452,8 +454,13 @@ describe('lifecycles', () => {
         }
         ngAfterContentChecked() { allEvents.push(`${name}${this.val} check`); }
 
-        static ngComponentDef = defineComponent(
-            {tag: name, factory: () => new Component(), inputs: {val: 'val'}, template: template});
+        static ngComponentDef = defineComponent({
+          type: Component,
+          tag: name,
+          factory: () => new Component(),
+          inputs: {val: 'val'},
+          template: template,
+        });
       };
     }
 
@@ -516,7 +523,7 @@ describe('lifecycles', () => {
       class Directive {
         ngAfterContentInit() { events.push('dir'); }
 
-        static ngDirectiveDef = defineDirective({factory: () => new Directive()});
+        static ngDirectiveDef = defineDirective({type: Directive, factory: () => new Directive()});
       }
 
       function Template(ctx: any, cm: boolean) {
@@ -816,6 +823,7 @@ describe('lifecycles', () => {
         ngAfterViewChecked() { allEvents.push(`${name}${this.val} check`); }
 
         static ngComponentDef = defineComponent({
+          type: Component,
           tag: name,
           factory: () => new Component(),
           refresh: (directiveIndex: number, elementIndex: number) => {
@@ -1227,8 +1235,13 @@ describe('lifecycles', () => {
         val: string = '';
         ngOnDestroy() { events.push(`${name}${this.val}`); }
 
-        static ngComponentDef = defineComponent(
-            {tag: name, factory: () => new Component(), inputs: {val: 'val'}, template: template});
+        static ngComponentDef = defineComponent({
+          type: Component,
+          tag: name,
+          factory: () => new Component(),
+          inputs: {val: 'val'},
+          template: template
+        });
       };
     }
 
@@ -1677,6 +1690,7 @@ describe('lifecycles', () => {
         ngAfterViewChecked() { events.push(`viewCheck ${name}${this.val}`); }
 
         static ngComponentDef = defineComponent({
+          type: Component,
           tag: name,
           factory: () => new Component(),
           hostBindings: function(directiveIndex: number, elementIndex: number): void {

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {C, E, L, T, V, cR, cr, defineComponent, e, v} from '../../src/render3/index';
+import {C, E, L, T, V, cR, cr, defineComponent, e, r, v} from '../../src/render3/index';
 
 import {containerEl, renderComponent, renderToHtml} from './render_util';
 
@@ -208,8 +208,8 @@ describe('event listeners', () => {
           }
           MyComp.ngComponentDef.h(2, 1);
           MyComp.ngComponentDef.h(4, 3);
-          MyComp.ngComponentDef.r(2, 1);
-          MyComp.ngComponentDef.r(4, 3);
+          r(2, 1);
+          r(4, 3);
           v();
         }
       }

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -21,6 +21,7 @@ describe('event listeners', () => {
     onClick() { this.counter++; }
 
     static ngComponentDef = defineComponent({
+      type: MyComp,
       tag: 'comp',
       /** <button (click)="onClick()"> Click me </button> */
       template: function CompTemplate(ctx: any, cm: boolean) {

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -8,7 +8,7 @@
 
 import {EventEmitter} from '@angular/core';
 
-import {C, E, L, LifecycleHook, T, V, b, cR, cr, defineComponent, defineDirective, e, l, p, v} from '../../src/render3/index';
+import {C, E, L, T, V, b, cR, cr, defineComponent, defineDirective, e, p, v} from '../../src/render3/index';
 
 import {containerEl, renderToHtml} from './render_util';
 

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -214,11 +214,7 @@ describe('outputs', () => {
       static ngComponentDef = defineComponent({
         tag: 'destroy-comp',
         template: function(ctx: any, cm: boolean) {},
-        factory: () => {
-          destroyComp = new DestroyComp();
-          l(LifecycleHook.ON_DESTROY, destroyComp, destroyComp.ngOnDestroy);
-          return destroyComp;
-        }
+        factory: () => destroyComp = new DestroyComp()
       });
     }
 

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -8,7 +8,7 @@
 
 import {EventEmitter} from '@angular/core';
 
-import {C, E, L, T, V, b, cR, cr, defineComponent, defineDirective, e, p, v} from '../../src/render3/index';
+import {C, E, L, T, V, b, cR, cr, defineComponent, defineDirective, e, p, r, v} from '../../src/render3/index';
 
 import {containerEl, renderToHtml} from './render_util';
 
@@ -49,7 +49,7 @@ describe('outputs', () => {
         e();
       }
       ButtonToggle.ngComponentDef.h(1, 0);
-      ButtonToggle.ngComponentDef.r(1, 0);
+      r(1, 0);
     }
 
     let counter = 0;
@@ -75,7 +75,7 @@ describe('outputs', () => {
         e();
       }
       ButtonToggle.ngComponentDef.h(1, 0);
-      ButtonToggle.ngComponentDef.r(1, 0);
+      r(1, 0);
     }
 
     let counter = 0;
@@ -99,7 +99,7 @@ describe('outputs', () => {
         e();
       }
       ButtonToggle.ngComponentDef.h(1, 0);
-      ButtonToggle.ngComponentDef.r(1, 0);
+      r(1, 0);
     }
 
     const ctx = {counter: 0};
@@ -133,7 +133,7 @@ describe('outputs', () => {
             e();
           }
           ButtonToggle.ngComponentDef.h(1, 0);
-          ButtonToggle.ngComponentDef.r(1, 0);
+          r(1, 0);
           v();
         }
       }
@@ -183,7 +183,7 @@ describe('outputs', () => {
                 e();
               }
               ButtonToggle.ngComponentDef.h(1, 0);
-              ButtonToggle.ngComponentDef.r(1, 0);
+              r(1, 0);
               v();
             }
           }
@@ -252,8 +252,8 @@ describe('outputs', () => {
           }
           ButtonToggle.ngComponentDef.h(3, 2);
           DestroyComp.ngComponentDef.h(5, 4);
-          ButtonToggle.ngComponentDef.r(3, 2);
-          DestroyComp.ngComponentDef.r(5, 4);
+          r(3, 2);
+          r(5, 4);
           v();
         }
       }
@@ -326,7 +326,7 @@ describe('outputs', () => {
         e();
       }
       ButtonToggle.ngComponentDef.h(1, 0);
-      ButtonToggle.ngComponentDef.r(1, 0);
+      r(1, 0);
     }
 
     let counter = 0;
@@ -358,7 +358,7 @@ describe('outputs', () => {
       }
       p(0, 'change', b(ctx.change));
       ButtonToggle.ngComponentDef.h(1, 0);
-      ButtonToggle.ngComponentDef.r(1, 0);
+      r(1, 0);
     }
 
     let counter = 0;
@@ -401,7 +401,7 @@ describe('outputs', () => {
             e();
           }
           ButtonToggle.ngComponentDef.h(1, 0);
-          ButtonToggle.ngComponentDef.r(1, 0);
+          r(1, 0);
           v();
         } else {
           if (V(1)) {

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -20,6 +20,7 @@ describe('outputs', () => {
     resetStream = new EventEmitter();
 
     static ngComponentDef = defineComponent({
+      type: ButtonToggle,
       tag: 'button-toggle',
       template: function(ctx: any, cm: boolean) {},
       factory: () => buttonToggle = new ButtonToggle(),
@@ -32,8 +33,11 @@ describe('outputs', () => {
   class OtherDir {
     changeStream = new EventEmitter();
 
-    static ngDirectiveDef = defineDirective(
-        {factory: () => otherDir = new OtherDir, outputs: {changeStream: 'change'}});
+    static ngDirectiveDef = defineDirective({
+      type: OtherDir,
+      factory: () => otherDir = new OtherDir,
+      outputs: {changeStream: 'change'}
+    });
   }
 
   it('should call component output function when event is emitted', () => {
@@ -212,6 +216,7 @@ describe('outputs', () => {
       ngOnDestroy() { this.events.push('destroy'); }
 
       static ngComponentDef = defineComponent({
+        type: DestroyComp,
         tag: 'destroy-comp',
         template: function(ctx: any, cm: boolean) {},
         factory: () => destroyComp = new DestroyComp()
@@ -287,8 +292,8 @@ describe('outputs', () => {
     class MyButton {
       click = new EventEmitter();
 
-      static ngDirectiveDef =
-          defineDirective({factory: () => buttonDir = new MyButton, outputs: {click: 'click'}});
+      static ngDirectiveDef = defineDirective(
+          {type: MyButton, factory: () => buttonDir = new MyButton, outputs: {click: 'click'}});
     }
 
     function Template(ctx: any, cm: boolean) {
@@ -340,8 +345,8 @@ describe('outputs', () => {
     class OtherDir {
       change: boolean;
 
-      static ngDirectiveDef =
-          defineDirective({factory: () => otherDir = new OtherDir, inputs: {change: 'change'}});
+      static ngDirectiveDef = defineDirective(
+          {type: OtherDir, factory: () => otherDir = new OtherDir, inputs: {change: 'change'}});
     }
 
     /** <button-toggle (change)="onChange()" otherDir [change]="change"></button-toggle> */

--- a/packages/core/test/render3/properties_spec.ts
+++ b/packages/core/test/render3/properties_spec.ts
@@ -8,7 +8,7 @@
 
 import {EventEmitter} from '@angular/core';
 
-import {C, E, L, T, V, b, b1, cR, cr, defineComponent, defineDirective, e, m, p, t, v} from '../../src/render3/index';
+import {C, E, L, T, V, b, b1, cR, cr, defineComponent, defineDirective, e, m, p, r, t, v} from '../../src/render3/index';
 import {NO_CHANGE} from '../../src/render3/instructions';
 
 import {renderToHtml} from './render_util';
@@ -157,7 +157,7 @@ describe('elementProperty', () => {
         }
         p(0, 'id', b(ctx.id));
         Comp.ngComponentDef.h(1, 0);
-        Comp.ngComponentDef.r(1, 0);
+        r(1, 0);
       }
 
       expect(renderToHtml(Template, {id: 1})).toEqual(`<comp></comp>`);
@@ -502,7 +502,7 @@ describe('elementProperty', () => {
               e();
             }
             Comp.ngComponentDef.h(1, 0);
-            Comp.ngComponentDef.r(1, 0);
+            r(1, 0);
             v();
           }
         }

--- a/packages/core/test/render3/properties_spec.ts
+++ b/packages/core/test/render3/properties_spec.ts
@@ -69,8 +69,8 @@ describe('elementProperty', () => {
     class MyButton {
       disabled: boolean;
 
-      static ngDirectiveDef =
-          defineDirective({factory: () => button = new MyButton(), inputs: {disabled: 'disabled'}});
+      static ngDirectiveDef = defineDirective(
+          {type: MyButton, factory: () => button = new MyButton(), inputs: {disabled: 'disabled'}});
     }
 
     class OtherDir {
@@ -78,6 +78,7 @@ describe('elementProperty', () => {
       clickStream = new EventEmitter();
 
       static ngDirectiveDef = defineDirective({
+        type: OtherDir,
         factory: () => otherDir = new OtherDir(),
         inputs: {id: 'id'},
         outputs: {clickStream: 'click'}
@@ -140,6 +141,7 @@ describe('elementProperty', () => {
         id: number;
 
         static ngComponentDef = defineComponent({
+          type: Comp,
           tag: 'comp',
           template: function(ctx: any, cm: boolean) {},
           factory: () => comp = new Comp(),
@@ -172,6 +174,7 @@ describe('elementProperty', () => {
         disabled: boolean;
 
         static ngDirectiveDef = defineDirective({
+          type: OtherDisabledDir,
           factory: () => otherDisabledDir = new OtherDisabledDir(),
           inputs: {disabled: 'disabled'}
         });
@@ -231,8 +234,8 @@ describe('elementProperty', () => {
       class IdDir {
         idNumber: number;
 
-        static ngDirectiveDef =
-            defineDirective({factory: () => idDir = new IdDir(), inputs: {idNumber: 'id'}});
+        static ngDirectiveDef = defineDirective(
+            {type: IdDir, factory: () => idDir = new IdDir(), inputs: {idNumber: 'id'}});
       }
 
       /**
@@ -294,6 +297,7 @@ describe('elementProperty', () => {
       changeStream = new EventEmitter();
 
       static ngDirectiveDef = defineDirective({
+        type: MyDir,
         factory: () => myDir = new MyDir(),
         inputs: {role: 'role', direction: 'dir'},
         outputs: {changeStream: 'change'}
@@ -304,8 +308,8 @@ describe('elementProperty', () => {
     class MyDirB {
       roleB: string;
 
-      static ngDirectiveDef =
-          defineDirective({factory: () => dirB = new MyDirB(), inputs: {roleB: 'role'}});
+      static ngDirectiveDef = defineDirective(
+          {type: MyDirB, factory: () => dirB = new MyDirB(), inputs: {roleB: 'role'}});
     }
 
     it('should set input property based on attribute if existing', () => {
@@ -467,6 +471,7 @@ describe('elementProperty', () => {
 
       class Comp {
         static ngComponentDef = defineComponent({
+          type: Comp,
           tag: 'comp',
           template: function(ctx: any, cm: boolean) {
             if (cm) {

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -82,14 +82,20 @@ export function createComponent(
     name: string, template: ComponentTemplate<any>): ComponentType<any> {
   return class Component {
     value: any;
-    static ngComponentDef = defineComponent(
-        {tag: name, factory: () => new Component, template: template, features: [PublicFeature]});
+    static ngComponentDef = defineComponent({
+      type: Component,
+      tag: name,
+      factory: () => new Component,
+      template: template,
+      features: [PublicFeature]
+    });
   };
 }
 
 export function createDirective({exportAs}: {exportAs?: string} = {}): DirectiveType<any> {
   return class Directive {
     static ngDirectiveDef = defineDirective({
+      type: Directive,
       factory: () => new Directive(),
       features: [PublicFeature],
       exportAs: exportAs,

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -29,6 +29,7 @@ describe('renderer factory lifecycle', () => {
 
   class SomeComponent {
     static ngComponentDef = defineComponent({
+      type: SomeComponent,
       tag: 'some-component',
       template: function(ctx: SomeComponent, cm: boolean) {
         logs.push('component');
@@ -42,6 +43,7 @@ describe('renderer factory lifecycle', () => {
 
   class SomeComponentWhichThrows {
     static ngComponentDef = defineComponent({
+      type: SomeComponentWhichThrows,
       tag: 'some-component-with-Error',
       template: function(ctx: SomeComponentWhichThrows, cm: boolean) {
         throw(new Error('SomeComponentWhichThrows threw'));
@@ -120,6 +122,7 @@ describe('animation renderer factory', () => {
 
   class SomeComponent {
     static ngComponentDef = defineComponent({
+      type: SomeComponent,
       tag: 'some-component',
       template: function(ctx: SomeComponent, cm: boolean) {
         if (cm) {
@@ -136,6 +139,7 @@ describe('animation renderer factory', () => {
       eventLogs.push(`${event.fromState ? event.fromState : event.toState} - ${event.phaseName}`);
     }
     static ngComponentDef = defineComponent({
+      type: SomeComponentWithAnimation,
       tag: 'some-component',
       template: function(ctx: SomeComponentWithAnimation, cm: boolean) {
         if (cm) {

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -10,7 +10,7 @@ import {AnimationEvent} from '@angular/animations';
 import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/browser/testing';
 
 import {RendererType2, ViewEncapsulation} from '../../src/core';
-import {E, L, T, b, defineComponent, detectChanges, e, p} from '../../src/render3/index';
+import {E, L, T, b, defineComponent, detectChanges, e, p, r} from '../../src/render3/index';
 import {createRendererType2} from '../../src/view/index';
 
 import {getAnimationRendererFactory2, getRendererFactory2} from './imported_renderer2';
@@ -67,7 +67,7 @@ describe('renderer factory lifecycle', () => {
       e();
     }
     SomeComponent.ngComponentDef.h(2, 1);
-    SomeComponent.ngComponentDef.r(2, 1);
+    r(2, 1);
   }
 
   beforeEach(() => { logs = []; });

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {TemplateRef, ViewContainerRef} from '../../src/core';
-import {C, T, b, cR, cr, defineComponent, defineDirective, injectTemplateRef, injectViewContainerRef, m, t} from '../../src/render3/index';
+import {C, T, b, cR, cr, defineComponent, defineDirective, injectTemplateRef, injectViewContainerRef, m, r, t} from '../../src/render3/index';
 
 import {renderComponent, toHtml} from './render_util';
 
@@ -16,6 +16,7 @@ describe('ViewContainerRef', () => {
     constructor(public viewContainer: ViewContainerRef, public template: TemplateRef<any>, ) {}
 
     static ngDirectiveDef = defineDirective({
+      type: TestDirective,
       factory: () => new TestDirective(injectViewContainerRef(), injectTemplateRef(), ),
     });
   }
@@ -24,6 +25,7 @@ describe('ViewContainerRef', () => {
     testDir: TestDirective;
 
     static ngComponentDef = defineComponent({
+      type: TestComponent,
       tag: 'test-cmp',
       factory: () => new TestComponent(),
       template: (cmp: TestComponent, cm: boolean) => {
@@ -38,7 +40,8 @@ describe('ViewContainerRef', () => {
         }
         cR(0);
         cmp.testDir = m(1) as TestDirective;
-        TestDirective.ngDirectiveDef.r(1, 0);
+        TestDirective.ngDirectiveDef.h(1, 0);
+        r(1, 0);
         cr();
       },
     });


### PR DESCRIPTION
This PR adds support for the `afterContentInit` and `afterContentChecked` hooks to render3. It also adds some missing tests for how projected components will work with other lifecycle hooks.

Update:
This PR now also rewrites lifecycle hooks to remove the `l()` instruction. We now queue all hooks on the `TView` as we build up the node tree and execute them implicitly in `componentRefresh` and view end.

Notes: 
- `type` has been added back to `DirectiveDef`. This allows us to copy over lifecycle hooks from the type during `defineComponent`. This is a megamorphic lookup, but it only runs once per component and it saves us from conducting a megamorphic lookup for each component instance.
-  `r` has been removed from the `DirectiveDef`, as it no longer has a purpose. Previously, it contained view hook declarations, but now that these are implicit, we can just call `componentRefresh` directly.

cc @jelbourn 