### PR TITLE
fix(ivy): fix views manipulation logic

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -582,8 +582,13 @@ class ViewContainerRef implements viewEngine_ViewContainerRef {
     const lView = (viewRef as EmbeddedViewRef<any>)._lViewNode;
     insertView(this._node, lView, index);
 
-    // TODO(pk): this is super-hackish, but we need to adjust nextIndex so the containerRefreshEnd
-    // instruction is not removing dynamically inserted views
+    // TODO(pk): this is a temporary index adjustment so imperativelly inserted (through
+    // ViewContainerRef) views
+    // are not removed in the containerRefreshEnd instruction.
+    // The final fix will consist of creating a dedicated container node for views inserted through
+    // ViewContainerRef.
+    // Such container should not be trimmed as it is the case in the containerRefreshEnd
+    // instruction.
     this._node.data.nextIndex = this._node.data.views.length;
 
     // If the view is dynamic (has a template), it needs to be counted both at the container

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -582,6 +582,10 @@ class ViewContainerRef implements viewEngine_ViewContainerRef {
     const lView = (viewRef as EmbeddedViewRef<any>)._lViewNode;
     insertView(this._node, lView, index);
 
+    // TODO(pk): this is super-hackish, but we need to adjust nextIndex so the containerRefreshEnd
+    // instruction is not removing dynamically inserted views
+    this._node.data.nextIndex = this._node.data.views.length;
+
     // If the view is dynamic (has a template), it needs to be counted both at the container
     // level and at the node above the container.
     if (lView.data.template !== null) {

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -270,16 +270,11 @@ export function insertView(
     setViewNext(views[index - 1], newView);
   }
 
-  if (index < views.length && views[index].data.id !== newView.data.id) {
-    // View ID change replace the view.
+  if (index < views.length) {
     setViewNext(newView, views[index]);
     views.splice(index, 0, newView);
-  } else if (index >= views.length) {
+  } else {
     views.push(newView);
-  }
-
-  if (state.nextIndex <= index) {
-    state.nextIndex++;
   }
 
   // If the container's renderParent is null, we know that it is a root node of its own parent view

--- a/packages/core/test/render3/control_flow_spec.ts
+++ b/packages/core/test/render3/control_flow_spec.ts
@@ -134,7 +134,7 @@ describe('JS control flow', () => {
     *     1
     *   % }; if(ctx.condition2) {
     *     2
-    *   % } ; if(ctx.condition3) {
+    *   % }; if(ctx.condition3) {
     *     3
     *   % }
     */
@@ -149,14 +149,14 @@ describe('JS control flow', () => {
           text(0, '1');
         }
         embeddedViewEnd();
-      };
+      }  // can't have ; here due linting rules
       if (ctx.condition2) {
         const cm2 = embeddedViewStart(2);
         if (cm2) {
           text(0, '2');
         }
         embeddedViewEnd();
-      };
+      }  // can't have ; here due linting rules
       if (ctx.condition3) {
         const cm3 = embeddedViewStart(3);
         if (cm3) {

--- a/packages/core/test/render3/control_flow_spec.ts
+++ b/packages/core/test/render3/control_flow_spec.ts
@@ -125,6 +125,54 @@ describe('JS control flow', () => {
     expect(renderToHtml(Template, ctx)).toEqual('<div><span>Hello</span></div>');
   });
 
+  it('should work with adjacent if blocks managing views in the same container', () => {
+
+    const ctx = {condition1: true, condition2: true, condition3: true};
+
+    /**
+    *   % if(ctx.condition1) {
+    *     1
+    *   % }; if(ctx.condition2) {
+    *     2
+    *   % } ; if(ctx.condition3) {
+    *     3
+    *   % }
+    */
+    function Template(ctx: any, cm: boolean) {
+      if (cm) {
+        container(0);
+      }
+      containerRefreshStart(0);
+      if (ctx.condition1) {
+        const cm1 = embeddedViewStart(1);
+        if (cm1) {
+          text(0, '1');
+        }
+        embeddedViewEnd();
+      };
+      if (ctx.condition2) {
+        const cm2 = embeddedViewStart(2);
+        if (cm2) {
+          text(0, '2');
+        }
+        embeddedViewEnd();
+      };
+      if (ctx.condition3) {
+        const cm3 = embeddedViewStart(3);
+        if (cm3) {
+          text(0, '3');
+        }
+        embeddedViewEnd();
+      }
+      containerRefreshEnd();
+    }
+
+    expect(renderToHtml(Template, ctx)).toEqual('123');
+
+    ctx.condition2 = false;
+    expect(renderToHtml(Template, ctx)).toEqual('13');
+  });
+
   it('should work with containers with views as parents', () => {
     function Template(ctx: any, cm: boolean) {
       if (cm) {
@@ -490,6 +538,15 @@ describe('JS for loop', () => {
     const ctx: {data1: string[] | null,
                 data2: number[] | null} = {data1: ['a', 'b', 'c'], data2: [1, 2]};
 
+    /**
+     * <div>
+     *    % for (let i = 0; i < ctx.data1.length; i++) {
+     *        {{data1[i]}}
+     *    % } for (let j = 0; j < ctx.data2.length; j++) {
+     *        {{data1[j]}}
+     *    % }
+     * </div>
+     */
     function Template(ctx: any, cm: boolean) {
       if (cm) {
         elementStart(0, 'div');


### PR DESCRIPTION
This commit fixes a bug that would result in views insert / remove
even if a view needed only refresh operation.

The crux of the bug was that we were looking for a view to update
only in the LContainer.nextIndex position. This is incorrect as a
view with a given block id could be present later in the views
array (this happens if we about to remove a view in the middle of
the views array).

The code in this fix searches for a view to update in the views array and
can remove views in the middle of the views collection. Previously we
would remove views at the end of the collection only.
