### PR TITLE
feat(bazel): change ng_package rule to APF v6

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,9 +2,9 @@ workspace(name = "angular")
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    url = "https://github.com/bazelbuild/rules_nodejs/archive/f03c8b5df155da2a640b6775afdd4fe4aa6fec72.zip",
-    strip_prefix = "rules_nodejs-f03c8b5df155da2a640b6775afdd4fe4aa6fec72",
-    sha256 = "9d541f49af8cf60c73efb102186bfa5670ee190a088ce52638dcdf90cd9e2de6",
+    url = "https://github.com/bazelbuild/rules_nodejs/archive/0.5.3.zip",
+    strip_prefix = "rules_nodejs-0.5.3",
+    sha256 = "17a5515f59777b00cb25dbc710017a14273f825029b2ec60e0969d28914870be",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories")

--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -2,9 +2,9 @@ workspace(name = "bazel_integration_test")
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    url = "https://github.com/bazelbuild/rules_nodejs/archive/0.5.0.zip",
-    strip_prefix = "rules_nodejs-0.5.0",
-    sha256 = "06aabb253c3867d51724386ac5622a0a238bbd82e2c70ce1d09ee3ceac4c31d6",
+    url = "https://github.com/bazelbuild/rules_nodejs/archive/0.5.3.zip",
+    strip_prefix = "rules_nodejs-0.5.3",
+    sha256 = "17a5515f59777b00cb25dbc710017a14273f825029b2ec60e0969d28914870be",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")

