### PR TITLE
[WIP] feat(compiler-cli): support RegExp literal in metadata

### DIFF
--- a/packages/compiler-cli/integrationtest/src/module.ts
+++ b/packages/compiler-cli/integrationtest/src/module.ts
@@ -72,6 +72,7 @@ export {SomeModule as JitSummariesSomeModule} from './jit_summaries';
     // disable sanity check for material because it throws an error when used server-side
     // see https://github.com/angular/material2/issues/6292
     {provide: MATERIAL_SANITY_CHECKS, useValue: false},
+    {provide: 'regexpToken', useValue: [/\d/, /[a-z]/]},
   ],
   entryComponents: [
     AnimateCmp,

--- a/packages/compiler-cli/integrationtest/test/ng_module_spec.ts
+++ b/packages/compiler-cli/integrationtest/test/ng_module_spec.ts
@@ -72,6 +72,15 @@ multi-lines`);
     });
   });
 
+  describe('metadata collector', () => {
+    // https://github.com/angular/angular/issues/14187
+    it('should support RegExp literal in provider', () => {
+      const moduleRef = createModule();
+      const regexps = moduleRef.injector.get('regexpToken');
+      expect(regexps[0].toString()).toBe('/\\d/');
+    });
+  });
+
   it('should support module directives and pipes', () => {
     const compFixture = createComponent(CompUsingRootModuleDirectiveAndPipe);
     compFixture.detectChanges();

--- a/packages/compiler-cli/src/metadata/evaluator.ts
+++ b/packages/compiler-cli/src/metadata/evaluator.ts
@@ -511,6 +511,9 @@ export class Evaluator {
         return (<ts.LiteralLikeNode>node).text;
       case ts.SyntaxKind.NumericLiteral:
         return parseFloat((<ts.LiteralExpression>node).text);
+      case ts.SyntaxKind.RegularExpressionLiteral:
+        return recordEntry(
+            {__symbolic: 'reference', name: (<ts.LiteralExpression>node).text}, node);
       case ts.SyntaxKind.AnyKeyword:
         return recordEntry({__symbolic: 'reference', name: 'any'}, node);
       case ts.SyntaxKind.StringKeyword:

--- a/packages/compiler-cli/test/metadata/evaluator_spec.ts
+++ b/packages/compiler-cli/test/metadata/evaluator_spec.ts
@@ -225,6 +225,20 @@ describe('Evaluator', () => {
         .toEqual({__symbolic: 'new', expression: {__symbolic: 'reference', name: 'f'}});
   });
 
+  it('should treat RegExp literal as reference', () => {
+    const source = sourceFileOf(`
+      export var a = [
+        { provide: 'someValue': useValue: /\\d/ }
+      ];
+    `);
+    const expr = findVar(source, 'a');
+
+    expect(evaluator.evaluateNode(expr !.initializer !)).toEqual([
+      {provide: 'someValue', useValue: {__symbolic: 'reference', name: '/\\d/'}}
+    ]);
+
+  });
+
   describe('with substitution', () => {
     let evaluator: Evaluator;
     const lambdaTemp = 'lambdaTemp';


### PR DESCRIPTION
closes #14187

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #14187


## What is the new behavior?

Using RegExp literal is supported in AOT.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
