### PR TITLE
refactor(ivy): save check methods separately 

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -25,7 +25,7 @@
   "hello_world__render3__rollup": {
     "master": {
       "uncompressed": {
-        "bundle": 34304
+        "bundle": 34694
       }
     }
   }

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -70,8 +70,6 @@ export {
   queryRefresh as qR,
 } from './query';
 
-export {LifecycleHook} from './hooks';
-
 // clang-format on
 
 export {

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -21,7 +21,7 @@ import {isNodeMatchingSelector} from './node_selector_matcher';
 import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveType} from './interfaces/definition';
 import {RElement, RText, Renderer3, RendererFactory3, ProceduralRenderer3, ObjectOrientedRenderer3, RendererStyleFlags3} from './interfaces/renderer';
 import {isDifferent, stringify} from './util';
-import {executeViewHooks, executeContentHooks, queueLifecycleHooks, queueInitHooks, executeInitHooks} from './hooks';
+import {executeHooks, executeContentHooks, queueLifecycleHooks, queueInitHooks, executeInitHooks} from './hooks';
 
 
 /**
@@ -151,7 +151,9 @@ export function enterView(newView: LView, host: LElementNode | LViewNode | null)
  * the direction of traversal (up or down the view tree) a bit clearer.
  */
 export function leaveView(newView: LView): void {
-  executeViewHooks(currentView);
+  executeHooks(
+      currentView.data, currentView.tView.viewHooks, currentView.tView.viewCheckHooks,
+      creationMode);
   currentView.creationMode = false;
   currentView.lifecycleStage = LifecycleStage.INIT;
   currentView.tView.firstTemplatePass = false;
@@ -486,8 +488,11 @@ export function createTView(): TView {
     data: [],
     firstTemplatePass: true,
     initHooks: null,
+    checkHooks: null,
     contentHooks: null,
+    contentCheckHooks: null,
     viewHooks: null,
+    viewCheckHooks: null,
     destroyHooks: null
   };
 }
@@ -1044,7 +1049,7 @@ export function containerRefreshStart(index: number): void {
 
   // We need to execute init hooks here so ngOnInit hooks are called in top level views
   // before they are called in embedded views (for backwards compatibility).
-  executeInitHooks(currentView);
+  executeInitHooks(currentView, currentView.tView, creationMode);
 }
 
 /**
@@ -1175,8 +1180,8 @@ export function viewEnd(): void {
  * @param elementIndex
  */
 export function componentRefresh<T>(directiveIndex: number, elementIndex: number): void {
-  executeInitHooks(currentView);
-  executeContentHooks(currentView);
+  executeInitHooks(currentView, currentView.tView, creationMode);
+  executeContentHooks(currentView, currentView.tView, creationMode);
   const template = (tData[directiveIndex] as ComponentDef<T>).template;
   if (template != null) {
     ngDevMode && assertDataInRange(elementIndex);

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -200,30 +200,57 @@ export interface TView {
   firstTemplatePass: boolean;
 
   /**
-   * Array of ngOnInit and ngDoCheck hooks that should be executed for this view.
+   * Array of ngOnInit and ngDoCheck hooks that should be executed for this view in
+   * creation mode.
    *
-   * Even indices: Flags (1st bit: hook type, remaining: directive index)
+   * Even indices: Directive index
    * Odd indices: Hook function
    */
   initHooks: HookData|null;
 
   /**
-   * Array of ngAfterContentInit and ngAfterContentChecked hooks that should be executed for
-   * this view.
+   * Array of ngDoCheck hooks that should be executed for this view in update mode.
    *
-   * Even indices: Flags (1st bit: hook type, remaining: directive index)
+   * Even indices: Directive index
+   * Odd indices: Hook function
+   */
+  checkHooks: HookData|null;
+
+  /**
+   * Array of ngAfterContentInit and ngAfterContentChecked hooks that should be executed
+   * for this view in creation mode.
+   *
+   * Even indices: Directive index
    * Odd indices: Hook function
    */
   contentHooks: HookData|null;
 
   /**
-   * Array of ngAfterViewInit and ngAfterViewChecked hooks that should be executed for
-   * this view.
+   * Array of ngAfterContentChecked hooks that should be executed for this view in update
+   * mode.
    *
-   * Even indices: Flags (1st bit: hook type, remaining: directive index)
+   * Even indices: Directive index
+   * Odd indices: Hook function
+   */
+  contentCheckHooks: HookData|null;
+
+  /**
+   * Array of ngAfterViewInit and ngAfterViewChecked hooks that should be executed for
+   * this view in creation mode.
+   *
+   * Even indices: Directive index
    * Odd indices: Hook function
    */
   viewHooks: HookData|null;
+
+  /**
+   * Array of ngAfterViewChecked hooks that should be executed for this view in
+   * update mode.
+   *
+   * Even indices: Directive index
+   * Odd indices: Hook function
+   */
+  viewCheckHooks: HookData|null;
 
   /**
    * Array of ngOnDestroy hooks that should be executed when this view is destroyed.
@@ -237,7 +264,7 @@ export interface TView {
 /**
  * Array of hooks that should be executed for a view and their directive indices.
  *
- * Even indices: Flags (1st bit: hook type, remaining: directive index)
+ * Even indices: Directive index
  * Odd indices: Hook function
  */
 export type HookData = (number | (() => void))[];

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {assertNotEqual, assertNotNull} from './assert';
+import {assertNotNull} from './assert';
+import {callHooks} from './hooks';
 import {LContainer, unusedValueExportToPlacateAjd as unused1} from './interfaces/container';
 import {LContainerNode, LElementNode, LNode, LNodeFlags, LProjectionNode, LTextNode, LViewNode, unusedValueExportToPlacateAjd as unused2} from './interfaces/node';
 import {unusedValueExportToPlacateAjd as unused3} from './interfaces/projection';
@@ -385,10 +386,7 @@ function executeOnDestroys(view: LView): void {
   const tView = view.tView;
   let destroyHooks: HookData|null;
   if (tView != null && (destroyHooks = tView.destroyHooks) != null) {
-    for (let i = 0; i < destroyHooks.length; i += 2) {
-      const instance = view.data[destroyHooks[i] as number];
-      (destroyHooks[i | 1] as() => void).call(instance);
-    }
+    callHooks(view.data, destroyHooks);
   }
 }
 


### PR DESCRIPTION
Re-opening 21795 (reverted because payload limits conflicted on merge)

Currently, we wrap up hook type and directive index in one number, then unwrap each number to check whether the hook is init-only as we loop through hooks every change detection run.

Instead, we can create one array for creation mode and one array in update mode for each set of hooks. This avoids having to iterate over dead init hooks each change detection run and also avoids wrapping/unwrapping the hook type.

cc @jelbourn