### PR TITLE
docs(aio): fix typo in "preserveWhitespaces" example

### DIFF
--- a/aio/content/guide/aot-compiler.md
+++ b/aio/content/guide/aot-compiler.md
@@ -92,7 +92,7 @@ You can control your app compilation by providing template compiler options in t
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,
-    "preserveWhiteSpaces": false,
+    "preserveWhitespaces": false,
     ...
   }
 }


### PR DESCRIPTION
Fixes #22147

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The property name is "preserveWhiteSpaces" with uppercase "s" after "preserveWhite" (but should be "preserveWhitespaces" with lowercase "s" after "preserveWhite")

## What is the new behavior?
`preserveWhitespaces` is used instead

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
Maybe this PR should be merged after #22027 ? To avoid merge conflicts in `aot-compiler.md` for that PR ?