### PR TITLE
build(bazel): allow ng_modules to elide .ngsummary.closure.js files

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -57,7 +57,8 @@ def _expected_outs(ctx):
     else:
       continue
 
-    closure_js = [f.replace(".js", ".closure.js") for f in devmode_js]
+    filter_summaries = ctx.attr.filter_summaries
+    closure_js = [f.replace(".js", ".closure.js") for f in devmode_js if not filter_summaries or not f.endswith(".ngsummary.js")]
     declarations = [f.replace(".js", ".d.ts") for f in devmode_js]
 
     devmode_js_files += [ctx.new_file(ctx.bin_dir, basename + ext) for ext in devmode_js]
@@ -281,6 +282,8 @@ NG_MODULE_ATTRIBUTES = {
     "factories": attr.label_list(
         allow_files = [".ts", ".html"],
         mandatory = False),
+
+    "filter_summaries": attr.bool(default = False),
 
     "type_check": attr.bool(default = True),
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Build related changes
```

## What is the current behavior?

ngsummary.closure.js files are always emitted and are part of the es6 output.

## What is the new behavior?

Allows filtering out .ngsummary.closure.js files from output if the summaries are not being used for production.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
