### PR TITLE
release: add ng update package group metadata to angular

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,6 +33,11 @@ TSC_PACKAGES=(compiler-cli
 NODE_PACKAGES=(compiler-cli
   benchpress)
 
+NG_UPDATE_PACKAGE_GROUP=$(
+  echo \[\"${PACKAGES[@]}\"] | sed 's/ /", "/g'
+)
+
+
 BUILD_ALL=true
 BUNDLE=true
 VERSION_PREFIX=$(node -p "require('./package.json').version")
@@ -490,6 +495,9 @@ do
     echo "======        Copy ${PACKAGE} package.json and .externs.js files"
     rsync -am --include="package.json" --include="*/" --exclude=* ${SRC_DIR}/ ${NPM_DIR}/
     rsync -am --include="*.externs.js" --include="*/" --exclude=* ${SRC_DIR}/ ${NPM_DIR}/
+
+    # Replace the NG_UPDATE_PACKAGE_GROUP value with the JSON array of packages.
+    perl -p -i -e "s/\"NG_UPDATE_PACKAGE_GROUP\"/${NG_UPDATE_PACKAGE_GROUP}/g" ${NPM_DIR}/package.json < /dev/null 2> /dev/null
 
     cp ${ROOT_DIR}/README.md ${NPM_DIR}/
   fi

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -17,5 +17,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,5 +19,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -34,5 +34,8 @@
   "bugs": {
     "url": "https://github.com/angular/angular/issues"
   },
-  "homepage": "https://github.com/angular/angular/tree/master/packages/compiler-cli"
+  "homepage": "https://github.com/angular/angular/tree/master/packages/compiler-cli",
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
+  }
 }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -14,5 +14,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,5 +18,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -20,5 +20,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -19,5 +19,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -10,5 +10,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/packages/platform-browser-dynamic/package.json
+++ b/packages/platform-browser-dynamic/package.json
@@ -20,5 +20,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -18,5 +18,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -24,5 +24,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/packages/platform-webworker-dynamic/package.json
+++ b/packages/platform-webworker-dynamic/package.json
@@ -21,5 +21,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/packages/platform-webworker/package.json
+++ b/packages/platform-webworker/package.json
@@ -19,5 +19,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -28,5 +28,8 @@
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER",
     "rxjs": "^5.5.0"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -21,5 +21,8 @@
   },
   "bin": {
     "ngsw-config": "./ngsw-config.js"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -20,5 +20,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }


### PR DESCRIPTION
"ng update" supports having multiple packages as part of a group which should be updated together, meaning that e.g. calling "ng update @angular/core" would be equivalent to updating all packages of the group (that are part of the package.json already).

In order to support the grouping feature, the package.json of the version the user is updating to needs to include an "ng-update" key that points to this metadata.

The entire specification for the update workflow can be found here: https://github.com/hansl/devkit/blob/2e8b12a4ef53833dc006e8711acf95cf3a6cf24e/docs/specifications/update.md
