### PR TITLE
refactor(router): expose the bare minimum API requirements to overrid…

### DIFF
--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -60,6 +60,8 @@ function canLoadFails(route: Route): Observable<LoadedRouterConfig> {
  * Returns the `UrlTree` with the redirection applied.
  *
  * Lazy modules are loaded along the way.
+ *
+ * @stable
  */
 export function applyRedirects(
     moduleInjector: Injector, configLoader: RouterConfigLoader, urlSerializer: UrlSerializer,

--- a/packages/router/src/create_router_state.ts
+++ b/packages/router/src/create_router_state.ts
@@ -12,6 +12,10 @@ import {DetachedRouteHandleInternal, RouteReuseStrategy} from './route_reuse_str
 import {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot} from './router_state';
 import {TreeNode} from './utils/tree';
 
+/**
+ *
+ * @stable
+ */
 export function createRouterState(
     routeReuseStrategy: RouteReuseStrategy, curr: RouterStateSnapshot,
     prevState: RouterState): RouterState {

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -7,22 +7,28 @@
  */
 
 
+export {applyRedirects} from './apply_redirects';
+export {createRouterState} from './create_router_state';
+export {recognize} from './recognize';
 export {Data, LoadChildren, LoadChildrenCallback, ResolveData, Route, Routes, RunGuardsAndResolvers, UrlMatchResult, UrlMatcher} from './config';
 export {RouterLink, RouterLinkWithHref} from './directives/router_link';
 export {RouterLinkActive} from './directives/router_link_active';
 export {RouterOutlet} from './directives/router_outlet';
 export {ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouterEvent, RoutesRecognized} from './events';
 export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, Resolve} from './interfaces';
+export {PreActivation} from './pre_activation';
 export {DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
 export {NavigationExtras, Router} from './router';
 export {ROUTES} from './router_config_loader';
 export {ExtraOptions, ROUTER_CONFIGURATION, ROUTER_INITIALIZER, RouterModule, provideRoutes} from './router_module';
 export {ChildrenOutletContexts, OutletContext} from './router_outlet_context';
 export {NoPreloading, PreloadAllModules, PreloadingStrategy, RouterPreloader} from './router_preloader';
-export {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot} from './router_state';
-export {PRIMARY_OUTLET, ParamMap, Params, convertToParamMap} from './shared';
+export {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot, advanceActivatedRoute} from './router_state';
+export {PRIMARY_OUTLET, ParamMap, Params, convertToParamMap, isNavigationCancelingError} from './shared';
 export {UrlHandlingStrategy} from './url_handling_strategy';
 export {DefaultUrlSerializer, UrlSegment, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
+export {TreeNode, nodeChildrenAsMap} from './utils/tree';
+export {forEach} from './utils/collection';
 export {VERSION} from './version';
 
 export * from './private_export';

--- a/packages/router/src/pre_activation.ts
+++ b/packages/router/src/pre_activation.ts
@@ -38,6 +38,7 @@ class CanDeactivate {
 
 /**
  * This class bundles the actions involved in preactivation of a route.
+ * @stable
  */
 export class PreActivation {
   private canActivateChecks: CanActivate[] = [];

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -20,6 +20,10 @@ import {TreeNode} from './utils/tree';
 
 class NoMatch {}
 
+/**
+ *
+ * @stable
+ */
 export function recognize(
     rootComponentType: Type<any>| null, config: Routes, urlTree: UrlTree, url: string,
     paramsInheritanceStrategy: ParamsInheritanceStrategy =

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -164,21 +164,16 @@ function defaultErrorHandler(error: any): any {
   throw error;
 }
 
-type NavigationParams = {
-  id: number,
-  rawUrl: UrlTree,
-  extras: NavigationExtras,
-  resolve: any,
-  reject: any,
-  promise: Promise<boolean>,
-  source: NavigationTrigger,
-  state: {navigationId: number} | null
-};
-
-/**
- * @internal
- */
-export type RouterHook = (snapshot: RouterStateSnapshot) => Observable<void>;
+interface NavigationParams {
+  id: number;
+  rawUrl: UrlTree;
+  extras: NavigationExtras;
+  resolve: any;
+  reject: any;
+  promise: Promise<boolean>;
+  source: NavigationTrigger;
+  state: {navigationId: number} | null;
+}
 
 /**
  * @internal
@@ -197,17 +192,17 @@ function defaultRouterHook(snapshot: RouterStateSnapshot): Observable<void> {
  * @stable
  */
 export class Router {
-  private currentUrlTree: UrlTree;
-  private rawUrlTree: UrlTree;
+  protected currentUrlTree: UrlTree;
+  protected rawUrlTree: UrlTree;
   private navigations = new BehaviorSubject<NavigationParams>(null !);
 
   private locationSubscription: Subscription;
-  private navigationId: number = 0;
-  private configLoader: RouterConfigLoader;
-  private ngModule: NgModuleRef<any>;
+  protected navigationId: number = 0;
+  protected configLoader: RouterConfigLoader;
+  protected ngModule: NgModuleRef<any>;
 
-  public readonly events: Observable<Event> = new Subject<Event>();
-  public readonly routerState: RouterState;
+  public events: Subject<Event> = new Subject<Event>();
+  public routerState: RouterState;
 
   /**
    * Error handler that is invoked when a navigation errors.
@@ -222,14 +217,13 @@ export class Router {
    * Indicates if at least one navigation happened.
    */
   navigated: boolean = false;
-  private lastSuccessfulId: number = -1;
+  protected lastSuccessfulId: number = -1;
 
   /**
    * Used by RouterModule. This allows us to
    * pause the navigation either before preactivation or after it.
-   * @internal
    */
-  hooks: {beforePreactivation: RouterHook, afterPreactivation: RouterHook} = {
+  hooks: {beforePreactivation: (snapshot: RouterStateSnapshot) => Observable<void>, afterPreactivation: (snapshot: RouterStateSnapshot) => Observable<void>} = {
     beforePreactivation: defaultRouterHook,
     afterPreactivation: defaultRouterHook
   };
@@ -264,8 +258,8 @@ export class Router {
    */
   // TODO: vsavkin make internal after the final is out.
   constructor(
-      private rootComponentType: Type<any>|null, private urlSerializer: UrlSerializer,
-      private rootContexts: ChildrenOutletContexts, private location: Location, injector: Injector,
+      protected rootComponentType: Type<any>|null, protected urlSerializer: UrlSerializer,
+      protected rootContexts: ChildrenOutletContexts, protected location: Location, injector: Injector,
       loader: NgModuleFactoryLoader, compiler: Compiler, public config: Routes) {
     const onLoadStart = (r: Route) => this.triggerEvent(new RouteConfigLoadStart(r));
     const onLoadEnd = (r: Route) => this.triggerEvent(new RouteConfigLoadEnd(r));
@@ -606,7 +600,7 @@ export class Router {
     }
   }
 
-  private runNavigate(
+  protected runNavigate(
       url: UrlTree, rawUrl: UrlTree, skipLocationChange: boolean, replaceUrl: boolean, id: number,
       precreatedState: RouterStateSnapshot|null): Promise<boolean> {
     if (id !== this.navigationId) {
@@ -785,14 +779,14 @@ export class Router {
     });
   }
 
-  private resetStateAndUrl(storedState: RouterState, storedUrl: UrlTree, rawUrl: UrlTree): void {
+  protected resetStateAndUrl(storedState: RouterState, storedUrl: UrlTree, rawUrl: UrlTree): void {
     (this as{routerState: RouterState}).routerState = storedState;
     this.currentUrlTree = storedUrl;
     this.rawUrlTree = this.urlHandlingStrategy.merge(this.currentUrlTree, rawUrl);
     this.resetUrlToCurrentUrlTree();
   }
 
-  private resetUrlToCurrentUrlTree(): void {
+  protected resetUrlToCurrentUrlTree(): void {
     this.location.replaceState(
         this.urlSerializer.serialize(this.rawUrlTree), '', {navigationId: this.lastSuccessfulId});
   }

--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -377,6 +377,8 @@ function serializeNode(node: TreeNode<ActivatedRouteSnapshot>): string {
  * The expectation is that the activate route is created with the right set of parameters.
  * So we push new values into the observables only when they are not the initial values.
  * And we detect that by checking if the snapshot field is set.
+ *
+ * @stable
  */
 export function advanceActivatedRoute(route: ActivatedRoute): void {
   if (route.snapshot) {

--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -103,6 +103,10 @@ export function navigationCancelingError(message: string) {
   return error;
 }
 
+/**
+ *
+ * @stable
+ */
 export function isNavigationCancelingError(error: Error) {
   return error && (error as any)[NAVIGATION_CANCELING_ERROR];
 }

--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -62,6 +62,10 @@ export function and(bools: boolean[]): boolean {
   return !bools.some(v => !v);
 }
 
+/**
+ *
+ * @stable
+ */
 export function forEach<K, V>(map: {[key: string]: V}, callback: (v: V, k: string) => void): void {
   for (const prop in map) {
     if (map.hasOwnProperty(prop)) {

--- a/packages/router/src/utils/tree.ts
+++ b/packages/router/src/utils/tree.ts
@@ -83,13 +83,20 @@ function findPath<T>(value: T, node: TreeNode<T>): TreeNode<T>[] {
   return [];
 }
 
+/**
+ * @stable
+ */
 export class TreeNode<T> {
   constructor(public value: T, public children: TreeNode<T>[]) {}
 
   toString(): string { return `TreeNode(${this.value})`; }
 }
 
-// Return the list of T indexed by outlet name
+/**
+ * Return the list of T indexed by outlet name
+ *
+ * @stable
+ */
 export function nodeChildrenAsMap<T extends{outlet: string}>(node: TreeNode<T>| null) {
   const map: {[outlet: string]: TreeNode<T>} = {};
 

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -56,6 +56,12 @@ export declare class ActivationStart {
 }
 
 /** @stable */
+export declare function advanceActivatedRoute(route: ActivatedRoute): void;
+
+/** @stable */
+export declare function applyRedirects(moduleInjector: Injector, configLoader: RouterConfigLoader, urlSerializer: UrlSerializer, urlTree: UrlTree, config: Routes): Observable<UrlTree>;
+
+/** @stable */
 export interface CanActivate {
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean;
 }
@@ -105,6 +111,9 @@ export declare class ChildrenOutletContexts {
 export declare function convertToParamMap(params: Params): ParamMap;
 
 /** @stable */
+export declare function createRouterState(routeReuseStrategy: RouteReuseStrategy, curr: RouterStateSnapshot, prevState: RouterState): RouterState;
+
+/** @stable */
 export declare type Data = {
     [name: string]: any;
 };
@@ -132,6 +141,11 @@ export interface ExtraOptions {
     useHash?: boolean;
 }
 
+/** @stable */
+export declare function forEach<K, V>(map: {
+    [key: string]: V;
+}, callback: (v: V, k: string) => void): void;
+
 /** @experimental */
 export declare class GuardsCheckEnd extends RouterEvent {
     shouldActivate: boolean;
@@ -157,6 +171,9 @@ export declare class GuardsCheckStart extends RouterEvent {
         state: RouterStateSnapshot);
     toString(): string;
 }
+
+/** @stable */
+export declare function isNavigationCancelingError(error: Error): any;
 
 /** @stable */
 export declare type LoadChildren = string | LoadChildrenCallback;
@@ -222,6 +239,13 @@ export declare class NavigationStart extends RouterEvent {
     toString(): string;
 }
 
+/** @stable */
+export declare function nodeChildrenAsMap<T extends {
+    outlet: string;
+}>(node: TreeNode<T> | null): {
+    [outlet: string]: TreeNode<T>;
+};
+
 /** @experimental */
 export declare class NoPreloading implements PreloadingStrategy {
     preload(route: Route, fn: () => Observable<any>): Observable<any>;
@@ -249,6 +273,16 @@ export declare type Params = {
     [key: string]: any;
 };
 
+/** @stable */
+export declare class PreActivation {
+    constructor(future: RouterStateSnapshot, curr: RouterStateSnapshot, moduleInjector: Injector, forwardEvent?: ((evt: Event) => void) | undefined);
+    checkGuards(): Observable<boolean>;
+    initialize(parentContexts: ChildrenOutletContexts): void;
+    isActivating(): boolean;
+    isDeactivating(): boolean;
+    resolveData(paramsInheritanceStrategy: 'emptyOnly' | 'always'): Observable<any>;
+}
+
 /** @experimental */
 export declare class PreloadAllModules implements PreloadingStrategy {
     preload(route: Route, fn: () => Observable<any>): Observable<any>;
@@ -264,6 +298,9 @@ export declare const PRIMARY_OUTLET = "primary";
 
 /** @stable */
 export declare function provideRoutes(routes: Routes): any;
+
+/** @stable */
+export declare function recognize(rootComponentType: Type<any> | null, config: Routes, urlTree: UrlTree, url: string, paramsInheritanceStrategy?: ParamsInheritanceStrategy): Observable<RouterStateSnapshot>;
 
 /** @stable */
 export interface Resolve<T> {
@@ -337,15 +374,29 @@ export declare class RouteConfigLoadStart {
 /** @stable */
 export declare class Router {
     config: Routes;
+    protected configLoader: RouterConfigLoader;
+    protected currentUrlTree: UrlTree;
     errorHandler: ErrorHandler;
-    readonly events: Observable<Event>;
+    events: Subject<Event>;
+    hooks: {
+        beforePreactivation: (snapshot: RouterStateSnapshot) => Observable<void>;
+        afterPreactivation: (snapshot: RouterStateSnapshot) => Observable<void>;
+    };
+    protected lastSuccessfulId: number;
+    protected location: Location;
     navigated: boolean;
+    protected navigationId: number;
+    protected ngModule: NgModuleRef<any>;
     onSameUrlNavigation: 'reload' | 'ignore';
     paramsInheritanceStrategy: 'emptyOnly' | 'always';
+    protected rawUrlTree: UrlTree;
+    protected rootComponentType: Type<any> | null;
+    protected rootContexts: ChildrenOutletContexts;
     routeReuseStrategy: RouteReuseStrategy;
-    readonly routerState: RouterState;
+    routerState: RouterState;
     readonly url: string;
     urlHandlingStrategy: UrlHandlingStrategy;
+    protected urlSerializer: UrlSerializer;
     constructor(rootComponentType: Type<any> | null, urlSerializer: UrlSerializer, rootContexts: ChildrenOutletContexts, location: Location, injector: Injector, loader: NgModuleFactoryLoader, compiler: Compiler, config: Routes);
     createUrlTree(commands: any[], navigationExtras?: NavigationExtras): UrlTree;
     dispose(): void;
@@ -356,6 +407,9 @@ export declare class Router {
     ngOnDestroy(): void;
     parseUrl(url: string): UrlTree;
     resetConfig(config: Routes): void;
+    protected resetStateAndUrl(storedState: RouterState, storedUrl: UrlTree, rawUrl: UrlTree): void;
+    protected resetUrlToCurrentUrlTree(): void;
+    protected runNavigate(url: UrlTree, rawUrl: UrlTree, skipLocationChange: boolean, replaceUrl: boolean, id: number, precreatedState: RouterStateSnapshot | null): Promise<boolean>;
     serializeUrl(url: UrlTree): string;
     setUpLocationChangeListener(): void;
 }
@@ -503,6 +557,14 @@ export declare class RoutesRecognized extends RouterEvent {
 
 /** @experimental */
 export declare type RunGuardsAndResolvers = 'paramsChange' | 'paramsOrQueryParamsChange' | 'always';
+
+/** @stable */
+export declare class TreeNode<T> {
+    children: TreeNode<T>[];
+    value: T;
+    constructor(value: T, children: TreeNode<T>[]);
+    toString(): string;
+}
 
 /** @experimental */
 export declare abstract class UrlHandlingStrategy {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

It is not presently very easy/possible to extend the ng-router due to it using private APIs and types that aren't exported.

## What is the new behavior?
This PR exports the bare minimum apis for extending the router

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
## Other information
I have been chatting with Jason about this PR

Thanks,
Dan