### PR TITLE
fix(forms): teach FormControlDirective to clean up connection to valu…

### DIFF
--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -8,7 +8,7 @@
 
 import {Component, Directive, Input, Type, forwardRef} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, tick} from '@angular/core/testing';
-import {AbstractControl, AsyncValidator, AsyncValidatorFn, COMPOSITION_BUFFER_MODE, FormArray, FormControl, FormGroup, FormGroupDirective, FormsModule, NG_ASYNC_VALIDATORS, NG_VALIDATORS, ReactiveFormsModule, Validators} from '@angular/forms';
+import {AbstractControl, AsyncValidator, AsyncValidatorFn, COMPOSITION_BUFFER_MODE, DefaultValueAccessor, FormArray, FormControl, FormGroup, FormGroupDirective, FormsModule, NG_ASYNC_VALIDATORS, NG_VALIDATORS, ReactiveFormsModule, Validators} from '@angular/forms';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
@@ -74,6 +74,47 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         dispatchEvent(input.nativeElement, 'input');
 
         expect(form.value).toEqual({'login': 'updatedValue'});
+      });
+
+      it('cleans up when control is replaced with the new one', () => {
+        const oldControl = new FormControl();
+        const newControl = new FormControl();
+
+        const fixture = initTest(FormControlNgIfWrapper);
+
+        fixture.componentInstance.control = oldControl;
+        fixture.detectChanges();
+
+        fixture.componentInstance.control = newControl;
+        fixture.detectChanges();
+
+        const spy = spyOn(DefaultValueAccessor.prototype, 'writeValue');
+
+        oldControl.setValue('My Value');
+
+        // oldControl is not longer connected to value accessor, so it should
+        // not call writeValue on it.
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      it('cleans up when FormControlDirective is destroyed', () => {
+        const control = new FormControl();
+
+        const fixture = initTest(FormControlNgIfWrapper);
+
+        fixture.componentInstance.control = control;
+        fixture.detectChanges();
+
+        fixture.componentInstance.visible = false;
+        fixture.detectChanges();
+
+        const spy = spyOn(DefaultValueAccessor.prototype, 'writeValue');
+
+        control.setValue('My Value');
+
+        // FormControlDirective have been destroyed and connection to value
+        // accessor should be destroyed together with it.
+        expect(spy).not.toHaveBeenCalled();
       });
 
     });
@@ -2609,4 +2650,13 @@ class FormControlCheckboxRequiredValidator {
 })
 class UniqLoginWrapper {
   form: FormGroup;
+}
+
+@Component({
+  selector: 'form-control-ng-if-wrapper',
+  template: '<input *ngIf="visible" type="text" [formControl]="control" required>'
+})
+class FormControlNgIfWrapper {
+  visible = true;
+  control: FormControl;
 }

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -251,7 +251,7 @@ export declare class FormControl extends AbstractControl {
 }
 
 /** @stable */
-export declare class FormControlDirective extends NgControl implements OnChanges {
+export declare class FormControlDirective extends NgControl implements OnChanges, OnDestroy {
     readonly asyncValidator: AsyncValidatorFn | null;
     readonly control: FormControl;
     form: FormControl;
@@ -263,6 +263,7 @@ export declare class FormControlDirective extends NgControl implements OnChanges
     viewModel: any;
     constructor(validators: Array<Validator | ValidatorFn>, asyncValidators: Array<AsyncValidator | AsyncValidatorFn>, valueAccessors: ControlValueAccessor[], _ngModelWarningConfig: string | null);
     ngOnChanges(changes: SimpleChanges): void;
+    ngOnDestroy(): void;
     viewToModelUpdate(newValue: any): void;
 }
 


### PR DESCRIPTION
…e accessor

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~Docs have been added / updated (for bug fixes / features)~ not relevant


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #21434 

Which I believe was incorrectly closed. Even though removing form directive from DOM does not destroy `FormControl` instance it should destroy connection between `FormControl` and corresponding value accessor, which it created. 

First issue with the current behavior is that it keeps sending values to value accessors, which were destroyed. The practical example of this is described in the linked issue: `ValueAccessor.writeValue()` is called multiple times although all except the newest one were destroyed.

Second issue is that it creates a memory leak. Because connection between control and destroyed value accessor is never cleaned up, it retains destroyed value accessor directives/components and associated DOM nodes until `FormControl` itself is garbage-collected.

## What is the new behavior?

When `FormControlDirective` is destroyed it will clean up connection between `FormControl` and value accessor, which was created by the directive.

When `FormControlDirective.control` is changed it will clean up connection between old `FormControl` and value accessor, which was created by the directive.

## Does this PR introduce a breaking change?
```
[x] Yes (well, if somebody was relying on current undocumented behavior... which I hope they didn't)
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
