### PR TITLE
ci: add github bot config to triage issues

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -51,3 +51,18 @@ merge:
 \n**If you want your PR to be merged, it has to pass all the CI checks.**
 \n
 \nIf you can't get the PR to a green state due to flakes or broken master, please try rebasing to master and/or restarting the CI job. If that fails and you believe that the issue is not due to your change, please contact the caretaker and ask for help."
+
+# options for the triage plugin
+triage:
+  # number of the milestone to apply when the issue is triaged
+  defaultMilestone: 82,
+  # arrays of labels that determine if an issue is triaged
+  triagedLabels:
+    -
+      - "type: bug"
+      - "severity"
+      - "freq"
+      - "comp:"
+    -
+      - "type: feature"
+      - "comp:"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] CI related changes
```

## What is the current behavior?
Issues are not added to backlog milestone

Issue Number: #21635


## What is the new behavior?
Issues are added to the backlog milestone when triaged


## Does this PR introduce a breaking change?
```
[x] No
```