### PR TITLE
feat(ivy): support deep queries through view boundaries

### DIFF
--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -8,7 +8,9 @@
 
 import {ComponentTemplate} from './definition';
 import {LElementNode, LViewNode} from './node';
+import {LQuery} from './query';
 import {LView, TView} from './view';
+
 
 
 /** The state associated with an LContainer */
@@ -67,12 +69,17 @@ export interface LContainer {
    */
   readonly template: ComponentTemplate<any>|null;
 
-
   /**
    * A count of dynamic views rendered into this container. If this is non-zero, the `views` array
    * will be traversed when refreshing dynamic views on this container.
    */
   dynamicViewCount: number;
+
+  /**
+   * Queries active for this container - all the views inserted to / removed from
+   * this container are reported to queries referenced here.
+   */
+  query: LQuery|null;
 }
 
 /**

--- a/packages/core/src/render3/interfaces/query.ts
+++ b/packages/core/src/render3/interfaces/query.ts
@@ -8,9 +8,7 @@
 
 import {QueryList} from '../../linker';
 import {Type} from '../../type';
-
-import {LInjector} from './injector';
-import {LContainerNode, LNode, LViewNode} from './node';
+import {LNode} from './node';
 
 
 /** Used for tracking queries (e.g. ViewChild, ContentChild). */
@@ -25,19 +23,28 @@ export interface LQuery {
   child(): LQuery|null;
 
   /**
-   * Notify `LQuery` that a  `LNode` has been created.
+   * Notify `LQuery` that a new `LNode` has been created and needs to be added to query results
+   * if matching query predicate.
    */
   addNode(node: LNode): void;
 
   /**
-   * Notify `LQuery` that an `LViewNode` has been added to `LContainerNode`.
+   * Notify `LQuery` that a  `LNode` has been created and needs to be added to query results
+   * if matching query predicate.
    */
-  insertView(container: LContainerNode, view: LViewNode, insertIndex: number): void;
+  container(): LQuery|null;
 
   /**
-   * Notify `LQuery` that an `LViewNode` has been removed from `LContainerNode`.
+   * Notify `LQuery` that a new view was created and is being entered in the creation mode.
+   * This allow queries to prepare space for matching nodes from views.
    */
-  removeView(container: LContainerNode, view: LViewNode, removeIndex: number): void;
+  enterView(newViewIndex: number): LQuery|null;
+
+  /**
+   * Notify `LQuery` that an `LViewNode` has been removed from `LContainerNode`. As a result all
+   * the matching nodes from this view should be removed from container's queries.
+   */
+  removeView(removeIndex: number): void;
 
   /**
    * Add additional `QueryList` to track.

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -9,6 +9,7 @@
 import {LContainer} from './container';
 import {ComponentTemplate, DirectiveDef} from './definition';
 import {LElementNode, LViewNode, TNode} from './node';
+import {LQuery} from './query';
 import {Renderer3} from './renderer';
 
 
@@ -156,6 +157,11 @@ export interface LView {
    * after refreshing the view itself.
    */
   dynamicViewCount: number;
+
+  /**
+   * Queries active for this view - nodes from a view are reported to those queries
+   */
+  query: LQuery|null;
 }
 
 /** Interface necessary to work with view tree traversal */

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -222,8 +222,6 @@ export function insertView(
         container, newView, true, findBeforeNode(index, state, container.native));
   }
 
-  // Notify query that view has been inserted
-  container.query && container.query.insertView(container, newView, index);
   return newView;
 }
 
@@ -248,7 +246,7 @@ export function removeView(container: LContainerNode, removeIndex: number): LVie
   destroyViewTree(viewNode.data);
   addRemoveViewFromContainer(container, viewNode, false);
   // Notify query that view has been removed
-  container.query && container.query.removeView(container, viewNode, removeIndex);
+  container.data.query && container.data.query.removeView(removeIndex);
   return viewNode;
 }
 

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -10,36 +10,20 @@
 // correctly implementing its interfaces for backwards compatibility.
 import {Observable} from 'rxjs/Observable';
 
-import {ElementRef as viewEngine_ElementRef} from '../linker/element_ref';
 import {QueryList as viewEngine_QueryList} from '../linker/query_list';
