### PR TITLE
fix(compiler-cli): emit correct css string escape sequences

### DIFF
--- a/packages/compiler-cli/src/transformers/node_emitter.ts
+++ b/packages/compiler-cli/src/transformers/node_emitter.ts
@@ -150,13 +150,26 @@ function firstAfter<T>(a: T[], predicate: (value: T) => boolean) {
 // NodeEmitterVisitor
 type RecordedNode<T extends ts.Node = ts.Node> = (T & { __recorded: any; }) | null;
 
+function escapeDoubleQuotes(value: string): string {
+  return value.replace(/\"/g, '\\"');
+}
+
 function createLiteral(value: any) {
   if (value === null) {
     return ts.createNull();
   } else if (value === undefined) {
     return ts.createIdentifier('undefined');
   } else {
-    return ts.createLiteral(value);
+    const result = ts.createLiteral(value);
+    if (ts.isStringLiteral(result) && result.text.indexOf('\\') >= 0) {
+      // Hack to avoid problems cause indirectly by:
+      //    https://github.com/Microsoft/TypeScript/issues/20192
+      // This avoids the string escaping normally performed for a string relying on that
+      // TypeScript just emits the text raw for a numeric literal.
+      (result as any).kind = ts.SyntaxKind.NumericLiteral;
+      result.text = `"${escapeDoubleQuotes(result.text)}"`;
+    }
+    return result;
   }
 }
 

--- a/packages/compiler-cli/src/transformers/node_emitter.ts
+++ b/packages/compiler-cli/src/transformers/node_emitter.ts
@@ -151,7 +151,7 @@ function firstAfter<T>(a: T[], predicate: (value: T) => boolean) {
 type RecordedNode<T extends ts.Node = ts.Node> = (T & { __recorded: any; }) | null;
 
 function escapeDoubleQuotes(value: string): string {
-  return value.replace(/\"/g, '\\"');
+  return value.replace(/(\"|\\)/g, '\\$1');
 }
 
 function createLiteral(value: any) {

--- a/packages/compiler-cli/src/transformers/node_emitter.ts
+++ b/packages/compiler-cli/src/transformers/node_emitter.ts
@@ -150,8 +150,10 @@ function firstAfter<T>(a: T[], predicate: (value: T) => boolean) {
 // NodeEmitterVisitor
 type RecordedNode<T extends ts.Node = ts.Node> = (T & { __recorded: any; }) | null;
 
-function escapeDoubleQuotes(value: string): string {
-  return value.replace(/(\"|\\)/g, '\\$1');
+function escapeLiteral(value: string): string {
+  return value.replace(/(\"|\\)/g, '\\$1').replace(/(\n)|(\r)/g, function(v, n, r) {
+    return n ? '\\n' : '\\r';
+  });
 }
 
 function createLiteral(value: any) {
@@ -167,7 +169,7 @@ function createLiteral(value: any) {
       // This avoids the string escaping normally performed for a string relying on that
       // TypeScript just emits the text raw for a numeric literal.
       (result as any).kind = ts.SyntaxKind.NumericLiteral;
-      result.text = `"${escapeDoubleQuotes(result.text)}"`;
+      result.text = `"${escapeLiteral(result.text)}"`;
     }
     return result;
   }

--- a/packages/compiler-cli/test/transformers/node_emitter_spec.ts
+++ b/packages/compiler-cli/test/transformers/node_emitter_spec.ts
@@ -182,6 +182,8 @@ describe('TypeScriptNodeEmitter', () => {
     expect(emitStmt(o.literal('"some value"').toStmt())).toEqual('"\\"some value\\"";');
     expect(emitStmt(o.literal('"some \\0025BC value"').toStmt()))
         .toEqual('"\\"some \\\\0025BC value\\"";');
+    expect(emitStmt(o.literal('\n \\0025BC \n ').toStmt())).toEqual('"\\n \\\\0025BC \\n ";');
+    expect(emitStmt(o.literal('\r \\0025BC \r ').toStmt())).toEqual('"\\r \\\\0025BC \\r ";');
   });
 
   it('should support blank literals', () => {

--- a/packages/compiler-cli/test/transformers/node_emitter_spec.ts
+++ b/packages/compiler-cli/test/transformers/node_emitter_spec.ts
@@ -178,10 +178,10 @@ describe('TypeScriptNodeEmitter', () => {
         .toEqual(`({someKey:1,a:"a","b":"b","*":"star"});`);
 
     // Regressions #22774
-    expect(emitStmt(o.literal('\\\\0025BC').toStmt())).toEqual('"\\\\0025BC";');
+    expect(emitStmt(o.literal('\\0025BC').toStmt())).toEqual('"\\\\0025BC";');
     expect(emitStmt(o.literal('"some value"').toStmt())).toEqual('"\\"some value\\"";');
     expect(emitStmt(o.literal('"some \\0025BC value"').toStmt()))
-        .toEqual('"\\"some \\0025BC value\\"";');
+        .toEqual('"\\"some \\\\0025BC value\\"";');
   });
 
   it('should support blank literals', () => {

--- a/packages/compiler-cli/test/transformers/node_emitter_spec.ts
+++ b/packages/compiler-cli/test/transformers/node_emitter_spec.ts
@@ -176,6 +176,12 @@ describe('TypeScriptNodeEmitter', () => {
                      ]).toStmt())
                .replace(/\s+/gm, ''))
         .toEqual(`({someKey:1,a:"a","b":"b","*":"star"});`);
+
+    // Regressions #22774
+    expect(emitStmt(o.literal('\\\\0025BC').toStmt())).toEqual('"\\\\0025BC";');
+    expect(emitStmt(o.literal('"some value"').toStmt())).toEqual('"\\"some value\\"";');
+    expect(emitStmt(o.literal('"some \\0025BC value"').toStmt()))
+        .toEqual('"\\"some \\0025BC value\\"";');
   });
 
   it('should support blank literals', () => {


### PR DESCRIPTION
Works around an issue with TypeScript 2.6 and 2.7 that causes
the tranformer emit to emit incorrect escapes for css string
literals.

Fixes: #22774

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?

Issue Number: #22774

## What is the new behavior?

Bypasses TypeScript incorrect string escaping to produce the correct `.js` file.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
