### PR TITLE
fix(forms): properly handle special properties in FormGroup.get

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -44,7 +44,7 @@ function _find(control: AbstractControl, path: Array<string|number>| string, del
 
   return (<Array<string|number>>path).reduce((v: AbstractControl, name) => {
     if (v instanceof FormGroup) {
-      return v.controls[name] || null;
+      return v.controls.hasOwnProperty(name as string) ? v.controls[name] : null;
     }
 
     if (v instanceof FormArray) {

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -629,6 +629,18 @@ import {of } from 'rxjs';
       });
     });
 
+    describe('retrieve', () => {
+      let group: FormGroup;
+
+      beforeEach(() => {
+        group = new FormGroup({
+          'required': new FormControl('requiredValue'),
+        });
+      });
+
+      it('should not get inherited properties',
+         () => { expect(group.get('constructor')).toBe(null); });
+    });
 
     describe('statusChanges', () => {
       let control: FormControl;


### PR DESCRIPTION
closes #17195

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #17195


## What is the new behavior?

`formGroup.get('constructor')` will now return `null`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
