### PR TITLE
test(ivy): normalize template names in canonical spec

### DIFF
--- a/packages/core/test/render3/compiler_canonical_spec.ts
+++ b/packages/core/test/render3/compiler_canonical_spec.ts
@@ -318,7 +318,7 @@ describe('compiler specification', () => {
       static ngComponentDef = r3.defineComponent({
         type: SimpleLayout,
         tag: 'simple-layout',
-        factory: function SimpleLayout_Factory() { return simpleLayout = new SimpleLayout(); } ,
+        factory: function SimpleLayout_Factory() { return simpleLayout = new SimpleLayout(); },
         template: function SimpleLayout_Template(ctx: SimpleLayout, cm: boolean) {
           if (cm) {
             r3.E(0, LifecycleComp);

--- a/packages/core/test/render3/compiler_canonical_spec.ts
+++ b/packages/core/test/render3/compiler_canonical_spec.ts
@@ -276,7 +276,7 @@ describe('compiler specification', () => {
 
     @Component({selector: 'lifecycle-comp', template: ``})
     class LifecycleComp {
-      @Input() nameMin: string;
+      @Input('name') nameMin: string;
 
       ngOnChanges() { events.push('changes' + this.nameMin); }
 
@@ -291,14 +291,16 @@ describe('compiler specification', () => {
 
       ngOnDestroy() { events.push(this.nameMin); }
 
+      // NORMATIVE
       static ngComponentDef = r3.defineComponent({
         type: LifecycleComp,
         tag: 'lifecycle-comp',
-        factory: () => new LifecycleComp(),
-        template: function(ctx: any, cm: boolean) {},
+        factory: function LifecycleComp_Factory() { return new LifecycleComp(); },
+        template: function LifecycleComp_Template(ctx: LifecycleComp, cm: boolean) {},
         inputs: {nameMin: 'name'},
         features: [r3.NgOnChangesFeature(LifecycleComp)]
       });
+      // /NORMATIVE
     }
 
     @Component({
@@ -312,11 +314,12 @@ describe('compiler specification', () => {
       name1 = '1';
       name2 = '2';
 
+      // NORMATIVE
       static ngComponentDef = r3.defineComponent({
         type: SimpleLayout,
         tag: 'simple-layout',
-        factory: () => simpleLayout = new SimpleLayout(),
-        template: function(ctx: any, cm: boolean) {
+        factory: function SimpleLayout_Factory() { return simpleLayout = new SimpleLayout(); } ,
+        template: function SimpleLayout_Template(ctx: SimpleLayout, cm: boolean) {
           if (cm) {
             r3.E(0, LifecycleComp);
             r3.e();
@@ -331,6 +334,7 @@ describe('compiler specification', () => {
           r3.r(3, 2);
         }
       });
+      // /NORMATIVE
     }
 
     it('should gen hooks with a few simple components', () => {


### PR DESCRIPTION
Fixes up the canonical spec change in https://github.com/angular/angular/pull/21793 to use consistent factory and template names.