### PR TITLE
docs: fix minor error for sample and add detailed docs for reactive form

### DIFF
--- a/aio/content/examples/reactive-forms/src/app/hero-detail/hero-detail-7.component.ts
+++ b/aio/content/examples/reactive-forms/src/app/hero-detail/hero-detail-7.component.ts
@@ -59,8 +59,10 @@ export class HeroDetailComponent7 implements OnChanges {
     this.heroForm.setValue({
       name:    this.hero.name,
       // #docregion set-value-address
-      address: this.hero.addresses[0] || new Address()
+      address: this.hero.addresses[0] || new Address(),
       // #enddocregion set-value-address
+      power: '',
+      sidekick: ''
     });
     // #enddocregion set-value
   }

--- a/aio/content/examples/reactive-forms/src/app/hero-detail/hero-detail-8.component.ts
+++ b/aio/content/examples/reactive-forms/src/app/hero-detail/hero-detail-8.component.ts
@@ -49,7 +49,7 @@ export class HeroDetailComponent8 implements OnChanges {
   // #docregion get-secret-lairs
   get secretLairs(): FormArray {
     return this.heroForm.get('secretLairs') as FormArray;
-  };
+  }
   // #enddocregion get-secret-lairs
 
   // #docregion set-addresses


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```


## What is the new behavior?

Add detailed information to reactive form. Which I think better to have when I read the document.

- update document for `setValue` code sample, current sample will report error, because `power` and `sidekick` is missing`.
- remove a additional `;` in `aio/content/examples/reactive-forms/src/app/hero-detail/hero-detail-8.component.ts` which will trigger `tslint` error.
- add code sample to explain `setValue` missing property error.
- add document and code sample to explain `reset` behavior`.
  - if the control is a `FormControl` and the `reset value` is not specified, the value will be reset to `null`.
  - if the control is a `FormArray` and the `reset value` is not specified, the value will be reset to `empty array`.
- add code sample to explain `setValue/patchValue/reset` to `FormArray`.

Please review, thank you!