### PR TITLE
fix(aio): do not rewrite /styleguide URL in Service Worker

### DIFF
--- a/aio/ngsw-manifest.json
+++ b/aio/ngsw-manifest.json
@@ -19,7 +19,7 @@
   "routing": {
     "index": "/index.html",
     "routes": {
-      "^(?!/docs/.|(?:/guide/(?:cli-quickstart|metadata|ngmodule|service-worker-(?:getstart|comm|configref)|learning-angular)|/news)(?:\\.html|/)?$|/testing|/api/(?:.+/[^/]+-|platform-browser/AnimationDriver|testing|api/|(?:common/(?:NgModel|Control|MaxLengthValidator))|(?:[^/]+/)?(?:NgFor(?:$|-)|AnimationStateDeclarationMetadata|CORE_DIRECTIVES|PLATFORM_PIPES|DirectiveMetadata|HTTP_PROVIDERS))|.*/stackblitz(?:\\.html)?$|.*\\.[^\/.]+$)": {
+      "^(?!/styleguide|/docs/.|(?:/guide/(?:cli-quickstart|metadata|ngmodule|service-worker-(?:getstart|comm|configref)|learning-angular)|/news)(?:\\.html|/)?$|/testing|/api/(?:.+/[^/]+-|platform-browser/AnimationDriver|testing|api/|(?:common/(?:NgModel|Control|MaxLengthValidator))|(?:[^/]+/)?(?:NgFor(?:$|-)|AnimationStateDeclarationMetadata|CORE_DIRECTIVES|PLATFORM_PIPES|DirectiveMetadata|HTTP_PROVIDERS))|.*/stackblitz(?:\\.html)?$|.*\\.[^\/.]+$)": {
         "match": "regex"
       }
     }

--- a/aio/tests/deployment/URLS_TO_REDIRECT.txt
+++ b/aio/tests/deployment/URLS_TO_REDIRECT.txt
@@ -150,6 +150,7 @@
 /docs/js/latest/guide/ngmodule	/guide/ngmodules
 /docs/js/latest/resources	/resources
 /docs/latest/tutorial	/tutorial
+/styleguide	/guide/styleguide
 /docs/styleguide	/guide/styleguide
 /docs/styleguide.html	/guide/styleguide
 /docs/ts/latest/api/core/HostBinding-var.html	/api/core/HostBinding


### PR DESCRIPTION
This URL needs to be redirected via the server, so
we must exclude it from being rewitten.

Closes #22078