### PR TITLE
docs(aio): update toh-pt6.md to fix angular-in-memory-web-api issue

### DIFF
--- a/aio/content/tutorial/toh-pt6.md
+++ b/aio/content/tutorial/toh-pt6.md
@@ -62,6 +62,13 @@ Add the `InMemoryWebApiModule` to the `@NgModule.imports` array&mdash;
 _after importing the `HttpClient`_,
 &mdash;while configuring it with the `InMemoryDataService`.
 
+As for angular-in-memory-web-api **ver0.5.0** or above, you need add below line 
+**`InMemoryWebApiModule.forRoot(InMemoryDataService, { dataEncapsulation: true }),`**
+into `@NgModule.imports` array
+instead of 
+**`InMemoryWebApiModule.forRoot(InMemoryDataService),`**
+It caused by the broken change of angular-in-memory-web-api, you can refer to [angular-in-memory-web-api](https://www.npmjs.com/package/angular-in-memory-web-api) explanation if would like to know the detail.
+
 <code-example   
   path="toh-pt6/src/app/app.module.ts" 
   region="in-mem-web-api-imports">


### PR DESCRIPTION

As for angular-in-memory-web-api **ver0.5.0** or above, you need add below line 
**`InMemoryWebApiModule.forRoot(InMemoryDataService, { dataEncapsulation: true }),`**
into `@NgModule.imports` array
instead of 
**`InMemoryWebApiModule.forRoot(InMemoryDataService),`**
It caused by the broken change of angular-in-memory-web-api, you can refer to [angular-in-memory-web-api](https://www.npmjs.com/package/angular-in-memory-web-api) explanation if would like to know the detail.



## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 22644


## What is the new behavior?
Resolve the web API issue for the https://www.angular.cn/tutorial/toh-pt6  

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
