### PR TITLE
fix(common): then and else template might be set to null

### DIFF
--- a/packages/common/src/directives/ng_if.ts
+++ b/packages/common/src/directives/ng_if.ts
@@ -117,7 +117,7 @@ export class NgIf {
   }
 
   @Input()
-  set ngIfThen(templateRef: TemplateRef<NgIfContext>) {
+  set ngIfThen(templateRef: TemplateRef<NgIfContext>|null) {
     assertTemplate('ngIfThen', templateRef);
     this._thenTemplateRef = templateRef;
     this._thenViewRef = null;  // clear previous view if any.
@@ -125,7 +125,7 @@ export class NgIf {
   }
 
   @Input()
-  set ngIfElse(templateRef: TemplateRef<NgIfContext>) {
+  set ngIfElse(templateRef: TemplateRef<NgIfContext>|null) {
     assertTemplate('ngIfElse', templateRef);
     this._elseTemplateRef = templateRef;
     this._elseViewRef = null;  // clear previous view if any.
@@ -166,9 +166,9 @@ export class NgIfContext {
   public ngIf: any = null;
 }
 
-function assertTemplate(property: string, templateRef: TemplateRef<any>): void {
-  const isTemplateRef = templateRef.createEmbeddedView != null;
-  if (!isTemplateRef) {
+function assertTemplate(property: string, templateRef: TemplateRef<any>| null): void {
+  const isTemplateRefOrNull = !!(!templateRef || templateRef.createEmbeddedView);
+  if (!isTemplateRefOrNull) {
     throw new Error(`${property} must be a TemplateRef, but received '${stringify(templateRef)}'.`);
   }
 }

--- a/packages/common/test/directives/ng_if_spec.ts
+++ b/packages/common/test/directives/ng_if_spec.ts
@@ -138,7 +138,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
          expect(fixture.nativeElement).toHaveText('hello');
        }));
 
-    describe('else', () => {
+    describe('then/else templates', () => {
       it('should support else', async(() => {
            const template = '<span *ngIf="booleanCondition; else elseBlock">TRUE</span>' +
                '<ng-template #elseBlock>FALSE</ng-template>';
@@ -168,6 +168,39 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
            fixture.detectChanges();
            expect(fixture.nativeElement).toHaveText('ELSE');
          }));
+
+      it('should support removing the then/else templates', () => {
+        const template = `<span *ngIf="booleanCondition;
+            then nestedBooleanCondition ? tplRef : null;
+            else nestedBooleanCondition ? tplRef : null"></span>
+        <ng-template #tplRef>Template</ng-template>`;
+
+        fixture = createTestComponent(template);
+        const comp = fixture.componentInstance;
+        // then
+        comp.booleanCondition = true;
+
+        comp.nestedBooleanCondition = true;
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveText('Template');
+
+        comp.nestedBooleanCondition = false;
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveText('');
+
+        // else
+        comp.booleanCondition = true;
+
+        comp.nestedBooleanCondition = true;
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveText('Template');
+
+        comp.nestedBooleanCondition = false;
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveText('');
+
+
+      });
 
       it('should support dynamic else', async(() => {
            const template =

--- a/packages/common/test/directives/ng_if_spec.ts
+++ b/packages/common/test/directives/ng_if_spec.ts
@@ -177,7 +177,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 
         fixture = createTestComponent(template);
         const comp = fixture.componentInstance;
-        // then
+        // then template
         comp.booleanCondition = true;
 
         comp.nestedBooleanCondition = true;
@@ -188,7 +188,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
         fixture.detectChanges();
         expect(fixture.nativeElement).toHaveText('');
 
-        // else
+        // else template
         comp.booleanCondition = true;
 
         comp.nestedBooleanCondition = true;
@@ -198,8 +198,6 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
         comp.nestedBooleanCondition = false;
         fixture.detectChanges();
         expect(fixture.nativeElement).toHaveText('');
-
-
       });
 
       it('should support dynamic else', async(() => {

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -275,8 +275,8 @@ export declare class NgForOfContext<T> {
 /** @stable */
 export declare class NgIf {
     ngIf: any;
-    ngIfElse: TemplateRef<NgIfContext>;
-    ngIfThen: TemplateRef<NgIfContext>;
+    ngIfElse: TemplateRef<NgIfContext> | null;
+    ngIfThen: TemplateRef<NgIfContext> | null;
     constructor(_viewContainer: ViewContainerRef, templateRef: TemplateRef<NgIfContext>);
 }
 


### PR DESCRIPTION
Merging #22274 caused a breakage because the templates could be `null` in the setters.

This PR
- fixes the types,
- fixes the code

http://test/OCL:186173815:BASE:186173819:1519008274294:1ee8e53c