### PR TITLE
fix(core): fix memory leak on application reference destroy

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -564,6 +564,10 @@ export class ApplicationRef {
   private _unloadComponent(componentRef: ComponentRef<any>): void {
     this.detachView(componentRef.hostView);
     remove(this.components, componentRef);
+    const testabilityRegistry = componentRef.injector.get(TestabilityRegistry, null);
+    if (testabilityRegistry) {
+      testabilityRegistry.unregisterApplication(componentRef.location.nativeElement);
+    }
   }
 
   /** @internal */


### PR DESCRIPTION
When an application reference is destroyed it stays in memory because it is still registered in the testability registry.

Closes #22106, #13725

## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
When an application is destroyed the application still remains in memory because the testability registry still holds a reference to the application.

Issue Number:  #22106, #13725


## What is the new behavior?
When an application is destroyed it is also removed from the testability registry.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
I have created a simple example application at https://github.com/tmair/angular-app-destroy
There are two commits, one using the current version of angular and the other one using the fixed version of angular