### PR TITLE
fix(upgrade): wrap $digest in setTimeout()

### DIFF
--- a/modules/@angular/upgrade/src/aot/upgrade_module.ts
+++ b/modules/@angular/upgrade/src/aot/upgrade_module.ts
@@ -204,12 +204,10 @@ export class UpgradeModule {
                 // Wire up the ng1 rootScope to run a digest cycle whenever the zone settles
                 // We need to do this in the next tick so that we don't prevent the bootup
                 // stabilizing
-                setTimeout(() => {
-                  const $rootScope = $injector.get('$rootScope');
-                  const subscription =
-                      this.ngZone.onMicrotaskEmpty.subscribe(() => $rootScope.$digest());
-                  $rootScope.$on('$destroy', () => { subscription.unsubscribe(); });
-                }, 0);
+                const $rootScope = $injector.get('$rootScope');
+                const subscription = this.ngZone.onMicrotaskEmpty.subscribe(
+                    () => { setTimeout(() => { $rootScope.$digest(); }, 0); });
+                $rootScope.$on('$destroy', () => { subscription.unsubscribe(); });
               }
             ]);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Since Angular 2.4.6 (in particular, since this commit https://github.com/angular/angular/commit/117fa79c7c1a0e38ea98dd7328e6396a7c089b5f#diff-22d66718b7fa0e584e99fb44c90054ebR210), the `upgrade` module has had an unchecked `$digest`.

This is because, while the surrounding code sits inside a `setTimeout`, it also sits inside a `subscribe` which changes the timing for that line.

Issue Number: N/A


## What is the new behavior?
Now it waits until the next tick before trying to `digest`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

I can't get the automated tests to run on v2 locally but I hope this change is obvious enough to not need that.