### PR TITLE
fix(bazel): correct expected outs for external sources in ng_module

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -37,8 +37,12 @@ def _expected_outs(ctx):
   for src in ctx.files.srcs + ctx.files.assets:
     package_prefix = ctx.label.package + "/" if ctx.label.package else ""
 
-    if src.short_path.endswith(".ts") and not src.short_path.endswith(".d.ts"):
-      basename = src.short_path[len(package_prefix):-len(".ts")]
+    # Strip external repository name from path if src is from external repository
+    # If src is from external repository, it's short_path will be ../<external_repo_name>/...
+    short_path = src.short_path if src.short_path[0:2] != ".." else "/".join(src.short_path.split("/")[2:])
+
+    if short_path.endswith(".ts") and not short_path.endswith(".d.ts"):
+      basename = short_path[len(package_prefix):-len(".ts")]
       if len(factory_basename_set) == 0 or basename in factory_basename_set:
         devmode_js = [
             ".ngfactory.js",
@@ -49,8 +53,8 @@ def _expected_outs(ctx):
       else:
         devmode_js = [".js"]
         summaries = []
-    elif src.short_path.endswith(".css"):
-      basename = src.short_path[len(package_prefix):-len(".css")]
+    elif short_path.endswith(".css"):
+      basename = short_path[len(package_prefix):-len(".css")]
       devmode_js = [
           ".css.shim.ngstyle.js",
           ".css.ngstyle.js",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
ng_module rule does not compute correct expected_outs for external repository sources.

Issue Number: #22613 
(Note: this PR replaces #22659)

/cc @alexeagle 

I tried adding a test for this but could not find a way to have a local_repository use the ng_module rule in the parent repository.

The failure can be reproduced on this branch of angular-bazel-example: https://github.com/gregmagolan/angular-bazel-example/tree/ng_module_module_name_bug

```
bazel run @yarn//:yarn
bazel build //src:src_with_ng_module
```

The failure seen is:

```
greg@Gregs-MacBook-Pro angular-bazel-example (ng_module_module_name_bug) $ bazel build //src:src_with_ng_module
Warning: failed to raise resource limit 8 to 524288: Invalid argument
.................
ERROR: /private/var/tmp/_bazel_greg/2c2a834fcea131eff2d962ffe20e1c87/external/external_rule/BUILD.bazel:15:1: in ng_module rule @external_rule//:ng_module: 
Traceback (most recent call last):
	File "/private/var/tmp/_bazel_greg/2c2a834fcea131eff2d962ffe20e1c87/external/external_rule/BUILD.bazel", line 15
		ng_module(name = 'ng_module')
	File "/private/var/tmp/_bazel_greg/2c2a834fcea131eff2d962ffe20e1c87/external/angular/src/ng_module.bzl", line 325, in _ng_module_impl
		ts_providers_dict_to_struct(ng_module_impl(ctx, compile_ts))
	File "/private/var/tmp/_bazel_greg/2c2a834fcea131eff2d962ffe20e1c87/external/angular/src/ng_module.bzl", line 325, in ts_providers_dict_to_struct
		ng_module_impl(ctx, compile_ts)
	File "/private/var/tmp/_bazel_greg/2c2a834fcea131eff2d962ffe20e1c87/external/angular/src/ng_module.bzl", line 300, in ng_module_impl
		ts_compile_actions(ctx, is_library = True, compile_acti..., <3 more arguments>)
	File "/private/var/tmp/_bazel_greg/2c2a834fcea131eff2d962ffe20e1c87/external/build_bazel_rules_typescript/internal/common/compilation.bzl", line 191, in ts_compile_actions
		outputs(ctx, ctx.label)
	File "/private/var/tmp/_bazel_greg/2c2a834fcea131eff2d962ffe20e1c87/external/angular/src/ng_module.bzl", line 242, in outputs
		_expected_outs(ctx)
	File "/private/var/tmp/_bazel_greg/2c2a834fcea131eff2d962ffe20e1c87/external/angular/src/ng_module.bzl", line 67, in _expected_outs
		ctx.new_file(ctx.bin_dir, (basename + ext))
external/external_rule/../external_rule/index.ngfactory.js
ERROR: Analysis of target '//src:src_with_ng_module' failed; build aborted: Analysis of target '@external_rule//:ng_module' failed; build aborted
INFO: Elapsed time: 31.525s
FAILED: Build did NOT complete successfully (27 packages loaded)
```

Notice that the expected out file for index.ts in the `external_rule` local_repository is `external/external_rule/../external_rule/index.ngfactory.js`. It should be `external/external_rule/index.ngfactory.js`.

## What is the new behavior?

ng_module rule expected outs fixed to handle sources from external repository. If the source starts with `..` then the external repository name is dropped. In the above example, the expected out is correctly resolved to `external/external_rule/index.ngfactory.js`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
## Other information
