### PR TITLE
fix(compiler): allow tree-shakeable injectables to depend on string tokens

### DIFF
--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/string.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/string.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, Inject, Injectable, NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {ServerModule} from '@angular/platform-server';
+
+
+@Component({
+  selector: 'string-app',
+  template: '{{data}}',
+})
+export class AppComponent {
+  data: string;
+  constructor(service: Service) { this.data = service.data; }
+}
+
+@NgModule({
+  imports: [
+    BrowserModule.withServerTransition({appId: 'id-app'}),
+    ServerModule,
+  ],
+  declarations: [AppComponent],
+  bootstrap: [AppComponent],
+  providers: [{provide: 'someStringToken', useValue: 'works'}],
+})
+export class StringAppModule {
+}
+
+@Injectable({scope: StringAppModule})
+export class Service {
+  constructor(@Inject('someStringToken') readonly data: string) {}
+}

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/test/app_spec.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/test/app_spec.ts
@@ -13,6 +13,7 @@ import {DepAppModuleNgFactory} from 'app_built/src/dep.ngfactory';
 import {HierarchyAppModuleNgFactory} from 'app_built/src/hierarchy.ngfactory';
 import {RootAppModuleNgFactory} from 'app_built/src/root.ngfactory';
 import {SelfAppModuleNgFactory} from 'app_built/src/self.ngfactory';
+import {StringAppModuleNgFactory} from 'app_built/src/string.ngfactory';
 import {TokenAppModuleNgFactory} from 'app_built/src/token.ngfactory';
 
 enableProdMode();
@@ -74,6 +75,16 @@ describe('ngInjectableDef Bazel Integration', () => {
       url: '/',
     }).then(html => {
       expect(html).toMatch(/>true<\//);
+      done();
+    });
+  });
+
+  it('string tokens work', done => {
+    renderModuleFactory(StringAppModuleNgFactory, {
+      document: '<string-app></string-app>',
+      url: '/',
+    }).then(html => {
+      expect(html).toMatch(/>works<\//);
       done();
     });
   });

--- a/packages/compiler/src/injectable_compiler.ts
+++ b/packages/compiler/src/injectable_compiler.ts
@@ -55,10 +55,11 @@ export class InjectableCompiler {
           }
         }
       }
+      const tokenExpr = typeof token === 'string' ? o.literal(token) : ctx.importExpr(token);
       if (flags !== InjectFlags.Default || defaultValue !== undefined) {
-        args = [ctx.importExpr(token), o.literal(defaultValue), o.literal(flags)];
+        args = [tokenExpr, o.literal(defaultValue), o.literal(flags)];
       } else {
-        args = [ctx.importExpr(token)];
+        args = [tokenExpr];
       }
       return o.importExpr(Identifiers.inject).callFn(args);
     });


### PR DESCRIPTION
Previously the injectable compiler assumed all tree-shakeable injectables
would have dependencies that were injectables or InjectionTokens. However
old code still uses string tokens (e.g. NgUpgrade and '$injector'). Using
such tokens would cause the injectable compiler to crash.

Now, the injectable compiler can properly generate a dependency on such a
string token.