### PR TITLE
feat(bazel): add ts_config extending support for ng_module

### DIFF
--- a/packages/bazel/src/external.bzl
+++ b/packages/bazel/src/external.bzl
@@ -18,9 +18,14 @@ load(
     _NodeModuleInfo = "NodeModuleInfo",
     _collect_node_modules_aspect = "collect_node_modules_aspect",
 )
+load(
+    "@npm_bazel_typescript//internal:ts_config.bzl",
+    _TsConfigInfo = "TsConfigInfo",
+)
 
 NodeModuleInfo = _NodeModuleInfo
 collect_node_modules_aspect = _collect_node_modules_aspect
+
 tsc_wrapped_tsconfig = _tsc_wrapped_tsconfig
 COMMON_ATTRIBUTES = _COMMON_ATTRIBUTES
 COMMON_OUTPUTS = _COMMON_OUTPUTS
@@ -31,3 +36,4 @@ ts_providers_dict_to_struct = _ts_providers_dict_to_struct
 DEFAULT_NG_COMPILER = "@angular//:@angular/bazel/ngc-wrapped"
 DEFAULT_NG_XI18N = "@npm//@angular/bazel/bin:xi18n"
 FLAT_DTS_FILE_SUFFIX = ".bundle.d.ts"
+TsConfigInfo = _TsConfigInfo

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -13,6 +13,7 @@ load(
     "DEFAULT_NG_XI18N",
     "DEPS_ASPECTS",
     "NodeModuleInfo",
+    "TsConfigInfo",
     "collect_node_modules_aspect",
     "compile_ts",
     "ts_providers_dict_to_struct",
@@ -463,6 +464,8 @@ def _compile_action(ctx, inputs, outputs, dts_bundle_out, messages_out, tsconfig
     # If the user supplies a tsconfig.json file, the Angular compiler needs to read it
     if hasattr(ctx.attr, "tsconfig") and ctx.file.tsconfig:
         file_inputs.append(ctx.file.tsconfig)
+        if TsConfigInfo in ctx.attr.tsconfig:
+            file_inputs += ctx.attr.tsconfig[TsConfigInfo].deps
 
     # Also include files from npm fine grained deps as action_inputs.
     # These deps are identified by the NodeModuleInfo provider.


### PR DESCRIPTION
Support using the extending feature of ts_config in rules_typescript (it didn't add the father ts_config file to the sandbox in the past).


(This is a step towards supporting importing material2 as a Bazel dependency as well.)

/cc @alexeagle @pshields 