### PR TITLE
fix(platform-browser): support 0/false/null values in transfer_state

### DIFF
--- a/packages/platform-browser/src/browser/transfer_state.ts
+++ b/packages/platform-browser/src/browser/transfer_state.ts
@@ -93,7 +93,9 @@ export class TransferState {
   /**
    * Get the value corresponding to a key. Return `defaultValue` if key is not found.
    */
-  get<T>(key: StateKey<T>, defaultValue: T): T { return this.store[key] as T || defaultValue; }
+  get<T>(key: StateKey<T>, defaultValue: T): T {
+    return this.store[key] !== undefined ? this.store[key] as T : defaultValue;
+  }
 
   /**
    * Set the value corresponding to a key.

--- a/packages/platform-browser/test/browser/transfer_state_spec.ts
+++ b/packages/platform-browser/test/browser/transfer_state_spec.ts
@@ -70,6 +70,27 @@ import {DOCUMENT} from '@angular/platform-browser/src/dom/dom_tokens';
       expect(transferState.hasKey(TEST_KEY)).toBe(true);
     });
 
+    it('supports setting and accessing value \'0\' via get', () => {
+      const transferState: TransferState = TestBed.get(TransferState);
+      transferState.set(TEST_KEY, 0);
+      expect(transferState.get(TEST_KEY, 20)).toBe(0);
+      expect(transferState.hasKey(TEST_KEY)).toBe(true);
+    });
+
+    it('supports setting and accessing value \'false\' via get', () => {
+      const transferState: TransferState = TestBed.get(TransferState);
+      transferState.set(TEST_KEY, false);
+      expect(transferState.get(TEST_KEY, 20)).toBe(false);
+      expect(transferState.hasKey(TEST_KEY)).toBe(true);
+    });
+
+    it('supports setting and accessing value \'null\' via get', () => {
+      const transferState: TransferState = TestBed.get(TransferState);
+      transferState.set(TEST_KEY, null);
+      expect(transferState.get(TEST_KEY, 20)).toBe(null);
+      expect(transferState.hasKey(TEST_KEY)).toBe(true);
+    });
+
     it('supports removing keys', () => {
       const transferState: TransferState = TestBed.get(TransferState);
       transferState.set(TEST_KEY, 20);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #22178
```
this.transferState.set(KEY, 0);
this.transferState.set(KEY2, false);
this.transferState.set(KEY3, null);
this.transferState.set(KEY3, TestEnum.first);

console.log(this.transferState.get(KEY, 'DEFAULT');
console.log(this.transferState.get(KEY2,  'DEFAULT');
console.log(this.transferState.get(KEY3,  'DEFAULT');
console.log(this.transferState.get(KEY3,  'DEFAULT');
```
output:
```
 DEFAULT
 DEFAULT
 DEFAULT
 DEFAULT
```


## What is the new behavior?
output:
```
0
false
null
0
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
