### PR TITLE
feat(ivy): support ng-content projection in the ivy compiler

### DIFF
--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -66,6 +66,9 @@ export class Identifiers {
 
   static memory: o.ExternalReference = {name: 'ɵm', moduleName: CORE};
 
+  static projection: o.ExternalReference = {name: 'ɵP', moduleName: CORE};
+  static projectionDef: o.ExternalReference = {name: 'ɵpD', moduleName: CORE};
+
   static refreshComponent: o.ExternalReference = {name: 'ɵr', moduleName: CORE};
 
   static directiveLifeCycle: o.ExternalReference = {name: 'ɵl', moduleName: CORE};


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Feature
```

## What is the current behavior?

The ivy compiler doesn't support content projection.

## What is the new behavior?

The ivy compiler supports content projection.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
