### PR TITLE
feat(platform-browser): wait for DOMContentLoaded when using BrowserT…

### DIFF
--- a/packages/platform-browser/src/browser/transfer_state.ts
+++ b/packages/platform-browser/src/browser/transfer_state.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_ID, Injectable, NgModule} from '@angular/core';
+import {APP_ID, Injectable, NgModule, APP_INITIALIZER} from '@angular/core';
 import {DOCUMENT} from '../dom/dom_tokens';
 
 export function escapeHtml(text: string): string {
@@ -152,6 +152,14 @@ export function initTransferState(doc: Document, appId: string) {
   return TransferState.init(initialState);
 }
 
+export function domContentLoadedFactory(doc: Document) {
+  return () => {
+    return new Promise ((resolve, reject) => {
+      document.addEventListener('DOMContentLoaded', () => resolve());
+    });
+  };
+}
+
 /**
  * NgModule to install on the client side while using the `TransferState` to transfer state from
  * server to client.
@@ -159,7 +167,8 @@ export function initTransferState(doc: Document, appId: string) {
  * @experimental
  */
 @NgModule({
-  providers: [{provide: TransferState, useFactory: initTransferState, deps: [DOCUMENT, APP_ID]}],
+  providers: [{provide: APP_INITIALIZER, multi: true, useFactory: () => domContentLoadedFactory, deps: [DOCUMENT]},
+    {provide: TransferState, useFactory: initTransferState, deps: [DOCUMENT, APP_ID]}],
 })
 export class BrowserTransferStateModule {
 }


### PR DESCRIPTION
…ransferState

## PR Checklist
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Feature
```

## What is the current behavior?
It is possible that the data being transfered by state transfer has to been loaded onto the DOM before the app boots and tries to access it.

## What is the new behavior?
When using BrowserStateTransfer the app will automatically wait for DOM content to be loaded before booting.


Not sure how to test this :/