--- a/packages/animations/BUILD.bazel
+++ b/packages/animations/BUILD.bazel
@@ -18,7 +18,11 @@ ng_module(
 
 ng_package(
     name = "npm_package",
-    srcs = ["package.json"],
+    srcs = [
+        "package.json",
+        "//packages/animations/browser:package.json",
+        "//packages/animations/browser/testing:package.json",
+    ],
     entry_point = "packages/animations/index.js",
     secondary_entry_points = [
         "browser",

--- a/packages/animations/browser/BUILD.bazel
+++ b/packages/animations/browser/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["package.json"])
+
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(

--- a/packages/animations/browser/testing/BUILD.bazel
+++ b/packages/animations/browser/testing/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["package.json"])
+
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(

--- a/packages/bazel/BUILD.bazel
+++ b/packages/bazel/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package")
+load("//tools:defaults.bzl", "npm_package")
 
 genrule(
     name = "workspace",
@@ -9,6 +9,7 @@ genrule(
 npm_package(
     name = "npm_package",
     srcs = [
+        "BUILD.bazel",
         "index.bzl",
         "package.json",
         "//packages/bazel/src:package_assets",
@@ -18,6 +19,5 @@ npm_package(
         "//packages/bazel/": "//",
         "angular/packages/bazel/": "angular/",
     },
-    stamp_data = "//tools:stamp_data",
     deps = [":workspace"],
 )

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -18,5 +18,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"
+  },
+  "ng-update": {
+    "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   }
 }

--- a/packages/bazel/src/esm5.bzl
+++ b/packages/bazel/src/esm5.bzl
@@ -77,6 +77,7 @@ def _esm5_outputs_aspect(target, ctx):
       arguments = [tsconfig.path],
       executable = target.typescript.replay_params.compiler,
       execution_requirements = {
+          # TODO(alexeagle): enable worker mode for these compilations
           "supports-workers": "0",
       },
   )

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -246,6 +246,7 @@ def _write_bundle_index(ctx):
   tsconfig_file = ctx.actions.declare_file("%s.tsconfig.json" % basename)
   metadata_file = ctx.actions.declare_file("%s.metadata.json" % basename)
   tstyping_file = ctx.actions.declare_file("%s.d.ts" % basename)
+  js_file = ctx.actions.declare_file("%s.js" % basename)
 
   tsconfig = dict(tsc_wrapped_tsconfig(ctx, ctx.files.srcs, ctx.files.srcs), **{
     "angularCompilerOptions": {
@@ -271,7 +272,7 @@ def _write_bundle_index(ctx):
 
   ctx.actions.write(tsconfig_file, json_marshal(tsconfig))
 
-  outputs = [metadata_file, tstyping_file]
+  outputs = [metadata_file, tstyping_file, js_file]
 
   ctx.action(
       progress_message = "Producing metadata for bundle %s" % ctx.label.name,

--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -11,6 +11,11 @@ load("@build_bazel_rules_nodejs//:internal/rollup/rollup_bundle.bzl",
      "rollup_module_mappings_aspect",
      "run_uglify",
      "ROLLUP_ATTRS")
+load("@build_bazel_rules_nodejs//:internal/npm_package/npm_package.bzl",
+     "NPM_PACKAGE_ATTRS",
+     "NPM_PACKAGE_OUTPUTS",
+     "create_package")
+load("@build_bazel_rules_nodejs//:internal/node.bzl", "sources_aspect")
 load("//packages/bazel/src:esm5.bzl", "esm5_outputs_aspect", "ESM5Info")
 
 # TODO(alexeagle): this list is incomplete, add more as material ramps up
@@ -198,10 +203,10 @@ def _rollup(ctx, rollup_config, entry_point, inputs, js_output, format = "es"):
   args.add(externals, join_with=",")
 
   other_inputs = [ctx.executable._rollup, rollup_config]
-  if ctx.file.stamp_data:
-    other_inputs.append(ctx.file.stamp_data)
   if ctx.file.license_banner:
     other_inputs.append(ctx.file.license_banner)
+  if ctx.file.stamp_data:
+    other_inputs.append(ctx.file.stamp_data)
   ctx.actions.run(
       progress_message = "Angular Packaging: rolling up %s" % ctx.label.name,
       mnemonic = "AngularPackageRollup",
@@ -220,12 +225,14 @@ def _rollup(ctx, rollup_config, entry_point, inputs, js_output, format = "es"):
 def _flatten_paths(directory):
   result = []
   for f in directory:
-    result.extend([f.js.path, f.map.path])
+    result.append(f.js.path)
+    if f.map:
+      result.append(f.map.path)
   return result
 
 # ng_package produces package that is npm-ready.
 def _ng_package_impl(ctx):
-  npm_package_directory = ctx.actions.declare_directory(ctx.label.name)
+  npm_package_directory = ctx.actions.declare_directory("%s.ng_pkg" % ctx.label.name)
 
   esm_2015_files = collect_es6_sources(ctx)
 
@@ -247,6 +254,15 @@ def _ng_package_impl(ctx):
   esm2015 = []
   esm5 = []
   bundles = []
+
+  # For Angular Package Format v6, we put all the individual .js files in the
+  # esm5/ and esm2015/ folders.
+  for f in esm5_sources.to_list():
+    if f.path.endswith(".js"):
+      esm5.append(struct(js = f, map = None))
+  for f in esm_2015_files.to_list():
+    if f.path.endswith(".js"):
+      esm2015.append(struct(js = f, map = None))
 
   for entry_point in [""] + ctx.attr.secondary_entry_points:
     es2015_entry_point = "/".join([p for p in [
@@ -279,8 +295,12 @@ def _ng_package_impl(ctx):
       min_output = ctx.outputs.umd_min
 
     config = write_rollup_config(ctx, [], root_dirs)
-    esm2015.append(_rollup(ctx, config, es2015_entry_point, esm_2015_files, fesm2015_output))
-    esm5.append(_rollup(ctx, config, es5_entry_point, esm5_sources, fesm5_output))
+
+    # Currently we don't include these rollup "FESM" files in the package.
+    # They are only accessible as named outputs from the rule.
+    _rollup(ctx, config, es2015_entry_point, esm_2015_files, fesm2015_output)
+    _rollup(ctx, config, es5_entry_point, esm5_sources, fesm5_output)
+
     bundles.append(_rollup(ctx, config, es5_entry_point, esm5_sources, umd_output, format = "umd"))
     uglify_sourcemap = run_uglify(ctx, umd_output, min_output,
         config_name = entry_point.replace("/", "_"))
@@ -294,20 +314,19 @@ def _ng_package_impl(ctx):
   args.use_param_file("%s", use_always = True)
   args.add(npm_package_directory.path)
   args.add(ctx.label.package)
+  args.add(primary_entry_point_name(ctx.attr.name, ctx.attr.entry_point))
+  args.add(ctx.attr.secondary_entry_points, join_with=",")
   args.add([ctx.bin_dir.path, ctx.label.package], join_with="/")
   args.add(ctx.file.readme_md.path if ctx.file.readme_md else "")
   args.add(_flatten_paths(esm2015), join_with=",")
   args.add(_flatten_paths(esm5), join_with=",")
   args.add(_flatten_paths(bundles), join_with=",")
   args.add([s.path for s in ctx.files.srcs], join_with=",")
-  args.add(ctx.file.stamp_data.path if ctx.file.stamp_data else "")
   args.add(ctx.file.license_banner.path if ctx.file.license_banner else "")
 
   other_inputs = (metadata_files.to_list() +
       [f.js for f in esm2015 + esm5 + bundles] +
-      [f.map for f in esm2015 + esm5 + bundles])
-  if ctx.file.stamp_data:
-    other_inputs.append(ctx.file.stamp_data)
+      [f.map for f in esm2015 + esm5 + bundles if f.map])
   if ctx.file.readme_md:
     other_inputs.append(ctx.file.readme_md)
   if ctx.file.license_banner:
@@ -323,24 +342,32 @@ def _ng_package_impl(ctx):
           ctx.files.srcs +
           other_inputs,
       outputs = [npm_package_directory],
-      executable = ctx.executable._packager,
+      executable = ctx.executable._ng_packager,
       arguments = [args],
   )
 
+  devfiles = depset()
+  if ctx.attr.include_devmode_srcs:
+    for d in ctx.attr.deps:
+      devfiles = depset(transitive = [devfiles, d.files, d.node_sources])
+
+  package_dir = create_package(ctx, devfiles.to_list(), [npm_package_directory])
   return struct(
-    files = depset([npm_package_directory])
+    files = depset([package_dir])
   )
 
-NG_PACKAGE_ATTRS = dict(ROLLUP_ATTRS, **{
+NG_PACKAGE_ATTRS = dict(NPM_PACKAGE_ATTRS, **dict(ROLLUP_ATTRS, **{
     "srcs": attr.label_list(allow_files = True),
     "deps": attr.label_list(aspects = [
         rollup_module_mappings_aspect,
         esm5_outputs_aspect,
+        sources_aspect,
     ]),
+    "include_devmode_srcs": attr.bool(default = False),
     "readme_md": attr.label(allow_single_file = FileType([".md"])),
     "globals": attr.string_dict(default={}),
     "secondary_entry_points": attr.string_list(),
-    "_packager": attr.label(
+    "_ng_packager": attr.label(
         default=Label("//packages/bazel/src/ng_package:packager"),
         executable=True, cfg="host"),
     "_rollup": attr.label(
@@ -352,22 +379,32 @@ NG_PACKAGE_ATTRS = dict(ROLLUP_ATTRS, **{
     "_uglify": attr.label(
         default=Label("@build_bazel_rules_nodejs//internal/rollup:uglify"),
         executable=True, cfg="host"),
-})
+}))
+
+# Angular wants these named after the entry_point,
+# eg. for //packages/core it looks like "packages/core/index.js", we want
+# core.js produced by this rule.
+# Currently we just borrow the entry point for this, if it looks like
+# some/path/to/my/package/index.js
+# we assume the files should be named "package.*.js"
+def primary_entry_point_name(name, entry_point):
+  return entry_point.split("/")[-2] if entry_point.find("/") >=0 else name
 
 def ng_package_outputs(name, entry_point):
-  # Angular wants these named after the entry_point,
-  # eg. for //packages/core it looks like "packages/core/index.js", we want
-  # core.js produced by this rule.
-  # Currently we just borrow the entry point for this, if it looks like
-  # some/path/to/my/package/index.js
-  # we assume the files should be named "package.*.js"
-  basename = entry_point.split("/")[-2] if entry_point.find("/") >=0 else name
-  return {
+  basename = primary_entry_point_name(name, entry_point)
+  outputs = {
       "fesm5": "fesm5/%s.js" % basename,
       "fesm2015": "fesm2015/%s.js" % basename,
       "umd": "%s.umd.js" % basename,
       "umd_min": "%s.umd.min.js" % basename,
   }
+  for key in NPM_PACKAGE_OUTPUTS:
+    # NPM_PACKAGE_OUTPUTS is a "normal" dict-valued outputs so it looks like
+    #  "pack": "%{name}.pack",
+    # But this is a function-valued outputs.
+    # Bazel won't replace the %{name} token so we have to do it.
+    outputs[key] = NPM_PACKAGE_OUTPUTS[key].replace("%{name}", name)
+  return outputs
 
 ng_package = rule(
     implementation = _ng_package_impl,

--- a/packages/bazel/test/ng_package/common_package.spec.ts
+++ b/packages/bazel/test/ng_package/common_package.spec.ts
@@ -6,12 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as fs from 'fs';
 import * as path from 'path';
 import * as shx from 'shelljs';
 
 shx.cd(path.join(process.env['TEST_SRCDIR'], 'angular', 'packages', 'common', 'npm_package'));
 
-describe('ng_package', () => {
+describe('@angular/common ng_package', () => {
   it('should have right bundle files', () => {
     expect(shx.ls('-R', 'bundles').stdout.split('\n').filter(n => !!n).sort()).toEqual([
       'common-http-testing.umd.js',
@@ -32,7 +33,8 @@ describe('ng_package', () => {
       'common.umd.min.js.map',
     ]);
   });
-  it('should have right fesm files', () => {
+  // FESMS currently not part of APF v6
+  xit('should have right fesm files', () => {
     const expected = [
       'common.js',
       'common.js.map',
@@ -46,5 +48,33 @@ describe('ng_package', () => {
     ];
     expect(shx.ls('-R', 'esm5').stdout.split('\n').filter(n => !!n).sort()).toEqual(expected);
     expect(shx.ls('-R', 'esm2015').stdout.split('\n').filter(n => !!n).sort()).toEqual(expected);
+  });
+  describe('should have module resolution properties in the package.json file for', () => {
+    // https://github.com/angular/common-builds/blob/master/package.json
+    it('/', () => {
+      const actual = JSON.parse(fs.readFileSync('package.json', {encoding: 'utf-8'}));
+      expect(actual['main']).toEqual('./bundles/common.umd.js');
+    });
+    // https://github.com/angular/common-builds/blob/master/http/package.json
+    it('/http', () => {
+      const actual = JSON.parse(fs.readFileSync('http/package.json', {encoding: 'utf-8'}));
+      expect(actual['main']).toEqual('../bundles/common-http.umd.js');
+      expect(actual['es2015']).toEqual('../esm2015/http/http.js');
+      expect(actual['module']).toEqual('../esm5/http/http.js');
+      expect(actual['typings']).toEqual('./http.d.ts');
+    });
+    // https://github.com/angular/common-builds/blob/master/testing/package.json
+    it('/testing', () => {
+      const actual = JSON.parse(fs.readFileSync('testing/package.json', {encoding: 'utf-8'}));
+      expect(actual['main']).toEqual('../bundles/common-testing.umd.js');
+    });
+    // https://github.com/angular/common-builds/blob/master/http/testing/package.json
+    it('/http/testing', () => {
+      const actual = JSON.parse(fs.readFileSync('http/testing/package.json', {encoding: 'utf-8'}));
+      expect(actual['main']).toEqual('../../bundles/common-http-testing.umd.js');
+      expect(actual['es2015']).toEqual('../../esm2015/http/testing/testing.js');
+      expect(actual['module']).toEqual('../../esm5/http/testing/testing.js');
+      expect(actual['typings']).toEqual('./testing.d.ts');
+    });
   });
 });

--- a/packages/bazel/test/ng_package/core_package.spec.ts
+++ b/packages/bazel/test/ng_package/core_package.spec.ts
@@ -26,7 +26,7 @@ function p(templateStringArray: TemplateStringsArray) {
 }
 
 
-describe('ng_package', () => {
+describe('@angular/core ng_package', () => {
 
   describe('misc root files', () => {
 
@@ -55,11 +55,16 @@ describe('ng_package', () => {
       });
 
       it('should contain module resolution mappings', () => {
-        const packageJson = 'package.json';
         expect(shx.grep('"main":', packageJson)).toContain(`./bundles/core.umd.js`);
         expect(shx.grep('"module":', packageJson)).toContain(`./esm5/core.js`);
         expect(shx.grep('"es2015":', packageJson)).toContain(`./esm2015/core.js`);
         expect(shx.grep('"typings":', packageJson)).toContain(`./core.d.ts`);
+      });
+
+      it('should contain metadata for ng update', () => {
+        expect(shx.cat(packageJson)).not.toContain('NG_UPDATE_PACKAGE_GROUP');
+        expect(JSON.parse(shx.cat(packageJson))['ng-update']['packageGroup'])
+            .toContain('@angular/core');
       });
     });
 
@@ -87,8 +92,8 @@ describe('ng_package', () => {
     });
 
 
-    describe('fesm15', () => {
-
+    // FESMS currently not part of APF v6
+    xdescribe('esm2015', () => {
       it('should have a fesm15 file in the /esm2015 directory',
          () => { expect(shx.cat('esm2015/core.js')).toContain(`export {`); });
 
@@ -98,23 +103,24 @@ describe('ng_package', () => {
       });
 
       it('should have the version info in the header', () => {
-        expect(shx.cat('esm2015/core.js'))
+        expect(shx.cat('esm2015/index.js'))
             .toMatch(/@license Angular v\d+\.\d+\.\d+(?!-PLACEHOLDER)/);
       });
     });
 
 
-    describe('fesm5', () => {
+    describe('esm5', () => {
 
-      it('should have a fesm5 file in the /esm5 directory',
-         () => { expect(shx.cat('esm5/core.js')).toContain(`export {`); });
-
-      it('should have a source map', () => {
+      // FESMS currently not part of APF v6
+      xit('should have a fesm5 file in the /esm5 directory',
+          () => { expect(shx.cat('esm5/core.js')).toContain(`export {`); });
+      // FESMS currently not part of APF v6
+      xit('should have a source map', () => {
         expect(shx.cat('esm5/core.js.map')).toContain(`{"version":3,"file":"core.js","sources":`);
       });
 
       it('should not be processed by tsickle', () => {
-        expect(shx.cat('esm5/core.js')).not.toContain('@fileoverview added by tsickle');
+        expect(shx.cat('esm5/index.js')).not.toContain('@fileoverview added by tsickle');
       });
     });
 
@@ -132,6 +138,11 @@ describe('ng_package', () => {
 
       it('should have a source map next to the minified umd file',
          () => { expect(shx.ls('bundles/core.umd.min.js.map').length).toBe(1, 'File not found'); });
+
+      it('should have the version info in the header', () => {
+        expect(shx.cat('bundles/core.umd.js'))
+            .toMatch(/@license Angular v\d+\.\d+\.\d+(?!-PLACEHOLDER)/);
+      });
     });
   });
 
@@ -146,14 +157,14 @@ describe('ng_package', () => {
       it('should have its module resolution mappings defined in the nested package.json', () => {
         const packageJson = p `testing/package.json`;
         expect(shx.grep('"main":', packageJson)).toContain(`../bundles/core-testing.umd.js`);
-        expect(shx.grep('"module":', packageJson)).toContain(`../esm5/testing.js`);
-        expect(shx.grep('"es2015":', packageJson)).toContain(`../esm2015/testing.js`);
+        expect(shx.grep('"module":', packageJson)).toContain(`../esm5/testing/testing.js`);
+        expect(shx.grep('"es2015":', packageJson)).toContain(`../esm2015/testing/testing.js`);
         expect(shx.grep('"typings":', packageJson)).toContain(`./testing.d.ts`);
       });
     });
 
     describe('typings', () => {
-      const typingsFile = p `testing/testing.d.ts`;
+      const typingsFile = p `testing/index.d.ts`;
       it('should have a typings file',
          () => { expect(shx.cat(typingsFile)).toContain('export * from \'./public_api\';'); });
     });
@@ -164,7 +175,7 @@ describe('ng_package', () => {
          () => { expect(shx.cat('testing.d.ts')).toContain(`export *`); });
 
       it('should have a \'actual\' d.ts file in the parent dir', () => {
-        expect(shx.cat('testing/testing.d.ts')).toContain(`export * from './public_api';`);
+        expect(shx.cat('testing/index.d.ts')).toContain(`export * from './public_api';`);
       });
     });
 
@@ -180,8 +191,8 @@ describe('ng_package', () => {
       });
     });
 
-    describe('fesm15', () => {
-
+    // FESMS currently not part of APF v6
+    xdescribe('esm2015', () => {
       it('should have a fesm15 file in the /esm2015 directory',
          () => { expect(shx.cat('esm2015/testing.js')).toContain(`export {`); });
 
@@ -191,12 +202,13 @@ describe('ng_package', () => {
       });
 
       it('should have the version info in the header', () => {
-        expect(shx.cat('esm2015/testing.js'))
+        expect(shx.cat('esm2015/index.js'))
             .toMatch(/@license Angular v\d+\.\d+\.\d+(?!-PLACEHOLDER)/);
       });
     });
 
-    describe('fesm5', () => {
+    // FESMS currently not part of APF v6
+    xdescribe('esm5', () => {
       it('should have a fesm5 file in the /esm5 directory',
          () => { expect(shx.cat('esm5/testing.js')).toContain(`export {`); });
 

--- a/packages/bazel/test/ng_package/example_package.spec.ts
+++ b/packages/bazel/test/ng_package/example_package.spec.ts
@@ -18,7 +18,7 @@ shx.cd(path.join(
     process.env['TEST_SRCDIR'], 'angular', 'packages', 'bazel', 'test', 'ng_package', 'example',
     'npm_package'));
 
-describe('ng_package', () => {
+describe('example ng_package', () => {
   it('should have right bundle files', () => {
     expect(shx.ls('-R', 'bundles').stdout.split('\n').filter(n => !!n).sort()).toEqual([
       'example-secondary.umd.js',
@@ -31,7 +31,8 @@ describe('ng_package', () => {
       'example.umd.min.js.map',
     ]);
   });
-  it('should have right fesm files', () => {
+  // FESMS currently not part of APF v6
+  xit('should have right fesm files', () => {
     const expected = [
       'example.js',
       'example.js.map',
@@ -61,8 +62,8 @@ describe('ng_package', () => {
   it('should have secondary entry point package.json properties set', () => {
     const packageJson = JSON.parse(fs.readFileSync(path.join('secondary', 'package.json'), UTF8));
     expect(packageJson['main']).toBe('../bundles/example-secondary.umd.js');
-    expect(packageJson['module']).toBe('../esm5/secondary.js');
-    expect(packageJson['es2015']).toBe('../esm2015/secondary.js');
+    expect(packageJson['module']).toBe('../esm5/secondary/secondary.js');
+    expect(packageJson['es2015']).toBe('../esm2015/secondary/secondary.js');
     expect(packageJson['typings']).toBe('./secondary.d.ts');
   });
 });

--- a/packages/common/BUILD.bazel
+++ b/packages/common/BUILD.bazel
@@ -19,7 +19,12 @@ ng_module(
 
 ng_package(
     name = "npm_package",
-    srcs = ["package.json"],
+    srcs = [
+        "package.json",
+        "//packages/common/http:package.json",
+        "//packages/common/http/testing:package.json",
+        "//packages/common/testing:package.json",
+    ],
     entry_point = "packages/common/index.js",
     secondary_entry_points = [
         "testing",

--- a/packages/common/http/BUILD.bazel
+++ b/packages/common/http/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["package.json"])
+
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(

--- a/packages/common/http/testing/BUILD.bazel
+++ b/packages/common/http/testing/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["package.json"])
+
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(

--- a/packages/common/testing/BUILD.bazel
+++ b/packages/common/testing/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["package.json"])
+
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(

--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -1,5 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
+load("//tools:defaults.bzl", "npm_package")
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_library", "ts_config")
 
 ts_config(
@@ -16,7 +17,6 @@ ts_library(
             "src/**/*.ts",
         ],
         exclude = [
-            "src/extract_i18n.ts",
             "src/integrationtest/**/*.ts",
         ],
     ),
@@ -26,4 +26,12 @@ ts_library(
     deps = [
         "//packages/compiler",
     ],
+)
+
+npm_package(
+    name = "npm_package",
+    srcs = [
+        "package.json",
+    ],
+    deps = [":compiler-cli"],
 )

--- a/packages/compiler/BUILD.bazel
+++ b/packages/compiler/BUILD.bazel
@@ -11,12 +11,17 @@ ts_library(
         ],
     ),
     module_name = "@angular/compiler",
+    # module_root = "index.d.ts",
 )
 
 ng_package(
     name = "npm_package",
-    srcs = ["package.json"],
+    srcs = [
+        "package.json",
+        "//packages/compiler/testing:package.json",
+    ],
     entry_point = "packages/compiler/compiler.js",
+    include_devmode_srcs = True,
     secondary_entry_points = [
         "testing",
     ],

--- a/packages/compiler/testing/BUILD.bazel
+++ b/packages/compiler/testing/BUILD.bazel
@@ -1,13 +1,19 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
+exports_files(["package.json"])
 
-ts_library(
+load("//tools:defaults.bzl", "ng_module")
+
+ng_module(
     name = "testing",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["testing.ts"],
+    ),
     module_name = "@angular/compiler/testing",
     deps = [
         "//packages:types",
         "//packages/compiler",
+        "//packages/core",
     ],
 )

--- a/packages/compiler/testing/index.ts
+++ b/packages/compiler/testing/index.ts
@@ -11,4 +11,4 @@
 // replaces this file with production index.ts when it rewrites private symbol
 // names.
 
-export * from './testing';
+export * from './public_api';

--- a/packages/core/BUILD.bazel
+++ b/packages/core/BUILD.bazel
@@ -19,10 +19,10 @@ ng_module(
 
 ng_package(
     name = "npm_package",
-    srcs = glob([
-        "**/*.externs.js",
-        "**/package.json",
-    ]) + ["//packages/core/testing:npm_package_assets"],
+    srcs = glob(["**/*.externs.js"]) + [
+        "package.json",
+        "//packages/core/testing:package.json",
+    ],
     entry_point = "packages/core/index.js",
     secondary_entry_points = ["testing"],
     deps = [

--- a/packages/core/testing/BUILD.bazel
+++ b/packages/core/testing/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["package.json"])
+
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(
@@ -12,9 +14,4 @@ ng_module(
         "//packages:types",
         "//packages/core",
     ],
-)
-
-filegroup(
-    name = "npm_package_assets",
-    srcs = ["package.json"],
 )

--- a/packages/http/BUILD.bazel
+++ b/packages/http/BUILD.bazel
@@ -20,7 +20,10 @@ ng_module(
 
 ng_package(
     name = "npm_package",
-    srcs = ["package.json"],
+    srcs = [
+        "package.json",
+        "//packages/http/testing:package.json",
+    ],
     entry_point = "packages/http/index.js",
     secondary_entry_points = [
         "testing",

--- a/packages/http/testing/BUILD.bazel
+++ b/packages/http/testing/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["package.json"])
+
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(

--- a/packages/language-service/BUILD.bazel
+++ b/packages/language-service/BUILD.bazel
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults.bzl", "ts_library", "npm_package")
 
 ts_library(
     name = "language-service",
@@ -17,4 +17,10 @@ ts_library(
         "//packages/compiler-cli",
         "//packages/core",
     ],
+)
+
+npm_package(
+    name = "npm_package",
+    srcs = ["package.json"],
+    deps = [":language-service"],
 )

--- a/packages/platform-browser-dynamic/BUILD.bazel
+++ b/packages/platform-browser-dynamic/BUILD.bazel
@@ -22,7 +22,10 @@ ng_module(
 
 ng_package(
     name = "npm_package",
-    srcs = ["package.json"],
+    srcs = [
+        "package.json",
+        "//packages/platform-browser-dynamic/testing:package.json",
+    ],
     entry_point = "packages/platform-browser-dynamic/index.js",
     secondary_entry_points = [
         "testing",

--- a/packages/platform-browser-dynamic/testing/BUILD.bazel
+++ b/packages/platform-browser-dynamic/testing/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["package.json"])
+
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(

--- a/packages/platform-browser/BUILD.bazel
+++ b/packages/platform-browser/BUILD.bazel
@@ -20,7 +20,11 @@ ng_module(
 
 ng_package(
     name = "npm_package",
-    srcs = ["package.json"],
+    srcs = [
+        "package.json",
+        "//packages/platform-browser/animations:package.json",
+        "//packages/platform-browser/testing:package.json",
+    ],
     entry_point = "packages/platform-browser/index.js",
     secondary_entry_points = [
         "animations",

--- a/packages/platform-browser/animations/BUILD.bazel
+++ b/packages/platform-browser/animations/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["package.json"])
+
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(

--- a/packages/platform-browser/testing/BUILD.bazel
+++ b/packages/platform-browser/testing/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["package.json"])
+
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -27,7 +27,10 @@ ng_module(
 
 ng_package(
     name = "npm_package",
-    srcs = ["package.json"],
+    srcs = [
+        "package.json",
+        "//packages/platform-server/testing:package.json",
+    ],
     entry_point = "packages/platform-server/index.js",
     secondary_entry_points = [
         "testing",

--- a/packages/platform-server/testing/BUILD.bazel
+++ b/packages/platform-server/testing/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["package.json"])
+
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(

--- a/packages/router/BUILD.bazel
+++ b/packages/router/BUILD.bazel
@@ -22,7 +22,11 @@ ng_module(
 
 ng_package(
     name = "npm_package",
-    srcs = ["package.json"],
+    srcs = [
+        "package.json",
+        "//packages/router/testing:package.json",
+        "//packages/router/upgrade:package.json",
+    ],
     entry_point = "packages/router/index.js",
     secondary_entry_points = [
         "testing",

--- a/packages/router/testing/BUILD.bazel
+++ b/packages/router/testing/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["package.json"])
+
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(

--- a/packages/router/upgrade/BUILD.bazel
+++ b/packages/router/upgrade/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["package.json"])
+
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(

--- a/packages/service-worker/BUILD.bazel
+++ b/packages/service-worker/BUILD.bazel
@@ -20,7 +20,10 @@ ng_module(
 
 ng_package(
     name = "npm_package",
-    srcs = ["package.json"],
+    srcs = [
+        "package.json",
+        "//packages/service-worker/config:package.json",
+    ],
     entry_point = "packages/service-worker/index.js",
     secondary_entry_points = ["config"],
     deps = [

--- a/packages/service-worker/config/BUILD.bazel
+++ b/packages/service-worker/config/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["package.json"])
+
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(

--- a/packages/upgrade/BUILD.bazel
+++ b/packages/upgrade/BUILD.bazel
@@ -20,7 +20,10 @@ ng_module(
 
 ng_package(
     name = "npm_package",
-    srcs = ["package.json"],
+    srcs = [
+        "package.json",
+        "//packages/upgrade/static:package.json",
+    ],
     entry_point = "packages/upgrade/index.js",
     secondary_entry_points = [
         "static",

--- a/packages/upgrade/static/BUILD.bazel
+++ b/packages/upgrade/static/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["package.json"])
+
 load("//tools:defaults.bzl", "ng_module")
 
 ng_module(


### PR DESCRIPTION
Angular Package Format v6 stops bundling files in the esm5 and esm2015
directories, now that Webpack 4 can tree-shake per-file.

Adds some missing files like package.json to make packages closer to
what we publish today.

Refactor ng_package to be a type of npm_package and re-use the packaging
action from that rule.

