### PR TITLE
build: enable inlineHelpers in tsconfig

### DIFF
--- a/packages/bazel/test/ng_package/core_package.spec.ts
+++ b/packages/bazel/test/ng_package/core_package.spec.ts
@@ -143,6 +143,9 @@ describe('@angular/core ng_package', () => {
         expect(shx.cat('bundles/core.umd.js'))
             .toMatch(/@license Angular v\d+\.\d+\.\d+(?!-PLACEHOLDER)/);
       });
+
+      it('should have tslib helpers',
+         () => { expect(shx.cat('bundles/core.umd.js')).not.toContain('undefined.__extends'); });
     });
   });
 

--- a/packages/common/test/BUILD.bazel
+++ b/packages/common/test/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -32,12 +31,7 @@ jasmine_node_test(
 
 ts_web_test(
     name = "test_web",
-    bootstrap = [
-        "//:web_test_bootstrap_scripts",
-    ],
-    # do not sort
     deps = [
-        "//tools/testing:browser",
         ":test_lib",
     ],
 )

--- a/packages/compiler/test/BUILD.bazel
+++ b/packages/compiler/test/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -49,14 +48,9 @@ jasmine_node_test(
 
 ts_web_test(
     name = "test_web",
-    bootstrap = [
-        "//:web_test_bootstrap_scripts",
-    ],
-    # dissable since tests are running but not yet passing
+    # disable since tests are running but not yet passing
     tags = ["manual"],
-    # do not sort
     deps = [
-        "//tools/testing:browser",
         ":test_lib",
     ],
 )

--- a/packages/core/test/BUILD.bazel
+++ b/packages/core/test/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -62,12 +61,7 @@ jasmine_node_test(
 
 ts_web_test(
     name = "test_web",
-    bootstrap = [
-        "//:web_test_bootstrap_scripts",
-    ],
-    # do not sort
     deps = [
-        "//tools/testing:browser",
         ":test_lib",
     ],
 )

--- a/packages/core/test/render3/BUILD.bazel
+++ b/packages/core/test/render3/BUILD.bazel
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//tools:defaults.bzl", "ts_library")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -57,12 +56,7 @@ jasmine_node_test(
 
 ts_web_test(
     name = "render3_web",
-    bootstrap = [
-        "//:web_test_bootstrap_scripts",
-    ],
-    # do not sort
     deps = [
-        "//tools/testing:browser",
         ":render3_lib",
     ],
 )

--- a/packages/examples/build.sh
+++ b/packages/examples/build.sh
@@ -13,7 +13,7 @@ cd `dirname $0`
 
 DIST="../../dist/examples";
 rm -rf -- $DIST
-$(npm bin)/tsc -p ./tsconfig-build.json
+$(npm bin)/tsc -p ./tsconfig-build.json --importHelpers false
 
 mkdir $DIST/vendor/
 

--- a/packages/forms/test/BUILD.bazel
+++ b/packages/forms/test/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -27,12 +26,7 @@ jasmine_node_test(
 
 ts_web_test(
     name = "test_web",
-    bootstrap = [
-        "//:web_test_bootstrap_scripts",
-    ],
-    # do not sort
     deps = [
-        "//tools/testing:browser",
         ":test_lib",
     ],
 )

--- a/packages/http/test/BUILD.bazel
+++ b/packages/http/test/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -28,12 +27,7 @@ jasmine_node_test(
 
 ts_web_test(
     name = "test_web",
-    bootstrap = [
-        "//:web_test_bootstrap_scripts",
-    ],
-    # do not sort
     deps = [
-        "//tools/testing:browser",
         ":test_lib",
     ],
 )

--- a/packages/language-service/test/BUILD.bazel
+++ b/packages/language-service/test/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -16,10 +15,9 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
-    # dissable since tests are running but not yet passing
+    # disable since tests are running but not yet passing
     tags = ["manual"],
     deps = [
-        ":test_lib",
         "//tools/testing:node",
     ],
 )

--- a/packages/platform-browser-dynamic/test/BUILD.bazel
+++ b/packages/platform-browser-dynamic/test/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -30,14 +29,9 @@ jasmine_node_test(
 
 ts_web_test(
     name = "test_web",
-    bootstrap = [
-        "//:web_test_bootstrap_scripts",
-    ],
-    # dissable since tests are running but not yet passing
+    # disable since tests are running but not yet passing
     tags = ["manual"],
-    # do not sort
     deps = [
-        "//tools/testing:browser",
         ":test_lib",
     ],
 )

--- a/packages/platform-browser/test/BUILD.bazel
+++ b/packages/platform-browser/test/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -36,14 +35,9 @@ jasmine_node_test(
 
 ts_web_test(
     name = "test_web",
-    bootstrap = [
-        "//:web_test_bootstrap_scripts",
-    ],
-    # dissable since tests are running but not yet passing
+    # disable since tests are running but not yet passing
     tags = ["manual"],
-    # do not sort
     deps = [
-        "//tools/testing:browser",
         ":test_lib",
     ],
 )

--- a/packages/platform-server/test/BUILD.bazel
+++ b/packages/platform-server/test/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//tools:defaults.bzl", "ts_library")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(

--- a/packages/platform-webworker/test/BUILD.bazel
+++ b/packages/platform-webworker/test/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -30,12 +29,7 @@ jasmine_node_test(
 
 ts_web_test(
     name = "test_web",
-    bootstrap = [
-        "//:web_test_bootstrap_scripts",
-    ],
-    # do not sort
     deps = [
-        "//tools/testing:browser",
         ":test_lib",
     ],
 )

--- a/packages/router/test/BUILD.bazel
+++ b/packages/router/test/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -31,12 +30,7 @@ jasmine_node_test(
 
 ts_web_test(
     name = "test_web",
-    bootstrap = [
-        "//:web_test_bootstrap_scripts",
-    ],
-    # do not sort
     deps = [
-        "//tools/testing:browser",
         ":test_lib",
     ],
 )

--- a/packages/service-worker/test/BUILD.bazel
+++ b/packages/service-worker/test/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -29,12 +28,7 @@ jasmine_node_test(
 
 ts_web_test(
     name = "test_web",
-    bootstrap = [
-        "//:web_test_bootstrap_scripts",
-    ],
-    # do not sort
     deps = [
-        "//tools/testing:browser",
         ":test_lib",
     ],
 )

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -22,7 +22,8 @@
     // As tsickle will lower decorators before TS, this is not a problem for our build.
     "emitDecoratorMetadata": true,
     "sourceMap": true,
-    "inlineSources": true
+    "inlineSources": true,
+    "importHelpers": true
   },
   "bazelOptions": {
     "suppressTsconfigOverrideWarnings": true

--- a/packages/upgrade/test/BUILD.bazel
+++ b/packages/upgrade/test/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_web_test")
+load("//tools:defaults.bzl", "ts_library", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
@@ -22,16 +21,13 @@ ts_library(
 ts_web_test(
     name = "test_web",
     bootstrap = [
-        "//:web_test_bootstrap_scripts",
         # "//:angularjs",
     ],
     # Disable since tests need to request different AngularJS versions at
     # runtime, which is not yet supported.
     # (Related issue: https://github.com/bazelbuild/rules_typescript/issues/131)
     tags = ["manual"],
-    # do not sort
     deps = [
-        "//tools/testing:browser",
         ":test_lib",
     ],
 )

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -1,6 +1,6 @@
 """Re-export of some bazel rules with repository-wide defaults."""
 load("@build_bazel_rules_nodejs//:defs.bzl", _npm_package = "npm_package")
-load("@build_bazel_rules_typescript//:defs.bzl", _ts_library = "ts_library")
+load("@build_bazel_rules_typescript//:defs.bzl", _ts_library = "ts_library", _ts_web_test = "ts_web_test")
 load("//packages/bazel:index.bzl", _ng_module = "ng_module", _ng_package = "ng_package")
 
 DEFAULT_TSCONFIG = "//packages:tsconfig-build.json"
@@ -65,4 +65,17 @@ def npm_package(name, replacements = {}, **kwargs):
       name = name,
       stamp_data = "//tools:stamp_data",
       replacements = dict(replacements, **PKG_GROUP_REPLACEMENTS),
+      **kwargs)
+
+def ts_web_test(bootstrap = [], deps = [], **kwargs):
+  if not bootstrap:
+    bootstrap = ["//:web_test_bootstrap_scripts"]
+  local_deps = [
+    "//:node_modules/tslib/tslib.js",
+    "//tools/testing:browser",
+  ] + deps
+
+  _ts_web_test(
+      bootstrap = bootstrap,
+      deps = local_deps,
       **kwargs)


### PR DESCRIPTION
This is the primary tsconfig file used for Bazel builds.
Previously, we enabled this option only for releases.
