### PR TITLE
build(aio): render param descriptions for function exports

### DIFF
--- a/aio/tools/transforms/templates/api/class.template.html
+++ b/aio/tools/transforms/templates/api/class.template.html
@@ -1,29 +1,23 @@
 {% import "lib/memberHelpers.html" as memberHelpers -%}
 {% import "lib/descendants.html" as descendants -%}
 {% import "lib/paramList.html" as params -%}
-{% extends 'base.template.html' -%}
+{% extends 'export-base.template.html' -%}
 
-{% block body %}
-  <p class="short-description">{$ doc.shortDescription | marked $}</p>
-  {% include "includes/security-notes.html" %}
-  {% include "includes/deprecation.html" %}
-  {% block overview %}
+{% block overview %}
   {% include "includes/class-overview.html" %}
-  {% endblock %}
-  {% block details %}
-    {% block additional %}{% endblock %}
-    {% include "includes/description.html" %}
-    {$ memberHelpers.renderProperties(doc.staticProperties, 'static-properties', 'static-property', 'Static Properties') $}
-    {$ memberHelpers.renderMethodDetails(doc.staticMethods, 'static-methods', 'static-method', 'Static Methods') $}
-    {% if doc.constructorDoc %}
-    <h2>Constructor</h2>
-    {$ memberHelpers.renderMethodDetail(doc.constructorDoc, 'constructor') $}{% endif %}
+{% endblock %}
+{% block details %}
+  {% block additional %}{% endblock %}
+  {% include "includes/description.html" %}
+  {$ memberHelpers.renderProperties(doc.staticProperties, 'static-properties', 'static-property', 'Static Properties') $}
+  {$ memberHelpers.renderMethodDetails(doc.staticMethods, 'static-methods', 'static-method', 'Static Methods') $}
+  {% if doc.constructorDoc %}
+  <h2>Constructor</h2>
+  {$ memberHelpers.renderMethodDetail(doc.constructorDoc, 'constructor') $}{% endif %}
 
-    {$ memberHelpers.renderProperties(doc.properties, 'instance-properties', 'instance-property', 'Properties') $}
+  {$ memberHelpers.renderProperties(doc.properties, 'instance-properties', 'instance-property', 'Properties') $}
 
-    {$ memberHelpers.renderMethodDetails(doc.methods, 'instance-methods', 'instance-method', 'Methods') $}
+  {$ memberHelpers.renderMethodDetails(doc.methods, 'instance-methods', 'instance-method', 'Methods') $}
 
-    {% block annotations %}{% include "includes/annotations.html" %}{% endblock %}
-  {% endblock %}
-  {% include "includes/usageNotes.html" %}
+  {% block annotations %}{% include "includes/annotations.html" %}{% endblock %}
 {% endblock %}

--- a/aio/tools/transforms/templates/api/export-base.template.html
+++ b/aio/tools/transforms/templates/api/export-base.template.html
@@ -5,6 +5,6 @@
   {% include "includes/security-notes.html" %}
   {% include "includes/deprecation.html" %}
   {% block overview %}{% endblock %}
-  {% include "includes/usageNotes.html" %}
   {% block details %}{% endblock %}
+  {% include "includes/usageNotes.html" %}
 {% endblock %}

--- a/aio/tools/transforms/templates/api/function.template.html
+++ b/aio/tools/transforms/templates/api/function.template.html
@@ -1,24 +1,33 @@
+{% import "lib/memberHelpers.html" as memberHelpers -%}
 {% import "lib/paramList.html" as params -%}
 {% extends 'export-base.template.html' -%}
 
 {% block overview %}
-<code-example language="ts" hideCopy="true" class="no-box api-heading">
-function {$ doc.name $}{$ doc.typeParameters | escape $}{$ params.paramList(doc.parameters) $}
-{%- if doc.type %}: {$ doc.type | escape $}{% endif %};
-</code-example>
+{% if doc.overloads.length > 0 and doc.overloads < 3 -%}
+  {% for overload in doc.overloads -%}
+    {$ memberHelpers.renderOverloadInfo(overload, 'function-overload', doc) $}
+    {% if not loop.last %}<hr class="hr-margin fullwidth">{% endif %}
+    {% endfor -%}
+{% else %}
+  {$ memberHelpers.renderOverloadInfo(doc, 'function-overload', doc) $}
+{% endif %}
 {% endblock %}
+
 
 {% block details %}
 {% include "includes/description.html" %}
-{% if doc.overloads.length %}
-  <h2>Overloads</h2>{% for overload in doc.overloads %}
-  <code-example language="ts" hideCopy="true" class="no-box api-heading">
-  function {$ overload.name $}{$ doc.typeParameters | escape $}{$ params.paramList(overload.parameters) $}
-  {%- if overload.type %}: {$ overload.type | escape $}{% endif %};
-  </code-example>
-  <section class="description">
-    {$ overload.description | trimBlankLines | marked $}
-  </section>
-{% endfor %}
+{% if doc.overloads.length >= 3 %}
+<section class="overloads">
+  <h2>Overloads</h2>
+  <table>
+  {% for overload in doc.overloads %}
+  <tr>
+    <td>
+      {$ memberHelpers.renderOverloadInfo(overload, 'function-overload', doc) $}
+    </td>
+  </tr>
+  {% endfor %}
+  </table>
+</section>
 {% endif %}
 {% endblock %}

--- a/aio/tools/transforms/templates/api/function.template.html
+++ b/aio/tools/transforms/templates/api/function.template.html
@@ -7,7 +7,7 @@
   {% for overload in doc.overloads -%}
     {$ memberHelpers.renderOverloadInfo(overload, 'function-overload', doc) $}
     {% if not loop.last %}<hr class="hr-margin fullwidth">{% endif %}
-    {% endfor -%}
+  {% endfor -%}
 {% else %}
   {$ memberHelpers.renderOverloadInfo(doc, 'function-overload', doc) $}
 {% endif %}


### PR DESCRIPTION
This change aligns the rendering of exported functions with how methods in classes are rendered.
I am not actually sure if we would ever have overloads of such export functions (I couldn't find any examples in the codebase) but the logic for rendering them is in place.

Closes #22501
