### PR TITLE
fix(common): weaken AsyncPipe transform signature

### DIFF
--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -85,8 +85,8 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
 
   transform<T>(obj: null): null;
   transform<T>(obj: undefined): undefined;
-  transform<T>(obj: Observable<T>): T|null;
-  transform<T>(obj: Promise<T>): T|null;
+  transform<T>(obj: Observable<T>|null|undefined): T|null;
+  transform<T>(obj: Promise<T>|null|undefined): T|null;
   transform(obj: Observable<any>|Promise<any>|null|undefined): any {
     if (!this._obj) {
       if (obj) {

--- a/packages/compiler-cli/test/diagnostics/check_types_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/check_types_spec.ts
@@ -620,12 +620,12 @@ describe('ng type checker', () => {
     });
   });
 
-  describe('regressions ', () => {
+  describe('core', () => {
     const a = (files: MockFiles, options: ng.AngularCompilerOptions = {}) => {
       accept(files, {fullTemplateTypeCheck: true, ...options});
     };
 
-    // #19905
+    // Regression #19905
     it('should accept an event binding', () => {
       a({
         'src/app.component.ts': '',
@@ -649,6 +649,38 @@ describe('ng type checker', () => {
 
         @NgModule({
           declarations: [MainComp, SomeDirective],
+        })
+        export class MainModule {}`
+      });
+    });
+  });
+
+  describe('common', () => {
+    const a = (files: MockFiles, options: ng.AngularCompilerOptions = {}) => {
+      accept(files, {fullTemplateTypeCheck: true, ...options});
+    };
+
+    // Regression #19905
+    it('should accept a |undefined or |null parameter for async_pipe', () => {
+      a({
+        'src/app.component.ts': '',
+        'src/lib.ts': '',
+        'src/app.module.ts': `
+        import {NgModule, Component} from '@angular/core';
+        import {CommonModule} from '@angular/common';
+
+        @Component({
+          selector: 'comp',
+          template: '<div>{{ name | async}}</div>'
+        })
+        export class MainComp {
+          name: Promise<string>|undefined;
+        }
+
+
+        @NgModule({
+          declarations: [MainComp],
+          imports: [CommonModule]
         })
         export class MainModule {}`
       });

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -5,8 +5,8 @@ export declare const APP_BASE_HREF: InjectionToken<string>;
 export declare class AsyncPipe implements OnDestroy, PipeTransform {
     constructor(_ref: ChangeDetectorRef);
     ngOnDestroy(): void;
-    transform<T>(obj: Promise<T>): T | null;
-    transform<T>(obj: Observable<T>): T | null;
+    transform<T>(obj: Promise<T> | null | undefined): T | null;
+    transform<T>(obj: Observable<T> | null | undefined): T | null;
     transform<T>(obj: undefined): undefined;
     transform<T>(obj: null): null;
 }


### PR DESCRIPTION
The AsyncPipe type signature was changed to allow
deferred creation of promises and observalbes that
is supported by the implementation by allowing
`Promise<T>|null|undefined` and by allowing
`Observable<T>|null|undefined`.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue Number: #22100 

The type signature of AsyncPipe is too strict and causes `fullTemplateTypeCheck` to report an error if the pipe is an optional property such as `address?: Observable<Address>` which is supported by the class.

## What is the new behavior?

The type signature of the `transform` method now supports `Observable<T>|null|undefined` and `Promise<T>|null|undefined`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

This is not a breaking change even though it is an API change as the type signature is weaker than the prior signature and it will accept all programs that the previous signature accepted.