### PR TITLE
fix(service-worker): need to check if there was a previous before accessing its next property

### DIFF
--- a/packages/service-worker/worker/src/data.ts
+++ b/packages/service-worker/worker/src/data.ts
@@ -153,8 +153,11 @@ class LruList {
     // If it is not, then it has a next. First, grab the previous node.
     const previous = this.state.map[node.previous !] !;
 
-    // Fix the forward pointer to skip over node and go directly to node.next.
-    previous.next = node.next;
+    // Check if there was a previous before accessing its next property.
+    if (previous !== undefined) {
+      // Fix the forward pointer to skip over node and go directly to node.next.
+      previous.next = node.next;
+    }
 
     // node.next may or may not be set. If it is, fix the back pointer to skip over node.
     // If it's not set, then this node happened to be the tail, and the tail needs to be


### PR DESCRIPTION

We did not check if a previous node existed before accessing its next property. This could result in a crash with "Cannot read property 'next' of undefined".

This fixes #22218

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

After updating some files on the server where the serviceworker is active it sometimes fails with
> Serviceworker: Cannot read property 'next' of undefined

in line 913 of **ngsw-worker.js** which is:

>  // The node is not the head, so it has a previous. It may or may not be the tail.
        // If it is not, then it has a next. First, grab the previous node.
        const previous = this.state.map[node.previous];
        // Fix the forward pointer to skip over node and go directly to node.next.
        previous.next = node.next; **// <-- THIS ASSERTION FAILS**
        // node.next may or may not be set. If it is, fix the back pointer to skip over node.
        // If it's not set, then this node happened to be the tail, and the tail needs to be
        // updated to point to the previous node (removing the tail).

It seems that `previous` is not set because there was no node in the `this.state.map` array.

Issue Number: 22218


## What is the new behavior?

We check if `previous` is set before accessing its property `next`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

I hope this does not break anything or changes the behaviour of the server-worker

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
