### PR TITLE
docs: add docs for IE

### DIFF
--- a/aio/README.md
+++ b/aio/README.md
@@ -105,8 +105,7 @@ The general setup is as follows:
 * Open a terminal, ensure the dependencies are installed; run an initial doc generation; then start the doc-viewer:
 
 ```bash
-yarn
-yarn docs
+yarn setup
 yarn start
 ```
 

--- a/aio/content/guide/browser-support.md
+++ b/aio/content/guide/browser-support.md
@@ -625,8 +625,13 @@ If you aren't using the CLI, you should add your polyfill scripts directly to th
     // __Zone_disable_requestAnimationFrame = true; // disable patch requestAnimationFrame
     // __Zone_disable_on_property = true; // disable patch onProperty such as onclick
     // __zone_symbol__BLACK_LISTED_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames
-  &lt;/script>
 
+    /*
+     * in IE/Edge developer tools, the addEventListener will also be wrapped by zone.js
+     * with the following flag, it will bypass `zone.js` patch for IE/Edge
+     */
+    // __Zone_enable_cross_context_check = true;
+  &lt;/script>
   &lt;!-- zone.js required by Angular -->
   &lt;script src="node_modules/zone.js/dist/zone.js">&lt;/script>
 

--- a/aio/content/guide/setup.md
+++ b/aio/content/guide/setup.md
@@ -350,3 +350,10 @@ It's the perfect place to reproduce a bug when you want to
 <a href="https://github.com/angular/angular/issues/new" title="File an Angular issue">file an issue with Angular itself</a>.
 
 For real development, we strongly recommend [developing locally](guide/setup#develop-locally).
+
+## Appendix: develop locally with IE
+
+If you develop angular locally with `ng serve`, there will be `websocket` connection being setup automatically between browser and local dev server, so when your code change, browser can automatically refresh.
+
+In windows, by default one application can only have 6 websocket connections, <a href="https://msdn.microsoft.com/library/ee330736%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396#websocket_maxconn" title="MSDN WebSocket settings">MSDN WebSocket Settings</a>.
+So if IE was refreshed manunally or automatically by `ng serve`, sometimes, the websocket will not close properly, when websocket connections exceed limitations, `SecurityError` will be thrown, this error will not affect the angular application, you can just restart IE to clear this error, or modify the windows registry to update the limitations.

--- a/aio/content/guide/typescript-configuration.md
+++ b/aio/content/guide/typescript-configuration.md
@@ -135,3 +135,12 @@ QuickStart identifies two *typings*, or `d.ts`, files:
 you can view an example in the [webpack](guide/webpack) page.
 
 QuickStart doesn't require these typings but many of the samples do.
+
+
+{@a target}
+
+
+### *target*
+
+By default, the target is `es5`, you can configure the target to `es6` if you only want to deploy the application to
+es6 compatible browser. But if you configure the target to `es6` in some old browser such as `IE`, `Syntax Error` will be thrown.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #21202


## What is the new behavior?

add document for `IE`.

- add document for `__Zone_enable_cross_context_check = true;`, if user want to development in `IE/Edge` and open developer tools, sometimes error will be thrown. set this flag will resolve this error, but this flag should only be set in development mode.
- add document for `tsconfig.json` settings, several issues were posted about develop in `IE` and change target to `es6` in `tsconfig.json`.
- add document for `ng serve` in `IE`, sometimes `SecurityError` will throw, the reason is `websocket` have limitations in Windows.

also update `aio/README.md`. without run `yarn generate-stackblitz`, `yarn docs` will report error.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```