### PR TITLE
fix(aio): correctly handle all-internal props/methods and empty ctor/method description

### DIFF
--- a/aio/tests/e2e/api.e2e-spec.ts
+++ b/aio/tests/e2e/api.e2e-spec.ts
@@ -40,4 +40,14 @@ describe('Api pages', function() {
     const page = new ApiPage('api/common/HashLocationStrategy');
     expect(page.getOverview('class').getText()).toContain('path(includeHash: boolean = false): string');
   });
+
+  it('should show a "Properties" section if there are public properties', () => {
+    const page = new ApiPage('api/core/ViewContainerRef');
+    expect(page.getSection('instance-properties').isPresent()).toBe(true);
+  });
+
+  it('should not show a "Properties" section if there are only internal properties', () => {
+    const page = new ApiPage('api/forms/FormControl');
+    expect(page.getSection('instance-properties').isPresent()).toBe(false);
+  });
 });

--- a/aio/tests/e2e/api.po.ts
+++ b/aio/tests/e2e/api.po.ts
@@ -31,4 +31,8 @@ export class ApiPage extends SitePage {
   getOverview(docType) {
     return element(by.css(`.${docType}-overview`));
   }
+
+  getSection(cls) {
+    return element(by.css(`section.${cls}`));
+  }
 }

--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -106,36 +106,40 @@
 {% endmacro -%}
 
 {%- macro renderMethodDetails(methods, containerClass, itemClass, headingText) -%}
-{% if methods.length %}
+{% set nonInternalMethods = methods | filterByPropertyValue('internal', undefined) %}
+{% if nonInternalMethods.length %}
 <section class="{$ containerClass $}">
   <h2>{$ headingText $}</h2>
-  {% for member in methods %}{% if not member.internal %}
+  {% for member in nonInternalMethods %}
     {$ renderMethodDetail(member, itemClass) $}
-  {% endif %}{% endfor %}
+  {% endfor %}
 </section>
 {% endif %}
 {%- endmacro -%}
 
 
 {%- macro renderProperties(properties, containerClass, propertyClass, headingText) -%}
-{%- if properties.length -%}
-<h2>{$ headingText $}</h2>
-<table class="is-full-width list-table properties-table">
-  <thead>
-    <tr><th>Property</th><th>Type</th><th>Description</th></tr>
-  </thead>
-  <tbody>
-  {% for property in properties %}{% if not property.internal %}
-    <tr class="{$ propertyClass $}">
-      <td><a id="{$ property.anchor $}"></a>{$ property.name $}</td>
-      <td><label class="property-type-label"><code>{$ property.type | escape $}</code></label></td>
-      <td>
-        {$ (property.description or property.constructorParamDoc.description) | marked $}
-        {% if property.constructorParamDoc %} <span class='from-constructor'>Declared in constructor.</span>{% endif %}
-      </td>
-  </tr>
-  {% endif %}{% endfor %}
-  </tbody>
-</table>
+{% set nonInternalProperties = properties | filterByPropertyValue('internal', undefined) %}
+{% if nonInternalProperties.length -%}
+<section class="{$ containerClass $}">
+  <h2>{$ headingText $}</h2>
+  <table class="is-full-width list-table properties-table">
+    <thead>
+      <tr><th>Property</th><th>Type</th><th>Description</th></tr>
+    </thead>
+    <tbody>
+    {% for property in nonInternalProperties %}
+      <tr class="{$ propertyClass $}">
+        <td><a id="{$ property.anchor $}"></a>{$ property.name $}</td>
+        <td><label class="property-type-label"><code>{$ property.type | escape $}</code></label></td>
+        <td>
+          {$ (property.description or property.constructorParamDoc.description) | marked $}
+          {% if property.constructorParamDoc %} <span class='from-constructor'>Declared in constructor.</span>{% endif %}
+        </td>
+    </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</section>
 {%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
_Commit #&#8203;1:_
Do not show Properties/Methods sections if only internal members.

**Before:**
![api-props-before](https://user-images.githubusercontent.com/8604205/36720424-bb634b6c-1bb0-11e8-955e-2cb0d60de979.png)

**After:**
![api-props-after](https://user-images.githubusercontent.com/8604205/36720316-54c2c126-1bb0-11e8-8dc5-45278576057e.png)

---
_Commit #&#8203;2:_
Omit empty `<tr>` when there is no constructor/method description.

**Before:**
![api-constructor-before](https://user-images.githubusercontent.com/8604205/36720411-a5b5a13e-1bb0-11e8-95ea-aaf33a8e61fb.png)

**After:**
![api-constructor-after](https://user-images.githubusercontent.com/8604205/36720343-6c94ace2-1bb0-11e8-8986-b43f576468e7.png)
