### PR TITLE
test(aio): increase `docs-test` timeouts to prevent flakes on Travis

### DIFF
--- a/aio/tools/transforms/authors-package/index.spec.js
+++ b/aio/tools/transforms/authors-package/index.spec.js
@@ -5,7 +5,14 @@ const {generateDocs} = require('./index.js');
 const { DOCS_OUTPUT_PATH } = require('../config');
 
 describe('authors-package (integration tests)', () => {
+  let originalJasmineTimeout;
   let files;
+
+  beforeAll(() => {
+    originalJasmineTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+  });
+  afterAll(() => jasmine.DEFAULT_TIMEOUT_INTERVAL = originalJasmineTimeout);
 
   beforeEach(() => {
     files = [];
@@ -24,7 +31,7 @@ describe('authors-package (integration tests)', () => {
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, '../resources.json'));
       done();
     });
-  }, 4000);
+  });
 
   it('should generate tutorial docs if the "fileChanged" is a tutorial doc', (done) => {
     generateDocs('aio/content/tutorial/toh-pt5.md', { silent: true }).then(() => {
@@ -32,7 +39,7 @@ describe('authors-package (integration tests)', () => {
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, 'tutorial/toh-pt5.json'));
       done();
     });
-  }, 4000);
+  });
 
   it('should generate tutorial docs if the "fileChanged" is the tutorial index', (done) => {
     generateDocs('aio/content/tutorial/index.md', { silent: true }).then(() => {
@@ -40,7 +47,7 @@ describe('authors-package (integration tests)', () => {
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, 'tutorial.json'));
       done();
     });
-  }, 4000);
+  });
 
   it('should generate tutorial docs if the "fileChanged" is a tutorial example', (done) => {
     generateDocs('aio/content/examples/toh-pt3/app/app.component.1.html', { silent: true }).then(() => {
@@ -48,7 +55,7 @@ describe('authors-package (integration tests)', () => {
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, 'tutorial/toh-pt3.json'));
       done();
     });
-  }, 4000);
+  });
 
   it('should generate guide doc if the "fileChanged" is a guide doc', (done) => {
     generateDocs('aio/content/guide/architecture.md', { silent: true }).then(() => {
@@ -56,7 +63,7 @@ describe('authors-package (integration tests)', () => {
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, 'guide/architecture.json'));
       done();
     });
-  }, 4000);
+  });
 
   it('should generate guide doc if the "fileChanged" is a guide example', (done) => {
     generateDocs('aio/content/examples/architecture/src/app/app.module.ts', { silent: true }).then(() => {
@@ -64,7 +71,7 @@ describe('authors-package (integration tests)', () => {
       expect(files).toContain(resolve(DOCS_OUTPUT_PATH, 'guide/architecture.json'));
       done();
     });
-  }, 4000);
+  });
 
   it('should generate API doc if the "fileChanged" is an API doc', (done) => {
     generateDocs('packages/forms/src/form_builder.ts', { silent: true }).then(() => {


### PR DESCRIPTION
Increasing jasmine timeouts on some slow tests to reduce flakes. The old timeouts are usually fine, but every now and then Travis is more slow than usual, which may cause some of these tests to time out.