### PR TITLE
feat(core): turn whitespace removal on by default

### DIFF
--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -46,6 +46,6 @@ export class CompilerConfig {
 }
 
 export function preserveWhitespacesDefault(
-    preserveWhitespacesOption: boolean | null, defaultSetting = true): boolean {
+    preserveWhitespacesOption: boolean | null, defaultSetting = false): boolean {
   return preserveWhitespacesOption === null ? defaultSetting : preserveWhitespacesOption;
 }

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -192,8 +192,8 @@ class TestApp {
       fixture = TestBed.createComponent(ParentComp);
       fixture.detectChanges();
 
-      // The root component has 3 elements and 2 text node children.
-      expect(fixture.debugElement.childNodes.length).toEqual(5);
+      // The root component has 3 elements and 2 text node whitespace children.
+      expect(fixture.debugElement.childNodes.length).toEqual(3);
     });
 
     it('should list all component child elements', () => {

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -1280,7 +1280,7 @@ function declareTests({useJit}: {useJit: boolean}) {
         fixture.detectChanges();
         expect(fixture.nativeElement)
             .toHaveText(
-                'Default Interpolation\nCustom Interpolation A\nCustom Interpolation B (Default Interpolation)');
+                'Default InterpolationCustom Interpolation ACustom Interpolation B (Default Interpolation)');
       });
     });
 
@@ -1781,7 +1781,7 @@ function declareTests({useJit}: {useJit: boolean}) {
     });
 
     describe('whitespaces in templates', () => {
-      it('should not remove whitespaces by default', async(() => {
+      it('should remove whitespaces by default', async(() => {
            @Component({
              selector: 'comp',
              template: '<span>foo</span>  <span>bar</span>',
@@ -1792,7 +1792,7 @@ function declareTests({useJit}: {useJit: boolean}) {
            const f = TestBed.configureTestingModule({declarations: [MyCmp]}).createComponent(MyCmp);
            f.detectChanges();
 
-           expect(f.nativeElement.childNodes.length).toBe(3);
+           expect(f.nativeElement.childNodes.length).toBe(2);
          }));
 
       it('should not remove whitespaces when explicitly requested not to do so', async(() => {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1618,20 +1618,20 @@ describe('Integration', () => {
 
          router.navigateByUrl('/');
          advance(fixture);
-         expect(fixture.nativeElement).toHaveText(' ');
+         expect(fixture.nativeElement).toHaveText('-');
          const cmp = fixture.componentInstance;
 
          cmp.show = true;
          advance(fixture);
 
-         expect(fixture.nativeElement).toHaveText('link ');
+         expect(fixture.nativeElement).toHaveText('link-');
          const native = fixture.nativeElement.querySelector('a');
 
          expect(native.getAttribute('href')).toEqual('/simple');
          native.click();
          advance(fixture);
 
-         expect(fixture.nativeElement).toHaveText('link simple');
+         expect(fixture.nativeElement).toHaveText('link-simple');
        })));
 
     it('should support query params and fragments',
@@ -4031,7 +4031,7 @@ class RouteCmp {
 @Component({
   selector: 'link-cmp',
   template:
-      `<div *ngIf="show"><a [routerLink]="['./simple']">link</a></div> <router-outlet></router-outlet>`
+      `<div *ngIf="show"><a [routerLink]="['./simple']">link</a></div>-<router-outlet></router-outlet>`
 })
 class RelativeLinkInIfCmp {
   show: boolean = false;


### PR DESCRIPTION
BREAKING CHANGE:

The defalut value for `preserveWhitespaces` has change from `true` to `false`. In most cases this should have no impact other than smaller payload. In some circumstances it may cause the render text to be missing space between words. For example: `<span>Hello</span> <span>World</span>` would
have the whitespace removed which would render as `HelloWorld`. For this reason the change is marked as breaking.

To fix the above situation there are two options:
- Revert to preserve whitespace `@Component({preserveWhitespaces: true})`.
- Manually insert non removable space `&ngsp;` (ng-space) into template: `<span>Hello</span>&ngsp;<span>World</span>`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[X] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
