### PR TITLE
 fix(ivy): cache local names and support multiple locals with same value

### DIFF
--- a/packages/core/test/render3/exports_spec.ts
+++ b/packages/core/test/render3/exports_spec.ts
@@ -17,7 +17,7 @@ describe('exports', () => {
     /** <input value="one" #myInput> {{ myInput.value }} */
     function Template(ctx: any, cm: boolean) {
       if (cm) {
-        elementStart(0, 'input', ['value', 'one']);
+        elementStart(0, 'input', ['value', 'one'], null, ['myInput', '']);
         elementEnd();
         text(1);
       }
@@ -33,7 +33,7 @@ describe('exports', () => {
     /** <comp #myComp></comp> {{ myComp.name }} */
     function Template(ctx: any, cm: boolean) {
       if (cm) {
-        elementStart(0, MyComponent);
+        elementStart(0, MyComponent, null, null, ['myComp', '']);
         elementEnd();
         text(2);
       }
@@ -78,7 +78,7 @@ describe('exports', () => {
     /** <comp #myComp></comp> <div [myDir]="myComp"></div> */
     function Template(ctx: any, cm: boolean) {
       if (cm) {
-        elementStart(0, MyComponent);
+        elementStart(0, MyComponent, null, null, ['myComp', '']);
         elementEnd();
         elementStart(2, 'div', null, [MyDir]);
         elementEnd();
@@ -95,7 +95,7 @@ describe('exports', () => {
     /** <div someDir #myDir="someDir"></div> {{ myDir.name }} */
     function Template(ctx: any, cm: boolean) {
       if (cm) {
-        elementStart(0, 'div', null, [SomeDir]);
+        elementStart(0, 'div', null, [SomeDir], ['myDir', 'someDir']);
         elementEnd();
         text(2);
       }
@@ -116,7 +116,7 @@ describe('exports', () => {
       function Template(ctx: any, cm: boolean) {
         if (cm) {
           text(0);
-          elementStart(1, 'input', ['value', 'one']);
+          elementStart(1, 'input', ['value', 'one'], null, ['myInput', '']);
           elementEnd();
         }
         let myInput = elementStart(1);
@@ -133,7 +133,7 @@ describe('exports', () => {
         if (cm) {
           elementStart(0, 'div');
           elementEnd();
-          elementStart(1, 'input', ['value', 'one']);
+          elementStart(1, 'input', ['value', 'one'], null, ['myInput', '']);
           elementEnd();
         }
         let myInput = elementStart(1);
@@ -149,7 +149,7 @@ describe('exports', () => {
         if (cm) {
           elementStart(0, 'div');
           elementEnd();
-          elementStart(1, 'input', ['value', 'one']);
+          elementStart(1, 'input', ['value', 'one'], null, ['myInput', '']);
           elementEnd();
         }
         let myInput = elementStart(1);
@@ -165,7 +165,7 @@ describe('exports', () => {
         if (cm) {
           elementStart(0, 'div');
           elementEnd();
-          elementStart(1, 'input', ['type', 'checkbox', 'checked', 'true']);
+          elementStart(1, 'input', ['type', 'checkbox', 'checked', 'true'], null, ['myInput', '']);
           elementEnd();
         }
         let myInput = elementStart(1);
@@ -206,7 +206,7 @@ describe('exports', () => {
         if (cm) {
           elementStart(0, 'div', null, [MyDir]);
           elementEnd();
-          elementStart(2, MyComponent);
+          elementStart(2, MyComponent, null, null, ['myComp', '']);
           elementEnd();
         }
         elementProperty(0, 'myDir', bind(load<MyComponent>(3)));
@@ -223,9 +223,9 @@ describe('exports', () => {
         if (cm) {
           text(0);
           text(1);
-          elementStart(2, MyComponent);
+          elementStart(2, MyComponent, null, null, ['myComp', '']);
           elementEnd();
-          elementStart(4, 'input', ['value', 'one']);
+          elementStart(4, 'input', ['value', 'one'], null, ['myInput', '']);
           elementEnd();
         }
         let myInput = elementStart(4);
@@ -265,7 +265,7 @@ describe('exports', () => {
             {
               if (cm1) {
                 text(0);
-                elementStart(1, 'input', ['value', 'one']);
+                elementStart(1, 'input', ['value', 'one'], null, ['myInput', '']);
                 elementEnd();
               }
               let myInput = elementStart(1);


### PR DESCRIPTION
This PR:

- Fixes a bug where multiple local variables with the same value weren't caught in queries
- Refactors to only query for local name matches on the first template pass

It also updates some tests in exports_spec and adds some tests to query_spec.