### PR TITLE
aio + api: render heading anchors on the right

### DIFF
--- a/aio/src/styles/2-modules/_heading-anchors.scss
+++ b/aio/src/styles/2-modules/_heading-anchors.scss
@@ -1,48 +1,18 @@
 .sidenav-content {
   h1, h2, h3, h4, h5, h6 {
 
-    &.no-anchor .header-link {
-      display: none;
-    }
-
     .header-link {
-      box-sizing: border-box;
       color: $mediumgray;
-      display: inline-block;
-      margin-left: -42px;
-      padding: 0 8px;
+      margin-left: 8px;
       text-decoration: none;
       user-select: none;
-      vertical-align: middle;
       visibility: hidden;
-      width: 40px;
-
-      @media (max-width: 600px) {
-        float: right;
-        margin-left: 0;
-      }
+      display: inline-block;
+      vertical-align: text-top;
     }
 
     &:hover .header-link {
       visibility: visible;
-    }
-  }
-
-  .l-sub-section {
-    h1, h2, h3, h4, h5, h6 {
-      a {
-        padding-right: 64px;
-        margin-left: -74px;
-      }
-    }
-  }
-
-  .alert {
-    h1, h2, h3, h4, h5, h6 {
-      a {
-        padding-right: 80px;
-        margin-left: -90px;
-      }
     }
   }
 }

--- a/aio/tools/transforms/angular-base-package/post-processors/autolink-headings.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/autolink-headings.js
@@ -20,7 +20,7 @@ const hasClass = (node, cls) => {
 const link = options =>
   tree => visit(tree, node => {
     if (is(node, HEADINGS) && has(node, 'id') && !hasClass(node, NO_ANCHOR_CLASS)) {
-      node.children.unshift({
+      node.children.push({
         type: 'element',
         tagName: 'a',
         properties: Object.assign(clone(options.properties), {href: `#${node.properties.id}`}),

--- a/aio/tools/transforms/angular-base-package/post-processors/autolink-headings.spec.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/autolink-headings.spec.js
@@ -20,9 +20,9 @@ describe('autolink-headings postprocessor', () => {
       <h3>Heading with encoded chars &#x26;</h3>
     `;
     const processedContent = `
-      <h1 id="heading-1"><a title="Link to this heading" class="header-link" aria-hidden="true" href="#heading-1"><i class="material-icons">link</i></a>Heading 1</h1>
-      <h2 id="heading-with-bold"><a title="Link to this heading" class="header-link" aria-hidden="true" href="#heading-with-bold"><i class="material-icons">link</i></a>Heading with <strong>bold</strong></h2>
-      <h3 id="heading-with-encoded-chars-"><a title="Link to this heading" class="header-link" aria-hidden="true" href="#heading-with-encoded-chars-"><i class="material-icons">link</i></a>Heading with encoded chars &#x26;</h3>
+      <h1 id="heading-1">Heading 1<a title="Link to this heading" class="header-link" aria-hidden="true" href="#heading-1"><i class="material-icons">link</i></a></h1>
+      <h2 id="heading-with-bold">Heading with <strong>bold</strong><a title="Link to this heading" class="header-link" aria-hidden="true" href="#heading-with-bold"><i class="material-icons">link</i></a></h2>
+      <h3 id="heading-with-encoded-chars-">Heading with encoded chars &#x26;<a title="Link to this heading" class="header-link" aria-hidden="true" href="#heading-with-encoded-chars-"><i class="material-icons">link</i></a></h3>
     `;
 
     const docs = [{docType: 'a', renderedContent: originalContent}];

--- a/aio/tools/transforms/templates/api/base.template.html
+++ b/aio/tools/transforms/templates/api/base.template.html
@@ -22,7 +22,7 @@
       </script>
     {% for crumb in doc.breadCrumbs %}{% if not loop.last %}
       {$ slash() $}
-      {% if crumb.path %}<a href="{$ crumb.path $}">{$ crumb.text $}<a>{% else %}{$ crumb.text $}{% endif %}
+      {% if crumb.path %}<a href="{$ crumb.path $}">{$ crumb.text $}</a>{% else %}{$ crumb.text $}{% endif %}
     {% endif %}{% endfor %}
   </div>
   <header class="api-header">

--- a/aio/tools/transforms/templates/api/base.template.html
+++ b/aio/tools/transforms/templates/api/base.template.html
@@ -30,9 +30,7 @@
     {% if doc.experimental !== undefined %}<label class="api-status-label experimental">experimental</label>{% endif %}
     {% if doc.stable !== undefined %}<label class="api-status-label stable">stable</label>{% endif %}
     <label class="api-type-label {$ doc.docType $}">{$ doc.docType $}</label>
-    <h1>
-      {$ doc.name $}
-    </h1>
+    <h1>{$ doc.name $}</h1>
     <span class="version">{$ version $}</span>
   </header>
   <div class="page-actions">


### PR DESCRIPTION
Closes #22131

Relies upon the fix in #22446 to make the API H1 heading render correctly.

I think that by landing this PR, #22407 will be fixed and so #22431 would be redundant (although perhaps we could land it on the `patch` branch until we roll out the new API templating.