### PR TITLE
fix(http): sanity check against undefined header values

### DIFF
--- a/packages/common/http/src/headers.ts
+++ b/packages/common/http/src/headers.ts
@@ -69,7 +69,7 @@ export class HttpHeaders {
           if (typeof values === 'string') {
             values = [values];
           }
-          if (values.length > 0) {
+          if (values && values.length > 0) {
             this.headers.set(key, values);
             this.maybeSetNormalizedName(name, key);
           }

--- a/packages/common/http/test/headers_spec.ts
+++ b/packages/common/http/test/headers_spec.ts
@@ -39,6 +39,13 @@ import {HttpHeaders} from '../src/headers';
         expect(c.getAll('foo')).toEqual(['a', 'b', 'c']);
       });
 
+      it('should handle undefined values', () => {
+        const src = new HttpHeaders({
+          'X-My-Custom-Header': undefined,
+        });
+        expect(src.has('X-My-Custom-Header')).toEqual(true);
+      });
+
       it('should keep the last value when initialized from an object', () => {
         const headers = new HttpHeaders({
           'foo': 'first',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
```javascript
headers = new HttpHeaders({'some-header': undefined});
```
"Cannot read property 'length' of undefined..." in the browser console.

Issue Number: N/A


## What is the new behavior?
```javascript
headers = new HttpHeaders({'some-header': undefined});
headers.get('some-header'); // returns null
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
