### PR TITLE
ci: update ngbot config file

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -50,13 +50,15 @@ merge:
     noConflict: true
     # list of labels that a PR needs to have, checked with a regexp (e.g. "PR target:" will work for the label "PR target: master")
     requiredLabels:
-      - "PR target:"
+      - "PR target: *"
       - "cla: yes"
 
     # list of labels that a PR shouldn't have, checked after the required labels with a regexp
     forbiddenLabels:
       - "PR target: TBD"
       - "PR action: cleanup"
+      - "PR action: review"
+      - "PR state: blocked"
       - "cla: no"
 
     # list of PR statuses that need to be successful
@@ -84,9 +86,15 @@ triage:
   triagedLabels:
     -
       - "type: bug"
-      - "severity"
-      - "freq"
-      - "comp:"
+      - "severity*"
+      - "freq*"
+      - "comp: *"
     -
       - "type: feature"
-      - "comp:"
+      - "comp: *"
+    -
+      - "type: refactor"
+      - "comp: *"
+    -
+      - "type: RFC / Discussion / question"
+      - "comp: *"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] CI related changes
```

## What is the current behavior?
Some `type` labels aren't considered as triaged.
Some PR state/action aren't blocking the merge when they should.

Issue Number: #22053


## What is the new behavior?
Type refactor and type RFC/Discussion/question are now considered as triaged.
The labels PR action review and PR state blocked are now forbidden labels that will prevent the merge status to go green.
I've also slightly updated some regexp to be compliant with minimatch instead of just simple regexp. It should be easier to understand like that.


## Does this PR introduce a breaking change?
```
[x] No
```