### PR TITLE
test(common): disable deprecated date pipe tests on chrome mobile

### DIFF
--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -19,7 +19,7 @@ import localeAr from '@angular/common/locales/ar';
 
 {
   let date: Date;
-  xdescribe('DatePipe', () => {
+  describe('DatePipe', () => {
     const isoStringWithoutTime = '2015-01-01';
     let pipe: DatePipe;
 

--- a/packages/common/test/pipes/deprecated/date_pipe_spec.ts
+++ b/packages/common/test/pipes/deprecated/date_pipe_spec.ts
@@ -12,14 +12,19 @@ import {JitReflector} from '@angular/platform-browser-dynamic/src/compiler_refle
 import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
 
 {
-  xdescribe('DeprecatedDatePipe', () => {
+  describe('DeprecatedDatePipe', () => {
     let date: Date;
     const isoStringWithoutTime = '2015-01-01';
     let pipe: DeprecatedDatePipe;
 
     // Check the transformation of a date into a pattern
     function expectDateFormatAs(date: Date | string, pattern: any, output: string): void {
-      expect(pipe.transform(date, pattern)).toEqual(output);
+      // disabled on chrome mobile because of the following bug affecting the intl API
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=796583
+      // the android 7 emulator of saucelabs uses chrome mobile 63
+      if (!browserDetection.isAndroid && !browserDetection.isWebkit) {
+        expect(pipe.transform(date, pattern)).toEqual(output);
+      }
     }
 
     // TODO: reactivate the disabled expectations once emulators are fixed in SauceLabs
@@ -160,7 +165,6 @@ import {browserDetection} from '@angular/platform-browser/testing/src/browser_ut
         Object.keys(dateFixtures).forEach((pattern: string) => {
           expectDateFormatAs(date, pattern, dateFixtures[pattern]);
         });
-
       });
 
       it('should format with pattern aliases', () => {
@@ -192,7 +196,6 @@ import {browserDetection} from '@angular/platform-browser/testing/src/browser_ut
         Object.keys(dateFixtures).forEach((pattern: string) => {
           expectDateFormatAs(date, pattern, dateFixtures[pattern]);
         });
-
       });
 
       it('should format invalid in IE ISO date',


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] CI related changes
```

## What is the current behavior?
There's a bug in chrome mobile 63 with the intl API: https://bugs.chromium.org/p/chromium/issues/detail?id=796583
because of that, the deprecated date pipe tests are failing.

Issue Number: #21907


## What is the new behavior?
Those tests are disabled on chrome mobile


## Does this PR introduce a breaking change?
```
[x] No
```