-import {TemplateRef as viewEngine_TemplateRef} from '../linker/template_ref';
 import {Type} from '../type';
 
-import {assertNotNull} from './assert';
+import {assertEqual, assertNotNull} from './assert';
 import {ReadFromInjectorFn, getOrCreateNodeInjectorForNode} from './di';
 import {assertPreviousIsParent, getCurrentQuery} from './instructions';
-import {DirectiveDef, TypedDirectiveDef, unusedValueExportToPlacateAjd as unused1} from './interfaces/definition';
+import {TypedDirectiveDef, unusedValueExportToPlacateAjd as unused1} from './interfaces/definition';
 import {LInjector, unusedValueExportToPlacateAjd as unused2} from './interfaces/injector';
-import {LContainerNode, LElementNode, LNode, LNodeFlags, LViewNode, TNode, unusedValueExportToPlacateAjd as unused3} from './interfaces/node';
+import {LContainerNode, LElementNode, LNode, LNodeFlags, TNode, unusedValueExportToPlacateAjd as unused3} from './interfaces/node';
 import {LQuery, QueryReadType, unusedValueExportToPlacateAjd as unused4} from './interfaces/query';
-import {assertNodeOfPossibleTypes} from './node_assert';
+import {flatten} from './util';
 
 const unusedValueToPlacateAjd = unused1 + unused2 + unused3 + unused4;
 
-
-export function query<T>(
-    predicate: Type<any>| string[], descend?: boolean,
-    read?: QueryReadType<T>| Type<T>): QueryList<T> {
-  ngDevMode && assertPreviousIsParent();
-  const queryList = new QueryList<T>();
-  const query = getCurrentQuery(LQuery_);
-  query.track(queryList, predicate, descend, read);
-  return queryList;
-}
-
-export function queryRefresh(query: QueryList<any>): boolean {
-  return (query as any)._refresh();
-}
 
 /**
  * A predicate which determines if a given element/directive should be included in the query
@@ -112,17 +96,90 @@ export class LQuery_ implements LQuery {
     }
   }
 
+  container(): LQuery|null {
+    let result: QueryPredicate<any>|null = null;
+    let predicate = this.deep;
+
+    while (predicate) {
+      const containerValues: any[] = [];  // prepare room for views
+      predicate.values.push(containerValues);
+      const clonedPredicate: QueryPredicate<any> = {
+        next: null,
+        list: predicate.list,
+        type: predicate.type,
+        selector: predicate.selector,
+        read: predicate.read,
+        values: containerValues
+      };
+      clonedPredicate.next = result;
+      result = clonedPredicate;
+      predicate = predicate.next;
+    }
+
+    return result ? new LQuery_(result) : null;
+  }
+
+  enterView(index: number): LQuery|null {
+    let result: QueryPredicate<any>|null = null;
+    let predicate = this.deep;
+
+    while (predicate) {
+      const viewValues: any[] = [];  // prepare room for view nodes
+      predicate.values.splice(index, 0, viewValues);
+      const clonedPredicate: QueryPredicate<any> = {
+        next: null,
+        list: predicate.list,
+        type: predicate.type,
+        selector: predicate.selector,
+        read: predicate.read,
+        values: viewValues
+      };
+      clonedPredicate.next = result;
+      result = clonedPredicate;
+      predicate = predicate.next;
+    }
+
+    return result ? new LQuery_(result) : null;
+  }
+
   addNode(node: LNode): void {
     add(this.shallow, node);
     add(this.deep, node);
   }
 
-  insertView(container: LContainerNode, view: LViewNode, index: number): void {
-    throw new Error('Method not implemented.');
+  removeView(index: number): void {
+    let predicate = this.deep;
+    while (predicate) {
+      const removed = predicate.values.splice(index, 1);
+
+      // mark a query as dirty only when removed view had matching modes
+      ngDevMode && assertEqual(removed.length, 1, 'removed.length');
+      if (removed[0].length) {
+        predicate.list.setDirty();
+      }
+
+      predicate = predicate.next;
+    }
   }
 
-  removeView(container: LContainerNode, view: LViewNode, index: number): void {
-    throw new Error('Method not implemented.');
+  /**
+   * Clone LQuery by taking all the deep query predicates and cloning those using a provided clone
+   * function.
+   * Shallow predicates are ignored.
+   */
+  private _clonePredicates(
+      predicateCloneFn: (predicate: QueryPredicate<any>) => QueryPredicate<any>): LQuery|null {
+    let result: QueryPredicate<any>|null = null;
+    let predicate = this.deep;
+
+    while (predicate) {
+      const clonedPredicate = predicateCloneFn(predicate);
+      clonedPredicate.next = result;
+      result = clonedPredicate;
+      predicate = predicate.next;
+    }
+
+    return result ? new LQuery_(result) : null;
   }
 }
 
