### PR TITLE
fix(common): inconsistency on TitleCasePipe

### DIFF
--- a/packages/common/src/pipes/case_conversion_pipes.ts
+++ b/packages/common/src/pipes/case_conversion_pipes.ts
@@ -29,13 +29,32 @@ export class LowerCasePipe implements PipeTransform {
 
 
 /**
- * Helper method to transform a single word to titlecase.
+ * Helper method to transform strings to title case
  *
  * @stable
  */
-function titleCaseWord(word: string) {
-  if (!word) return word;
-  return word[0].toUpperCase() + word.substr(1).toLowerCase();
+function titleCase(str: string): string {
+  if (!str) return str;
+
+  const beforeCapital = [/\s/, /\./, /,/];
+
+  let shouldLookforFirstLetter = true;
+
+  return Array.from(str)
+      .map((letter) => {
+        if (beforeCapital.some(regex => regex.test(letter))) {
+          shouldLookforFirstLetter = true;
+          return letter;
+        }
+
+        if (shouldLookforFirstLetter) {
+          shouldLookforFirstLetter = false;
+          return letter.toUpperCase();
+        }
+
+        return letter.toLowerCase();
+      })
+      .join('');
 }
 
 /**
@@ -51,7 +70,7 @@ export class TitleCasePipe implements PipeTransform {
       throw invalidPipeArgumentError(TitleCasePipe, value);
     }
 
-    return value.split(/\b/g).map(word => titleCaseWord(word)).join('');
+    return titleCase(value);
   }
 }
 

--- a/packages/common/test/pipes/case_conversion_pipes_spec.ts
+++ b/packages/common/test/pipes/case_conversion_pipes_spec.ts
@@ -19,6 +19,7 @@ import {LowerCasePipe, TitleCasePipe, UpperCasePipe} from '@angular/common';
     it('should lowercase when there is a new value', () => {
       expect(pipe.transform('FOO')).toEqual('foo');
       expect(pipe.transform('BAr')).toEqual('bar');
+      expect(pipe.transform('avanÇaDO')).toEqual('avançado');
     });
 
     it('should not support other objects',
@@ -30,15 +31,24 @@ import {LowerCasePipe, TitleCasePipe, UpperCasePipe} from '@angular/common';
 
     beforeEach(() => { pipe = new TitleCasePipe(); });
 
-    it('should return titlecase', () => { expect(pipe.transform('foo')).toEqual('Foo'); });
+    it('should return titlecase', () => {
+      expect(pipe.transform('foo')).toEqual('Foo');
+      expect(pipe.transform('intermediário')).toEqual('Intermediário');
+      expect(pipe.transform('føderation')).toEqual('Føderation');
+      expect(pipe.transform('bênção')).toEqual('Bênção');
+    });
 
-    it('should return titlecase for subsequent words',
-       () => { expect(pipe.transform('one TWO Three fouR')).toEqual('One Two Three Four'); });
+    it('should return titlecase for subsequent words', () => {
+      expect(pipe.transform('one TWO Three fouR')).toEqual('One Two Three Four');
+      expect(pipe.transform('isto é um teSTE avançado')).toEqual('Isto É Um Teste Avançado');
+    });
 
     it('should support empty strings', () => { expect(pipe.transform('')).toEqual(''); });
 
-    it('should persist whitespace',
-       () => { expect(pipe.transform('one   two')).toEqual('One   Two'); });
+    it('should persist whitespace', () => {
+      expect(pipe.transform('one   two')).toEqual('One   Two');
+      expect(pipe.transform('coração   átomo')).toEqual('Coração   Átomo');
+    });
 
     it('should titlecase when there is a new value', () => {
       expect(pipe.transform('bar')).toEqual('Bar');
@@ -59,9 +69,17 @@ import {LowerCasePipe, TitleCasePipe, UpperCasePipe} from '@angular/common';
     it('should uppercase when there is a new value', () => {
       expect(pipe.transform('foo')).toEqual('FOO');
       expect(pipe.transform('bar')).toEqual('BAR');
+      expect(pipe.transform('doçura')).toEqual('DOÇURA');
     });
 
     it('should not support other objects',
        () => { expect(() => pipe.transform(<any>{})).toThrowError(); });
+
+    it('should not replace \n \t by space',
+       () => { expect(pipe.transform('isto\té\tum\nteste')).toEqual('Isto\tÉ\tUm\nTeste'); });
+
+    it('should capitalize after comma, dot and whitespaces',
+       () => { expect(pipe.transform('um,dois.três, quatro')).toEqual('Um,Dois.Três, Quatro'); });
+
   });
 }


### PR DESCRIPTION
TitleCasePipe was not behaving as expected with on strings containing accents like é ó ú ã, etc.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
TitleCasePipe was not working on strings containing accent characters. Ex: é ó å ä ü, etc, thanks to the way regex treats Unicode chars.

Closes to  #20123, #16586 (added its tests to make sure)

## What is the new behavior?
It works with those.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Bug was found on https://br.udacity.com