### PR TITLE
docs(core): replace ancient live demos

### DIFF
--- a/packages/core/src/change_detection/change_detector_ref.ts
+++ b/packages/core/src/change_detection/change_detector_ref.ts
@@ -15,15 +15,15 @@ export abstract class ChangeDetectorRef {
    *
    * <!-- TODO: Add a link to a chapter on OnPush components -->
    *
-   * ### Example ([live demo](http://plnkr.co/edit/GC512b?p=preview))
+   * ### Example ([live demo](https://stackblitz.com/edit/angular-kx7rrw))
    *
    * ```typescript
    * @Component({
-   *   selector: 'cmp',
-   *   changeDetection: ChangeDetectionStrategy.OnPush,
+   *   selector: 'my-app',
    *   template: `Number of ticks: {{numberOfTicks}}`
+   *   changeDetection: ChangeDetectionStrategy.OnPush,
    * })
-   * class Cmp {
+   * class AppComponent {
    *   numberOfTicks = 0;
    *
    *   constructor(private ref: ChangeDetectorRef) {
@@ -33,16 +33,6 @@ export abstract class ChangeDetectorRef {
    *       this.ref.markForCheck();
    *     }, 1000);
    *   }
-   * }
-   *
-   * @Component({
-   *   selector: 'app',
-   *   changeDetection: ChangeDetectionStrategy.OnPush,
-   *   template: `
-   *     <cmp><cmp>
-   *   `,
-   * })
-   * class App {
    * }
    * ```
    */
@@ -136,12 +126,9 @@ export abstract class ChangeDetectorRef {
   /**
    * Reattach the change detector to the change detector tree.
    *
-   * This also marks OnPush ancestors as to be checked. This reattached change detector will be
-   * checked during the next change detection run.
-   *
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->
    *
-   * ### Example ([live demo](http://plnkr.co/edit/aUhZha?p=preview))
+   * ### Example ([live demo](https://stackblitz.com/edit/angular-ymgsxw))
    *
    * The following example creates a component displaying `live` data. The component will detach
    * its change detector from the main change detector tree when the component's live property
@@ -176,14 +163,14 @@ export abstract class ChangeDetectorRef {
    * }
    *
    * @Component({
-   *   selector: 'app',
+   *   selector: 'my-app',
    *   providers: [DataProvider],
    *   template: `
    *     Live Update: <input type="checkbox" [(ngModel)]="live">
    *     <live-data [live]="live"><live-data>
    *   `,
    * })
-   * class App {
+   * class AppComponent {
    *   live = true;
    * }
    * ```


### PR DESCRIPTION
Replaces a few ancient live demos in the `ChangeDetectorRef` docs. The originals were from back when we had `@View` decorators and `@Inputs` were still called `properties`.

Also removes outdated docs info about `reattach`.