### PR TITLE
feat(router) Add 'skipLocationChange' and 'replaceUrl' to NavigationEnd event object #22177

### DIFF
--- a/goldens/public-api/router/router.d.ts
+++ b/goldens/public-api/router/router.d.ts
@@ -175,11 +175,13 @@ export declare class NavigationCancel extends RouterEvent {
 }
 
 export declare class NavigationEnd extends RouterEvent {
+    extras?: Partial<NavigationExtras> | undefined;
     urlAfterRedirects: string;
     constructor(
     id: number,
     url: string,
-    urlAfterRedirects: string);
+    urlAfterRedirects: string,
+    extras?: Partial<NavigationExtras> | undefined);
     toString(): string;
 }
 

--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -10,8 +10,8 @@ import {NgModuleFactory, NgModuleRef, Type} from '@angular/core';
 import {Observable} from 'rxjs';
 
 import {EmptyOutletComponent} from './components/empty_outlet';
-import {ActivatedRouteSnapshot} from './router_state';
-import {PRIMARY_OUTLET} from './shared';
+import {ActivatedRoute, ActivatedRouteSnapshot} from './router_state';
+import {Params, PRIMARY_OUTLET} from './shared';
 import {UrlSegment, UrlSegmentGroup} from './url_tree';
 
 
@@ -594,4 +594,131 @@ export function standardizeConfig(r: Route): Route {
     c.component = EmptyOutletComponent;
   }
   return c;
+}
+
+/**
+ * @description
+ *
+ * Options that modify the navigation strategy.
+ *
+ * @publicApi
+ */
+export interface NavigationExtras {
+  /**
+   * Specifies a root URI to use for relative navigation.
+   *
+   * For example, consider the following route configuration where the parent route
+   * has two children.
+   *
+   * ```
+   * [{
+   *   path: 'parent',
+   *   component: ParentComponent,
+   *   children: [{
+   *     path: 'list',
+   *     component: ListComponent
+   *   },{
+   *     path: 'child',
+   *     component: ChildComponent
+   *   }]
+   * }]
+   * ```
+   *
+   * The following `go()` function navigates to the `list` route by
+   * interpreting the destination URI as relative to the activated `child`  route
+   *
+   * ```
+   *  @Component({...})
+   *  class ChildComponent {
+   *    constructor(private router: Router, private route: ActivatedRoute) {}
+   *
+   *    go() {
+   *      this.router.navigate(['../list'], { relativeTo: this.route });
+   *    }
+   *  }
+   * ```
+   */
+  relativeTo?: ActivatedRoute|null;
+
+  /**
+   * Sets query parameters to the URL.
+   *
+   * ```
+   * // Navigate to /results?page=1
+   * this.router.navigate(['/results'], { queryParams: { page: 1 } });
+   * ```
+   */
+  queryParams?: Params|null;
+
+  /**
+   * Sets the hash fragment for the URL.
+   *
+   * ```
+   * // Navigate to /results#top
+   * this.router.navigate(['/results'], { fragment: 'top' });
+   * ```
+   */
+  fragment?: string;
+
+  /**
+   * **DEPRECATED**: Use `queryParamsHandling: "preserve"` instead to preserve
+   * query parameters for the next navigation.
+   *
+   * @deprecated since v4
+   */
+  preserveQueryParams?: boolean;
+
+  /**
+   * How to handle query parameters in the router link for the next navigation.
+   * One of:
+   * * `merge` : Merge new with current parameters.
+   * * `preserve` : Preserve current parameters.
+   *
+   * ```
+   * // from /results?page=1 to /view?page=1&page=2
+   * this.router.navigate(['/view'], { queryParams: { page: 2 },  queryParamsHandling: "merge" });
+   * ```
+   */
+  queryParamsHandling?: QueryParamsHandling|null;
+  /**
+   * When true, preserves the URL fragment for the next navigation
+   *
+   * ```
+   * // Preserve fragment from /results#top to /view#top
+   * this.router.navigate(['/view'], { preserveFragment: true });
+   * ```
+   */
+  preserveFragment?: boolean;
+  /**
+   * When true, navigates without pushing a new state into history.
+   *
+   * ```
+   * // Navigate silently to /view
+   * this.router.navigate(['/view'], { skipLocationChange: true });
+   * ```
+   */
+  skipLocationChange?: boolean;
+  /**
+   * When true, navigates while replacing the current state in history.
+   *
+   * ```
+   * // Navigate to /view
+   * this.router.navigate(['/view'], { replaceUrl: true });
+   * ```
+   */
+  replaceUrl?: boolean;
+  /**
+   * Developer-defined state that can be passed to any navigation.
+   * Access this value through the `Navigation.extras` object
+   * returned from `router.getCurrentNavigation()` while a navigation is executing.
+   *
+   * After a navigation completes, the router writes an object containing this
+   * value together with a `navigationId` to `history.state`.
+   * The value is written when `location.go()` or `location.replaceState()`
+   * is called before activating this route.
+   *
+   * Note that `history.state` does not pass an object equality test because
+   * the router adds the `navigationId` on each navigation.
+   */
+  state?: {[k: string]: any};
 }

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Route} from './config';
+import {NavigationExtras, Route} from './config';
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
 
 /**
@@ -113,14 +113,19 @@ export class NavigationEnd extends RouterEvent {
       /** @docsNotRequired */
       url: string,
       /** @docsNotRequired */
