### PR TITLE
feat(core): add prependChild to Renderer2

### DIFF
--- a/packages/core/src/render/api.ts
+++ b/packages/core/src/render/api.ts
@@ -161,6 +161,7 @@ export abstract class Renderer2 {
    */
   destroyNode: ((node: any) => void)|null;
   abstract appendChild(parent: any, newChild: any): void;
+  abstract prependChild(parent: any, newChild: any): void;
   abstract insertBefore(parent: any, newChild: any, refChild: any): void;
   abstract removeChild(parent: any, oldChild: any): void;
   abstract selectRootElement(selectorOrNode: string|any): any;

--- a/packages/core/src/view/services.ts
+++ b/packages/core/src/view/services.ts
@@ -699,6 +699,15 @@ class DebugRenderer2 implements Renderer2 {
     this.delegate.appendChild(parent, newChild);
   }
 
+  prependChild(parent: any, newChild: any): void {
+    const debugEl = getDebugNode(parent);
+    const debugChildEl = getDebugNode(newChild);
+    if (debugEl && debugChildEl && debugEl instanceof DebugElement) {
+      debugEl.insertBefore(debugEl.childNodes[0], debugChildEl);
+    }
+    this.delegate.prependChild(parent, newChild);
+  }
+
   insertBefore(parent: any, newChild: any, refChild: any): void {
     const debugEl = getDebugNode(parent);
     const debugChildEl = getDebugNode(newChild);

--- a/packages/platform-browser/animations/src/animation_renderer.ts
+++ b/packages/platform-browser/animations/src/animation_renderer.ts
@@ -143,6 +143,11 @@ export class BaseAnimationRenderer implements Renderer2 {
     this.engine.onInsert(this.namespaceId, newChild, parent, false);
   }
 
+  prependChild(parent: any, newChild: any): void {
+    this.delegate.prependChild(parent, newChild);
+    this.engine.onInsert(this.namespaceId, newChild, parent, false);
+  }
+
   insertBefore(parent: any, newChild: any, refChild: any): void {
     this.delegate.insertBefore(parent, newChild, refChild);
     this.engine.onInsert(this.namespaceId, newChild, parent, true);

--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -178,6 +178,7 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
     }
   }
   appendChild(el: Node, node: Node) { el.appendChild(node); }
+  prependChild(el: Node, node: Node) { el.insertBefore(node, this.firstChild(el)); }
   removeChild(el: Node, node: Node) { el.removeChild(node); }
   replaceChild(el: Node, newChild: Node, oldChild: Node) { el.replaceChild(newChild, oldChild); }
   remove(node: Node): Node {

--- a/packages/platform-browser/src/dom/dom_adapter.ts
+++ b/packages/platform-browser/src/dom/dom_adapter.ts
@@ -78,6 +78,7 @@ export abstract class DomAdapter {
   abstract childNodesAsList(el: any): Node[];
   abstract clearNodes(el: any): any;
   abstract appendChild(el: any, node: any): any;
+  abstract prependChild(el: any, node: any): any;
   abstract removeChild(el: any, node: any): any;
   abstract replaceChild(el: any, newNode: any, oldNode: any): any;
   abstract remove(el: any): Node;

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -122,6 +122,12 @@ class DefaultDomRenderer2 implements Renderer2 {
 
   appendChild(parent: any, newChild: any): void { parent.appendChild(newChild); }
 
+  prependChild(parent: any, newChild: any): void {
+    if (parent) {
+      parent.insertBefore(newChild, parent.firstChild);
+    }
+  }
+
   insertBefore(parent: any, newChild: any, refChild: any): void {
     if (parent) {
       parent.insertBefore(newChild, refChild);

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -26,6 +26,29 @@ import {NAMESPACE_URIS} from '../../src/dom/dom_renderer';
       renderer = TestBed.createComponent(TestCmp).componentInstance.renderer;
     });
 
+    describe('prependChild', () => {
+      it('should work when parent has no existing child', () => {
+        const div = document.createElement('div');
+        const p = document.createElement('p');
+
+        renderer.prependChild(div, p);
+
+        expect(div.childNodes).toContain(p);
+      });
+
+      it('should work when parent has existing child', () => {
+        const div = document.createElement('div');
+        const oldP = document.createElement('p');
+        const newP = document.createElement('p');
+
+        renderer.appendChild(div, oldP);
+        renderer.prependChild(div, newP);
+
+        expect(div.childNodes[0]).toBe(newP);
+        expect(div.childNodes[1]).toBe(oldP);
+      });
+    });
+
     describe('setAttribute', () => {
       describe('with namespace', () => {
         it('xmlns', () => shouldSetAttributeWithNs('xmlns'));

--- a/packages/platform-server/src/server_renderer.ts
+++ b/packages/platform-server/src/server_renderer.ts
@@ -81,6 +81,8 @@ class DefaultServerRenderer2 implements Renderer2 {
 
   appendChild(parent: any, newChild: any): void { getDOM().appendChild(parent, newChild); }
 
+  prependChild(parent: any, newChild: any): void { getDOM().prependChild(parent, newChild); }
+
   insertBefore(parent: any, newChild: any, refChild: any): void {
     if (parent) {
       getDOM().insertBefore(parent, refChild, newChild);

--- a/packages/platform-webworker/src/web_workers/ui/renderer.ts
+++ b/packages/platform-webworker/src/web_workers/ui/renderer.ts
@@ -41,6 +41,7 @@ export class MessageBasedRenderer2 {
       ['createElement', this.createElement, RSO, P, P, P],
       ['createComment', this.createComment, RSO, P, P], ['createText', this.createText, RSO, P, P],
       ['appendChild', this.appendChild, RSO, RSO, RSO],
+      ['prependChild', this.prependChild, RSO, RSO, RSO],
       ['insertBefore', this.insertBefore, RSO, RSO, RSO, RSO],
       ['removeChild', this.removeChild, RSO, RSO, RSO],
       ['selectRootElement', this.selectRootElement, RSO, P, P],
@@ -87,6 +88,8 @@ export class MessageBasedRenderer2 {
   }
 
   private appendChild(r: Renderer2, parent: any, child: any) { r.appendChild(parent, child); }
+
+  private prependChild(r: Renderer2, parent: any, child: any) { r.prependChild(parent, child); }
 
   private insertBefore(r: Renderer2, parent: any, child: any, ref: any) {
     r.insertBefore(parent, child, ref);

--- a/packages/platform-webworker/src/web_workers/worker/renderer.ts
+++ b/packages/platform-webworker/src/web_workers/worker/renderer.ts
@@ -166,6 +166,13 @@ export class WebWorkerRenderer2 implements Renderer2 {
     ]);
   }
 
+  prependChild(parent: any, newChild: any): void {
+    this.callUIWithRenderer('prependChild', [
+      new FnArg(parent, SerializerTypes.RENDER_STORE_OBJECT),
+      new FnArg(newChild, SerializerTypes.RENDER_STORE_OBJECT),
+    ]);
+  }
+
   insertBefore(parent: any, newChild: any, refChild: any): void {
     if (!parent) {
       return;

--- a/packages/platform-webworker/src/web_workers/worker/worker_adapter.ts
+++ b/packages/platform-webworker/src/web_workers/worker/worker_adapter.ts
@@ -79,6 +79,7 @@ export class WorkerDomAdapter extends DomAdapter {
   childNodesAsList(el: any): Node[] { throw 'not implemented'; }
   clearNodes(el: any) { throw 'not implemented'; }
   appendChild(el: any, node: any) { throw 'not implemented'; }
+  prependChild(el: any, node: any) { throw 'not implemented'; }
   removeChild(el: any, node: any) { throw 'not implemented'; }
   replaceChild(el: any, newNode: any, oldNode: any) { throw 'not implemented'; }
   remove(el: any): Node { throw 'not implemented'; }

--- a/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
+++ b/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
@@ -154,6 +154,20 @@ let lastCreatedRenderer: Renderer2;
       expect(rootEl).toHaveText('');
     });
 
+    it('should prepend fragments', () => {
+      const fixture =
+          TestBed.overrideTemplate(MyComp2, '<div>world</div>').createComponent(MyComp2);
+
+      const rootEl = getRenderElement(fixture.nativeElement);
+      fixture.detectChanges();
+      expect(rootEl).toHaveText('world');
+
+      const textNode = getDOM().createTextNode('hello ');
+      getDOM().prependChild(rootEl, textNode);
+      fixture.detectChanges();
+      expect(rootEl).toHaveText('hello world');
+    });
+
     if (getDOM().supportsDOMEvents()) {
       it('should listen to events', () => {
         const fixture = TestBed.overrideTemplate(MyComp2, '<input (change)="ctxNumProp = 1">')

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -841,6 +841,7 @@ export declare abstract class Renderer2 {
     abstract listen(target: 'window' | 'document' | 'body' | any, eventName: string, callback: (event: any) => boolean | void): () => void;
     abstract nextSibling(node: any): any;
     abstract parentNode(node: any): any;
+    abstract prependChild(parent: any, newChild: any): void;
     abstract removeAttribute(el: any, name: string, namespace?: string | null): void;
     abstract removeChild(parent: any, oldChild: any): void;
     abstract removeClass(el: any, name: string): void;


### PR DESCRIPTION
closes #18645

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #18645


## What is the new behavior?

A new `prependChild` method on `Renderer2`.

## Does this PR introduce a breaking change?
```
[x] Yes (Only for platform implementor)
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

For other platforms (like NativeScript), they should either implement it according the original DOM semantics or throw an error for that method.


## Other information
