### PR TITLE
refactor(ivy): remove directiveRefresh instruction

### DIFF
--- a/modules/benchmarks/src/tree/render3/tree.ts
+++ b/modules/benchmarks/src/tree/render3/tree.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵC as C, ɵE as E, ɵT as T, ɵV as V, ɵb as b, ɵcR as cR, ɵcr as cr, ɵdefineComponent as defineComponent, ɵdetectChanges as _detectChanges, ɵe as e, ɵi1 as i1, ɵp as p, ɵr as r, ɵs as s, ɵt as t, ɵv as v} from '@angular/core';
+import {ɵC as C, ɵE as E, ɵT as T, ɵV as V, ɵb as b, ɵcR as cR, ɵcr as cr, ɵdefineComponent as defineComponent, ɵdetectChanges as _detectChanges, ɵe as e, ɵi1 as i1, ɵp as p, ɵs as s, ɵt as t, ɵv as v} from '@angular/core';
 import {ComponentDef} from '@angular/core/src/render3/interfaces/definition';
 
 import {TreeNode, buildTree, emptyTree} from '../util';
@@ -59,7 +59,6 @@ export class TreeComponent {
             }
             p(0, 'data', b(ctx.data.left));
             TreeComponent.ngComponentDef.h(1, 0);
-            r(1, 0);
           }
           v();
         }
@@ -76,7 +75,6 @@ export class TreeComponent {
             }
             p(0, 'data', b(ctx.data.right));
             TreeComponent.ngComponentDef.h(1, 0);
