### PR TITLE
fix(router): remove @internal tag on ParamInheritanceType

### DIFF
--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -175,7 +175,6 @@ export class ActivatedRoute {
   }
 }
 
-/** @internal */
 export type ParamsInheritanceStrategy = 'emptyOnly' | 'always';
 
 /** @internal */


### PR DESCRIPTION
This is a more defensive approach to ensure that references to
ParamInheritanceType from the published declarations do not cause
compilation errors when compiling Angular from the published packages.

Fixes #21456

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

When attempting to compile Angular from the published package:

```node_modules/@angular/router/src/recognize.d.ts(11,10): error TS2305: Module '"[...]/node_modules/@angular/router/src/router_state"' has no exported member 'ParamsInheritanceStrategy'.```

Issue Number: 21456

## What is the new behavior?

`ParamsInheritanceStrategy` will remain in the published declarations, avoiding compilation errors stemming from its removal.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```