### PR TITLE
feat(compiler): allow multiple input/output binding on same property

### DIFF
--- a/packages/compiler/src/directive_resolver.ts
+++ b/packages/compiler/src/directive_resolver.ts
@@ -64,22 +64,26 @@ export class DirectiveResolver {
     const host: {[key: string]: string} = {};
     const queries: {[key: string]: any} = {};
     Object.keys(propertyMetadata).forEach((propName: string) => {
-      const input = findLast(propertyMetadata[propName], (a) => createInput.isTypeOf(a));
-      if (input) {
+      const inputDecoratorFactories =
+          propertyMetadata[propName].filter((a) => createInput.isTypeOf(a));
+      inputDecoratorFactories.forEach(input => {
         if (input.bindingPropertyName) {
           inputs.push(`${propName}: ${input.bindingPropertyName}`);
         } else {
           inputs.push(propName);
         }
-      }
-      const output = findLast(propertyMetadata[propName], (a) => createOutput.isTypeOf(a));
-      if (output) {
+      });
+
+      const outputDecoratorFactories =
+          propertyMetadata[propName].filter((a) => createOutput.isTypeOf(a));
+      outputDecoratorFactories.forEach(output => {
         if (output.bindingPropertyName) {
           outputs.push(`${propName}: ${output.bindingPropertyName}`);
         } else {
           outputs.push(propName);
         }
-      }
+      });
+
       const hostBindings = propertyMetadata[propName].filter(a => createHostBinding.isTypeOf(a));
       hostBindings.forEach(hostBinding => {
         if (hostBinding.hostPropertyName) {

--- a/packages/compiler/test/directive_resolver_spec.ts
+++ b/packages/compiler/test/directive_resolver_spec.ts
@@ -228,7 +228,18 @@ class SomeDirectiveWithoutMetadata {}
         }
 
         const directiveMetadata = resolver.resolve(Child);
-        expect(directiveMetadata.inputs).toEqual(['p1', 'p2: p22', 'p3']);
+        expect(directiveMetadata.inputs).toEqual(['p1', 'p2: p21', 'p2: p22', 'p3']);
+      });
+
+      it('should support multiple inputs on same property', () => {
+        @Directive({selector: 'p'})
+        class Dir {
+          @Input() @Input('p11')
+          p1: any;
+        }
+
+        const directiveMetadata = resolver.resolve(Dir);
+        expect(directiveMetadata.inputs).toEqual(['p1', 'p1: p11']);
       });
     });
 
@@ -288,7 +299,18 @@ class SomeDirectiveWithoutMetadata {}
         }
 
         const directiveMetadata = resolver.resolve(Child);
-        expect(directiveMetadata.outputs).toEqual(['p1', 'p2: p22', 'p3']);
+        expect(directiveMetadata.outputs).toEqual(['p1', 'p2: p21', 'p2: p22', 'p3']);
+      });
+
+      it('should support multiple outputs on same property', () => {
+        @Directive({selector: 'p'})
+        class Dir {
+          @Output() @Output('p11')
+          p1: any;
+        }
+
+        const directiveMetadata = resolver.resolve(Dir);
+        expect(directiveMetadata.outputs).toEqual(['p1', 'p1: p11']);
       });
     });
 


### PR DESCRIPTION
closes #11663

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #11663

## What is the new behavior?

A directive could have multiple bindings on same property, like:

```typescript
@Directive({
  selector: 'my-group, [myGroup]'
})
class MyGroup {
  @Input('name')
  @Input('myGroup')
  myGroup: string = 'default'
}
```

```html
<my-group name="foo"></my-group>
<!-- equals to -->
<div myGroup="foo"></div>
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This change is just following #13474 and make `Input`, `Output` inheritance behavior consistent to `HostBinding`, if that one is marked as `fix` and `non-breaking`, so should this one be.

But given the purpose of this PR is to allow some additional case, marked it `feat`.

This change would also relax some use case (still non-breaking), given directives:

```typescript
@Directive({ selector: '[myParent]' })
class Parent {
  @Input('foo')
  baz: string
}

@Directive({ selector: '[myChild]' })
class Child extends Parent {
  @Input('bar')
  baz: string
}
```

Before this change:

```html
<!-- Invalid before -->
<div myChild foo="hello"></div>
<!-- Valid before -->
<div myChild bar="hello"></div>
```

After this change:

```html
<!-- Valid now -->
<div myChild foo="hello"></div>
<!-- Valid now -->
<div myChild bar="hello"></div>
```

Given the `HostBinding` behavior has already been changed this way, should also give `Input` and `Output` with a consistent behavior.