### PR TITLE
feat(platform-browser): do not throw error when Hammer.js not loaded

### DIFF
--- a/packages/platform-browser/src/dom/events/hammer_gestures.ts
+++ b/packages/platform-browser/src/dom/events/hammer_gestures.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, InjectionToken} from '@angular/core';
+import {Inject, Injectable, InjectionToken, ɵConsole as Console} from '@angular/core';
 
 import {DOCUMENT} from '../dom_tokens';
 
@@ -99,7 +99,8 @@ export class HammerGestureConfig {
 export class HammerGesturesPlugin extends EventManagerPlugin {
   constructor(
       @Inject(DOCUMENT) doc: any,
-      @Inject(HAMMER_GESTURE_CONFIG) private _config: HammerGestureConfig) {
+      @Inject(HAMMER_GESTURE_CONFIG) private _config: HammerGestureConfig,
+      private console: Console) {
     super(doc);
   }
 
@@ -109,7 +110,8 @@ export class HammerGesturesPlugin extends EventManagerPlugin {
     }
 
     if (!(window as any).Hammer) {
-      throw new Error(`Hammer.js is not loaded, can not bind ${eventName} event`);
+      this.console.warn(`Hammer.js is not loaded, can not bind '${eventName}' event.`);
+      return false;
     }
 
     return true;

--- a/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
+++ b/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
@@ -10,14 +10,27 @@ import {HammerGestureConfig, HammerGesturesPlugin} from '@angular/platform-brows
 
 {
   describe('HammerGesturesPlugin', () => {
+    let plugin: HammerGesturesPlugin;
+    let mockConsole: any;
     if (isNode) return;
 
-    it('should implement addGlobalEventListener', () => {
-      const plugin = new HammerGesturesPlugin(document, new HammerGestureConfig());
+    beforeEach(() => {
+      mockConsole = {warn: () => {}};
+      plugin = new HammerGesturesPlugin(document, new HammerGestureConfig(), mockConsole);
+    });
 
+    it('should implement addGlobalEventListener', () => {
       spyOn(plugin, 'addEventListener').and.callFake(() => {});
 
       expect(() => plugin.addGlobalEventListener('document', 'swipe', () => {})).not.toThrowError();
+    });
+
+    it('shoud warn user and do nothing when Hammer.js not loaeded', () => {
+      spyOn(mockConsole, 'warn');
+
+      expect(plugin.supports('swipe')).toBe(false);
+      expect(mockConsole.warn)
+          .toHaveBeenCalledWith(`Hammer.js is not loaded, can not bind 'swipe' event.`);
     });
   });
 }


### PR DESCRIPTION
closes #16992

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #16992


## What is the new behavior?

Just leave a warning and perform no functionality when Hammer.js not loaded.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
