### PR TITLE
docs: fix table in comparing observables guide

### DIFF
--- a/aio/content/guide/comparing-observables.md
+++ b/aio/content/guide/comparing-observables.md
@@ -89,47 +89,51 @@ promise.then(() => {
 The following code snippets illustrate how the same kind of operation is defined using observables and promises.
 
 <table>
-  <tr>
-    <th>Operation</th>
-    <th>Observable</th>
-    <th>Promise</th>
-  </tr>
-  <tr>
-    <td>Creation</td>
-    <td>
-      <pre>new Observable((observer) => {
-  observer.next(123);
-});</pre>
-    </td>
-    <td>
-      <pre>new Promise((resolve, reject) => {
-  resolve(123);
-});</pre>
-    </td>
-  </tr>
-  <tr>
-    <td>Transform</td>
-    <td><pre>obs.map((value) => value * 2 );</pre></td>
-    <td><pre>promise.then((value) => value * 2);</pre></td>
-  </tr>
-  <tr>
-    <td>Subscribe</td>
-    <td>
-      <pre>sub = obs.subscribe((value) => {
-  console.log(value)
-});</pre>
-    </td>
-    <td>
-      <pre>promise.then((value) => {
-  console.log(value);
-});</pre>
-    </td>
-  </tr>
-  <tr>
-    <td>Unsubscribe</td>
-    <td><pre>sub.unsubscribe();</pre></td>
-    <td>Implied by promise resolution.</td>
-  </tr>
+  <thead>
+    <tr>
+      <th>Operation</th>
+      <th>Observable</th>
+      <th>Promise</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Creation</td>
+      <td>
+        <pre>new Observable((observer) => {
+    observer.next(123);
+  });</pre>
+      </td>
+      <td>
+        <pre>new Promise((resolve, reject) => {
+    resolve(123);
+  });</pre>
+      </td>
+    </tr>
+    <tr>
+      <td>Transform</td>
+      <td><pre>obs.map((value) => value * 2 );</pre></td>
+      <td><pre>promise.then((value) => value * 2);</pre></td>
+    </tr>
+    <tr>
+      <td>Subscribe</td>
+      <td>
+        <pre>sub = obs.subscribe((value) => {
+    console.log(value)
+  });</pre>
+      </td>
+      <td>
+        <pre>promise.then((value) => {
+    console.log(value);
+  });</pre>
+      </td>
+    </tr>
+    <tr>
+      <td>Unsubscribe</td>
+      <td><pre>sub.unsubscribe();</pre></td>
+      <td>Implied by promise resolution.</td>
+    </tr>
+  </tbody>
 </table>
 
 ## Observables compared to events API


### PR DESCRIPTION
Fix table in comparing-observables.md that was incorrectly formatted.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Table columns are off by one.

Issue Number: N/A


## What is the new behavior?
Table formatted correctly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```