### PR TITLE
fix(upgrade): need to call markForCheck on child changeDetectorRef

### DIFF
--- a/packages/upgrade/src/common/downgrade_component_adapter.ts
+++ b/packages/upgrade/src/common/downgrade_component_adapter.ts
@@ -25,6 +25,7 @@ export class DowngradeComponentAdapter {
   private componentRef: ComponentRef<any>;
   private component: any;
   private changeDetector: ChangeDetectorRef;
+  private viewChangeDetector: ChangeDetectorRef;
 
   constructor(
       private element: angular.IAugmentedJQuery, private attrs: angular.IAttributes,
@@ -60,6 +61,7 @@ export class DowngradeComponentAdapter {
 
     this.componentRef =
         this.componentFactory.create(childInjector, projectableNodes, this.element[0]);
+    this.viewChangeDetector = this.componentRef.injector.get(ChangeDetectorRef);
     this.changeDetector = this.componentRef.changeDetectorRef;
     this.component = this.componentRef.instance;
 
@@ -138,6 +140,8 @@ export class DowngradeComponentAdapter {
         this.inputChanges = {};
         (<OnChanges>this.component).ngOnChanges(inputChanges !);
       }
+
+      this.viewChangeDetector.markForCheck();
 
       // If opted out of propagating digests, invoke change detection when inputs change.
       if (!propagateDigest) {

--- a/packages/upgrade/test/static/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/test/static/integration/downgrade_component_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, Compiler, Component, ComponentFactoryResolver, Directive, ElementRef, EventEmitter, Injector, Input, NgModule, NgModuleRef, OnChanges, OnDestroy, Output, SimpleChanges, destroyPlatform} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Compiler, Component, ComponentFactoryResolver, Directive, ElementRef, EventEmitter, Injector, Input, NgModule, NgModuleRef, OnChanges, OnDestroy, Output, SimpleChanges, destroyPlatform} from '@angular/core';
 import {async, fakeAsync, tick} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
@@ -145,6 +145,51 @@ withEachNg1Version(() => {
                    'literal: Text; interpolate: Hello everyone; ' +
                    'oneWayA: A; oneWayB: B; twoWayA: newA; twoWayB: newB; (3) | ' +
                    'modelA: newA; modelB: newB; eventA: aFired; eventB: bFired;');
+         });
+       }));
+
+    it('should bind properties to onpush components', async(() => {
+         const ng1Module =
+             angular.module('ng1', []).value('$exceptionHandler', (err: any) => {
+                                        throw err;
+                                      }).run(($rootScope: angular.IScope) => {
+               $rootScope['dataB'] = 'B';
+             });
+
+         @Component({
+           selector: 'ng2',
+           inputs: ['oneWayB'],
+           template: 'oneWayB: {{oneWayB}}',
+           changeDetection: ChangeDetectionStrategy.OnPush
+         })
+
+         class Ng2Component {
+           ngOnChangesCount = 0;
+           oneWayB = '?';
+         }
+
+         ng1Module.directive('ng2', downgradeComponent({
+                               component: Ng2Component,
+                             }));
+
+         @NgModule({
+           declarations: [Ng2Component],
+           entryComponents: [Ng2Component],
+           imports: [BrowserModule, UpgradeModule]
+         })
+         class Ng2Module {
+           ngDoBootstrap() {}
+         }
+
+         const element = html(`
+          <div>
+            <ng2 [one-way-b]="dataB"></ng2>
+          </div>`);
+
+         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module).then((upgrade) => {
+           expect(multiTrim(document.body.textContent)).toEqual('oneWayB: B');
+           $apply(upgrade, 'dataB= "everyone"');
+           expect(multiTrim(document.body.textContent)).toEqual('oneWayB: everyone');
          });
        }));
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [n/a ] Tests for the changes have been added (for bug fixes / features)
- [n/a ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
I found a bug within matCheckbox. I added a disabled class to the checkbox based on a method call. When disabled, the checkbox had class disabled and therefore had grey css etc, but if it was still clicked on, it had a click event which added a disabled class to the input within the checkbox. When the disabled class was removed from the outer matCheckbox, the disabled class remained on the input, so even though the checkbox appeared not to be disabled, it couldn't accept any more input.

Issue Number: 9763


## What is the new behavior?
Clicking on a disabled checkbox should not change it in any way.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
