### PR TITLE
fix(router): add router config validation check in defaultUrlMatcher()

### DIFF
--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -110,6 +110,11 @@ export function isNavigationCancelingError(error: Error) {
 // Matches the route configuration (`route`) against the actual URL (`segments`).
 export function defaultUrlMatcher(
     segments: UrlSegment[], segmentGroup: UrlSegmentGroup, route: Route): UrlMatchResult|null {
+  if (!route.hasOwnProperty('path')) {
+    // This is an invalid router config
+    return null;
+  }
+
   const parts = route.path !.split('/');
 
   if (parts.length > segments.length) {


### PR DESCRIPTION
`defaultUrlMatcher()` will stopped by an error if the router config
does not have a `path` property, router config validation check is
needed for reason of robustness.

fixes #22487

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #22487 


## What is the new behavior?

`defaultUrlMatcher()` checks the config item has own the `path` property or not before using it, which will fix #22487 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Full test has been performed in my work evn.