-            r(1, 0);
           }
           v();
         }

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -67,7 +67,6 @@ export {
   s as ɵs,
   t as ɵt,
   v as ɵv,
-  r as ɵr,
   st as ɵst,
   ld as ɵld,
   Pp as ɵPp,

--- a/packages/core/src/render3/hooks.ts
+++ b/packages/core/src/render3/hooks.ts
@@ -97,20 +97,7 @@ function queueDestroyHooks(def: DirectiveDef<any>, tView: TView, i: number): voi
 export function executeInitHooks(currentView: LView, tView: TView, creationMode: boolean): void {
   if (currentView.lifecycleStage === LifecycleStage.INIT) {
     executeHooks(currentView.data, tView.initHooks, tView.checkHooks, creationMode);
-    currentView.lifecycleStage = LifecycleStage.CONTENT_INIT;
-  }
-}
-
-/**
- * Calls all afterContentInit and afterContentChecked hooks for the view, then splices
- * out afterContentInit hooks to prep for the next run in update mode.
- *
- * @param currentView The current view
- */
-export function executeContentHooks(currentView: LView, tView: TView, creationMode: boolean): void {
-  if (currentView.lifecycleStage < LifecycleStage.VIEW_INIT) {
-    executeHooks(currentView.data, tView.contentHooks, tView.contentCheckHooks, creationMode);
-    currentView.lifecycleStage = LifecycleStage.VIEW_INIT;
+    currentView.lifecycleStage = LifecycleStage.AFTER_INIT;
   }
 }
 

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -40,8 +40,6 @@ export {
   interpolation8 as i8,
   interpolationV as iV,
 
-  directiveRefresh as r,
-
   container as C,
   containerRefreshStart as cR,
   containerRefreshEnd as cr,

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -276,6 +276,12 @@ export interface TView {
    * Odd indices: Hook function
    */
   destroyHooks: HookData|null;
+
+  /**
+   * A list of element indices for child components that will need to be refreshed when the
+   * current view has finished its check.
+   */
+  components: number[]|null;
 }
 
 /**
@@ -312,15 +318,14 @@ export interface RootContext {
 export type HookData = (number | (() => void))[];
 
 /** Possible values of LView.lifecycleStage, used to determine which hooks to run.  */
+// TODO: Remove this enum when containerRefresh instructions are removed
 export const enum LifecycleStage {
+
   /* Init hooks need to be run, if any. */
   INIT = 1,
 
   /* Content hooks need to be run, if any. Init hooks have already run. */
-  CONTENT_INIT = 2,
-
-  /* View hooks need to be run, if any. Any init hooks/content hooks have ran. */
-  VIEW_INIT = 3
+  AFTER_INIT = 2,
 }
 
 /**

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -57,6 +57,9 @@
     "name": "checkNoChangesMode"
   },
   {
+    "name": "componentRefresh"
+  },
+  {
     "name": "createLNode"
   },
   {
@@ -93,7 +96,7 @@
     "name": "executeHooks"
   },
   {
-    "name": "executeInitHooks"
+    "name": "executeInitAndContentHooks"
   },
   {
     "name": "findFirstRNode"
@@ -166,6 +169,9 @@
   },
   {
     "name": "renderComponentOrTemplate"
+  },
+  {
+    "name": "refreshChildComponents"
   },
   {
     "name": "renderEmbeddedTemplate"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -81,22 +81,19 @@
     "name": "directiveCreate"
   },
   {
-    "name": "directiveRefresh"
-  },
-  {
     "name": "domRendererFactory3"
   },
   {
     "name": "enterView"
   },
   {
-    "name": "executeContentHooks"
-  },
-  {
     "name": "executeHooks"
   },
   {
     "name": "executeInitAndContentHooks"
+  },
+  {
+    "name": "executeInitHooks"
   },
   {
     "name": "findFirstRNode"
@@ -162,6 +159,9 @@
     "name": "queueInitHooks"
   },
   {
+    "name": "refreshChildComponents"
+  },
+  {
     "name": "refreshDynamicChildren"
   },
   {
@@ -169,9 +169,6 @@
   },
   {
     "name": "renderComponentOrTemplate"
-  },
-  {
-    "name": "refreshChildComponents"
   },
   {
     "name": "renderEmbeddedTemplate"

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -8,12 +8,12 @@
 
 import {withBody} from '@angular/core/testing';
 
-import {ChangeDetectionStrategy, ChangeDetectorRef, DoCheck, EmbeddedViewRef, TemplateRef, ViewContainerRef} from '../../src/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, DoCheck} from '../../src/core';
 import {getRenderedText, whenRendered} from '../../src/render3/component';
-import {NgOnChangesFeature, PublicFeature, defineComponent, defineDirective, injectChangeDetectorRef, injectTemplateRef, injectViewContainerRef} from '../../src/render3/index';
-import {bind, container, containerRefreshEnd, containerRefreshStart, detectChanges, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, interpolation1, interpolation2, listener, markDirty, text, textBinding, tick} from '../../src/render3/instructions';
+import {defineComponent, defineDirective, injectChangeDetectorRef} from '../../src/render3/index';
+import {bind, container, containerRefreshEnd, containerRefreshStart, detectChanges, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, interpolation1, interpolation2, listener, markDirty, text, textBinding, tick} from '../../src/render3/instructions';
 
-import {containerEl, renderComponent, requestAnimationFrame, toHtml} from './render_util';
+import {containerEl, renderComponent, requestAnimationFrame} from './render_util';
 
 describe('change detection', () => {
 
@@ -133,7 +133,6 @@ describe('change detection', () => {
           }
           elementProperty(0, 'name', bind(ctx.name));
           MyComponent.ngComponentDef.h(1, 0);
-          directiveRefresh(1, 0);
         }
       });
     }
@@ -214,7 +213,6 @@ describe('change detection', () => {
               elementEnd();
             }
             MyComponent.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
           }
         });
       }
@@ -247,7 +245,6 @@ describe('change detection', () => {
             }
             textBinding(0, interpolation1('', ctx.doCheckCount, ' - '));
             MyComponent.ngComponentDef.h(2, 1);
-            directiveRefresh(2, 1);
           },
           changeDetection: ChangeDetectionStrategy.OnPush
         });
@@ -265,7 +262,6 @@ describe('change detection', () => {
               elementEnd();
             }
             ButtonParent.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
           }
         });
       }
@@ -342,7 +338,6 @@ describe('change detection', () => {
             }
             textBinding(0, interpolation1('', ctx.doCheckCount, ' - '));
             MyComp.ngComponentDef.h(2, 1);
-            directiveRefresh(2, 1);
           }
         });
       }
@@ -422,8 +417,6 @@ describe('change detection', () => {
               }
               MyComp.ngComponentDef.h(1, 0);
               Dir.ngDirectiveDef.h(2, 0);
-              directiveRefresh(1, 0);
-              directiveRefresh(2, 0);
             }
           });
         }
@@ -456,7 +449,6 @@ describe('change detection', () => {
               }
               textBinding(1, bind(ctx.name));
               Dir.ngDirectiveDef.h(2, 1);
-              directiveRefresh(2, 1);
             }
           });
         }
@@ -500,7 +492,6 @@ describe('change detection', () => {
                     elementEnd();
                   }
                   Dir.ngDirectiveDef.h(1, 0);
-                  directiveRefresh(1, 0);
                 }
                 embeddedViewEnd();
               }
@@ -594,7 +585,6 @@ describe('change detection', () => {
               elementEnd();
             }
             DetachedComp.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
           }
         });
       }
@@ -734,7 +724,6 @@ describe('change detection', () => {
               }
               elementProperty(0, 'value', bind(ctx.value));
               OnPushComp.ngComponentDef.h(1, 0);
-              directiveRefresh(1, 0);
             }
           });
         }
@@ -802,7 +791,6 @@ describe('change detection', () => {
             }
             textBinding(0, interpolation1('', ctx.value, ' - '));
             OnPushComp.ngComponentDef.h(2, 1);
-            directiveRefresh(2, 1);
           },
           changeDetection: ChangeDetectionStrategy.OnPush
         });
@@ -878,7 +866,6 @@ describe('change detection', () => {
                     elementEnd();
                   }
                   OnPushComp.ngComponentDef.h(1, 0);
-                  directiveRefresh(1, 0);
                   embeddedViewEnd();
                 }
               }
@@ -962,7 +949,6 @@ describe('change detection', () => {
             }
             textBinding(0, interpolation1('', ctx.value, ' - '));
             NoChangesComp.ngComponentDef.h(2, 1);
-            directiveRefresh(2, 1);
           }
         });
       }

--- a/packages/core/test/render3/common_integration_spec.ts
+++ b/packages/core/test/render3/common_integration_spec.ts
@@ -9,7 +9,7 @@
 import {NgForOfContext} from '@angular/common';
 
 import {defineComponent} from '../../src/render3/index';
-import {bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementProperty, elementStart, text, textBinding} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, text, textBinding} from '../../src/render3/instructions';
 
 import {NgForOf} from './common_with_def';
 import {renderComponent, toHtml} from './render_util';
@@ -35,7 +35,6 @@ describe('@angular/common integration', () => {
             }
             elementProperty(1, 'ngForOf', bind(myApp.items));
             containerRefreshStart(1);
-            directiveRefresh(2, 0);
             containerRefreshEnd();
 
             function liTemplate(row: NgForOfContext<string>, cm: boolean) {

--- a/packages/core/test/render3/compiler_canonical/component_directives_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/component_directives_spec.ts
@@ -73,8 +73,6 @@ describe('components & directives', () => {
           }
           ChildComponent.ngComponentDef.h(1, 0);
           SomeDirective.ngDirectiveDef.h(2, 0);
-          $r3$.ɵr(1, 0);
-          $r3$.ɵr(2, 0);
         }
       });
       // /NORMATIVE
@@ -122,7 +120,6 @@ describe('components & directives', () => {
             $r3$.ɵe();
           }
           HostBindingDir.ngDirectiveDef.h(1, 0);
-          $r3$.ɵr(1, 0);
         }
       });
     }
@@ -171,7 +168,6 @@ describe('components & directives', () => {
             $r3$.ɵe();
           }
           HostListenerDir.ngDirectiveDef.h(1, 0);
-          $r3$.ɵr(1, 0);
         }
       });
     }
@@ -214,7 +210,6 @@ describe('components & directives', () => {
             $r3$.ɵe();
           }
           HostAttributeDir.ngDirectiveDef.h(1, 0);
-          $r3$.ɵr(1, 0);
         }
       });
     }
@@ -260,7 +255,6 @@ describe('components & directives', () => {
             $r3$.ɵe();
           }
           HostBindingDir.ngDirectiveDef.h(1, 0);
-          $r3$.ɵr(1, 0);
         }
       });
     }
@@ -319,7 +313,6 @@ describe('components & directives', () => {
           }
           $r3$.ɵp(0, 'name', $r3$.ɵb(ctx.name));
           MyComp.ngComponentDef.h(1, 0);
-          $r3$.ɵr(1, 0);
         }
       });
     }
@@ -367,7 +360,6 @@ describe('components & directives', () => {
           }
           let $foo$ = $r3$.ɵld<any>(1);
           $r3$.ɵcR(2);
-          $r3$.ɵr(3, 2);
           $r3$.ɵcr();
 
           function C1(ctx1: $any$, cm: $boolean$) {
@@ -439,7 +431,6 @@ describe('components & directives', () => {
             }
             $r3$.ɵp(0, 'names', cm ? $e0_arr$ : $r3$.ɵNC);
             MyArrayComp.ngComponentDef.h(1, 0);
-            $r3$.ɵr(1, 0);
           }
         });
         // /NORMATIVE
@@ -479,7 +470,6 @@ describe('components & directives', () => {
             }
             $r3$.ɵp(0, 'names', $r3$.ɵb(ctx.someFn($r3$.ɵf0($e0_ff$))));
             MyArrayComp.ngComponentDef.h(1, 0);
-            $r3$.ɵr(1, 0);
           }
         });
         // /NORMATIVE
@@ -533,7 +523,6 @@ describe('components & directives', () => {
             }
             $r3$.ɵp(0, 'num', $r3$.ɵb($r3$.ɵf0($e0_ff$).length + 1));
             MyComp.ngComponentDef.h(1, 0);
-            $r3$.ɵr(1, 0);
           }
         });
         // /NORMATIVE
@@ -571,7 +560,6 @@ describe('components & directives', () => {
             }
             $r3$.ɵp(0, 'names', $r3$.ɵb($r3$.ɵf1($e0_ff$, ctx.customName)));
             MyArrayComp.ngComponentDef.h(1, 0);
-            $r3$.ɵr(1, 0);
           }
         });
         // /NORMATIVE
@@ -676,7 +664,6 @@ describe('components & directives', () => {
                 0, 'names',
                 $r3$.ɵb($r3$.ɵfV($e0_ff$, [c.n0, c.n1, c.n2, c.n3, c.n4, c.n5, c.n6, c.n7, c.n8])));
             MyComp.ngComponentDef.h(1, 0);
-            $r3$.ɵr(1, 0);
           }
         });
         // /NORMATIVE
@@ -744,7 +731,6 @@ describe('components & directives', () => {
             }
             $r3$.ɵp(0, 'config', $r3$.ɵb($r3$.ɵf1($e0_ff$, ctx.name)));
             ObjectComp.ngComponentDef.h(1, 0);
-            $r3$.ɵr(1, 0);
           }
         });
         // /NORMATIVE
@@ -825,7 +811,6 @@ describe('components & directives', () => {
                                  $e0_ff_2$, ctx.name,
                                  $r3$.ɵb($r3$.ɵf1($e0_ff_1$, $r3$.ɵf1($e0_ff$, ctx.duration)))));
             NestedComp.ngComponentDef.h(1, 0);
-            $r3$.ɵr(1, 0);
           }
         });
         // /NORMATIVE

--- a/packages/core/test/render3/compiler_canonical/injection_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/injection_spec.ts
@@ -58,7 +58,6 @@ describe('injection', () => {
               $r3$.ɵe();
             }
             MyComp.ngComponentDef.h(1, 0);
-            $r3$.ɵr(1, 0);
           }
         });
       }
@@ -103,7 +102,6 @@ describe('injection', () => {
               $r3$.ɵe();
             }
             MyComp.ngComponentDef.h(1, 0);
-            $r3$.ɵr(1, 0);
           }
         });
       }

--- a/packages/core/test/render3/compiler_canonical/life_cycle_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/life_cycle_spec.ts
@@ -77,8 +77,6 @@ describe('lifecycle hooks', () => {
         $r3$.ɵp(2, 'name', $r3$.ɵb(ctx.name2));
         LifecycleComp.ngComponentDef.h(1, 0);
         LifecycleComp.ngComponentDef.h(3, 2);
-        $r3$.ɵr(1, 0);
-        $r3$.ɵr(3, 2);
       }
     });
     // /NORMATIVE

--- a/packages/core/test/render3/compiler_canonical/pipes_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/pipes_spec.ts
@@ -171,7 +171,6 @@ describe('pipes', () => {
           $r3$.ɵt(2, $r3$.ɵi1('', $r3$.ɵpb2(3, ctx.name, ctx.size), ''));
           $r3$.ɵp(4, 'oneTimeIf', $r3$.ɵb(ctx.more));
           $r3$.ɵcR(4);
-          $r3$.ɵr(5, 4);
           $r3$.ɵcr();
 
           function C4(ctx1: $any$, cm: $boolean$) {

--- a/packages/core/test/render3/compiler_canonical/query_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/query_spec.ts
@@ -63,7 +63,6 @@ describe('queries', () => {
           $r3$.ɵqR($tmp$ = $r3$.ɵld<QueryList<any>>(1)) &&
               (ctx.someDirList = $tmp$ as QueryList<any>);
           SomeDirective.ngDirectiveDef.h(3, 2);
-          $r3$.ɵr(3, 2);
         }
       });
       // /NORMATIVE
@@ -148,8 +147,6 @@ describe('queries', () => {
           }
           ContentQueryComponent.ngComponentDef.h(1, 0);
           SomeDirective.ngDirectiveDef.h(3, 2);
-          $r3$.ɵr(1, 0);
-          $r3$.ɵr(3, 2);
         }
       });
       // /NON-NORMATIVE

--- a/packages/core/test/render3/compiler_canonical/template_variables_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/template_variables_spec.ts
@@ -104,7 +104,6 @@ describe('template variables', () => {
           }
           $r3$.ɵp(1, 'forOf', $r3$.ɵb(ctx.items));
           $r3$.ɵcR(1);
-          $r3$.ɵr(2, 1);
           $r3$.ɵcr();
 
           function MyComponent_ForOfDirective_Template_1(ctx1: $any$, cm: $boolean$) {
@@ -173,7 +172,6 @@ describe('template variables', () => {
           }
           $r3$.ɵp(1, 'forOf', $r3$.ɵb(ctx.items));
           $r3$.ɵcR(1);
-          $r3$.ɵr(2, 1);
           $r3$.ɵcr();
 
           function MyComponent_ForOfDirective_Template_1(ctx1: $any$, cm: $boolean$) {
@@ -191,7 +189,6 @@ describe('template variables', () => {
             $r3$.ɵp(4, 'forOf', $r3$.ɵb($l0_item$.infos));
             $r3$.ɵt(2, $r3$.ɵi1('', $l0_item$.name, ''));
             $r3$.ɵcR(4);
-            $r3$.ɵr(5, 4);
             $r3$.ɵcr();
 
             function MyComponent_ForOfDirective_ForOfDirective_Template_3(

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -8,8 +8,9 @@
 
 
 import {DoCheck, ViewEncapsulation} from '../../src/core';
-import {defineComponent, markDirty} from '../../src/render3/index';
-import {bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, text, textBinding} from '../../src/render3/instructions';
+import {getRenderedText} from '../../src/render3/component';
+import {LifecycleHooksFeature, defineComponent, markDirty} from '../../src/render3/index';
+import {bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, text, textBinding, tick} from '../../src/render3/instructions';
 import {createRendererType2} from '../../src/view/index';
 
 import {getRendererFactory2} from './imported_renderer2';
@@ -229,4 +230,79 @@ describe('encapsulation', () => {
             /<div host="" _nghost-c(\d+)=""><leaf _ngcontent-c\1="" _nghost-c(\d+)=""><span _ngcontent-c\2="">bar<\/span><\/leaf><\/div>/);
   });
 
+});
+
+describe('recursive components', () => {
+  let events: string[] = [];
+  let count = 0;
+
+  class TreeNode {
+    constructor(
+        public value: number, public depth: number, public left: TreeNode|null,
+        public right: TreeNode|null) {}
+  }
+
+  class TreeComponent {
+    data: TreeNode = _buildTree(0);
+
+    ngDoCheck() { events.push('check' + this.data.value); }
+
+    static ngComponentDef = defineComponent({
+      type: TreeComponent,
+      tag: 'tree-comp',
+      factory: () => new TreeComponent(),
+      template: (ctx: TreeComponent, cm: boolean) => {
+        if (cm) {
+          text(0);
+          container(1);
+          container(2);
+        }
+        textBinding(0, bind(ctx.data.value));
+        containerRefreshStart(1);
+        {
+          if (ctx.data.left != null) {
+            if (embeddedViewStart(0)) {
+              elementStart(0, TreeComponent);
+              elementEnd();
+            }
+            elementProperty(0, 'data', bind(ctx.data.left));
+            TreeComponent.ngComponentDef.h(1, 0);
+            embeddedViewEnd();
+          }
+        }
+        containerRefreshEnd();
+        containerRefreshStart(2);
+        {
+          if (ctx.data.right != null) {
+            if (embeddedViewStart(0)) {
+              elementStart(0, TreeComponent);
+              elementEnd();
+            }
+            elementProperty(0, 'data', bind(ctx.data.right));
+            TreeComponent.ngComponentDef.h(1, 0);
+            embeddedViewEnd();
+          }
+        }
+        containerRefreshEnd();
+      },
+      inputs: {data: 'data'}
+    });
+  }
+
+
+  function _buildTree(currDepth: number): TreeNode {
+    const children = currDepth < 2 ? _buildTree(currDepth + 1) : null;
+    const children2 = currDepth < 2 ? _buildTree(currDepth + 1) : null;
+    return new TreeNode(count++, currDepth, children, children2);
+  }
+
+  it('should check each component just once', () => {
+    const comp = renderComponent(TreeComponent, {hostFeatures: [LifecycleHooksFeature]});
+    expect(getRenderedText(comp)).toEqual('6201534');
+    expect(events).toEqual(['check6', 'check2', 'check0', 'check1', 'check5', 'check3', 'check4']);
+
+    events = [];
+    tick(comp);
+    expect(events).toEqual(['check6', 'check2', 'check0', 'check1', 'check5', 'check3', 'check4']);
+  });
 });

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -9,7 +9,7 @@
 
 import {DoCheck, ViewEncapsulation} from '../../src/core';
 import {defineComponent, markDirty} from '../../src/render3/index';
-import {bind, container, containerRefreshEnd, containerRefreshStart, detectChanges, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, text, textBinding} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, text, textBinding} from '../../src/render3/instructions';
 import {createRendererType2} from '../../src/view/index';
 
 import {getRendererFactory2} from './imported_renderer2';
@@ -111,7 +111,6 @@ describe('component with a container', () => {
     }
     elementProperty(0, 'items', bind(ctx.items));
     WrapperComponent.ngComponentDef.h(1, 0);
-    directiveRefresh(1, 0);
   }
 
   it('should re-render on input change', () => {
@@ -137,7 +136,6 @@ describe('encapsulation', () => {
           elementEnd();
         }
         EncapsulatedComponent.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       },
       factory: () => new WrapperComponent,
     });
@@ -154,7 +152,6 @@ describe('encapsulation', () => {
           elementEnd();
         }
         LeafComponent.ngComponentDef.h(2, 1);
-        directiveRefresh(2, 1);
       },
       factory: () => new EncapsulatedComponent,
       rendererType:
@@ -202,7 +199,6 @@ describe('encapsulation', () => {
             elementEnd();
           }
           LeafComponentwith.ngComponentDef.h(1, 0);
-          directiveRefresh(1, 0);
         },
         factory: () => new WrapperComponentWith,
         rendererType:

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {detectChanges} from '../../src/render3/index';
-import {container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, load, projection, projectionDef, text} from '../../src/render3/instructions';
+import {container, containerRefreshEnd, containerRefreshStart, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, load, projection, projectionDef, text} from '../../src/render3/instructions';
 
 import {createComponent, renderComponent, toHtml} from './render_util';
 
@@ -36,7 +36,6 @@ describe('content projection', () => {
         elementEnd();
       }
       Child.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div>content</div></child>');
@@ -56,7 +55,6 @@ describe('content projection', () => {
         elementEnd();
       }
       Child.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child>content</child>');
@@ -78,7 +76,6 @@ describe('content projection', () => {
         { projection(3, 0); }
         elementEnd();
         GrandChild.ngComponentDef.h(2, 1);
-        directiveRefresh(2, 1);
       }
     });
     const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
@@ -93,7 +90,6 @@ describe('content projection', () => {
         elementEnd();
       }
       Child.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent))
@@ -134,8 +130,6 @@ describe('content projection', () => {
       }
       Child.ngComponentDef.h(1, 0);
       ProjectedComp.ngComponentDef.h(3, 2);
-      directiveRefresh(3, 2);
-      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent))
@@ -172,7 +166,6 @@ describe('content projection', () => {
       }
       containerRefreshEnd();
       Child.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div>()</div></child>');
@@ -208,7 +201,6 @@ describe('content projection', () => {
       }
       containerRefreshEnd();
       Child.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child></child>');
@@ -257,7 +249,6 @@ describe('content projection', () => {
       }
       containerRefreshEnd();
       Child.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div>(else)</div></child>');
@@ -315,7 +306,6 @@ describe('content projection', () => {
         elementEnd();
       }
       Child.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div><span>content</span></div></child>');
@@ -368,7 +358,6 @@ describe('content projection', () => {
            elementEnd();
          }
          Child.ngComponentDef.h(1, 0);
-         directiveRefresh(1, 0);
        });
        const parent = renderComponent(Parent);
        expect(toHtml(parent)).toEqual('<child><div>content</div></child>');
@@ -423,7 +412,6 @@ describe('content projection', () => {
            elementEnd();
          }
          Child.ngComponentDef.h(1, 0);
-         directiveRefresh(1, 0);
        });
        const parent = renderComponent(Parent);
        expect(toHtml(parent)).toEqual('<child><div>before-content-after</div></child>');
@@ -460,7 +448,6 @@ describe('content projection', () => {
         elementEnd();
       }
       Child.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div></div><span>content</span></child>');
@@ -518,7 +505,6 @@ describe('content projection', () => {
         elementEnd();
       }
       Child.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child>content<div></div></child>');
@@ -569,7 +555,6 @@ describe('content projection', () => {
           elementEnd();
         }
         Child.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -617,7 +602,6 @@ describe('content projection', () => {
           elementEnd();
         }
         Child.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -665,7 +649,6 @@ describe('content projection', () => {
           elementEnd();
         }
         Child.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -713,7 +696,6 @@ describe('content projection', () => {
           elementEnd();
         }
         Child.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -760,7 +742,6 @@ describe('content projection', () => {
           elementEnd();
         }
         Child.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -808,7 +789,6 @@ describe('content projection', () => {
           elementEnd();
         }
         Child.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -856,7 +836,6 @@ describe('content projection', () => {
           }
           elementEnd();
           GrandChild.ngComponentDef.h(2, 1);
-          directiveRefresh(2, 1);
         }
       });
 
@@ -878,7 +857,6 @@ describe('content projection', () => {
           elementEnd();
         }
         Child.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -924,7 +902,6 @@ describe('content projection', () => {
           }
           elementEnd();
           Card.ngComponentDef.h(2, 1);
-          directiveRefresh(2, 1);
         }
       });
 
@@ -940,7 +917,6 @@ describe('content projection', () => {
           elementEnd();
         }
         CardWithTitle.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       });
 
       const app = renderComponent(App);
@@ -987,7 +963,6 @@ describe('content projection', () => {
           }
           elementEnd();
           Card.ngComponentDef.h(2, 1);
-          directiveRefresh(2, 1);
         }
       });
 
@@ -1003,7 +978,6 @@ describe('content projection', () => {
           elementEnd();
         }
         CardWithTitle.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       });
 
       const app = renderComponent(App);
@@ -1044,7 +1018,6 @@ describe('content projection', () => {
           elementEnd();
         }
         Child.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -1091,7 +1064,6 @@ describe('content projection', () => {
         }
         containerRefreshEnd();
         Child.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       });
       const parent = renderComponent(Parent);
       expect(toHtml(parent)).toEqual('<child><span><div>content</div></span></child>');

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -11,7 +11,7 @@ import {ChangeDetectorRef, ElementRef, TemplateRef, ViewContainerRef} from '@ang
 import {defineComponent} from '../../src/render3/definition';
 import {InjectFlags, bloomAdd, bloomFindPossibleInjector, getOrCreateNodeInjector, injectAttribute} from '../../src/render3/di';
 import {NgOnChangesFeature, PublicFeature, defineDirective, directiveInject, injectChangeDetectorRef, injectElementRef, injectTemplateRef, injectViewContainerRef} from '../../src/render3/index';
-import {bind, container, containerRefreshEnd, containerRefreshStart, createLNode, createLView, createTView, directiveRefresh, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, enterView, interpolation2, leaveView, load, projection, projectionDef, text, textBinding} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, createLNode, createLView, createTView, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, enterView, interpolation2, leaveView, load, projection, projectionDef, text, textBinding} from '../../src/render3/instructions';
 import {LInjector} from '../../src/render3/interfaces/injector';
 import {LNodeFlags} from '../../src/render3/interfaces/node';
 import {LViewFlags} from '../../src/render3/interfaces/view';
@@ -261,9 +261,6 @@ describe('di', () => {
             MyComp.ngComponentDef.h(1, 0);
             Directive.ngDirectiveDef.h(2, 0);
             DirectiveSameInstance.ngDirectiveDef.h(3, 0);
-            directiveRefresh(1, 0);
-            directiveRefresh(2, 0);
-            directiveRefresh(3, 0);
           }
         });
       }
@@ -296,8 +293,6 @@ describe('di', () => {
             textBinding(3, bind(load<Directive>(1).value));
             Directive.ngDirectiveDef.h(1, 0);
             DirectiveSameInstance.ngDirectiveDef.h(2, 0);
-            directiveRefresh(1, 0);
-            directiveRefresh(2, 0);
           }
         });
       }
@@ -338,9 +333,6 @@ describe('di', () => {
             MyComp.ngComponentDef.h(1, 0);
             Directive.ngDirectiveDef.h(3, 2);
             DirectiveSameInstance.ngDirectiveDef.h(4, 2);
-            directiveRefresh(1, 0);
-            directiveRefresh(3, 2);
-            directiveRefresh(4, 2);
           }
         });
       }
@@ -385,8 +377,6 @@ describe('di', () => {
                 textBinding(3, bind(load<Directive>(1).value));
                 Directive.ngDirectiveDef.h(1, 0);
                 DirectiveSameInstance.ngDirectiveDef.h(2, 0);
-                directiveRefresh(1, 0);
-                directiveRefresh(2, 0);
               }
               embeddedViewEnd();
             }
@@ -439,7 +429,6 @@ describe('di', () => {
               container(0, [IfDirective], C1);
             }
             containerRefreshStart(0);
-            { directiveRefresh(1, 0); }
             containerRefreshEnd();
 
             function C1(ctx1: any, cm1: boolean) {
@@ -451,8 +440,6 @@ describe('di', () => {
               textBinding(3, bind(load<Directive>(1).value));
               Directive.ngDirectiveDef.h(1, 0);
               DirectiveSameInstance.ngDirectiveDef.h(2, 0);
-              directiveRefresh(1, 0);
-              directiveRefresh(2, 0);
             }
           }
         });

--- a/packages/core/test/render3/directive_spec.ts
+++ b/packages/core/test/render3/directive_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {defineDirective} from '../../src/render3/index';
-import {bind, directiveRefresh, elementEnd, elementProperty, elementStart, load} from '../../src/render3/instructions';
+import {bind, elementEnd, elementProperty, elementStart, load} from '../../src/render3/instructions';
 
 import {renderToHtml} from './render_util';
 
@@ -35,7 +35,6 @@ describe('directive', () => {
           elementEnd();
         }
         Directive.ngDirectiveDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       expect(renderToHtml(Template, {})).toEqual('<span class="foo"></span>');

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {defineComponent, defineDirective} from '../../src/render3/index';
-import {NO_CHANGE, bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementAttribute, elementClass, elementEnd, elementProperty, elementStart, elementStyle, embeddedViewEnd, embeddedViewStart, interpolation1, interpolation2, interpolation3, interpolation4, interpolation5, interpolation6, interpolation7, interpolation8, interpolationV, load, projection, projectionDef, text, textBinding} from '../../src/render3/instructions';
+import {NO_CHANGE, bind, container, containerRefreshEnd, containerRefreshStart, elementAttribute, elementClass, elementEnd, elementProperty, elementStart, elementStyle, embeddedViewEnd, embeddedViewStart, interpolation1, interpolation2, interpolation3, interpolation4, interpolation5, interpolation6, interpolation7, interpolation8, interpolationV, load, projection, projectionDef, text, textBinding} from '../../src/render3/instructions';
 
 import {containerEl, renderToHtml} from './render_util';
 
@@ -201,7 +201,6 @@ describe('render3 integration test', () => {
           elementEnd();
         }
         TodoComponent.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       expect(renderToHtml(Template, null)).toEqual('<todo><p>Todo one</p></todo>');
@@ -215,7 +214,6 @@ describe('render3 integration test', () => {
           text(2, 'two');
         }
         TodoComponent.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
       expect(renderToHtml(Template, null)).toEqual('<todo><p>Todo one</p></todo>two');
     });
@@ -234,8 +232,6 @@ describe('render3 integration test', () => {
         }
         TodoComponent.ngComponentDef.h(1, 0);
         TodoComponent.ngComponentDef.h(3, 2);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
       }
       expect(renderToHtml(Template, null))
           .toEqual('<todo><p>Todo one</p></todo><todo><p>Todo one</p></todo>');
@@ -271,7 +267,6 @@ describe('render3 integration test', () => {
           elementEnd();
         }
         TodoComponentHostBinding.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       expect(renderToHtml(Template, {})).toEqual('<todo title="one">one</todo>');
@@ -304,7 +299,6 @@ describe('render3 integration test', () => {
           elementEnd();
         }
         MyComp.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       expect(renderToHtml(Template, null)).toEqual('<comp><p>Bess</p></comp>');
@@ -351,7 +345,6 @@ describe('render3 integration test', () => {
         }
         elementProperty(0, 'condition', bind(ctx.condition));
         MyComp.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       expect(renderToHtml(Template, {condition: true})).toEqual('<comp><div>text</div></comp>');
@@ -472,7 +465,6 @@ describe('render3 integration test', () => {
       }
       containerRefreshEnd();
       ChildComponent.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     }
 
     it('should work with a tree', () => {
@@ -648,7 +640,6 @@ describe('render3 integration test', () => {
             elementEnd();
           }
           HostBindingDir.ngDirectiveDef.h(1, 0);
-          directiveRefresh(1, 0);
         }
 
         expect(renderToHtml(Template, {}))

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -8,7 +8,7 @@
 
 import {SimpleChanges} from '../../src/core';
 import {ComponentTemplate, LifecycleHooksFeature, NgOnChangesFeature, defineComponent, defineDirective} from '../../src/render3/index';
-import {bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, listener, markDirty, projection, projectionDef, store, text} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, listener, markDirty, projection, projectionDef, store, text} from '../../src/render3/instructions';
 
 import {containerEl, renderComponent, renderToHtml, requestAnimationFrame} from './render_util';
 
@@ -22,7 +22,6 @@ describe('lifecycles', () => {
       }
       elementProperty(0, 'val', bind(ctx.val));
       type.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     };
   }
 
@@ -76,7 +75,6 @@ describe('lifecycles', () => {
            }
            elementProperty(0, 'val', bind(ctx.val));
            Comp.ngComponentDef.h(1, 0);
-           directiveRefresh(1, 0);
          }
 
          renderToHtml(Template, {val: '1'});
@@ -107,7 +105,6 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Parent.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -133,8 +130,6 @@ describe('lifecycles', () => {
         elementProperty(2, 'val', 2);
         Parent.ngComponentDef.h(1, 0);
         Parent.ngComponentDef.h(3, 2);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -161,7 +156,6 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Comp.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -192,8 +186,6 @@ describe('lifecycles', () => {
         }
         Comp.ngComponentDef.h(1, 0);
         ProjectedComp.ngComponentDef.h(3, 2);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -226,10 +218,6 @@ describe('lifecycles', () => {
         ProjectedComp.ngComponentDef.h(3, 2);
         Comp.ngComponentDef.h(5, 4);
         ProjectedComp.ngComponentDef.h(7, 6);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
-        directiveRefresh(5, 4);
-        directiveRefresh(7, 6);
       }
 
       renderToHtml(Template, {});
@@ -245,8 +233,6 @@ describe('lifecycles', () => {
         }
         Comp.ngComponentDef.h(1, 0);
         Directive.ngDirectiveDef.h(2, 0);
-        directiveRefresh(1, 0);
-        directiveRefresh(2, 0);
       }
 
       renderToHtml(Template, {});
@@ -265,7 +251,6 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Directive.ngDirectiveDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -305,13 +290,10 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val', j);
             Comp.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
         containerRefreshEnd();
-        directiveRefresh(1, 0);
-        directiveRefresh(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -351,13 +333,10 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val', j);
             Parent.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
         containerRefreshEnd();
-        directiveRefresh(1, 0);
-        directiveRefresh(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -412,7 +391,6 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Comp.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -443,7 +421,6 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Parent.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -458,7 +435,6 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Comp.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -477,8 +453,6 @@ describe('lifecycles', () => {
         }
         Comp.ngComponentDef.h(1, 0);
         Directive.ngDirectiveDef.h(2, 0);
-        directiveRefresh(1, 0);
-        directiveRefresh(2, 0);
       }
 
       renderToHtml(Template, {});
@@ -497,7 +471,6 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Directive.ngDirectiveDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -534,7 +507,6 @@ describe('lifecycles', () => {
       }
       elementProperty(1, 'val', bind(ctx.val));
       Comp.ngComponentDef.h(2, 1);
-      directiveRefresh(2, 1);
     });
 
     let ProjectedComp = createAfterContentInitComp('projected', (ctx: any, cm: boolean) => {
@@ -572,7 +544,6 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Comp.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -610,7 +581,6 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Comp.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -640,7 +610,6 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Parent.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -667,8 +636,6 @@ describe('lifecycles', () => {
         elementProperty(3, 'val', 2);
         Parent.ngComponentDef.h(1, 0);
         Parent.ngComponentDef.h(4, 3);
-        directiveRefresh(1, 0);
-        directiveRefresh(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -698,8 +665,6 @@ describe('lifecycles', () => {
         }
         Parent.ngComponentDef.h(1, 0);
         ProjectedComp.ngComponentDef.h(3, 2);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -745,10 +710,6 @@ describe('lifecycles', () => {
         ProjectedComp.ngComponentDef.h(3, 2);
         Parent.ngComponentDef.h(6, 5);
         ProjectedComp.ngComponentDef.h(8, 7);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
-        directiveRefresh(6, 5);
-        directiveRefresh(8, 7);
       }
 
       renderToHtml(Template, {});
@@ -787,13 +748,10 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val', i);
             Comp.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
         containerRefreshEnd();
-        directiveRefresh(1, 0);
-        directiveRefresh(5, 4);
       }
 
       renderToHtml(Template, {});
@@ -824,13 +782,10 @@ describe('lifecycles', () => {
           }
           elementProperty(0, 'val', i);
           Parent.ngComponentDef.h(1, 0);
-          directiveRefresh(1, 0);
           embeddedViewEnd();
         }
       }
       containerRefreshEnd();
-      directiveRefresh(1, 0);
-      directiveRefresh(5, 4);
     }
 
     it('should be called in correct order in a for loop with children', () => {
@@ -858,7 +813,6 @@ describe('lifecycles', () => {
             elementEnd();
           }
           Comp.ngComponentDef.h(1, 0);
-          directiveRefresh(1, 0);
         }
 
         renderToHtml(Template, {});
@@ -897,8 +851,6 @@ describe('lifecycles', () => {
           }
           Comp.ngComponentDef.h(1, 0);
           Directive.ngDirectiveDef.h(2, 0);
-          directiveRefresh(1, 0);
-          directiveRefresh(2, 0);
         }
 
         renderToHtml(Template, {});
@@ -913,7 +865,6 @@ describe('lifecycles', () => {
             elementEnd();
           }
           Directive.ngDirectiveDef.h(1, 0);
-          directiveRefresh(1, 0);
         }
 
         renderToHtml(Template, {});
@@ -974,7 +925,6 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Comp.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -1011,7 +961,6 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Comp.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -1041,7 +990,6 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Parent.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -1067,8 +1015,6 @@ describe('lifecycles', () => {
         elementProperty(2, 'val', 2);
         Parent.ngComponentDef.h(1, 0);
         Parent.ngComponentDef.h(3, 2);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
       }
       renderToHtml(Template, {});
       expect(events).toEqual(['comp1', 'comp2', 'parent1', 'parent2']);
@@ -1092,8 +1038,6 @@ describe('lifecycles', () => {
         }
         Comp.ngComponentDef.h(1, 0);
         ProjectedComp.ngComponentDef.h(3, 2);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -1132,10 +1076,6 @@ describe('lifecycles', () => {
         ProjectedComp.ngComponentDef.h(3, 2);
         Comp.ngComponentDef.h(5, 4);
         ProjectedComp.ngComponentDef.h(7, 6);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
-        directiveRefresh(5, 4);
-        directiveRefresh(7, 6);
       }
 
       renderToHtml(Template, {});
@@ -1161,8 +1101,6 @@ describe('lifecycles', () => {
         elementProperty(2, 'val', bind(ctx.val));
         Comp.ngComponentDef.h(1, 0);
         ProjectedComp.ngComponentDef.h(3, 2);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
       });
 
       /**
@@ -1180,8 +1118,6 @@ describe('lifecycles', () => {
         elementProperty(2, 'val', 2);
         ParentComp.ngComponentDef.h(1, 0);
         ParentComp.ngComponentDef.h(3, 2);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -1217,13 +1153,10 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val', i);
             Comp.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
         containerRefreshEnd();
-        directiveRefresh(1, 0);
-        directiveRefresh(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -1260,13 +1193,10 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val', i);
             Parent.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
         containerRefreshEnd();
-        directiveRefresh(1, 0);
-        directiveRefresh(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -1285,7 +1215,6 @@ describe('lifecycles', () => {
             elementEnd();
           }
           Comp.ngComponentDef.h(1, 0);
-          directiveRefresh(1, 0);
         }
 
         renderToHtml(Template, {});
@@ -1313,7 +1242,6 @@ describe('lifecycles', () => {
           }
           elementProperty(0, 'val', bind(ctx.myVal));
           Comp.ngComponentDef.h(1, 0);
-          directiveRefresh(1, 0);
         }
 
         renderToHtml(Template, {myVal: 5});
@@ -1352,13 +1280,10 @@ describe('lifecycles', () => {
               }
               elementProperty(0, 'val', i);
               Parent.ngComponentDef.h(1, 0);
-              directiveRefresh(1, 0);
               embeddedViewEnd();
             }
           }
           containerRefreshEnd();
-          directiveRefresh(1, 0);
-          directiveRefresh(4, 3);
         }
 
         renderToHtml(Template, {});
@@ -1389,8 +1314,6 @@ describe('lifecycles', () => {
           }
           Comp.ngComponentDef.h(1, 0);
           Directive.ngDirectiveDef.h(2, 0);
-          directiveRefresh(1, 0);
-          directiveRefresh(2, 0);
         }
 
         renderToHtml(Template, {});
@@ -1405,7 +1328,6 @@ describe('lifecycles', () => {
             elementEnd();
           }
           Directive.ngDirectiveDef.h(1, 0);
-          directiveRefresh(1, 0);
         }
 
         renderToHtml(Template, {});
@@ -1467,7 +1389,6 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Comp.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -1504,8 +1425,6 @@ describe('lifecycles', () => {
             elementProperty(2, 'val', bind('2'));
             Comp.ngComponentDef.h(1, 0);
             Comp.ngComponentDef.h(3, 2);
-            directiveRefresh(1, 0);
-            directiveRefresh(3, 2);
             embeddedViewEnd();
           }
         }
@@ -1538,7 +1457,6 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Parent.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -1566,7 +1484,6 @@ describe('lifecycles', () => {
           elementEnd();
         }
         Parent.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       });
 
       function Template(ctx: any, cm: boolean) {
@@ -1581,7 +1498,6 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Grandparent.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -1635,10 +1551,6 @@ describe('lifecycles', () => {
             ProjectedComp.ngComponentDef.h(3, 2);
             Comp.ngComponentDef.h(5, 4);
             ProjectedComp.ngComponentDef.h(7, 6);
-            directiveRefresh(1, 0);
-            directiveRefresh(3, 2);
-            directiveRefresh(5, 4);
-            directiveRefresh(7, 6);
             embeddedViewEnd();
           }
         }
@@ -1690,13 +1602,10 @@ describe('lifecycles', () => {
                 }
                 elementProperty(0, 'val', bind('2'));
                 Comp.ngComponentDef.h(1, 0);
-                directiveRefresh(1, 0);
                 embeddedViewEnd();
               }
             }
             containerRefreshEnd();
-            directiveRefresh(1, 0);
-            directiveRefresh(4, 3);
             embeddedViewEnd();
           }
         }
@@ -1766,13 +1675,10 @@ describe('lifecycles', () => {
                 }
                 elementProperty(0, 'val', bind(j));
                 Comp.ngComponentDef.h(1, 0);
-                directiveRefresh(1, 0);
                 embeddedViewEnd();
               }
             }
             containerRefreshEnd();
-            directiveRefresh(1, 0);
-            directiveRefresh(4, 3);
             embeddedViewEnd();
           }
         }
@@ -1841,7 +1747,6 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Comp.ngComponentDef.h(3, 2);
-            directiveRefresh(3, 2);
             embeddedViewEnd();
           }
         }
@@ -1891,8 +1796,6 @@ describe('lifecycles', () => {
             }
             Comp.ngComponentDef.h(1, 0);
             Directive.ngDirectiveDef.h(2, 0);
-            directiveRefresh(1, 0);
-            directiveRefresh(2, 0);
             embeddedViewEnd();
           }
         }
@@ -1926,7 +1829,6 @@ describe('lifecycles', () => {
               elementEnd();
             }
             Directive.ngDirectiveDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -1963,7 +1865,6 @@ describe('lifecycles', () => {
       elementProperty(0, 'val1', bind(ctx.a));
       elementProperty(0, 'publicName', bind(ctx.b));
       Comp.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     });
     const ProjectedComp = createOnChangesComponent('projected', (ctx: any, cm: boolean) => {
       if (cm) {
@@ -2021,7 +1922,6 @@ describe('lifecycles', () => {
         elementProperty(0, 'val1', bind(ctx.val1));
         elementProperty(0, 'publicName', bind(ctx.val2));
         Comp.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {val1: '1', val2: 'a'});
@@ -2048,7 +1948,6 @@ describe('lifecycles', () => {
         elementProperty(0, 'val1', bind(ctx.val1));
         elementProperty(0, 'publicName', bind(ctx.val2));
         Parent.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {val1: '1', val2: 'a'});
@@ -2079,8 +1978,6 @@ describe('lifecycles', () => {
         elementProperty(2, 'publicName', bind(2));
         Parent.ngComponentDef.h(1, 0);
         Parent.ngComponentDef.h(3, 2);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -2114,7 +2011,6 @@ describe('lifecycles', () => {
             elementProperty(0, 'val1', bind(1));
             elementProperty(0, 'publicName', bind(1));
             Comp.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
@@ -2152,8 +2048,6 @@ describe('lifecycles', () => {
         elementProperty(2, 'publicName', bind(2));
         Comp.ngComponentDef.h(1, 0);
         ProjectedComp.ngComponentDef.h(3, 2);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -2193,10 +2087,6 @@ describe('lifecycles', () => {
         ProjectedComp.ngComponentDef.h(3, 2);
         Comp.ngComponentDef.h(5, 4);
         ProjectedComp.ngComponentDef.h(7, 6);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
-        directiveRefresh(5, 4);
-        directiveRefresh(7, 6);
       }
 
       renderToHtml(Template, {});
@@ -2218,7 +2108,6 @@ describe('lifecycles', () => {
         elementProperty(0, 'val1', bind(1));
         elementProperty(0, 'publicName', bind(1));
         Comp.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -2243,7 +2132,6 @@ describe('lifecycles', () => {
         elementProperty(0, 'val1', bind(1));
         elementProperty(0, 'publicName', bind(1));
         Directive.ngDirectiveDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -2286,13 +2174,10 @@ describe('lifecycles', () => {
             elementProperty(0, 'val1', bind(j));
             elementProperty(0, 'publicName', bind(j));
             Comp.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
         containerRefreshEnd();
-        directiveRefresh(1, 0);
-        directiveRefresh(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -2341,13 +2226,10 @@ describe('lifecycles', () => {
             elementProperty(0, 'val1', bind(j));
             elementProperty(0, 'publicName', bind(j));
             Parent.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }
         containerRefreshEnd();
-        directiveRefresh(1, 0);
-        directiveRefresh(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -2419,8 +2301,6 @@ describe('lifecycles', () => {
         elementProperty(2, 'val', 2);
         Comp.ngComponentDef.h(1, 0);
         Comp.ngComponentDef.h(3, 2);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -2449,7 +2329,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val', bind(ctx.val));
         Comp.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       });
 
       /**
@@ -2467,8 +2346,6 @@ describe('lifecycles', () => {
         elementProperty(2, 'val', 2);
         Parent.ngComponentDef.h(1, 0);
         Parent.ngComponentDef.h(3, 2);
-        directiveRefresh(1, 0);
-        directiveRefresh(3, 2);
       }
 
       renderToHtml(Template, {});

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {defineComponent, defineDirective} from '../../src/render3/index';
-import {container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, listener, text} from '../../src/render3/instructions';
+import {container, containerRefreshEnd, containerRefreshStart, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, listener, text} from '../../src/render3/instructions';
 
 import {getRendererFactory2} from './imported_renderer2';
 import {containerEl, renderComponent, renderToHtml} from './render_util';
@@ -250,7 +250,6 @@ describe('event listeners', () => {
         elementEnd();
       }
       HostListenerDir.ngDirectiveDef.h(1, 0);
-      directiveRefresh(1, 0);
     }
 
     renderToHtml(Template, {});
@@ -346,8 +345,6 @@ describe('event listeners', () => {
           }
           MyComp.ngComponentDef.h(2, 1);
           MyComp.ngComponentDef.h(4, 3);
-          directiveRefresh(2, 1);
-          directiveRefresh(4, 3);
           embeddedViewEnd();
         }
       }

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -9,7 +9,7 @@
 import {EventEmitter} from '@angular/core';
 
 import {defineComponent, defineDirective} from '../../src/render3/index';
-import {bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, listener, text} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, listener, text} from '../../src/render3/instructions';
 
 import {containerEl, renderToHtml} from './render_util';
 
@@ -52,7 +52,6 @@ describe('outputs', () => {
         elementEnd();
       }
       ButtonToggle.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     }
 
     let counter = 0;
@@ -78,7 +77,6 @@ describe('outputs', () => {
         elementEnd();
       }
       ButtonToggle.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     }
 
     let counter = 0;
@@ -104,7 +102,6 @@ describe('outputs', () => {
         elementEnd();
       }
       ButtonToggle.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     }
 
     const ctx = {counter: 0};
@@ -140,7 +137,6 @@ describe('outputs', () => {
             elementEnd();
           }
           ButtonToggle.ngComponentDef.h(1, 0);
-          directiveRefresh(1, 0);
           embeddedViewEnd();
         }
       }
@@ -192,7 +188,6 @@ describe('outputs', () => {
                 elementEnd();
               }
               ButtonToggle.ngComponentDef.h(1, 0);
-              directiveRefresh(1, 0);
               embeddedViewEnd();
             }
           }
@@ -263,8 +258,6 @@ describe('outputs', () => {
           }
           ButtonToggle.ngComponentDef.h(3, 2);
           DestroyComp.ngComponentDef.h(5, 4);
-          directiveRefresh(3, 2);
-          directiveRefresh(5, 4);
           embeddedViewEnd();
         }
       }
@@ -341,7 +334,6 @@ describe('outputs', () => {
         elementEnd();
       }
       ButtonToggle.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     }
 
     let counter = 0;
@@ -375,7 +367,6 @@ describe('outputs', () => {
       }
       elementProperty(0, 'change', bind(ctx.change));
       ButtonToggle.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     }
 
     let counter = 0;
@@ -420,7 +411,6 @@ describe('outputs', () => {
             elementEnd();
           }
           ButtonToggle.ngComponentDef.h(1, 0);
-          directiveRefresh(1, 0);
           embeddedViewEnd();
         } else {
           if (embeddedViewStart(1)) {

--- a/packages/core/test/render3/pipe_spec.ts
+++ b/packages/core/test/render3/pipe_spec.ts
@@ -10,7 +10,7 @@ import {Directive, OnChanges, OnDestroy, Pipe, PipeTransform, SimpleChange, Simp
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 import {NgOnChangesFeature, defineComponent, defineDirective, definePipe} from '../../src/render3/definition';
-import {bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, interpolation1, load, text, textBinding} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, interpolation1, load, text, textBinding} from '../../src/render3/instructions';
 import {pipe, pipeBind1, pipeBind3, pipeBind4, pipeBindV} from '../../src/render3/pipe';
 
 import {RenderLog, getRendererFactory2, patchLoggingRenderer2} from './imported_renderer2';
@@ -73,7 +73,6 @@ describe('pipe', () => {
       }
       MyDir.ngDirectiveDef.h(1, 0);
       elementProperty(0, 'elprop', bind(pipeBind1(2, ctx)));
-      directiveRefresh(1, 0);
       directive = load(1);
     }
     renderToHtml(Template, 'a');

--- a/packages/core/test/render3/properties_spec.ts
+++ b/packages/core/test/render3/properties_spec.ts
@@ -9,7 +9,7 @@
 import {EventEmitter} from '@angular/core';
 
 import {defineComponent, defineDirective} from '../../src/render3/index';
-import {NO_CHANGE, bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, interpolation1, listener, load, text, textBinding} from '../../src/render3/instructions';
+import {NO_CHANGE, bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, interpolation1, listener, load, text, textBinding} from '../../src/render3/instructions';
 
 import {renderToHtml} from './render_util';
 
@@ -157,7 +157,6 @@ describe('elementProperty', () => {
         }
         elementProperty(0, 'id', bind(ctx.id));
         Comp.ngComponentDef.h(1, 0);
-        directiveRefresh(1, 0);
       }
 
       expect(renderToHtml(Template, {id: 1})).toEqual(`<comp></comp>`);
@@ -502,7 +501,6 @@ describe('elementProperty', () => {
               elementEnd();
             }
             Comp.ngComponentDef.h(1, 0);
-            directiveRefresh(1, 0);
             embeddedViewEnd();
           }
         }

--- a/packages/core/test/render3/pure_function_spec.ts
+++ b/packages/core/test/render3/pure_function_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {defineComponent} from '../../src/render3/index';
-import {bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, load} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, load} from '../../src/render3/instructions';
 import {pureFunction1, pureFunction2, pureFunction3, pureFunction4, pureFunction5, pureFunction6, pureFunction7, pureFunction8, pureFunctionV} from '../../src/render3/pure_function';
 import {renderToHtml} from '../../test/render3/render_util';
 
@@ -36,7 +36,6 @@ describe('array literals', () => {
       }
       elementProperty(0, 'names', bind(pureFunction1(e0_ff, ctx.customName)));
       MyComp.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     }
 
     renderToHtml(Template, {customName: 'Carson'});
@@ -91,7 +90,6 @@ describe('array literals', () => {
       elementProperty(0, 'names1', bind(pureFunction1(e0_ff, ctx.customName)));
       elementProperty(0, 'names2', bind(pureFunction1(e0_ff_1, ctx.customName2)));
       ManyPropComp.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     }
 
     renderToHtml(Template, {customName: 'Carson', customName2: 'George'});
@@ -129,7 +127,6 @@ describe('array literals', () => {
           }
           elementProperty(0, 'names', bind(ctx.someFn(pureFunction1(e0_ff, ctx.customName))));
           MyComp.ngComponentDef.h(1, 0);
-          directiveRefresh(1, 0);
         }
       });
     }
@@ -143,8 +140,6 @@ describe('array literals', () => {
       }
       ParentComp.ngComponentDef.h(1, 0);
       ParentComp.ngComponentDef.h(3, 2);
-      directiveRefresh(1, 0);
-      directiveRefresh(3, 2);
     }
 
     renderToHtml(Template, {});
@@ -172,7 +167,6 @@ describe('array literals', () => {
       }
       elementProperty(0, 'names', bind(pureFunction2(e0_ff, ctx.customName, ctx.customName2)));
       MyComp.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     }
 
     renderToHtml(Template, {customName: 'Carson', customName2: 'Hannah'});
@@ -255,12 +249,6 @@ describe('array literals', () => {
       MyComp.ngComponentDef.h(7, 6);
       MyComp.ngComponentDef.h(9, 8);
       MyComp.ngComponentDef.h(11, 10);
-      directiveRefresh(1, 0);
-      directiveRefresh(3, 2);
-      directiveRefresh(5, 4);
-      directiveRefresh(7, 6);
-      directiveRefresh(9, 8);
-      directiveRefresh(11, 10);
     }
 
     renderToHtml(Template, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']);
@@ -308,7 +296,6 @@ describe('array literals', () => {
                         c[0], c[1], c[2], c[3], pureFunction1(e0_ff_1, c[4]), c[5], c[6], c[7], c[8]
                       ])));
       MyComp.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     }
 
     expect(myComp !.names).toEqual([
@@ -353,7 +340,6 @@ describe('object literals', () => {
       }
       elementProperty(0, 'config', bind(pureFunction1(e0_ff, ctx.name)));
       ObjectComp.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     }
 
     renderToHtml(Template, {name: 'slide'});
@@ -391,7 +377,6 @@ describe('object literals', () => {
           bind(pureFunction2(
               e0_ff, ctx.name, pureFunction1(e0_ff_1, pureFunction1(e0_ff_2, ctx.duration)))));
       ObjectComp.ngComponentDef.h(1, 0);
-      directiveRefresh(1, 0);
     }
 
     renderToHtml(Template, {name: 'slide', duration: 100});
@@ -459,7 +444,6 @@ describe('object literals', () => {
               0, 'config',
               bind(pureFunction2(e0_ff, ctx.configs[i].opacity, ctx.configs[i].duration)));
           ObjectComp.ngComponentDef.h(1, 0);
-          directiveRefresh(1, 0);
           embeddedViewEnd();
         }
       }

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -11,7 +11,7 @@ import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/brow
 
 import {RendererType2, ViewEncapsulation} from '../../src/core';
 import {defineComponent, detectChanges} from '../../src/render3/index';
-import {bind, directiveRefresh, elementEnd, elementProperty, elementStart, listener, text, tick} from '../../src/render3/instructions';
+import {bind, elementEnd, elementProperty, elementStart, listener, text, tick} from '../../src/render3/instructions';
 import {createRendererType2} from '../../src/view/index';
 
 import {getAnimationRendererFactory2, getRendererFactory2} from './imported_renderer2';
@@ -68,7 +68,6 @@ describe('renderer factory lifecycle', () => {
       elementEnd();
     }
     SomeComponent.ngComponentDef.h(2, 1);
-    directiveRefresh(2, 1);
   }
 
   beforeEach(() => { logs = []; });

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -8,7 +8,7 @@
 
 import {TemplateRef, ViewContainerRef} from '../../src/core';
 import {defineComponent, defineDirective, injectTemplateRef, injectViewContainerRef} from '../../src/render3/index';
-import {bind, container, containerRefreshEnd, containerRefreshStart, directiveRefresh, load, text, textBinding} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, load, text, textBinding} from '../../src/render3/instructions';
 
 import {renderComponent, toHtml} from './render_util';
 
@@ -42,7 +42,6 @@ describe('ViewContainerRef', () => {
         containerRefreshStart(0);
         cmp.testDir = load<TestDirective>(1);
         TestDirective.ngDirectiveDef.h(1, 0);
-        directiveRefresh(1, 0);
         containerRefreshEnd();
       },
     });


### PR DESCRIPTION
This PR refactors ivy to remove `directiveRefresh` instructions from the template (instead calling for refresh at view end). This should save us quite a bit of generated code (8 bytes per directive instance).