### PR TITLE
feat(platform-browser): make Renderer2 available in global scope

### DIFF
--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule, PlatformLocation, ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {APP_ID, APP_ROOT_SCOPE, ApplicationModule, ErrorHandler, ModuleWithProviders, NgModule, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, PlatformRef, RendererFactory2, RootRenderer, Sanitizer, SkipSelf, StaticProvider, Testability, createPlatformFactory, platformCore} from '@angular/core';
+import {APP_ID, APP_ROOT_SCOPE, ApplicationModule, ErrorHandler, ModuleWithProviders, NgModule, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, PlatformRef, Renderer2, RendererFactory2, RootRenderer, Sanitizer, SkipSelf, StaticProvider, Testability, createPlatformFactory, platformCore} from '@angular/core';
 
 import {BrowserDomAdapter} from './browser/browser_adapter';
 import {BrowserPlatformLocation} from './browser/location/browser_platform_location';
@@ -63,6 +63,10 @@ export function _document(): any {
   return document;
 }
 
+export function getRenderer(rendererFactory: RendererFactory2): Renderer2 {
+  return rendererFactory.createRenderer(null, null);
+}
+
 /**
  * The ng module for the browser.
  *
@@ -79,6 +83,7 @@ export function _document(): any {
     {provide: HAMMER_GESTURE_CONFIG, useClass: HammerGestureConfig},
     DomRendererFactory2,
     {provide: RendererFactory2, useExisting: DomRendererFactory2},
+    {provide: Renderer2, useFactory: getRenderer, deps: [RendererFactory2]},
     {provide: SharedStylesHost, useExisting: DomSharedStylesHost},
     DomSharedStylesHost,
     Testability,

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -10,6 +10,7 @@ import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {BrowserModule} from '../../src/browser';
 import {NAMESPACE_URIS} from '../../src/dom/dom_renderer';
 
 {
@@ -105,6 +106,15 @@ import {NAMESPACE_URIS} from '../../src/dom/dom_renderer';
            expect(window.getComputedStyle(none).color).toEqual('rgb(0, 255, 0)');
          });
     }
+  });
+
+  describe('Providers', () => {
+    beforeEach(() => { TestBed.configureTestingModule({imports: [BrowserModule]}); });
+
+    it('should inject Renderer2 outside a component', () => {
+      const renderer = TestBed.get(Renderer2, null);
+      expect(renderer).not.toBe(null);
+    });
   });
 }
 


### PR DESCRIPTION
closes #17824

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #17824


## What is the new behavior?

User can inject `Renderer2` directly in service.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
