### PR TITLE
fix(aio): from `tour-of-heroes/services` removed `MessageService` from a code example under a code example under `Provide the HeroService` title

### DIFF
--- a/aio/content/examples/toh-pt4/src/app/app.module.ts
+++ b/aio/content/examples/toh-pt4/src/app/app.module.ts
@@ -21,7 +21,7 @@ import { MessagesComponent } from './messages/messages.component';
     FormsModule
   ],
   // #docregion providers
-  providers: [ HeroService, MessageService ],
+  providers: [ HeroService ],
   // #enddocregion providers
   bootstrap: [ AppComponent ]
 })


### PR DESCRIPTION
fix(aio): from `tour-of-heroes/services` removed `MessageService` from a code example under a code example under `Provide the HeroService` title

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
When a user goes through the Tour of heroes tutorial's service page (https://angular.io/tutorial/toh-pt4#create-the-heroservice) he is instructed to add the `HeroService` to the appModule's `@NgModule.providers` array. In the example shown there, the  `MessageService` is also included in the array. It will cause a `reference not found` error in some IDEs. It will be confusing to the beginners.

Issue Number: N/A


## What is the new behavior?
Removed `MessageService` from the example code so that the error will not be shown again.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
