### PR TITLE
 fix(language-service): ensure correct paths are passed to typescript

### DIFF
--- a/packages/language-service/src/reflector_host.ts
+++ b/packages/language-service/src/reflector_host.ts
@@ -69,7 +69,7 @@ export class ReflectorHost implements StaticSymbolResolverHost {
         throw new Error('Resolution of relative paths requires a containing file.');
       }
       // Any containing file gives the same result for absolute imports
-      containingFile = path.join(this.options.basePath !, 'index.ts');
+      containingFile = path.join(this.options.basePath !, 'index.ts').replace(/\\/g, '/');
     }
     const resolved =
         ts.resolveModuleName(moduleName, containingFile !, this.options, this.hostAdapter)

--- a/packages/language-service/test/language_service_spec.ts
+++ b/packages/language-service/test/language_service_spec.ts
@@ -26,7 +26,7 @@ describe('service without angular', () => {
 
   it('should not crash a get template references',
      () => expect(() => ngService.getTemplateReferences()));
-  it('should not crash a get dianostics',
+  it('should not crash a get diagnostics',
      () => expect(() => ngService.getDiagnostics(fileName)).not.toThrow());
   it('should not crash a completion',
      () => expect(() => ngService.getCompletionsAt(fileName, position)).not.toThrow());

--- a/packages/language-service/test/reflector_host_spec.ts
+++ b/packages/language-service/test/reflector_host_spec.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as path from 'path';
+import * as ts from 'typescript';
+
+import {createLanguageService} from '../src/language_service';
+import {ReflectorHost} from '../src/reflector_host';
+import {Completions, LanguageService} from '../src/types';
+import {TypeScriptServiceHost} from '../src/typescript_host';
+
+import {toh} from './test_data';
+import {MockTypescriptHost} from './test_utils';
+
+describe('reflector_host_spec', () => {
+
+  // Regression #21811
+  it('should be able to find angular under windows', () => {
+    const originalJoin = path.join;
+    let mockHost = new MockTypescriptHost(
+        ['/app/main.ts', '/app/parsing-cases.ts'], toh, 'app/node_modules',
+        {...path, join: (...args: string[]) => originalJoin.apply(path, args)});
+    let service = ts.createLanguageService(mockHost);
+    let ngHost = new TypeScriptServiceHost(mockHost, service);
+    let ngService = createLanguageService(ngHost);
+    const reflectorHost = new ReflectorHost(() => undefined as any, mockHost, {basePath: '\\app'});
+
+    spyOn(path, 'join').and.callFake((...args: string[]) => { return path.win32.join(...args); });
+    const result = reflectorHost.moduleNameToFileName('@angular/core');
+    expect(result).not.toBeNull('could not find @angular/core using path.win32');
+  });
+});


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue Number: #21811


## What is the new behavior?

Language service works correctly on Windows.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
