### PR TITLE
feat(core): can provide finishCallback for async test

### DIFF
--- a/aio/content/examples/testing/src/app/twain/twain.component.spec.ts
+++ b/aio/content/examples/testing/src/app/twain/twain.component.spec.ts
@@ -139,7 +139,6 @@ describe('TwainComponent', () => {
     }));
     // #enddocregion async-test
 
-
     // #docregion quote-done-test
     it('should show last quote (quote done)', (done: DoneFn) => {
       fixture.detectChanges();
@@ -180,5 +179,21 @@ describe('TwainComponent', () => {
       expect(quoteEl.textContent).toBe('...', 'should show placeholder');
     }));
     // #enddocregion async-error-test
+  });
+
+  describe('simple async test', () => {
+    const log: string[] = [];
+    // #docregion async-test-finish-callback
+    it('should call finish callback after async tasks done', async(() => {
+      setTimeout(() => {
+        log.push('timeout1');
+      });
+      setTimeout(() => {
+        log.push('timeout2');
+      });
+    }, () => {
+      expect(log).toEqual(['timeout1', 'timeout2']);
+    }));
+    // #enddocregion async-test-finish-callback
   });
 });

--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -1167,6 +1167,15 @@ which breaks the linear flow of control.
 
 {@a when-stable}
 
+You can also pass a finishCallback(optional) to async() which will be invoked when
+all async task finished. This is useful when you just want to test some simple async
+operations and don't want to use fixture at all.
+
+<code-example 
+  path="testing/src/app/twain/twain.component.spec.ts" 
+  region="async-test-finish-callback">
+</code-example>
+
 #### _whenStable_
 
 The test must wait for the `getQuote()` observable to emit the next quote.

--- a/packages/core/test/async_spec.ts
+++ b/packages/core/test/async_spec.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {async} from '@angular/core/testing';
+
+describe('async', () => {
+  let logs:string[] = [];
+  beforeEach(() => {
+    logs = [];
+  });
+  it ('should automatically done after all async tasks finished', async(() => {
+    setTimeout(() => {
+      logs.push('timeout');
+    }, 100);
+  }, () => {
+    expect(logs).toEqual(['timeout']);
+  }));
+
+  it ('should automatically done after all sync tasks finished', async(() => {
+    logs.push('sync');
+  }, () => {
+    expect(logs).toEqual(['sync']);
+  }));
+});

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -1,5 +1,5 @@
 /** @stable */
-export declare function async(fn: Function): (done: any) => any;
+export declare function async(fn: Function, finishCallback?: (error?: any) => void): (done: any) => any;
 
 /** @experimental */
 export declare function cleanupDocument(): void;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the new behavior?

Add a `optional finishCallback` parameter in `async` of `@angular/core/testing`.
the new API becomes to

```javascript
export function async(fn: Function, finishCallback?: (error?: any) => void): (done: any) => any {}
```

The motivation is  :

when use `async` to test, user can't provide a `finishCallback`. I know we can use `whenStable`, but sometimes, we may just want to test some `services`, and we don't need `Fixture` at all. 
Sometimes we want to do some `expect test` when all async tasks finished, in this PR we can do like this.

for example.

```javascript
logs = [];
it('service should return data', async(() => {
  someService.getData().subscribe((data) => {
    logs.push('someData');
  });
  
  anotherService.getData().subscribe((data) => {
    logs.push('anotherData');
  });
}, (err?: any) => {
  expect(log).toEqual('someData', 'anotherData');
});
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

If the idea is ok, I will add test cases and document.