### PR TITLE
ci: remove bazel job from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ env:
     - CI_MODE=aio
     - CI_MODE=aio_e2e AIO_SHARD=0
     - CI_MODE=aio_e2e AIO_SHARD=1
-    - CI_MODE=bazel
 
 matrix:
   fast_finish: true

--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -62,7 +62,7 @@ if [[ ${TRAVIS} &&
 fi
 
 # Install bazel
-if [[ ${TRAVIS} && (${CI_MODE} == "bazel" || ${CI_MODE} == "e2e_2") ]]; then
+if [[ ${TRAVIS} && ${CI_MODE} == "e2e_2" ]]; then
   travisFoldStart "bazel-install"
   (
     mkdir tmp

--- a/scripts/ci/test-bazel.sh
+++ b/scripts/ci/test-bazel.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -u -e -o pipefail
-
-bazel build --config=ci packages/...

--- a/scripts/ci/test.sh
+++ b/scripts/ci/test.sh
@@ -46,7 +46,4 @@ case ${CI_MODE} in
   aio_e2e)
     ${thisDir}/test-aio-e2e.sh
     ;;
-  bazel)
-    ${thisDir}/test-bazel.sh
-    ;;
 esac


### PR DESCRIPTION
This saves us an executor on Travis.

Note that we still do a bazel build on travis when we run the integration tests under e2e_2.

We expect that CircleCI is the only place we'll ever consume bazel-built artifacts.
