### PR TITLE
refactor(ivy): rename componentRefresh to directiveRefresh

### DIFF
--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -39,7 +39,7 @@ export {
   interpolation8 as i8,
   interpolationV as iV,
 
-  componentRefresh as r,
+  directiveRefresh as r,
 
   container as C,
   containerRefreshStart as cR,

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -372,7 +372,7 @@ export function renderComponentOrTemplate<T>(
     } else {
       // Element was stored at 0 and directive was stored at 1 in renderComponent
       // so to refresh the component, refresh() needs to be called with (1, 0)
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     }
   } finally {
     if (rendererFactory.end) {
@@ -1208,14 +1208,15 @@ export function embeddedViewEnd(): void {
 /////////////
 
 /**
- * Refreshes the component view.
+ * Refreshes the directive, triggering init and content hooks.
  *
- * In other words, enters the component's view and processes it to update bindings, queries, etc.
+ * When it is a component, it also enters the component's view and processes it to update bindings,
+ * queries, etc.
  *
  * @param directiveIndex
  * @param elementIndex
  */
-export function componentRefresh<T>(directiveIndex: number, elementIndex: number): void {
+export function directiveRefresh<T>(directiveIndex: number, elementIndex: number): void {
   executeInitHooks(currentView, currentView.tView, creationMode);
   executeContentHooks(currentView, currentView.tView, creationMode);
   const template = (tData[directiveIndex] as ComponentDef<T>).template;

--- a/packages/core/test/render3/common_integration_spec.ts
+++ b/packages/core/test/render3/common_integration_spec.ts
@@ -9,7 +9,7 @@
 import {NgForOfContext} from '@angular/common';
 
 import {defineComponent} from '../../src/render3/index';
-import {bind, componentRefresh, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, text, textBinding} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementProperty, elementStart, text, textBinding} from '../../src/render3/instructions';
 
 import {NgForOf} from './common_with_def';
 import {renderComponent, toHtml} from './render_util';
@@ -35,7 +35,7 @@ describe('@angular/common integration', () => {
             }
             elementProperty(1, 'ngForOf', bind(myApp.items));
             containerRefreshStart(1);
-            componentRefresh(2, 0);
+            directiveRefresh(2, 0);
             containerRefreshEnd();
 
             function liTemplate(row: NgForOfContext<string>, cm: boolean) {

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -11,7 +11,7 @@ import {withBody} from '@angular/core/testing';
 import {DoCheck, ViewEncapsulation} from '../../src/core';
 import {detectChanges, getRenderedText, whenRendered} from '../../src/render3/component';
 import {defineComponent, markDirty} from '../../src/render3/index';
-import {bind, componentRefresh, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, text, textBinding} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, text, textBinding} from '../../src/render3/instructions';
 import {createRendererType2} from '../../src/view/index';
 
 import {getRendererFactory2} from './imported_renderer2';
@@ -114,7 +114,7 @@ describe('component with a container', () => {
     }
     elementProperty(0, 'items', bind(ctx.items));
     WrapperComponent.ngComponentDef.h(1, 0);
-    componentRefresh(1, 0);
+    directiveRefresh(1, 0);
   }
 
   it('should re-render on input change', () => {
@@ -140,7 +140,7 @@ describe('encapsulation', () => {
           elementEnd();
         }
         EncapsulatedComponent.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       },
       factory: () => new WrapperComponent,
     });
@@ -157,7 +157,7 @@ describe('encapsulation', () => {
           elementEnd();
         }
         LeafComponent.ngComponentDef.h(2, 1);
-        componentRefresh(2, 1);
+        directiveRefresh(2, 1);
       },
       factory: () => new EncapsulatedComponent,
       rendererType:
@@ -205,7 +205,7 @@ describe('encapsulation', () => {
             elementEnd();
           }
           LeafComponentwith.ngComponentDef.h(1, 0);
-          componentRefresh(1, 0);
+          directiveRefresh(1, 0);
         },
         factory: () => new WrapperComponentWith,
         rendererType:

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {detectChanges} from '../../src/render3/index';
-import {componentRefresh, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, load, projection, projectionDef, text} from '../../src/render3/instructions';
+import {container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, load, projection, projectionDef, text} from '../../src/render3/instructions';
 
 import {createComponent, renderComponent, toHtml} from './render_util';
 
@@ -36,7 +36,7 @@ describe('content projection', () => {
         elementEnd();
       }
       Child.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div>content</div></child>');
@@ -56,7 +56,7 @@ describe('content projection', () => {
         elementEnd();
       }
       Child.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child>content</child>');
@@ -78,7 +78,7 @@ describe('content projection', () => {
         { projection(3, 0); }
         elementEnd();
         GrandChild.ngComponentDef.h(2, 1);
-        componentRefresh(2, 1);
+        directiveRefresh(2, 1);
       }
     });
     const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
@@ -93,7 +93,7 @@ describe('content projection', () => {
         elementEnd();
       }
       Child.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent))
@@ -134,8 +134,8 @@ describe('content projection', () => {
       }
       Child.ngComponentDef.h(1, 0);
       ProjectedComp.ngComponentDef.h(3, 2);
-      componentRefresh(3, 2);
-      componentRefresh(1, 0);
+      directiveRefresh(3, 2);
+      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent))
@@ -172,7 +172,7 @@ describe('content projection', () => {
       }
       containerRefreshEnd();
       Child.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div>()</div></child>');
@@ -208,7 +208,7 @@ describe('content projection', () => {
       }
       containerRefreshEnd();
       Child.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child></child>');
@@ -257,7 +257,7 @@ describe('content projection', () => {
       }
       containerRefreshEnd();
       Child.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div>(else)</div></child>');
@@ -315,7 +315,7 @@ describe('content projection', () => {
         elementEnd();
       }
       Child.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div><span>content</span></div></child>');
@@ -368,7 +368,7 @@ describe('content projection', () => {
            elementEnd();
          }
          Child.ngComponentDef.h(1, 0);
-         componentRefresh(1, 0);
+         directiveRefresh(1, 0);
        });
        const parent = renderComponent(Parent);
        expect(toHtml(parent)).toEqual('<child><div>content</div></child>');
@@ -423,7 +423,7 @@ describe('content projection', () => {
            elementEnd();
          }
          Child.ngComponentDef.h(1, 0);
-         componentRefresh(1, 0);
+         directiveRefresh(1, 0);
        });
        const parent = renderComponent(Parent);
        expect(toHtml(parent)).toEqual('<child><div>before-content-after</div></child>');
@@ -460,7 +460,7 @@ describe('content projection', () => {
         elementEnd();
       }
       Child.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div></div><span>content</span></child>');
@@ -518,7 +518,7 @@ describe('content projection', () => {
         elementEnd();
       }
       Child.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child>content<div></div></child>');
@@ -568,7 +568,7 @@ describe('content projection', () => {
           elementEnd();
         }
         Child.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -615,7 +615,7 @@ describe('content projection', () => {
           elementEnd();
         }
         Child.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -662,7 +662,7 @@ describe('content projection', () => {
           elementEnd();
         }
         Child.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -708,7 +708,7 @@ describe('content projection', () => {
           elementEnd();
         }
         Child.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -755,7 +755,7 @@ describe('content projection', () => {
           elementEnd();
         }
         Child.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -803,7 +803,7 @@ describe('content projection', () => {
           elementEnd();
         }
         Child.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -851,7 +851,7 @@ describe('content projection', () => {
           }
           elementEnd();
           GrandChild.ngComponentDef.h(2, 1);
-          componentRefresh(2, 1);
+          directiveRefresh(2, 1);
         }
       });
 
@@ -873,7 +873,7 @@ describe('content projection', () => {
           elementEnd();
         }
         Child.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -917,7 +917,7 @@ describe('content projection', () => {
           }
           elementEnd();
           Card.ngComponentDef.h(2, 1);
-          componentRefresh(2, 1);
+          directiveRefresh(2, 1);
         }
       });
 
@@ -933,7 +933,7 @@ describe('content projection', () => {
           elementEnd();
         }
         CardWithTitle.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       });
 
       const app = renderComponent(App);
@@ -982,7 +982,7 @@ describe('content projection', () => {
         }
         containerRefreshEnd();
         Child.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       });
       const parent = renderComponent(Parent);
       expect(toHtml(parent)).toEqual('<child><span><div>content</div></span></child>');

--- a/packages/core/test/render3/directive_spec.ts
+++ b/packages/core/test/render3/directive_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {defineDirective} from '../../src/render3/index';
-import {bind, componentRefresh, elementEnd, elementProperty, elementStart, load} from '../../src/render3/instructions';
+import {bind, directiveRefresh, elementEnd, elementProperty, elementStart, load} from '../../src/render3/instructions';
 
 import {renderToHtml} from './render_util';
 
@@ -35,7 +35,7 @@ describe('directive', () => {
           elementEnd();
         }
         Directive.ngDirectiveDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       expect(renderToHtml(Template, {})).toEqual('<span class="foo"></span>');

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {defineComponent, defineDirective} from '../../src/render3/index';
-import {NO_CHANGE, bind, componentRefresh, container, containerRefreshEnd, containerRefreshStart, elementAttribute, elementClass, elementEnd, elementProperty, elementStart, elementStyle, embeddedViewEnd, embeddedViewStart, interpolation1, interpolation2, interpolation3, interpolation4, interpolation5, interpolation6, interpolation7, interpolation8, interpolationV, load, projection, projectionDef, text, textBinding} from '../../src/render3/instructions';
+import {NO_CHANGE, bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementAttribute, elementClass, elementEnd, elementProperty, elementStart, elementStyle, embeddedViewEnd, embeddedViewStart, interpolation1, interpolation2, interpolation3, interpolation4, interpolation5, interpolation6, interpolation7, interpolation8, interpolationV, load, projection, projectionDef, text, textBinding} from '../../src/render3/instructions';
 
 import {containerEl, renderToHtml} from './render_util';
 
@@ -201,7 +201,7 @@ describe('render3 integration test', () => {
           elementEnd();
         }
         TodoComponent.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       expect(renderToHtml(Template, null)).toEqual('<todo><p>Todo one</p></todo>');
@@ -215,7 +215,7 @@ describe('render3 integration test', () => {
           text(2, 'two');
         }
         TodoComponent.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
       expect(renderToHtml(Template, null)).toEqual('<todo><p>Todo one</p></todo>two');
     });
@@ -234,8 +234,8 @@ describe('render3 integration test', () => {
         }
         TodoComponent.ngComponentDef.h(1, 0);
         TodoComponent.ngComponentDef.h(3, 2);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
       }
       expect(renderToHtml(Template, null))
           .toEqual('<todo><p>Todo one</p></todo><todo><p>Todo one</p></todo>');
@@ -271,7 +271,7 @@ describe('render3 integration test', () => {
           elementEnd();
         }
         TodoComponentHostBinding.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       expect(renderToHtml(Template, {})).toEqual('<todo title="one">one</todo>');
@@ -304,7 +304,7 @@ describe('render3 integration test', () => {
           elementEnd();
         }
         MyComp.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       expect(renderToHtml(Template, null)).toEqual('<comp><p>Bess</p></comp>');
@@ -351,7 +351,7 @@ describe('render3 integration test', () => {
         }
         elementProperty(0, 'condition', bind(ctx.condition));
         MyComp.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       expect(renderToHtml(Template, {condition: true})).toEqual('<comp><div>text</div></comp>');
@@ -472,7 +472,7 @@ describe('render3 integration test', () => {
       }
       containerRefreshEnd();
       ChildComponent.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     }
 
     it('should work with a tree', () => {
@@ -648,7 +648,7 @@ describe('render3 integration test', () => {
             elementEnd();
           }
           HostBindingDir.ngDirectiveDef.h(1, 0);
-          componentRefresh(1, 0);
+          directiveRefresh(1, 0);
         }
 
         expect(renderToHtml(Template, {}))

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -8,7 +8,7 @@
 
 import {SimpleChanges} from '../../src/core';
 import {ComponentTemplate, NgOnChangesFeature, defineComponent, defineDirective} from '../../src/render3/index';
-import {bind, componentRefresh, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, listener, projection, projectionDef, store, text} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, listener, projection, projectionDef, store, text} from '../../src/render3/instructions';
 
 import {containerEl, renderToHtml} from './render_util';
 
@@ -22,7 +22,7 @@ describe('lifecycles', () => {
       }
       elementProperty(0, 'val', bind(ctx.val));
       type.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     };
   }
 
@@ -76,7 +76,7 @@ describe('lifecycles', () => {
            }
            elementProperty(0, 'val', bind(ctx.val));
            Comp.ngComponentDef.h(1, 0);
-           componentRefresh(1, 0);
+           directiveRefresh(1, 0);
          }
 
          renderToHtml(Template, {val: '1'});
@@ -98,7 +98,7 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Parent.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -124,8 +124,8 @@ describe('lifecycles', () => {
         elementProperty(2, 'val', 2);
         Parent.ngComponentDef.h(1, 0);
         Parent.ngComponentDef.h(3, 2);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -152,7 +152,7 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Comp.ngComponentDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -183,8 +183,8 @@ describe('lifecycles', () => {
         }
         Comp.ngComponentDef.h(1, 0);
         ProjectedComp.ngComponentDef.h(3, 2);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -217,10 +217,10 @@ describe('lifecycles', () => {
         ProjectedComp.ngComponentDef.h(3, 2);
         Comp.ngComponentDef.h(5, 4);
         ProjectedComp.ngComponentDef.h(7, 6);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
-        componentRefresh(5, 4);
-        componentRefresh(7, 6);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
+        directiveRefresh(5, 4);
+        directiveRefresh(7, 6);
       }
 
       renderToHtml(Template, {});
@@ -236,8 +236,8 @@ describe('lifecycles', () => {
         }
         Comp.ngComponentDef.h(1, 0);
         Directive.ngDirectiveDef.h(2, 0);
-        componentRefresh(1, 0);
-        componentRefresh(2, 0);
+        directiveRefresh(1, 0);
+        directiveRefresh(2, 0);
       }
 
       renderToHtml(Template, {});
@@ -256,7 +256,7 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Directive.ngDirectiveDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -296,13 +296,13 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val', j);
             Comp.ngComponentDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
         containerRefreshEnd();
-        componentRefresh(1, 0);
-        componentRefresh(4, 3);
+        directiveRefresh(1, 0);
+        directiveRefresh(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -342,13 +342,13 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val', j);
             Parent.ngComponentDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
         containerRefreshEnd();
-        componentRefresh(1, 0);
-        componentRefresh(4, 3);
+        directiveRefresh(1, 0);
+        directiveRefresh(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -403,7 +403,7 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Comp.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -425,7 +425,7 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Parent.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -440,7 +440,7 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Comp.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -459,8 +459,8 @@ describe('lifecycles', () => {
         }
         Comp.ngComponentDef.h(1, 0);
         Directive.ngDirectiveDef.h(2, 0);
-        componentRefresh(1, 0);
-        componentRefresh(2, 0);
+        directiveRefresh(1, 0);
+        directiveRefresh(2, 0);
       }
 
       renderToHtml(Template, {});
@@ -479,7 +479,7 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Directive.ngDirectiveDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -516,7 +516,7 @@ describe('lifecycles', () => {
       }
       elementProperty(1, 'val', bind(ctx.val));
       Comp.ngComponentDef.h(2, 1);
-      componentRefresh(2, 1);
+      directiveRefresh(2, 1);
     });
 
     let ProjectedComp = createAfterContentInitComp('projected', (ctx: any, cm: boolean) => {
@@ -554,7 +554,7 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Comp.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -583,7 +583,7 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Comp.ngComponentDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -613,7 +613,7 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Parent.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -640,8 +640,8 @@ describe('lifecycles', () => {
         elementProperty(3, 'val', 2);
         Parent.ngComponentDef.h(1, 0);
         Parent.ngComponentDef.h(4, 3);
-        componentRefresh(1, 0);
-        componentRefresh(4, 3);
+        directiveRefresh(1, 0);
+        directiveRefresh(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -671,8 +671,8 @@ describe('lifecycles', () => {
         }
         Parent.ngComponentDef.h(1, 0);
         ProjectedComp.ngComponentDef.h(3, 2);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -718,10 +718,10 @@ describe('lifecycles', () => {
         ProjectedComp.ngComponentDef.h(3, 2);
         Parent.ngComponentDef.h(6, 5);
         ProjectedComp.ngComponentDef.h(8, 7);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
-        componentRefresh(6, 5);
-        componentRefresh(8, 7);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
+        directiveRefresh(6, 5);
+        directiveRefresh(8, 7);
       }
 
       renderToHtml(Template, {});
@@ -760,13 +760,13 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val', i);
             Comp.ngComponentDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
         containerRefreshEnd();
-        componentRefresh(1, 0);
-        componentRefresh(5, 4);
+        directiveRefresh(1, 0);
+        directiveRefresh(5, 4);
       }
 
       renderToHtml(Template, {});
@@ -797,13 +797,13 @@ describe('lifecycles', () => {
           }
           elementProperty(0, 'val', i);
           Parent.ngComponentDef.h(1, 0);
-          componentRefresh(1, 0);
+          directiveRefresh(1, 0);
           embeddedViewEnd();
         }
       }
       containerRefreshEnd();
-      componentRefresh(1, 0);
-      componentRefresh(5, 4);
+      directiveRefresh(1, 0);
+      directiveRefresh(5, 4);
     }
 
     it('should be called in correct order in a for loop with children', () => {
@@ -831,7 +831,7 @@ describe('lifecycles', () => {
             elementEnd();
           }
           Comp.ngComponentDef.h(1, 0);
-          componentRefresh(1, 0);
+          directiveRefresh(1, 0);
         }
 
         renderToHtml(Template, {});
@@ -861,8 +861,8 @@ describe('lifecycles', () => {
           }
           Comp.ngComponentDef.h(1, 0);
           Directive.ngDirectiveDef.h(2, 0);
-          componentRefresh(1, 0);
-          componentRefresh(2, 0);
+          directiveRefresh(1, 0);
+          directiveRefresh(2, 0);
         }
 
         renderToHtml(Template, {});
@@ -877,7 +877,7 @@ describe('lifecycles', () => {
             elementEnd();
           }
           Directive.ngDirectiveDef.h(1, 0);
-          componentRefresh(1, 0);
+          directiveRefresh(1, 0);
         }
 
         renderToHtml(Template, {});
@@ -938,7 +938,7 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Comp.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -966,7 +966,7 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Comp.ngComponentDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -996,7 +996,7 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Parent.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -1022,8 +1022,8 @@ describe('lifecycles', () => {
         elementProperty(2, 'val', 2);
         Parent.ngComponentDef.h(1, 0);
         Parent.ngComponentDef.h(3, 2);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
       }
       renderToHtml(Template, {});
       expect(events).toEqual(['comp1', 'comp2', 'parent1', 'parent2']);
@@ -1047,8 +1047,8 @@ describe('lifecycles', () => {
         }
         Comp.ngComponentDef.h(1, 0);
         ProjectedComp.ngComponentDef.h(3, 2);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -1087,10 +1087,10 @@ describe('lifecycles', () => {
         ProjectedComp.ngComponentDef.h(3, 2);
         Comp.ngComponentDef.h(5, 4);
         ProjectedComp.ngComponentDef.h(7, 6);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
-        componentRefresh(5, 4);
-        componentRefresh(7, 6);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
+        directiveRefresh(5, 4);
+        directiveRefresh(7, 6);
       }
 
       renderToHtml(Template, {});
@@ -1116,8 +1116,8 @@ describe('lifecycles', () => {
         elementProperty(2, 'val', bind(ctx.val));
         Comp.ngComponentDef.h(1, 0);
         ProjectedComp.ngComponentDef.h(3, 2);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
       });
 
       /**
@@ -1135,8 +1135,8 @@ describe('lifecycles', () => {
         elementProperty(2, 'val', 2);
         ParentComp.ngComponentDef.h(1, 0);
         ParentComp.ngComponentDef.h(3, 2);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -1172,13 +1172,13 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val', i);
             Comp.ngComponentDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
         containerRefreshEnd();
-        componentRefresh(1, 0);
-        componentRefresh(4, 3);
+        directiveRefresh(1, 0);
+        directiveRefresh(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -1215,13 +1215,13 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val', i);
             Parent.ngComponentDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
         containerRefreshEnd();
-        componentRefresh(1, 0);
-        componentRefresh(4, 3);
+        directiveRefresh(1, 0);
+        directiveRefresh(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -1240,7 +1240,7 @@ describe('lifecycles', () => {
             elementEnd();
           }
           Comp.ngComponentDef.h(1, 0);
-          componentRefresh(1, 0);
+          directiveRefresh(1, 0);
         }
 
         renderToHtml(Template, {});
@@ -1259,7 +1259,7 @@ describe('lifecycles', () => {
           }
           elementProperty(0, 'val', bind(ctx.myVal));
           Comp.ngComponentDef.h(1, 0);
-          componentRefresh(1, 0);
+          directiveRefresh(1, 0);
         }
 
         renderToHtml(Template, {myVal: 5});
@@ -1298,13 +1298,13 @@ describe('lifecycles', () => {
               }
               elementProperty(0, 'val', i);
               Parent.ngComponentDef.h(1, 0);
-              componentRefresh(1, 0);
+              directiveRefresh(1, 0);
               embeddedViewEnd();
             }
           }
           containerRefreshEnd();
-          componentRefresh(1, 0);
-          componentRefresh(4, 3);
+          directiveRefresh(1, 0);
+          directiveRefresh(4, 3);
         }
 
         renderToHtml(Template, {});
@@ -1335,8 +1335,8 @@ describe('lifecycles', () => {
           }
           Comp.ngComponentDef.h(1, 0);
           Directive.ngDirectiveDef.h(2, 0);
-          componentRefresh(1, 0);
-          componentRefresh(2, 0);
+          directiveRefresh(1, 0);
+          directiveRefresh(2, 0);
         }
 
         renderToHtml(Template, {});
@@ -1351,7 +1351,7 @@ describe('lifecycles', () => {
             elementEnd();
           }
           Directive.ngDirectiveDef.h(1, 0);
-          componentRefresh(1, 0);
+          directiveRefresh(1, 0);
         }
 
         renderToHtml(Template, {});
@@ -1413,7 +1413,7 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Comp.ngComponentDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -1450,8 +1450,8 @@ describe('lifecycles', () => {
             elementProperty(2, 'val', bind('2'));
             Comp.ngComponentDef.h(1, 0);
             Comp.ngComponentDef.h(3, 2);
-            componentRefresh(1, 0);
-            componentRefresh(3, 2);
+            directiveRefresh(1, 0);
+            directiveRefresh(3, 2);
             embeddedViewEnd();
           }
         }
@@ -1484,7 +1484,7 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Parent.ngComponentDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -1512,7 +1512,7 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Parent.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       });
 
       function Template(ctx: any, cm: boolean) {
@@ -1527,7 +1527,7 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Grandparent.ngComponentDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -1581,10 +1581,10 @@ describe('lifecycles', () => {
             ProjectedComp.ngComponentDef.h(3, 2);
             Comp.ngComponentDef.h(5, 4);
             ProjectedComp.ngComponentDef.h(7, 6);
-            componentRefresh(1, 0);
-            componentRefresh(3, 2);
-            componentRefresh(5, 4);
-            componentRefresh(7, 6);
+            directiveRefresh(1, 0);
+            directiveRefresh(3, 2);
+            directiveRefresh(5, 4);
+            directiveRefresh(7, 6);
             embeddedViewEnd();
           }
         }
@@ -1636,13 +1636,13 @@ describe('lifecycles', () => {
                 }
                 elementProperty(0, 'val', bind('2'));
                 Comp.ngComponentDef.h(1, 0);
-                componentRefresh(1, 0);
+                directiveRefresh(1, 0);
                 embeddedViewEnd();
               }
             }
             containerRefreshEnd();
-            componentRefresh(1, 0);
-            componentRefresh(4, 3);
+            directiveRefresh(1, 0);
+            directiveRefresh(4, 3);
             embeddedViewEnd();
           }
         }
@@ -1712,13 +1712,13 @@ describe('lifecycles', () => {
                 }
                 elementProperty(0, 'val', bind(j));
                 Comp.ngComponentDef.h(1, 0);
-                componentRefresh(1, 0);
+                directiveRefresh(1, 0);
                 embeddedViewEnd();
               }
             }
             containerRefreshEnd();
-            componentRefresh(1, 0);
-            componentRefresh(4, 3);
+            directiveRefresh(1, 0);
+            directiveRefresh(4, 3);
             embeddedViewEnd();
           }
         }
@@ -1787,7 +1787,7 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Comp.ngComponentDef.h(3, 2);
-            componentRefresh(3, 2);
+            directiveRefresh(3, 2);
             embeddedViewEnd();
           }
         }
@@ -1837,8 +1837,8 @@ describe('lifecycles', () => {
             }
             Comp.ngComponentDef.h(1, 0);
             Directive.ngDirectiveDef.h(2, 0);
-            componentRefresh(1, 0);
-            componentRefresh(2, 0);
+            directiveRefresh(1, 0);
+            directiveRefresh(2, 0);
             embeddedViewEnd();
           }
         }
@@ -1872,7 +1872,7 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Directive.ngDirectiveDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -1909,7 +1909,7 @@ describe('lifecycles', () => {
       elementProperty(0, 'val1', bind(ctx.a));
       elementProperty(0, 'publicName', bind(ctx.b));
       Comp.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     });
     const ProjectedComp = createOnChangesComponent('projected', (ctx: any, cm: boolean) => {
       if (cm) {
@@ -1969,7 +1969,7 @@ describe('lifecycles', () => {
         elementProperty(0, 'val1', bind(ctx.val1));
         elementProperty(0, 'publicName', bind(ctx.val2));
         Comp.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {val1: '1', val2: 'a'});
@@ -1996,7 +1996,7 @@ describe('lifecycles', () => {
         elementProperty(0, 'val1', bind(ctx.val1));
         elementProperty(0, 'publicName', bind(ctx.val2));
         Parent.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {val1: '1', val2: 'a'});
@@ -2027,8 +2027,8 @@ describe('lifecycles', () => {
         elementProperty(2, 'publicName', bind(2));
         Parent.ngComponentDef.h(1, 0);
         Parent.ngComponentDef.h(3, 2);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -2062,7 +2062,7 @@ describe('lifecycles', () => {
             elementProperty(0, 'val1', bind(1));
             elementProperty(0, 'publicName', bind(1));
             Comp.ngComponentDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -2100,8 +2100,8 @@ describe('lifecycles', () => {
         elementProperty(2, 'publicName', bind(2));
         Comp.ngComponentDef.h(1, 0);
         ProjectedComp.ngComponentDef.h(3, 2);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -2141,10 +2141,10 @@ describe('lifecycles', () => {
         ProjectedComp.ngComponentDef.h(3, 2);
         Comp.ngComponentDef.h(5, 4);
         ProjectedComp.ngComponentDef.h(7, 6);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
-        componentRefresh(5, 4);
-        componentRefresh(7, 6);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
+        directiveRefresh(5, 4);
+        directiveRefresh(7, 6);
       }
 
       renderToHtml(Template, {});
@@ -2166,7 +2166,7 @@ describe('lifecycles', () => {
         elementProperty(0, 'val1', bind(1));
         elementProperty(0, 'publicName', bind(1));
         Comp.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -2191,7 +2191,7 @@ describe('lifecycles', () => {
         elementProperty(0, 'val1', bind(1));
         elementProperty(0, 'publicName', bind(1));
         Directive.ngDirectiveDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -2234,13 +2234,13 @@ describe('lifecycles', () => {
             elementProperty(0, 'val1', bind(j));
             elementProperty(0, 'publicName', bind(j));
             Comp.ngComponentDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
         containerRefreshEnd();
-        componentRefresh(1, 0);
-        componentRefresh(4, 3);
+        directiveRefresh(1, 0);
+        directiveRefresh(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -2289,13 +2289,13 @@ describe('lifecycles', () => {
             elementProperty(0, 'val1', bind(j));
             elementProperty(0, 'publicName', bind(j));
             Parent.ngComponentDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
         containerRefreshEnd();
-        componentRefresh(1, 0);
-        componentRefresh(4, 3);
+        directiveRefresh(1, 0);
+        directiveRefresh(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -2367,8 +2367,8 @@ describe('lifecycles', () => {
         elementProperty(2, 'val', 2);
         Comp.ngComponentDef.h(1, 0);
         Comp.ngComponentDef.h(3, 2);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -2397,7 +2397,7 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val', bind(ctx.val));
         Comp.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       });
 
       /**
@@ -2415,8 +2415,8 @@ describe('lifecycles', () => {
         elementProperty(2, 'val', 2);
         Parent.ngComponentDef.h(1, 0);
         Parent.ngComponentDef.h(3, 2);
-        componentRefresh(1, 0);
-        componentRefresh(3, 2);
+        directiveRefresh(1, 0);
+        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {defineComponent, defineDirective} from '../../src/render3/index';
-import {componentRefresh, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, listener, text} from '../../src/render3/instructions';
+import {container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, listener, text} from '../../src/render3/instructions';
 
 import {containerEl, renderComponent, renderToHtml} from './render_util';
 
@@ -183,7 +183,7 @@ describe('event listeners', () => {
         elementEnd();
       }
       HostListenerDir.ngDirectiveDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     }
 
     renderToHtml(Template, {});
@@ -279,8 +279,8 @@ describe('event listeners', () => {
           }
           MyComp.ngComponentDef.h(2, 1);
           MyComp.ngComponentDef.h(4, 3);
-          componentRefresh(2, 1);
-          componentRefresh(4, 3);
+          directiveRefresh(2, 1);
+          directiveRefresh(4, 3);
           embeddedViewEnd();
         }
       }

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -9,7 +9,7 @@
 import {EventEmitter} from '@angular/core';
 
 import {defineComponent, defineDirective} from '../../src/render3/index';
-import {bind, componentRefresh, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, listener, text} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, listener, text} from '../../src/render3/instructions';
 
 import {containerEl, renderToHtml} from './render_util';
 
@@ -52,7 +52,7 @@ describe('outputs', () => {
         elementEnd();
       }
       ButtonToggle.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     }
 
     let counter = 0;
@@ -78,7 +78,7 @@ describe('outputs', () => {
         elementEnd();
       }
       ButtonToggle.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     }
 
     let counter = 0;
@@ -104,7 +104,7 @@ describe('outputs', () => {
         elementEnd();
       }
       ButtonToggle.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     }
 
     const ctx = {counter: 0};
@@ -140,7 +140,7 @@ describe('outputs', () => {
             elementEnd();
           }
           ButtonToggle.ngComponentDef.h(1, 0);
-          componentRefresh(1, 0);
+          directiveRefresh(1, 0);
           embeddedViewEnd();
         }
       }
@@ -192,7 +192,7 @@ describe('outputs', () => {
                 elementEnd();
               }
               ButtonToggle.ngComponentDef.h(1, 0);
-              componentRefresh(1, 0);
+              directiveRefresh(1, 0);
               embeddedViewEnd();
             }
           }
@@ -263,8 +263,8 @@ describe('outputs', () => {
           }
           ButtonToggle.ngComponentDef.h(3, 2);
           DestroyComp.ngComponentDef.h(5, 4);
-          componentRefresh(3, 2);
-          componentRefresh(5, 4);
+          directiveRefresh(3, 2);
+          directiveRefresh(5, 4);
           embeddedViewEnd();
         }
       }
@@ -341,7 +341,7 @@ describe('outputs', () => {
         elementEnd();
       }
       ButtonToggle.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     }
 
     let counter = 0;
@@ -375,7 +375,7 @@ describe('outputs', () => {
       }
       elementProperty(0, 'change', bind(ctx.change));
       ButtonToggle.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     }
 
     let counter = 0;
@@ -420,7 +420,7 @@ describe('outputs', () => {
             elementEnd();
           }
           ButtonToggle.ngComponentDef.h(1, 0);
-          componentRefresh(1, 0);
+          directiveRefresh(1, 0);
           embeddedViewEnd();
         } else {
           if (embeddedViewStart(1)) {

--- a/packages/core/test/render3/properties_spec.ts
+++ b/packages/core/test/render3/properties_spec.ts
@@ -9,7 +9,7 @@
 import {EventEmitter} from '@angular/core';
 
 import {defineComponent, defineDirective} from '../../src/render3/index';
-import {NO_CHANGE, bind, componentRefresh, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, interpolation1, listener, load, text, textBinding} from '../../src/render3/instructions';
+import {NO_CHANGE, bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, interpolation1, listener, load, text, textBinding} from '../../src/render3/instructions';
 
 import {renderToHtml} from './render_util';
 
@@ -157,7 +157,7 @@ describe('elementProperty', () => {
         }
         elementProperty(0, 'id', bind(ctx.id));
         Comp.ngComponentDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
       }
 
       expect(renderToHtml(Template, {id: 1})).toEqual(`<comp></comp>`);
@@ -502,7 +502,7 @@ describe('elementProperty', () => {
               elementEnd();
             }
             Comp.ngComponentDef.h(1, 0);
-            componentRefresh(1, 0);
+            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }

--- a/packages/core/test/render3/pure_function_spec.ts
+++ b/packages/core/test/render3/pure_function_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {defineComponent} from '../../src/render3/index';
-import {bind, componentRefresh, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, load} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, load} from '../../src/render3/instructions';
 import {pureFunction1, pureFunction2, pureFunction3, pureFunction4, pureFunction5, pureFunction6, pureFunction7, pureFunction8, pureFunctionV} from '../../src/render3/pure_function';
 import {renderToHtml} from '../../test/render3/render_util';
 
@@ -36,7 +36,7 @@ describe('array literals', () => {
       }
       elementProperty(0, 'names', bind(pureFunction1(e0_ff, ctx.customName)));
       MyComp.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     }
 
     renderToHtml(Template, {customName: 'Carson'});
@@ -91,7 +91,7 @@ describe('array literals', () => {
       elementProperty(0, 'names1', bind(pureFunction1(e0_ff, ctx.customName)));
       elementProperty(0, 'names2', bind(pureFunction1(e0_ff_1, ctx.customName2)));
       ManyPropComp.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     }
 
     renderToHtml(Template, {customName: 'Carson', customName2: 'George'});
@@ -129,7 +129,7 @@ describe('array literals', () => {
           }
           elementProperty(0, 'names', bind(ctx.someFn(pureFunction1(e0_ff, ctx.customName))));
           MyComp.ngComponentDef.h(1, 0);
-          componentRefresh(1, 0);
+          directiveRefresh(1, 0);
         }
       });
     }
@@ -143,8 +143,8 @@ describe('array literals', () => {
       }
       ParentComp.ngComponentDef.h(1, 0);
       ParentComp.ngComponentDef.h(3, 2);
-      componentRefresh(1, 0);
-      componentRefresh(3, 2);
+      directiveRefresh(1, 0);
+      directiveRefresh(3, 2);
     }
 
     renderToHtml(Template, {});
@@ -172,7 +172,7 @@ describe('array literals', () => {
       }
       elementProperty(0, 'names', bind(pureFunction2(e0_ff, ctx.customName, ctx.customName2)));
       MyComp.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     }
 
     renderToHtml(Template, {customName: 'Carson', customName2: 'Hannah'});
@@ -255,12 +255,12 @@ describe('array literals', () => {
       MyComp.ngComponentDef.h(7, 6);
       MyComp.ngComponentDef.h(9, 8);
       MyComp.ngComponentDef.h(11, 10);
-      componentRefresh(1, 0);
-      componentRefresh(3, 2);
-      componentRefresh(5, 4);
-      componentRefresh(7, 6);
-      componentRefresh(9, 8);
-      componentRefresh(11, 10);
+      directiveRefresh(1, 0);
+      directiveRefresh(3, 2);
+      directiveRefresh(5, 4);
+      directiveRefresh(7, 6);
+      directiveRefresh(9, 8);
+      directiveRefresh(11, 10);
     }
 
     renderToHtml(Template, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']);
@@ -308,7 +308,7 @@ describe('array literals', () => {
                         c[0], c[1], c[2], c[3], pureFunction1(e0_ff_1, c[4]), c[5], c[6], c[7], c[8]
                       ])));
       MyComp.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     }
 
     expect(myComp !.names).toEqual([
@@ -353,7 +353,7 @@ describe('object literals', () => {
       }
       elementProperty(0, 'config', bind(pureFunction1(e0_ff, ctx.name)));
       ObjectComp.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     }
 
     renderToHtml(Template, {name: 'slide'});
@@ -391,7 +391,7 @@ describe('object literals', () => {
           bind(pureFunction2(
               e0_ff, ctx.name, pureFunction1(e0_ff_1, pureFunction1(e0_ff_2, ctx.duration)))));
       ObjectComp.ngComponentDef.h(1, 0);
-      componentRefresh(1, 0);
+      directiveRefresh(1, 0);
     }
 
     renderToHtml(Template, {name: 'slide', duration: 100});
@@ -459,7 +459,7 @@ describe('object literals', () => {
               0, 'config',
               bind(pureFunction2(e0_ff, ctx.configs[i].opacity, ctx.configs[i].duration)));
           ObjectComp.ngComponentDef.h(1, 0);
-          componentRefresh(1, 0);
+          directiveRefresh(1, 0);
           embeddedViewEnd();
         }
       }

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -11,7 +11,7 @@ import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/brow
 
 import {RendererType2, ViewEncapsulation} from '../../src/core';
 import {defineComponent, detectChanges} from '../../src/render3/index';
-import {bind, componentRefresh, elementEnd, elementProperty, elementStart, listener, text} from '../../src/render3/instructions';
+import {bind, directiveRefresh, elementEnd, elementProperty, elementStart, listener, text} from '../../src/render3/instructions';
 import {createRendererType2} from '../../src/view/index';
 
 import {getAnimationRendererFactory2, getRendererFactory2} from './imported_renderer2';
@@ -68,7 +68,7 @@ describe('renderer factory lifecycle', () => {
       elementEnd();
     }
     SomeComponent.ngComponentDef.h(2, 1);
-    componentRefresh(2, 1);
+    directiveRefresh(2, 1);
   }
 
   beforeEach(() => { logs = []; });

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -8,7 +8,7 @@
 
 import {TemplateRef, ViewContainerRef} from '../../src/core';
 import {defineComponent, defineDirective, injectTemplateRef, injectViewContainerRef} from '../../src/render3/index';
-import {bind, componentRefresh, container, containerRefreshEnd, containerRefreshStart, load, text, textBinding} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, load, text, textBinding} from '../../src/render3/instructions';
 
 import {renderComponent, toHtml} from './render_util';
 
@@ -42,7 +42,7 @@ describe('ViewContainerRef', () => {
         containerRefreshStart(0);
         cmp.testDir = load<TestDirective>(1);
         TestDirective.ngDirectiveDef.h(1, 0);
-        componentRefresh(1, 0);
+        directiveRefresh(1, 0);
         containerRefreshEnd();
       },
     });


### PR DESCRIPTION
Since the `componentRefresh` instruction is also used to refresh directives, we rename it to `directiveRefresh`.