### PR TITLE
fix(common): prevent name collision after minimizing

### DIFF
--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -21,12 +21,12 @@ const XSSI_PREFIX = /^\)\]\}',?\n/;
  * Determine an appropriate URL for the response, by checking either
  * XMLHttpRequest.responseURL or the X-Request-URL header.
  */
-function getResponseUrl(xhr: any): string|null {
-  if ('responseURL' in xhr && xhr.responseURL) {
-    return xhr.responseURL;
+function getResponseUrl(localXhr: any): string|null {
+  if ('responseURL' in localXhr && localXhr.responseURL) {
+    return localXhr.responseURL;
   }
-  if (/^X-Request-URL:/m.test(xhr.getAllResponseHeaders())) {
-    return xhr.getResponseHeader('X-Request-URL');
+  if (/^X-Request-URL:/m.test(localXhr.getAllResponseHeaders())) {
+    return localXhr.getResponseHeader('X-Request-URL');
   }
   return null;
 }


### PR DESCRIPTION
When compiling for production the param in this method collided with a constant defined in the caller method.

This fixes #21948

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Name of a constant is colliding and producing a wrong code after minimized for production

Issue Number: 21948


## What is the new behavior?
There won't be collision and the code produce won't produce an error after minimized

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
