### PR TITLE
docs(aio): fix incorrect quote mark usage

### DIFF
--- a/aio/content/examples/toh-pt5/src/app/messages/messages.component.html
+++ b/aio/content/examples/toh-pt5/src/app/messages/messages.component.html
@@ -3,6 +3,6 @@
   <h2>Messages</h2>
   <button class="clear"
           (click)="messageService.clear()">clear</button>
-  <div *ngFor='let message of messageService.messages'> {{message}} </div>
+  <div *ngFor="let message of messageService.messages"> {{message}} </div>
 
 </div>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Docs use `"` for properties, however in this section it was using a `'`
```  <div *ngFor='let message of messageService.messages'> {{message}} </div>```

Issue Number: N/A


## What is the new behavior?
Updated example code to use `"` for properties
```  <div *ngFor="let message of messageService.messages"> {{message}} </div>```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
