### PR TITLE
build(aio): rendering of optional parameters

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -107,7 +107,7 @@
     "cross-spawn": "^5.1.0",
     "css-selector-parser": "^1.3.0",
     "dgeni": "^0.4.7",
-    "dgeni-packages": "0.24.1",
+    "dgeni-packages": "^0.24.2",
     "entities": "^1.1.1",
     "eslint": "^3.19.0",
     "eslint-plugin-jasmine": "^2.2.0",

--- a/aio/package.json
+++ b/aio/package.json
@@ -107,7 +107,7 @@
     "cross-spawn": "^5.1.0",
     "css-selector-parser": "^1.3.0",
     "dgeni": "^0.4.7",
-    "dgeni-packages": "^0.24.2",
+    "dgeni-packages": "^0.24.3",
     "entities": "^1.1.1",
     "eslint": "^3.19.0",
     "eslint-plugin-jasmine": "^2.2.0",

--- a/aio/tools/transforms/templates/api/lib/paramList.html
+++ b/aio/tools/transforms/templates/api/lib/paramList.html
@@ -20,7 +20,7 @@
       <td class="param-name"><a id="{$ parameter.anchor $}"></a>{$ parameter.name $}</td>
       <td class="param-description">
       {% marked %}
-        {% if parameter.isOptional %}Optional.{% endif %}
+        {% if parameter.isOptional or parameter.defaultValue !== undefined %}Optional. Default is `{$ parameter.defaultValue === undefined and 'undefined' or parameter.defaultValue $}`.{% endif %}
 
         {% if parameter.description | trim %}{$ parameter.description $}
         {% elseif parameter.type %}<code>{$ parameter.type $}</code>

--- a/aio/tools/transforms/templates/api/lib/paramList.html
+++ b/aio/tools/transforms/templates/api/lib/paramList.html
@@ -19,9 +19,13 @@
     <tr class="{$ parameterClass $}">
       <td class="param-name"><a id="{$ parameter.anchor $}"></a>{$ parameter.name $}</td>
       <td class="param-description">
-        {% if parameter.description | trim %}{$ parameter.description | marked $}
+      {% marked %}
+        {% if parameter.isOptional %}Optional.{% endif %}
+
+        {% if parameter.description | trim %}{$ parameter.description $}
         {% elseif parameter.type %}<code>{$ parameter.type $}</code>
         {% endif %}
+      {% endmarked %}
       </td>
     </tr>{% endfor %}
   </tbody>

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -2312,9 +2312,9 @@ devtools-timeline-model@1.1.6:
     chrome-devtools-frontend "1.0.401423"
     resolve "1.1.7"
 
-dgeni-packages@0.24.1:
-  version "0.24.1"
-  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.24.1.tgz#e3e99eb82615b30a9e43fe1a9bb9911ff6bbf913"
+dgeni-packages@^0.24.2:
+  version "0.24.2"
+  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.24.2.tgz#88e75f0f4cfd135a2c6c8ec431b66f32d63760d2"
   dependencies:
     canonical-path "0.0.2"
     catharsis "^0.8.1"

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -2312,9 +2312,9 @@ devtools-timeline-model@1.1.6:
     chrome-devtools-frontend "1.0.401423"
     resolve "1.1.7"
 
-dgeni-packages@^0.24.2:
-  version "0.24.2"
-  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.24.2.tgz#88e75f0f4cfd135a2c6c8ec431b66f32d63760d2"
+dgeni-packages@^0.24.3:
+  version "0.24.3"
+  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.24.3.tgz#153ce2bf9d71a70cd8c71171c7f49adf0d725ab9"
   dependencies:
     canonical-path "0.0.2"
     catharsis "^0.8.1"


### PR DESCRIPTION
Closes #22134 

Now we automatically render `Optional.` at the start of the parameter description if the parameter is not required. We also render the value given to the parameter if it is not provided in the call.

An example is in the Location class... (https://pr22435-d01479e.ngbuilds.io/api/common/Location#path)

<img width="1023" alt="screen shot 2018-02-25 at 09 24 44" src="https://user-images.githubusercontent.com/15655/36639907-cde354fc-1a0d-11e8-8213-62a6d4e6a41f.png">

Note that if there is no description for the parameter then we currently just display the type of the parameter. This is up for negotiation.
