### PR TITLE
fix(compiler): Pretty print object instead of [Object object]

### DIFF
--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -162,6 +162,8 @@ export interface OutputContext {
   importExpr(reference: any, typeParams?: o.Type[]|null, useSummaries?: boolean): o.Expression;
 }
 
+const MAX_LENGTH_STRINGIFY = 100;
+
 export function stringify(token: any): string {
   if (typeof token === 'string') {
     return token;
@@ -183,14 +185,27 @@ export function stringify(token: any): string {
     return `${token.name}`;
   }
 
-  const res = token.toString();
+  let res;
+  try {
+    res = JSON.stringify(token);
+  } catch {
+    res = token.toString();
+  }
 
   if (res == null) {
     return '' + res;
   }
 
   const newLineIndex = res.indexOf('\n');
-  return newLineIndex === -1 ? res : res.substring(0, newLineIndex);
+  if (0 < newLineIndex) {
+    res = res.substring(0, newLineIndex);
+  }
+
+  if (MAX_LENGTH_STRINGIFY < res.length) {
+    res = res.substring(0, MAX_LENGTH_STRINGIFY) + '...';
+  }
+
+  return res;
 }
 
 /**

--- a/packages/compiler/test/metadata_resolver_spec.ts
+++ b/packages/compiler/test/metadata_resolver_spec.ts
@@ -409,7 +409,7 @@ import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
          expect(() => { resolver.getNgModuleMetadata(InvalidModule); })
              .toThrowError(
-                 `Unexpected value '[object Object]' imported by the module 'InvalidModule'. Please add a @NgModule annotation.`);
+                 `Unexpected value '{"ngModule":true}' imported by the module 'InvalidModule'. Please add a @NgModule annotation.`);
        }));
   });
 

--- a/packages/compiler/test/util_spec.ts
+++ b/packages/compiler/test/util_spec.ts
@@ -7,7 +7,8 @@
  */
 
 import {fakeAsync} from '@angular/core/testing/src/fake_async';
-import {SyncAsync, escapeRegExp, splitAtColon, utf8Encode} from '../src/util';
+
+import {SyncAsync, escapeRegExp, splitAtColon, stringify, utf8Encode} from '../src/util';
 
 {
   describe('util', () => {
@@ -73,6 +74,24 @@ import {SyncAsync, escapeRegExp, splitAtColon, utf8Encode} from '../src/util';
         ];
         tests.forEach(
             ([input, output]: [string, string]) => { expect(utf8Encode(input)).toEqual(output); });
+      });
+    });
+
+    describe('stringify', () => {
+      it('should pretty print an Object', () => {
+        const result = stringify({hello: 'world'});
+        expect(result).toBe('{"hello":"world"}');
+      });
+
+      it('should truncate large object', () => {
+        const result = stringify({
+          selector: 'app-root',
+          preserveWhitespaces: false,
+          templateUrl: './app.component.ng.html',
+          styleUrls: ['./app.component.css']
+        });
+        expect(result).toBe(
+            '{"selector":"app-root","preserveWhitespaces":false,"templateUrl":"./app.component.ng.html","styleUrl...');
       });
     });
   });


### PR DESCRIPTION
The 'stringify' function prints an object as [Object object] which
is not very helpful in many cases, especially in a diagnostics
message. This commit changes the behavior to pretty print an object.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
An object is printed as [Object object]
Issue Number: N/A

## What is the new behavior?
Object is pretty-printed, i.e. its contents are shown

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
