### PR TITLE
Update to latest rules_typescript.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,12 +15,8 @@ node_repositories(package_json = ["//:package.json"])
 
 git_repository(
     name = "build_bazel_rules_typescript",
-    # Use alexeagle's branch temporarily to allow a green build in the middle of
-    # the tsconfig refactoring.
-    # TODO(alexeagle): after the change lands in google3, push it to bazelbuild
-    # mirror and point this back to upstream.
-    remote = "https://github.com/alexeagle/rules_typescript.git",
-    commit = "5ccf967a393d94f53b5b1a97760eb1e18367faa3"
+    remote = "https://github.com/bazelbuild/rules_typescript.git",
+    commit = "c4ea003acd7d42269b81a2d25eb832972cd24912"
 )
 
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")

--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -13,12 +13,8 @@ node_repositories(package_json = ["//:package.json"])
 
 git_repository(
     name = "build_bazel_rules_typescript",
-    # Use alexeagle's branch temporarily to allow a green build in the middle of
-    # the tsconfig refactoring.
-    # TODO(alexeagle): after the change lands in google3, push it to bazelbuild
-    # mirror and point this back to upstream.
-    remote = "https://github.com/alexeagle/rules_typescript.git",
-    commit = "5ccf967a393d94f53b5b1a97760eb1e18367faa3"
+    remote = "https://github.com/bazelbuild/rules_typescript.git",
+    commit = "c4ea003acd7d42269b81a2d25eb832972cd24912"
 )
 
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")

--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -189,15 +189,18 @@ export function compile({allowNonHermeticReads, allDepsCompiledWithBazel = true,
     }
     return bazelOpts.workspaceName + '/' + result;
   };
-  ngHost.toSummaryFileName = (fileName: string, referringSrcFileName: string) =>
-      relativeToRootDirs(fileName, compilerOpts.rootDirs).replace(EXT, '');
+  ngHost.toSummaryFileName = (fileName: string, referringSrcFileName: string) => path.join(
+      bazelOpts.workspaceName,
+      relativeToRootDirs(fileName, compilerOpts.rootDirs).replace(EXT, ''));
   if (allDepsCompiledWithBazel) {
     // Note: The default implementation would work as well,
     // but we can be faster as we know how `toSummaryFileName` works.
     // Note: We can't do this if some deps have been compiled with the command line,
     // as that has a different implementation of fromSummaryFileName / toSummaryFileName
-    ngHost.fromSummaryFileName = (fileName: string, referringLibFileName: string) =>
-        path.resolve(bazelBin, fileName) + '.d.ts';
+    ngHost.fromSummaryFileName = (fileName: string, referringLibFileName: string) => {
+      const workspaceRelative = fileName.split('/').splice(1).join('/');
+      return path.resolve(bazelBin, workspaceRelative) + '.d.ts';
+    };
   }
 
   const emitCallback: ng.TsEmitCallback = ({


### PR DESCRIPTION
Fixes #21481

Undoes a hack that was needed to land the tsconfig refactoring.