### PR TITLE
docs: update i18n guide for projects that don't use the cli

### DIFF
--- a/aio/content/guide/i18n.md
+++ b/aio/content/guide/i18n.md
@@ -402,9 +402,12 @@ By default, the tool generates a translation file named `messages.xlf` in the
 
 <div class="l-sub-section">
 
-If you don't use the CLI, you can use the `ng-xi18n` tool directly from the `@angular/compiler-cli`
-package, or you can manually use the CLI Webpack plugin `ExtractI18nPlugin` from the
-`@ngtools/webpack` package.
+If you don't use the CLI, you have two options:
+* You can use the `ng-xi18n` tool directly from the `@angular/compiler-cli` package.
+For more information, see [i18n in the CLI documentation](https://github.com/angular/angular-cli/wiki/xi18n).
+* You can use the CLI Webpack plugin `AngularCompilerPlugin` from the `@ngtools/webpack` package.
+Set the parameters `i18nOutFile` and `i18nOutFormat` to trigger the extraction.
+For more information, see the [Angular Ahead-of-Time Webpack Plugin documentation](https://github.com/angular/angular-cli/tree/master/packages/%40ngtools/webpack).
 
 </div>
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Documentation content changes
```

## What is the current behavior?
We tell people to use the `ExtractI18nPlugin` if they don't use the cli, but this plugin doesn't work anymore with Angular 5

## What is the new behavior?
We tell people to use `AngularCompilerPlugin` instead (see https://github.com/ocombe/i18n-demo-no-cli/blob/master/webpack.config.js#L328-L361 for a demo that uses that)

## Does this PR introduce a breaking change?
```
[x] No
```
