### PR TITLE
feat(common): display default template in NgForOf when empty

### DIFF
--- a/goldens/public-api/common/common.d.ts
+++ b/goldens/public-api/common/common.d.ts
@@ -219,6 +219,7 @@ export declare class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> impleme
     set ngForTemplate(value: TemplateRef<NgForOfContext<T, U>>);
     set ngForTrackBy(fn: TrackByFunction<T>);
     get ngForTrackBy(): TrackByFunction<T>;
+    set ngForWhenEmpty(value: TemplateRef<void>);
     constructor(_viewContainer: ViewContainerRef, _template: TemplateRef<NgForOfContext<T, U>>, _differs: IterableDiffers);
     ngDoCheck(): void;
     static ngTemplateContextGuard<T, U extends NgIterable<T>>(dir: NgForOf<T, U>, ctx: any): ctx is NgForOfContext<T, U>;

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3033,
-        "main-es2015": 447975,
+        "main-es2015": 448772,
         "polyfills-es2015": 52493
       }
     }
@@ -21,7 +21,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3153,
-        "main-es2015": 431696,
+        "main-es2015": 432650,
         "polyfills-es2015": 52493
       }
     }

--- a/packages/common/test/directives/ng_for_spec.ts
+++ b/packages/common/test/directives/ng_for_spec.ts
@@ -380,6 +380,26 @@ let thisArg: any;
            detectChangesAndExpectText('efh');
          }));
     });
+
+    describe('Default', () => {
+      it('should display default block when no items available', () => {
+        const template = `<div *ngFor="let item of items; whenEmpty: noItems">{{item}}</div>` +
+            `<ng-template #noItems>No items</ng-template>`;
+        fixture = createTestComponent(template);
+
+        getComponent().items = [];
+        detectChangesAndExpectText('No items');
+
+        getComponent().items = ['a', 'b', 'c'];
+        detectChangesAndExpectText('abc');
+
+        getComponent().items = [];
+        detectChangesAndExpectText('No items');
+
+        getComponent().items = [];
+        detectChangesAndExpectText('No items');
+      });
+    });
   });
 }
 


### PR DESCRIPTION
closes #14479

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #14479


## What is the new behavior?

`NgForOf` can now have a default template when no items available.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Question:

+ What should be the property name? `default`, `else`, `empty`, `otherwise`, `fallback`...
+ Should **structural directives** guide being updated as well or leave that to separate PR?