### PR TITLE
feat(platform-server): prepend the hostname/origin to all http requests

### DIFF
--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -7,7 +7,7 @@
  */
 
 import {Injectable} from '@angular/core';
-import {Observable, of } from 'rxjs';
+import {Observable, of as observableOf} from 'rxjs';
 import {concatMap, filter, map} from 'rxjs/operators';
 
 import {HttpHandler} from './backend';
@@ -381,7 +381,7 @@ export class HttpClient {
     // inside an Observable chain, which causes interceptors to be re-run on every
     // subscription (this also makes retries re-run the handler, including interceptors).
     const events$: Observable<HttpEvent<any>> =
-        of (req).pipe(concatMap((req: HttpRequest<any>) => this.handler.handle(req)));
+        observableOf(req).pipe(concatMap((req: HttpRequest<any>) => this.handler.handle(req)));
 
     // If coming via the API signature which accepts a previously constructed HttpRequest,
     // the only option is to get the event stream. Otherwise, return the event stream if

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -694,6 +694,23 @@ class EscapedTransferStoreModule {
              });
            });
          }));
+      it('can make relative HttpClient requests with initial url', async(() => {
+           const platform = platformDynamicServer([{
+             provide: INITIAL_CONFIG,
+             useValue: {document: '<app></app>', url: 'http://localhost:4000'}
+           }]);
+           platform.bootstrapModule(HttpClientExmapleModule).then(ref => {
+             const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
+             const http = ref.injector.get(HttpClient);
+             ref.injector.get<NgZone>(NgZone).run(() => {
+               http.get('/testing').subscribe(body => {
+                 NgZone.assertInAngularZone();
+                 expect(body).toEqual('success!');
+               });
+               mock.expectOne('http://localhost:4000/testing').flush('success!');
+             });
+           });
+         }));
       it('requests are macrotasks', async(() => {
            const platform = platformDynamicServer(
                [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);


### PR DESCRIPTION
* Add an interceptor that prepends the hostname or the origin
  to all URLs so that they're resolved correctly on the server
* Path resolution appends the hostname for non-relative URLs and
  the origin for all others
  * E.g. for origin localhost:4000/shop/20
	`http.get('api')` -> localhost:4000/api 
    and `http.get('../token')` -> localhost:4000/shop/token

Fixes #19224
PR Close #22280