### PR TITLE
refactor(ivy): fix rebase error

### DIFF
--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -81,15 +81,6 @@
     "name": "noop$2"
   },
   {
-    "name": "queueContentHooks"
-  },
-  {
-    "name": "queueDestroyHooks"
-  },
-  {
-    "name": "queueViewHooks"
-  },
-  {
     "name": "refreshDynamicChildren"
   },
   {


### PR DESCRIPTION
These symbols were accidentally retained during a rebase conflict resolution.