### PR TITLE
fix(compiler-cli): do not fold errors past calls in the collector

### DIFF
--- a/packages/compiler-cli/src/metadata/collector.ts
+++ b/packages/compiler-cli/src/metadata/collector.ts
@@ -289,7 +289,7 @@ export class MetadataCollector {
          ts.TypeAliasDeclaration | ts.EnumDeclaration) => exportedIdentifierName(node.name);
 
 
-    // Predeclare classes and functions
+    // Pre-declare classes and functions
     ts.forEachChild(sourceFile, node => {
       switch (node.kind) {
         case ts.SyntaxKind.ClassDeclaration:
@@ -454,7 +454,7 @@ export class MetadataCollector {
                 };
               } else {
                 nextDefaultValue =
-                    recordEntry(errorSym('Unsuppported enum member name', member.name), node);
+                    recordEntry(errorSym('Unsupported enum member name', member.name), node);
               }
             }
             if (writtenMembers) {

--- a/packages/compiler-cli/src/metadata/evaluator.ts
+++ b/packages/compiler-cli/src/metadata/evaluator.ts
@@ -356,9 +356,6 @@ export class Evaluator {
           }
         }
         const args = arrayOrEmpty(callExpression.arguments).map(arg => this.evaluateNode(arg));
-        if (!this.options.verboseInvalidExpression && args.some(isMetadataError)) {
-          return args.find(isMetadataError);
-        }
         if (this.isFoldable(callExpression)) {
           if (isMethodCallOf(callExpression, 'concat')) {
             const arrayValue = <MetadataValue[]>this.evaluateNode(

--- a/packages/compiler-cli/test/metadata/collector_spec.ts
+++ b/packages/compiler-cli/test/metadata/collector_spec.ts
@@ -1054,10 +1054,20 @@ describe('Collector', () => {
       expect(metadata.metadata.MyComponent).toEqual({
         __symbolic: 'class',
         decorators: [{
-          __symbolic: 'error',
-          message: 'Expression form not supported',
-          line: 5,
-          character: 55
+          __symbolic: 'call',
+          expression: {
+            __symbolic: 'reference',
+            module: '@angular/core',
+            name: 'Component',
+            line: 4,
+            character: 9
+          },
+          arguments: [{
+            __symbolic: 'error',
+            message: 'Expression form not supported',
+            line: 5,
+            character: 55
+          }]
         }]
       });
     });

--- a/packages/compiler/test/aot/static_reflector_spec.ts
+++ b/packages/compiler/test/aot/static_reflector_spec.ts
@@ -364,7 +364,8 @@ describe('StaticReflector', () => {
       const classData: any = moduleMetadata['InvalidMetadata'];
       expect(classData).toBeDefined();
       simplify(
-          reflector.getStaticSymbol('/tmp/src/invalid-metadata.ts', ''), classData.decorators[0]);
+          reflector.getStaticSymbol('/tmp/src/invalid-metadata.ts', ''),
+          classData.decorators[0].arguments);
     } catch (e) {
       expect(e.position).toBeDefined();
       threw = true;


### PR DESCRIPTION
Folding errors passed calls prevented the static reflector from
begin able to ignore errors in annotations it doesn't know as
the call to the unknown annotation was elided from the metadata.

Fixes: #21273

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue Number: #21273

The collector elides the call expression when the arguments contain an error.

## What is the new behavior?

The collector no longer elides the call expression allowing the static reflector to detect when the error is reported in an annotation it should ignore.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
