### PR TITLE
WIP(compiler): fix #19878, can config zone/once/passive/capture in template/HostListener decorator

### DIFF
--- a/aio/content/guide/cheatsheet.md
+++ b/aio/content/guide/cheatsheet.md
@@ -257,7 +257,7 @@ so the <code>@Directive</code> configuration applies to components as well</p>
 </td>
 </tr><tr>
 <td><code><b>@HostListener('click', ['$event'])</b> onClick(e) {...}</code></td>
-<td><p>Subscribes to a host element event (<code>click</code>) with a directive/component method (<code>onClick</code>), optionally passing an argument (<code>$event</code>).</p>
+<td><p>Subscribes to a host element event (<code>click</code>) with a directive/component method (<code>onClick</code>), optionally passing an argument (<code>$event</code>).You can also pass passive/capture/once/ngzone/nozone as as the modifier of the event name like (<code>click.capture.once.ngzone</code>)</p>
 </td>
 </tr><tr>
 <td><code><b>@ContentChild(myPredicate)</b> myChildComponent;</code></td>

--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -939,6 +939,21 @@ the component's `onSave()` method whenever a click occurs:
 <code-example path="template-syntax/src/app/app.component.html" region="event-binding-1" title="src/app/app.component.html" linenums="false">
 </code-example>
 
+Event binding also support pass the following options.
+- capture
+- passive
+- once
+- ngzone
+- nozone
+
+The capture/passive/once are the options will be passed to addEventListener. ngzone/nozone will define which zone the event handler will run into, by default, the event handler will run into the zone when the addEventListener was called(in most cases, it will be ngZone), but sometimes user may want to run the event handler outside of ngZone or explicitly in ngZone.
+
+To pass those modifiers, user can write like this.
+
+<code-example language="html">
+  &lt;button (click.capture.passive.once.nozone)="onSave()"&gt;Save&lt;/button&gt;
+</code-example>
+
 ### Target event
 
 A **name between parentheses** &mdash; for example, `(click)` &mdash;

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -27,6 +27,7 @@ module.exports = function(config) {
       {pattern: 'node_modules/angular/angular.js', included: false, watched: false},
       {pattern: 'node_modules/angular-mocks/angular-mocks.js', included: false, watched: false},
 
+      'test-events.js',
       'node_modules/core-js/client/core.js',
       'node_modules/zone.js/dist/zone.js',
       'node_modules/zone.js/dist/long-stack-trace-zone.js',
@@ -38,7 +39,6 @@ module.exports = function(config) {
       'node_modules/zone.js/dist/fake-async-test.js',
 
       // Including systemjs because it defines `__eval`, which produces correct stack traces.
-      'test-events.js',
       'shims_for_IE.js',
       'node_modules/systemjs/dist/system.src.js',
 

--- a/modules/playground/e2e_test/hello_world/hello_world_spec.ts
+++ b/modules/playground/e2e_test/hello_world/hello_world_spec.ts
@@ -28,6 +28,30 @@ describe('hello world', function() {
       clickComponentButton('hello-app', '.changeButton');
       expect(getComponentText('hello-app', '.greeting')).toEqual('howdy world!');
     });
+
+    it('should handle HostListener window:click', function() {
+      browser.get(URL);
+      clickBody();
+      clickComponentText('hello-app', '.greeting');
+
+      // HostListener was registered as 'outsideOfAngular', so dom will not refresh
+      expect(getComponentText('hello-app', '.windowZone')).toEqual('window click zone: ');
+      expect(getComponentText('hello-app', '.compZone')).toEqual('Hello Component click zone: ');
+      // refresh by click button
+      clickComponentButton('hello-app', '.changeButton');
+      expect(getComponentText('hello-app', '.windowZone')).toEqual('window click zone: <root>');
+      expect(getComponentText('hello-app', '.compZone'))
+          .toEqual('Hello Component click zone: <root>');
+      clickComponentButton('hello-app', '.changeButton');
+      expect(getComponentText('hello-app', '.windowZone')).toEqual('');
+      clickComponentText('hello-app', '.divZone');
+      expect(getComponentText('hello-app', '.windowZone')).toEqual('window click zone: <root>');
+      expect(getComponentText('hello-app', '.divZone')).toEqual('div click zone: <root>');
+      clickComponentButton('hello-app', '.changeButton');
+      clickComponentText('hello-app', '.divZone');
+      expect(getComponentText('hello-app', '.divZone')).toEqual('');
+      expect(getComponentText('hello-app', '.windowZone')).toEqual('');
+    });
   });
 
 });
@@ -38,6 +62,15 @@ function getComponentText(selector: string, innerSelector: string) {
 }
 
 function clickComponentButton(selector: string, innerSelector: string) {
+  return browser.executeScript(
+      `return document.querySelector("${selector}").querySelector("${innerSelector}").click()`);
+}
+
+function clickBody() {
+  return browser.executeScript(`return document.body.click()`);
+}
+
+function clickComponentText(selector: string, innerSelector: string) {
   return browser.executeScript(
       `return document.querySelector("${selector}").querySelector("${innerSelector}").click()`);
 }

