### PR TITLE
docs: Move compiler options to the last section of the doc

### DIFF
--- a/aio/content/guide/aot-compiler.md
+++ b/aio/content/guide/aot-compiler.md
@@ -2,7 +2,7 @@
 
 The Angular Ahead-of-Time (AOT) compiler converts your Angular HTML and TypeScript code into efficient JavaScript code during the build phase _before_ the browser downloads and runs that code.
 
-This guide explains how to build efficiently with the AOT compiler using the available compiler options and  Angular metadata.
+This guide explains how to build efficiently with the AOT compiler using the available compiler options and Angular metadata.
 
 <div class="l-sub-section">
 
@@ -65,7 +65,7 @@ You can control your app compilation by providing template compiler options in t
   }
 }
 ```
-To find the list of Angular compiler options available, see the [Angular Compiler Options](#compiler-options) section.
+To find a list of compiler options available, see the [Angular Compiler Options](#compiler-options) section.
 
 ### Angular metadata and AOT
 
@@ -73,7 +73,7 @@ Angular metadata tells Angular how to construct instances of your application cl
 
 The Angular **AOT compiler** extracts and interprets **metadata** about the parts of the application that Angular is supposed to manage.
 
-To learn how to specify Angular Metadata, see the [Specifying Metadata](#metadata-aot) section
+To learn how to specify Angular metadata in your application, see the [Specifying Metadata](#metadata-aot) section.
 
 {@a why-aot}
 
@@ -110,7 +110,7 @@ there are fewer opportunities for injection attacks.
 
 ## Specifying Metadata
 
-You can use the Angular metadata to specify how to interpret different parts of your applications. 
+You can use the Angular metadata to specify how to interpret different parts of your application. 
 You specify the metadata with **decorators** such as `@Component()` and `@Input()`.
 You also specify metadata implicitly in the constructor declarations of these decorated classes.
 

--- a/aio/content/guide/cheatsheet.md
+++ b/aio/content/guide/cheatsheet.md
@@ -140,6 +140,11 @@ is available to <code>declarations</code> of this module.</p>
 <td><p>Binds the presence of CSS classes on the element to the truthiness of the associated map values. The right-hand expression should return {class-name: true/false} map.</p>
 </td>
 </tr>
+<tr>
+<td><code>&lt;div <b>[ngStyle]</b>="{'property': 'value'}"&gt;</code><br><code>&lt;div <b>[ngStyle]</b>="dynamicStyles()"&gt;</code></td>
+<td><p>Allows you to assign styles to an HTML element using CSS. You can use CSS directly, as in the first example, or you can call a method from the component.</p>
+</td>
+</tr>
 </tbody></table>
 
 <table class="is-full-width is-fixed-layout">


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Compiler options are listed at the beginning of the doc.

Issue Number: 21829


## What is the new behavior?
Moved compiler options to the last section of the doc before Summary.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
