### PR TITLE
refactor(compiler): Drop support for the deprecated `<template>`. Use…

### DIFF
--- a/aio/content/guide/aot-compiler.md
+++ b/aio/content/guide/aot-compiler.md
@@ -215,13 +215,6 @@ value           | description
 
 This tells the compiler to print extra information while compiling templates.
 
-### *enableLegacyTemplate*
-
-The use of `<template>` element was deprecated starting in Angular 4.0 in favor of using
-`<ng-template>` to avoid colliding with the DOM's element of the same name. Setting this option to
-`true` enables the use of the deprecated `<template>` element . This option
-is `false` by default. This option might be required by some third-party Angular libraries.
-
 ### *disableExpressionLowering*
 
 The Angular template compiler transforms code that is used, or could be used, in an annotation

--- a/modules/benchmarks/src/old/naive_infinite_scroll/app.ts
+++ b/modules/benchmarks/src/old/naive_infinite_scroll/app.ts
@@ -25,9 +25,9 @@ import {ScrollAreaComponent} from './scroll_area';
     <div style="display: flex">
       <scroll-area id="testArea"></scroll-area>
     </div>
-    <div template="ngIf scrollAreas.length > 0">
+    <div *ngIf="scrollAreas.length > 0">
       <p>Following tables are only here to add weight to the UI:</p>
-      <scroll-area template="ngFor let scrollArea of scrollAreas"></scroll-area>
+      <scroll-area *ngFor="let scrollArea of scrollAreas"></scroll-area>
     </div>
   </div>`
 })

--- a/modules/benchmarks/src/old/naive_infinite_scroll/cells.ts
+++ b/modules/benchmarks/src/old/naive_infinite_scroll/cells.ts
@@ -62,7 +62,7 @@ export class Stage {
   directives: [NgFor],
   template: `
       <div [style.width.px]="cellWidth">
-          <button template="ngFor let stage of stages"
+          <button *ngFor="let stage of stages"
                   [disabled]="stage.isDisabled"
                   [style.background-color]="stage.backgroundColor"
                   on-click="setStage(stage)">

--- a/modules/benchmarks/src/old/naive_infinite_scroll/scroll_area.ts
+++ b/modules/benchmarks/src/old/naive_infinite_scroll/scroll_area.ts
@@ -25,7 +25,7 @@ import {ScrollItemComponent} from './scroll_item';
             <div id="padding"></div>
             <div id="inner">
                 <scroll-item
-                    template="ngFor let item of visibleItems"
+                    *ngFor="let item of visibleItems"
                     [offering]="item">
                 </scroll-item>
             </div>

