### PR TITLE
fix(core): properly handle function without prototype in reflector

### DIFF
--- a/packages/core/src/reflection/reflection_capabilities.ts
+++ b/packages/core/src/reflection/reflection_capabilities.ts
@@ -252,7 +252,7 @@ function convertTsickleDecoratorIntoMetadata(decoratorInvocations: any[]): any[]
 }
 
 function getParentCtor(ctor: Function): Type<any> {
-  const parentProto = Object.getPrototypeOf(ctor.prototype);
+  const parentProto = ctor.prototype ? Object.getPrototypeOf(ctor.prototype) : null;
   const parentCtor = parentProto ? parentProto.constructor : null;
   // Note: We always use `Object` as the null value
   // to simplify checking later on.

--- a/packages/core/test/reflection/reflector_spec.ts
+++ b/packages/core/test/reflection/reflector_spec.ts
@@ -181,6 +181,13 @@ class TestObj {
         expect(DELEGATE_CTOR.exec(ChildNoCtorPrivateProps.toString())).toBeTruthy();
         expect(DELEGATE_CTOR.exec(ChildWithCtor.toString())).toBeFalsy();
       });
+
+      it('should not throw when no prototype on type', () => {
+        // Cannot test arrow function here due to the compilation
+        const dummyArrowFn = function() {};
+        Object.defineProperty(dummyArrowFn, 'prototype', {value: undefined});
+        expect(() => reflector.annotations(dummyArrowFn as any)).not.toThrow();
+      });
     });
 
     describe('inheritance with decorators', () => {


### PR DESCRIPTION
closes #19978

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #19978

Some context:

+ Arrow function does not have a `prototype` property;
+ Arrow function can be used in `loadChildren`;
+ `Router` provides `component`s and `loadChildren`s to `ANALYZE_FOR_ENTRY_COMPONENTS`;
+ `MetadataResolver` checks whether these type-like functions are `Component`;
+ `Reflector` try to retrieve metadata from these functions;
+ `ReflectionCapabilities` try to merge the parent type's metadata with current metadata;
+ `ReflectionCapabilities` try to access prototype and throws;

## What is the new behavior?

Don't throw error any more.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
