### PR TITLE
fix(core): ensure initial value of QueryList length

### DIFF
--- a/packages/core/src/linker/query_list.ts
+++ b/packages/core/src/linker/query_list.ts
@@ -41,7 +41,7 @@ export class QueryList<T>/* implements Iterable<T> */ {
   private _results: Array<T> = [];
   public readonly changes: Observable<any> = new EventEmitter();
 
-  readonly length: number;
+  readonly length: number = 0;
   readonly first: T;
   readonly last: T;
 

--- a/packages/core/test/linker/query_list_spec.ts
+++ b/packages/core/test/linker/query_list_spec.ts
@@ -23,6 +23,22 @@ import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
     function logAppend(item: any /** TODO #9100 */) { log += (log.length == 0 ? '' : ', ') + item; }
 
+    describe('dirty and reset', () => {
+
+      it('should initially be dirty and empty', () => {
+        expect(queryList.dirty).toBeTruthy();
+        expect(queryList.length).toBe(0);
+      });
+
+      it('should be not dirty after reset', () => {
+        expect(queryList.dirty).toBeTruthy();
+        queryList.reset(['one', 'two']);
+        expect(queryList.dirty).toBeFalsy();
+        expect(queryList.length).toBe(2);
+      });
+
+    });
+
     it('should support resetting and iterating over the new objects', () => {
       queryList.reset(['one']);
       queryList.reset(['two']);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #21980


## What is the new behavior?
Length has been initialized to `0`, which would have been the initial value returned by `get length()` before it was refactored in https://github.com/angular/angular/commit/e54474215629aa6a0e0497fe61bfc896cea532c9#diff-a85dbe0991a7577ea24b49374e9ae90b.

Closes #21980.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