-      public urlAfterRedirects: string) {
+      public urlAfterRedirects: string,
+      /**
+         Contains the NavigationExtras#skipLocationChange and NavigationExtras#replaceUrl values
+         used during the navigation.
+       */
+      public extras?: Partial<NavigationExtras>) {
     super(id, url);
   }
 
   /** @docsNotRequired */
   toString(): string {
     return `NavigationEnd(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${
-        this.urlAfterRedirects}')`;
+        this.urlAfterRedirects}', extras: '${this.extras}')`;
   }
 }
 

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -7,14 +7,14 @@
  */
 
 
-export {Data, DeprecatedLoadChildren, LoadChildren, LoadChildrenCallback, QueryParamsHandling, ResolveData, Route, Routes, RunGuardsAndResolvers, UrlMatcher, UrlMatchResult} from './config';
+export {Data, DeprecatedLoadChildren, LoadChildren, LoadChildrenCallback, NavigationExtras, QueryParamsHandling, ResolveData, Route, Routes, RunGuardsAndResolvers, UrlMatcher, UrlMatchResult} from './config';
 export {RouterLink, RouterLinkWithHref} from './directives/router_link';
 export {RouterLinkActive} from './directives/router_link_active';
 export {RouterOutlet} from './directives/router_outlet';
 export {ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouterEvent, RoutesRecognized, Scroll} from './events';
 export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, Resolve} from './interfaces';
 export {DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
-export {Navigation, NavigationExtras, Router} from './router';
+export {Navigation, Router} from './router';
 export {ROUTES} from './router_config_loader';
 export {ExtraOptions, InitialNavigation, provideRoutes, ROUTER_CONFIGURATION, ROUTER_INITIALIZER, RouterModule} from './router_module';
 export {ChildrenOutletContexts, OutletContext} from './router_outlet_context';

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -12,7 +12,7 @@ import {ChangeDetectionStrategy, Component, Injectable, NgModule, NgModuleFactor
 import {ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DefaultUrlSerializer, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, Navigation, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ParamMap, Params, PreloadAllModules, PreloadingStrategy, PRIMARY_OUTLET, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, Router, RouteReuseStrategy, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
+import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DefaultUrlSerializer, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, Navigation, NavigationCancel, NavigationEnd, NavigationError, NavigationExtras, NavigationStart, ParamMap, Params, PreloadAllModules, PreloadingStrategy, PRIMARY_OUTLET, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, Router, RouteReuseStrategy, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
 import {EMPTY, Observable, Observer, of, Subscription} from 'rxjs';
 import {filter, first, map, tap} from 'rxjs/operators';
 
@@ -615,6 +615,39 @@ describe('Integration', () => {
        expect(location.path()).toEqual('/team/22');
 
        expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
+     })));
+
+  it('should provide skipLocationUpdate in the NavigationEnd event when changed with navigateByUrl',
+     fakeAsync(inject([Router, Location], (router: Router) => {
+       const fixture = TestBed.createComponent(RootCmp);
+       let extras: Partial<NavigationExtras>|undefined;
+
+       router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
+       router.events.subscribe(event => {
+         if (event instanceof NavigationEnd) {
+           extras = (event as NavigationEnd).extras;
+         }
+       });
+
+       router.navigateByUrl('/team/33', {skipLocationChange: true});
+       advance(fixture);
+       expect(extras?.skipLocationChange).toBe(true);
+     })));
+
+  it('should provide replaceUrl in the NavigationEnd event when changed with navigateByUrl',
+     fakeAsync(inject([Router, Location], (router: Router) => {
+       const fixture = TestBed.createComponent(RootCmp);
+       let extras: Partial<NavigationExtras>|undefined;
+       router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
+       router.events.subscribe(event => {
+         if (event instanceof NavigationEnd) {
+           extras = (event as NavigationEnd).extras;
+         }
+       });
+
+       router.navigateByUrl('/team/33', {replaceUrl: true});
+       advance(fixture);
+       expect(extras?.replaceUrl).toBe(true);
      })));
 
   it('should navigate after navigation with skipLocationChange',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, router events such as NavigationEnd does not provide us the details when navigation is done with 'skipLocationChange' or 'replaceUrl' flags
Issue Number: #22177


## What is the new behavior?
As per new behavior, event of type NavigationEnd has one additional parameter called extras with 'skipLocationChange' or 'replaceUrl' flags.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is my first pull request to angular repository. Please guide me to the doc page where I should make the changes.