### PR TITLE
docs(aio): Typo fix - components to component's

### DIFF
--- a/aio/content/tutorial/toh-pt1.md
+++ b/aio/content/tutorial/toh-pt1.md
@@ -29,7 +29,7 @@ and annotate the component class with `@Component`.
 
 The CLI generated three metadata properties:
 
-1. `selector`&mdash; the components CSS element selector
+1. `selector`&mdash; the component's CSS element selector
 1. `templateUrl`&mdash; the location of the component's template file.
 1. `styleUrls`&mdash; the location of the component's private CSS styles.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The word "components" in the following line should be "component's" (possessive) as it is in the two subsequent lines.

"1. selector— the components CSS element selector"


Issue Number: N/A


## What is the new behavior?

Changed "components" to "component's"

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
