### PR TITLE
fix(upgrade): propagate return value of resumeBootstrap

### DIFF
--- a/packages/upgrade/src/dynamic/upgrade_adapter.ts
+++ b/packages/upgrade/src/dynamic/upgrade_adapter.ts
@@ -389,8 +389,9 @@ export class UpgradeAdapter {
         const originalResumeBootstrap: () => void = windowAngular.resumeBootstrap;
         windowAngular.resumeBootstrap = function() {
           windowAngular.resumeBootstrap = originalResumeBootstrap;
-          windowAngular.resumeBootstrap.apply(this, arguments);
+          const r = windowAngular.resumeBootstrap.apply(this, arguments);
           resolve();
+          return r;
         };
       } else {
         resolve();

--- a/packages/upgrade/src/static/upgrade_module.ts
+++ b/packages/upgrade/src/static/upgrade_module.ts
@@ -268,7 +268,7 @@ export class UpgradeModule {
       windowAngular.resumeBootstrap = function() {
         let args = arguments;
         windowAngular.resumeBootstrap = originalResumeBootstrap;
-        ngZone.run(() => { windowAngular.resumeBootstrap.apply(this, args); });
+        return ngZone.run(() => windowAngular.resumeBootstrap.apply(this, args));
       };
     }
   }

--- a/packages/upgrade/test/dynamic/upgrade_spec.ts
+++ b/packages/upgrade/test/dynamic/upgrade_spec.ts
@@ -2909,6 +2909,29 @@ withEachNg1Version(() => {
            }, 100);
          }));
 
+      it('should propagate return value of resumeBootstrap', fakeAsync(() => {
+           @NgModule({imports: [BrowserModule]})
+           class MyNg2Module {
+           }
+
+           const adapter: UpgradeAdapter = new UpgradeAdapter(MyNg2Module);
+           const ng1Module = angular.module('ng1', []);
+           let a1Injector: angular.IInjectorService|undefined;
+           ng1Module.run([
+             '$injector', function($injector: angular.IInjectorService) { a1Injector = $injector; }
+           ]);
+
+           const element = html('<div></div>');
+           window.name = 'NG_DEFER_BOOTSTRAP!' + window.name;
+
+           adapter.bootstrap(element, [ng1Module.name]).ready((ref) => { ref.dispose(); });
+
+           tick(100);
+
+           const value = (<any>window).angular.resumeBootstrap();
+           expect(value).toBe(a1Injector);
+         }));
+
       it('should wait for ng2 testability', async(() => {
            @NgModule({imports: [BrowserModule]})
            class MyNg2Module {

--- a/packages/upgrade/test/static/integration/testability_spec.ts
+++ b/packages/upgrade/test/static/integration/testability_spec.ts
@@ -8,7 +8,7 @@
 
 import {NgModule, Testability, destroyPlatform} from '@angular/core';
 import {NgZone} from '@angular/core/src/zone/ng_zone';
-import {fakeAsync, tick} from '@angular/core/testing';
+import {fakeAsync, flush, tick} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {UpgradeModule} from '@angular/upgrade/static';
@@ -46,6 +46,25 @@ withEachNg1Version(() => {
          tick(100);
          expect(applicationRunning).toEqual(true);
          expect(stayedInTheZone).toEqual(true);
+       }));
+
+    it('should propagate return value of resumeBootstrap', fakeAsync(() => {
+         const ng1Module = angular.module('ng1', []);
+         let a1Injector: angular.IInjectorService|undefined;
+         ng1Module.run([
+           '$injector', function($injector: angular.IInjectorService) { a1Injector = $injector; }
+         ]);
+         const element = html('<div></div>');
+         window.name = 'NG_DEFER_BOOTSTRAP!' + window.name;
+
+         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module);
+
+         tick(100);
+
+         const value = (<any>window).angular.resumeBootstrap();
+         expect(value).toBe(a1Injector);
+
+         flush();
        }));
 
     it('should wait for ng2 testability', fakeAsync(() => {


### PR DESCRIPTION
Fixes #22723 

I wonder of the same should be done for [the bootstrap call](https://github.com/jbedard/angular/blob/8aa5d194ecc882c691179c6635091e4e37d1ab08/packages/upgrade/src/static/upgrade_module.ts#L262)? That isn't quite the same since it isn't monkey-patching it, however `upgrade.bootstrap()` does replace `angular.bootstrap()` so consistent signatures would be nice. The dynamic version already [has a return value](https://github.com/jbedard/angular/blob/8aa5d194ecc882c691179c6635091e4e37d1ab08/packages/upgrade/src/dynamic/upgrade_adapter.ts#L406), but maybe that inconsistency wouldn't matter since it is deprecated.