### PR TITLE
feat(common): add toString method for http request and response class

### DIFF
--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -382,4 +382,8 @@ export class HttpRequest<T> {
                                params, headers, reportProgress, responseType, withCredentials,
                            });
   }
+
+  toString(): string {
+    return `Request for URL: ${this.urlWithParams} using method: ${this.method}`;
+  }
 }

--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -197,6 +197,10 @@ export abstract class HttpResponseBase {
     // Cache the ok value to avoid defining a getter.
     this.ok = this.status >= 200 && this.status < 300;
   }
+
+  toString(): string {
+    return `Response with status: ${this.status} ${this.statusText} for URL: ${this.url}`;
+  }
 }
 
 /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is no toString method for Request and Response, which results into `[object Object]`.


## What is the new behavior?
It returns `Request for URL: http://localhost:8080/api using method: GET` and `Response with status: 200 OK for URL: http://localhost:8080/api`.


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
