### PR TITLE
build(aio): initialise `exampleMap` correctly

### DIFF
--- a/aio/tools/transforms/examples-package/processors/collect-examples.js
+++ b/aio/tools/transforms/examples-package/processors/collect-examples.js
@@ -27,6 +27,7 @@ module.exports = function collectExamples(exampleMap, regionParser, log, createD
     },
     $process(docs) {
       const exampleFolders = this.exampleFolders;
+      exampleFolders.forEach(folder => exampleMap[folder] = exampleMap[folder] || {});
       const regionDocs = [];
       docs = docs.filter((doc) => {
         if (doc.docType === 'example-file') {
@@ -36,7 +37,6 @@ module.exports = function collectExamples(exampleMap, regionParser, log, createD
               if (doc.fileInfo.relativePath.indexOf(folder) === 0) {
                 const relativePath =
                     doc.fileInfo.relativePath.substr(folder.length).replace(/^\//, '');
-                exampleMap[folder] = exampleMap[folder] || {};
                 exampleMap[folder][relativePath] = doc;
 
                 // We treat files that end in `.annotated` specially

--- a/aio/tools/transforms/examples-package/processors/collect-examples.spec.js
+++ b/aio/tools/transforms/examples-package/processors/collect-examples.spec.js
@@ -25,6 +25,12 @@ describe('collectExampleRegions processor', () => {
 
   describe('$process', () => {
 
+    it('should initialise the `exampleMap` even if there are no examples to collect', () => {
+      processor.$process([]);
+      expect(exampleMap['examples-1']).toEqual(jasmine.any(Object));
+      expect(exampleMap['examples-2']).toEqual(jasmine.any(Object));
+    });
+
     it('should identify example files that are in the exampleFolders', () => {
       const docs = [
         createDoc('A', 'examples-1/x/app.js'), createDoc('B', 'examples-1/y/index.html'),


### PR DESCRIPTION
The `exampleMap` needs to hold an hash object for each
of the `collectExamples.exampleFolders` paths.

Previously these hash objects were only created if there
was actually an example file the hash's respective
example folder.  This could cause crashes during
`yarn docs-watch` (and so also `yarn sync-and-serve`)
if no examples were read in for a particular run of
the doc-gen.

