### PR TITLE
fix(ivy): compiler should emit new refresh pattern

### DIFF
--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -21,7 +21,6 @@ export class Identifiers {
   /* Methods */
   static NEW_METHOD = 'n';
   static HOST_BINDING_METHOD = 'h';
-  static REFRESH_METHOD = 'r';
 
   /* Instructions */
   static createElement: o.ExternalReference = {name: 'ɵE', moduleName: CORE};

--- a/packages/compiler/src/render3/r3_view_compiler.ts
+++ b/packages/compiler/src/render3/r3_view_compiler.ts
@@ -428,11 +428,10 @@ class TemplateDefinitionBuilder implements TemplateAstVisitor, LocalResolver {
             o.importExpr(R3.bind).callFn([convertedBinding.currValExpr]));
       }
 
-      // e.g. TodoComponentDef.r(0, 0);
-      this._refreshMode.push(
-          this.definitionOf(directiveType, kind)
-              .callMethod(R3.REFRESH_METHOD, [o.literal(directiveIndex), o.literal(nodeIndex)])
-              .toStmt());
+      // e.g. r(0, 0);
+      this.instruction(
+          this._refreshMode, directive.sourceSpan, R3.refreshComponent, o.literal(directiveIndex),
+          o.literal(nodeIndex));
     }
   }
 

--- a/packages/compiler/test/render3/r3_view_compiler_spec.ts
+++ b/packages/compiler/test/render3/r3_view_compiler_spec.ts
@@ -208,8 +208,8 @@ describe('r3_view_compiler', () => {
               IDENT.ɵe();
               IDENT.ɵT(3, '!');
             }
-            ChildComponent.ngComponentDef.r(1, 0);
-            SomeDirective.ngDirectiveDef.r(2, 0);
+            IDENT.ɵr(1, 0);
+            IDENT.ɵr(2, 0);
           }
         });
       `;
@@ -272,7 +272,7 @@ describe('r3_view_compiler', () => {
             }
             const IDENT = IDENT.ɵm(1);
             IDENT.ɵcR(2);
-            IfDirective.ngDirectiveDef.r(3,2);
+            IDENT.ɵr(3,2);
             IDENT.ɵcr();
 
             function MyComponent_IfDirective_Template_2(ctx0: IDENT, cm: IDENT) {
@@ -419,13 +419,11 @@ describe('r3_view_compiler', () => {
         // TODO(chuckj): Enforce this when the directives are specified
         const ForDirectiveDefinition = `
           static ngDirectiveDef = IDENT.ɵdefineDirective({
+            type: ForOfDirective,
             factory: function ForOfDirective_Factory() {
               return new ForOfDirective(IDENT.ɵinjectViewContainerRef(), IDENT.ɵinjectTemplateRef());
             },
             features: [IDENT.ɵNgOnChangesFeature(NgForOf)],
-            refresh: function ForOfDirective_Refresh(directiveIndex: IDENT, elementIndex: IDENT) {
-              IDENT.ɵm<ForOfDirective>(directiveIndex).ngDoCheck();
-            },
             inputs: {forOf: 'forOf'}
           });
         `;
@@ -443,7 +441,7 @@ describe('r3_view_compiler', () => {
               }
               IDENT.ɵp(1, 'forOf', IDENT.ɵb(ctx.items));
               IDENT.ɵcR(1);
-              ForOfDirective.ngDirectiveDef.r(2, 1);
+              IDENT.ɵr(2, 1);
               IDENT.ɵcr();
 
               function MyComponent_ForOfDirective_Template_1(ctx0: IDENT, cm: IDENT) {
@@ -517,7 +515,7 @@ describe('r3_view_compiler', () => {
               }
               IDENT.ɵp(1, 'forOf', IDENT.ɵb(ctx.items));
               IDENT.ɵcR(1);
-              IDENT.r(2, 1);
+              IDENT.ɵr(2, 1);
               IDENT.ɵcr();
 
               function MyComponent_ForOfDirective_Template_1(ctx0: IDENT, cm: IDENT) {
@@ -535,7 +533,7 @@ describe('r3_view_compiler', () => {
                 IDENT.ɵp(4, 'forOf', IDENT.ɵb(IDENT.infos));
                 IDENT.ɵt(2, IDENT.ɵb1('', IDENT.name, ''));
                 IDENT.ɵcR(4);
-                IDENT.r(5, 4);
+                IDENT.ɵr(5, 4);
                 IDENT.ɵcr();
 
                 function MyComponent_ForOfDirective_ForOfDirective_Template_4(


### PR DESCRIPTION
Change compiler to reflect changes made in #21650

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Compile emitted the old refresh pattern for Ivy directives.

## What is the new behavior?

The compile emits the new refresh pattern for ivy directives.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
