### PR TITLE
test(ivy): adding a test showing an issue with the projected nodes

### DIFF
--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -121,6 +121,10 @@ export function addRemoveViewFromContainer(
                           parent.removeChild(node.native !));
         nextNode = childContainerData.views.length ? childContainerData.views[0].child : null;
       } else if (type === LNodeFlags.Projection) {
+        // Note: when doing this, we loose access to the current node, because a projected node
+        // does not keep the reference to the place where it is inserted (its parent property is
+        // in the light DOM, not in the shadow DOM), and we can never append the following nodes
+        // from the shadow DOM
         nextNode = (node as LProjectionNode).data[0];
       } else {
         nextNode = (node as LViewNode).child;

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -348,7 +348,7 @@ describe('content projection', () => {
         */
        const Child = createComponent('child', function(ctx: any, cm: boolean) {
          if (cm) {
-           m(0, pD());
+           pD(0);
            E(1, 'div');
            { C(2); }
            e();

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -335,6 +335,61 @@ describe('content projection', () => {
        expect(toHtml(parent)).toEqual('<child><div></div></child>');
      });
 
+  it('should support projection in embedded views when ng-content is a root node of an embedded view, with other nodes after',
+     () => {
+       let childCmptInstance: any;
+
+       /**
+        * <div>
+        *  % if (!skipContent) {
+        *    before-<ng-content></ng-content>-after
+        *  % }
+        * </div>
+        */
+       const Child = createComponent('child', function(ctx: any, cm: boolean) {
+         if (cm) {
+           m(0, pD());
+           E(1, 'div');
+           { C(2); }
+           e();
+         }
+         cR(2);
+         {
+           if (!ctx.skipContent) {
+             if (V(0)) {
+               T(0, 'before-');
+               P(1, 0);
+               T(2, '-after');
+             }
+             v();
+           }
+         }
+         cr();
+       });
+
+       /**
+        * <child>content</child>
+        */
+       const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
+         if (cm) {
+           E(0, Child);
+           {
+             childCmptInstance = m(1);
+             T(2, 'content');
+           }
+           e();
+         }
+         Child.ngComponentDef.h(1, 0);
+         Child.ngComponentDef.r(1, 0);
+       });
+       const parent = renderComponent(Parent);
+       expect(toHtml(parent)).toEqual('<child><div>before-content-after</div></child>');
+
+       childCmptInstance.skipContent = true;
+       detectChanges(parent);
+       expect(toHtml(parent)).toEqual('<child><div></div></child>');
+     });
+
   it('should project nodes into the last ng-content', () => {
     /**
      * <div><ng-content></ng-content></div>


### PR DESCRIPTION
This PR is a bug report: I have added a test that fails but should pass.

The test I added (in `content_spec.ts`) is simply is a copy of the previous test, with an extra node before and after `<ng-content></ng-content>`.
The node `before-` is correctly rendered, but the node `-after` is not rendered.

This issue comes from the way `addRemoveViewFromContainer` iterates over elements to add them in the DOM. When we do `nextNode = (node as LProjectionNode).data[0];`, we actually lose the reference to `node` (which is in the shadow DOM), because, unlike other types of nodes, `node.parent`  will not allow to come back to the same node, as it refers to the parent in the light DOM (and not the place where the element was projected in the shadow DOM).

We could either use a stack instead of this tree traversal, or we could, for each node, add a reference to the place where a node is projected.

I am considering this second option, and I will probably add the fix to my PR #21638 because I already had to add a reference to the place where a node is projected: cf https://github.com/angular/angular/pull/21638/files#diff-22300601613bfcac54617f461c394872R127 . I will also have to fix `findFirstNativeNode` in PR #21638 because it relies on the same problematic tree traversal.
