### PR TITLE
fix(compiler): collapse whitespace before scanning for CSS rules

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -565,8 +565,10 @@ export class CssRule {
 export function processRules(input: string, ruleCallback: (rule: CssRule) => CssRule): string {
   const inputWithEscapedBlocks = escapeBlocks(input);
   let nextBlockIndex = 0;
-  // NOTE: Collapsing extra whitespace from escaped CSS to avoid catastrophic
-  // backtrack issue in `_ruleRe`. See #20105
+  // NOTE: Collapsing extra whitespace from escaped CSS to avoid a whitespace
+  // backtracking issue in `_ruleRe`.
+  //  See https://github.com/angular/angular/issues/20105#issuecomment-368368216
+  //  See http://stackstatus.net/post/147710624694/outage-postmortem-july-20-2016
   return inputWithEscapedBlocks.escapedString.replace(/\s+/g, ' ')
       .replace(_ruleRe, function(...m: string[]) {
         const selector = m[2];

--- a/packages/compiler/test/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css_spec.ts
@@ -355,6 +355,20 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
                    (cssRule: CssRule) => new CssRule(cssRule.selector, cssRule.content + '2')))
             .toEqual('a {b2}');
       });
+
+      it('should collapse whitespace between rules', () => {
+        expect(processRules(
+                   'a { }      b {c} d   {e; f}',
+                   (cssRule: CssRule) => new CssRule(cssRule.selector, cssRule.content)))
+            .toEqual('a { } b {c} d {e; f}');
+      });
+
+      it('should not collapse whitespace within a rule body', () => {
+        expect(processRules(
+                   'a { content: \'    \' } b { a;   c }',
+                   (cssRule: CssRule) => new CssRule(cssRule.selector, cssRule.content)))
+            .toEqual('a { content: \'    \' } b { a;   c }');
+      });
     });
   });
 }

--- a/packages/compiler/test/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css_spec.ts
@@ -355,6 +355,11 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
                    (cssRule: CssRule) => new CssRule(cssRule.selector, cssRule.content + '2')))
             .toEqual('a {b2}');
       });
+    });
+
+    describe('whitespace', () => {
+
+      // See issue #20105
 
       it('should collapse whitespace between rules', () => {
         expect(processRules(
@@ -369,6 +374,6 @@ import {normalizeCSS} from '@angular/platform-browser/testing/src/browser_util';
                    (cssRule: CssRule) => new CssRule(cssRule.selector, cssRule.content)))
             .toEqual('a { content: \'    \' } b { a;   c }');
       });
-    });
+    })
   });
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
This fixes a catastrophic backtrack in a regular expression used to process CSS rules in the Shadow DOM shim.

The issue occurs when processing CSS which large amounts of white space. Excess white space may also occur when processing a CSS file which originally contained a large number of comments - an earlier step in the compile strips the comments but leaves the white space between them intact.

Issue Number: [20105](https://github.com/angular/angular/issues/20105)


## What is the new behavior?
Collapsing contiguous white space characters to a single character effectively side-steps the problem.


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
