### PR TITLE
fix(common): properly check NaN value

### DIFF
--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, EventEmitter, Injectable, OnDestroy, Pipe, PipeTransform, WrappedValue, ɵisObservable, ɵisPromise} from '@angular/core';
+import {ChangeDetectorRef, EventEmitter, Injectable, OnDestroy, Pipe, PipeTransform, WrappedValue, ɵisObservable, ɵisPromise, ɵlooseIdentical} from '@angular/core';
 import {Observable, SubscriptionLike} from 'rxjs';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
@@ -103,7 +103,7 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
       return this.transform(obj as any);
     }
 
-    if (this._latestValue === this._latestReturnedValue) {
+    if (ɵlooseIdentical(this._latestValue, this._latestReturnedValue)) {
       return this._latestReturnedValue;
     }
 

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -82,6 +82,18 @@ import {SpyChangeDetectorRef} from '../spies';
                async.done();
              }, 10);
            }));
+
+        it('should return unwrapped value for unchanged NaN', () => {
+          const emitter = new EventEmitter<any>();
+          emitter.emit(null);
+          pipe.transform(emitter);
+          emitter.next(NaN);
+          const firstResult = pipe.transform(emitter);
+          const secondResult = pipe.transform(emitter);
+          expect(firstResult instanceof WrappedValue).toBe(true);
+          expect((firstResult as WrappedValue).wrapped).toBeNaN();
+          expect(secondResult).toBeNaN();
+        });
       });
 
       describe('ngOnDestroy', () => {


### PR DESCRIPTION
closes #15721 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #15721, ~~#18129~~


## What is the new behavior?

When the previous value is a wrapped one but the new value is not (while they're same), this still indicates no change happened, should not throw. (but not the opposite)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

~~Note: #15723 cannot fix the problem alone.~~ 
#15723 is correct, my thoughts were wrong.