--- a/modules/playground/src/hello_world/index.ts
+++ b/modules/playground/src/hello_world/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, ElementRef, Injectable, NgModule, Renderer} from '@angular/core';
+import {Component, Directive, ElementRef, HostListener, Injectable, NgModule, Renderer} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
@@ -47,14 +47,31 @@ export class RedDec {
   // Expressions in the template (like {{greeting}}) are evaluated in the
   // context of the HelloCmp class below.
   template: `<div class="greeting">{{greeting}} <span red>world</span>!</div>
-           <button class="changeButton" (click)="changeGreeting()">change greeting</button>`
+           <button class="changeButton" (click)="changeGreeting()">change greeting</button>           <button class="changeButton" (click)="changeGreeting()">change greeting</button>
+           <div class="windowZone">window click zone: {{windowZone}}</div>
+          <div class="compZone">Hello Component click zone: {{compZone}}</div>
+          <div class="divZone" (click.nozone.capture.once)="divClick()">div click zone: {{divZone}}</div>`
 })
 export class HelloCmp {
   greeting: string;
+  windowZone: string;
+  compZone: string;
+  divZone: string;
 
   constructor(service: GreetingService) { this.greeting = service.greeting; }
 
-  changeGreeting(): void { this.greeting = 'howdy'; }
+  changeGreeting(): void {
+    this.greeting = 'howdy';
+    this.windowZone = '';
+    this.divZone = '';
+  }
+  @HostListener('click.nozone', null)
+  onClick() { this.compZone = Zone.current.name; }
+
+  @HostListener('window:click.nozone', null)
+  onWindowClick() { this.windowZone = Zone.current.name; }
+
+  divClick() { this.divZone = Zone.current.name; }
 }
 
 @NgModule({declarations: [HelloCmp, RedDec], bootstrap: [HelloCmp], imports: [BrowserModule]})

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "reflect-metadata": "^0.1.3",
     "rxjs": "5.5.6",
     "tslib": "^1.7.1",
-    "zone.js": "^0.8.12"
+    "zone.js": "^0.8.20"
   },
   "optionalDependencies": {
     "fsevents": "1.1.2"

--- a/packages/compiler/src/core.ts
+++ b/packages/compiler/src/core.ts
@@ -105,9 +105,11 @@ export const createHostBinding = makeMetadataFactory<HostBinding>(
 export interface HostListener {
   eventName?: string;
   args?: string[];
+  modifier?: string;
 }
 export const createHostListener = makeMetadataFactory<HostListener>(
-    'HostListener', (eventName?: string, args?: string[]) => ({eventName, args}));
+    'HostListener',
+    (eventName?: string, args?: string[], modifier?: string) => ({eventName, args, modifier}));
 
 export interface NgModule {
   providers?: Provider[];

--- a/packages/compiler/src/directive_resolver.ts
+++ b/packages/compiler/src/directive_resolver.ts
@@ -98,7 +98,11 @@ export class DirectiveResolver {
       const hostListeners = propertyMetadata[propName].filter(a => createHostListener.isTypeOf(a));
       hostListeners.forEach(hostListener => {
         const args = hostListener.args || [];
-        host[`(${hostListener.eventName})`] = `${propName}(${args.join(',')})`;
+        if (hostListener.modifier) {
+          host[`(${hostListener.eventName})`] = `${propName}(${args.join(',')})`;
+        } else {
+          host[`(${hostListener.eventName})`] = `${propName}(${args.join(',')})`;
+        }
       });
       const query = findLast(
           propertyMetadata[propName], (a) => QUERY_METADATA_IDENTIFIERS.some(i => i.isTypeOf(a)));

--- a/packages/compiler/src/template_parser/template_ast.ts
+++ b/packages/compiler/src/template_parser/template_ast.ts
@@ -14,7 +14,6 @@ import {LifecycleHooks} from '../lifecycle_reflector';
 import {ParseSourceSpan} from '../parse_util';
 
 
-
 /**
  * An Abstract Syntax Tree node representing part of a parsed Angular template.
  */

--- a/packages/compiler/test/directive_resolver_spec.ts
+++ b/packages/compiler/test/directive_resolver_spec.ts
@@ -54,6 +54,16 @@ class SomeDirectiveWithHostListeners {
   onA() {}
   @HostListener('b', ['$event.value'])
   onB(value: any) {}
+  @HostListener('t:f.ngzone', ['$event.value'])
+  onF(value: any) {}
+  @HostListener('g.h.nozone', ['$event.value'])
+  onG(value: any) {}
+  @HostListener('i:j.k.nozone', ['$event.value'])
+  onH(value: any) {}
+  @HostListener('l.m', ['$event.value'])
+  onI(value: any) {}
+  @HostListener('n:o.nozone.capture.once.passive', ['$event.value'])
+  onP(value: any) {}
 }
 
 @Directive({selector: 'someDirective', queries: {'cs': new ContentChildren('c')}})
@@ -306,8 +316,16 @@ class SomeDirectiveWithoutMetadata {}
 
       it('should append host listeners', () => {
         const directiveMetadata = resolver.resolve(SomeDirectiveWithHostListeners);
-        expect(directiveMetadata.host)
-            .toEqual({'(c)': 'onC()', '(a)': 'onA()', '(b)': 'onB($event.value)'});
+        expect(directiveMetadata.host).toEqual({
+          '(c)': 'onC()',
+          '(a)': 'onA()',
+          '(b)': 'onB($event.value)',
+          '(t:f.ngzone)': 'onF($event.value)',
+          '(g.h.nozone)': 'onG($event.value)',
+          '(i:j.k.nozone)': 'onH($event.value)',
+          '(l.m)': 'onI($event.value)',
+          '(n:o.nozone.capture.once.passive)': 'onP($event.value)'
+        });
       });
 
       it('should throw when @HostBinding name starts with "("', () => {

--- a/packages/compiler/test/template_parser/template_parser_spec.ts
+++ b/packages/compiler/test/template_parser/template_parser_spec.ts
@@ -851,6 +851,20 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
           ]);
         });
 
+        it('should parse bound events with modifiers', () => {
+          expect(humanizeTplAst(parse('<div (event.nozone.capture.passive.once)="v">', []))).toEqual([
+            [ElementAst, 'div'],
+            [BoundEventAst, 'event.nozone.capture.passive.once', null, 'v'],
+          ]);
+        });
+
+        it('should parse bound events with modifiers and target', () => {
+          expect(humanizeTplAst(parse('<div (window:event.nozone.capture.passive.once)="v">', []))).toEqual([
+            [ElementAst, 'div'],
+            [BoundEventAst, 'event.nozone.capture.passive.once', 'window', 'v'],
+          ]);
+        });
+
         it('should report an error on empty expression', () => {
           expect(() => parse('<div (event)="">', []))
               .toThrowError(/Empty expressions are not allowed/);
@@ -1018,6 +1032,17 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
                        }).toSummary();
           expect(humanizeTplAst(parse('<div></div>', [dirA]))).toEqual([
             [ElementAst, 'div'], [DirectiveAst, dirA], [BoundEventAst, 'a', null, 'expr']
+          ]);
+        });
+
+        it('should parse directive host listeners with modifiers', () => {
+          const dirA = compileDirectiveMetadataCreate({
+                         selector: 'div',
+                         type: createTypeMeta({reference: {filePath: someModuleUrl, name: 'DirA'}}),
+                         host: {'(a.nozone.capture.once.passive)': 'expr'}
+                       }).toSummary();
+          expect(humanizeTplAst(parse('<div></div>', [dirA]))).toEqual([
+            [ElementAst, 'div'], [DirectiveAst, dirA], [BoundEventAst, 'a.nozone.capture.once.passive', null, 'expr']
           ]);
         });
 

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -7,10 +7,11 @@
  */
 
 import {Injector} from '../di';
+import {EventOptions} from '../render/api';
 import {DebugContext} from '../view/index';
 
 export class EventListener {
-  constructor(public name: string, public callback: Function) {}
+  constructor(public name: string, public callback: Function, public options?: EventOptions) {}
 }
 
 /**

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -7,4 +7,4 @@
  */
 
 // Public API for render
-export {RenderComponentType, Renderer, Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2, RootRenderer} from './render/api';
+export {EventOptions, RenderComponentType, Renderer, Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2, RootRenderer} from './render/api';

--- a/packages/core/src/render/api.ts
+++ b/packages/core/src/render/api.ts
@@ -186,5 +186,11 @@ export abstract class Renderer2 {
   abstract setValue(node: any, value: string): void;
   abstract listen(
       target: 'window'|'document'|'body'|any, eventName: string,
-      callback: (event: any) => boolean | void): () => void;
+      callback: (event: any) => boolean | void, eventOptions?: EventOptions): () => void;
 }
+
+/**
+ * Event Listener Options
+ * @experimental
+ */
+export interface EventOptions extends AddEventListenerOptions { zone?: string; }

--- a/packages/core/src/view/services.ts
+++ b/packages/core/src/view/services.ts
@@ -13,7 +13,7 @@ import {InjectableType} from '../di/injectable';
 import {ErrorHandler} from '../error_handler';
 import {ComponentFactory} from '../linker/component_factory';
 import {NgModuleRef} from '../linker/ng_module_factory';
-import {Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2} from '../render/api';
+import {EventOptions, Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2} from '../render/api';
 import {Sanitizer} from '../sanitization/security';
 import {Type} from '../type';
 import {tokenKey} from '../view/util';
@@ -820,16 +820,16 @@ class DebugRenderer2 implements Renderer2 {
   }
 
   listen(
-      target: 'document'|'windows'|'body'|any, eventName: string,
-      callback: (event: any) => boolean): () => void {
+      target: 'document'|'windows'|'body'|any, eventName: string, callback: (event: any) => boolean,
+      eventOptions?: EventOptions): () => void {
     if (typeof target !== 'string') {
       const debugEl = getDebugNode(target);
       if (debugEl) {
-        debugEl.listeners.push(new EventListener(eventName, callback));
+        debugEl.listeners.push(new EventListener(eventName, callback, eventOptions));
       }
     }
 
-    return this.delegate.listen(target, eventName, callback);
+    return this.delegate.listen(target, eventName, callback, eventOptions);
   }
 
   parentNode(node: any): any { return this.delegate.parentNode(node); }

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -936,12 +936,21 @@ function declareTests({useJit}: {useJit: boolean}) {
       });
 
       it('should not use template variables for expressions in hostListeners', () => {
-        @Directive({selector: '[host-listener]', host: {'(click)': 'doIt(id, unknownProp)'}})
+        @Directive({
+          selector: '[host-listener]',
+          host: {
+            '(click)': 'doIt(id, unknownProp)',
+            '(mouseover.nozone)': 'mouseover(id, unknownProp)',
+            '(mousemove.nozone.capture.once.passive)': 'mousemove(id, unknownProp)'
+          }
+        })
         class DirectiveWithHostListener {
           id = 'one';
           receivedArgs: any[];
 
           doIt(...args: any[]) { this.receivedArgs = args; }
+          mouseover(...args: any[]) { this.receivedArgs = args; }
+          mousemove(...args: any[]) { this.receivedArgs = args; }
         }
 
         const fixture =
@@ -954,6 +963,12 @@ function declareTests({useJit}: {useJit: boolean}) {
         const tc = fixture.debugElement.children[0];
         tc.triggerEventHandler('click', {});
         const dir: DirectiveWithHostListener = tc.injector.get(DirectiveWithHostListener);
+        expect(dir.receivedArgs).toEqual(['one', undefined]);
+        dir.receivedArgs = [];
+        tc.triggerEventHandler('mouseover', {});
+        expect(dir.receivedArgs).toEqual(['one', undefined]);
+        dir.receivedArgs = [];
+        tc.triggerEventHandler('mousemove', {});
         expect(dir.receivedArgs).toEqual(['one', undefined]);
       });
 

--- a/packages/core/test/view/component_view_spec.ts
+++ b/packages/core/test/view/component_view_spec.ts
@@ -17,8 +17,10 @@ import {callMostRecentEventListenerHandler, compViewDef, createAndGetRootNodes, 
 /**
  * We map addEventListener to the Zones internal name. This is because we want to be fast
  * and bypass the zone bookkeeping. We know that we can do the bookkeeping faster.
+ * TODO @JiaLiPassion, current DOMEventManager does not bypass zone.js correctly
+ * so we will still map to addEventListener/removeEventListener
  */
-const addEventListener = '__zone_symbol__addEventListener';
+const addEventListener = 'addEventListener';
 
 {
   describe(`Component Views`, () => {

--- a/packages/core/test/view/element_spec.ts
+++ b/packages/core/test/view/element_spec.ts
@@ -19,9 +19,11 @@ import {ARG_TYPE_VALUES, callMostRecentEventListenerHandler, checkNodeInlineOrDy
 /**
  * We map addEventListener to the Zones internal name. This is because we want to be fast
  * and bypass the zone bookkeeping. We know that we can do the bookkeeping faster.
+ * TODO @JiaLiPassion, current DOMEventManager does not bypass zone.js correctly
+ * so we will still map to addEventListener/removeEventListener
  */
-const addEventListener = '__zone_symbol__addEventListener';
-const removeEventListener = '__zone_symbol__removeEventListener';
+const addEventListener = 'addEventListener';
+const removeEventListener = 'removeEventListener';
 
 {
   describe(`View Elements`, () => {

--- a/packages/platform-browser/animations/src/animation_renderer.ts
+++ b/packages/platform-browser/animations/src/animation_renderer.ts
@@ -7,7 +7,7 @@
  */
 import {AnimationTriggerMetadata} from '@angular/animations';
 import {ɵAnimationEngine as AnimationEngine} from '@angular/animations/browser';
-import {Injectable, NgZone, Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2} from '@angular/core';
+import {EventOptions, Injectable, NgZone, Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2} from '@angular/core';
 
 const ANIMATION_PREFIX = '@';
 const DISABLE_ANIMATIONS_FLAG = '@.disabled';
@@ -188,8 +188,10 @@ export class BaseAnimationRenderer implements Renderer2 {
 
   setValue(node: any, value: string): void { this.delegate.setValue(node, value); }
 
-  listen(target: any, eventName: string, callback: (event: any) => boolean | void): () => void {
-    return this.delegate.listen(target, eventName, callback);
+  listen(
+      target: any, eventName: string, callback: (event: any) => boolean | void,
+      eventOptions?: EventOptions): () => void {
+    return this.delegate.listen(target, eventName, callback, eventOptions);
   }
 
   protected disableAnimations(element: any, value: boolean) {
@@ -218,8 +220,9 @@ export class AnimationRenderer extends BaseAnimationRenderer implements Renderer
     }
   }
 
-  listen(target: 'window'|'document'|'body'|any, eventName: string, callback: (event: any) => any):
-      () => void {
+  listen(
+      target: 'window'|'document'|'body'|any, eventName: string, callback: (event: any) => any,
+      eventOptions?: EventOptions): () => void {
     if (eventName.charAt(0) == ANIMATION_PREFIX) {
       const element = resolveElementFromTarget(target);
       let name = eventName.substr(1);
@@ -234,7 +237,7 @@ export class AnimationRenderer extends BaseAnimationRenderer implements Renderer
         this.factory.scheduleListenerCallback(countId, callback, event);
       });
     }
-    return this.delegate.listen(target, eventName, callback);
+    return this.delegate.listen(target, eventName, callback, eventOptions);
   }
 }
 

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2, ViewEncapsulation} from '@angular/core';
+import {EventOptions, Injectable, Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2, ViewEncapsulation} from '@angular/core';
 
 import {EventManager} from './events/event_manager';
 import {DomSharedStylesHost} from './shared_styles_host';
@@ -205,15 +205,16 @@ class DefaultDomRenderer2 implements Renderer2 {
 
   setValue(node: any, value: string): void { node.nodeValue = value; }
 
-  listen(target: 'window'|'document'|'body'|any, event: string, callback: (event: any) => boolean):
-      () => void {
+  listen(
+      target: 'window'|'document'|'body'|any, event: string, callback: (event: any) => boolean,
+      eventOptions?: EventOptions): () => void {
     checkNoSyntheticProp(event, 'listener');
     if (typeof target === 'string') {
       return <() => void>this.eventManager.addGlobalEventListener(
-          target, event, decoratePreventDefault(callback));
+          target, event, decoratePreventDefault(callback), eventOptions);
     }
     return <() => void>this.eventManager.addEventListener(
-               target, event, decoratePreventDefault(callback)) as() => void;
+               target, event, decoratePreventDefault(callback), eventOptions) as() => void;
   }
 }
 

--- a/packages/platform-browser/src/dom/events/dom_events.ts
+++ b/packages/platform-browser/src/dom/events/dom_events.ts
@@ -6,18 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, NgZone} from '@angular/core';
-// Import zero symbols from zone.js. This causes the zone ambient type to be
-// added to the type-checker, without emitting any runtime module load statement
-import {} from 'zone.js';
+import {EventOptions, Inject, Injectable, NgZone, ɵglobal as global} from '@angular/core';
 
 import {DOCUMENT} from '../dom_tokens';
 
 import {EventManagerPlugin} from './event_manager';
 
+
 /**
- * Detect if Zone is present. If it is then use simple zone aware 'addEventListener'
- * since Angular can do much more
+ * Detect if Zone is present. If it is then bypass 'addEventListener' since Angular can do much more
  * efficient bookkeeping than Zone can, because we have additional information. This speeds up
  * addEventListener by 3x.
  */
@@ -28,201 +25,48 @@ const __symbol__ =
 const ADD_EVENT_LISTENER: 'addEventListener' = __symbol__('addEventListener');
 const REMOVE_EVENT_LISTENER: 'removeEventListener' = __symbol__('removeEventListener');
 
-const symbolNames: {[key: string]: string} = {};
-
-const FALSE = 'FALSE';
-const ANGULAR = 'ANGULAR';
-const NATIVE_ADD_LISTENER = 'addEventListener';
-const NATIVE_REMOVE_LISTENER = 'removeEventListener';
-
-// use the same symbol string which is used in zone.js
-const stopSymbol = '__zone_symbol__propagationStopped';
-const stopMethodSymbol = '__zone_symbol__stopImmediatePropagation';
-
-const blackListedEvents: string[] =
-    (typeof Zone !== 'undefined') && (Zone as any)[__symbol__('BLACK_LISTED_EVENTS')];
-let blackListedMap: {[eventName: string]: string};
-if (blackListedEvents) {
-  blackListedMap = {};
-  blackListedEvents.forEach(eventName => { blackListedMap[eventName] = eventName; });
-}
-
-const isBlackListedEvent = function(eventName: string) {
-  if (!blackListedMap) {
-    return false;
-  }
-  return blackListedMap.hasOwnProperty(eventName);
-};
-
-interface TaskData {
-  zone: any;
-  handler: Function;
-}
-
-// a global listener to handle all dom event,
-// so we do not need to create a closure everytime
-const globalListener = function(event: Event) {
-  const symbolName = symbolNames[event.type];
-  if (!symbolName) {
-    return;
-  }
-  const taskDatas: TaskData[] = this[symbolName];
-  if (!taskDatas) {
-    return;
-  }
-  const args: any = [event];
-  if (taskDatas.length === 1) {
-    // if taskDatas only have one element, just invoke it
-    const taskData = taskDatas[0];
-    if (taskData.zone !== Zone.current) {
-      // only use Zone.run when Zone.current not equals to stored zone
-      return taskData.zone.run(taskData.handler, this, args);
-    } else {
-      return taskData.handler.apply(this, args);
-    }
-  } else {
-    // copy tasks as a snapshot to avoid event handlers remove
-    // itself or others
-    const copiedTasks = taskDatas.slice();
-    for (let i = 0; i < copiedTasks.length; i++) {
-      // if other listener call event.stopImmediatePropagation
-      // just break
-      if ((event as any)[stopSymbol] === true) {
-        break;
-      }
-      const taskData = copiedTasks[i];
-      if (taskData.zone !== Zone.current) {
-        // only use Zone.run when Zone.current not equals to stored zone
-        taskData.zone.run(taskData.handler, this, args);
-      } else {
-        taskData.handler.apply(this, args);
-      }
-    }
-  }
-};
-
 @Injectable()
 export class DomEventsPlugin extends EventManagerPlugin {
-  constructor(@Inject(DOCUMENT) doc: any, private ngZone: NgZone) {
-    super(doc);
-
-    this.patchEvent();
-  }
-
-  private patchEvent() {
-    if (!Event || !Event.prototype) {
-      return;
-    }
-    if ((Event.prototype as any)[stopMethodSymbol]) {
-      // already patched by zone.js
-      return;
-    }
-    const delegate = (Event.prototype as any)[stopMethodSymbol] =
-        Event.prototype.stopImmediatePropagation;
-    Event.prototype.stopImmediatePropagation = function() {
-      if (this) {
-        this[stopSymbol] = true;
-      }
-
-      // should call native delegate in case
-      // in some enviroment part of the application
-      // will not use the patched Event
-      delegate && delegate.apply(this, arguments);
-    };
-  }
+  constructor(@Inject(DOCUMENT) doc: any, private ngZone: NgZone) { super(doc); }
 
   // This plugin should come last in the list of plugins, because it accepts all
   // events.
   supports(eventName: string): boolean { return true; }
 
-  addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
+  addEventListener(
+      element: HTMLElement, eventName: string, handler: Function,
+      eventOptions?: EventOptions): Function {
     /**
      * This code is about to add a listener to the DOM. If Zone.js is present, than
      * `addEventListener` has been patched. The patched code adds overhead in both
      * memory and speed (3x slower) than native. For this reason if we detect that
-     * Zone.js is present we use a simple version of zone aware addEventListener instead.
-     * The result is faster registration and the zone will be restored.
-     * But ZoneSpec.onScheduleTask, ZoneSpec.onInvokeTask, ZoneSpec.onCancelTask
-     * will not be invoked
-     * We also do manual zone restoration in element.ts renderEventHandlerClosure method.
+     * Zone.js is present we bypass zone and use native addEventListener instead.
+     * The result is faster registration but the zone will not be restored. We do
+     * manual zone restoration in element.ts renderEventHandlerClosure method.
      *
      * NOTE: it is possible that the element is from different iframe, and so we
      * have to check before we execute the method.
      */
-    const self = this;
     const zoneJsLoaded = element[ADD_EVENT_LISTENER];
+
     let callback: EventListener = handler as EventListener;
-    // if zonejs is loaded and current zone is not ngZone
-    // we keep Zone.current on target for later restoration.
-    if (zoneJsLoaded && (!NgZone.isInAngularZone() || isBlackListedEvent(eventName))) {
-      let symbolName = symbolNames[eventName];
-      if (!symbolName) {
-        symbolName = symbolNames[eventName] = __symbol__(ANGULAR + eventName + FALSE);
-      }
-      let taskDatas: TaskData[] = (element as any)[symbolName];
-      const globalListenerRegistered = taskDatas && taskDatas.length > 0;
-      if (!taskDatas) {
-        taskDatas = (element as any)[symbolName] = [];
-      }
-
-      const zone = isBlackListedEvent(eventName) ? Zone.root : Zone.current;
-      if (taskDatas.length === 0) {
-        taskDatas.push({zone: zone, handler: callback});
-      } else {
-        let callbackRegistered = false;
-        for (let i = 0; i < taskDatas.length; i++) {
-          if (taskDatas[i].handler === callback) {
-            callbackRegistered = true;
-            break;
-          }
+    let addFn: string = 'addEventListener';
+    let removeFn: string = 'removeEventListener';
+    if (eventOptions) {
+      if (eventOptions.zone === 'nozone') {
+        if (zoneJsLoaded) {
+          addFn = ADD_EVENT_LISTENER;
+          removeFn = REMOVE_EVENT_LISTENER;
         }
-        if (!callbackRegistered) {
-          taskDatas.push({zone: zone, handler: callback});
+      } else if (eventOptions.zone === 'ngzone') {
+        if (!NgZone.isInAngularZone()) {
+          const self = this;
+          callback = function() { return self.ngZone.run(callback, this, arguments as any); };
         }
       }
-
-      if (!globalListenerRegistered) {
-        element[ADD_EVENT_LISTENER](eventName, globalListener, false);
-      }
-    } else {
-      element[NATIVE_ADD_LISTENER](eventName, callback, false);
     }
-    return () => this.removeEventListener(element, eventName, callback);
-  }
-
-  removeEventListener(target: any, eventName: string, callback: Function): void {
-    let underlyingRemove = target[REMOVE_EVENT_LISTENER];
-    // zone.js not loaded, use native removeEventListener
-    if (!underlyingRemove) {
-      return target[NATIVE_REMOVE_LISTENER].apply(target, [eventName, callback, false]);
-    }
-    let symbolName = symbolNames[eventName];
-    let taskDatas: TaskData[] = symbolName && target[symbolName];
-    if (!taskDatas) {
-      // addEventListener not using patched version
-      // just call native removeEventListener
-      return target[NATIVE_REMOVE_LISTENER].apply(target, [eventName, callback, false]);
-    }
-    // fix issue 20532, should be able to remove
-    // listener which was added inside of ngZone
-    let found = false;
-    for (let i = 0; i < taskDatas.length; i++) {
-      // remove listener from taskDatas if the callback equals
-      if (taskDatas[i].handler === callback) {
-        found = true;
-        taskDatas.splice(i, 1);
-        break;
-      }
-    }
-    if (found) {
-      if (taskDatas.length === 0) {
-        // all listeners are removed, we can remove the globalListener from target
-        underlyingRemove.apply(target, [eventName, globalListener, false]);
-      }
-    } else {
-      // not found in taskDatas, the callback may be added inside of ngZone
-      // use native remove listener to remove the calback
-      target[NATIVE_REMOVE_LISTENER].apply(target, [eventName, callback, false]);
-    }
+    (element as any)[addFn](eventName, callback, eventOptions ? eventOptions : false);
+    return () => (element as any)[removeFn](
+               eventName, callback as any, eventOptions ? eventOptions : false);
   }
 }

--- a/packages/platform-browser/src/dom/events/event_manager.ts
+++ b/packages/platform-browser/src/dom/events/event_manager.ts
@@ -6,9 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, InjectionToken, NgZone} from '@angular/core';
+import {EventOptions, Inject, Injectable, InjectionToken, NgZone} from '@angular/core';
 
 import {getDOM} from '../dom_adapter';
+
+
 
 /**
  * @stable
@@ -29,14 +31,17 @@ export class EventManager {
     this._plugins = plugins.slice().reverse();
   }
 
-  addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
+  addEventListener(
+      element: HTMLElement, eventName: string, handler: Function,
+      eventOptions?: EventOptions): Function {
     const plugin = this._findPluginFor(eventName);
-    return plugin.addEventListener(element, eventName, handler);
+    return plugin.addEventListener(element, eventName, handler, eventOptions);
   }
 
-  addGlobalEventListener(target: string, eventName: string, handler: Function): Function {
+  addGlobalEventListener(
+      target: string, eventName: string, handler: Function, eventOptions?: EventOptions): Function {
     const plugin = this._findPluginFor(eventName);
-    return plugin.addGlobalEventListener(target, eventName, handler);
+    return plugin.addGlobalEventListener(target, eventName, handler, eventOptions);
   }
 
   getZone(): NgZone { return this._zone; }
@@ -67,13 +72,17 @@ export abstract class EventManagerPlugin {
 
   abstract supports(eventName: string): boolean;
 
-  abstract addEventListener(element: HTMLElement, eventName: string, handler: Function): Function;
+  abstract addEventListener(
+      element: HTMLElement, eventName: string, handler: Function,
+      eventOptions?: EventOptions): Function;
 
-  addGlobalEventListener(element: string, eventName: string, handler: Function): Function {
+  addGlobalEventListener(
+      element: string, eventName: string, handler: Function,
+      eventOptions?: EventOptions): Function {
     const target: HTMLElement = getDOM().getGlobalEventTarget(this._doc, element);
     if (!target) {
       throw new Error(`Unsupported event target ${target} for event ${eventName}`);
     }
-    return this.addEventListener(target, eventName, handler);
+    return this.addEventListener(target, eventName, handler, eventOptions);
   }
 }

--- a/packages/platform-browser/test/dom/events/event_manager_spec.ts
+++ b/packages/platform-browser/test/dom/events/event_manager_spec.ts
@@ -19,6 +19,10 @@ import {el} from '../../../testing/src/browser_util';
   let doc: any;
   let zone: NgZone;
 
+  function dispatchEventInRootZone(target: any, event: any) {
+    Zone.root.run(() => { getDOM().dispatchEvent(target, event); });
+  }
+
   describe('EventManager', () => {
 
     beforeEach(() => {
@@ -69,7 +73,7 @@ import {el} from '../../../testing/src/browser_util';
       const handler = (e: any /** TODO #9100 */) => { receivedEvent = e; };
       const manager = new EventManager([domEventPlugin], new FakeNgZone());
       manager.addEventListener(element, 'click', handler);
-      getDOM().dispatchEvent(child, dispatchedEvent);
+      dispatchEventInRootZone(child, dispatchedEvent);
 
       expect(receivedEvent).toBe(dispatchedEvent);
     });
@@ -83,12 +87,12 @@ import {el} from '../../../testing/src/browser_util';
       const manager = new EventManager([domEventPlugin], new FakeNgZone());
 
       const remover = manager.addGlobalEventListener('document', 'click', handler);
-      getDOM().dispatchEvent(element, dispatchedEvent);
+      dispatchEventInRootZone(element, dispatchedEvent);
       expect(receivedEvent).toBe(dispatchedEvent);
 
       receivedEvent = null;
       remover();
-      getDOM().dispatchEvent(element, dispatchedEvent);
+      dispatchEventInRootZone(element, dispatchedEvent);
       expect(receivedEvent).toBe(null);
     });
 
@@ -108,13 +112,13 @@ import {el} from '../../../testing/src/browser_util';
 
       let remover: any = null;
       Zone.root.run(() => { remover = manager.addEventListener(element, 'click', handler); });
-      getDOM().dispatchEvent(element, dispatchedEvent);
+      dispatchEventInRootZone(element, dispatchedEvent);
       expect(receivedEvent).toBe(dispatchedEvent);
       expect(receivedZone.name).toBe(Zone.root.name);
 
       receivedEvent = null;
       remover && remover();
-      getDOM().dispatchEvent(element, dispatchedEvent);
+      dispatchEventInRootZone(element, dispatchedEvent);
       expect(receivedEvent).toBe(null);
     });
 
@@ -142,14 +146,14 @@ import {el} from '../../../testing/src/browser_util';
       Zone.root.fork({name: 'test'}).run(() => {
         remover2 = manager.addEventListener(element, 'click', handler2);
       });
-      getDOM().dispatchEvent(element, dispatchedEvent);
+      dispatchEventInRootZone(element, dispatchedEvent);
       expect(receivedEvents).toEqual([dispatchedEvent, dispatchedEvent]);
       expect(receivedZones).toEqual([Zone.root.name, 'test']);
 
       receivedEvents = [];
       remover1 && remover1();
       remover2 && remover2();
-      getDOM().dispatchEvent(element, dispatchedEvent);
+      dispatchEventInRootZone(element, dispatchedEvent);
       expect(receivedEvents).toEqual([]);
     });
 
@@ -178,14 +182,14 @@ import {el} from '../../../testing/src/browser_util';
       Zone.root.fork({name: 'test'}).run(() => {
         remover2 = manager.addEventListener(element, 'click', handler2);
       });
-      getDOM().dispatchEvent(element, dispatchedEvent);
+      dispatchEventInRootZone(element, dispatchedEvent);
       expect(receivedEvents).toEqual([dispatchedEvent]);
       expect(receivedZones).toEqual([Zone.root.name]);
 
       receivedEvents = [];
       remover1 && remover1();
       remover2 && remover2();
-      getDOM().dispatchEvent(element, dispatchedEvent);
+      dispatchEventInRootZone(element, dispatchedEvent);
       expect(receivedEvents).toEqual([]);
     });
 
@@ -214,14 +218,14 @@ import {el} from '../../../testing/src/browser_util';
       Zone.root.fork({name: 'test'}).run(() => {
         remover2 = manager.addEventListener(element, 'click', handler2);
       });
-      getDOM().dispatchEvent(element, dispatchedEvent);
+      dispatchEventInRootZone(element, dispatchedEvent);
       expect(receivedEvents).toEqual([dispatchedEvent, dispatchedEvent]);
       expect(receivedZones).toEqual([Zone.root.name, 'test']);
 
       receivedEvents = [];
       remover1 && remover1();
       remover2 && remover2();
-      getDOM().dispatchEvent(element, dispatchedEvent);
+      dispatchEventInRootZone(element, dispatchedEvent);
       expect(receivedEvents).toEqual([]);
     });
 
@@ -245,14 +249,14 @@ import {el} from '../../../testing/src/browser_util';
       Zone.root.fork({name: 'test'}).run(() => {
         remover2 = manager.addEventListener(element, 'click', handler);
       });
-      getDOM().dispatchEvent(element, dispatchedEvent);
+      dispatchEventInRootZone(element, dispatchedEvent);
       expect(receivedEvents).toEqual([dispatchedEvent]);
       expect(receivedZones).toEqual([Zone.root.name]);
 
       receivedEvents = [];
       remover1 && remover1();
       remover2 && remover2();
-      getDOM().dispatchEvent(element, dispatchedEvent);
+      dispatchEventInRootZone(element, dispatchedEvent);
       expect(receivedEvents).toEqual([]);
     });
 
@@ -282,14 +286,14 @@ import {el} from '../../../testing/src/browser_util';
       Zone.root.fork({name: 'fakeAngularZone', properties: {isAngularZone: true}}).run(() => {
         remover2 = manager.addEventListener(element, 'click', handler2);
       });
-      getDOM().dispatchEvent(element, dispatchedEvent);
+      dispatchEventInRootZone(element, dispatchedEvent);
       expect(receivedEvents).toEqual([dispatchedEvent, dispatchedEvent]);
       expect(receivedZones).toEqual([Zone.root.name, 'fakeAngularZone']);
 
       receivedEvents = [];
       remover1 && remover1();
       remover2 && remover2();
-      getDOM().dispatchEvent(element, dispatchedEvent);
+      dispatchEventInRootZone(element, dispatchedEvent);
       // handler1 and handler2 are added in different zone
       // one is angular zone, the other is not
       // should still be able to remove them correctly
@@ -310,13 +314,53 @@ import {el} from '../../../testing/src/browser_util';
       const manager = new EventManager([domEventPlugin], new FakeNgZone());
 
       let remover = manager.addEventListener(element, 'scroll', handler);
-      getDOM().dispatchEvent(element, dispatchedEvent);
+      dispatchEventInRootZone(element, dispatchedEvent);
       expect(receivedEvent).toBe(dispatchedEvent);
       expect(receivedZone.name).toBe(Zone.root.name);
 
       receivedEvent = null;
       remover && remover();
+      dispatchEventInRootZone(element, dispatchedEvent);
+      expect(receivedEvent).toBe(null);
+    });
+
+    it('should keep zone which is passed in addEventListener', () => {
+      const Zone = (window as any)['Zone'];
+
+      const element = el('<div><div></div></div>');
+      getDOM().appendChild(doc.body, element);
+      const dispatchedEvent = getDOM().createMouseEvent('click');
+      let receivedEvent: any /** TODO #9100 */ = null;
+      let receivedZone: any = null;
+      const handler = (e: any /** TODO #9100 */) => {
+        receivedEvent = e;
+        receivedZone = Zone.current;
+      };
+      const fakeNgZone = new FakeNgZone();
+      const manager = new EventManager([domEventPlugin], fakeNgZone);
+
+      let remover: any = null;
+      Zone.root.run(() => { remover = manager.addEventListener(element, 'click', handler); });
       getDOM().dispatchEvent(element, dispatchedEvent);
+      expect(receivedEvent).toBe(dispatchedEvent);
+      expect(receivedZone.name).toBe('<root>');
+
+      receivedEvent = null;
+      remover && remover();
+      getDOM().dispatchEvent(element, dispatchedEvent);
+      expect(receivedEvent).toBe(null);
+
+      fakeNgZone.run(() => {
+        remover = manager.addEventListener(element, 'click', handler, {zone: 'nozone'});
+      });
+      Zone.root.run(() => { getDOM().dispatchEvent(element, dispatchedEvent); });
+      expect(receivedEvent).toBe(dispatchedEvent);
+      expect(receivedZone.name).toBe('<root>');
+
+      receivedEvent = null;
+      remover && remover();
+      getDOM().dispatchEvent(element, dispatchedEvent);
+      expect(receivedEvent).toBe(null);
       expect(receivedEvent).toBe(null);
     });
   });

--- a/test-events.js
+++ b/test-events.js
@@ -6,4 +6,4 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-Zone[Zone.__symbol__('BLACK_LISTED_EVENTS')] = ['scroll'];
+window['__zone_symbol__BLACK_LISTED_EVENTS'] = ['scroll'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -7957,6 +7957,6 @@ zip-stream@~0.6.0:
     lodash "~3.10.1"
     readable-stream "~1.0.26"
 
-zone.js@^0.8.12:
+zone.js@^0.8.20:
   version "0.8.20"
   resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.20.tgz#a218c48db09464b19ff6fc8f0d4bb5b1046e185d"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #19878

### can't pass `passive`, `capture`, `once` parameters to `addEventListener`.

### not easy to config use ngzone or nozone with HostListener

user need to explicitly call `runOutsideOfAngular` to make sure  `eventhandler` run outsideof`ngZone` 

```javascript
@HostListener('window:resize', ['$event.target'])
  onResize(target: any) {
    this.ngZone.runOutsideOfAngular(() => {
       console.log('resize triggered');
    });
  }
```
or call `ngZone.run` explicitly make sure `eventhandler` run into `ngZone`.

```javascript
@HostListener('window:resize', ['$event.target'])
  onResize(target: any) {
    this.ngZone.run(() => {
       console.log('resize triggered');
    });
  }
```

### not easy to run event handler outsideOfAngular in template

```javascript
<div (mouseover)="mouseover();"></div>
```

```javascript
mouseover() {
  this.ngZone.runOfAngular(() => {
    ...
  });
}
```

## What is the new behavior?
Can config which `zone` will event handler will run into in `@HostListener` decorator.

### can config `passive`, `capture`, `once` parameters to `addEventListener`.
- in template, can config those parameter like below.

```javascript
<div (mouseover.capture.once.passive)="mouseover();"></div>
```

### can config `ngzone` which will guarantee eventhandler run in `ngZone` even the handler was 
added not in `ngZone`.

```javascript
 @HostListener('window:resize.ngzone', ['$event.target'])
  onResize(target: any) {
    console.log('resize triggered');
  }
```

- can config `nozone` which will guarantee eventhandler run outside of  `ngZone` even the handler was added  in `ngZone`. **and if config `outsideOfAngular`, DOMEventManager will bypass zone.js and directly use native addEventListener to improve performance.**

And it can also work with #20672 to get better performance.

```javascript
 @HostListener('window:resize.nozone', ['$event.target'])
  onResize(target: any) {
    console.log('resize triggered');
  }
```
## Does this PR introduce a breaking change?
```
[] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


