### PR TITLE
feat(aio): dynamically, pre-emptively, add `noindex`

### DIFF
--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -31,6 +31,14 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="translucent">
 
+  <script>
+    // Dynamically, pre-emptively, add `noindex`, which will be removed when the doc is ready and valid
+    var tag = document.createElement('meta'); tag.name = 'googlebot'; tag.content = 'noindex';
+    document.head.appendChild(tag);
+    tag = document.createElement('meta'); tag.name = 'robots'; tag.content = 'noindex';
+    document.head.appendChild(tag);
+  </script>
+
   <!-- Google Analytics -->
   <script>
   // Note this is a customised version of the GA tracking snippet


### PR DESCRIPTION
These tags are removed when the doc is ready and valid, but this will
allow us to block indexing in the case that the Angular app fails to
bootstrap or load the document for some non-404 reason.

This should get around the problem with hardcoded tags. See
https://github.com/angular/angular/commit/c3fb820473d64036ef0dd3d4c004cc7fbc67be75

Closes #21941