### PR TITLE
fix(core): typo in property name.

### DIFF
--- a/packages/core/src/util/decorators.ts
+++ b/packages/core/src/util/decorators.ts
@@ -35,7 +35,7 @@ export interface TypeDecorator {
 }
 
 export const ANNOTATIONS = '__annotations__';
-export const PARAMETERS = '__paramaters__';
+export const PARAMETERS = '__parameters__';
 export const PROP_METADATA = '__prop__metadata__';
 
 /**


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[X] Bugfix
[X] Other... Please describe: Typo causes issues with component inspection by 3rd parties. 
```

## What is the current behavior?

Angular's behaviour is not affected, but property name is unexpected for 3rd party inspection apps like Augury.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No