### PR TITLE
fix(bazel): allow TS to read ambient typings

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,7 +16,7 @@ node_repositories(package_json = ["//:package.json"])
 git_repository(
     name = "build_bazel_rules_typescript",
     remote = "https://github.com/bazelbuild/rules_typescript.git",
-    commit = "eb3244363e1cb265c84e723b347926f28c29aa35"
+    commit = "d3ad16d1f105e2490859da9ad528ba4c45991d09"
 )
 
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")

--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -14,7 +14,7 @@ node_repositories(package_json = ["//:package.json"])
 git_repository(
     name = "build_bazel_rules_typescript",
     remote = "https://github.com/bazelbuild/rules_typescript.git",
-    commit = "eb3244363e1cb265c84e723b347926f28c29aa35"
+    commit = "d3ad16d1f105e2490859da9ad528ba4c45991d09"
 )
 
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")

--- a/packages/bazel/test/ngc-wrapped/index_test.ts
+++ b/packages/bazel/test/ngc-wrapped/index_test.ts
@@ -18,12 +18,22 @@ describe('ngc_wrapped', () => {
 
     write('some_project/index.ts', `
       import {Component} from '@angular/core';
+      import {a} from 'ambient_module';
       console.log('works: ', Component);
     `);
 
-    writeConfig({
+    const tsconfig = writeConfig({
       srcTargetPath: 'some_project',
     });
+    const typesFile = path.resolve(
+        tsconfig.compilerOptions.rootDir, tsconfig.compilerOptions.typeRoots[0], 'thing',
+        'index.d.ts');
+
+    write(typesFile, `
+      declare module "ambient_module" {
+        declare const a = 1;
+      }
+    `);
 
     // expect no error
     expect(runOneBuild()).toBe(true);

--- a/packages/bazel/test/ngc-wrapped/test_support.ts
+++ b/packages/bazel/test/ngc-wrapped/test_support.ts
@@ -24,7 +24,7 @@ export interface TestSupport {
     srcTargetPath: string,
     depPaths?: string[],
     pathMapping?: Array<{moduleName: string; path: string;}>,
-  }): void;
+  }): {compilerOptions: ts.CompilerOptions};
   read(fileName: string): string;
   write(fileName: string, content: string): void;
   writeFiles(...mockDirs: {[fileName: string]: string}[]): void;
@@ -68,11 +68,19 @@ export function setup(
   // -----------------
   // helpers
 
+  function mkdirp(dirname: string) {
+    const parent = path.dirname(dirname);
+    if (!fs.existsSync(parent)) {
+      mkdirp(parent);
+    }
+    fs.mkdirSync(dirname);
+  }
+
   function write(fileName: string, content: string) {
     const dir = path.dirname(fileName);
     if (dir != '.') {
       const newDir = path.resolve(basePath, dir);
-      if (!fs.existsSync(newDir)) fs.mkdirSync(newDir);
+      if (!fs.existsSync(newDir)) mkdirp(newDir);
     }
     fs.writeFileSync(path.resolve(basePath, fileName), content, {encoding: 'utf-8'});
   }
@@ -126,6 +134,7 @@ export function setup(
       pathMapping: pathMappingObj,
     });
     write(path.resolve(basePath, tsConfigJsonPath), JSON.stringify(tsconfig, null, 2));
+    return tsconfig;
   }
 
   function shouldExist(fileName: string) {


### PR DESCRIPTION
Same fix as https://github.com/bazelbuild/rules_typescript/commit/e70d7a2a7c08d7031f4dd4a385a7a6aa27296948
This is because the CompilerOptions needs to have directoryExists undefined in order to get the google3 behavior,
so we have to set the property outside the constructor.

Fixes #21872

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
