### PR TITLE
 feat(ivy): support ChangeDetectorRef.detectChanges

### DIFF
--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {RootLifecycleHooks, createComponentRef, getHostElement, getRenderedText, renderComponent, whenRendered} from './component';
+import {LifecycleHooksFeature, createComponentRef, getHostElement, getRenderedText, renderComponent, whenRendered} from './component';
 import {NgOnChangesFeature, PublicFeature, defineComponent, defineDirective, definePipe} from './definition';
 import {InjectFlags} from './di';
 import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefFlags, DirectiveType} from './interfaces/definition';
@@ -109,7 +109,7 @@ export {
   DirectiveType,
   NgOnChangesFeature,
   PublicFeature,
-  RootLifecycleHooks,
+  LifecycleHooksFeature,
   defineComponent,
   defineDirective,
   definePipe,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createComponentRef, getHostElement, getRenderedText, renderComponent, whenRendered} from './component';
+import {RootLifecycleHooks, createComponentRef, getHostElement, getRenderedText, renderComponent, whenRendered} from './component';
 import {NgOnChangesFeature, PublicFeature, defineComponent, defineDirective, definePipe} from './definition';
 import {InjectFlags} from './di';
 import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefFlags, DirectiveType} from './interfaces/definition';
@@ -109,6 +109,7 @@ export {
   DirectiveType,
   NgOnChangesFeature,
   PublicFeature,
+  RootLifecycleHooks,
   defineComponent,
   defineDirective,
   definePipe,

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, ViewRef as viewEngine_ViewRef} from '../linker/view_ref';
-
+import {EmbeddedViewRef as viewEngine_EmbeddedViewRef} from '../linker/view_ref';
+import {detectChanges} from './instructions';
 import {ComponentTemplate} from './interfaces/definition';
 import {LViewNode} from './interfaces/node';
 import {notImplemented} from './util';
@@ -26,7 +26,9 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T> {
   onDestroy(callback: Function) { notImplemented(); }
   markForCheck(): void { notImplemented(); }
   detach(): void { notImplemented(); }
-  detectChanges(): void { notImplemented(); }
+
+  detectChanges(): void { detectChanges(this.context); }
+
   checkNoChanges(): void { notImplemented(); }
   reattach(): void { notImplemented(); }
 }

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -24,6 +24,9 @@
     "name": "__window$1"
   },
   {
+    "name": "_getComponentHostLElementNode"
+  },
+  {
     "name": "_renderCompCount"
   },
   {
@@ -40,9 +43,6 @@
   },
   {
     "name": "currentView"
-  },
-  {
-    "name": "detectChanges"
   },
   {
     "name": "domRendererFactory3"
@@ -81,7 +81,19 @@
     "name": "noop$2"
   },
   {
+    "name": "queueContentHooks"
+  },
+  {
+    "name": "queueDestroyHooks"
+  },
+  {
+    "name": "queueViewHooks"
+  },
+  {
     "name": "refreshDynamicChildren"
+  },
+  {
+    "name": "renderComponentOrTemplate"
   },
   {
     "name": "renderEmbeddedTemplate"

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -6,217 +6,577 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectionStrategy, DoCheck} from '../../src/core';
-import {getRenderedText} from '../../src/render3/component';
-import {defineComponent} from '../../src/render3/index';
-import {bind, detectChanges, directiveRefresh, elementEnd, elementProperty, elementStart, interpolation1, interpolation2, listener, text, textBinding} from '../../src/render3/instructions';
-import {containerEl, renderComponent, requestAnimationFrame} from './render_util';
+import {withBody} from '@angular/core/testing';
 
