### PR TITLE
feat(core): `SimpleChange` and `SimpleChanges` now accepts `T` as arg…

### DIFF
--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -130,7 +130,7 @@ export class NgForOf<T> implements DoCheck, OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     if ('ngForOf' in changes) {
       // React on ngForOf changes only once all inputs have been initialized
-      const value = changes['ngForOf'].currentValue;
+      const value = changes['ngForOf'] !.currentValue;
       if (!this._differ && value) {
         try {
           this._differ = this._differs.find(value).create(this.ngForTrackBy);

--- a/packages/common/src/directives/ng_template_outlet.ts
+++ b/packages/common/src/directives/ng_template_outlet.ts
@@ -73,7 +73,8 @@ export class NgTemplateOutlet implements OnChanges {
    */
   private _shouldRecreateView(changes: SimpleChanges): boolean {
     const ctxChange = changes['ngTemplateOutletContext'];
-    return !!changes['ngTemplateOutlet'] || (ctxChange && this._hasContextShapeChanged(ctxChange));
+    return !!changes['ngTemplateOutlet'] ||
+        (!!ctxChange && this._hasContextShapeChanged(ctxChange));
   }
 
   private _hasContextShapeChanged(ctxChange: SimpleChange): boolean {

--- a/packages/core/src/change_detection/change_detection_util.ts
+++ b/packages/core/src/change_detection/change_detection_util.ts
@@ -66,8 +66,8 @@ export class WrappedValue {
  * Represents a basic change from a previous to a new value.
  *
  */
-export class SimpleChange {
-  constructor(public previousValue: any, public currentValue: any, public firstChange: boolean) {}
+export class SimpleChange<P = any, C = P> {
+  constructor(public previousValue: P, public currentValue: C, public firstChange: boolean) {}
 
   /**
    * Check whether the new value is the first value assigned.

--- a/packages/core/src/metadata/lifecycle_hooks.ts
+++ b/packages/core/src/metadata/lifecycle_hooks.ts
@@ -14,7 +14,9 @@ import {SimpleChange} from '../change_detection/change_detection_util';
  * values are instances of {@link SimpleChange}. See {@link OnChanges}
  *
  */
-export interface SimpleChanges { [propName: string]: SimpleChange; }
+export type SimpleChanges<T = any> = {
+  [P in keyof T]?: SimpleChange<T[P]>;
+};
 
 /**
  * @usageNotes

--- a/packages/core/test/render3/define_spec.ts
+++ b/packages/core/test/render3/define_spec.ts
@@ -23,8 +23,8 @@ describe('define', () => {
           ngDoCheck(): void { this.log.push('ngDoCheck'); }
           ngOnChanges(changes: SimpleChanges): void {
             this.log.push('ngOnChanges');
-            this.log.push('valA', changes['valA'].previousValue, changes['valA'].currentValue);
-            this.log.push('valB', changes['valB'].previousValue, changes['valB'].currentValue);
+            this.log.push('valA', changes['valA'] !.previousValue, changes['valA'] !.currentValue);
+            this.log.push('valB', changes['valB'] !.previousValue, changes['valB'] !.currentValue);
           }
 
           static ngDirectiveDef = defineDirective({

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -258,9 +258,9 @@ function expectSimpleChanges(actual: SimpleChanges, expected: SimpleChanges) {
   Object.keys(expected).forEach(key => {
     expect(actual[key]).toBeTruthy(`Change should have included key ${key}`);
     if (actual[key]) {
-      expect(actual[key].previousValue).toBe(expected[key].previousValue);
-      expect(actual[key].currentValue).toBe(expected[key].currentValue);
-      expect(actual[key].firstChange).toBe(expected[key].firstChange);
+      expect(actual[key] !.previousValue).toBe(expected[key] !.previousValue);
+      expect(actual[key] !.currentValue).toBe(expected[key] !.currentValue);
+      expect(actual[key] !.firstChange).toBe(expected[key] !.firstChange);
     }
   });
 }

--- a/packages/examples/core/ts/metadata/lifecycle_hooks_spec.ts
+++ b/packages/examples/core/ts/metadata/lifecycle_hooks_spec.ts
@@ -119,7 +119,7 @@ import {TestBed} from '@angular/core/testing';
       expect(log.length).toBe(1);
       expect(log[0][0]).toBe('ngOnChanges');
       const changes: SimpleChanges = log[0][1][0];
-      expect(changes['prop'].currentValue).toBe(true);
+      expect(changes['prop'] !.currentValue).toBe(true);
     });
   });
 

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -257,7 +257,7 @@ export class NgModel extends NgControl implements OnChanges,
               }
 
               private _updateDisabled(changes: SimpleChanges) {
-                const disabledValue = changes['isDisabled'].currentValue;
+                const disabledValue = changes['isDisabled'] !.currentValue;
 
                 const isDisabled =
                     disabledValue === '' || (disabledValue && disabledValue !== 'false');

--- a/packages/upgrade/src/dynamic/upgrade_ng1_adapter.ts
+++ b/packages/upgrade/src/dynamic/upgrade_ng1_adapter.ts
@@ -230,7 +230,7 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
   ngOnChanges(changes: SimpleChanges) {
     const ng1Changes: any = {};
     Object.keys(changes).forEach(name => {
-      const change: SimpleChange = changes[name];
+      const change: SimpleChange = changes[name] !;
       this.setComponentProperty(name, change.currentValue);
       ng1Changes[this.propertyMap[name]] = change;
     });

--- a/packages/upgrade/src/static/upgrade_component.ts
+++ b/packages/upgrade/src/static/upgrade_component.ts
@@ -289,7 +289,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
   private forwardChanges(changes: SimpleChanges) {
     // Forward input changes to `bindingDestination`
     Object.keys(changes).forEach(
-        propName => this.bindingDestination[propName] = changes[propName].currentValue);
+        propName => this.bindingDestination[propName] = changes[propName] !.currentValue);
 
     if (isFunction(this.bindingDestination.$onChanges)) {
       this.bindingDestination.$onChanges(changes);

--- a/packages/upgrade/test/dynamic/upgrade_spec.ts
+++ b/packages/upgrade/test/dynamic/upgrade_spec.ts
@@ -233,14 +233,15 @@ withEachNg1Version(() => {
              constructor(private zone: NgZone) {}
 
              ngOnChanges(changes: SimpleChanges) {
-               if (changes['value'].isFirstChange()) return;
+               if (changes['value'] !.isFirstChange()) return;
 
                this.zone.onMicrotaskEmpty.subscribe(() => {
                  expect(element.textContent).toEqual('5');
                  upgradeRef.dispose();
                });
 
-               Promise.resolve().then(() => this.valueFromPromise = changes['value'].currentValue);
+               Promise.resolve().then(
+                   () => this.valueFromPromise = changes['value'] !.currentValue);
              }
            }
 
@@ -363,7 +364,7 @@ withEachNg1Version(() => {
                  if (!changes[prop]) {
                    throw new Error(`Changes record for '${prop}' not found.`);
                  }
-                 const actValue = changes[prop].currentValue;
+                 const actValue = changes[prop] !.currentValue;
                  if (actValue != value) {
                    throw new Error(
                        `Expected changes record for'${prop}' to be '${value}' but was '${actValue}'`);
@@ -451,11 +452,11 @@ withEachNg1Version(() => {
              ngOnChanges(changes: SimpleChanges) {
                switch (this.ngOnChangesCount++) {
                  case 0:
-                   expect(changes.model.currentValue).toBe('world');
+                   expect(changes.model !.currentValue).toBe('world');
                    this.modelChange.emit('newC');
                    break;
                  case 1:
-                   expect(changes.model.currentValue).toBe('newC');
+                   expect(changes.model !.currentValue).toBe('newC');
                    break;
                  default:
                    throw new Error('Called too many times! ' + JSON.stringify(changes));
@@ -506,7 +507,7 @@ withEachNg1Version(() => {
                  this.initialValue = this.foo;
                }
 
-               if (changes['foo'] && changes['foo'].isFirstChange()) {
+               if (changes['foo'] && changes['foo'] !.isFirstChange()) {
                  this.firstChangesCount++;
                }
              }

--- a/packages/upgrade/test/static/integration/change_detection_spec.ts
+++ b/packages/upgrade/test/static/integration/change_detection_spec.ts
@@ -96,12 +96,12 @@ withEachNg1Version(() => {
            constructor(private zone: NgZone) {}
 
            ngOnChanges(changes: SimpleChanges) {
-             if (changes['value'].isFirstChange()) return;
+             if (changes['value'] !.isFirstChange()) return;
 
              this.zone.onMicrotaskEmpty.subscribe(
                  () => { expect(element.textContent).toEqual('5'); });
 
-             Promise.resolve().then(() => this.valueFromPromise = changes['value'].currentValue);
+             Promise.resolve().then(() => this.valueFromPromise = changes['value'] !.currentValue);
            }
          }
 

--- a/packages/upgrade/test/static/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/test/static/integration/downgrade_component_spec.ts
@@ -73,7 +73,7 @@ withEachNg1Version(() => {
                if (!changes[prop]) {
                  throw new Error(`Changes record for '${prop}' not found.`);
                }
-               const actualValue = changes[prop].currentValue;
+               const actualValue = changes[prop] !.currentValue;
                if (actualValue != value) {
                  throw new Error(
                      `Expected changes record for'${prop}' to be '${value}' but was '${actualValue}'`);
@@ -209,11 +209,11 @@ withEachNg1Version(() => {
            ngOnChanges(changes: SimpleChanges) {
              switch (this.ngOnChangesCount++) {
                case 0:
-                 expect(changes.model.currentValue).toBe('world');
+                 expect(changes.model !.currentValue).toBe('world');
                  this.modelChange.emit('newC');
                  break;
                case 1:
-                 expect(changes.model.currentValue).toBe('newC');
+                 expect(changes.model !.currentValue).toBe('newC');
                  break;
                default:
                  throw new Error('Called too many times! ' + JSON.stringify(changes));
@@ -428,7 +428,7 @@ withEachNg1Version(() => {
                this.initialValue = this.foo;
              }
 
-             if (changes['foo'] && changes['foo'].isFirstChange()) {
+             if (changes['foo'] && changes['foo'] !.isFirstChange()) {
                this.firstChangesCount++;
              }
            }

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -794,17 +794,17 @@ export interface SelfDecorator {
 /** @experimental */
 export declare function setTestabilityGetter(getter: GetTestability): void;
 
-export declare class SimpleChange {
-    currentValue: any;
+export declare class SimpleChange<P = any, C = P> {
+    currentValue: C;
     firstChange: boolean;
-    previousValue: any;
-    constructor(previousValue: any, currentValue: any, firstChange: boolean);
+    previousValue: P;
+    constructor(previousValue: P, currentValue: C, firstChange: boolean);
     isFirstChange(): boolean;
 }
 
-export interface SimpleChanges {
-    [propName: string]: SimpleChange;
-}
+export declare type SimpleChanges<T = any> = {
+    [P in keyof T]?: SimpleChange<T[P]>;
+};
 
 export declare const SkipSelf: SkipSelfDecorator;
 


### PR DESCRIPTION
Following the high request for this feature I have re-created the PR.

`SimpleChange` class now requires a `T` argument

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
