### PR TITLE
fix(compiler-cli): add missing entry point

### DIFF
--- a/packages/compiler-cli/tsconfig-build.json
+++ b/packages/compiler-cli/tsconfig-build.json
@@ -24,6 +24,7 @@
     "index.ts",
     "ngtools2.ts",
     "src/main.ts",
+    "src/bundle_index_main.ts",
     "src/extract_i18n.ts",
     "src/language_services.ts",
     "../../node_modules/@types/node/index.d.ts",


### PR DESCRIPTION
Without this entry, the corresponding bundle_index_main.js was not produced in the compiler-cli-builds package.
