### PR TITLE
build: make git revert messages valid

### DIFF
--- a/tools/validate-commit-message/validate-commit-message.js
+++ b/tools/validate-commit-message/validate-commit-message.js
@@ -22,7 +22,7 @@ const configPath = path.resolve(__dirname, './commit-message.json');
 const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
 const PATTERN = /^(\w+)(?:\(([^)]+)\))?\: (.+)$/;
 const FIXUP_SQUASH = /^(fixup|squash)\! /i;
-const REVERT = /^revert: (\"(.*)\"|(.*))?$/i;
+const REVERT = /^revert:? (\"(.*)\"|(.*))?$/i;
 
 module.exports = function(commitSubject) {
   commitSubject = commitSubject.replace(FIXUP_SQUASH, '');

--- a/tools/validate-commit-message/validate-commit-message.spec.js
+++ b/tools/validate-commit-message/validate-commit-message.spec.js
@@ -45,9 +45,9 @@ describe('validate-commit-message.js', function() {
       expect(validateMessage('fixup! release(packaging): something')).toBe(VALID);
       expect(validateMessage('squash! release(packaging): something')).toBe(VALID);
       expect(validateMessage('Revert: "release(packaging): something"')).toBe(VALID);
+      expect(validateMessage('Revert "release(packaging): something"')).toBe(VALID);
       expect(errors).toEqual([]);
     });
-
 
     it('should fail when scope is invalid', function() {
       expect(validateMessage('fix(Compiler): something')).toBe(INVALID);


### PR DESCRIPTION
`git revert` default message is "Revert <original message>" (no semi-colon)
