### PR TITLE
fix(bazel): re-export angular summaries for empty & non-empty ts_library rules in collect summaries aspect

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -101,11 +101,11 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
 def _collect_summaries_aspect_impl(target, ctx):
   results = depset(target.angular.summaries if hasattr(target, "angular") else [])
 
-  # If we are visiting empty-srcs ts_library, this is a re-export
+  # If we are visiting an empty-srcs or non-empty-srcs ts_library or an empty-srcs
+  # ng_module rule, this is a re-export. See https://github.com/angular/angular/issues/22612
+  # "re-export" rules should expose all the angular summary files of their deps
   srcs = ctx.rule.attr.srcs if hasattr(ctx.rule.attr, "srcs") else []
-
-  # "re-export" rules should expose all the files of their deps
-  if not srcs:
+  if not srcs or not hasattr(target, "angular"):
     for dep in ctx.rule.attr.deps:
       if (hasattr(dep, "angular")):
         results = depset(dep.angular.summaries, transitive = [results])


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
ng_module collect summaries aspect only exposes summary files of deps for ng_module targets without sources.

See issue: #22612

/cc @alexeagle

## What is the new behavior?
ng_module collect summaries aspect always exposes summary files of deps for ng_module targets.


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
