### PR TITLE
fix(bazel): Fix bug of wrong path in ng_module expectedOuts

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -35,7 +35,7 @@ def _expected_outs(ctx):
 
   for src in ctx.files.srcs + ctx.files.assets:
     if src.short_path.endswith(".ts") and not src.short_path.endswith(".d.ts"):
-      basename = src.short_path[len(ctx.label.package) + 1:-len(".ts")]
+      basename = src.path[src.path.find(ctx.build_file_path[:ctx.build_file_path.rfind("/")]) + ctx.build_file_path.rfind("/") + 1:-len(".ts")]
       if len(factory_basename_set) == 0 or basename in factory_basename_set:
         devmode_js = [
             ".ngfactory.js",
@@ -47,7 +47,7 @@ def _expected_outs(ctx):
         devmode_js = [".js"]
         summaries = []
     elif src.short_path.endswith(".css"):
-      basename = src.short_path[len(ctx.label.package) + 1:-len(".css")]
+      basename = src.path[src.path.find(ctx.build_file_path[:ctx.build_file_path.rfind("/")]) + ctx.build_file_path.rfind("/") + 1:-len(".css")]
       devmode_js = [
           ".css.shim.ngstyle.js",
           ".css.ngstyle.js",


### PR DESCRIPTION
Fix a bug in ng_module rule causing build failure if building as an external package (bazel build with a given workspace name).

Originally, the logic is `src.short_path[len(ctx.label.package) + 1:-len(".ts")]`.
However, if we are building the package as an external module (build with a workspace name), the short_path would be "../workspace_name/xxx/yyy/zzz.ts" instead of "xxx/yyy/zzz.ts", while the ctx.label.package is still "xxx", and the result would be wrong (something like "ace_name/xxx/yyy/zzz")

This fix changes it to `src.path[src.path.find(ctx.build_file_path[:ctx.build_file_path.rfind("/")]) + ctx.build_file_path.rfind("/") + 1:-len(".ts")]`. In this case, `ctx.build_file_path[:ctx.build_file_path.rfind("/")]` would be "external/workspace_name/xxx" and src.path is "external/workspace_name/xxx/yyy/zzz.ts". In this way, we can get the correct "yyy/zzz".

/cc @alexeagle 