--- a/packages/compiler-cli/src/ngtools_api2.ts
+++ b/packages/compiler-cli/src/ngtools_api2.ts
@@ -50,7 +50,6 @@ export interface CompilerOptions extends ts.CompilerOptions {
   annotateForClosureCompiler?: boolean;
   annotationsAs?: 'decorators'|'static fields';
   trace?: boolean;
-  enableLegacyTemplate?: boolean;
   disableExpressionLowering?: boolean;
   i18nOutLocale?: string;
   i18nOutFormat?: string;

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -125,9 +125,6 @@ export interface CompilerOptions extends ts.CompilerOptions {
   // Print extra information while running the compiler
   trace?: boolean;
 
-  // Whether to enable support for <template> and the template attribute (false by default)
-  enableLegacyTemplate?: boolean;
-
   // Whether to enable lowering expressions lambdas and expressions in a reference value
   // position.
   disableExpressionLowering?: boolean;

--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -828,7 +828,6 @@ function getAotCompilerOptions(options: CompilerOptions): AotCompilerOptions {
   return {
     locale: options.i18nInLocale,
     i18nFormat: options.i18nInFormat || options.i18nOutFormat, translations, missingTranslation,
-    enableLegacyTemplate: options.enableLegacyTemplate,
     enableSummariesForJit: options.enableSummariesForJit,
     preserveWhitespaces: options.preserveWhitespaces,
     fullTemplateTypeCheck: options.fullTemplateTypeCheck,

--- a/packages/compiler/design/separate_compilation.md
+++ b/packages/compiler/design/separate_compilation.md
@@ -536,7 +536,6 @@ The recommended options for producing a ivy application are
 | `"renderer2BackPatching"`      | `true`   | implied     |
 | `"generateCodeForLibraries"`   | `true`   | default     |
 | `"annotationsAs"`              | `remove` | implied     |
-| `"enableLegacyTemplate"`       | `false`  | default     |
 | `"preserveWhitespaces"`        | `false`  | default     |
 | `"skipMetadataEmit"`           | `true`   | default     |
 | `"strictMetadataEmit"`         | `false`  | implied     |
@@ -574,7 +573,6 @@ The recommended options for producing a ivy library are:
 | `"renderer2BackPatching"`      | `false`  | default     |
 | `"generateCodeForLibraries"`   | `false`  |             |
 | `"annotationsAs"`              | `remove` | implied     |
-| `"enableLegacyTemplate"`       | `false`  | default     |
 | `"preserveWhitespaces"`        | `false`  | default     |
 | `"skipMetadataEmit"`           | `false`  |             |
 | `"strictMetadataEmit"`         | `true `  |             |
@@ -598,25 +596,21 @@ depending on the target:
 |                   | `"renderer2BackPatching"`      | `true`       | enforced    |
 |                   | `"generateCodeForLibraries"`   | `true`       |             |
 |                   | `"annotationsAs"`              | `remove`     |             |
-|                   | `"enableLegacyTemplate"`       | `false`      |             |
 |                   | `"preserveWhitespaces"`        | `false`      |             |
 |                   | `"skipMetadataEmit"`           | `false`      |             |
 |                   | `"strictMetadataEmit"`         | `true`       |             |
 |                   | `"skipTemplateCodegen"`        | `false`      |             |
 |                   | `"fullTemplateTypeCheck"`      | `true`       |             |
-|                   | `"enableLegacyTemplate"`       | `false`      |             |
 |                   |                                |              |             |
 | `"library"`       | `"generateRenderer2Factories"` | `false`      | enforced    |
 |                   | `"renderer2BackPatching"`      | `false`      | enforced    |
 |                   | `"generateCodeForLibraries"`   | `false`      | enforced    |
 |                   | `"annotationsAs"`              | `decorators` |             |
-|                   | `"enableLegacyTemplate"`       | `false`      |             |
 |                   | `"preserveWhitespaces"`        | `false`      |             |
 |                   | `"skipMetadataEmit"`           | `false`      | enforced    |
 |                   | `"strictMetadataEmit"`         | `true`       |             |
 |                   | `"skipTemplateCodegen"`        | `false`      | enforced    |
 |                   | `"fullTemplateTypeCheck"`      | `true`       |             |
-|                   | `"enableLegacyTemplate"`       | `false`      |             |
 |                   |                                |              |             |
 | `"package"`       | `"flatModuleOutFile"`          |              | required    |
 |                   | `"flatModuleId"`               |              | required    |
@@ -625,13 +619,11 @@ depending on the target:
 |                   | `"renderer2BackPatching"`      | `false`      | enforced    |
 |                   | `"generateCodeForLibraries"`   | `false`      | enforced    |
 |                   | `"annotationsAs"`              | `remove`     |             |
-|                   | `"enableLegacyTemplate"`       | `false`      |             |
 |                   | `"preserveWhitespaces"`        | `false`      |             |
 |                   | `"skipMetadataEmit"`           | `false`      | enforced    |
 |                   | `"strictMetadataEmit"`         | `true`       |             |
 |                   | `"skipTemplateCodegen"`        | `false`      | enforced    |
 |                   | `"fullTemplateTypeCheck"`      | `true`       |             |
-|                   | `"enableLegacyTemplate"`       | `false`      |             |
 
 Options that are marked "enforced" are reported as an error if they are
 explicitly set to a value different from what is specified here. The options

--- a/packages/compiler/src/aot/compiler_factory.ts
+++ b/packages/compiler/src/aot/compiler_factory.ts
@@ -70,7 +70,6 @@ export function createAotCompiler(
   const config = new CompilerConfig({
     defaultEncapsulation: ViewEncapsulation.Emulated,
     useJit: false,
-    enableLegacyTemplate: options.enableLegacyTemplate === true,
     missingTranslation: options.missingTranslation,
     preserveWhitespaces: options.preserveWhitespaces,
     strictInjectionParameters: options.strictInjectionParameters,

--- a/packages/compiler/src/aot/compiler_options.ts
+++ b/packages/compiler/src/aot/compiler_options.ts
@@ -13,7 +13,6 @@ export interface AotCompilerOptions {
   i18nFormat?: string;
   translations?: string;
   missingTranslation?: MissingTranslationStrategy;
-  enableLegacyTemplate?: boolean;
   enableSummariesForJit?: boolean;
   preserveWhitespaces?: boolean;
   fullTemplateTypeCheck?: boolean;

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -14,9 +14,6 @@ import {noUndefined} from './util';
 
 export class CompilerConfig {
   public defaultEncapsulation: ViewEncapsulation|null;
-  // Whether to support the `<template>` tag and the `template` attribute to define angular
-  // templates. They have been deprecated in 4.x, `<ng-template>` should be used instead.
-  public enableLegacyTemplate: boolean;
   public useJit: boolean;
   public jitDevMode: boolean;
   public missingTranslation: MissingTranslationStrategy|null;
@@ -25,13 +22,11 @@ export class CompilerConfig {
 
   constructor(
       {defaultEncapsulation = ViewEncapsulation.Emulated, useJit = true, jitDevMode = false,
-       missingTranslation = null, enableLegacyTemplate, preserveWhitespaces,
-       strictInjectionParameters}: {
+       missingTranslation = null, preserveWhitespaces, strictInjectionParameters}: {
         defaultEncapsulation?: ViewEncapsulation,
         useJit?: boolean,
         jitDevMode?: boolean,
         missingTranslation?: MissingTranslationStrategy,
-        enableLegacyTemplate?: boolean,
         preserveWhitespaces?: boolean,
         strictInjectionParameters?: boolean,
       } = {}) {
@@ -39,7 +34,6 @@ export class CompilerConfig {
     this.useJit = !!useJit;
     this.jitDevMode = !!jitDevMode;
     this.missingTranslation = missingTranslation;
-    this.enableLegacyTemplate = enableLegacyTemplate === true;
     this.preserveWhitespaces = preserveWhitespacesDefault(noUndefined(preserveWhitespaces));
     this.strictInjectionParameters = strictInjectionParameters === true;
   }

--- a/packages/compiler/src/ml_parser/tags.ts
+++ b/packages/compiler/src/ml_parser/tags.ts
@@ -71,7 +71,6 @@ export function mergeNsAndName(prefix: string, localName: string): string {
 // This list is not exhaustive to keep the compiler footprint low.
 // The `&#123;` / `&#x1ab;` syntax should be used when the named character reference does not
 // exist.
-
 export const NAMED_ENTITIES: {[k: string]: string} = {
   'Aacute': '\u00C1',
   'aacute': '\u00E1',

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -32,10 +32,6 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './ast_spe
         });
 
         it('should parse text nodes inside <ng-template> elements', () => {
-          // deprecated in 4.0
-          expect(humanizeDom(parser.parse('<template>a</template>', 'TestComp'))).toEqual([
-            [html.Element, 'template', 0], [html.Text, 'a', 1]
-          ]);
           expect(humanizeDom(parser.parse('<ng-template>a</ng-template>', 'TestComp'))).toEqual([
             [html.Element, 'ng-template', 0], [html.Text, 'a', 1]
           ]);
@@ -62,8 +58,6 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './ast_spe
         });
 
         it('should parse elements inside  <ng-template> elements', () => {
-          expect(humanizeDom(parser.parse('<template><span></span></template>', 'TestComp')))
-              .toEqual([[html.Element, 'template', 0], [html.Element, 'span', 1]]);
           expect(humanizeDom(parser.parse('<ng-template><span></span></ng-template>', 'TestComp')))
               .toEqual([[html.Element, 'ng-template', 0], [html.Element, 'span', 1]]);
         });
@@ -175,10 +169,6 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './ast_spe
         });
 
         it('should not add the requiredParent when the parent is a <ng-template>', () => {
-          expect(humanizeDom(parser.parse('<template><tr></tr></template>', 'TestComp'))).toEqual([
-            [html.Element, 'template', 0],
-            [html.Element, 'tr', 1],
-          ]);
           expect(humanizeDom(parser.parse('<ng-template><tr></tr></ng-template>', 'TestComp')))
               .toEqual([
                 [html.Element, 'ng-template', 0],
@@ -282,10 +272,6 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './ast_spe
         });
 
         it('should parse attributes on <ng-template> elements', () => {
-          expect(humanizeDom(parser.parse('<template k="v"></template>', 'TestComp'))).toEqual([
-            [html.Element, 'template', 0],
-            [html.Attribute, 'k', 'v'],
-          ]);
           expect(humanizeDom(parser.parse('<ng-template k="v"></ng-template>', 'TestComp')))
               .toEqual([
                 [html.Element, 'ng-template', 0],

--- a/packages/compiler/test/render3/mock_compile.ts
+++ b/packages/compiler/test/render3/mock_compile.ts
@@ -158,7 +158,6 @@ function doCompile(
   const config = new CompilerConfig({
     defaultEncapsulation: ViewEncapsulation.Emulated,
     useJit: false,
-    enableLegacyTemplate: options.enableLegacyTemplate === true,
     missingTranslation: options.missingTranslation,
     preserveWhitespaces: options.preserveWhitespaces,
     strictInjectionParameters: options.strictInjectionParameters,

--- a/packages/core/src/linker/compiler.ts
+++ b/packages/core/src/linker/compiler.ts
@@ -90,9 +90,6 @@ export type CompilerOptions = {
   defaultEncapsulation?: ViewEncapsulation,
   providers?: StaticProvider[],
   missingTranslation?: MissingTranslationStrategy,
-  // Whether to support the `<template>` tag and the `template` attribute to define angular
-  // templates. They have been deprecated in 4.x, `<ng-template>` should be used instead.
-  enableLegacyTemplate?: boolean,
   preserveWhitespaces?: boolean,
 };
 

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -38,14 +38,7 @@ const ANCHOR_ELEMENT = new InjectionToken('AnchorElement');
 function declareTests({useJit}: {useJit: boolean}) {
   describe('integration tests', function() {
 
-    beforeEach(() => {
-      TestBed.configureCompiler({
-        useJit,
-        providers: [
-          {provide: CompilerConfig, useValue: new CompilerConfig({enableLegacyTemplate: true})}
-        ]
-      });
-    });
+    beforeEach(() => { TestBed.configureCompiler({useJit}); });
 
     describe('react to record changes', function() {
       it('should consume text node changes', () => {
@@ -418,22 +411,6 @@ function declareTests({useJit}: {useJit: boolean}) {
         const childNodesOfWrapper = getDOM().childNodes(fixture.nativeElement);
         expect(childNodesOfWrapper.length).toBe(1);
         expect(getDOM().isCommentNode(childNodesOfWrapper[0])).toBe(true);
-      });
-
-      it('should support template directives via `template` attribute.', () => {
-        TestBed.configureTestingModule({declarations: [MyComp, SomeViewport]});
-        const template =
-            '<span template="some-viewport: let greeting=someTmpl">{{greeting}}</span>';
-        TestBed.overrideComponent(MyComp, {set: {template}});
-        const fixture = TestBed.createComponent(MyComp);
-
-        fixture.detectChanges();
-
-        const childNodesOfWrapper = getDOM().childNodes(fixture.nativeElement);
-        // 1 template + 2 copies.
-        expect(childNodesOfWrapper.length).toBe(3);
-        expect(childNodesOfWrapper[1]).toHaveText('hello');
-        expect(childNodesOfWrapper[2]).toHaveText('again');
       });
 
       it('should allow to transplant TemplateRefs into other ViewContainers', () => {

--- a/packages/platform-browser-dynamic/src/compiler_factory.ts
+++ b/packages/platform-browser-dynamic/src/compiler_factory.ts
@@ -162,7 +162,6 @@ export class JitCompilerFactory implements CompilerFactory {
       useJit: true,
       defaultEncapsulation: ViewEncapsulation.Emulated,
       missingTranslation: MissingTranslationStrategy.Warning,
-      enableLegacyTemplate: false,
     };
 
     this._defaultOptions = [compilerOptions, ...defaultOptions];
@@ -182,7 +181,6 @@ export class JitCompilerFactory implements CompilerFactory {
             // from the app providers
             defaultEncapsulation: opts.defaultEncapsulation,
             missingTranslation: opts.missingTranslation,
-            enableLegacyTemplate: opts.enableLegacyTemplate,
             preserveWhitespaces: opts.preserveWhitespaces,
           });
         },
@@ -200,7 +198,6 @@ function _mergeOptions(optionsArr: CompilerOptions[]): CompilerOptions {
     defaultEncapsulation: _lastDefined(optionsArr.map(options => options.defaultEncapsulation)),
     providers: _mergeArrays(optionsArr.map(options => options.providers !)),
     missingTranslation: _lastDefined(optionsArr.map(options => options.missingTranslation)),
-    enableLegacyTemplate: _lastDefined(optionsArr.map(options => options.enableLegacyTemplate)),
     preserveWhitespaces: _lastDefined(optionsArr.map(options => options.preserveWhitespaces)),
   };
 }

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -112,7 +112,6 @@ export declare type CompilerOptions = {
     defaultEncapsulation?: ViewEncapsulation;
     providers?: StaticProvider[];
     missingTranslation?: MissingTranslationStrategy;
-    enableLegacyTemplate?: boolean;
     preserveWhitespaces?: boolean;
 };
 


### PR DESCRIPTION
… `<ng-template>` instead

BREAKING CHANGE:

The `<template>` tag was deprecated in Angular v4 to avoid collisions (i.e. when
using Web Components).

This commit removes support for `<template>`. `<ng-template>` should be used
instead.

BEFORE:
```
    <!-- html template -->
    <template>some template content</template>

    # tsconfig.json
    {
      # ...
      "angularCompilerOptions": {
        # ...
        # This option is no more supported and will have no effect
        "enableLegacyTemplate": [true|false]
      }
    }
```
AFTER:
```
    <!-- html template -->
    <ng-template>some template content</ng-template>
```

fixes #22777