### PR TITLE
feat(compiler): support RegExp literal in template

### DIFF
--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -584,6 +584,21 @@ export class _ParseAST {
       this.advance();
       return new LiteralPrimitive(this.span(start), literalValue);
 
+    } else if (this.next.isRegExp()) {
+      const pattern = this.next.strValue;
+      const flags = this.next.extraValue;
+
+      let regex: RegExp;
+      try {
+        regex = new RegExp(pattern, flags);
+      } catch {
+        this.error(`Invalid regular expression: ${this.next}`);
+        return new EmptyExpr(this.span(start));
+      }
+
+      this.advance();
+      return new LiteralPrimitive(this.span(start), regex);
+
     } else if (this.index >= this.tokens.length) {
       this.error(`Unexpected end of expression: ${this.input}`);
       return new EmptyExpr(this.span(start));

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -388,7 +388,7 @@ export class InstantiateExpr extends Expression {
 
 export class LiteralExpr extends Expression {
   constructor(
-      public value: number|string|boolean|null|undefined, type?: Type|null,
+      public value: number|string|boolean|RegExp|null|undefined, type?: Type|null,
       sourceSpan?: ParseSourceSpan|null) {
     super(type, sourceSpan);
   }

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -171,6 +171,14 @@ import {validate} from './validator';
           checkAction('{}["a"]');
         });
 
+        it('should parse RegExp', () => {
+          checkAction('/\\d/');
+          checkAction('/[A-E]/gi');
+          checkAction('/.*?/.exec(input)');
+          expectActionError('/(/', 'Invalid regular expression: /(/');
+          expectActionError('/abc/def', 'Invalid regular expression: /abc/def');
+        });
+
         it('should only allow identifier, string, or keyword as map key', () => {
           expectActionError('{(:0}', 'expected identifier, keyword, or string');
           expectActionError('{1234:0}', 'expected identifier, keyword, or string');

--- a/packages/compiler/test/output/js_emitter_spec.ts
+++ b/packages/compiler/test/output/js_emitter_spec.ts
@@ -97,6 +97,7 @@ const externalModuleIdentifier = new o.ExternalReference(anotherModuleUrl, 'some
       expect(emitStmt(o.literal(0).toStmt())).toEqual('0;');
       expect(emitStmt(o.literal(true).toStmt())).toEqual('true;');
       expect(emitStmt(o.literal('someStr').toStmt())).toEqual(`'someStr';`);
+      expect(emitStmt(o.literal(/[A-Z]\/\d/gi).toStmt())).toEqual(`/[A-Z]\\/\\d/gi;`);
       expect(emitStmt(o.literalArr([o.literal(1)]).toStmt())).toEqual(`[1];`);
       expect(emitStmt(o.literalMap([
                          {key: 'someKey', value: o.literal(1), quoted: false},

--- a/packages/compiler/test/output/ts_emitter_spec.ts
+++ b/packages/compiler/test/output/ts_emitter_spec.ts
@@ -149,6 +149,7 @@ const externalModuleIdentifier = new o.ExternalReference(anotherModuleUrl, 'some
       expect(emitStmt(o.literal(0).toStmt())).toEqual('0;');
       expect(emitStmt(o.literal(true).toStmt())).toEqual('true;');
       expect(emitStmt(o.literal('someStr').toStmt())).toEqual(`'someStr';`);
+      expect(emitStmt(o.literal(/[A-Z]\/\d/gi).toStmt())).toEqual(`/[A-Z]\\/\\d/gi;`);
       expect(emitStmt(o.literalArr([o.literal(1)]).toStmt())).toEqual(`[1];`);
       expect(emitStmt(o.literalMap([
                          {key: 'someKey', value: o.literal(1), quoted: false},


### PR DESCRIPTION
closes #21978

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #21978


## What is the new behavior?

RegExp literals like `/[A-Z]+\d*/i` are now supported in template.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Treated RegExp literals as `LiteralPrimitive` in AST since:

+ It has its own syntax which should not be changed;
+ It does not contain any child node;
+ The existing output logic can be reused (simply appending `toString()` result for non-string primitives);

Given that there is no way to transpile a RegExp (even in AOT), requiring both compilation environment and runtime environment to have support for flags used, otherwise it would throw error.