### PR TITLE
fix(ngivy): correct query read logic after merges

### DIFF
--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -161,7 +161,7 @@ describe('query', () => {
 
   describe('local names predicate', () => {
 
-    it('should query for a single element and read ElementRef', () => {
+    it('should query for a single element and read ElementRef by default', () => {
 
       let elToQuery;
       /**
@@ -174,7 +174,7 @@ describe('query', () => {
       const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
         let tmp: any;
         if (cm) {
-          m(0, Q(['foo'], false, QUERY_READ_ELEMENT_REF));
+          m(0, Q(['foo'], false, QUERY_READ_FROM_NODE));
           elToQuery = E(1, 'div', null, null, ['foo', '']);
           e();
           E(2, 'div');
@@ -189,7 +189,7 @@ describe('query', () => {
       expect(query.first.nativeElement).toEqual(elToQuery);
     });
 
-    it('should query for multiple elements and read ElementRef', () => {
+    it('should query for multiple elements and read ElementRef by default', () => {
 
       let el1ToQuery;
       let el2ToQuery;
@@ -204,7 +204,7 @@ describe('query', () => {
       const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
         let tmp: any;
         if (cm) {
-          m(0, Q(['foo', 'bar'], undefined, QUERY_READ_ELEMENT_REF));
+          m(0, Q(['foo', 'bar'], undefined, QUERY_READ_FROM_NODE));
           el1ToQuery = E(1, 'div', null, null, ['foo', '']);
           e();
           E(2, 'div');
@@ -331,7 +331,7 @@ describe('query', () => {
       const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
         let tmp: any;
         if (cm) {
-          m(0, Q(['foo'], undefined, QUERY_READ_TEMPLATE_REF));
+          m(0, Q(['foo'], undefined, QUERY_READ_FROM_NODE));
           C(1, undefined, undefined, undefined, undefined, ['foo', '']);
         }
         qR(tmp = m<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -379,7 +379,7 @@ describe('query', () => {
       const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
         let tmp: any;
         if (cm) {
-          m(0, Q(['foo']));
+          m(0, Q(['foo'], true, QUERY_READ_FROM_NODE));
           E(1, Child, null, null, ['foo', '']);
           { childInstance = m(2); }
           e();
@@ -407,7 +407,7 @@ describe('query', () => {
          const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
            let tmp: any;
            if (cm) {
-             m(0, Q(['foo']));
+             m(0, Q(['foo'], true, QUERY_READ_FROM_NODE));
              E(1, 'div', null, [Child], ['foo', 'child']);
              childInstance = m(2);
              e();
@@ -435,7 +435,7 @@ describe('query', () => {
       const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
         let tmp: any;
         if (cm) {
-          m(0, Q(['foo', 'bar']));
+          m(0, Q(['foo', 'bar'], true, QUERY_READ_FROM_NODE));
           E(1, 'div', null, [Child1, Child2], ['foo', 'child1', 'bar', 'child2']);
           {
             child1Instance = m(2);
@@ -784,8 +784,8 @@ describe('query', () => {
       const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
         let tmp: any;
         if (cm) {
-          m(0, Q(['foo'], true));
-          m(1, Q(['foo'], false));
+          m(0, Q(['foo'], true, QUERY_READ_FROM_NODE));
+          m(1, Q(['foo'], false, QUERY_READ_FROM_NODE));
           C(2);
           E(3, 'span', null, null, ['foo', '']);
           e();


### PR DESCRIPTION
@alxhub @mhevery it seems like the query tests and read logic got modified in a subtle way making it not inline with the current system behaviour.

The essence of the issue is that we can't know which token should be read if the explicit `read` option was not provided. Today a different token will be read depending on a node type (element, container) _and_ directives presence, check this plunk: http://plnkr.co/edit/17o5uExhnudqwii8kUs4?p=preview

If I understand things correctly we _must_ use the `QUERY_READ_FROM_NODE` every time:
* predicate is a string
* there is no explicit `read` option in query metadata

This PR fixes the tests / logic but in the long run I would love to make the `read` parameter mandatory in the query instruction - this would make things more explicit and would simplify ngivy runtime logic (at the expense of few additional bytes of the generated code per query)