### PR TITLE
feat(service-worker): add helper script which will uninstall SW

### DIFF
--- a/packages/service-worker/build.sh
+++ b/packages/service-worker/build.sh
@@ -11,6 +11,8 @@ $BIN/rollup -c worker/rollup-worker.config.js
 $BIN/tsc -p cli/tsconfig.json
 $BIN/rollup -c cli/rollup-cli.config.js
 
+cp ./safety-worker.js ../../dist/packages-dist/service-worker/safety-worker.js
+
 echo "#!/usr/bin/env node" > ../../dist/packages-dist/service-worker/ngsw-config.js
 
 cat ../../dist/packages-dist/service-worker/ngsw-config-tmp.js >> ../../dist/packages-dist/service-worker/ngsw-config.js

--- a/packages/service-worker/safety-worker.js
+++ b/packages/service-worker/safety-worker.js
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// tslint:disable:no-console
+
+self.addEventListener('install', event => { self.skipWaiting(); });
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+  self.registration.unregister().then(
+      () => { console.log('NGSW Safety Worker - unregistered old service worker'); });
+});


### PR DESCRIPTION
Service Workers can be tricky to work with in production, and often
it becomes necessary to deactivate an existing SW. This is trickier
than one might imagine - as long as clients on the old SW may exist
it is important to serve some script at the old SW URL. This commit
adds safety-worker.js to the published NPM package, which is useful
for that purpose. On install the SW unregisters itself which safely
and gradually allows older clients to update.
