### PR TITLE
build(aio): fix API docs breadcrumbs

### DIFF
--- a/aio/tools/transforms/templates/api/base.template.html
+++ b/aio/tools/transforms/templates/api/base.template.html
@@ -22,7 +22,7 @@
       </script>
     {% for crumb in doc.breadCrumbs %}{% if not loop.last %}
       {$ slash() $}
-      {% if crumb.path %}<a href="{$ crumb.path $}">{$ crumb.text $}<a>{% else %}{$ crumb.text $}{% endif %}
+      {% if crumb.path %}<a href="{$ crumb.path $}">{$ crumb.text $}</a>{% else %}{$ crumb.text $}{% endif %}
     {% endif %}{% endfor %}
   </div>
   <header class="api-header">


### PR DESCRIPTION
This is an alternative to #22437.
This also prevents some extra `<a>` elements inserted by the browser's trying to fix the HTML structure, which also fixes the `.header-link` added in ToC.

Fixes #22387.