### PR TITLE
fix(http): need ability to flush bool in http test

### DIFF
--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -32,6 +32,13 @@ import {HttpClientTestingBackend} from '../testing/src/backend';
         });
         backend.expectOne('/test').flush({'data': 'hello world'});
       });
+      it('for JSON(boolean) data', (done: DoneFn) => {
+        client.get('/test').subscribe(res => {
+          expect((res as any)).toEqual(true);
+          done();
+        });
+        backend.expectOne('/test').flush(true);
+      });
       it('for text data', (done: DoneFn) => {
         client.get('/test', {responseType: 'text'}).subscribe(res => {
           expect(res).toEqual('hello world');

--- a/packages/common/http/testing/src/request.ts
+++ b/packages/common/http/testing/src/request.ts
@@ -36,11 +36,13 @@ export class TestRequest {
    *
    * Both successful and unsuccessful responses can be delivered via `flush()`.
    */
-  flush(body: ArrayBuffer|Blob|string|number|Object|(string|number|Object|null)[]|null, opts: {
-    headers?: HttpHeaders | {[name: string]: string | string[]},
-    status?: number,
-    statusText?: string,
-  } = {}): void {
+  flush(
+      body: ArrayBuffer|Blob|string|number|Object|boolean|(string|number|Object|null)[]|null,
+      opts: {
+        headers?: HttpHeaders | {[name: string]: string | string[]},
+        status?: number,
+        statusText?: string,
+      } = {}): void {
     if (this.cancelled) {
       throw new Error(`Cannot flush a cancelled request.`);
     }
@@ -144,7 +146,8 @@ function _toBlob(
  * Helper function to convert a response body to JSON data.
  */
 function _toJsonBody(
-    body: ArrayBuffer | Blob | string | number | Object | (string | number | Object | null)[],
+    body: ArrayBuffer | Blob | string | number | Object | boolean |
+        (string | number | Object | null)[],
     format: string = 'JSON'): Object|string|number|(Object | string | number)[] {
   if (typeof ArrayBuffer !== 'undefined' && body instanceof ArrayBuffer) {
     throw new Error(`Automatic conversion to ${format} is not supported for ArrayBuffers.`);
@@ -153,7 +156,7 @@ function _toJsonBody(
     throw new Error(`Automatic conversion to ${format} is not supported for Blobs.`);
   }
   if (typeof body === 'string' || typeof body === 'number' || typeof body === 'object' ||
-      Array.isArray(body)) {
+      typeof body === 'boolean' || Array.isArray(body)) {
     return body;
   }
   throw new Error(`Automatic conversion to ${format} is not supported for response type.`);

--- a/tools/public_api_guard/common/http/testing.d.ts
+++ b/tools/public_api_guard/common/http/testing.d.ts
@@ -37,7 +37,7 @@ export declare class TestRequest {
         statusText?: string;
     }): void;
     event(event: HttpEvent<any>): void;
-    flush(body: ArrayBuffer | Blob | string | number | Object | (string | number | Object | null)[] | null, opts?: {
+    flush(body: ArrayBuffer | Blob | string | number | Object | boolean | (string | number | Object | null)[] | null, opts?: {
         headers?: HttpHeaders | {
             [name: string]: string | string[];
         };


### PR DESCRIPTION
The flush method in TestRequest can return a boolean as this is a valid
json response.

Closes #20690

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 20690


## What is the new behavior?
TestRequest can flush a boolean response

## Does this PR introduce a breaking change?
```
[ ] Yes
[ X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
