### PR TITLE
fix(core): add stacktrace in log when error during cleanup component in TestBed

### DIFF
--- a/packages/core/test/linker/jit_summaries_integration_spec.ts
+++ b/packages/core/test/linker/jit_summaries_integration_spec.ts
@@ -9,7 +9,7 @@
 import {ResourceLoader} from '@angular/compiler';
 import {CompileMetadataResolver} from '@angular/compiler/src/metadata_resolver';
 import {MockResourceLoader} from '@angular/compiler/testing/src/resource_loader_mock';
-import {Component, Directive, Injectable, NgModule, Pipe, Type} from '@angular/core';
+import {Component, Directive, Injectable, NgModule, OnDestroy, Pipe, Type} from '@angular/core';
 import {TestBed, async, getTestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
@@ -56,6 +56,10 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
       constructor(service: SomeService) {}
     }
 
+    @Component({template: ''})
+    class TestCompErrorOnDestroy implements OnDestroy {
+      ngOnDestroy() {}
+    }
 
     function resetTestEnvironmentWithSummaries(summaries?: () => any[]) {
       const {platform, ngModule} = getTestBed();
@@ -206,6 +210,31 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
       expect(() => TestBed.overrideModule(SomeModule, {add: {}}).compileComponents())
           .toThrowError('SomeModule was AOT compiled, so its metadata cannot be changed.');
     });
+
+    it('should return stack trace and component data on resetTestingModule when error is thrown',
+       () => {
+         resetTestEnvironmentWithSummaries();
+
+         const fixture = TestBed.configureTestingModule({declarations: [TestCompErrorOnDestroy]})
+                             .createComponent<TestCompErrorOnDestroy>(TestCompErrorOnDestroy);
+
+         const expectedError = 'Error from ngOnDestroy';
+
+         const component: TestCompErrorOnDestroy = fixture.componentInstance;
+
+         spyOn(console, 'error');
+         spyOn(component, 'ngOnDestroy').and.throwError(expectedError);
+
+         const expectedObject = {
+           stacktrace: new Error(expectedError),
+           component,
+         };
+
+         TestBed.resetTestingModule();
+
+         expect(console.error)
+             .toHaveBeenCalledWith('Error during cleanup of component', expectedObject);
+       });
 
     it('should allow to add summaries via configureTestingModule', () => {
       resetTestEnvironmentWithSummaries();

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -287,7 +287,10 @@ export class TestBed implements Injector {
       try {
         fixture.destroy();
       } catch (e) {
-        console.error('Error during cleanup of component', fixture.componentInstance);
+        console.error('Error during cleanup of component', {
+          component: fixture.componentInstance,
+          stacktrace: e,
+        });
       }
     });
     this._activeFixtures = [];


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The current behavior is that when, using TestBed, a fixture failed to be destroyed, it logs an error 'Error during cleanup of component' with the component name and properties. But this error comes from a try/catch and doesn't send the real error cause to the user.

Issue Number: #17013


## What is the new behavior?
The new behavior consists in adding the root cause error stacktrace to the log. So the user is able to identify the real cause of the 'Error during cleanup component' log. 


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information

Done with @mbreton