### PR TITLE
style(aio): updated padding-right to h3 in _heading-anchors.scss

### DIFF
--- a/aio/src/styles/2-modules/_heading-anchors.scss
+++ b/aio/src/styles/2-modules/_heading-anchors.scss
@@ -31,7 +31,7 @@
   .l-sub-section {
     h1, h2, h3, h4, h5, h6 {
       a {
-        padding-right: 24px;
+        padding-right: 64px;
         margin-left: -74px;
       }
     }

--- a/aio/src/styles/2-modules/_heading-anchors.scss
+++ b/aio/src/styles/2-modules/_heading-anchors.scss
@@ -40,7 +40,7 @@
   .alert {
     h1, h2, h3, h4, h5, h6 {
       a {
-        padding-right: 40px;
+        padding-right: 80px;
         margin-left: -90px;
       }
     }


### PR DESCRIPTION
The h3 element is overflowing over its surrounding div element. Modified padding-left to align consistently with the remainder of div contents.

fixes: #22407

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<img width="409" alt="issue" src="https://user-images.githubusercontent.com/19397242/36632838-c33255ee-1959-11e8-85bf-175a74f1b656.png">

Issue Number: 22407


## What is the new behavior?
<img width="410" alt="fixed" src="https://user-images.githubusercontent.com/19397242/36632863-f1e24944-1959-11e8-9a60-15b10ea2b4e1.png">


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
