### PR TITLE
fix(ivy): Update rollup rule to prevent inlining symbols in debug.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,9 +2,9 @@ workspace(name = "angular")
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    url = "https://github.com/bazelbuild/rules_nodejs/archive/0.5.1.zip",
-    strip_prefix = "rules_nodejs-0.5.1",
-    sha256 = "dabd1a596a6f00939875762dcb1de93b5ada0515069244198aa6792bc37bb92a",
+    url = "https://github.com/bazelbuild/rules_nodejs/archive/f03c8b5df155da2a640b6775afdd4fe4aa6fec72.zip",
+    strip_prefix = "rules_nodejs-f03c8b5df155da2a640b6775afdd4fe4aa6fec72",
+    sha256 = "9d541f49af8cf60c73efb102186bfa5670ee190a088ce52638dcdf90cd9e2de6",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories")

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -6,13 +6,22 @@
     "name": "EMPTY$1"
   },
   {
+    "name": "EMPTY_RENDERER_TYPE_ID"
+  },
+  {
     "name": "NG_HOST_SYMBOL"
+  },
+  {
+    "name": "NG_PROJECT_AS_ATTR_NAME"
   },
   {
     "name": "NO_CHANGE"
   },
   {
     "name": "Symbol$1"
+  },
+  {
+    "name": "UNDEFINED_RENDERER_TYPE_ID"
   },
   {
     "name": "__global$1"
@@ -33,6 +42,15 @@
     "name": "_root"
   },
   {
+    "name": "appendChild"
+  },
+  {
+    "name": "bindingUpdated"
+  },
+  {
+    "name": "callHooks"
+  },
+  {
     "name": "canInsertNativeNode"
   },
   {
@@ -45,7 +63,22 @@
     "name": "createLView"
   },
   {
+    "name": "createTView"
+  },
+  {
     "name": "currentView"
+  },
+  {
+    "name": "defineComponent"
+  },
+  {
+    "name": "detectChangesInternal"
+  },
+  {
+    "name": "directiveCreate"
+  },
+  {
+    "name": "directiveRefresh"
   },
   {
     "name": "domRendererFactory3"
@@ -54,10 +87,22 @@
     "name": "enterView"
   },
   {
+    "name": "executeContentHooks"
+  },
+  {
     "name": "executeHooks"
   },
   {
+    "name": "executeInitHooks"
+  },
+  {
     "name": "findFirstRNode"
+  },
+  {
+    "name": "findNextRNodeSibling"
+  },
+  {
+    "name": "generateInitialInputs"
   },
   {
     "name": "getDirectiveInstance"
@@ -69,7 +114,34 @@
     "name": "getNextOrParentSiblingNode"
   },
   {
+    "name": "getOrCreateTView"
+  },
+  {
+    "name": "getRootView"
+  },
+  {
+    "name": "getSymbolObservable"
+  },
+  {
+    "name": "hostElement"
+  },
+  {
+    "name": "initBindings"
+  },
+  {
+    "name": "initChangeDetectorIfExisting"
+  },
+  {
+    "name": "insertChild"
+  },
+  {
+    "name": "interpolation1"
+  },
+  {
     "name": "invertObject"
+  },
+  {
+    "name": "isDifferent"
   },
   {
     "name": "isProceduralRenderer"
@@ -84,7 +156,13 @@
     "name": "noop$2"
   },
   {
+    "name": "queueInitHooks"
+  },
+  {
     "name": "refreshDynamicChildren"
+  },
+  {
+    "name": "renderComponent"
   },
   {
     "name": "renderComponentOrTemplate"
@@ -93,6 +171,36 @@
     "name": "renderEmbeddedTemplate"
   },
   {
+    "name": "resetApplicationState"
+  },
+  {
+    "name": "resolveRendererType2"
+  },
+  {
+    "name": "setInputsFromAttrs"
+  },
+  {
+    "name": "setUpAttributes"
+  },
+  {
     "name": "stringify$1"
+  },
+  {
+    "name": "symbolIteratorPonyfill"
+  },
+  {
+    "name": "text"
+  },
+  {
+    "name": "textBinding"
+  },
+  {
+    "name": "throwErrorIfNoChangesMode"
+  },
+  {
+    "name": "tick"
+  },
+  {
+    "name": "viewAttached"
   }
 ]


### PR DESCRIPTION
The new rollup rule disables inlining symbols in debug mode. This makes 
it look as if there would be more symbols but in reality these are the
symbols which are no longer being inlined.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
