### PR TITLE
feat(compiler-cli): reflect static methods added to classes in metadata

### DIFF
--- a/packages/compiler-cli/src/metadata/collector.ts
+++ b/packages/compiler-cli/src/metadata/collector.ts
@@ -76,6 +76,9 @@ export class MetadataCollector {
     }
 
     function recordEntry<T extends MetadataEntry>(entry: T, node: ts.Node): T {
+      if (composedSubstituter) {
+        entry = composedSubstituter(entry as MetadataValue, node) as T;
+      }
       return recordMapEntry(entry, node, nodeMap, sourceFile);
     }
 

--- a/packages/compiler-cli/src/transformers/metadata_cache.ts
+++ b/packages/compiler-cli/src/transformers/metadata_cache.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {MetadataCollector, MetadataValue, ModuleMetadata} from '../metadata/index';
+
+import {MetadataProvider} from './compiler_host';
+
+export type ValueTransform = (value: MetadataValue, node: ts.Node) => MetadataValue;
+
+export interface MetadataTransformer {
+  connect?(cache: MetadataCache): void;
+  start(sourceFile: ts.SourceFile): ValueTransform|undefined;
+}
+
+/**
+ * Cache, and potentially transform, metadata as it is being collected.
+ */
+export class MetadataCache implements MetadataProvider {
+  private metadataCache = new Map<string, ModuleMetadata|undefined>();
+
+  constructor(
+      private collector: MetadataCollector, private strict: boolean,
+      private transformers: MetadataTransformer[]) {
+    for (let transformer of transformers) {
+      if (transformer.connect) {
+        transformer.connect(this);
+      }
+    }
+  }
+
+  getMetadata(sourceFile: ts.SourceFile): ModuleMetadata|undefined {
+    if (this.metadataCache.has(sourceFile.fileName)) {
+      return this.metadataCache.get(sourceFile.fileName);
+    }
+    let substitute: ValueTransform|undefined = undefined;
+
+    // Only process transformers on modules that are not declaration files.
+    const declarationFile = sourceFile.isDeclarationFile;
+    const moduleFile = ts.isExternalModule(sourceFile);
+    if (!declarationFile && moduleFile) {
+      for (let transform of this.transformers) {
+        const transformSubstitute = transform.start(sourceFile);
+        if (transformSubstitute) {
+          if (substitute) {
+            const previous: ValueTransform = substitute;
+            substitute = (value: MetadataValue, node: ts.Node) =>
+                transformSubstitute(previous(value, node), node);
+          } else {
+            substitute = transformSubstitute;
+          }
+        }
+      }
+    }
+
+    const result = this.collector.getMetadata(sourceFile, this.strict, substitute);
+    this.metadataCache.set(sourceFile.fileName, result);
+    return result;
+  }
+}

--- a/packages/compiler-cli/src/transformers/r3_metadata_transform.ts
+++ b/packages/compiler-cli/src/transformers/r3_metadata_transform.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ClassStmt, PartialModule, Statement, StmtModifier} from '@angular/compiler';
+import * as ts from 'typescript';
+
+import {MetadataCollector, MetadataValue, ModuleMetadata, isClassMetadata} from '../metadata/index';
+
+import {MetadataTransformer, ValueTransform} from './metadata_cache';
+
+export class PartialModuleMetadataTransformer implements MetadataTransformer {
+  private moduleMap: Map<string, PartialModule>;
+
+  constructor(modules: PartialModule[]) {
+    this.moduleMap = new Map(modules.map<[string, PartialModule]>(m => [m.fileName, m]));
+  }
+
+  start(sourceFile: ts.SourceFile): ValueTransform|undefined {
+    const partialModule = this.moduleMap.get(sourceFile.fileName);
+    if (partialModule) {
+      const classMap = new Map<string, ClassStmt>(
+          partialModule.statements.filter(isClassStmt).map<[string, ClassStmt]>(s => [s.name, s]));
+      if (classMap.size > 0) {
+        return (value: MetadataValue, node: ts.Node): MetadataValue => {
+          // For class metadata that is going to be transformed to have a static method ensure the
+          // metadata contains a static declaration the new static method.
+          if (isClassMetadata(value) && node.kind === ts.SyntaxKind.ClassDeclaration) {
+            const classDeclaration = node as ts.ClassDeclaration;
+            if (classDeclaration.name) {
+              const partialClass = classMap.get(classDeclaration.name.text);
+              if (partialClass) {
+                for (const field of partialClass.fields) {
+                  if (field.name && field.modifiers &&
+                      field.modifiers.some(modifier => modifier === StmtModifier.Static)) {
+                    value.statics = {...(value.statics || {}), [field.name]: {}};
+                  }
+                }
+              }
+            }
+          }
+          return value;
+        };
+      }
+    }
+  }
+}
+
+function isClassStmt(v: Statement): v is ClassStmt {
+  return v instanceof ClassStmt;
+}

