### PR TITLE
build(aio): generate sitemap from the generated pages

### DIFF
--- a/aio/src/extra-files/stable/robots.txt
+++ b/aio/src/extra-files/stable/robots.txt
@@ -1,3 +1,4 @@
 # Allow all URLs (see http://www.robotstxt.org/robotstxt.html)
 User-agent: *
 Disallow:
+Sitemap: https://angular.io/generated/sitemap.xml

--- a/aio/tools/transforms/angular-base-package/index.js
+++ b/aio/tools/transforms/angular-base-package/index.js
@@ -25,6 +25,7 @@ module.exports = new Package('angular-base', [
   // Register the processors
   .processor(require('./processors/generateKeywords'))
   .processor(require('./processors/createOverviewDump'))
+  .processor(require('./processors/createSitemap'))
   .processor(require('./processors/checkUnbalancedBackTicks'))
   .processor(require('./processors/convertToJson'))
   .processor(require('./processors/fixInternalDocumentLinks'))

--- a/aio/tools/transforms/angular-base-package/processors/createSitemap.js
+++ b/aio/tools/transforms/angular-base-package/processors/createSitemap.js
@@ -1,0 +1,15 @@
+module.exports = function createSitemap() {
+  return {
+    $runAfter: ['paths-computed'],
+    $runBefore: ['rendering-docs'],
+    $process(docs) {
+      docs.push({
+        id: 'sitemap.xml',
+        path: 'sitemap.xml',
+        outputPath: '../sitemap.xml',
+        template: 'sitemap.template.xml',
+        urls: docs.filter(doc => doc.outputPath).map(doc => doc.path)
+      });
+    }
+  };
+};

--- a/aio/tools/transforms/angular-base-package/processors/createSitemap.spec.js
+++ b/aio/tools/transforms/angular-base-package/processors/createSitemap.spec.js
@@ -1,0 +1,51 @@
+var testPackage = require('../../helpers/test-package');
+var Dgeni = require('dgeni');
+
+describe('createSitemap processor', () => {
+  var injector, processor;
+
+  beforeEach(() => {
+    const dgeni = new Dgeni([testPackage('angular-base-package')]);
+
+    injector = dgeni.configureInjector();
+    processor = injector.get('createSitemap');
+  });
+
+  it('should be available from the injector', () => {
+    expect(processor).toBeDefined();
+  });
+
+  it('should run after "paths-computed"', () => {
+    expect(processor.$runAfter).toEqual(['paths-computed']);
+  });
+
+  it('should run before "rendering-docs"', () => {
+    expect(processor.$runBefore).toEqual(['rendering-docs']);
+  });
+
+  describe('$process', () => {
+    describe('should add a sitemap doc', () => {
+
+      it('with the correct id, path, outputPath and template properties', () => {
+        const docs = [];
+        processor.$process(docs);
+        expect(docs.pop()).toEqual(jasmine.objectContaining({
+          id: 'sitemap.xml',
+          path: 'sitemap.xml',
+          outputPath: '../sitemap.xml',
+          template: 'sitemap.template.xml'
+        }));
+      });
+
+      it('with an array of urls for each doc that has an outputPath', () => {
+        const docs = [
+          { path: 'abc', outputPath: 'abc' },
+          { path: 'cde' },
+          { path: 'fgh', outputPath: 'fgh' },
+        ];
+        processor.$process(docs);
+        expect(docs.pop().urls).toEqual(['abc', 'fgh']);
+      });
+    });
+  });
+});

--- a/aio/tools/transforms/templates/sitemap.template.xml
+++ b/aio/tools/transforms/templates/sitemap.template.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {%- for url in doc.urls %}
+  <url>
+    <loc>https://angular.io/{$ url $}</loc>
+  </url>{% endfor %}
+</urlset>


### PR DESCRIPTION
The sitemap is stored in the `generated` folder and is linked to from the `robots.txt` file.

Since we do not know the final deployment URL when running doc-gen, we leave a `@@DEPLOYMENT_HOST@@` marker, which is replaced at deployment time.

Closes #21684
