### PR TITLE
fix(compiler-cli): write bundled metadata via typescript compiler host

### DIFF
--- a/packages/compiler-cli/src/metadata/bundle_index_host.ts
+++ b/packages/compiler-cli/src/metadata/bundle_index_host.ts
@@ -51,7 +51,7 @@ function createSyntheticIndexHost<H extends ts.CompilerHost>(
             path.normalize(sourceFiles[0].fileName) == normalSyntheticIndexName) {
           // If we are writing the synthetic index, write the metadata along side.
           const metadataName = fileName.replace(DTS, '.metadata.json');
-          fs.writeFileSync(metadataName, indexMetadata, {encoding: 'utf8'});
+          delegate.writeFile(metadataName, indexMetadata, writeByteOrderMark, onError, sourceFiles);
         }
       };
   return newHost;

--- a/packages/compiler-cli/test/transformers/program_spec.ts
+++ b/packages/compiler-cli/test/transformers/program_spec.ts
@@ -551,7 +551,8 @@ describe('ng program', () => {
     compile(/*oldProgram*/ undefined, options, /*rootNames*/ undefined, host);
 
     // verify that `compilerHost.writeFile()` was called for the metadata json
-    expect(writtenFileNames.some(f => /built\/my-bundled-sources.metadata.json/.test(f))).toBe(true);
+    expect(writtenFileNames.some(f => /built\/my-bundled-sources.metadata.json/.test(f)))
+        .toBe(true);
   });
 
   describe('createSrcToOutPathMapper', () => {


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Bundled metadata json is written directly to disk. TypeScript compiler host is skipped.

Issue Number: #21339


## What is the new behavior?

Write bundle metadata via TypeScript compiler host, thus allowing users to 'capture' bundle metadata.

Minimal Usage Example:

```ts
import * as ts from 'typescript';

  const tsCompilerHost: ts.CompilerHost = /* .. */;
  tsCompilerHost.writeFile = (
    fileName: string,
    data: string,
    writeByteOrderMark: boolean,
    onError?: (message: string) => void,
    sourceFiles?: ReadonlyArray<ts.SourceFile>
  ): void => {
    /* Customize `writeFile` callback */
  };

  const ngCompilerHost = ng.createCompilerHost({
    options: tsConfig.options,
    tsHost: tsCompilerHost
  });
```



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```



## Other information
