### PR TITLE
fix(bazel): Use path instead of short_path for calculating ngfacotry paths

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -36,9 +36,10 @@ def _expected_outs(ctx):
 
   for src in ctx.files.srcs + ctx.files.assets:
     package_prefix = ctx.label.package + "/" if ctx.label.package else ""
+    path = src.path
 
-    if src.short_path.endswith(".ts") and not src.short_path.endswith(".d.ts"):
-      basename = src.short_path[len(package_prefix):-len(".ts")]
+    if path.endswith(".ts") and not path.endswith(".d.ts"):
+      basename = path[len(package_prefix):-len(".ts")]
       if len(factory_basename_set) == 0 or basename in factory_basename_set:
         devmode_js = [
             ".ngfactory.js",
@@ -49,8 +50,8 @@ def _expected_outs(ctx):
       else:
         devmode_js = [".js"]
         summaries = []
-    elif src.short_path.endswith(".css"):
-      basename = src.short_path[len(package_prefix):-len(".css")]
+    elif path.endswith(".css"):
+      basename = path[len(package_prefix):-len(".css")]
       devmode_js = [
           ".css.shim.ngstyle.js",
           ".css.ngstyle.js",

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -81,15 +81,6 @@
     "name": "noop$2"
   },
   {
-    "name": "queueContentHooks"
-  },
-  {
-    "name": "queueDestroyHooks"
-  },
-  {
-    "name": "queueViewHooks"
-  },
-  {
     "name": "refreshDynamicChildren"
   },
   {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
External workspaces cannot have ng_module targets others can depend upon.

See https://github.com/angular/angular/issues/22613

Issue Number: 22613

## What is the new behavior?
External workspaces can have ng_module targets others can depend upon.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
