### PR TITLE
feat(compiler): support hexadecimal/octal/binary number literals

### DIFF
--- a/packages/compiler/src/chars.ts
+++ b/packages/compiler/src/chars.ts
@@ -37,12 +37,15 @@ export const $GT = 62;
 export const $QUESTION = 63;
 
 export const $0 = 48;
+export const $1 = 49;
 export const $7 = 55;
 export const $9 = 57;
 
 export const $A = 65;
+export const $B = 66;
 export const $E = 69;
 export const $F = 70;
+export const $O = 79;
 export const $X = 88;
 export const $Z = 90;
 
@@ -57,6 +60,7 @@ export const $b = 98;
 export const $e = 101;
 export const $f = 102;
 export const $n = 110;
+export const $o = 111;
 export const $r = 114;
 export const $t = 116;
 export const $u = 117;
@@ -97,4 +101,8 @@ export function isNewLine(code: number): boolean {
 
 export function isOctalDigit(code: number): boolean {
   return $0 <= code && code <= $7;
+}
+
+export function isBinaryDigit(code: number): boolean {
+  return $0 <= code && code <= $1;
 }

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -95,10 +95,70 @@ function expectErrorToken(token: Token, index: any, end: number, message: string
         expectCharacterToken(tokens[3], 3, 4, ']');
       });
 
-      it('should tokenize numbers', () => {
+      it('should tokenize decimal numbers', () => {
         const tokens: number[] = lex('88');
         expect(tokens.length).toEqual(1);
         expectNumberToken(tokens[0], 0, 2, 88);
+      });
+
+      it('should tokenize numbers within index ops', () => {
+        expectNumberToken(lex('a[22]')[2], 2, 4, 22);
+      });
+
+      it('should tokenize hexadecimal numbers', () => {
+        const tokens: number[] = lex('0x88AbCdEf');
+        expect(tokens.length).toEqual(1);
+        expectNumberToken(tokens[0], 0, 10, 0x88AbCdEf);
+      });
+
+      it('should tokenize octal numbers', () => {
+        const tokens: number[] = lex('0o66');
+        expect(tokens.length).toEqual(1);
+        expectNumberToken(tokens[0], 0, 4, 0o66);
+      });
+
+      it('should throw error when octal digit out of range', () => {
+        expectErrorToken(
+            lex('0o88')[0], 2, 2,
+            `Lexer Error: Out of range digit '8' under radix '8' at column 2 in expression [0o88]`);
+      });
+
+      it('should tokenize binary numbers', () => {
+        const tokens: number[] = lex('0b11');
+        expect(tokens.length).toEqual(1);
+        expectNumberToken(tokens[0], 0, 4, 0b11);
+      });
+
+      it('should throw error when binary digit out of range', () => {
+        expectErrorToken(
+            lex('0b12')[0], 3, 3,
+            `Lexer Error: Out of range digit '2' under radix '2' at column 3 in expression [0b12]`);
+      });
+
+      it('should throw error when combine dot with non-decimal', () => {
+        expectErrorToken(
+            lex('0x88.12')[0], 0, 7,
+            `Lexer Error: Invalid number format at column 0 in expression [0x88.12]`);
+      });
+
+      it('should throw error when combine exponent with non-decimal', () => {
+        expectErrorToken(
+            lex('0o12e2')[0], 4, 4,
+            `Lexer Error: Out of range digit 'e' under radix '8' at column 4 in expression [0o12e2]`);
+      });
+
+      // Enable this tests once we want to align ourselves with JavaScript parsing rules.
+      xit('should throw error for deprecated legacy octal', () => {
+        expectErrorToken(
+            lex('01234')[0], 0, 1,
+            `Lexer Error: Legacy octal literals are not allowed in strict mode at column 0 in expression [01234]`);
+      });
+
+      // Delete this tests once the above test is enabled.
+      it('should parse as radix=10', () => {
+        const tokens: number[] = lex('01234');
+        expect(tokens.length).toEqual(1);
+        expectNumberToken(tokens[0], 0, 5, 1234);
       });
 
       it('should tokenize numbers within index ops', () => {


### PR DESCRIPTION
closes #12716

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #12716


## What is the new behavior?

Hexadecimal, octal, and binary literals allowed in template:

```html
<div>{{ 100 + 0x50 + 0o5 + 0b1 }}</div>
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

`012` is not supposed to be supported due to all templates are still module code, which always have `strict mode` turned on, making that being a syntax error. But current implementation treat it as decimal `12` which is incorrect. Now throw error for it.

Given that `012 === 12` is already the wrong result (should be `012 === 10` in non-strict mode), forbid that would not be consider a breaking change.

## Other information

The current validation for float and exponent number are not strict enough, invalid usage like `1e2e3` and `1.2.3` are allowed. Didn't change that.