### PR TITLE
refactor(language-service): Remove angularOnlyResults

### DIFF
--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -21,75 +21,10 @@ export function getExternalFiles(project: any): string[]|undefined {
   }
 }
 
-const angularOnlyResults = process.argv.indexOf('--angularOnlyResults') >= 0;
-
-function angularOnlyFilter(ls: ts.LanguageService): ts.LanguageService {
-  return {
-    cleanupSemanticCache: () => ls.cleanupSemanticCache(),
-    getSyntacticDiagnostics: fileName => <ts.Diagnostic[]>[],
-    getSemanticDiagnostics: fileName => <ts.Diagnostic[]>[],
-    getCompilerOptionsDiagnostics: () => <ts.Diagnostic[]>[],
-    getSyntacticClassifications: (fileName, span) => [],
-    getSemanticClassifications: (fileName, span) => [],
-    getEncodedSyntacticClassifications: (fileName, span) => <ts.Classifications><any>{undefined},
-    getEncodedSemanticClassifications: (fileName, span) => <ts.Classifications><any>undefined,
-    getCompletionsAtPosition: (fileName, position) => <ts.CompletionInfo><any>undefined,
-    getCompletionEntryDetails: (fileName, position, entryName) =>
-                                   <ts.CompletionEntryDetails><any>undefined,
-    getCompletionEntrySymbol: (fileName, position, entryName) => <ts.Symbol><any>undefined,
-    getQuickInfoAtPosition: (fileName, position) => <ts.QuickInfo><any>undefined,
-    getNameOrDottedNameSpan: (fileName, startPos, endPos) => <ts.TextSpan><any>undefined,
-    getBreakpointStatementAtPosition: (fileName, position) => <ts.TextSpan><any>undefined,
-    getSignatureHelpItems: (fileName, position) => <ts.SignatureHelpItems><any>undefined,
-    getRenameInfo: (fileName, position) => <ts.RenameInfo><any>undefined,
-    findRenameLocations: (fileName, position, findInStrings, findInComments) =>
-                             <ts.RenameLocation[]>[],
-    getDefinitionAtPosition: (fileName, position) => <ts.DefinitionInfo[]>[],
-    getTypeDefinitionAtPosition: (fileName, position) => <ts.DefinitionInfo[]>[],
-    getImplementationAtPosition: (fileName, position) => <ts.ImplementationLocation[]>[],
-    getReferencesAtPosition: (fileName: string, position: number) => <ts.ReferenceEntry[]>[],
-    findReferences: (fileName: string, position: number) => <ts.ReferencedSymbol[]>[],
-    getDocumentHighlights: (fileName, position, filesToSearch) => <ts.DocumentHighlights[]>[],
-    /** @deprecated */
-    getOccurrencesAtPosition: (fileName, position) => <ts.ReferenceEntry[]>[],
-    getNavigateToItems: searchValue => <ts.NavigateToItem[]>[],
-    getNavigationBarItems: fileName => <ts.NavigationBarItem[]>[],
-    getNavigationTree: fileName => <ts.NavigationTree><any>undefined,
-    getOutliningSpans: fileName => <ts.OutliningSpan[]>[],
-    getTodoComments: (fileName, descriptors) => <ts.TodoComment[]>[],
-    getBraceMatchingAtPosition: (fileName, position) => <ts.TextSpan[]>[],
-    getIndentationAtPosition: (fileName, position, options) => <number><any>undefined,
-    getFormattingEditsForRange: (fileName, start, end, options) => <ts.TextChange[]>[],
-    getFormattingEditsForDocument: (fileName, options) => <ts.TextChange[]>[],
-    getFormattingEditsAfterKeystroke: (fileName, position, key, options) => <ts.TextChange[]>[],
-    getDocCommentTemplateAtPosition: (fileName, position) => <ts.TextInsertion><any>undefined,
-    isValidBraceCompletionAtPosition: (fileName, position, openingBrace) => <boolean><any>undefined,
-    getSpanOfEnclosingComment: (fileName, position, onlyMultiLine) => <ts.TextSpan><any>undefined,
-    getCodeFixesAtPosition: (fileName, start, end, errorCodes) => <ts.CodeAction[]>[],
-    applyCodeActionCommand: (action: any) => <any>Promise.resolve(undefined),
-    getEmitOutput: fileName => <ts.EmitOutput><any>undefined,
-    getProgram: () => ls.getProgram(),
-    dispose: () => ls.dispose(),
-    getApplicableRefactors: (fileName, positionOrRaneg) => <ts.ApplicableRefactorInfo[]>[],
-    getEditsForRefactor: (fileName, formatOptions, positionOrRange, refactorName, actionName) =>
-                             undefined,
-    getDefinitionAndBoundSpan: (fileName: string, position: number):
-                                   ts.DefinitionInfoAndBoundSpan =>
-                                       ({definitions: [], textSpan: {start: 0, length: 0}}),
-    getCombinedCodeFix:
-        (scope: ts.CombinedCodeFixScope, fixId: {}, formatOptions: ts.FormatCodeSettings):
-            ts.CombinedCodeActions => ({changes: [], commands: undefined})
-  };
-}
-
 export function create(info: any /* ts.server.PluginCreateInfo */): ts.LanguageService {
   // Create the proxy
   const proxy: ts.LanguageService = Object.create(null);
   let oldLS: ts.LanguageService = info.languageService;
-
-  if (angularOnlyResults) {
-    oldLS = angularOnlyFilter(oldLS);
-  }
 
   function tryCall<T>(fileName: string | undefined, callback: () => T): T {
     if (fileName && !oldLS.getProgram().getSourceFile(fileName)) {


### PR DESCRIPTION
This commit is a duplicate of https://github.com/angular/angular/pull/18637
to remove Angular-specific results from the language service.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Remove Angular-specific results from language service.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
angularOnlyResults flag present in language-service

Issue Number: N/A


## What is the new behavior?
angularOnlyResults flag removed from language-service

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
