### PR TITLE
Don't mutate route configs provided by the user

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -457,3 +457,9 @@ function getFullPath(parentPath: string, currentRoute: Route): string {
     return `${parentPath}/${currentRoute.path}`;
   }
 }
+
+
+export function copyConfig(r: Route): Route {
+  const children = r.children && r.children.map(copyConfig);
+  return children ? {...r, children} : {...r};
+}

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -18,7 +18,7 @@ import {map} from 'rxjs/operator/map';
 import {mergeMap} from 'rxjs/operator/mergeMap';
 
 import {applyRedirects} from './apply_redirects';
-import {LoadedRouterConfig, QueryParamsHandling, Route, Routes, validateConfig} from './config';
+import {LoadedRouterConfig, QueryParamsHandling, Route, Routes, copyConfig, validateConfig} from './config';
 import {createRouterState} from './create_router_state';
 import {createUrlTree} from './create_url_tree';
 import {ActivationEnd, ChildActivationEnd, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, NavigationTrigger, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RoutesRecognized} from './events';
@@ -33,6 +33,7 @@ import {DefaultUrlHandlingStrategy, UrlHandlingStrategy} from './url_handling_st
 import {UrlSerializer, UrlTree, containsTree, createEmptyUrlTree} from './url_tree';
 import {forEach} from './utils/collection';
 import {TreeNode, nodeChildrenAsMap} from './utils/tree';
+
 
 /**
  * @whatItDoes Represents the extra options used during navigation.
@@ -342,7 +343,7 @@ export class Router {
    */
   resetConfig(config: Routes): void {
     validateConfig(config);
-    this.config = config;
+    this.config = config.map(copyConfig);
     this.navigated = false;
     this.lastSuccessfulId = -1;
   }

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -12,7 +12,7 @@ import {fromPromise} from 'rxjs/observable/fromPromise';
 import {of } from 'rxjs/observable/of';
 import {map} from 'rxjs/operator/map';
 import {mergeMap} from 'rxjs/operator/mergeMap';
-import {LoadChildren, LoadedRouterConfig, Route} from './config';
+import {LoadChildren, LoadedRouterConfig, Route, copyConfig} from './config';
 import {flatten, wrapIntoObservable} from './utils/collection';
 
 /**
@@ -41,7 +41,7 @@ export class RouterConfigLoader {
 
       const module = factory.create(parentInjector);
 
-      return new LoadedRouterConfig(flatten(module.injector.get(ROUTES)), module);
+      return new LoadedRouterConfig(flatten(module.injector.get(ROUTES)).map(copyConfig), module);
     });
   }
 

--- a/packages/router/test/router.spec.ts
+++ b/packages/router/test/router.spec.ts
@@ -22,6 +22,38 @@ import {RouterTestingModule} from '../testing/src/router_testing_module';
 import {Logger, createActivatedRouteSnapshot, provideTokenLogger} from './helpers';
 
 describe('Router', () => {
+
+  describe('resetConfig', () => {
+    class TestComponent {}
+
+    beforeEach(() => { TestBed.configureTestingModule({imports: [RouterTestingModule]}); });
+
+    it('should copy config to avoid mutations of user-provided objects', () => {
+      const r: Router = TestBed.get(Router);
+      const configs = [{
+        path: 'a',
+        component: TestComponent,
+        children: [{path: 'b', component: TestComponent}, {path: 'c', component: TestComponent}]
+      }];
+      r.resetConfig(configs);
+
+      let rConfigs = r.config;
+
+      // routes array and shallow copy
+      expect(configs).not.toBe(rConfigs);
+      expect(configs[0]).not.toBe(rConfigs[0]);
+      expect(configs[0].path).toBe(rConfigs[0].path);
+      expect(configs[0].component).toBe(rConfigs[0].component);
+
+      // children should be new array and routes shallow copied
+      expect(configs[0].children).not.toBe(rConfigs[0].children);
+      expect(configs[0].children[0]).not.toBe(rConfigs[0].children ![0]);
+      expect(configs[0].children[0].path).toBe(rConfigs[0].children ![0].path);
+      expect(configs[0].children[1]).not.toBe(rConfigs[0].children ![1]);
+      expect(configs[0].children[1].path).toBe(rConfigs[0].children ![1].path);
+    });
+  });
+
   describe('resetRootComponentType', () => {
     class NewRootComponent {}
 


### PR DESCRIPTION
Previously we mutated route configs provided by the user. This can break Universal as it expects it's objects to never be mutated.

Fixes #22203