### PR TITLE
feat(aio): enable print stylesheets

### DIFF
--- a/aio/src/styles/2-modules/_modules-dir.scss
+++ b/aio/src/styles/2-modules/_modules-dir.scss
@@ -22,6 +22,7 @@
    @import 'progress-bar';
    @import 'table';
    @import 'presskit';
+   @import 'print';
    @import 'resources';
    @import 'scrollbar';
    @import 'search-results';

--- a/aio/src/styles/2-modules/_print.scss
+++ b/aio/src/styles/2-modules/_print.scss
@@ -1,0 +1,20 @@
+@media print {
+  mat-sidenav, mat-toolbar, footer, .copy-button, .toc-container {
+    display: none !important;
+  }
+
+  mat-sidenav-container {
+    max-width: 100% !important;
+  }
+
+  .sidenav-content, mat-sidenav-content {
+    padding-top: 0;
+    width: 100% !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+  }
+
+  h1, h2, h3, h4, h5 {
+    page-break-after: avoid;
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
This improves the way the docs look when printing, and has no effect otherwise.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x ] Documentation content changes
[x ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, if you attempt to print the docs, they are quite narrow and result in wasted space during printing.

Issue Number: N/A


## What is the new behavior?
Now, when printing, the TOC and top bar are hidden and the contents take up the full width of the page.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```
