### PR TITLE
feat(compiler): allow trailing comma in array literal

### DIFF
--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -820,11 +820,14 @@ export class _ParseAST {
 
   parseExpressionList(terminator: number): AST[] {
     const result: AST[] = [];
-    if (!this.next.isCharacter(terminator)) {
-      do {
+
+    do {
+      if (!this.next.isCharacter(terminator)) {
         result.push(this.parsePipe());
-      } while (this.consumeOptionalCharacter(chars.$COMMA));
-    }
+      } else {
+        break;
+      }
+    } while (this.consumeOptionalCharacter(chars.$COMMA));
     return result;
   }
 

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -106,6 +106,7 @@ describe('parser', () => {
         checkAction('[]');
         checkAction('[].length');
         checkAction('[1, 2].length');
+        checkAction('[1, 2,]', '[1, 2]');
       });
 
       it('should parse map', () => {


### PR DESCRIPTION
closes #20773

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #20773


## What is the new behavior?

Trailing comma is allowed in `Array` literal since ES5, it's now supported in Angular as well.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
