### PR TITLE
build(aio): add API static members to search index

### DIFF
--- a/aio/e2e/search.e2e-spec.ts
+++ b/aio/e2e/search.e2e-spec.ts
@@ -1,0 +1,28 @@
+import { SitePage } from './app.po';
+
+describe('site search', () => {
+  let page;
+
+  beforeEach(() => {
+    page = new SitePage();
+    page.navigateTo('');
+  });
+
+  it('should find pages when searching by a partial word in the title', () => {
+    page.enterSearch('ngCont');
+    expect(page.getSearchResults()).toContain('NgControl');
+
+    page.enterSearch('accessor');
+    expect(page.getSearchResults()).toContain('ControlValueAccessor');
+  });
+
+  it('should find API docs whose instance member name matches the search query', () => {
+    page.enterSearch('decode');
+    expect(page.getSearchResults()).toContain('HttpParameterCodec');
+  });
+
+  it('should find API docs whose static method name matches the search query', () => {
+    page.enterSearch('compose');
+    expect(page.getSearchResults()).toContain('Validators');
+  });
+});

--- a/aio/tests/e2e/app.e2e-spec.ts
+++ b/aio/tests/e2e/app.e2e-spec.ts
@@ -115,18 +115,6 @@ describe('site App', function() {
     });
   });
 
-  describe('search', () => {
-    it('should find pages when searching by a partial word in the title', () => {
-      page.navigateTo('');
-
-      page.enterSearch('ngCont');
-      expect(page.getSearchResults()).toContain('NgControl');
-
-      page.enterSearch('accessor');
-      expect(page.getSearchResults()).toContain('ControlValueAccessor');
-    });
-  });
-
   describe('404 page', () => {
     it('should add or remove the "noindex" meta tag depending upon the validity of the page', () => {
       page.navigateTo('');

--- a/aio/tools/transforms/angular-base-package/processors/generateKeywords.js
+++ b/aio/tools/transforms/angular-base-package/processors/generateKeywords.js
@@ -97,7 +97,7 @@ module.exports = function generateKeywordsProcessor(log, readFilesProcessor) {
 
           // Special case properties that contain content relating to "members"
           // of a doc that represents, say, a class or interface
-          if (key === 'methods' || key === 'properties' || key === 'events') {
+          if (key === 'members' || key === 'statics') {
             value.forEach(function(member) { extractWords(member.name, members, membersMap); });
           }
         });

--- a/aio/tools/transforms/angular-base-package/processors/generateKeywords.spec.js
+++ b/aio/tools/transforms/angular-base-package/processors/generateKeywords.spec.js
@@ -98,6 +98,36 @@ describe('generateKeywords processor', () => {
     expect(keywordsDoc.data[0].headingWords).toEqual('heading important secondary');
   });
 
+  it('should add member doc properties to the search terms', () => {
+    const processor = processorFactory(mockLogger, mockReadFilesProcessor);
+    const docs = [
+      {
+        docType: 'class',
+        name: 'PublicExport',
+        searchTitle: 'class PublicExport',
+        vFile: { headings: { h2: ['heading A'] } },
+        content: 'Some content with ngClass in it.',
+        members: [
+          { name: 'instanceMethodA' },
+          { name: 'instancePropertyA' },
+          { name: 'instanceMethodB' },
+          { name: 'instancePropertyB' },
+        ],
+        statics: [
+          { name: 'staticMethodA' },
+          { name: 'staticPropertyA' },
+          { name: 'staticMethodB' },
+          { name: 'staticPropertyB' },
+        ],
+      },
+    ];
+    processor.$process(docs);
+    const keywordsDoc = docs[docs.length - 1];
+    expect(keywordsDoc.data[0].members).toEqual(
+      'instancemethoda instancemethodb instancepropertya instancepropertyb staticmethoda staticmethodb staticpropertya staticpropertyb'
+    );
+  });
+
   it('should process terms prefixed with "ng" to include the term stripped of "ng"', () => {
     const processor = processorFactory(mockLogger, mockReadFilesProcessor);
     const docs = [


### PR DESCRIPTION
Previously searching for `compose` did not include `Validators`
in the search results because we were not including all the
static members in the index.

