### PR TITLE
fix(forms): for option elements without parent select control value accessor do not set value of native element

### DIFF
--- a/packages/forms/src/directives/select_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_control_value_accessor.ts
@@ -186,8 +186,10 @@ export class NgSelectOption implements OnDestroy {
 
   @Input('value')
   set value(value: any) {
-    this._setElementValue(value);
-    if (this._select) this._select.writeValue(this._select.value);
+    if (this._select) {
+      this._setElementValue(value);
+      this._select.writeValue(this._select.value);
+    }
   }
 
   /** @internal */

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -8,7 +8,7 @@
 
 import {Component, Directive, EventEmitter, Input, Output, Type} from '@angular/core';
 import {ComponentFixture, TestBed, async, fakeAsync, tick} from '@angular/core/testing';
-import {AbstractControl, ControlValueAccessor, FormControl, FormGroup, FormsModule, NG_VALIDATORS, NG_VALUE_ACCESSOR, NgControl, NgForm, NgModel, ReactiveFormsModule, Validators} from '@angular/forms';
+import {AbstractControl, ControlValueAccessor, FormControl, FormGroup, FormsModule, NG_VALIDATORS, NG_VALUE_ACCESSOR, NgControl, NgForm, NgModel, NgSelectOption, ReactiveFormsModule, Validators} from '@angular/forms';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
 
@@ -402,6 +402,20 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
       });
 
+      it(`options without parent select control value accessor should not set the element's value`,
+         () => {
+           if (isNode) return;
+           const fixture = initTest(OptionWithoutSelectFormControl);
+           fixture.detectChanges();
+
+           const sfOption = fixture.debugElement.query(By.css('option'));
+
+           const sfOptionDirective = sfOption.injector.get(NgSelectOption);
+           expect(sfOption.nativeElement.value).toEqual('SF');
+
+           sfOptionDirective.value = 'NY';
+           expect(sfOption.nativeElement.value).toEqual('SF');
+         });
     });
 
     describe('select multiple controls', () => {
@@ -1271,6 +1285,20 @@ class NgModelSelectMultipleWithCustomCompareFnForm {
 class NgModelSelectMultipleForm {
   selectedCities: any[];
   cities: any[] = [];
+}
+
+@Component({
+  selector: 'option-without-select-form-control',
+  template: `
+    <div [formGroup]="form">
+      <select>
+        <option [value]="city"></option>
+      </select>
+    </div>`
+})
+class OptionWithoutSelectFormControl {
+  city = 'SF';
+  form = new FormGroup({});
 }
 
 @Component({


### PR DESCRIPTION
fix(forms): for option elements without parent select control value accessor do not set value of
native element

The NgSelectOption directive should only perform any actions if the corresponding option is used
in the context of an @angular/forms form as to not interfere with other libraries that interact with
option elements.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `NgSelectOption` directive of the `forms` package is always applied to `option` elements regardless of whether they are used in a corresponding form. In its `value` binding it unconditionally sets the `value` attribute of the underlying native element, i.e. even if the `option` is not used as part of a form the `value` will be set. Every other code in that directive that performs any action is protected by a guard that checks for the presence of parent select control value accessor.

This behaviour leads to issues when any of the forms modules are imported in a module that uses another library or custom directive which interacts with the `value` attribute of the native element (see [this issue](https://github.com/MrWolfZ/ngrx-forms/issues/32) as an example for how this behavior interferes with my `ngrx-forms` library).

Issue Number: N/A

## What is the new behavior?
The new behavior is to extend the guard that checks for the presence of parent select control value accessor to also prevent the directive from modifying the native element's value if no accessor is present.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
