### PR TITLE
fix(upgrade): $attrs and $tranclude dependencies for upgrade component

### DIFF
--- a/packages/upgrade/src/common/angular1.ts
+++ b/packages/upgrade/src/common/angular1.ts
@@ -40,6 +40,12 @@ export interface ILinkFnOptions {
   transcludeControllers?: {[key: string]: any};
   futureParentElement?: Node;
 }
+export interface ITranscludeFn {
+  (scope: IScope, cloneAttachFn?: ICloneAttachFunction, futureParentElement?: Node,
+   slotName?: string): IAugmentedJQuery;
+  $$slots?: {[slotName: string]: ILinkFn};
+  isSlotFilled?: (slotName: string) => boolean;
+}
 export interface IRootScopeService {
   $new(isolate?: boolean): IScope;
   $id: string;

--- a/packages/upgrade/src/dynamic/upgrade_ng1_adapter.ts
+++ b/packages/upgrade/src/dynamic/upgrade_ng1_adapter.ts
@@ -186,14 +186,17 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
 
   ngOnInit() {
     // Collect contents, insert and compile template
-    const attachChildNodes: angular.ILinkFn|undefined = this.helper.prepareTransclusion();
+    const attachChildNodes: angular.ILinkFn = this.helper.prepareTransclusion();
     const linkFn = this.helper.compileTemplate(this.template);
 
     // Instantiate controller (if not already done so)
     const controllerType = this.directive.controller;
     const bindToController = this.directive.bindToController;
     if (controllerType && !bindToController) {
-      this.controllerInstance = this.helper.buildController(controllerType, this.componentScope);
+      const $transclude: angular.ITranscludeFn|undefined =
+          this.helper.getTranscludeFn(attachChildNodes);
+      this.controllerInstance =
+          this.helper.buildController(controllerType, this.componentScope, undefined, $transclude);
     }
 
     // Require other controllers

--- a/packages/upgrade/src/static/upgrade_component.ts
+++ b/packages/upgrade/src/static/upgrade_component.ts
@@ -126,14 +126,17 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
 
   ngOnInit() {
     // Collect contents, insert and compile template
-    const attachChildNodes: angular.ILinkFn|undefined = this.helper.prepareTransclusion();
+    const attachChildNodes: angular.ILinkFn = this.helper.prepareTransclusion();
     const linkFn = this.helper.compileTemplate();
 
     // Instantiate controller
     const controllerType = this.directive.controller;
     const bindToController = this.directive.bindToController;
     if (controllerType) {
-      this.controllerInstance = this.helper.buildController(controllerType, this.$componentScope);
+      const $transclude: angular.ITranscludeFn|undefined =
+          this.helper.getTranscludeFn(attachChildNodes);
+      this.controllerInstance =
+          this.helper.buildController(controllerType, this.$componentScope, undefined, $transclude);
     } else if (bindToController) {
       throw new Error(
           `Upgraded directive '${this.directive.name}' specifies 'bindToController' but no controller.`);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When upgrading angularjs component, $attrs and $transclude dependencies are not provided as they are passed as locals.
Workaround is not really possible either as you can't get a reference to these locals from $injector and do something different for upgraded component without changing previous behavior.

Issue Number: #22824


## What is the new behavior?
$transclude is polyfilled, while $attrs is still left unsupported but provided as undefined

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