--- a/packages/compiler-cli/test/transformers/r3_metadata_transform_spec.ts
+++ b/packages/compiler-cli/test/transformers/r3_metadata_transform_spec.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ClassField, ClassMethod, ClassStmt, PartialModule, Statement, StmtModifier} from '@angular/compiler';
+import * as ts from 'typescript';
+
+import {MetadataCollector, isClassMetadata} from '../../src/metadata/index';
+import {MetadataCache} from '../../src/transformers/metadata_cache';
+import {PartialModuleMetadataTransformer} from '../../src/transformers/r3_metadata_transform';
+
+describe('r3_transform_spec', () => {
+
+  it('should add a static method to collected metadata', () => {
+    const fileName = '/some/directory/someFileName.ts';
+    const className = 'SomeClass';
+    const newFieldName = 'newStaticField';
+    const source = `
+      export class ${className} {
+        myMethod(): void {}
+      }
+    `;
+
+    const sourceFile =
+        ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, /* setParentNodes */ true);
+    const partialModule: PartialModule = {
+      fileName,
+      statements: [new ClassStmt(
+          className, /* parent */ null, /* fields */[new ClassField(
+              /* name */ newFieldName, /* type */ null, /* modifiers */[StmtModifier.Static])],
+          /* getters */[],
+          /* constructorMethod */ new ClassMethod(/* name */ null, /* params */[], /* body */[]),
+          /* methods */[])]
+    };
+
+    const cache = new MetadataCache(
+        new MetadataCollector(), /* strict */ true,
+        [new PartialModuleMetadataTransformer([partialModule])]);
+    const metadata = cache.getMetadata(sourceFile);
+    expect(metadata).toBeDefined('Expected metadata from test source file');
+    if (metadata) {
+      const classData = metadata.metadata[className];
+      expect(classData && isClassMetadata(classData))
+          .toBeDefined(`Expected metadata to contain data for "${className}"`);
+      if (classData && isClassMetadata(classData)) {
+        const statics = classData.statics;
+        expect(statics).toBeDefined(`Expected "${className}" metadata to contain statics`);
+        if (statics) {
+          expect(statics[newFieldName]).toEqual({}, 'Expected new field to recorded as a function');
+        }
+      }
+    }
+  });
+});

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -67,7 +67,7 @@ export * from './ml_parser/html_tags';
 export * from './ml_parser/interpolation_config';
 export * from './ml_parser/tags';
 export {NgModuleCompiler} from './ng_module_compiler';
-export {AssertNotNull, BinaryOperator, BinaryOperatorExpr, BuiltinMethod, BuiltinVar, CastExpr, ClassMethod, ClassStmt, CommaExpr, CommentStmt, ConditionalExpr, DeclareFunctionStmt, DeclareVarStmt, ExpressionStatement, ExpressionVisitor, ExternalExpr, ExternalReference, FunctionExpr, IfStmt, InstantiateExpr, InvokeFunctionExpr, InvokeMethodExpr, LiteralArrayExpr, LiteralExpr, LiteralMapExpr, NotExpr, ReadKeyExpr, ReadPropExpr, ReadVarExpr, ReturnStatement, StatementVisitor, ThrowStmt, TryCatchStmt, WriteKeyExpr, WritePropExpr, WriteVarExpr, StmtModifier, Statement, collectExternalReferences} from './output/output_ast';
+export {AssertNotNull, BinaryOperator, BinaryOperatorExpr, BuiltinMethod, BuiltinVar, CastExpr, ClassField, ClassMethod, ClassStmt, CommaExpr, CommentStmt, ConditionalExpr, DeclareFunctionStmt, DeclareVarStmt, ExpressionStatement, ExpressionVisitor, ExternalExpr, ExternalReference, FunctionExpr, IfStmt, InstantiateExpr, InvokeFunctionExpr, InvokeMethodExpr, LiteralArrayExpr, LiteralExpr, LiteralMapExpr, NotExpr, ReadKeyExpr, ReadPropExpr, ReadVarExpr, ReturnStatement, StatementVisitor, ThrowStmt, TryCatchStmt, WriteKeyExpr, WritePropExpr, WriteVarExpr, StmtModifier, Statement, collectExternalReferences} from './output/output_ast';
 export {EmitterVisitorContext} from './output/abstract_emitter';
 export * from './output/ts_emitter';
 export * from './parse_util';


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Feature
```

## What is the current behavior?

Metadata does not reflect rewriting made during the transformation phase.

## What is the new behavior?

The metadata for a class is augmented when a static field is injected.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
