### PR TITLE
fix(router): remove ParamsInheritanceStrategy usage from recognize.ts

### DIFF
--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -12,7 +12,7 @@ import {Observer} from 'rxjs/Observer';
 import {of } from 'rxjs/observable/of';
 
 import {Data, ResolveData, Route, Routes} from './config';
-import {ActivatedRouteSnapshot, ParamsInheritanceStrategy, RouterStateSnapshot, inheritedParamsDataResolve} from './router_state';
+import {ActivatedRouteSnapshot, RouterStateSnapshot, inheritedParamsDataResolve} from './router_state';
 import {PRIMARY_OUTLET, defaultUrlMatcher} from './shared';
 import {UrlSegment, UrlSegmentGroup, UrlTree, mapChildrenIntoArray} from './url_tree';
 import {forEach, last} from './utils/collection';
@@ -22,7 +22,7 @@ class NoMatch {}
 
 export function recognize(
     rootComponentType: Type<any>| null, config: Routes, urlTree: UrlTree, url: string,
-    paramsInheritanceStrategy: ParamsInheritanceStrategy =
+    paramsInheritanceStrategy: 'emptyOnly' | 'always' =
         'emptyOnly'): Observable<RouterStateSnapshot> {
   return new Recognizer(rootComponentType, config, urlTree, url, paramsInheritanceStrategy)
       .recognize();
@@ -31,7 +31,7 @@ export function recognize(
 class Recognizer {
   constructor(
       private rootComponentType: Type<any>|null, private config: Routes, private urlTree: UrlTree,
-      private url: string, private paramsInheritanceStrategy: ParamsInheritanceStrategy) {}
+      private url: string, private paramsInheritanceStrategy: 'emptyOnly' | 'always') {}
 
   recognize(): Observable<RouterStateSnapshot> {
     try {


### PR DESCRIPTION
Follow up from https://github.com/angular/angular/pull/21574

Removes usage of `ParamsInheritanceStrategy`

cc @alexeagle

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See #21456 and https://github.com/angular/angular/pull/21574

## What is the new behavior?

`ParamsInheritanceStrategy` will not be stripped from the .d.ts files.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

There's still a pending issue that throws when compiling from source, but seems that the fix would require a different approach, so I'll open another issue and/or PR when I find a fix.

```
[1] node_modules/@angular/router/upgrade/src/upgrade.d.ts(9,31): error TS2307: Cannot find module '@angular/upgrade/static'.
```