### PR TITLE
build: disable bazel-out symlink

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -14,9 +14,12 @@ test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test
 # Filesystem interactions     #
 ###############################
 
-# Put bazel's symlinks under dist, so results go to dist/bin
-# There is still a `bazel-out` symlink created in the project root.
-build --symlink_prefix=dist/
+# Don't create symlinks like bazel-out in the project.
+# These cause VSCode to traverse a massive tree, opening file handles and
+# eventually a surprising failure with auto-discovery of the C++ toolchain in
+# MacOS High Sierra.
+# See https://github.com/bazelbuild/bazel/issues/4603
+build --symlink_prefix=/
 
 # Performance: avoid stat'ing input files
 build --watchfs


### PR DESCRIPTION
It causes headaches on MacOS High Sierra, see https://github.com/bazelbuild/bazel/issues/4603
