### PR TITLE
build(aio): indicate whether properties are read-only in API pages

### DIFF
--- a/aio/src/styles/2-modules/_api-pages.scss
+++ b/aio/src/styles/2-modules/_api-pages.scss
@@ -64,7 +64,7 @@
     background-color: rgba(241, 241, 241, 0.2);
   }
 
-  .from-constructor {
+  .from-constructor, .read-only-property {
     font-style: italic;
     color: $blue;
   }

--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -133,6 +133,7 @@
         <td><a id="{$ property.anchor $}"></a>{$ property.name $}</td>
         <td><label class="property-type-label"><code>{$ property.type | escape $}</code></label></td>
         <td>
+          {%- if (property.isGetAccessor or property.isReadonly) and not property.isSetAccessor %}<span class='read-only-property'>Read-only.</span>{% endif %}
           {$ (property.description or property.constructorParamDoc.description) | marked $}
           {% if property.constructorParamDoc %} <span class='from-constructor'>Declared in constructor.</span>{% endif %}
         </td>


### PR DESCRIPTION
Although we were displaying the `get` modifier in the overview, there was no indication in the properties table of whether a property was readonly or not.