### PR TITLE
docs: fix incorrect selector references

### DIFF
--- a/aio/content/guide/forms.md
+++ b/aio/content/guide/forms.md
@@ -152,7 +152,8 @@ nothing to distinguish it from any component you've written before.
 Understanding this component requires only the Angular concepts covered in previous pages.
 
 * The code imports the Angular core library and the `Hero` model you just created.
-* The `@Component` selector value of "hero-form" means you can drop this form in a parent template with a `<hero-form>` tag.
+* The `@Component` selector value of "app-hero-form" means you can drop this form in a parent
+template with a `<app-hero-form>` tag.
 * The `templateUrl` property points to a separate file for the template HTML.
 * You defined dummy data for `model` and `powers`, as befits a demo.
 


### PR DESCRIPTION
Fix incorrect "hero-form" references to "app-hero-form" selector.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Docs content typos that did not match sample code referenced.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Documentation content incorrectly references selector "hero-form" and tag `<hero-form>` while the sample code's component property is `selector: 'app-hero-form'`.

Issue Number: N/A


## What is the new behavior?

Documentation content correctly references selector "app-hero-form" and tag `<app-hero-form>` when referring to the sample code's component property of `selector: 'app-hero-form'`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I've also introduced a line break in the modified documentation content, to keep within the 100 character limit.