### PR TITLE
build: fall back on default version number if there the .git directory is not found

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,14 @@ NODE_PACKAGES=(compiler-cli
 BUILD_ALL=true
 BUNDLE=true
 VERSION_PREFIX=$(node -p "require('./package.json').version")
-VERSION_SUFFIX="-$(git log --oneline -1 | awk '{print $1}')"
+
+if [ -d .git ]; then
+  VERSION_SUFFIX="-$(git log --oneline -1 | awk '{print $1}')"
+else
+  VERSION_SUFFIX="0.0.0-PLACEHOLDER"
+  echo "WARNING: Unable to determine version from git repository status, defaulting to $VERSION_SUFFIX"
+fi
+
 REMOVE_BENCHPRESS=false
 BUILD_EXAMPLES=true
 COMPILE_SOURCE=true


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The build script fails when git log fails, for example because it cannot access the .git directory.
`./build.sh`
`fatal: Not a git repository (or any of the parent directories): .git`

## Issue Number: #22551


## What is the new behavior?
A warning is shown that says the current version cannot be determined and a placeholder (invalid) version would be used, but the build finishes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
I was unsure where/if documentation updates need to be made, because of this I left the checkbox open