### PR TITLE
fix(router): Fix _lastPathIndex in deeply nested empty paths

### DIFF
--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -247,8 +247,9 @@ function split(
   if (slicedSegments.length === 0 &&
       containsEmptyPathMatches(segmentGroup, slicedSegments, config)) {
     const s = new UrlSegmentGroup(
-        segmentGroup.segments, addEmptyPathsToChildrenIfNeeded(
-                                   segmentGroup, slicedSegments, config, segmentGroup.children));
+        segmentGroup.segments,
+        addEmptyPathsToChildrenIfNeeded(
+            segmentGroup, consumedSegments, slicedSegments, config, segmentGroup.children));
     s._sourceSegment = segmentGroup;
     s._segmentIndexShift = consumedSegments.length;
     return {segmentGroup: s, slicedSegments};
@@ -261,14 +262,15 @@ function split(
 }
 
 function addEmptyPathsToChildrenIfNeeded(
-    segmentGroup: UrlSegmentGroup, slicedSegments: UrlSegment[], routes: Route[],
+    segmentGroup: UrlSegmentGroup, consumedSegments: UrlSegment[], slicedSegments: UrlSegment[],
+    routes: Route[],
     children: {[name: string]: UrlSegmentGroup}): {[name: string]: UrlSegmentGroup} {
   const res: {[name: string]: UrlSegmentGroup} = {};
   for (const r of routes) {
     if (emptyPathMatch(segmentGroup, slicedSegments, r) && !children[getOutlet(r)]) {
       const s = new UrlSegmentGroup([], {});
       s._sourceSegment = segmentGroup;
-      s._segmentIndexShift = segmentGroup.segments.length;
+      s._segmentIndexShift = consumedSegments.length;
       res[getOutlet(r)] = s;
     }
   }

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -20,20 +20,24 @@ class NoMatch {}
 
 export function recognize(
     rootComponentType: Type<any>| null, config: Routes, urlTree: UrlTree, url: string,
-    paramsInheritanceStrategy: ParamsInheritanceStrategy =
-        'emptyOnly'): Observable<RouterStateSnapshot> {
-  return new Recognizer(rootComponentType, config, urlTree, url, paramsInheritanceStrategy)
+    paramsInheritanceStrategy: ParamsInheritanceStrategy = 'emptyOnly',
+    relativeLinkResolution: 'legacy' | 'corrected' = 'legacy'): Observable<RouterStateSnapshot> {
+  return new Recognizer(
+             rootComponentType, config, urlTree, url, paramsInheritanceStrategy,
+             relativeLinkResolution)
       .recognize();
 }
 
 class Recognizer {
   constructor(
       private rootComponentType: Type<any>|null, private config: Routes, private urlTree: UrlTree,
-      private url: string, private paramsInheritanceStrategy: ParamsInheritanceStrategy) {}
+      private url: string, private paramsInheritanceStrategy: ParamsInheritanceStrategy,
+      private relativeLinkResolution: 'legacy'|'corrected') {}
 
   recognize(): Observable<RouterStateSnapshot> {
     try {
-      const rootSegmentGroup = split(this.urlTree.root, [], [], this.config).segmentGroup;
+      const rootSegmentGroup =
+          split(this.urlTree.root, [], [], this.config, this.relativeLinkResolution).segmentGroup;
 
       const children = this.processSegmentGroup(this.config, rootSegmentGroup, PRIMARY_OUTLET);
 
@@ -134,8 +138,8 @@ class Recognizer {
 
     const childConfig: Route[] = getChildConfig(route);
 
-    const {segmentGroup, slicedSegments} =
-        split(rawSegment, consumedSegments, rawSlicedSegments, childConfig);
+    const {segmentGroup, slicedSegments} = split(
+        rawSegment, consumedSegments, rawSlicedSegments, childConfig, this.relativeLinkResolution);
 
     if (slicedSegments.length === 0 && segmentGroup.hasChildren()) {
       const children = this.processChildren(childConfig, segmentGroup);
@@ -232,7 +236,7 @@ function getPathIndexShift(segmentGroup: UrlSegmentGroup): number {
 
 function split(
     segmentGroup: UrlSegmentGroup, consumedSegments: UrlSegment[], slicedSegments: UrlSegment[],
-    config: Route[]) {
+    config: Route[], relativeLinkResolution: 'legacy' | 'corrected') {
   if (slicedSegments.length > 0 &&
       containsEmptyPathMatchesWithNamedOutlets(segmentGroup, slicedSegments, config)) {
     const s = new UrlSegmentGroup(
@@ -247,9 +251,9 @@ function split(
   if (slicedSegments.length === 0 &&
       containsEmptyPathMatches(segmentGroup, slicedSegments, config)) {
     const s = new UrlSegmentGroup(
-        segmentGroup.segments,
-        addEmptyPathsToChildrenIfNeeded(
-            segmentGroup, consumedSegments, slicedSegments, config, segmentGroup.children));
+        segmentGroup.segments, addEmptyPathsToChildrenIfNeeded(
+                                   segmentGroup, consumedSegments, slicedSegments, config,
+                                   segmentGroup.children, relativeLinkResolution));
     s._sourceSegment = segmentGroup;
     s._segmentIndexShift = consumedSegments.length;
     return {segmentGroup: s, slicedSegments};
@@ -263,14 +267,18 @@ function split(
 
 function addEmptyPathsToChildrenIfNeeded(
     segmentGroup: UrlSegmentGroup, consumedSegments: UrlSegment[], slicedSegments: UrlSegment[],
-    routes: Route[],
-    children: {[name: string]: UrlSegmentGroup}): {[name: string]: UrlSegmentGroup} {
+    routes: Route[], children: {[name: string]: UrlSegmentGroup},
+    relativeLinkResolution: 'legacy' | 'corrected'): {[name: string]: UrlSegmentGroup} {
   const res: {[name: string]: UrlSegmentGroup} = {};
   for (const r of routes) {
     if (emptyPathMatch(segmentGroup, slicedSegments, r) && !children[getOutlet(r)]) {
       const s = new UrlSegmentGroup([], {});
       s._sourceSegment = segmentGroup;
-      s._segmentIndexShift = consumedSegments.length;
+      if (relativeLinkResolution === 'legacy') {
+        s._segmentIndexShift = segmentGroup.segments.length;
+      } else {
+        s._segmentIndexShift = consumedSegments.length;
+      }
       res[getOutlet(r)] = s;
     }
   }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -298,6 +298,11 @@ export class Router {
   urlUpdateStrategy: 'deferred'|'eager' = 'deferred';
 
   /**
+   * See {@link RouterModule} for more information.
+   */
+  relativeLinkResolution: 'legacy'|'corrected' = 'legacy';
+
+  /**
    * Creates the router service.
    */
   // TODO: vsavkin make internal after the final is out.
@@ -676,7 +681,7 @@ export class Router {
         urlAndSnapshot$ = redirectsApplied$.pipe(mergeMap((appliedUrl: UrlTree) => {
           return recognize(
                      this.rootComponentType, this.config, appliedUrl, this.serializeUrl(appliedUrl),
-                     this.paramsInheritanceStrategy)
+                     this.paramsInheritanceStrategy, this.relativeLinkResolution)
               .pipe(map((snapshot: any) => {
                 (this.events as Subject<Event>)
                     .next(new RoutesRecognized(

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -417,6 +417,36 @@ export interface ExtraOptions {
    * - `'eager'`, updates browser URL at the beginning of navigation.
    */
   urlUpdateStrategy?: 'deferred'|'eager';
+
+  /**
+   * Enables a bug fix that corrects relative link resolution in components with empty paths.
+   * Example:
+   *
+   * ```
+   * const routes = [
+   *   {
+   *     path: '',
+   *     component: ContainerComponent,
+   *     children: [
+   *       { path: 'a', component: AComponent },
+   *       { path: 'b', component: BComponent },
+   *     ]
+   *   }
+   * ];
+   * ```
+   *
+   * From the `ContainerComponent`, this will not work:
+   *
+   * `<a [routerLink]="['./a']">Link to A</a>`
+   *
+   * However, this will work:
+   *
+   * `<a [routerLink]="['../a']">Link to A</a>`
+   *
+   * In other words, you're required to use `../` rather than `./`. The current default in v6
+   * is `legacy`, and this option will be removed in v7 to default to the corrected behavior.
+   */
+  relativeLinkResolution?: 'legacy'|'corrected';
 }
 
 export function setupRouter(
@@ -463,6 +493,10 @@ export function setupRouter(
 
   if (opts.urlUpdateStrategy) {
     router.urlUpdateStrategy = opts.urlUpdateStrategy;
+  }
+
+  if (opts.relativeLinkResolution) {
+    router.relativeLinkResolution = opts.relativeLinkResolution;
   }
 
   return router;

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -425,21 +425,15 @@ describe('recognize', () => {
       });
 
       it('should set url segment and index properly when nested empty-path segments', () => {
-        const url = tree('a/b') as any;
+        const url = tree('a') as any;
         recognize(
             RootComponent, [{
               path: 'a',
-              children: [{
-                path: 'b',
-                component: ComponentB,
-                children: [{
-                  path: '',
-                  component: ComponentC,
-                  children: [{path: '', component: ComponentD}]
-                }]
-              }]
+              children: [
+                {path: '', component: ComponentB, children: [{path: '', component: ComponentC}]}
+              ]
             }],
-            url, 'a/b')
+            url, 'a')
             .forEach((s: any) => {
               expect(s.root._urlSegment).toBe(url.root);
               expect(s.root._lastPathIndex).toBe(-1);
@@ -450,17 +444,52 @@ describe('recognize', () => {
 
               const b = s.firstChild(a) !;
               expect(b._urlSegment).toBe(url.root.children[PRIMARY_OUTLET]);
-              expect(b._lastPathIndex).toBe(1);
+              expect(b._lastPathIndex).toBe(0);
 
               const c = s.firstChild(b) !;
               expect(c._urlSegment).toBe(url.root.children[PRIMARY_OUTLET]);
-              expect(c._lastPathIndex).toBe(1);
-
-              const d = s.firstChild(c) !;
-              expect(d._urlSegment).toBe(url.root.children[PRIMARY_OUTLET]);
-              expect(d._lastPathIndex).toBe(1);
+              expect(c._lastPathIndex).toBe(0);
             });
       });
+
+      it('should set url segment and index properly with the "corrected" option for nested empty-path segments',
+         () => {
+           const url = tree('a/b') as any;
+           recognize(
+               RootComponent, [{
+                 path: 'a',
+                 children: [{
+                   path: 'b',
+                   component: ComponentB,
+                   children: [{
+                     path: '',
+                     component: ComponentC,
+                     children: [{path: '', component: ComponentD}]
+                   }]
+                 }]
+               }],
+               url, 'a/b', 'emptyOnly', 'corrected')
+               .forEach((s: any) => {
+                 expect(s.root._urlSegment).toBe(url.root);
+                 expect(s.root._lastPathIndex).toBe(-1);
+
+                 const a = s.firstChild(s.root) !;
+                 expect(a._urlSegment).toBe(url.root.children[PRIMARY_OUTLET]);
+                 expect(a._lastPathIndex).toBe(0);
+
+                 const b = s.firstChild(a) !;
+                 expect(b._urlSegment).toBe(url.root.children[PRIMARY_OUTLET]);
+                 expect(b._lastPathIndex).toBe(1);
+
+                 const c = s.firstChild(b) !;
+                 expect(c._urlSegment).toBe(url.root.children[PRIMARY_OUTLET]);
+                 expect(c._lastPathIndex).toBe(1);
+
+                 const d = s.firstChild(c) !;
+                 expect(d._urlSegment).toBe(url.root.children[PRIMARY_OUTLET]);
+                 expect(d._lastPathIndex).toBe(1);
+               });
+         });
 
       it('should set url segment and index properly when nested empty-path segments (2)', () => {
         const url = tree('');

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -425,15 +425,21 @@ describe('recognize', () => {
       });
 
       it('should set url segment and index properly when nested empty-path segments', () => {
-        const url = tree('a') as any;
+        const url = tree('a/b') as any;
         recognize(
             RootComponent, [{
               path: 'a',
-              children: [
-                {path: '', component: ComponentB, children: [{path: '', component: ComponentC}]}
-              ]
+              children: [{
+                path: 'b',
+                component: ComponentB,
+                children: [{
+                  path: '',
+                  component: ComponentC,
+                  children: [{path: '', component: ComponentD}]
+                }]
+              }]
             }],
-            url, 'a')
+            url, 'a/b')
             .forEach((s: any) => {
               expect(s.root._urlSegment).toBe(url.root);
               expect(s.root._lastPathIndex).toBe(-1);
@@ -444,11 +450,15 @@ describe('recognize', () => {
 
               const b = s.firstChild(a) !;
               expect(b._urlSegment).toBe(url.root.children[PRIMARY_OUTLET]);
-              expect(b._lastPathIndex).toBe(0);
+              expect(b._lastPathIndex).toBe(1);
 
               const c = s.firstChild(b) !;
               expect(c._urlSegment).toBe(url.root.children[PRIMARY_OUTLET]);
-              expect(c._lastPathIndex).toBe(0);
+              expect(c._lastPathIndex).toBe(1);
+
+              const d = s.firstChild(c) !;
+              expect(d._urlSegment).toBe(url.root.children[PRIMARY_OUTLET]);
+              expect(d._lastPathIndex).toBe(1);
             });
       });
 

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -119,6 +119,7 @@ export interface ExtraOptions {
     onSameUrlNavigation?: 'reload' | 'ignore';
     paramsInheritanceStrategy?: 'emptyOnly' | 'always';
     preloadingStrategy?: any;
+    relativeLinkResolution?: 'legacy' | 'corrected';
     scrollOffset?: [number, number] | (() => [number, number]);
     scrollPositionRestoration?: 'disabled' | 'enabled' | 'top';
     urlUpdateStrategy?: 'deferred' | 'eager';
@@ -320,6 +321,7 @@ export declare class Router {
     navigated: boolean;
     onSameUrlNavigation: 'reload' | 'ignore';
     paramsInheritanceStrategy: 'emptyOnly' | 'always';
+    relativeLinkResolution: 'legacy' | 'corrected';
     routeReuseStrategy: RouteReuseStrategy;
     readonly routerState: RouterState;
     readonly url: string;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
See https://github.com/angular/angular/issues/13011#issuecomment-274414952 and https://github.com/angular/angular/issues/13011#issuecomment-364789825

When an empty path is deeply nested, its _lastPathIndex is too high and relative nagivation to its parent needs lot of additional '../'

Issue Number: #13011 


## What is the new behavior?
_lastPathIndex (computed from _segmentIndexShift) is correct and relative navigation works as expected

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
