### PR TITLE
feat(forms): drop ngModel support in reactive forms

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -69,8 +69,6 @@ export class FormControlDirective extends NgControl implements OnChanges {
   viewModel: any;
 
   @Input('formControl') form: FormControl;
-  @Input('ngModel') model: any;
-  @Output('ngModelChange') update = new EventEmitter();
 
   @Input('disabled')
   set isDisabled(isDisabled: boolean) { ReactiveErrors.disabledAttrWarning(); }
@@ -93,10 +91,6 @@ export class FormControlDirective extends NgControl implements OnChanges {
                   }
                   this.form.updateValueAndValidity({emitEvent: false});
                 }
-                if (isPropertyUpdated(changes, this.viewModel)) {
-                  this.form.setValue(this.model);
-                  this.viewModel = this.model;
-                }
               }
 
               get path(): string[] { return []; }
@@ -109,10 +103,7 @@ export class FormControlDirective extends NgControl implements OnChanges {
 
               get control(): FormControl { return this.form; }
 
-              viewToModelUpdate(newValue: any): void {
-                this.viewModel = newValue;
-                this.update.emit(newValue);
-              }
+              viewToModelUpdate(newValue: any): void { this.viewModel = newValue; }
 
               private _isControlChanged(changes: {[key: string]: any}): boolean {
                 return changes.hasOwnProperty('form');

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -1625,90 +1625,6 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
     });
 
-    describe('ngModel interactions', () => {
-
-      it('should support ngModel for complex forms', fakeAsync(() => {
-           const fixture = initTest(FormGroupNgModel);
-           fixture.componentInstance.form = new FormGroup({'login': new FormControl('')});
-           fixture.componentInstance.login = 'oldValue';
-           fixture.detectChanges();
-           tick();
-
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           expect(input.value).toEqual('oldValue');
-
-           input.value = 'updatedValue';
-           dispatchEvent(input, 'input');
-
-           tick();
-           expect(fixture.componentInstance.login).toEqual('updatedValue');
-         }));
-
-      it('should support ngModel for single fields', fakeAsync(() => {
-           const fixture = initTest(FormControlNgModel);
-           fixture.componentInstance.control = new FormControl('');
-           fixture.componentInstance.login = 'oldValue';
-           fixture.detectChanges();
-           tick();
-
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           expect(input.value).toEqual('oldValue');
-
-           input.value = 'updatedValue';
-           dispatchEvent(input, 'input');
-           tick();
-
-           expect(fixture.componentInstance.login).toEqual('updatedValue');
-         }));
-
-      it('should not update the view when the value initially came from the view', fakeAsync(() => {
-           if (isNode) return;
-           const fixture = initTest(FormControlNgModel);
-           fixture.componentInstance.control = new FormControl('');
-           fixture.detectChanges();
-           tick();
-
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           input.value = 'aa';
-           input.setSelectionRange(1, 2);
-           dispatchEvent(input, 'input');
-
-           fixture.detectChanges();
-           tick();
-
-           // selection start has not changed because we did not reset the value
-           expect(input.selectionStart).toEqual(1);
-         }));
-
-      it('should work with updateOn submit', fakeAsync(() => {
-           const fixture = initTest(FormGroupNgModel);
-           const formGroup = new FormGroup({login: new FormControl('', {updateOn: 'submit'})});
-           fixture.componentInstance.form = formGroup;
-           fixture.componentInstance.login = 'initial';
-           fixture.detectChanges();
-           tick();
-
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
-           input.value = 'Nancy';
-           dispatchEvent(input, 'input');
-           fixture.detectChanges();
-           tick();
-
-           expect(fixture.componentInstance.login)
-               .toEqual('initial', 'Expected ngModel value to remain unchanged on input.');
-
-           const form = fixture.debugElement.query(By.css('form')).nativeElement;
-           dispatchEvent(form, 'submit');
-           fixture.detectChanges();
-           tick();
-
-           expect(fixture.componentInstance.login)
-               .toEqual('Nancy', 'Expected ngModel value to update on submit.');
-
-         }));
-
-    });
-
     describe('validations', () => {
       it('required validator should validate checkbox', () => {
         const fixture = initTest(FormControlCheckboxRequiredValidator);
@@ -2442,27 +2358,6 @@ class FormArrayComp {
 class FormArrayNestedGroup {
   form: FormGroup;
   cityArray: FormArray;
-}
-
-@Component({
-  selector: 'form-group-ng-model',
-  template: `
-  <form [formGroup]="form">
-    <input type="text" formControlName="login" [(ngModel)]="login">
-   </form>`
-})
-class FormGroupNgModel {
-  form: FormGroup;
-  login: string;
-}
-
-@Component({
-  selector: 'form-control-ng-model',
-  template: `<input type="text" [formControl]="control" [(ngModel)]="login">`
-})
-class FormControlNgModel {
-  control: FormControl;
-  login: string;
 }
 
 @Component({

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -255,9 +255,7 @@ export declare class FormControlDirective extends NgControl implements OnChanges
     readonly control: FormControl;
     form: FormControl;
     isDisabled: boolean;
-    model: any;
     readonly path: string[];
-    update: EventEmitter<{}>;
     readonly validator: ValidatorFn | null;
     viewModel: any;
     constructor(validators: Array<Validator | ValidatorFn>, asyncValidators: Array<AsyncValidator | AsyncValidatorFn>, valueAccessors: ControlValueAccessor[]);


### PR DESCRIPTION
BREAKING CHANGE: ngModel is no longer valid on formControl directive
Closes #12708

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #12708

As per [documentation](https://angular.io/guide/reactive-forms#template-driven-forms):

> ### Template-driven forms
> ...
> For this reason, **the ngModel directive is not part of the ReactiveFormsModule**

`ngModel` should not be provided in `ReactiveFormsModule`, but current implementation does support it.

## What is the new behavior?

Remove the undesired support for `ngModel` in `ReactiveFormsModule`.

## Does this PR introduce a breaking change?
```
[x] Yes (for disobedient users only)
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Since this is totally private API which has never been documented, no need to provide deprecation stage for it?

## Other information
