### PR TITLE
fix(ivy): remove unnecessary parameter of NgOnChangesFeature

### DIFF
--- a/packages/core/test/render3/common_with_def.ts
+++ b/packages/core/test/render3/common_with_def.ts
@@ -19,7 +19,7 @@ NgForOf.ngDirectiveDef = defineDirective({
   factory: () => new NgForOfDef(
                injectViewContainerRef(), injectTemplateRef(),
                inject(IterableDiffers, InjectFlags.Default, defaultIterableDiffers)),
-  features: [NgOnChangesFeature(NgForOf)],
+  features: [NgOnChangesFeature],
   inputs: {
     ngForOf: 'ngForOf',
     ngForTrackBy: 'ngForTrackBy',

--- a/packages/core/test/render3/compiler_canonical_spec.ts
+++ b/packages/core/test/render3/compiler_canonical_spec.ts
@@ -297,7 +297,7 @@ describe('compiler specification', () => {
         factory: () => new LifecycleComp(),
         template: function(ctx: any, cm: boolean) {},
         inputs: {nameMin: 'name'},
-        features: [r3.NgOnChangesFeature(LifecycleComp)]
+        features: [r3.NgOnChangesFeature]
       });
     }
 

--- a/packages/core/test/render3/define_spec.ts
+++ b/packages/core/test/render3/define_spec.ts
@@ -30,7 +30,7 @@ describe('define', () => {
           static ngDirectiveDef = defineDirective({
             type: MyDirective,
             factory: () => new MyDirective(),
-            features: [NgOnChangesFeature(MyDirective)],
+            features: [NgOnChangesFeature],
             inputs: {valA: 'valA', valB: 'valB'}
           });
         }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

`NgOnChangesFeature` parameter is no longer necessary as the definition now contains `type`.

## What is the new behavior?

`NgOnChangesFeature` no longer takes a parameter.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
