### PR TITLE
feat(platform-browser): support bind to multiple events in one place

### DIFF
--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -19,6 +19,7 @@ import {ELEMENT_PROBE_PROVIDERS} from './dom/debug/ng_probe';
 import {getDOM} from './dom/dom_adapter';
 import {DomRendererFactory2} from './dom/dom_renderer';
 import {DOCUMENT} from './dom/dom_tokens';
+import {CompositionEventsPlugin} from './dom/events/composition_events';
 import {DomEventsPlugin} from './dom/events/dom_events';
 import {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 import {HAMMER_GESTURE_CONFIG, HammerGestureConfig, HammerGesturesPlugin} from './dom/events/hammer_gestures';
@@ -76,6 +77,7 @@ export function _document(): any {
     {provide: EVENT_MANAGER_PLUGINS, useClass: DomEventsPlugin, multi: true},
     {provide: EVENT_MANAGER_PLUGINS, useClass: KeyEventsPlugin, multi: true},
     {provide: EVENT_MANAGER_PLUGINS, useClass: HammerGesturesPlugin, multi: true},
+    {provide: EVENT_MANAGER_PLUGINS, useClass: CompositionEventsPlugin, multi: true},
     {provide: HAMMER_GESTURE_CONFIG, useClass: HammerGestureConfig},
     DomRendererFactory2,
     {provide: RendererFactory2, useExisting: DomRendererFactory2},

--- a/packages/platform-browser/src/dom/events/composition_events.ts
+++ b/packages/platform-browser/src/dom/events/composition_events.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DOCUMENT} from '@angular/common';
+import {Inject, Injectable} from '@angular/core';
+
+import {EventManagerPlugin} from './event_manager';
+
+@Injectable()
+export class CompositionEventsPlugin extends EventManagerPlugin {
+  constructor(@Inject(DOCUMENT) doc: any) { super(doc); }
+
+  supports(eventName: string): boolean { return eventName.indexOf(',') >= 0; }
+
+  addEventListener(element: HTMLElement, rawEventName: string, handler: Function): Function {
+    const eventNames = this.parseEventNames(rawEventName);
+    return this.dispatchEvents(
+        eventNames, eventName => this.manager.addEventListener(element, eventName, handler));
+  }
+
+  addGlobalEventListener(target: string, rawEventName: string, handler: Function): Function {
+    const eventNames = this.parseEventNames(rawEventName);
+    return this.dispatchEvents(
+        eventNames, eventName => this.manager.addGlobalEventListener(target, eventName, handler));
+  }
+
+  private dispatchEvents(eventNames: string[], handleEvent: (eventName: string) => Function):
+      Function {
+    const disposers: Function[] = [];
+    for (let i = 0; i < eventNames.length; i++) {
+      const eventName = eventNames[i];
+      const disposer = handleEvent(eventName);
+      disposers.push(disposer);
+    }
+
+    return () => {
+      for (let i = 0; i < disposers.length; i++) {
+        disposers[i]();
+      }
+    };
+  }
+
+  private parseEventNames(rawEventName: string): string[] {
+    return rawEventName.split(',').filter(str => str.length > 0);
+  }
+}

--- a/packages/platform-browser/test/dom/events/composition_events_spec.ts
+++ b/packages/platform-browser/test/dom/events/composition_events_spec.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {describe, expect, it} from '@angular/core/testing/src/testing_internal';
+import {CompositionEventsPlugin} from '@angular/platform-browser/src/dom/events/composition_events';
+import {EventManager} from '@angular/platform-browser/src/dom/events/event_manager';
+
+{
+  describe('CompositionEventsPlugin', () => {
+    if (isNode) return;
+    let plugin: CompositionEventsPlugin;
+    let manager: EventManager;
+
+    beforeEach(() => {
+      plugin = new CompositionEventsPlugin(document);
+      manager = { addEventListener: () => {}, addGlobalEventListener: () => {} } as any;
+      plugin.manager = manager;
+    });
+
+    it('should only process composition events', () => {
+      expect(plugin.supports('click')).toBe(false);
+      expect(plugin.supports('click,keydown')).toBe(true);
+    });
+
+    it('should dispatch element event listener', () => {
+      let unlistenCount = 0;
+      spyOn(manager, 'addEventListener').and.returnValue(() => unlistenCount++);
+      const element = document.createElement('div');
+      const handler = () => {};
+
+      const disposer = plugin.addEventListener(element, 'click,keydown', handler);
+      expect(manager.addEventListener).toHaveBeenCalledWith(element, 'click', handler);
+      expect(manager.addEventListener).toHaveBeenCalledWith(element, 'keydown', handler);
+
+      disposer();
+      expect(unlistenCount).toBe(2);
+    });
+
+    it('should dispatch global event listener', () => {
+      let unlistenCount = 0;
+      spyOn(manager, 'addGlobalEventListener').and.returnValue(() => unlistenCount++);
+      const handler = () => {};
+
+      const disposer = plugin.addGlobalEventListener('window', 'scroll,resize', handler);
+      expect(manager.addGlobalEventListener).toHaveBeenCalledWith('window', 'scroll', handler);
+      expect(manager.addGlobalEventListener).toHaveBeenCalledWith('window', 'resize', handler);
+
+      disposer();
+      expect(unlistenCount).toBe(2);
+    });
+  });
+}


### PR DESCRIPTION
closes #19675

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #19675


## What is the new behavior?

Support listen to several events in one binding:

```html
<div (mouseenter,mouseleave)="fooFighters()">...</div>
```

Note: space in between is not allowed as per HTML syntax.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Currently there is no documentation for any kind of event, should be added together.