-describe('OnPush change detection', () => {
-  let comp: MyComponent;
+import {ChangeDetectionStrategy, ChangeDetectorRef, DoCheck, EmbeddedViewRef, TemplateRef, ViewContainerRef} from '../../src/core';
+import {getRenderedText, whenRendered} from '../../src/render3/component';
+import {NgOnChangesFeature, PublicFeature, defineComponent, defineDirective, injectChangeDetectorRef, injectTemplateRef, injectViewContainerRef} from '../../src/render3/index';
+import {bind, container, containerRefreshEnd, containerRefreshStart, detectChanges, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, interpolation1, interpolation2, listener, markDirty, text, textBinding} from '../../src/render3/instructions';
 
-  class MyComponent implements DoCheck {
-    /* @Input() */
-    name = 'Nancy';
-    doCheckCount = 0;
+import {containerEl, renderComponent, requestAnimationFrame, toHtml} from './render_util';
 
-    ngDoCheck(): void { this.doCheckCount++; }
+describe('change detection', () => {
 
-    onClick() {}
-
-    static ngComponentDef = defineComponent({
-      type: MyComponent,
-      tag: 'my-comp',
-      factory: () => comp = new MyComponent(),
-      /**
-       * {{ doCheckCount }} - {{ name }}
-       * <button (click)="onClick()"></button>
-       */
-      template: (ctx: MyComponent, cm: boolean) => {
-        if (cm) {
-          text(0);
-          elementStart(1, 'button');
-          {
-            listener('click', () => { ctx.onClick(); });
-          }
-          elementEnd();
-        }
-        textBinding(0, interpolation2('', ctx.doCheckCount, ' - ', ctx.name, ''));
-      },
-      changeDetection: ChangeDetectionStrategy.OnPush,
-      inputs: {name: 'name'}
-    });
-  }
-
-  class MyApp {
-    name: string = 'Nancy';
-
-    static ngComponentDef = defineComponent({
-      type: MyApp,
-      tag: 'my-app',
-      factory: () => new MyApp(),
-      /** <my-comp [name]="name"></my-comp> */
-      template: (ctx: MyApp, cm: boolean) => {
-        if (cm) {
-          elementStart(0, MyComponent);
-          elementEnd();
-        }
-        elementProperty(0, 'name', bind(ctx.name));
-        MyComponent.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
-      }
-    });
-  }
-
-  it('should check OnPush components on initialization', () => {
-    const myApp = renderComponent(MyApp);
-    expect(getRenderedText(myApp)).toEqual('1 - Nancy');
-  });
-
-  it('should call doCheck even when OnPush components are not dirty', () => {
-    const myApp = renderComponent(MyApp);
-
-    detectChanges(myApp);
-    expect(comp.doCheckCount).toEqual(2);
-
-    detectChanges(myApp);
-    expect(comp.doCheckCount).toEqual(3);
-  });
-
-  it('should skip OnPush components in update mode when they are not dirty', () => {
-    const myApp = renderComponent(MyApp);
-
-    detectChanges(myApp);
-    // doCheckCount is 2, but 1 should be rendered since it has not been marked dirty.
-    expect(getRenderedText(myApp)).toEqual('1 - Nancy');
-
-    detectChanges(myApp);
-    // doCheckCount is 3, but 1 should be rendered since it has not been marked dirty.
-    expect(getRenderedText(myApp)).toEqual('1 - Nancy');
-  });
-
-  it('should check OnPush components in update mode when inputs change', () => {
-    const myApp = renderComponent(MyApp);
-
-    myApp.name = 'Bess';
-    detectChanges(myApp);
-    expect(getRenderedText(myApp)).toEqual('2 - Bess');
-
-    myApp.name = 'George';
-    detectChanges(myApp);
-    expect(getRenderedText(myApp)).toEqual('3 - George');
-
-    detectChanges(myApp);
-    expect(getRenderedText(myApp)).toEqual('3 - George');
-  });
-
-  it('should check OnPush components in update mode when component events occur', () => {
-    const myApp = renderComponent(MyApp);
-    expect(getRenderedText(myApp)).toEqual('1 - Nancy');
-
-    const button = containerEl.querySelector('button') !;
-    button.click();
-    requestAnimationFrame.flush();
-    expect(getRenderedText(myApp)).toEqual('2 - Nancy');
-
-    detectChanges(myApp);
-    expect(getRenderedText(myApp)).toEqual('2 - Nancy');
-  });
-
-  it('should not check OnPush components in update mode when parent events occur', () => {
-    class ButtonParent {
-      noop() {}
+  describe('markDirty, detectChanges, whenRendered, getRenderedText', () => {
+    class MyComponent implements DoCheck {
+      value: string = 'works';
+      doCheckCount = 0;
+      ngDoCheck(): void { this.doCheckCount++; }
 
       static ngComponentDef = defineComponent({
-        type: ButtonParent,
-        tag: 'button-parent',
-        factory: () => new ButtonParent(),
+        type: MyComponent,
+        tag: 'my-comp',
+        factory: () => new MyComponent(),
+        template: (ctx: MyComponent, cm: boolean) => {
+          if (cm) {
+            elementStart(0, 'span');
+            text(1);
+            elementEnd();
+          }
+          textBinding(1, bind(ctx.value));
+        }
+      });
+    }
+
+    it('should mark a component dirty and schedule change detection', withBody('my-comp', () => {
+         const myComp = renderComponent(MyComponent);
+         expect(getRenderedText(myComp)).toEqual('works');
+         myComp.value = 'updated';
+         markDirty(myComp);
+         expect(getRenderedText(myComp)).toEqual('works');
+         requestAnimationFrame.flush();
+         expect(getRenderedText(myComp)).toEqual('updated');
+       }));
+
+    it('should detectChanges on a component', withBody('my-comp', () => {
+         const myComp = renderComponent(MyComponent);
+         expect(getRenderedText(myComp)).toEqual('works');
+         myComp.value = 'updated';
+         detectChanges(myComp);
+         expect(getRenderedText(myComp)).toEqual('updated');
+       }));
+
+    it('should detectChanges only once if markDirty is called multiple times',
+       withBody('my-comp', () => {
+         const myComp = renderComponent(MyComponent);
+         expect(getRenderedText(myComp)).toEqual('works');
+         expect(myComp.doCheckCount).toBe(1);
+         myComp.value = 'ignore';
+         markDirty(myComp);
+         myComp.value = 'updated';
+         markDirty(myComp);
+         expect(getRenderedText(myComp)).toEqual('works');
+         requestAnimationFrame.flush();
+         expect(getRenderedText(myComp)).toEqual('updated');
+         expect(myComp.doCheckCount).toBe(2);
+       }));
+
+    it('should notify whenRendered', withBody('my-comp', async() => {
+         const myComp = renderComponent(MyComponent);
+         await whenRendered(myComp);
+         myComp.value = 'updated';
+         markDirty(myComp);
+         setTimeout(requestAnimationFrame.flush, 0);
+         await whenRendered(myComp);
+         expect(getRenderedText(myComp)).toEqual('updated');
+       }));
+  });
+
+  describe('onPush', () => {
+    let comp: MyComponent;
+
+    class MyComponent implements DoCheck {
+      /* @Input() */
+      name = 'Nancy';
+      doCheckCount = 0;
+
+      ngDoCheck(): void { this.doCheckCount++; }
+
+      onClick() {}
+
+      static ngComponentDef = defineComponent({
+        type: MyComponent,
+        tag: 'my-comp',
+        factory: () => comp = new MyComponent(),
         /**
-         * <my-comp></my-comp>
-         * <button id="parent" (click)="noop()"></button>
+         * {{ doCheckCount }} - {{ name }}
+         * <button (click)="onClick()"></button>
          */
-        template: (ctx: ButtonParent, cm: boolean) => {
+        template: (ctx: MyComponent, cm: boolean) => {
+          if (cm) {
+            text(0);
+            elementStart(1, 'button');
+            {
+              listener('click', () => { ctx.onClick(); });
+            }
+            elementEnd();
+          }
+          textBinding(0, interpolation2('', ctx.doCheckCount, ' - ', ctx.name, ''));
+        },
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        inputs: {name: 'name'}
+      });
+    }
+
+    class MyApp {
+      name: string = 'Nancy';
+
+      static ngComponentDef = defineComponent({
+        type: MyApp,
+        tag: 'my-app',
+        factory: () => new MyApp(),
+        /** <my-comp [name]="name"></my-comp> */
+        template: (ctx: MyApp, cm: boolean) => {
           if (cm) {
             elementStart(0, MyComponent);
             elementEnd();
-            elementStart(2, 'button', ['id', 'parent']);
-            { listener('click', () => ctx.noop()); }
-            elementEnd();
           }
+          elementProperty(0, 'name', bind(ctx.name));
           MyComponent.ngComponentDef.h(1, 0);
           directiveRefresh(1, 0);
         }
       });
     }
-    const buttonParent = renderComponent(ButtonParent);
-    expect(getRenderedText(buttonParent)).toEqual('1 - Nancy');
 
-    const button = containerEl.querySelector('button#parent') !;
-    (button as HTMLButtonElement).click();
-    requestAnimationFrame.flush();
-    expect(getRenderedText(buttonParent)).toEqual('1 - Nancy');
+    it('should check OnPush components on initialization', () => {
+      const myApp = renderComponent(MyApp);
+      expect(getRenderedText(myApp)).toEqual('1 - Nancy');
+    });
+
+    it('should call doCheck even when OnPush components are not dirty', () => {
+      const myApp = renderComponent(MyApp);
+
+      detectChanges(myApp);
+      expect(comp.doCheckCount).toEqual(2);
+
+      detectChanges(myApp);
+      expect(comp.doCheckCount).toEqual(3);
+    });
+
+    it('should skip OnPush components in update mode when they are not dirty', () => {
+      const myApp = renderComponent(MyApp);
+
+      detectChanges(myApp);
+      // doCheckCount is 2, but 1 should be rendered since it has not been marked dirty.
+      expect(getRenderedText(myApp)).toEqual('1 - Nancy');
+
+      detectChanges(myApp);
+      // doCheckCount is 3, but 1 should be rendered since it has not been marked dirty.
+      expect(getRenderedText(myApp)).toEqual('1 - Nancy');
+    });
+
+    it('should check OnPush components in update mode when inputs change', () => {
+      const myApp = renderComponent(MyApp);
+
+      myApp.name = 'Bess';
+      detectChanges(myApp);
+      expect(getRenderedText(myApp)).toEqual('2 - Bess');
+
+      myApp.name = 'George';
+      detectChanges(myApp);
+      expect(getRenderedText(myApp)).toEqual('3 - George');
+
+      detectChanges(myApp);
+      expect(getRenderedText(myApp)).toEqual('3 - George');
+    });
+
+    it('should check OnPush components in update mode when component events occur', () => {
+      const myApp = renderComponent(MyApp);
+      expect(getRenderedText(myApp)).toEqual('1 - Nancy');
+
+      const button = containerEl.querySelector('button') !;
+      button.click();
+      requestAnimationFrame.flush();
+      expect(getRenderedText(myApp)).toEqual('2 - Nancy');
+
+      detectChanges(myApp);
+      expect(getRenderedText(myApp)).toEqual('2 - Nancy');
+    });
+
+    it('should not check OnPush components in update mode when parent events occur', () => {
+      class ButtonParent {
+        noop() {}
+
+        static ngComponentDef = defineComponent({
+          type: ButtonParent,
+          tag: 'button-parent',
+          factory: () => new ButtonParent(),
+          /**
+           * <my-comp></my-comp>
+           * <button id="parent" (click)="noop()"></button>
+           */
+          template: (ctx: ButtonParent, cm: boolean) => {
+            if (cm) {
+              elementStart(0, MyComponent);
+              elementEnd();
+              elementStart(2, 'button', ['id', 'parent']);
+              { listener('click', () => ctx.noop()); }
+              elementEnd();
+            }
+            MyComponent.ngComponentDef.h(1, 0);
+            directiveRefresh(1, 0);
+          }
+        });
+      }
+      const buttonParent = renderComponent(ButtonParent);
+      expect(getRenderedText(buttonParent)).toEqual('1 - Nancy');
+
+      const button = containerEl.querySelector('button#parent') !;
+      (button as HTMLButtonElement).click();
+      requestAnimationFrame.flush();
+      expect(getRenderedText(buttonParent)).toEqual('1 - Nancy');
+    });
+
+    it('should check parent OnPush components in update mode when child events occur', () => {
+      let parent: ButtonParent;
+
+      class ButtonParent implements DoCheck {
+        doCheckCount = 0;
+        ngDoCheck(): void { this.doCheckCount++; }
+
+        static ngComponentDef = defineComponent({
+          type: ButtonParent,
+          tag: 'button-parent',
+          factory: () => parent = new ButtonParent(),
+          /** {{ doCheckCount }} - <my-comp></my-comp> */
+          template: (ctx: ButtonParent, cm: boolean) => {
+            if (cm) {
+              text(0);
+              elementStart(1, MyComponent);
+              elementEnd();
+            }
+            textBinding(0, interpolation1('', ctx.doCheckCount, ' - '));
+            MyComponent.ngComponentDef.h(2, 1);
+            directiveRefresh(2, 1);
+          },
+          changeDetection: ChangeDetectionStrategy.OnPush
+        });
+      }
+
+      class MyButtonApp {
+        static ngComponentDef = defineComponent({
+          type: MyButtonApp,
+          tag: 'my-button-app',
+          factory: () => new MyButtonApp(),
+          /** <button-parent></button-parent> */
+          template: (ctx: MyButtonApp, cm: boolean) => {
+            if (cm) {
+              elementStart(0, ButtonParent);
+              elementEnd();
+            }
+            ButtonParent.ngComponentDef.h(1, 0);
+            directiveRefresh(1, 0);
+          }
+        });
+      }
+
+      const myButtonApp = renderComponent(MyButtonApp);
+      expect(parent !.doCheckCount).toEqual(1);
+      expect(comp !.doCheckCount).toEqual(1);
+      expect(getRenderedText(myButtonApp)).toEqual('1 - 1 - Nancy');
+
+      detectChanges(myButtonApp);
+      expect(parent !.doCheckCount).toEqual(2);
+      // parent isn't checked, so child doCheck won't run
+      expect(comp !.doCheckCount).toEqual(1);
+      expect(getRenderedText(myButtonApp)).toEqual('1 - 1 - Nancy');
+
+      const button = containerEl.querySelector('button');
+      button !.click();
+      requestAnimationFrame.flush();
+      expect(parent !.doCheckCount).toEqual(3);
+      expect(comp !.doCheckCount).toEqual(2);
+      expect(getRenderedText(myButtonApp)).toEqual('3 - 2 - Nancy');
+    });
   });
 
-  it('should check parent OnPush components in update mode when child events occur', () => {
-    let parent: ButtonParent;
+  describe('ChangeDetectorRef', () => {
 
-    class ButtonParent implements DoCheck {
-      doCheckCount = 0;
-      ngDoCheck(): void { this.doCheckCount++; }
+    describe('detectChanges()', () => {
+      let myComp: MyComp;
+      let dir: Dir;
 
-      static ngComponentDef = defineComponent({
-        type: ButtonParent,
-        tag: 'button-parent',
-        factory: () => parent = new ButtonParent(),
-        /** {{ doCheckCount }} - <my-comp></my-comp> */
-        template: (ctx: ButtonParent, cm: boolean) => {
-          if (cm) {
-            text(0);
-            elementStart(1, MyComponent);
-            elementEnd();
+      class MyComp {
+        doCheckCount = 0;
+        name = 'Nancy';
+
+        constructor(public cdr: ChangeDetectorRef) {}
+
+        ngDoCheck() { this.doCheckCount++; }
+
+        static ngComponentDef = defineComponent({
+          type: MyComp,
+          tag: 'my-comp',
+          factory: () => myComp = new MyComp(injectChangeDetectorRef()),
+          /** {{ name }} */
+          template: (ctx: MyComp, cm: boolean) => {
+            if (cm) {
+              text(0);
+            }
+            textBinding(0, bind(ctx.name));
+          },
+          changeDetection: ChangeDetectionStrategy.OnPush
+        });
+      }
+
+      class ParentComp {
+        doCheckCount = 0;
+
+        constructor(public cdr: ChangeDetectorRef) {}
+
+        ngDoCheck() { this.doCheckCount++; }
+
+        static ngComponentDef = defineComponent({
+          type: ParentComp,
+          tag: 'parent-comp',
+          factory: () => new ParentComp(injectChangeDetectorRef()),
+          /**
+           * {{ doCheckCount}} -
+           * <my-comp></my-comp>
+           */
+          template: (ctx: ParentComp, cm: boolean) => {
+            if (cm) {
+              text(0);
+              elementStart(1, MyComp);
+              elementEnd();
+            }
+            textBinding(0, interpolation1('', ctx.doCheckCount, ' - '));
+            MyComp.ngComponentDef.h(2, 1);
+            directiveRefresh(2, 1);
           }
-          textBinding(0, interpolation1('', ctx.doCheckCount, ' - '));
-          MyComponent.ngComponentDef.h(2, 1);
-          directiveRefresh(2, 1);
-        },
-        changeDetection: ChangeDetectionStrategy.OnPush
+        });
+      }
+
+      class Dir {
+        constructor(public cdr: ChangeDetectorRef) {}
+
+        static ngDirectiveDef =
+            defineDirective({type: Dir, factory: () => dir = new Dir(injectChangeDetectorRef())});
+      }
+
+
+      it('should check the component view when called by component (even when OnPush && clean)',
+         () => {
+           const comp = renderComponent(MyComp);
+           expect(getRenderedText(comp)).toEqual('Nancy');
+
+           comp.name = 'Bess';  // as this is not an Input, the component stays clean
+           comp.cdr.detectChanges();
+           expect(getRenderedText(comp)).toEqual('Bess');
+         });
+
+      it('should NOT call component doCheck when called by a component', () => {
+        const comp = renderComponent(MyComp);
+        expect(comp.doCheckCount).toEqual(1);
+
+        // NOTE: in current Angular, detectChanges does not itself trigger doCheck, but you
+        // may see doCheck called in some cases bc of the extra CD run triggered by zone.js.
+        // It's important not to call doCheck to allow calls to detectChanges in that hook.
+        comp.cdr.detectChanges();
+        expect(comp.doCheckCount).toEqual(1);
       });
-    }
 
-    class MyButtonApp {
-      static ngComponentDef = defineComponent({
-        type: MyButtonApp,
-        tag: 'my-button-app',
-        factory: () => new MyButtonApp(),
-        /** <button-parent></button-parent> */
-        template: (ctx: MyButtonApp, cm: boolean) => {
-          if (cm) {
-            elementStart(0, ButtonParent);
-            elementEnd();
-          }
-          ButtonParent.ngComponentDef.h(1, 0);
-          directiveRefresh(1, 0);
+      it('should NOT check the component parent when called by a child component', () => {
+        const parentComp = renderComponent(ParentComp);
+        expect(getRenderedText(parentComp)).toEqual('1 - Nancy');
+
+        parentComp.doCheckCount = 100;
+        myComp.cdr.detectChanges();
+        expect(parentComp.doCheckCount).toEqual(100);
+        expect(getRenderedText(parentComp)).toEqual('1 - Nancy');
+      });
+
+      it('should check component children when called by component if dirty or check-always',
+         () => {
+           const parentComp = renderComponent(ParentComp);
+           expect(parentComp.doCheckCount).toEqual(1);
+
+           myComp.name = 'Bess';
+           parentComp.cdr.detectChanges();
+           expect(parentComp.doCheckCount).toEqual(1);
+           expect(myComp.doCheckCount).toEqual(2);
+           // OnPush child is not dirty, so its change isn't rendered.
+           expect(getRenderedText(parentComp)).toEqual('1 - Nancy');
+         });
+
+      it('should not group detectChanges calls (call every time)', () => {
+        const parentComp = renderComponent(ParentComp);
+        expect(myComp.doCheckCount).toEqual(1);
+
+        parentComp.cdr.detectChanges();
+        parentComp.cdr.detectChanges();
+        expect(myComp.doCheckCount).toEqual(3);
+      });
+
+      it('should check component view when called by directive on component node', () => {
+        class MyApp {
+          static ngComponentDef = defineComponent({
+            type: MyApp,
+            tag: 'my-app',
+            factory: () => new MyApp(),
+            /** <my-comp dir></my-comp> */
+            template: (ctx: MyApp, cm: boolean) => {
+              if (cm) {
+                elementStart(0, MyComp, ['dir', ''], [Dir]);
+                elementEnd();
+              }
+              MyComp.ngComponentDef.h(1, 0);
+              Dir.ngDirectiveDef.h(2, 0);
+              directiveRefresh(1, 0);
+              directiveRefresh(2, 0);
+            }
+          });
         }
+
+        const app = renderComponent(MyApp);
+        expect(getRenderedText(app)).toEqual('Nancy');
+
+        myComp.name = 'George';
+        dir !.cdr.detectChanges();
+        expect(getRenderedText(app)).toEqual('George');
       });
-    }
 
-    const myButtonApp = renderComponent(MyButtonApp);
-    expect(parent !.doCheckCount).toEqual(1);
-    expect(comp !.doCheckCount).toEqual(1);
-    expect(getRenderedText(myButtonApp)).toEqual('1 - 1 - Nancy');
+      it('should check host component when called by directive on element node', () => {
+        class MyApp {
+          name = 'Frank';
 
-    detectChanges(myButtonApp);
-    expect(parent !.doCheckCount).toEqual(2);
-    // parent isn't checked, so child doCheck won't run
-    expect(comp !.doCheckCount).toEqual(1);
-    expect(getRenderedText(myButtonApp)).toEqual('1 - 1 - Nancy');
+          static ngComponentDef = defineComponent({
+            type: MyApp,
+            tag: 'my-app',
+            factory: () => new MyApp(),
+            /**
+             * {{ name }}
+             * <div dir></div>
+             */
+            template: (ctx: MyApp, cm: boolean) => {
+              if (cm) {
+                text(0);
+                elementStart(1, 'div', ['dir', ''], [Dir]);
+                elementEnd();
+              }
+              textBinding(1, bind(ctx.name));
+              Dir.ngDirectiveDef.h(2, 1);
+              directiveRefresh(2, 1);
+            }
+          });
+        }
 
-    const button = containerEl.querySelector('button');
-    button !.click();
-    requestAnimationFrame.flush();
-    expect(parent !.doCheckCount).toEqual(3);
-    expect(comp !.doCheckCount).toEqual(2);
-    expect(getRenderedText(myButtonApp)).toEqual('3 - 2 - Nancy');
+        const app = renderComponent(MyApp);
+        expect(getRenderedText(app)).toEqual('Frank');
+
+        app.name = 'Joe';
+        dir !.cdr.detectChanges();
+        expect(getRenderedText(app)).toEqual('Joe');
+      });
+
+      it('should check the host component when called from EmbeddedViewRef', () => {
+        class MyApp {
+          showing = true;
+          name = 'Amelia';
+
+          constructor(public cdr: ChangeDetectorRef) {}
+
+          static ngComponentDef = defineComponent({
+            type: MyApp,
+            tag: 'my-app',
+            factory: () => new MyApp(injectChangeDetectorRef()),
+            /**
+             * {{ name}}
+             * % if (showing) {
+           *   <div dir></div>
+           * % }
+             */
+            template: function(ctx: MyApp, cm: boolean) {
+              if (cm) {
+                text(0);
+                container(1);
+              }
+              textBinding(0, bind(ctx.name));
+              containerRefreshStart(1);
+              {
+                if (ctx.showing) {
+                  if (embeddedViewStart(0)) {
+                    elementStart(0, 'div', ['dir', ''], [Dir]);
+                    elementEnd();
+                  }
+                  Dir.ngDirectiveDef.h(1, 0);
+                  directiveRefresh(1, 0);
+                }
+                embeddedViewEnd();
+              }
+              containerRefreshEnd();
+            }
+          });
+        }
+
+        const app = renderComponent(MyApp);
+        expect(getRenderedText(app)).toEqual('Amelia');
+
+        app.name = 'Emerson';
+        dir !.cdr.detectChanges();
+        expect(getRenderedText(app)).toEqual('Emerson');
+      });
+
+      it('should support call in ngOnInit', () => {
+        class DetectChangesComp {
+          value = 0;
+
+          constructor(public cdr: ChangeDetectorRef) {}
+
+          ngOnInit() {
+            this.value++;
+            this.cdr.detectChanges();
+          }
+
+          static ngComponentDef = defineComponent({
+            type: DetectChangesComp,
+            tag: 'detect-changes-comp',
+            factory: () => new DetectChangesComp(injectChangeDetectorRef()),
+            /** {{ value }} */
+            template: (ctx: DetectChangesComp, cm: boolean) => {
+              if (cm) {
+                text(0);
+              }
+              textBinding(0, bind(ctx.value));
+            }
+          });
+        }
+
+        const comp = renderComponent(DetectChangesComp);
+        expect(getRenderedText(comp)).toEqual('1');
+      });
+
+      it('should support call in ngDoCheck', () => {
+        class DetectChangesComp {
+          doCheckCount = 0;
+
+          constructor(public cdr: ChangeDetectorRef) {}
+
+          ngDoCheck() {
+            this.doCheckCount++;
+            this.cdr.detectChanges();
+          }
+
+          static ngComponentDef = defineComponent({
+            type: DetectChangesComp,
+            tag: 'detect-changes-comp',
+            factory: () => new DetectChangesComp(injectChangeDetectorRef()),
+            /** {{ doCheckCount }} */
+            template: (ctx: DetectChangesComp, cm: boolean) => {
+              if (cm) {
+                text(0);
+              }
+              textBinding(0, bind(ctx.doCheckCount));
+            }
+          });
+        }
+
+        const comp = renderComponent(DetectChangesComp);
+        expect(getRenderedText(comp)).toEqual('1');
+      });
+
+    });
+
   });
 
 });

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -181,14 +181,14 @@ describe('encapsulation', () => {
   }
 
   it('should encapsulate children, but not host nor grand children', () => {
-    renderComponent(WrapperComponent, getRendererFactory2(document));
+    renderComponent(WrapperComponent, {rendererFactory: getRendererFactory2(document)});
     expect(containerEl.outerHTML)
         .toMatch(
             /<div host=""><encapsulated _nghost-c(\d+)="">foo<leaf _ngcontent-c\1=""><span>bar<\/span><\/leaf><\/encapsulated><\/div>/);
   });
 
   it('should encapsulate host', () => {
-    renderComponent(EncapsulatedComponent, getRendererFactory2(document));
+    renderComponent(EncapsulatedComponent, {rendererFactory: getRendererFactory2(document)});
     expect(containerEl.outerHTML)
         .toMatch(
             /<div host="" _nghost-c(\d+)="">foo<leaf _ngcontent-c\1=""><span>bar<\/span><\/leaf><\/div>/);
@@ -230,7 +230,7 @@ describe('encapsulation', () => {
       });
     }
 
-    renderComponent(WrapperComponentWith, getRendererFactory2(document));
+    renderComponent(WrapperComponentWith, {rendererFactory: getRendererFactory2(document)});
     expect(containerEl.outerHTML)
         .toMatch(
             /<div host="" _nghost-c(\d+)=""><leaf _ngcontent-c\1="" _nghost-c(\d+)=""><span _ngcontent-c\2="">bar<\/span><\/leaf><\/div>/);

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -6,10 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {withBody} from '@angular/core/testing';
 
 import {DoCheck, ViewEncapsulation} from '../../src/core';
-import {getRenderedText, whenRendered} from '../../src/render3/component';
 import {defineComponent, markDirty} from '../../src/render3/index';
 import {bind, container, containerRefreshEnd, containerRefreshStart, detectChanges, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, text, textBinding} from '../../src/render3/instructions';
 import {createRendererType2} from '../../src/view/index';
@@ -236,68 +234,4 @@ describe('encapsulation', () => {
             /<div host="" _nghost-c(\d+)=""><leaf _ngcontent-c\1="" _nghost-c(\d+)=""><span _ngcontent-c\2="">bar<\/span><\/leaf><\/div>/);
   });
 
-  describe('markDirty, detectChanges, whenRendered, getRenderedText', () => {
-    class MyComponent implements DoCheck {
-      value: string = 'works';
-      doCheckCount = 0;
-      ngDoCheck(): void { this.doCheckCount++; }
-
-      static ngComponentDef = defineComponent({
-        type: MyComponent,
-        tag: 'my-comp',
-        factory: () => new MyComponent(),
-        template: (ctx: MyComponent, cm: boolean) => {
-          if (cm) {
-            elementStart(0, 'span');
-            text(1);
-            elementEnd();
-          }
-          textBinding(1, bind(ctx.value));
-        }
-      });
-    }
-
-    it('should mark a component dirty and schedule change detection', withBody('my-comp', () => {
-         const myComp = renderComponent(MyComponent);
-         expect(getRenderedText(myComp)).toEqual('works');
-         myComp.value = 'updated';
-         markDirty(myComp);
-         expect(getRenderedText(myComp)).toEqual('works');
-         requestAnimationFrame.flush();
-         expect(getRenderedText(myComp)).toEqual('updated');
-       }));
-
-    it('should detectChanges on a component', withBody('my-comp', () => {
-         const myComp = renderComponent(MyComponent);
-         expect(getRenderedText(myComp)).toEqual('works');
-         myComp.value = 'updated';
-         detectChanges(myComp);
-         expect(getRenderedText(myComp)).toEqual('updated');
-       }));
-
-    it('should detectChanges only once if markDirty is called multiple times',
-       withBody('my-comp', () => {
-         const myComp = renderComponent(MyComponent);
-         expect(getRenderedText(myComp)).toEqual('works');
-         expect(myComp.doCheckCount).toBe(1);
-         myComp.value = 'ignore';
-         markDirty(myComp);
-         myComp.value = 'updated';
-         markDirty(myComp);
-         expect(getRenderedText(myComp)).toEqual('works');
-         requestAnimationFrame.flush();
-         expect(getRenderedText(myComp)).toEqual('updated');
-         expect(myComp.doCheckCount).toBe(2);
-       }));
-
-    it('should notify whenRendered', withBody('my-comp', async() => {
-         const myComp = renderComponent(MyComponent);
-         await whenRendered(myComp);
-         myComp.value = 'updated';
-         markDirty(myComp);
-         setTimeout(requestAnimationFrame.flush, 0);
-         await whenRendered(myComp);
-         expect(getRenderedText(myComp)).toEqual('updated');
-       }));
-  });
 });

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -7,10 +7,10 @@
  */
 
 import {SimpleChanges} from '../../src/core';
-import {ComponentTemplate, NgOnChangesFeature, defineComponent, defineDirective} from '../../src/render3/index';
-import {bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, listener, projection, projectionDef, store, text} from '../../src/render3/instructions';
+import {ComponentTemplate, NgOnChangesFeature, RootLifecycleHooks, defineComponent, defineDirective} from '../../src/render3/index';
+import {bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, listener, markDirty, projection, projectionDef, store, text} from '../../src/render3/instructions';
 
-import {containerEl, renderToHtml} from './render_util';
+import {containerEl, renderComponent, renderToHtml, requestAnimationFrame} from './render_util';
 
 describe('lifecycles', () => {
 
@@ -85,6 +85,15 @@ describe('lifecycles', () => {
          renderToHtml(Template, {val: '2'});
          expect(events).toEqual(['comp1']);
        });
+
+    it('should be called on root component in creation mode', () => {
+      const comp = renderComponent(Comp, {features: [RootLifecycleHooks]});
+      expect(events).toEqual(['comp']);
+
+      markDirty(comp);
+      requestAnimationFrame.flush();
+      expect(events).toEqual(['comp']);
+    });
 
     it('should call parent onInit before child onInit', () => {
       /**
@@ -413,6 +422,15 @@ describe('lifecycles', () => {
       expect(events).toEqual(['comp', 'comp']);
     });
 
+    it('should be called on root component', () => {
+      const comp = renderComponent(Comp, {features: [RootLifecycleHooks]});
+      expect(events).toEqual(['comp']);
+
+      markDirty(comp);
+      requestAnimationFrame.flush();
+      expect(events).toEqual(['comp', 'comp']);
+    });
+
     it('should call parent doCheck before child doCheck', () => {
       /**
        * <parent></parent>
@@ -561,6 +579,15 @@ describe('lifecycles', () => {
       expect(events).toEqual(['comp']);
 
       renderToHtml(Template, {});
+      expect(events).toEqual(['comp']);
+    });
+
+    it('should be called on root component in creation mode', () => {
+      const comp = renderComponent(Comp, {features: [RootLifecycleHooks]});
+      expect(events).toEqual(['comp']);
+
+      markDirty(comp);
+      requestAnimationFrame.flush();
       expect(events).toEqual(['comp']);
     });
 
@@ -842,6 +869,15 @@ describe('lifecycles', () => {
 
       });
 
+      it('should be called on root component', () => {
+        const comp = renderComponent(Comp, {features: [RootLifecycleHooks]});
+        expect(allEvents).toEqual(['comp init', 'comp check']);
+
+        markDirty(comp);
+        requestAnimationFrame.flush();
+        expect(allEvents).toEqual(['comp init', 'comp check', 'comp check']);
+      });
+
     });
 
     describe('directives', () => {
@@ -945,6 +981,15 @@ describe('lifecycles', () => {
       expect(events).toEqual(['comp']);
 
       renderToHtml(Template, {});
+      expect(events).toEqual(['comp']);
+    });
+
+    it('should be called on root component in creation mode', () => {
+      const comp = renderComponent(Comp, {features: [RootLifecycleHooks]});
+      expect(events).toEqual(['comp']);
+
+      markDirty(comp);
+      requestAnimationFrame.flush();
       expect(events).toEqual(['comp']);
     });
 
@@ -1247,6 +1292,15 @@ describe('lifecycles', () => {
         expect(allEvents).toEqual(['comp init', 'comp check']);
 
         renderToHtml(Template, {});
+        expect(allEvents).toEqual(['comp init', 'comp check', 'comp check']);
+      });
+
+      it('should be called on root component', () => {
+        const comp = renderComponent(Comp, {features: [RootLifecycleHooks]});
+        expect(allEvents).toEqual(['comp init', 'comp check']);
+
+        markDirty(comp);
+        requestAnimationFrame.flush();
         expect(allEvents).toEqual(['comp init', 'comp check', 'comp check']);
       });
 

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {SimpleChanges} from '../../src/core';
-import {ComponentTemplate, NgOnChangesFeature, RootLifecycleHooks, defineComponent, defineDirective} from '../../src/render3/index';
+import {ComponentTemplate, LifecycleHooksFeature, NgOnChangesFeature, defineComponent, defineDirective} from '../../src/render3/index';
 import {bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, listener, markDirty, projection, projectionDef, store, text} from '../../src/render3/instructions';
 
 import {containerEl, renderComponent, renderToHtml, requestAnimationFrame} from './render_util';
@@ -87,7 +87,7 @@ describe('lifecycles', () => {
        });
 
     it('should be called on root component in creation mode', () => {
-      const comp = renderComponent(Comp, {features: [RootLifecycleHooks]});
+      const comp = renderComponent(Comp, {hostFeatures: [LifecycleHooksFeature]});
       expect(events).toEqual(['comp']);
 
       markDirty(comp);
@@ -423,7 +423,7 @@ describe('lifecycles', () => {
     });
 
     it('should be called on root component', () => {
-      const comp = renderComponent(Comp, {features: [RootLifecycleHooks]});
+      const comp = renderComponent(Comp, {hostFeatures: [LifecycleHooksFeature]});
       expect(events).toEqual(['comp']);
 
       markDirty(comp);
@@ -583,7 +583,7 @@ describe('lifecycles', () => {
     });
 
     it('should be called on root component in creation mode', () => {
-      const comp = renderComponent(Comp, {features: [RootLifecycleHooks]});
+      const comp = renderComponent(Comp, {hostFeatures: [LifecycleHooksFeature]});
       expect(events).toEqual(['comp']);
 
       markDirty(comp);
@@ -870,7 +870,7 @@ describe('lifecycles', () => {
       });
 
       it('should be called on root component', () => {
-        const comp = renderComponent(Comp, {features: [RootLifecycleHooks]});
+        const comp = renderComponent(Comp, {hostFeatures: [LifecycleHooksFeature]});
         expect(allEvents).toEqual(['comp init', 'comp check']);
 
         markDirty(comp);
@@ -985,7 +985,7 @@ describe('lifecycles', () => {
     });
 
     it('should be called on root component in creation mode', () => {
-      const comp = renderComponent(Comp, {features: [RootLifecycleHooks]});
+      const comp = renderComponent(Comp, {hostFeatures: [LifecycleHooksFeature]});
       expect(events).toEqual(['comp']);
 
       markDirty(comp);
@@ -1296,7 +1296,7 @@ describe('lifecycles', () => {
       });
 
       it('should be called on root component', () => {
-        const comp = renderComponent(Comp, {features: [RootLifecycleHooks]});
+        const comp = renderComponent(Comp, {hostFeatures: [LifecycleHooksFeature]});
         expect(allEvents).toEqual(['comp init', 'comp check']);
 
         markDirty(comp);

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -106,7 +106,8 @@ describe('event listeners', () => {
   });
 
   it('should retain event handler return values with renderer2', () => {
-    const preventDefaultComp = renderComponent(PreventDefaultComp, getRendererFactory2(document));
+    const preventDefaultComp =
+        renderComponent(PreventDefaultComp, {rendererFactory: getRendererFactory2(document)});
     const button = containerEl.querySelector('button') !;
 
     button.click();

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -10,6 +10,7 @@ import {stringifyElement} from '@angular/platform-browser/testing/src/browser_ut
 
 import {ComponentTemplate, ComponentType, DirectiveType, PublicFeature, defineComponent, defineDirective, renderComponent as _renderComponent} from '../../src/render3/index';
 import {NG_HOST_SYMBOL, createLNode, createLView, renderTemplate} from '../../src/render3/instructions';
+import {CreateComponentOptions} from '../../src/render3/component';
 import {DirectiveDefArgs} from '../../src/render3/interfaces/definition';
 import {LElementNode, LNodeFlags} from '../../src/render3/interfaces/node';
 import {RElement, RText, Renderer3, RendererFactory3, domRendererFactory3} from '../../src/render3/interfaces/renderer';
@@ -112,11 +113,12 @@ export function renderToHtml(
 
 beforeEach(resetDOM);
 
-export function renderComponent<T>(type: ComponentType<T>, rendererFactory?: RendererFactory3): T {
+export function renderComponent<T>(type: ComponentType<T>, opts?: CreateComponentOptions): T {
   return _renderComponent(type, {
-    rendererFactory: rendererFactory || testRendererFactory,
+    rendererFactory: opts && opts.rendererFactory || testRendererFactory,
     host: containerEl,
     scheduler: requestAnimationFrame,
+    features: opts && opts.features
   });
 }
 

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -8,9 +8,9 @@
 
 import {stringifyElement} from '@angular/platform-browser/testing/src/browser_util';
 
+import {CreateComponentOptions} from '../../src/render3/component';
 import {ComponentTemplate, ComponentType, DirectiveType, PublicFeature, defineComponent, defineDirective, renderComponent as _renderComponent} from '../../src/render3/index';
 import {NG_HOST_SYMBOL, createLNode, createLView, renderTemplate} from '../../src/render3/instructions';
-import {CreateComponentOptions} from '../../src/render3/component';
 import {DirectiveDefArgs} from '../../src/render3/interfaces/definition';
 import {LElementNode, LNodeFlags} from '../../src/render3/interfaces/node';
 import {RElement, RText, Renderer3, RendererFactory3, domRendererFactory3} from '../../src/render3/interfaces/renderer';
@@ -118,7 +118,7 @@ export function renderComponent<T>(type: ComponentType<T>, opts?: CreateComponen
     rendererFactory: opts && opts.rendererFactory || testRendererFactory,
     host: containerEl,
     scheduler: requestAnimationFrame,
-    features: opts && opts.features
+    hostFeatures: opts && opts.hostFeatures
   });
 }
 

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -74,7 +74,7 @@ describe('renderer factory lifecycle', () => {
   beforeEach(() => { logs = []; });
 
   it('should work with a component', () => {
-    const component = renderComponent(SomeComponent, rendererFactory);
+    const component = renderComponent(SomeComponent, {rendererFactory});
     expect(logs).toEqual(['create', 'create', 'begin', 'component', 'end']);
 
     logs = [];
@@ -83,7 +83,7 @@ describe('renderer factory lifecycle', () => {
   });
 
   it('should work with a component which throws', () => {
-    expect(() => renderComponent(SomeComponentWhichThrows, rendererFactory)).toThrow();
+    expect(() => renderComponent(SomeComponentWhichThrows, {rendererFactory})).toThrow();
     expect(logs).toEqual(['create', 'create', 'begin', 'end']);
   });
 
@@ -177,13 +177,13 @@ describe('animation renderer factory', () => {
   }
 
   it('should work with components without animations', () => {
-    renderComponent(SomeComponent, getAnimationRendererFactory2(document));
+    renderComponent(SomeComponent, {rendererFactory: getAnimationRendererFactory2(document)});
     expect(toHtml(containerEl)).toEqual('foo');
   });
 
   isBrowser && it('should work with animated components', (done) => {
-    const factory = getAnimationRendererFactory2(document);
-    const component = renderComponent(SomeComponentWithAnimation, factory);
+    const rendererFactory = getAnimationRendererFactory2(document);
+    const component = renderComponent(SomeComponentWithAnimation, {rendererFactory});
     expect(toHtml(containerEl))
         .toMatch(/<div class="ng-tns-c\d+-0 ng-trigger ng-trigger-myAnimation">foo<\/div>/);
 
@@ -197,7 +197,7 @@ describe('animation renderer factory', () => {
     ]);
     player.finish();
 
-    factory.whenRenderingDone !().then(() => {
+    rendererFactory.whenRenderingDone !().then(() => {
       expect(eventLogs).toEqual(['void - start', 'void - done', 'on - start', 'on - done']);
       done();
     });

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -11,7 +11,7 @@ import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/brow
 
 import {RendererType2, ViewEncapsulation} from '../../src/core';
 import {defineComponent, detectChanges} from '../../src/render3/index';
-import {bind, directiveRefresh, elementEnd, elementProperty, elementStart, listener, text} from '../../src/render3/instructions';
+import {bind, directiveRefresh, elementEnd, elementProperty, elementStart, listener, text, tick} from '../../src/render3/instructions';
 import {createRendererType2} from '../../src/view/index';
 
 import {getAnimationRendererFactory2, getRendererFactory2} from './imported_renderer2';
@@ -78,7 +78,7 @@ describe('renderer factory lifecycle', () => {
     expect(logs).toEqual(['create', 'create', 'begin', 'component', 'end']);
 
     logs = [];
-    detectChanges(component);
+    tick(component);
     expect(logs).toEqual(['begin', 'component', 'end']);
   });
 
@@ -188,7 +188,7 @@ describe('animation renderer factory', () => {
         .toMatch(/<div class="ng-tns-c\d+-0 ng-trigger ng-trigger-myAnimation">foo<\/div>/);
 
     component.exp = 'on';
-    detectChanges(component);
+    tick(component);
 
     const [player] = getLog();
     expect(player.keyframes).toEqual([


### PR DESCRIPTION
This PR adds support for `ChangeDetectorRef.detectChanges` calls in components and directives.

Notes:
- `detectChanges` as it was implemented before was re-named to `tick`. This was necessary because its implementation did not match the behavior of the historical `detectChanges` (which does not call lifecycle hooks or care about dirtiness), but it still needed to be retained for when change detection is queued. There is now a new `detectChanges` method that simply checks the view for manual calls.
- Moved `markDirty` tests from `component_spec.ts` to `change_detection_spec.ts`. The only new tests are in the `detectChanges()` describe block.

TODO in follow-up PRs:
- Support detectChanges calls in dynamically created views 
- Attach/detach from change detection
- `markForCheck`, etc