### PR TITLE
fix(upgrade): correctly destroy nested downgraded component

### DIFF
--- a/packages/upgrade/src/common/downgrade_component_adapter.ts
+++ b/packages/upgrade/src/common/downgrade_component_adapter.ts
@@ -209,12 +209,16 @@ export class DowngradeComponentAdapter {
 
   registerCleanup() {
     const destroyComponentRef = this.wrapCallback(() => this.componentRef.destroy());
+    let destroyed = false;
 
-    this.element.on !('$destroy', () => {
-      this.componentScope.$destroy();
-      this.componentRef.injector.get(TestabilityRegistry)
-          .unregisterApplication(this.componentRef.location.nativeElement);
-      destroyComponentRef();
+    this.element.on !('$destroy', () => this.componentScope.$destroy());
+    this.componentScope.$on('$destroy', () => {
+      if (!destroyed) {
+        destroyed = true;
+        this.componentRef.injector.get(TestabilityRegistry)
+            .unregisterApplication(this.componentRef.location.nativeElement);
+        destroyComponentRef();
+      }
     });
   }
 

--- a/packages/upgrade/src/dynamic/upgrade_ng1_adapter.ts
+++ b/packages/upgrade/src/dynamic/upgrade_ng1_adapter.ts
@@ -263,6 +263,8 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
     if (this.controllerInstance && isFunction(this.controllerInstance.$onDestroy)) {
       this.controllerInstance.$onDestroy();
     }
+
+    this.componentScope.$destroy();
   }
 
   setComponentProperty(name: string, value: any) {

--- a/packages/upgrade/test/common/downgrade_component_adapter_spec.ts
+++ b/packages/upgrade/test/common/downgrade_component_adapter_spec.ts
@@ -85,15 +85,21 @@ withEachNg1Version(() => {
       let element: angular.IAugmentedJQuery;
 
       class mockScope implements angular.IScope {
+        private destroyListeners: (() => void)[] = [];
+
         $new() { return this; }
         $watch(exp: angular.Ng1Expression, fn?: (a1?: any, a2?: any) => void) {
           return () => {};
         }
         $on(event: string, fn?: (event?: any, ...args: any[]) => void) {
+          if (event === '$destroy' && fn) {
+            this.destroyListeners.push(fn);
+          }
           return () => {};
         }
         $destroy() {
-          return () => {};
+          let listener: (() => void)|undefined;
+          while ((listener = this.destroyListeners.shift())) listener();
         }
         $apply(exp?: angular.Ng1Expression) {
           return () => {};

--- a/packages/upgrade/test/dynamic/test_helpers.ts
+++ b/packages/upgrade/test/dynamic/test_helpers.ts
@@ -12,6 +12,11 @@ import {$ROOT_SCOPE} from '@angular/upgrade/src/common/constants';
 
 export * from '../common/test_helpers';
 
+export function $apply(adapter: UpgradeAdapterRef, exp: angular.Ng1Expression) {
+  const $rootScope = adapter.ng1Injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+  $rootScope.$apply(exp);
+}
+
 export function $digest(adapter: UpgradeAdapterRef) {
   const $rootScope = adapter.ng1Injector.get($ROOT_SCOPE) as angular.IRootScopeService;
   $rootScope.$digest();


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] Bugfix
```

## What is the current behavior?
When a downgraded component is destroyed in a way that does not trigger the `$destroy` event on the element (e.g. when a parent element was removed from the DOM by Angular, not AngularJS), the `ComponentRef` is not destroyed and unregistered.

Issue Number: #22392


## What is the new behavior?
Downgraded components are always correctly destroyed and unregistered.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
Fixes #22392.