@@ -191,10 +248,10 @@ function add(predicate: QueryPredicate<any>| null, node: LNode) {
         if (predicate.read !== null) {
           const requestedRead = readFromNodeInjector(nodeInjector, node, predicate.read);
           if (requestedRead !== null) {
-            predicate.values.push(requestedRead);
+            addMatch(predicate, requestedRead);
           }
         } else {
-          predicate.values.push(node.view.data[directiveIdx]);
+          addMatch(predicate, node.view.data[directiveIdx]);
         }
       }
     } else {
@@ -207,10 +264,10 @@ function add(predicate: QueryPredicate<any>| null, node: LNode) {
           if (predicate.read !== null) {
             const result = readFromNodeInjector(nodeInjector, node, predicate.read !, directiveIdx);
             if (result !== null) {
-              predicate.values.push(result);
+              addMatch(predicate, result);
             }
           } else {
-            predicate.values.push(node.view.data[directiveIdx]);
+            addMatch(predicate, node.view.data[directiveIdx]);
           }
         }
       }
@@ -219,27 +276,31 @@ function add(predicate: QueryPredicate<any>| null, node: LNode) {
   }
 }
 
+function addMatch(predicate: QueryPredicate<any>, matchingValue: any): void {
+  predicate.values.push(matchingValue);
+  predicate.list.setDirty();
+}
+
 function createPredicate<T>(
     previous: QueryPredicate<any>| null, queryList: QueryList<T>, predicate: Type<T>| string[],
     read: QueryReadType<T>| Type<T>| null): QueryPredicate<T> {
   const isArray = Array.isArray(predicate);
-  const values = <any>[];
-  if ((queryList as any as QueryList_<T>)._valuesTree === null) {
-    (queryList as any as QueryList_<T>)._valuesTree = values;
-  }
   return {
     next: previous,
     list: queryList,
     type: isArray ? null : predicate as Type<T>,
     selector: isArray ? predicate as string[] : null,
     read: read,
-    values: values
+    values: (queryList as any as QueryList_<T>)._valuesTree
   };
 }
 
 class QueryList_<T>/* implements viewEngine_QueryList<T> */ {
-  dirty: boolean = false;
-  changes: Observable<T>;
+  readonly dirty = true;
+  readonly changes: Observable<T>;
+  private _values: T[]|null = null;
+  /** @internal */
+  _valuesTree: any[] = [];
 
   get length(): number {
     ngDevMode && assertNotNull(this._values, 'refreshed');
@@ -256,21 +317,6 @@ class QueryList_<T>/* implements viewEngine_QueryList<T> */ {
     ngDevMode && assertNotNull(this._values, 'refreshed');
     let values = this._values !;
     return values.length ? values[values.length - 1] : null;
-  }
-
-  /** @internal */
-  _valuesTree: any[]|null = null;
-  /** @internal */
-  _values: T[]|null = null;
-
-  /** @internal */
-  _refresh(): boolean {
-    // TODO(misko): needs more logic to flatten tree.
-    if (this._values === null) {
-      this._values = this._valuesTree;
-      return true;
-    }
-    return false;
   }
 
   map<U>(fn: (item: T, index: number, array: T[]) => U): U[] {
@@ -295,10 +341,16 @@ class QueryList_<T>/* implements viewEngine_QueryList<T> */ {
     ngDevMode && assertNotNull(this._values, 'refreshed');
     return this._values !;
   }
-  toString(): string { throw new Error('Method not implemented.'); }
-  reset(res: (any[]|T)[]): void { throw new Error('Method not implemented.'); }
+  toString(): string {
+    ngDevMode && assertNotNull(this._values, 'refreshed');
+    return this._values !.toString();
+  }
+  reset(res: (any[]|T)[]): void {
+    this._values = flatten(res);
+    (this as{dirty: boolean}).dirty = false;
+  }
   notifyOnChanges(): void { throw new Error('Method not implemented.'); }
-  setDirty(): void { throw new Error('Method not implemented.'); }
+  setDirty(): void { (this as{dirty: boolean}).dirty = true; }
   destroy(): void { throw new Error('Method not implemented.'); }
 }
 
@@ -306,3 +358,27 @@ class QueryList_<T>/* implements viewEngine_QueryList<T> */ {
 // it can't be implemented only extended.
 export type QueryList<T> = viewEngine_QueryList<T>;
 export const QueryList: typeof viewEngine_QueryList = QueryList_ as any;
+
+export function query<T>(
+    predicate: Type<any>| string[], descend?: boolean,
+    read?: QueryReadType<T>| Type<T>): QueryList<T> {
+  ngDevMode && assertPreviousIsParent();
+  const queryList = new QueryList<T>();
+  const query = getCurrentQuery(LQuery_);
+  query.track(queryList, predicate, descend, read);
+  return queryList;
+}
+
+/**
+ * Refreshes a query by combining matches from all active views and removing matches from deleted
+ * views.
+ * Returns true if a query got dirty during change detection, false otherwise.
+ */
+export function queryRefresh(query: QueryList<any>): boolean {
+  const queryImpl = (query as any as QueryList_<any>);
+  if (query.dirty) {
+    query.reset(queryImpl._valuesTree);
+    return true;
+  }
+  return false;
+}

--- a/packages/core/src/render3/util.ts
+++ b/packages/core/src/render3/util.ts
@@ -31,3 +31,28 @@ export function stringify(value: any): string {
 export function notImplemented(): Error {
   return new Error('NotImplemented');
 }
+
+/**
+ * Flattens an array in non-recursive way. Input arrays are not modified.
+ */
+export function flatten(list: any[]): any[] {
+  const result: any[] = [];
+  let i = 0;
+
+  while (i < list.length) {
+    const item = list[i];
+    if (Array.isArray(item)) {
+      if (item.length > 0) {
+        list = item.concat(list.slice(i + 1));
+        i = 0;
+      } else {
+        i++;
+      }
+    } else {
+      result.push(item);
+      i++;
+    }
+  }
+
+  return result;
+}

--- a/packages/core/test/render3/util_spec.ts
+++ b/packages/core/test/render3/util_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {isDifferent} from '../../src/render3/util';
+import {flatten, isDifferent} from '../../src/render3/util';
 
 describe('util', () => {
 
@@ -30,6 +30,22 @@ describe('util', () => {
     it('should mark NaN with other values as different', () => {
       expect(isDifferent(NaN, 'foo')).toBeTruthy();
       expect(isDifferent(5, NaN)).toBeTruthy();
+    });
+  });
+
+  describe('flatten', () => {
+
+    it('should flatten an empty array', () => { expect(flatten([])).toEqual([]); });
+
+    it('should flatten a flat array', () => { expect(flatten([1, 2, 3])).toEqual([1, 2, 3]); });
+
+    it('should flatten a nested array', () => {
+      expect(flatten([1, [2], 3])).toEqual([1, 2, 3]);
+      expect(flatten([[1], 2, [3]])).toEqual([1, 2, 3]);
+      expect(flatten([1, [2, [3]], 4])).toEqual([1, 2, 3, 4]);
+      expect(flatten([1, [2, [3]], [4]])).toEqual([1, 2, 3, 4]);
+      expect(flatten([1, [2, [3]], [[[4]]]])).toEqual([1, 2, 3, 4]);
+      expect(flatten([1, [], 2])).toEqual([1, 2]);
     });
   });
 });


### PR DESCRIPTION
@mhevery this is still WIP (requires rebase, proper description and more tests), but opening it early on so we can discuss data structure / impl choices.

The general idea is that both a container (`LContainer`) and a view (`LView`) have a pointer to all queries "active" for a given container / view. When encountering a container and view instructions, we are _cloning_ `LQuery` predicates (queries) to have new place (arrays) to store matching nodes from sub-views. 

I feel like I've missed millions of use-cases here, but at the same time feel like I'm digging a deeper and deeper rabbit hole, so opening early PR so we can have discussion about exact data structures and algs.