### PR TITLE
fix(core): fix proper propagation of subscriptions in EventEmitter

### DIFF
--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -7,6 +7,7 @@
  */
 
 import {Subject} from 'rxjs/Subject';
+import {Subscription} from 'rxjs/Subscription';
 
 /**
  * Use by directives and components to emit custom Events.
@@ -111,6 +112,12 @@ export class EventEmitter<T> extends Subject<T> {
       }
     }
 
-    return super.subscribe(schedulerFn, errorFn, completeFn);
+    const sink = super.subscribe(schedulerFn, errorFn, completeFn);
+
+    if (generatorOrNext instanceof Subscription) {
+      generatorOrNext.add(sink);
+    }
+
+    return sink;
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #21999

Live demo: https://stackblitz.com/edit/angular-9kvrfk?file=src/app/app.component.ts

Right now the `EventEmitter` class doesn't properly remove observers when not subscribing directly to `EventEmitter` and using an intermediate `Subscription` object. In other words when chaining `EventEmitter` with any operator that internally creates a `Subscription` object the `EventEmitter` isn't able to unsubscribe it properly by calling its teardown function.

This can be seen in the two following examples:

```
const ee = new EventEmitter();
ee.pipe(map(() => true)).subscribe().unsubscribe(); // can any other operator
console.log('EventEmitter', ee.observers.length); // 1 - wrong, should be 0

// This simulates `FilterSubscriber` or `MapSubscriber`
const subscriber = new Subscriber(val => {});
subscriber.add(() => console.log('Subscriber disposed')); // This is never called - wrong

const ee2 = new EventEmitter();
ee2.subscribe(subscriber).unsubscribe();
console.log('EventEmitter - Subscriber', ee2.observers.length); // 0
// This did unsubscribe because we're holding the direct `Subscription` for `EventEmitter`
// but didn't trigger the teardown function. The teardown function is
// where it unsubscribes from its parent in `FilterSubscriber` or `MapSubscriber`.
```

For example if I take the first example with just `ee.pipe(map(() => true)).subscribe().unsubscribe();` it should work just like it does with the original `Subject` from RxJS 5.5:

```
const s = new Subject();
s.pipe(map(() => true)).subscribe().unsubscribe();
console.log(s.observers.length); // 0 - correct
```

I described it in more detail in https://github.com/angular/angular/issues/21999#issuecomment-362921475 but basically the problem is that the `EventEmitter` creates functions `schedulerFn`, `errorFn` and `completeFn` that are inside `super.subscribe()` wrapped with another `Subscription` object which is then returned.

However it never "connects" the original `generatorOrNext` (which is `Subscription` object itself) with the new `Subscription` returned from `super.subscribe()`.

## What is the new behavior?

Properly calls teardown functions from the original `Subscription`. The following tests would fail without this PR:

```
it('remove a subscriber subscribed after applying operators with pipe()', () => {
  const sub = emitter.pipe(filter(() => true)).subscribe();
  expect(emitter.observers.length).toBe(1);
  sub.unsubscribe();
  expect(emitter.observers.length).toBe(0);
});

it('error thrown inside an Rx chain propagates to the error handler and disposes the chain',
   () => {
     let errorPropagated = false;
     emitter.pipe(filter(() => { throw new Error(); }), )
         .subscribe(() => {}, err => errorPropagated = true, );

     emitter.next(1);

     expect(errorPropagated).toBe(true);
     expect(emitter.observers.length).toBe(0);
   });
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
## Other information

Closes #21999