### PR TITLE
fix(forms): keep name attribute on DOM for controls

### DIFF
--- a/goldens/public-api/forms/forms.d.ts
+++ b/goldens/public-api/forms/forms.d.ts
@@ -255,7 +255,8 @@ export declare class FormControlName extends NgControl implements OnChanges, OnD
     get formDirective(): any;
     set isDisabled(isDisabled: boolean);
     /** @deprecated */ model: any;
-    name: string | number | null;
+    set name(value: string | null);
+    get name(): string | null;
     get path(): string[];
     /** @deprecated */ update: EventEmitter<any>;
     constructor(parent: ControlContainer, validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[], valueAccessors: ControlValueAccessor[], _ngModelWarningConfig: string | null);
@@ -349,7 +350,8 @@ export declare const NG_VALIDATORS: InjectionToken<(Function | Validator)[]>;
 export declare const NG_VALUE_ACCESSOR: InjectionToken<readonly ControlValueAccessor[]>;
 
 export declare abstract class NgControl extends AbstractControlDirective {
-    name: string | number | null;
+    set name(value: string | null);
+    get name(): string | null;
     valueAccessor: ControlValueAccessor | null;
     abstract viewToModelUpdate(newValue: any): void;
 }
@@ -397,7 +399,8 @@ export declare class NgModel extends NgControl implements OnChanges, OnDestroy {
     get formDirective(): any;
     isDisabled: boolean;
     model: any;
-    name: string;
+    set name(value: string | null);
+    get name(): string | null;
     options: {
         name?: string;
         standalone?: boolean;
@@ -406,7 +409,7 @@ export declare class NgModel extends NgControl implements OnChanges, OnDestroy {
     get path(): string[];
     update: EventEmitter<any>;
     viewModel: any;
-    constructor(parent: ControlContainer, validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[], valueAccessors: ControlValueAccessor[]);
+    constructor(parent: ControlContainer, validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[], valueAccessors: ControlValueAccessor[], _renderer: Renderer2, _elementRef: ElementRef);
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     viewToModelUpdate(newValue: any): void;
@@ -445,7 +448,8 @@ export declare class PatternValidator implements Validator, OnChanges {
 
 export declare class RadioControlValueAccessor implements ControlValueAccessor, OnDestroy, OnInit {
     formControlName: string;
-    name: string;
+    set name(value: string | null);
+    get name(): string | null;
     onChange: () => void;
     onTouched: () => void;
     value: any;

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -1605,6 +1605,9 @@
     "name": "stringifyForError"
   },
   {
+    "name": "stringifyTruthy"
+  },
+  {
     "name": "subscribeTo"
   },
   {

--- a/packages/forms/src/directives/ng_control.ts
+++ b/packages/forms/src/directives/ng_control.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {stringifyTruthy} from '../util/stringify_truthy';
 import {AbstractControlDirective} from './abstract_control_directive';
 import {ControlContainer} from './control_container';
 import {ControlValueAccessor} from './control_value_accessor';
@@ -27,17 +28,25 @@ export abstract class NgControl extends AbstractControlDirective {
    */
   _parent: ControlContainer|null = null;
 
-  /**
-   * @description
-   * The name for the control
-   */
-  name: string|number|null = null;
+  /** @internal */
+  _name: string|null = null;
 
   /**
    * @description
    * The value accessor for the control
    */
   valueAccessor: ControlValueAccessor|null = null;
+
+  /**
+   * @description
+   * The name for the control
+   */
+  set name(value: string|null) {
+    this._name = stringifyTruthy(value);
+  }
+  get name(): string|null {
+    return this._name;
+  }
 
   /**
    * @description

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -9,6 +9,7 @@
 import {AfterViewInit, Directive, EventEmitter, forwardRef, Inject, Input, Optional, Self} from '@angular/core';
 
 import {AbstractControl, FormControl, FormGroup, FormHooks} from '../model';
+import {stringifyTruthy} from '../util/stringify_truthy';
 import {composeAsyncValidators, composeValidators, NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../validators';
 
 import {ControlContainer} from './control_container';
@@ -188,7 +189,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
     resolvedPromise.then(() => {
       const container = this._findContainer(dir.path);
       (dir as {control: FormControl}).control =
-          <FormControl>container.registerControl(dir.name, dir.control);
+          <FormControl>container.registerControl(dir.name!, dir.control);
       setUpControl(dir.control, dir);
       dir.control.updateValueAndValidity({emitEvent: false});
       this._directives.push(dir);
@@ -215,7 +216,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
     resolvedPromise.then(() => {
       const container = this._findContainer(dir.path);
       if (container) {
-        container.removeControl(dir.name);
+        container.removeControl(dir.name!);
       }
       removeListItem(this._directives, dir);
     });

--- a/packages/forms/src/directives/radio_control_value_accessor.ts
+++ b/packages/forms/src/directives/radio_control_value_accessor.ts
@@ -7,6 +7,7 @@
  */
 
 import {Directive, ElementRef, forwardRef, Injectable, Injector, Input, OnDestroy, OnInit, Renderer2} from '@angular/core';
+import {stringifyTruthy} from '../util/stringify_truthy';
 
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 import {NgControl} from './ng_control';
@@ -123,12 +124,30 @@ export class RadioControlValueAccessor implements ControlValueAccessor, OnDestro
    */
   onTouched = () => {};
 
+  /** @internal */
+  @Input() _name: string|null = null;
+
   /**
    * @description
    * Tracks the name of the radio input element.
    */
-  // TODO(issue/24571): remove '!'.
-  @Input() name!: string;
+  @Input()
+  set name(value: string|null) {
+    this._name = stringifyTruthy(value);
+    if (this._name) {
+      this._renderer.setAttribute(this._elementRef.nativeElement, 'name', this._name);
+    } else {
+      this._renderer.removeAttribute(this._elementRef.nativeElement, 'name');
+    }
+  }
+
+  /**
+   * @description
+   * Tracks the name of the radio input element.
+   */
+  get name(): string|null {
+    return this._name;
+  }
 
   /**
    * @description
@@ -207,10 +226,10 @@ export class RadioControlValueAccessor implements ControlValueAccessor, OnDestro
   }
 
   private _checkName(): void {
-    if (this.name && this.formControlName && this.name !== this.formControlName &&
+    if (this._name && this.formControlName && this._name !== this.formControlName &&
         (typeof ngDevMode === 'undefined' || ngDevMode)) {
       throwNameError();
     }
-    if (!this.name && this.formControlName) this.name = this.formControlName;
+    if (!this._name && this.formControlName) this._name = this.formControlName;
   }
 }

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -9,6 +9,7 @@
 import {Directive, EventEmitter, forwardRef, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges, SkipSelf} from '@angular/core';
 
 import {FormControl} from '../../model';
+import {stringifyTruthy} from '../../util/stringify_truthy';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
 import {AbstractFormGroupDirective} from '../abstract_form_group_directive';
 import {ControlContainer} from '../control_container';
@@ -86,8 +87,13 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
    * while the numerical form allows for form controls to be bound
    * to indices when iterating over controls in a `FormArray`.
    */
-  // TODO(issue/24571): remove '!'.
-  @Input('formControlName') name!: string|number|null;
+  @Input('formControlName')
+  set name(value: string|null) {
+    this._name = stringifyTruthy(value);
+  }
+  get name(): string|null {
+    return this._name;
+  }
 
   /**
    * @description

--- a/packages/forms/src/util/stringify_truthy.ts
+++ b/packages/forms/src/util/stringify_truthy.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Stringify a truthy value. (preserve `null`/`undefined`).
+ */
+export function stringifyTruthy(value: string|number): string;
+export function stringifyTruthy(value: string|number|undefined): string|undefined;
+export function stringifyTruthy(value: string|number|null): string|null;
+export function stringifyTruthy(value: string|number|null|undefined): string|null|undefined;
+export function stringifyTruthy(value: any): string|null|undefined {
+  return value == null ? value : String(value);
+}

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {SimpleChange} from '@angular/core';
+import {ElementRef, Renderer2, SimpleChange} from '@angular/core';
 import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {beforeEach, describe, expect, it} from '@angular/core/testing/src/testing_internal';
 import {AbstractControl, CheckboxControlValueAccessor, ControlValueAccessor, DefaultValueAccessor, FormArray, FormArrayName, FormControl, FormControlDirective, FormControlName, FormGroup, FormGroupDirective, FormGroupName, NgControl, NgForm, NgModel, NgModelGroup, SelectControlValueAccessor, SelectMultipleControlValueAccessor, ValidationErrors, Validator, Validators} from '@angular/forms';
@@ -313,15 +313,23 @@ class CustomValidatorDirective implements Validator {
       let formModel: FormGroup;
       let loginControlDir: any /** TODO #9100 */;
       let personControlGroupDir: any /** TODO #9100 */;
+      let renderer: Renderer2;
+      let elementRef: ElementRef;
 
       beforeEach(() => {
         form = new NgForm([], []);
         formModel = form.form;
+        renderer = {
+          setAttribute: () => {},
+          removeAttribute: () => {},
+        } as any;
+        elementRef = new ElementRef(null);
 
         personControlGroupDir = new NgModelGroup(form, [], []);
         personControlGroupDir.name = 'person';
 
-        loginControlDir = new NgModel(personControlGroupDir, null!, null!, [defaultAccessor]);
+        loginControlDir = new NgModel(
+            personControlGroupDir, null!, null!, [defaultAccessor], renderer, elementRef);
         loginControlDir.name = 'login';
         loginControlDir.valueAccessor = new DummyControlValueAccessor();
       });
@@ -543,10 +551,18 @@ class CustomValidatorDirective implements Validator {
     describe('NgModel', () => {
       let ngModel: NgModel;
       let control: FormControl;
+      let renderer: Renderer2;
+      let elementRef: ElementRef;
 
       beforeEach(() => {
+        renderer = {
+          setAttribute: () => {},
+          removeAttribute: () => {},
+        } as any;
+        elementRef = new ElementRef(null);
         ngModel = new NgModel(
-            null!, [Validators.required], [asyncValidator('expected')], [defaultAccessor]);
+            null!, [Validators.required], [asyncValidator('expected')], [defaultAccessor], renderer,
+            elementRef);
         ngModel.valueAccessor = new DummyControlValueAccessor();
         control = ngModel.control;
       });
@@ -579,7 +595,7 @@ class CustomValidatorDirective implements Validator {
       });
 
       it('should throw when no value accessor with named control', () => {
-        const namedDir = new NgModel(null!, null!, null!, null!);
+        const namedDir = new NgModel(null!, null!, null!, null!, renderer, elementRef);
         namedDir.name = 'one';
 
         expect(() => namedDir.ngOnChanges({}))
@@ -587,7 +603,7 @@ class CustomValidatorDirective implements Validator {
       });
 
       it('should throw when no value accessor with unnamed control', () => {
-        const unnamedDir = new NgModel(null!, null!, null!, null!);
+        const unnamedDir = new NgModel(null!, null!, null!, null!, renderer, elementRef);
 
         expect(() => unnamedDir.ngOnChanges({}))
             .toThrowError(

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -177,6 +177,16 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
         const input = fixture.debugElement.query(By.css('input'));
         expect(input.nativeElement.value).toEqual('');
       });
+
+      // #19320
+      it('should keep name attribute', () => {
+        const fixture = initTest(NgModelTextForm);
+        fixture.detectChanges();
+
+        const inputs = fixture.debugElement.queryAll(By.css('input'));
+        expect(inputs[0].attributes['name']).toBe('foo');
+        expect(inputs[1].attributes['name']).toBeUndefined();
+      });
     });
 
     describe('select controls', () => {
@@ -799,6 +809,16 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           expect(inputs[0].nativeElement.checked).toBe(false);
           expect(inputs[1].nativeElement.checked).toBe(true);
         });
+
+        // #11757
+        it('should keep name attribute', () => {
+          const fixture = initTest(FormControlRadioInput);
+          fixture.detectChanges();
+
+          const inputs = fixture.debugElement.queryAll(By.css('input'));
+          expect(inputs[0].attributes['name']).toBe('foo');
+          expect(inputs[1].attributes['name']).toBeUndefined();
+        });
       });
 
       describe('in template-driven forms', () => {
@@ -1137,6 +1157,18 @@ class FormControlNumberInput {
 }
 
 @Component({
+  selector: 'form-control-radio-input',
+  template: `
+    <input type="radio" [name]="name" [formControl]="control">
+    <input type="radio" [formControl]="control">
+  `
+})
+class FormControlRadioInput {
+  name = 'foo';
+  control: FormControl = new FormControl(false);
+}
+
+@Component({
   selector: 'form-control-name-select',
   template: `
     <div [formGroup]="form">
@@ -1327,6 +1359,20 @@ export class FormControlRadioButtons {
   // TODO(issue/24571): remove '!'.
   form!: FormGroup;
   showRadio = new FormControl('yes');
+}
+
+@Component({
+  selector: 'ng-model-text-form',
+  template: `
+    <form>
+      <input type="text" name="foo" [(ngModel)]="foo">
+      <input type="text" [(ngModel)]="bar" [ngModelOptions]="{standalone: true}">
+    </form>
+  `
+})
+class NgModelTextForm {
+  foo: string = '';
+  bar: string = '';
 }
 
 @Component({


### PR DESCRIPTION
closes #11757, closes #19320

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #11757, #19320


## What is the new behavior?

Keep the `name` attribute for control element if it exists in HTML template.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
