### PR TITLE
feat(common): make SlicePipe support general iterable

### DIFF
--- a/packages/common/src/pipes/slice_pipe.ts
+++ b/packages/common/src/pipes/slice_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Pipe, PipeTransform} from '@angular/core';
+import {Pipe, PipeTransform, ɵgetSymbolIterator as getSymbolIterator} from '@angular/core';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
 /**
@@ -58,6 +58,10 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 export class SlicePipe implements PipeTransform {
   transform(value: any, start: number, end?: number): any {
     if (value == null) return value;
+
+    if (typeof value !== 'string' && value[getSymbolIterator()]) {
+      value = Array.from(value);
+    }
 
     if (!this.supports(value)) {
       throw invalidPipeArgumentError(SlicePipe, value);

--- a/packages/common/test/pipes/slice_pipe_spec.ts
+++ b/packages/common/test/pipes/slice_pipe_spec.ts
@@ -79,6 +79,10 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
         expect(list).toEqual([1, 2, 3, 4, 5]);
       });
 
+      it('should treat iterable as array', () => {
+        expect(pipe.transform(listGenerator(), 3)).toEqual([4, 5]);
+      });
+
     });
 
     describe('integration', () => {
@@ -105,4 +109,12 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
          }));
     });
   });
+}
+
+function* listGenerator(): Iterator<number> {
+  yield 1;
+  yield 2;
+  yield 3;
+  yield 4;
+  yield 5;
 }

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -17,7 +17,7 @@ export {CodegenComponentFactoryResolver as ɵCodegenComponentFactoryResolver} fr
 export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/reflection_capabilities';
 export {GetterFn as ɵGetterFn, MethodFn as ɵMethodFn, SetterFn as ɵSetterFn} from './reflection/types';
 export {DirectRenderer as ɵDirectRenderer, RenderDebugInfo as ɵRenderDebugInfo} from './render/api';
-export {global as ɵglobal, looseIdentical as ɵlooseIdentical, stringify as ɵstringify} from './util';
+export {getSymbolIterator as ɵgetSymbolIterator, global as ɵglobal, looseIdentical as ɵlooseIdentical, stringify as ɵstringify} from './util';
 export {makeDecorator as ɵmakeDecorator} from './util/decorators';
 export {isObservable as ɵisObservable, isPromise as ɵisPromise} from './util/lang';
 export {clearOverrides as ɵclearOverrides, overrideComponentView as ɵoverrideComponentView, overrideProvider as ɵoverrideProvider} from './view/index';


### PR DESCRIPTION
closes #17711

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #17711


## What is the new behavior?

`SlicePipe` accepts any kind of `Iterable`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
