### PR TITLE
feat: mark angular packages as side-effect free

### DIFF
--- a/packages/animations/browser/package.json
+++ b/packages/animations/browser/package.json
@@ -3,5 +3,6 @@
   "typings": "./browser.d.ts",
   "main": "../bundles/animations-browser.umd.js",
   "module": "../esm5/browser.js",
-  "es2015": "../esm2015/browser.js"
+  "es2015": "../esm2015/browser.js",
+  "sideEffects": false
 }

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -20,5 +20,6 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/common/http/package.json
+++ b/packages/common/http/package.json
@@ -3,5 +3,6 @@
   "typings": "./http.d.ts",
   "main": "../bundles/common-http.umd.js",
   "module": "../esm5/http.js",
-  "es2015": "../esm2015/http.js"
+  "es2015": "../esm2015/http.js",
+  "sideEffects": false
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -22,5 +22,6 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -17,5 +17,6 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,5 +21,6 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -23,5 +23,6 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -22,5 +22,6 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -13,5 +13,6 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/platform-browser-dynamic/package.json
+++ b/packages/platform-browser-dynamic/package.json
@@ -23,5 +23,6 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/platform-browser/animations/package.json
+++ b/packages/platform-browser/animations/package.json
@@ -3,5 +3,6 @@
   "typings": "./animations.d.ts",
   "main": "../bundles/platform-browser-animations.umd.js",
   "module": "../esm5/animations.js",
-  "es2015": "../esm2015/animations.js"
+  "es2015": "../esm2015/animations.js",
+  "sideEffects": false
 }

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -21,5 +21,6 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -27,5 +27,6 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/platform-webworker-dynamic/package.json
+++ b/packages/platform-webworker-dynamic/package.json
@@ -24,5 +24,6 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/platform-webworker/package.json
+++ b/packages/platform-webworker/package.json
@@ -22,5 +22,6 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -31,5 +31,6 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/router/upgrade/package.json
+++ b/packages/router/upgrade/package.json
@@ -3,5 +3,6 @@
   "typings": "./upgrade.d.ts",
   "main": "../bundles/router-upgrade.umd.js",
   "module": "../esm5/upgrade.js",
-  "es2015": "../esm2015/upgrade.js"
+  "es2015": "../esm2015/upgrade.js",
+  "sideEffects": false
 }

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -24,5 +24,6 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -23,5 +23,6 @@
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/upgrade/static/package.json
+++ b/packages/upgrade/static/package.json
@@ -3,5 +3,6 @@
   "typings": "./static.d.ts",
   "main": "../bundles/upgrade-static.umd.js",
   "module": "../esm5/static.js",
-  "es2015": "../esm2015/static.js"
+  "es2015": "../esm2015/static.js",
+  "sideEffects": false
 }


### PR DESCRIPTION
This flag is picked up by webpack v4 and used for more agressive optimizations.

Our code is already side-effect free, because that's what we needed for build-optimizer to work.
