### PR TITLE
test(ivy): adding a test that checks that a component is re-rendered correctly

### DIFF
--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -7,11 +7,11 @@
  */
 
 import {ViewEncapsulation} from '../../src/core';
-import {E, T, b, defineComponent, e, markDirty, t} from '../../src/render3/index';
+import {C, E, T, V, b, cR, cr, defineComponent, e, markDirty, p, t, v} from '../../src/render3/index';
 import {createRendererType2} from '../../src/view/index';
 
 import {getRendererFactory2} from './imported_renderer2';
-import {containerEl, renderComponent, requestAnimationFrame, toHtml} from './render_util';
+import {containerEl, renderComponent, renderToHtml, requestAnimationFrame, toHtml} from './render_util';
 
 describe('component', () => {
   class CounterComponent {
@@ -54,6 +54,69 @@ describe('component', () => {
       expect(toHtml(containerEl)).toEqual('124');
     });
 
+  });
+
+});
+
+describe('component with a container', () => {
+
+  function showItems(ctx: {items: string[]}, cm: boolean) {
+    if (cm) {
+      C(0);
+    }
+    cR(0);
+    {
+      for (const item of ctx.items) {
+        const cm0 = V(0);
+        {
+          if (cm0) {
+            T(0);
+          }
+          t(0, b(item));
+        }
+        v();
+      }
+    }
+    cr();
+  }
+
+  class WrapperComponent {
+    items: string[];
+    static ngComponentDef = defineComponent({
+      tag: 'wrapper',
+      template: function ChildComponentTemplate(ctx: {items: string[]}, cm: boolean) {
+        if (cm) {
+          C(0);
+        }
+        cR(0);
+        {
+          const cm0 = V(0);
+          { showItems({items: ctx.items}, cm0); }
+          v();
+        }
+        cr();
+      },
+      factory: () => new WrapperComponent,
+      inputs: {items: 'items'}
+    });
+  }
+
+  function template(ctx: {items: string[]}, cm: boolean) {
+    if (cm) {
+      E(0, WrapperComponent);
+      e();
+    }
+    p(0, 'items', b(ctx.items));
+    WrapperComponent.ngComponentDef.h(1, 0);
+    WrapperComponent.ngComponentDef.r(1, 0);
+  }
+
+  it('should re-render on input change', () => {
+    const ctx: {items: string[]} = {items: ['a']};
+    expect(renderToHtml(template, ctx)).toEqual('<wrapper>a</wrapper>');
+
+    ctx.items = [...ctx.items, 'b'];
+    expect(renderToHtml(template, ctx)).toEqual('<wrapper>ab</wrapper>');
   });
 
 });


### PR DESCRIPTION
This PR is a bug report regarding the render3 engine.
It contains a test that should pass but currently fails: the new text node "b" is not added to the DOM.

When the `showItems` template is called directly, the update is done correctly, but when it is wrapped inside the wrapper component, the update no longer happens.

I tried to investigate a bit, it seems that, when the new view is added, `container.data.renderParent` is null (cf https://github.com/angular/angular/blob/master/packages/core/src/render3/node_manipulation.ts#L220 ), so the new DOM element is correctly created but never inserted in the DOM.

`renderParent` probably has to be set somewhere (probably during the first render), or the condition may have to be changed.

What do you think?