### PR TITLE
ts-api-guardian: overloading a function doesn't generate all of the signatures

### DIFF
--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -303,7 +303,7 @@ export declare class NgLocaleLocalization extends NgLocalization {
     /** @deprecated */ protected deprecatedPluralFn: ((locale: string, value: string | number) => Plural) | null | undefined;
     protected locale: string;
     constructor(locale: string,
-        deprecatedPluralFn?: ((locale: string, value: string | number) => Plural) | null | undefined);
+        /** @deprecated */ deprecatedPluralFn?: ((locale: string, value: string | number) => Plural) | null | undefined);
     getPluralCategory(value: any, locale?: string): string;
 }
 

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -449,6 +449,7 @@ export declare const HostListener: HostListenerDecorator;
 
 /** @experimental */
 export declare function inject<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: undefined, flags?: InjectFlags): T;
+export declare function inject<T>(token: Type<T> | InjectionToken<T>, notFoundValue: T | null, flags?: InjectFlags): T | null;
 
 /** @stable */
 export declare const Inject: InjectDecorator;

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -156,3 +156,4 @@ export declare function withBody<T>(html: string, blockFn: T): T;
 
 /** @experimental */
 export declare function withModule(moduleDef: TestModuleMetadata): InjectSetupWrapper;
+export declare function withModule(moduleDef: TestModuleMetadata, fn: Function): () => any;

--- a/tools/public_api_guard/router/testing.d.ts
+++ b/tools/public_api_guard/router/testing.d.ts
@@ -5,6 +5,7 @@ export declare class RouterTestingModule {
 
 /** @stable */
 export declare function setupTestingRouter(urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location, loader: NgModuleFactoryLoader, compiler: Compiler, injector: Injector, routes: Route[][], opts?: ExtraOptions, urlHandlingStrategy?: UrlHandlingStrategy): Router;
+export declare function setupTestingRouter(urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location, loader: NgModuleFactoryLoader, compiler: Compiler, injector: Injector, routes: Route[][], urlHandlingStrategy?: UrlHandlingStrategy): Router;
 
 /** @stable */
 export declare class SpyNgModuleFactoryLoader implements NgModuleFactoryLoader {

--- a/tools/ts-api-guardian/lib/serializer.ts
+++ b/tools/ts-api-guardian/lib/serializer.ts
@@ -215,7 +215,15 @@ class ResolvedDeclarationEmitter {
       }
     }
 
-    let children = node.getChildren();
+    let children: ts.Node[] = [];
+    if (ts.isFunctionDeclaration(node)) {
+      // Used ts.isFunctionDeclaration instead of node.kind because this is a type guard
+      const symbol = this.typeChecker.getSymbolAtLocation(node.name);
+      symbol.declarations.forEach(x => children = children.concat(x.getChildren()));
+    } else {
+      children = node.getChildren();
+    }
+
     const sourceText = node.getSourceFile().text;
     if (children.length) {
       // Sort declarations under a class or an interface
@@ -252,7 +260,7 @@ class ResolvedDeclarationEmitter {
                                .join('');
 
       // Print stability annotation for fields
-      if (node.kind in memberDeclarationOrder) {
+      if (ts.isParameter(node) || node.kind in memberDeclarationOrder) {
         const trivia = sourceText.substr(node.pos, node.getLeadingTriviaWidth());
         const match = stabilityAnnotationPattern.exec(trivia);
         if (match) {

--- a/tools/ts-api-guardian/test/unit_test.ts
+++ b/tools/ts-api-guardian/test/unit_test.ts
@@ -59,6 +59,24 @@ describe('unit test', () => {
     check({'file.d.ts': input}, expected);
   });
 
+  it('should support overloads functions', () => {
+    const input = `
+      export declare function group(steps: AnimationMetadata[], options?: AnimationOptions | null): AnimationGroupMetadata;
+
+      export declare function registerLocaleData(data: any, extraData?: any): void;
+      export declare function registerLocaleData(data: any, localeId?: string, extraData?: any): void;
+    `;
+
+    const expected = `
+      export declare function group(steps: AnimationMetadata[], options?: AnimationOptions | null): AnimationGroupMetadata;
+
+      export declare function registerLocaleData(data: any, extraData?: any): void;
+      export declare function registerLocaleData(data: any, localeId?: string, extraData?: any): void;
+    `;
+
+    check({'file.d.ts': input}, expected);
+  });
+
   it('should ignore private props', () => {
     const input = `
       export declare class A {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Overloaded pure functions are not generated.

Issue Number: https://github.com/angular/ts-api-guardian/issues/22


## What is the new behavior?
Overloaded methods are generated

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Deltas
```bash
diff --git a/tools/public_api_guard/common/common.d.ts b/tools/public_api_guard/common/common.d.ts
index 9d07132c2..cebf029d7 100644
--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -306 +306 @@ export declare class NgLocaleLocalization extends NgLocalization {
-        deprecatedPluralFn?: ((locale: string, value: string | number) => Plural) | null | undefined);
+        /** @deprecated */ deprecatedPluralFn?: ((locale: string, value: string | number) => Plural) | null | undefined);
diff --git a/tools/public_api_guard/core/core.d.ts b/tools/public_api_guard/core/core.d.ts
index 835512649..83d605e4e 100644
--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -451,0 +452 @@ export declare function inject<T>(token: Type<T> | InjectionToken<T>, notFoundVa
+export declare function inject<T>(token: Type<T> | InjectionToken<T>, notFoundValue: T | null, flags?: InjectFlags): T | null;
diff --git a/tools/public_api_guard/core/testing.d.ts b/tools/public_api_guard/core/testing.d.ts
index d4c5452ba..b5fcd428c 100644
--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -158,0 +159 @@ export declare function withModule(moduleDef: TestModuleMetadata): InjectSetupWr
+export declare function withModule(moduleDef: TestModuleMetadata, fn: Function): () => any;
diff --git a/tools/public_api_guard/router/testing.d.ts b/tools/public_api_guard/router/testing.d.ts
index d14731865..e7877cdc2 100644
--- a/tools/public_api_guard/router/testing.d.ts
+++ b/tools/public_api_guard/router/testing.d.ts
@@ -7,0 +8 @@ export declare function setupTestingRouter(urlSerializer: UrlSerializer, context
+export declare function setupTestingRouter(urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location, loader: NgModuleFactoryLoader, compiler: Compiler, injector: Injector, routes: Route[][], urlHandlingStrategy?: UrlHandlingStrategy): Router;
```

/cc @ocombe 