### PR TITLE
fix(router): avoid freezing queryParams in-place

### DIFF
--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -38,8 +38,9 @@ class Recognizer {
       const children = this.processSegmentGroup(this.config, rootSegmentGroup, PRIMARY_OUTLET);
 
       const root = new ActivatedRouteSnapshot(
-          [], Object.freeze({}), Object.freeze(this.urlTree.queryParams), this.urlTree.fragment !,
-          {}, PRIMARY_OUTLET, this.rootComponentType, null, this.urlTree.root, -1, {});
+          [], Object.freeze({}), Object.freeze({...this.urlTree.queryParams}),
+          this.urlTree.fragment !, {}, PRIMARY_OUTLET, this.rootComponentType, null,
+          this.urlTree.root, -1, {});
 
       const rootNode = new TreeNode<ActivatedRouteSnapshot>(root, children);
       const routeState = new RouterStateSnapshot(this.url, rootNode);
@@ -116,7 +117,7 @@ class Recognizer {
     if (route.path === '**') {
       const params = segments.length > 0 ? last(segments) !.parameters : {};
       snapshot = new ActivatedRouteSnapshot(
-          segments, params, Object.freeze(this.urlTree.queryParams), this.urlTree.fragment !,
+          segments, params, Object.freeze({...this.urlTree.queryParams}), this.urlTree.fragment !,
           getData(route), outlet, route.component !, route, getSourceSegmentGroup(rawSegment),
           getPathIndexShift(rawSegment) + segments.length, getResolve(route));
     } else {
@@ -125,7 +126,7 @@ class Recognizer {
       rawSlicedSegments = segments.slice(result.lastChild);
 
       snapshot = new ActivatedRouteSnapshot(
-          consumedSegments, result.parameters, Object.freeze(this.urlTree.queryParams),
+          consumedSegments, result.parameters, Object.freeze({...this.urlTree.queryParams}),
           this.urlTree.fragment !, getData(route), outlet, route.component !, route,
           getSourceSegmentGroup(rawSegment),
           getPathIndexShift(rawSegment) + consumedSegments.length, getResolve(route));

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -748,6 +748,14 @@ describe('recognize', () => {
         expect(Object.isFrozen(s.root.queryParams)).toBeTruthy();
       });
     });
+
+    it('should not freeze UrlTree query params', () => {
+      const url = tree('a?q=11');
+      recognize(RootComponent, [{path: 'a', component: ComponentA}], url, 'a?q=11')
+          .subscribe((s: RouterStateSnapshot) => {
+            expect(Object.isFrozen(url.queryParams)).toBe(false);
+          });
+    });
   });
 
   describe('fragment', () => {


### PR DESCRIPTION
The recognizer code used to call Object.freeze() on queryParams before
using them to construct ActivatedRoutes, with the intent being to help
avoid common invalid usage. Unfortunately, Object.freeze() works
in-place, so this was also freezing the queryParams on the actual
UrlTree object, making it more difficult to manipulate UrlTrees in
things like UrlHandlingStrategy.

This change simply shallow-copies the queryParams before freezing them.

Fixes #22617

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #22617


## What is the new behavior?
`queryParams` are not frozen on the `UrlTree` (but are still frozen in the `ActivatedRouteSnapshot`).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
