### PR TITLE
ci: update github bot config

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -80,12 +80,14 @@ merge:
 
 # options for the triage plugin
 triage:
+  # number of the milestone to apply when the issue has not been triaged yet
+  needsTriageMilestone: 83,
   # number of the milestone to apply when the issue is triaged
   defaultMilestone: 82,
   # arrays of labels that determine if an issue is triaged
   triagedLabels:
     -
-      - "type: bug"
+      - "type: bug/fix"
       - "severity*"
       - "freq*"
       - "comp: *"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
```

## What is the current behavior?
The label "type: bug" has been renamed "type: bug/fix" which means that the bot cannot mark as triaged issues with that label because it doesn't match what's in the config.
Also I'm adding the new parameter to tag new issues with the needsTriage milestone

Issue Number: #22212


## What is the new behavior?
Issues with the label "type: bug/fix" are now correctly triaged.
Untriaged issues will be added to the milestone "needsTriage".


## Does this PR introduce a breaking change?
```
[x] No
```