### PR TITLE
feat(platform-server): bump Domino to v2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "cldrjs": "0.5.0",
     "conventional-changelog": "1.1.0",
     "cors": "2.8.4",
-    "domino": "1.0.29",
+    "domino": "2.0.1",
     "entities": "1.1.1",
     "firebase-tools": "3.12.0",
     "firefox-profile": "1.0.3",

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -10,15 +10,15 @@
   "license": "MIT",
   "peerDependencies": {
     "@angular/animations": "0.0.0-PLACEHOLDER",
-    "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/compiler": "0.0.0-PLACEHOLDER",
+    "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser-dynamic": "0.0.0-PLACEHOLDER"
   },
   "dependencies": {
+    "domino": "^2.0.1",
     "tslib": "^1.7.1",
-    "domino": "^1.0.29",
     "xhr2": "^0.1.4"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1944,9 +1944,9 @@ domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
 
-domino@1.0.29:
-  version "1.0.29"
-  resolved "https://registry.yarnpkg.com/domino/-/domino-1.0.29.tgz#de8aa1f6f98e3c5538feb7a61fa69c1eabbace06"
+domino@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domino/-/domino-2.0.1.tgz#9e1d63215d0fe8dcb8202bff07effa1a216db504"
 
 dot-prop@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
BREAKING CHANGE:

* Bump the dependency on Domino to 2.0 to resolve issues with
  namespacing