### PR TITLE
refactor(ivy): move hostBindings calls out of template

### DIFF
--- a/modules/benchmarks/src/tree/render3/tree.ts
+++ b/modules/benchmarks/src/tree/render3/tree.ts
@@ -58,7 +58,6 @@ export class TreeComponent {
               e();
             }
             p(0, 'data', b(ctx.data.left));
-            TreeComponent.ngComponentDef.h(1, 0);
           }
           v();
         }
@@ -74,7 +73,6 @@ export class TreeComponent {
               e();
             }
             p(0, 'data', b(ctx.data.right));
-            TreeComponent.ngComponentDef.h(1, 0);
           }
           v();
         }

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -133,7 +133,7 @@ export function renderComponent<T>(
     const elementNode = hostElement(hostNode, componentDef);
     // Create directive instance with n() and store at index 1 in data array (el is 0)
     component = rootContext.component =
-        getDirectiveInstance(directiveCreate(1, componentDef.n(), componentDef));
+        getDirectiveInstance(directiveCreate(1, componentDef.factory(), componentDef));
     initChangeDetectorIfExisting(elementNode.nodeInjector, component);
   } finally {
     // We must not use leaveView here because it will set creationMode to false too early,

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -39,10 +39,10 @@ export function defineComponent<T>(componentDefinition: ComponentDefArgs<T>): Co
   const def = <ComponentDef<any>>{
     type: type,
     diPublic: null,
-    n: componentDefinition.factory,
+    factory: componentDefinition.factory,
     tag: (componentDefinition as ComponentDefArgs<T>).tag || null !,
     template: (componentDefinition as ComponentDefArgs<T>).template || null !,
-    h: componentDefinition.hostBindings || null,
+    hostBindings: componentDefinition.hostBindings || null,
     attributes: componentDefinition.attributes || null,
     inputs: invertObject(componentDefinition.inputs),
     outputs: invertObject(componentDefinition.outputs),

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -42,7 +42,7 @@ export function defineComponent<T>(componentDefinition: ComponentDefArgs<T>): Co
     n: componentDefinition.factory,
     tag: (componentDefinition as ComponentDefArgs<T>).tag || null !,
     template: (componentDefinition as ComponentDefArgs<T>).template || null !,
-    h: componentDefinition.hostBindings || noop,
+    h: componentDefinition.hostBindings || null,
     attributes: componentDefinition.attributes || null,
     inputs: invertObject(componentDefinition.inputs),
     outputs: invertObject(componentDefinition.outputs),
@@ -157,8 +157,6 @@ export function PublicFeature<T>(definition: DirectiveDef<T>) {
 }
 
 const EMPTY = {};
-
-function noop() {}
 
 /** Swaps the keys and values of an object. */
 function invertObject(obj: any): any {

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -158,6 +158,9 @@ let cleanup: any[]|null;
  */
 let checkNoChangesMode = false;
 
+/** Whether or not this is the first time the current view has been processed. */
+let firstTemplatePass = true;
+
 const enum BindingDirection {
   Input,
   Output,
@@ -181,6 +184,7 @@ export function enterView(newView: LView, host: LElementNode | LViewNode | null)
   bindingIndex = newView && newView.bindingStartIndex || 0;
   tData = newView && newView.tView.data;
   creationMode = newView && (newView.flags & LViewFlags.CreationMode) === LViewFlags.CreationMode;
+  firstTemplatePass = newView && newView.tView.firstTemplatePass;
 
   cleanup = newView && newView.cleanup;
   renderer = newView && newView.renderer;
@@ -212,13 +216,33 @@ export function leaveView(newView: LView): void {
   enterView(newView, null);
 }
 
-/** Refreshes the views of child components, triggering any init/content hooks existing.  */
-function refreshChildComponents() {
+/**  Refreshes directives in this view and triggers any init/content hooks.  */
+function refreshDirectives() {
   executeInitAndContentHooks();
-  // This needs to be set before children are processed to support recursive components
-  currentView.tView.firstTemplatePass = false;
 
-  const components = currentView.tView.components;
+  const tView = currentView.tView;
+  // This needs to be set before children are processed to support recursive components
+  // so to refresh the component, refresh() needs to be called with (1, 0)
+  tView.firstTemplatePass = firstTemplatePass = false;
+
+  setHostBindings(tView.hostBindings);
+  refreshChildComponents(tView.components);
+}
+
+/** Sets the host bindings for the current view. */
+function setHostBindings(bindings: number[] | null): void {
+  if (bindings != null) {
+    for (let i = 0; i < bindings.length; i += 2) {
+      const dirIndex = bindings[i];
+      const elementIndex = bindings[i | 1];
+      const def = tData[dirIndex] as DirectiveDef<any>;
+      def.h && def.h(dirIndex, elementIndex);
+    }
+  }
+}
+
+/** Refreshes child components in the current view. */
+function refreshChildComponents(components: number[] | null): void {
   if (components != null) {
     for (let i = 0; i < components.length; i++) {
       componentRefresh(components[i] + 1, components[i]);
@@ -398,7 +422,7 @@ export function renderEmbeddedTemplate<T>(
 
     template(context, cm);
     refreshDynamicChildren();
-    refreshChildComponents();
+    refreshDirectives();
   } finally {
     leaveView(currentView !.parent !);
     isParent = _isParent;
@@ -416,11 +440,12 @@ export function renderComponentOrTemplate<T>(
     }
     if (template) {
       template(componentOrContext !, creationMode);
-      refreshChildComponents();
+      refreshDirectives();
     } else {
       executeInitAndContentHooks();
+
       // Element was stored at 0 and directive was stored at 1 in renderComponent
-      // so to refresh the component, refresh() needs to be called with (1, 0)
+      setHostBindings([1, 0]);
       componentRefresh(1, 0);
     }
   } finally {
@@ -466,7 +491,7 @@ export function elementStart(
     let hostComponentDef: ComponentDef<any>|null = null;
     let name = nameOrComponentType as string;
     if (isHostElement) {
-      hostComponentDef = currentView.tView.firstTemplatePass ?
+      hostComponentDef = firstTemplatePass ?
           (nameOrComponentType as ComponentType<any>).ngComponentDef :
           tData[index + 1] as ComponentDef<any>;
       name = hostComponentDef !.tag;
@@ -501,24 +526,36 @@ export function elementStart(
       if (attrs) setUpAttributes(native, attrs);
       appendChild(node.parent !, native, currentView);
 
+      const elementIndex = index;
+
       if (hostComponentDef) {
         // TODO(mhevery): This assumes that the directives come in correct order, which
         // is not guaranteed. Must be refactored to take it into account.
         const instance = hostComponentDef.n();
-        storeComponentIndex(index);
         directiveCreate(++index, instance, hostComponentDef, null);
         initChangeDetectorIfExisting(node.nodeInjector, instance);
+        queueComponentIndexForCheck(elementIndex);
+        if (hostComponentDef.h) queueHostBindingForCheck(index, elementIndex);
       }
-      hack_declareDirectives(index, directiveTypes, localRefs);
+      hack_declareDirectives(index, elementIndex, directiveTypes, localRefs);
     }
   }
   return native;
 }
 
-/** Stores index of component so it will be queued for refresh during change detection. */
-function storeComponentIndex(index: number): void {
-  if (currentView.tView.firstTemplatePass) {
-    (currentView.tView.components || (currentView.tView.components = [])).push(index);
+/** Stores index of component's host element so it will be queued for view refresh during CD. */
+function queueComponentIndexForCheck(elIndex: number): void {
+  if (firstTemplatePass) {
+    (currentView.tView.components || (currentView.tView.components = [])).push(elIndex);
+  }
+}
+
+/** Stores index of directive and host element so it will be queued for binding refresh during CD.
+ */
+function queueHostBindingForCheck(dirIndex: number, elIndex: number): void {
+  if (firstTemplatePass) {
+    (currentView.tView.hostBindings || (currentView.tView.hostBindings = [
+     ])).push(dirIndex, elIndex);
   }
 }
 
@@ -534,7 +571,7 @@ export function initChangeDetectorIfExisting(injector: LInjector | null, instanc
  * come in the correct order for DI.
  */
 function hack_declareDirectives(
-    index: number, directiveTypes: DirectiveType<any>[] | null | undefined,
+    index: number, elIndex: number, directiveTypes: DirectiveType<any>[] | null | undefined,
     localRefs: string[] | null | undefined, ) {
   if (directiveTypes) {
     // TODO(mhevery): This assumes that the directives come in correct order, which
@@ -542,13 +579,12 @@ function hack_declareDirectives(
     for (let i = 0; i < directiveTypes.length; i++) {
       index++;
       const directiveType = directiveTypes[i];
-      const directiveDef = currentView.tView.firstTemplatePass ? directiveType.ngDirectiveDef :
-                                                                 tData[index] as DirectiveDef<any>;
-      const localNames = currentView.tView.firstTemplatePass ?
-          findMatchingLocalNames(directiveDef, localRefs, index) :
-          null;
-
+      const directiveDef =
+          firstTemplatePass ? directiveType.ngDirectiveDef : tData[index] as DirectiveDef<any>;
+      const localNames =
+          firstTemplatePass ? findMatchingLocalNames(directiveDef, localRefs, index) : null;
       directiveCreate(index, directiveDef.n(), directiveDef, localNames);
+      if (directiveDef.h) queueHostBindingForCheck(index, elIndex);
     }
   }
 }
@@ -598,6 +634,7 @@ export function createTView(): TView {
     viewHooks: null,
     viewCheckHooks: null,
     destroyHooks: null,
+    hostBindings: null,
     components: null
   };
 }
@@ -777,12 +814,12 @@ export function elementProperty<T>(
   const tNode = node.tNode !;
   // if tNode.inputs is undefined, a listener has created outputs, but inputs haven't
   // yet been checked
-  if (tNode.inputs === undefined) {
+  if (tNode && tNode.inputs === undefined) {
     // mark inputs as checked
     tNode.inputs = generatePropertyAliases(node.flags, BindingDirection.Input);
   }
 
-  const inputData = tNode.inputs;
+  const inputData = tNode && tNode.inputs;
   let dataValue: PropertyAliasValue|undefined;
   if (inputData && (dataValue = inputData[propName])) {
     setInputsForProperty(dataValue, value);
@@ -1209,7 +1246,7 @@ export function container(
   // Containers are added to the current view tree instead of their embedded views
   // because views can be removed and re-inserted.
   addToViewTree(node.data);
-  hack_declareDirectives(index, directiveTypes, localRefs);
+  hack_declareDirectives(index, index, directiveTypes, localRefs);
 
   isParent = false;
   ngDevMode && assertNodeType(previousOrParentNode, LNodeFlags.Container);
@@ -1366,7 +1403,7 @@ function getOrCreateEmbeddedTView(viewIndex: number, parent: LContainerNode): TV
 
 /** Marks the end of an embedded view. */
 export function embeddedViewEnd(): void {
-  refreshChildComponents();
+  refreshDirectives();
   isParent = false;
   const viewNode = previousOrParentNode = currentView.node as LViewNode;
   const containerNode = previousOrParentNode.parent as LContainerNode;
@@ -1390,29 +1427,22 @@ export function embeddedViewEnd(): void {
 /////////////
 
 /**
- * Refreshes the directive.
- *
- * When it is a component, it also enters the component's view and processes it to update bindings,
- * queries, etc.
+ * Refreshes components by entering the component view and processing its bindings, queries, etc.
  *
  * @param directiveIndex
  * @param elementIndex
  */
 export function componentRefresh<T>(directiveIndex: number, elementIndex: number): void {
-  const template = (tData[directiveIndex] as ComponentDef<T>).template;
-  if (template != null) {
-    ngDevMode && assertDataInRange(elementIndex);
-    const element = data ![elementIndex] as LElementNode;
-    ngDevMode && assertNodeType(element, LNodeFlags.Element);
-    ngDevMode &&
-        assertNotNull(element.data, `Component's host node should have an LView attached.`);
-    const hostView = element.data !;
+  ngDevMode && assertDataInRange(elementIndex);
+  const element = data ![elementIndex] as LElementNode;
+  ngDevMode && assertNodeType(element, LNodeFlags.Element);
+  ngDevMode && assertNotNull(element.data, `Component's host node should have an LView attached.`);
+  const hostView = element.data !;
 
-    // Only attached CheckAlways components or attached, dirty OnPush components should be checked
-    if (viewAttached(hostView) && hostView.flags & (LViewFlags.CheckAlways | LViewFlags.Dirty)) {
-      ngDevMode && assertDataInRange(directiveIndex);
-      detectChangesInternal(hostView, element, getDirectiveInstance<T>(data[directiveIndex]));
-    }
+  // Only attached CheckAlways components or attached, dirty OnPush components should be checked
+  if (viewAttached(hostView) && hostView.flags & (LViewFlags.CheckAlways | LViewFlags.Dirty)) {
+    ngDevMode && assertDataInRange(directiveIndex);
+    detectChangesInternal(hostView, element, getDirectiveInstance<T>(data[directiveIndex]));
   }
 }
 
@@ -1756,16 +1786,14 @@ function throwErrorIfNoChangesMode(oldValue: any, currValue: any): never|void {
 function detectChangesInternal<T>(hostView: LView, hostNode: LElementNode, component: T) {
   const componentIndex = hostNode.flags >> LNodeFlags.INDX_SHIFT;
   const template = (hostNode.view.tView.data[componentIndex] as ComponentDef<T>).template;
-  const oldView = enterView(hostView, hostNode);
 
-  if (template != null) {
-    try {
-      template(component, creationMode);
-      refreshDynamicChildren();
-      refreshChildComponents();
-    } finally {
-      leaveView(oldView);
-    }
+  const oldView = enterView(hostView, hostNode);
+  try {
+    template(component, creationMode);
+    refreshDynamicChildren();
+    refreshDirectives();
+  } finally {
+    leaveView(oldView);
   }
 }
 

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -95,7 +95,7 @@ export interface DirectiveDef<T> {
    * Refreshes host bindings on the associated directive. Also calls lifecycle hooks
    * like ngOnInit and ngDoCheck, if they are defined on the directive.
    */
-  h(directiveIndex: number, elementIndex: number): void;
+  h: ((directiveIndex: number, elementIndex: number) => void)|null;
 
   /**
    * Static attributes to set on host element.

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -85,17 +85,11 @@ export interface DirectiveDef<T> {
    *
    * Usually returns the directive instance, but if the directive has a content query,
    * it instead returns an array that contains the instance as well as content query data.
-   *
-   * NOTE: this property is short (1 char) because it is used in
-   * component templates which is sensitive to size.
    */
-  n(): T|[T];
+  factory(): T|[T];
 
-  /**
-   * Refreshes host bindings on the associated directive. Also calls lifecycle hooks
-   * like ngOnInit and ngDoCheck, if they are defined on the directive.
-   */
-  h: ((directiveIndex: number, elementIndex: number) => void)|null;
+  /** Refreshes host bindings on the associated directive. */
+  hostBindings: ((directiveIndex: number, elementIndex: number) => void)|null;
 
   /**
    * Static attributes to set on host element.

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -282,6 +282,14 @@ export interface TView {
    * current view has finished its check.
    */
   components: number[]|null;
+
+  /**
+   * A list of indices for child directives that have host bindings.
+   *
+   * Even indices: Directive indices
+   * Odd indices: Element indices
+   */
+  hostBindings: number[]|null;
 }
 
 /**

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -153,13 +153,13 @@
     "name": "locateHostElement"
   },
   {
-    "name": "noop$2"
-  },
-  {
     "name": "queueInitHooks"
   },
   {
     "name": "refreshChildComponents"
+  },
+  {
+    "name": "refreshDirectives"
   },
   {
     "name": "refreshDynamicChildren"
@@ -178,6 +178,9 @@
   },
   {
     "name": "resolveRendererType2"
+  },
+  {
+    "name": "setHostBindings"
   },
   {
     "name": "setInputsFromAttrs"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -180,6 +180,9 @@
     "name": "resolveRendererType2"
   },
   {
+    "name": "rootDirectiveIndices"
+  },
+  {
     "name": "setHostBindings"
   },
   {

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -132,7 +132,6 @@ describe('change detection', () => {
             elementEnd();
           }
           elementProperty(0, 'name', bind(ctx.name));
-          MyComponent.ngComponentDef.h(1, 0);
         }
       });
     }
@@ -212,7 +211,6 @@ describe('change detection', () => {
               { listener('click', () => ctx.noop()); }
               elementEnd();
             }
-            MyComponent.ngComponentDef.h(1, 0);
           }
         });
       }
@@ -244,7 +242,6 @@ describe('change detection', () => {
               elementEnd();
             }
             textBinding(0, interpolation1('', ctx.doCheckCount, ' - '));
-            MyComponent.ngComponentDef.h(2, 1);
           },
           changeDetection: ChangeDetectionStrategy.OnPush
         });
@@ -261,7 +258,6 @@ describe('change detection', () => {
               elementStart(0, ButtonParent);
               elementEnd();
             }
-            ButtonParent.ngComponentDef.h(1, 0);
           }
         });
       }
@@ -337,7 +333,6 @@ describe('change detection', () => {
               elementEnd();
             }
             textBinding(0, interpolation1('', ctx.doCheckCount, ' - '));
-            MyComp.ngComponentDef.h(2, 1);
           }
         });
       }
@@ -415,8 +410,6 @@ describe('change detection', () => {
                 elementStart(0, MyComp, ['dir', ''], [Dir]);
                 elementEnd();
               }
-              MyComp.ngComponentDef.h(1, 0);
-              Dir.ngDirectiveDef.h(2, 0);
             }
           });
         }
@@ -448,7 +441,6 @@ describe('change detection', () => {
                 elementEnd();
               }
               textBinding(1, bind(ctx.name));
-              Dir.ngDirectiveDef.h(2, 1);
             }
           });
         }
@@ -491,7 +483,6 @@ describe('change detection', () => {
                     elementStart(0, 'div', ['dir', ''], [Dir]);
                     elementEnd();
                   }
-                  Dir.ngDirectiveDef.h(1, 0);
                 }
                 embeddedViewEnd();
               }
@@ -584,7 +575,6 @@ describe('change detection', () => {
               elementStart(0, DetachedComp);
               elementEnd();
             }
-            DetachedComp.ngComponentDef.h(1, 0);
           }
         });
       }
@@ -723,7 +713,6 @@ describe('change detection', () => {
                 elementEnd();
               }
               elementProperty(0, 'value', bind(ctx.value));
-              OnPushComp.ngComponentDef.h(1, 0);
             }
           });
         }
@@ -790,7 +779,6 @@ describe('change detection', () => {
               elementEnd();
             }
             textBinding(0, interpolation1('', ctx.value, ' - '));
-            OnPushComp.ngComponentDef.h(2, 1);
           },
           changeDetection: ChangeDetectionStrategy.OnPush
         });
@@ -865,7 +853,6 @@ describe('change detection', () => {
                     elementStart(0, OnPushComp);
                     elementEnd();
                   }
-                  OnPushComp.ngComponentDef.h(1, 0);
                   embeddedViewEnd();
                 }
               }
@@ -948,7 +935,6 @@ describe('change detection', () => {
               elementEnd();
             }
             textBinding(0, interpolation1('', ctx.value, ' - '));
-            NoChangesComp.ngComponentDef.h(2, 1);
           }
         });
       }

--- a/packages/core/test/render3/compiler_canonical/component_directives_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/component_directives_spec.ts
@@ -71,8 +71,6 @@ describe('components & directives', () => {
             $r3$.ɵe();
             $r3$.ɵT(3, '!');
           }
-          ChildComponent.ngComponentDef.h(1, 0);
-          SomeDirective.ngDirectiveDef.h(2, 0);
         }
       });
       // /NORMATIVE
@@ -119,7 +117,6 @@ describe('components & directives', () => {
             $r3$.ɵE(0, 'div', $e0_attrs$, $e0_dirs$);
             $r3$.ɵe();
           }
-          HostBindingDir.ngDirectiveDef.h(1, 0);
         }
       });
     }
@@ -167,7 +164,6 @@ describe('components & directives', () => {
             $r3$.ɵT(2, 'Click');
             $r3$.ɵe();
           }
-          HostListenerDir.ngDirectiveDef.h(1, 0);
         }
       });
     }
@@ -209,7 +205,6 @@ describe('components & directives', () => {
             $r3$.ɵE(0, 'div', $e0_attrs$, $e0_dirs$);
             $r3$.ɵe();
           }
-          HostAttributeDir.ngDirectiveDef.h(1, 0);
         }
       });
     }
@@ -254,7 +249,6 @@ describe('components & directives', () => {
             $r3$.ɵE(0, 'div', $e0_attrs$, $e0_dirs$);
             $r3$.ɵe();
           }
-          HostBindingDir.ngDirectiveDef.h(1, 0);
         }
       });
     }
@@ -312,7 +306,6 @@ describe('components & directives', () => {
             $r3$.ɵe();
           }
           $r3$.ɵp(0, 'name', $r3$.ɵb(ctx.name));
-          MyComp.ngComponentDef.h(1, 0);
         }
       });
     }
@@ -430,7 +423,6 @@ describe('components & directives', () => {
               $r3$.ɵe();
             }
             $r3$.ɵp(0, 'names', cm ? $e0_arr$ : $r3$.ɵNC);
-            MyArrayComp.ngComponentDef.h(1, 0);
           }
         });
         // /NORMATIVE
@@ -469,7 +461,6 @@ describe('components & directives', () => {
               $r3$.ɵe();
             }
             $r3$.ɵp(0, 'names', $r3$.ɵb(ctx.someFn($r3$.ɵf0($e0_ff$))));
-            MyArrayComp.ngComponentDef.h(1, 0);
           }
         });
         // /NORMATIVE
@@ -522,7 +513,6 @@ describe('components & directives', () => {
               $r3$.ɵe();
             }
             $r3$.ɵp(0, 'num', $r3$.ɵb($r3$.ɵf0($e0_ff$).length + 1));
-            MyComp.ngComponentDef.h(1, 0);
           }
         });
         // /NORMATIVE
@@ -559,7 +549,6 @@ describe('components & directives', () => {
               $r3$.ɵe();
             }
             $r3$.ɵp(0, 'names', $r3$.ɵb($r3$.ɵf1($e0_ff$, ctx.customName)));
-            MyArrayComp.ngComponentDef.h(1, 0);
           }
         });
         // /NORMATIVE
@@ -663,7 +652,6 @@ describe('components & directives', () => {
             $r3$.ɵp(
                 0, 'names',
                 $r3$.ɵb($r3$.ɵfV($e0_ff$, [c.n0, c.n1, c.n2, c.n3, c.n4, c.n5, c.n6, c.n7, c.n8])));
-            MyComp.ngComponentDef.h(1, 0);
           }
         });
         // /NORMATIVE
@@ -730,7 +718,6 @@ describe('components & directives', () => {
               $r3$.ɵe();
             }
             $r3$.ɵp(0, 'config', $r3$.ɵb($r3$.ɵf1($e0_ff$, ctx.name)));
-            ObjectComp.ngComponentDef.h(1, 0);
           }
         });
         // /NORMATIVE
@@ -810,7 +797,6 @@ describe('components & directives', () => {
                 0, 'config', $r3$.ɵf2(
                                  $e0_ff_2$, ctx.name,
                                  $r3$.ɵb($r3$.ɵf1($e0_ff_1$, $r3$.ɵf1($e0_ff$, ctx.duration)))));
-            NestedComp.ngComponentDef.h(1, 0);
           }
         });
         // /NORMATIVE

--- a/packages/core/test/render3/compiler_canonical/injection_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/injection_spec.ts
@@ -55,7 +55,6 @@ describe('injection', () => {
               $r3$.ɵE(0, MyComp);
               $r3$.ɵe();
             }
-            MyComp.ngComponentDef.h(1, 0);
           }
         });
       }
@@ -99,7 +98,6 @@ describe('injection', () => {
               $r3$.ɵE(0, MyComp, e0_attrs);
               $r3$.ɵe();
             }
-            MyComp.ngComponentDef.h(1, 0);
           }
         });
       }

--- a/packages/core/test/render3/compiler_canonical/life_cycle_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/life_cycle_spec.ts
@@ -75,8 +75,6 @@ describe('lifecycle hooks', () => {
         }
         $r3$.ɵp(0, 'name', $r3$.ɵb(ctx.name1));
         $r3$.ɵp(2, 'name', $r3$.ɵb(ctx.name2));
-        LifecycleComp.ngComponentDef.h(1, 0);
-        LifecycleComp.ngComponentDef.h(3, 2);
       }
     });
     // /NORMATIVE

--- a/packages/core/test/render3/compiler_canonical/query_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/query_spec.ts
@@ -62,7 +62,6 @@ describe('queries', () => {
           $r3$.ɵqR($tmp$ = $r3$.ɵld<QueryList<any>>(0)) && (ctx.someDir = $tmp$.first);
           $r3$.ɵqR($tmp$ = $r3$.ɵld<QueryList<any>>(1)) &&
               (ctx.someDirList = $tmp$ as QueryList<any>);
-          SomeDirective.ngDirectiveDef.h(3, 2);
         }
       });
       // /NORMATIVE
@@ -145,8 +144,6 @@ describe('queries', () => {
             $r3$.ɵe();
             $r3$.ɵe();
           }
-          ContentQueryComponent.ngComponentDef.h(1, 0);
-          SomeDirective.ngDirectiveDef.h(3, 2);
         }
       });
       // /NON-NORMATIVE

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -111,7 +111,6 @@ describe('component with a container', () => {
       elementEnd();
     }
     elementProperty(0, 'items', bind(ctx.items));
-    WrapperComponent.ngComponentDef.h(1, 0);
   }
 
   it('should re-render on input change', () => {
@@ -136,7 +135,6 @@ describe('encapsulation', () => {
           elementStart(0, EncapsulatedComponent);
           elementEnd();
         }
-        EncapsulatedComponent.ngComponentDef.h(1, 0);
       },
       factory: () => new WrapperComponent,
     });
@@ -152,7 +150,6 @@ describe('encapsulation', () => {
           elementStart(1, LeafComponent);
           elementEnd();
         }
-        LeafComponent.ngComponentDef.h(2, 1);
       },
       factory: () => new EncapsulatedComponent,
       rendererType:
@@ -199,7 +196,6 @@ describe('encapsulation', () => {
             elementStart(0, LeafComponentwith);
             elementEnd();
           }
-          LeafComponentwith.ngComponentDef.h(1, 0);
         },
         factory: () => new WrapperComponentWith,
         rendererType:
@@ -266,7 +262,6 @@ describe('recursive components', () => {
               elementEnd();
             }
             elementProperty(0, 'data', bind(ctx.data.left));
-            TreeComponent.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -279,7 +274,6 @@ describe('recursive components', () => {
               elementEnd();
             }
             elementProperty(0, 'data', bind(ctx.data.right));
-            TreeComponent.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -35,7 +35,6 @@ describe('content projection', () => {
         { text(2, 'content'); }
         elementEnd();
       }
-      Child.ngComponentDef.h(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div>content</div></child>');
@@ -54,7 +53,6 @@ describe('content projection', () => {
         { text(2, 'content'); }
         elementEnd();
       }
-      Child.ngComponentDef.h(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child>content</child>');
@@ -75,7 +73,6 @@ describe('content projection', () => {
         elementStart(1, GrandChild);
         { projection(3, 0); }
         elementEnd();
-        GrandChild.ngComponentDef.h(2, 1);
       }
     });
     const Parent = createComponent('parent', function(ctx: any, cm: boolean) {
@@ -89,7 +86,6 @@ describe('content projection', () => {
         }
         elementEnd();
       }
-      Child.ngComponentDef.h(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent))
@@ -128,8 +124,6 @@ describe('content projection', () => {
         }
         elementEnd();
       }
-      Child.ngComponentDef.h(1, 0);
-      ProjectedComp.ngComponentDef.h(3, 2);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent))
@@ -165,7 +159,6 @@ describe('content projection', () => {
         }
       }
       containerRefreshEnd();
-      Child.ngComponentDef.h(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div>()</div></child>');
@@ -200,7 +193,6 @@ describe('content projection', () => {
         }
       }
       containerRefreshEnd();
-      Child.ngComponentDef.h(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child></child>');
@@ -248,7 +240,6 @@ describe('content projection', () => {
         }
       }
       containerRefreshEnd();
-      Child.ngComponentDef.h(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div>(else)</div></child>');
@@ -305,7 +296,6 @@ describe('content projection', () => {
         }
         elementEnd();
       }
-      Child.ngComponentDef.h(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div><span>content</span></div></child>');
@@ -357,7 +347,6 @@ describe('content projection', () => {
            }
            elementEnd();
          }
-         Child.ngComponentDef.h(1, 0);
        });
        const parent = renderComponent(Parent);
        expect(toHtml(parent)).toEqual('<child><div>content</div></child>');
@@ -411,7 +400,6 @@ describe('content projection', () => {
            }
            elementEnd();
          }
-         Child.ngComponentDef.h(1, 0);
        });
        const parent = renderComponent(Parent);
        expect(toHtml(parent)).toEqual('<child><div>before-content-after</div></child>');
@@ -447,7 +435,6 @@ describe('content projection', () => {
         { text(2, 'content'); }
         elementEnd();
       }
-      Child.ngComponentDef.h(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child><div></div><span>content</span></child>');
@@ -504,7 +491,6 @@ describe('content projection', () => {
         }
         elementEnd();
       }
-      Child.ngComponentDef.h(1, 0);
     });
     const parent = renderComponent(Parent);
     expect(toHtml(parent)).toEqual('<child>content<div></div></child>');
@@ -554,7 +540,6 @@ describe('content projection', () => {
           }
           elementEnd();
         }
-        Child.ngComponentDef.h(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -601,7 +586,6 @@ describe('content projection', () => {
           }
           elementEnd();
         }
-        Child.ngComponentDef.h(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -648,7 +632,6 @@ describe('content projection', () => {
           }
           elementEnd();
         }
-        Child.ngComponentDef.h(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -695,7 +678,6 @@ describe('content projection', () => {
           }
           elementEnd();
         }
-        Child.ngComponentDef.h(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -741,7 +723,6 @@ describe('content projection', () => {
           }
           elementEnd();
         }
-        Child.ngComponentDef.h(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -788,7 +769,6 @@ describe('content projection', () => {
           }
           elementEnd();
         }
-        Child.ngComponentDef.h(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -835,7 +815,6 @@ describe('content projection', () => {
             elementEnd();
           }
           elementEnd();
-          GrandChild.ngComponentDef.h(2, 1);
         }
       });
 
@@ -856,7 +835,6 @@ describe('content projection', () => {
           }
           elementEnd();
         }
-        Child.ngComponentDef.h(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -901,7 +879,6 @@ describe('content projection', () => {
             projection(5, 0, 0, ['card-content', '']);
           }
           elementEnd();
-          Card.ngComponentDef.h(2, 1);
         }
       });
 
@@ -916,7 +893,6 @@ describe('content projection', () => {
           { text(2, 'content'); }
           elementEnd();
         }
-        CardWithTitle.ngComponentDef.h(1, 0);
       });
 
       const app = renderComponent(App);
@@ -962,7 +938,6 @@ describe('content projection', () => {
             projection(5, 0, 0, ['ngProjectAs', '[card-content]']);
           }
           elementEnd();
-          Card.ngComponentDef.h(2, 1);
         }
       });
 
@@ -977,7 +952,6 @@ describe('content projection', () => {
           { text(2, 'content'); }
           elementEnd();
         }
-        CardWithTitle.ngComponentDef.h(1, 0);
       });
 
       const app = renderComponent(App);
@@ -1017,7 +991,6 @@ describe('content projection', () => {
           }
           elementEnd();
         }
-        Child.ngComponentDef.h(1, 0);
       });
 
       const parent = renderComponent(Parent);
@@ -1063,7 +1036,6 @@ describe('content projection', () => {
           }
         }
         containerRefreshEnd();
-        Child.ngComponentDef.h(1, 0);
       });
       const parent = renderComponent(Parent);
       expect(toHtml(parent)).toEqual('<child><span><div>content</div></span></child>');

--- a/packages/core/test/render3/define_spec.ts
+++ b/packages/core/test/render3/define_spec.ts
@@ -35,7 +35,7 @@ describe('define', () => {
           });
         }
 
-        const myDir = MyDirective.ngDirectiveDef.n() as MyDirective;
+        const myDir = MyDirective.ngDirectiveDef.factory() as MyDirective;
         myDir.valA = 'first';
         expect(myDir.valA).toEqual('first');
         myDir.valB = 'second';

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -258,9 +258,6 @@ describe('di', () => {
               text(4);
             }
             textBinding(4, bind(load<Directive>(2).value));
-            MyComp.ngComponentDef.h(1, 0);
-            Directive.ngDirectiveDef.h(2, 0);
-            DirectiveSameInstance.ngDirectiveDef.h(3, 0);
           }
         });
       }
@@ -291,8 +288,6 @@ describe('di', () => {
               elementEnd();
             }
             textBinding(3, bind(load<Directive>(1).value));
-            Directive.ngDirectiveDef.h(1, 0);
-            DirectiveSameInstance.ngDirectiveDef.h(2, 0);
           }
         });
       }
@@ -330,9 +325,6 @@ describe('di', () => {
               text(5);
             }
             textBinding(5, bind(load<Directive>(3).value));
-            MyComp.ngComponentDef.h(1, 0);
-            Directive.ngDirectiveDef.h(3, 2);
-            DirectiveSameInstance.ngDirectiveDef.h(4, 2);
           }
         });
       }
@@ -375,8 +367,6 @@ describe('di', () => {
                   elementEnd();
                 }
                 textBinding(3, bind(load<Directive>(1).value));
-                Directive.ngDirectiveDef.h(1, 0);
-                DirectiveSameInstance.ngDirectiveDef.h(2, 0);
               }
               embeddedViewEnd();
             }
@@ -438,8 +428,6 @@ describe('di', () => {
                 elementEnd();
               }
               textBinding(3, bind(load<Directive>(1).value));
-              Directive.ngDirectiveDef.h(1, 0);
-              DirectiveSameInstance.ngDirectiveDef.h(2, 0);
             }
           }
         });

--- a/packages/core/test/render3/directive_spec.ts
+++ b/packages/core/test/render3/directive_spec.ts
@@ -34,7 +34,6 @@ describe('directive', () => {
           elementStart(0, 'span', null, [Directive]);
           elementEnd();
         }
-        Directive.ngDirectiveDef.h(1, 0);
       }
 
       expect(renderToHtml(Template, {})).toEqual('<span class="foo"></span>');

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -200,7 +200,6 @@ describe('render3 integration test', () => {
           elementStart(0, TodoComponent);
           elementEnd();
         }
-        TodoComponent.ngComponentDef.h(1, 0);
       }
 
       expect(renderToHtml(Template, null)).toEqual('<todo><p>Todo one</p></todo>');
@@ -213,7 +212,6 @@ describe('render3 integration test', () => {
           elementEnd();
           text(2, 'two');
         }
-        TodoComponent.ngComponentDef.h(1, 0);
       }
       expect(renderToHtml(Template, null)).toEqual('<todo><p>Todo one</p></todo>two');
     });
@@ -230,8 +228,6 @@ describe('render3 integration test', () => {
           elementStart(2, TodoComponent);
           elementEnd();
         }
-        TodoComponent.ngComponentDef.h(1, 0);
-        TodoComponent.ngComponentDef.h(3, 2);
       }
       expect(renderToHtml(Template, null))
           .toEqual('<todo><p>Todo one</p></todo><todo><p>Todo one</p></todo>');
@@ -266,7 +262,6 @@ describe('render3 integration test', () => {
           elementStart(0, TodoComponentHostBinding);
           elementEnd();
         }
-        TodoComponentHostBinding.ngComponentDef.h(1, 0);
       }
 
       expect(renderToHtml(Template, {})).toEqual('<todo title="one">one</todo>');
@@ -298,7 +293,6 @@ describe('render3 integration test', () => {
           elementStart(0, MyComp);
           elementEnd();
         }
-        MyComp.ngComponentDef.h(1, 0);
       }
 
       expect(renderToHtml(Template, null)).toEqual('<comp><p>Bess</p></comp>');
@@ -344,7 +338,6 @@ describe('render3 integration test', () => {
           elementEnd();
         }
         elementProperty(0, 'condition', bind(ctx.condition));
-        MyComp.ngComponentDef.h(1, 0);
       }
 
       expect(renderToHtml(Template, {condition: true})).toEqual('<comp><div>text</div></comp>');
@@ -464,7 +457,6 @@ describe('render3 integration test', () => {
         embeddedViewEnd();
       }
       containerRefreshEnd();
-      ChildComponent.ngComponentDef.h(1, 0);
     }
 
     it('should work with a tree', () => {
@@ -639,7 +631,6 @@ describe('render3 integration test', () => {
             elementStart(0, 'div', ['hostBindingDir', ''], [HostBindingDir]);
             elementEnd();
           }
-          HostBindingDir.ngDirectiveDef.h(1, 0);
         }
 
         expect(renderToHtml(Template, {}))

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -21,7 +21,6 @@ describe('lifecycles', () => {
         elementEnd();
       }
       elementProperty(0, 'val', bind(ctx.val));
-      type.ngComponentDef.h(1, 0);
     };
   }
 
@@ -74,7 +73,6 @@ describe('lifecycles', () => {
              elementEnd();
            }
            elementProperty(0, 'val', bind(ctx.val));
-           Comp.ngComponentDef.h(1, 0);
          }
 
          renderToHtml(Template, {val: '1'});
@@ -104,7 +102,6 @@ describe('lifecycles', () => {
           elementStart(0, Parent);
           elementEnd();
         }
-        Parent.ngComponentDef.h(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -128,8 +125,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val', 1);
         elementProperty(2, 'val', 2);
-        Parent.ngComponentDef.h(1, 0);
-        Parent.ngComponentDef.h(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -155,7 +150,6 @@ describe('lifecycles', () => {
               elementStart(0, Comp);
               elementEnd();
             }
-            Comp.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -184,8 +178,6 @@ describe('lifecycles', () => {
           { elementStart(2, ProjectedComp); }
           elementEnd();
         }
-        Comp.ngComponentDef.h(1, 0);
-        ProjectedComp.ngComponentDef.h(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -214,10 +206,6 @@ describe('lifecycles', () => {
         elementProperty(2, 'val', 1);
         elementProperty(4, 'val', 2);
         elementProperty(6, 'val', 2);
-        Comp.ngComponentDef.h(1, 0);
-        ProjectedComp.ngComponentDef.h(3, 2);
-        Comp.ngComponentDef.h(5, 4);
-        ProjectedComp.ngComponentDef.h(7, 6);
       }
 
       renderToHtml(Template, {});
@@ -231,8 +219,6 @@ describe('lifecycles', () => {
           elementStart(0, Comp, null, [Directive]);
           elementEnd();
         }
-        Comp.ngComponentDef.h(1, 0);
-        Directive.ngDirectiveDef.h(2, 0);
       }
 
       renderToHtml(Template, {});
@@ -250,7 +236,6 @@ describe('lifecycles', () => {
           elementStart(0, 'div', null, [Directive]);
           elementEnd();
         }
-        Directive.ngDirectiveDef.h(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -279,8 +264,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val', 1);
         elementProperty(3, 'val', 5);
-        Comp.ngComponentDef.h(1, 0);
-        Comp.ngComponentDef.h(4, 3);
         containerRefreshStart(2);
         {
           for (let j = 2; j < 5; j++) {
@@ -289,7 +272,6 @@ describe('lifecycles', () => {
               elementEnd();
             }
             elementProperty(0, 'val', j);
-            Comp.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -322,8 +304,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val', 1);
         elementProperty(3, 'val', 5);
-        Parent.ngComponentDef.h(1, 0);
-        Parent.ngComponentDef.h(4, 3);
         containerRefreshStart(2);
         {
           for (let j = 2; j < 5; j++) {
@@ -332,7 +312,6 @@ describe('lifecycles', () => {
               elementEnd();
             }
             elementProperty(0, 'val', j);
-            Parent.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -390,7 +369,6 @@ describe('lifecycles', () => {
           elementStart(0, Comp);
           elementEnd();
         }
-        Comp.ngComponentDef.h(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -420,7 +398,6 @@ describe('lifecycles', () => {
           elementStart(0, Parent);
           elementEnd();
         }
-        Parent.ngComponentDef.h(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -434,7 +411,6 @@ describe('lifecycles', () => {
           elementStart(0, Comp);
           elementEnd();
         }
-        Comp.ngComponentDef.h(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -451,8 +427,6 @@ describe('lifecycles', () => {
           elementStart(0, Comp, null, [Directive]);
           elementEnd();
         }
-        Comp.ngComponentDef.h(1, 0);
-        Directive.ngDirectiveDef.h(2, 0);
       }
 
       renderToHtml(Template, {});
@@ -470,7 +444,6 @@ describe('lifecycles', () => {
           elementStart(0, 'div', null, [Directive]);
           elementEnd();
         }
-        Directive.ngDirectiveDef.h(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -506,7 +479,6 @@ describe('lifecycles', () => {
         elementEnd();
       }
       elementProperty(1, 'val', bind(ctx.val));
-      Comp.ngComponentDef.h(2, 1);
     });
 
     let ProjectedComp = createAfterContentInitComp('projected', (ctx: any, cm: boolean) => {
@@ -543,7 +515,6 @@ describe('lifecycles', () => {
           { text(2, 'content'); }
           elementEnd();
         }
-        Comp.ngComponentDef.h(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -580,7 +551,6 @@ describe('lifecycles', () => {
               { text(2, 'content'); }
               elementEnd();
             }
-            Comp.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -609,7 +579,6 @@ describe('lifecycles', () => {
           { text(2, 'content'); }
           elementEnd();
         }
-        Parent.ngComponentDef.h(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -634,8 +603,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val', 1);
         elementProperty(3, 'val', 2);
-        Parent.ngComponentDef.h(1, 0);
-        Parent.ngComponentDef.h(4, 3);
       }
 
       renderToHtml(Template, {});
@@ -663,8 +630,6 @@ describe('lifecycles', () => {
           }
           elementEnd();
         }
-        Parent.ngComponentDef.h(1, 0);
-        ProjectedComp.ngComponentDef.h(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -706,10 +671,6 @@ describe('lifecycles', () => {
         elementProperty(2, 'val', 1);
         elementProperty(5, 'val', 2);
         elementProperty(7, 'val', 2);
-        Parent.ngComponentDef.h(1, 0);
-        ProjectedComp.ngComponentDef.h(3, 2);
-        Parent.ngComponentDef.h(6, 5);
-        ProjectedComp.ngComponentDef.h(8, 7);
       }
 
       renderToHtml(Template, {});
@@ -736,8 +697,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val', 1);
         elementProperty(4, 'val', 4);
-        Comp.ngComponentDef.h(1, 0);
-        Comp.ngComponentDef.h(5, 4);
         containerRefreshStart(3);
         {
           for (let i = 2; i < 4; i++) {
@@ -747,7 +706,6 @@ describe('lifecycles', () => {
               elementEnd();
             }
             elementProperty(0, 'val', i);
-            Comp.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -770,8 +728,6 @@ describe('lifecycles', () => {
       }
       elementProperty(0, 'val', 1);
       elementProperty(4, 'val', 4);
-      Parent.ngComponentDef.h(1, 0);
-      Parent.ngComponentDef.h(5, 4);
       containerRefreshStart(3);
       {
         for (let i = 2; i < 4; i++) {
@@ -781,7 +737,6 @@ describe('lifecycles', () => {
             elementEnd();
           }
           elementProperty(0, 'val', i);
-          Parent.ngComponentDef.h(1, 0);
           embeddedViewEnd();
         }
       }
@@ -812,7 +767,6 @@ describe('lifecycles', () => {
             { text(2, 'content'); }
             elementEnd();
           }
-          Comp.ngComponentDef.h(1, 0);
         }
 
         renderToHtml(Template, {});
@@ -849,8 +803,6 @@ describe('lifecycles', () => {
             elementStart(0, Comp, null, [Directive]);
             elementEnd();
           }
-          Comp.ngComponentDef.h(1, 0);
-          Directive.ngDirectiveDef.h(2, 0);
         }
 
         renderToHtml(Template, {});
@@ -864,7 +816,6 @@ describe('lifecycles', () => {
             elementStart(0, 'div', null, [Directive]);
             elementEnd();
           }
-          Directive.ngDirectiveDef.h(1, 0);
         }
 
         renderToHtml(Template, {});
@@ -924,7 +875,6 @@ describe('lifecycles', () => {
           elementStart(0, Comp);
           elementEnd();
         }
-        Comp.ngComponentDef.h(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -960,7 +910,6 @@ describe('lifecycles', () => {
               elementStart(0, Comp);
               elementEnd();
             }
-            Comp.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -989,7 +938,6 @@ describe('lifecycles', () => {
           elementStart(0, Parent);
           elementEnd();
         }
-        Parent.ngComponentDef.h(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -1013,8 +961,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val', 1);
         elementProperty(2, 'val', 2);
-        Parent.ngComponentDef.h(1, 0);
-        Parent.ngComponentDef.h(3, 2);
       }
       renderToHtml(Template, {});
       expect(events).toEqual(['comp1', 'comp2', 'parent1', 'parent2']);
@@ -1036,8 +982,6 @@ describe('lifecycles', () => {
           }
           elementEnd();
         }
-        Comp.ngComponentDef.h(1, 0);
-        ProjectedComp.ngComponentDef.h(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -1072,10 +1016,6 @@ describe('lifecycles', () => {
         elementProperty(2, 'val', 1);
         elementProperty(4, 'val', 2);
         elementProperty(6, 'val', 2);
-        Comp.ngComponentDef.h(1, 0);
-        ProjectedComp.ngComponentDef.h(3, 2);
-        Comp.ngComponentDef.h(5, 4);
-        ProjectedComp.ngComponentDef.h(7, 6);
       }
 
       renderToHtml(Template, {});
@@ -1099,8 +1039,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val', bind(ctx.val));
         elementProperty(2, 'val', bind(ctx.val));
-        Comp.ngComponentDef.h(1, 0);
-        ProjectedComp.ngComponentDef.h(3, 2);
       });
 
       /**
@@ -1116,8 +1054,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val', 1);
         elementProperty(2, 'val', 2);
-        ParentComp.ngComponentDef.h(1, 0);
-        ParentComp.ngComponentDef.h(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -1142,8 +1078,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val', 1);
         elementProperty(3, 'val', 4);
-        Comp.ngComponentDef.h(1, 0);
-        Comp.ngComponentDef.h(4, 3);
         containerRefreshStart(2);
         {
           for (let i = 2; i < 4; i++) {
@@ -1152,7 +1086,6 @@ describe('lifecycles', () => {
               elementEnd();
             }
             elementProperty(0, 'val', i);
-            Comp.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -1182,8 +1115,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val', 1);
         elementProperty(3, 'val', 4);
-        Parent.ngComponentDef.h(1, 0);
-        Parent.ngComponentDef.h(4, 3);
         containerRefreshStart(2);
         {
           for (let i = 2; i < 4; i++) {
@@ -1192,7 +1123,6 @@ describe('lifecycles', () => {
               elementEnd();
             }
             elementProperty(0, 'val', i);
-            Parent.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -1214,7 +1144,6 @@ describe('lifecycles', () => {
             elementStart(0, Comp);
             elementEnd();
           }
-          Comp.ngComponentDef.h(1, 0);
         }
 
         renderToHtml(Template, {});
@@ -1241,7 +1170,6 @@ describe('lifecycles', () => {
             elementEnd();
           }
           elementProperty(0, 'val', bind(ctx.myVal));
-          Comp.ngComponentDef.h(1, 0);
         }
 
         renderToHtml(Template, {myVal: 5});
@@ -1269,8 +1197,6 @@ describe('lifecycles', () => {
           }
           elementProperty(0, 'val', 1);
           elementProperty(3, 'val', 4);
-          Parent.ngComponentDef.h(1, 0);
-          Parent.ngComponentDef.h(4, 3);
           containerRefreshStart(2);
           {
             for (let i = 2; i < 4; i++) {
@@ -1279,7 +1205,6 @@ describe('lifecycles', () => {
                 elementEnd();
               }
               elementProperty(0, 'val', i);
-              Parent.ngComponentDef.h(1, 0);
               embeddedViewEnd();
             }
           }
@@ -1312,8 +1237,6 @@ describe('lifecycles', () => {
             elementStart(0, Comp, null, [Directive]);
             elementEnd();
           }
-          Comp.ngComponentDef.h(1, 0);
-          Directive.ngDirectiveDef.h(2, 0);
         }
 
         renderToHtml(Template, {});
@@ -1327,7 +1250,6 @@ describe('lifecycles', () => {
             elementStart(0, 'div', null, [Directive]);
             elementEnd();
           }
-          Directive.ngDirectiveDef.h(1, 0);
         }
 
         renderToHtml(Template, {});
@@ -1388,7 +1310,6 @@ describe('lifecycles', () => {
               elementStart(0, Comp);
               elementEnd();
             }
-            Comp.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -1423,8 +1344,6 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val', bind('1'));
             elementProperty(2, 'val', bind('2'));
-            Comp.ngComponentDef.h(1, 0);
-            Comp.ngComponentDef.h(3, 2);
             embeddedViewEnd();
           }
         }
@@ -1456,7 +1375,6 @@ describe('lifecycles', () => {
               elementStart(0, Parent);
               elementEnd();
             }
-            Parent.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -1483,7 +1401,6 @@ describe('lifecycles', () => {
           elementStart(0, Parent);
           elementEnd();
         }
-        Parent.ngComponentDef.h(1, 0);
       });
 
       function Template(ctx: any, cm: boolean) {
@@ -1497,7 +1414,6 @@ describe('lifecycles', () => {
               elementStart(0, Grandparent);
               elementEnd();
             }
-            Grandparent.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -1547,10 +1463,6 @@ describe('lifecycles', () => {
             elementProperty(2, 'val', 1);
             elementProperty(4, 'val', 2);
             elementProperty(6, 'val', 2);
-            Comp.ngComponentDef.h(1, 0);
-            ProjectedComp.ngComponentDef.h(3, 2);
-            Comp.ngComponentDef.h(5, 4);
-            ProjectedComp.ngComponentDef.h(7, 6);
             embeddedViewEnd();
           }
         }
@@ -1591,8 +1503,6 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val', bind('1'));
             elementProperty(3, 'val', bind('3'));
-            Comp.ngComponentDef.h(1, 0);
-            Comp.ngComponentDef.h(4, 3);
             containerRefreshStart(2);
             {
               if (ctx.condition2) {
@@ -1601,7 +1511,6 @@ describe('lifecycles', () => {
                   elementEnd();
                 }
                 elementProperty(0, 'val', bind('2'));
-                Comp.ngComponentDef.h(1, 0);
                 embeddedViewEnd();
               }
             }
@@ -1664,8 +1573,6 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val', bind('1'));
             elementProperty(3, 'val', bind('5'));
-            Comp.ngComponentDef.h(1, 0);
-            Comp.ngComponentDef.h(4, 3);
             containerRefreshStart(2);
             {
               for (let j = 2; j < ctx.len; j++) {
@@ -1674,7 +1581,6 @@ describe('lifecycles', () => {
                   elementEnd();
                 }
                 elementProperty(0, 'val', bind(j));
-                Comp.ngComponentDef.h(1, 0);
                 embeddedViewEnd();
               }
             }
@@ -1746,7 +1652,6 @@ describe('lifecycles', () => {
               }
               elementEnd();
             }
-            Comp.ngComponentDef.h(3, 2);
             embeddedViewEnd();
           }
         }
@@ -1794,8 +1699,6 @@ describe('lifecycles', () => {
               elementStart(0, Comp, null, [Directive]);
               elementEnd();
             }
-            Comp.ngComponentDef.h(1, 0);
-            Directive.ngDirectiveDef.h(2, 0);
             embeddedViewEnd();
           }
         }
@@ -1828,7 +1731,6 @@ describe('lifecycles', () => {
               elementStart(0, 'div', null, [Directive]);
               elementEnd();
             }
-            Directive.ngDirectiveDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -1864,7 +1766,6 @@ describe('lifecycles', () => {
       }
       elementProperty(0, 'val1', bind(ctx.a));
       elementProperty(0, 'publicName', bind(ctx.b));
-      Comp.ngComponentDef.h(1, 0);
     });
     const ProjectedComp = createOnChangesComponent('projected', (ctx: any, cm: boolean) => {
       if (cm) {
@@ -1921,7 +1822,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val1', bind(ctx.val1));
         elementProperty(0, 'publicName', bind(ctx.val2));
-        Comp.ngComponentDef.h(1, 0);
       }
 
       renderToHtml(Template, {val1: '1', val2: 'a'});
@@ -1947,7 +1847,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val1', bind(ctx.val1));
         elementProperty(0, 'publicName', bind(ctx.val2));
-        Parent.ngComponentDef.h(1, 0);
       }
 
       renderToHtml(Template, {val1: '1', val2: 'a'});
@@ -1976,8 +1875,6 @@ describe('lifecycles', () => {
         elementProperty(0, 'publicName', bind(1));
         elementProperty(2, 'val1', bind(2));
         elementProperty(2, 'publicName', bind(2));
-        Parent.ngComponentDef.h(1, 0);
-        Parent.ngComponentDef.h(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -2010,7 +1907,6 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val1', bind(1));
             elementProperty(0, 'publicName', bind(1));
-            Comp.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -2046,8 +1942,6 @@ describe('lifecycles', () => {
         elementProperty(0, 'publicName', bind(1));
         elementProperty(2, 'val1', bind(2));
         elementProperty(2, 'publicName', bind(2));
-        Comp.ngComponentDef.h(1, 0);
-        ProjectedComp.ngComponentDef.h(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -2083,10 +1977,6 @@ describe('lifecycles', () => {
         elementProperty(4, 'publicName', bind(3));
         elementProperty(6, 'val1', bind(4));
         elementProperty(6, 'publicName', bind(4));
-        Comp.ngComponentDef.h(1, 0);
-        ProjectedComp.ngComponentDef.h(3, 2);
-        Comp.ngComponentDef.h(5, 4);
-        ProjectedComp.ngComponentDef.h(7, 6);
       }
 
       renderToHtml(Template, {});
@@ -2107,7 +1997,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val1', bind(1));
         elementProperty(0, 'publicName', bind(1));
-        Comp.ngComponentDef.h(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -2131,7 +2020,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val1', bind(1));
         elementProperty(0, 'publicName', bind(1));
-        Directive.ngDirectiveDef.h(1, 0);
       }
 
       renderToHtml(Template, {});
@@ -2162,8 +2050,6 @@ describe('lifecycles', () => {
         elementProperty(0, 'publicName', bind(1));
         elementProperty(3, 'val1', bind(5));
         elementProperty(3, 'publicName', bind(5));
-        Comp.ngComponentDef.h(1, 0);
-        Comp.ngComponentDef.h(4, 3);
         containerRefreshStart(2);
         {
           for (let j = 2; j < 5; j++) {
@@ -2173,7 +2059,6 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val1', bind(j));
             elementProperty(0, 'publicName', bind(j));
-            Comp.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -2214,8 +2099,6 @@ describe('lifecycles', () => {
         elementProperty(0, 'publicName', bind(1));
         elementProperty(3, 'val1', bind(5));
         elementProperty(3, 'publicName', bind(5));
-        Parent.ngComponentDef.h(1, 0);
-        Parent.ngComponentDef.h(4, 3);
         containerRefreshStart(2);
         {
           for (let j = 2; j < 5; j++) {
@@ -2225,7 +2108,6 @@ describe('lifecycles', () => {
             }
             elementProperty(0, 'val1', bind(j));
             elementProperty(0, 'publicName', bind(j));
-            Parent.ngComponentDef.h(1, 0);
             embeddedViewEnd();
           }
         }
@@ -2299,8 +2181,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val', 1);
         elementProperty(2, 'val', 2);
-        Comp.ngComponentDef.h(1, 0);
-        Comp.ngComponentDef.h(3, 2);
       }
 
       renderToHtml(Template, {});
@@ -2328,7 +2208,6 @@ describe('lifecycles', () => {
           elementEnd();
         }
         elementProperty(0, 'val', bind(ctx.val));
-        Comp.ngComponentDef.h(1, 0);
       });
 
       /**
@@ -2344,8 +2223,6 @@ describe('lifecycles', () => {
         }
         elementProperty(0, 'val', 1);
         elementProperty(2, 'val', 2);
-        Parent.ngComponentDef.h(1, 0);
-        Parent.ngComponentDef.h(3, 2);
       }
 
       renderToHtml(Template, {});

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -249,7 +249,6 @@ describe('event listeners', () => {
         text(2, 'Click');
         elementEnd();
       }
-      HostListenerDir.ngDirectiveDef.h(1, 0);
     }
 
     renderToHtml(Template, {});
@@ -343,8 +342,6 @@ describe('event listeners', () => {
             elementStart(3, MyComp);
             elementEnd();
           }
-          MyComp.ngComponentDef.h(2, 1);
-          MyComp.ngComponentDef.h(4, 3);
           embeddedViewEnd();
         }
       }

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -51,7 +51,6 @@ describe('outputs', () => {
         }
         elementEnd();
       }
-      ButtonToggle.ngComponentDef.h(1, 0);
     }
 
     let counter = 0;
@@ -76,7 +75,6 @@ describe('outputs', () => {
         }
         elementEnd();
       }
-      ButtonToggle.ngComponentDef.h(1, 0);
     }
 
     let counter = 0;
@@ -101,7 +99,6 @@ describe('outputs', () => {
         }
         elementEnd();
       }
-      ButtonToggle.ngComponentDef.h(1, 0);
     }
 
     const ctx = {counter: 0};
@@ -136,7 +133,6 @@ describe('outputs', () => {
             }
             elementEnd();
           }
-          ButtonToggle.ngComponentDef.h(1, 0);
           embeddedViewEnd();
         }
       }
@@ -187,7 +183,6 @@ describe('outputs', () => {
                 }
                 elementEnd();
               }
-              ButtonToggle.ngComponentDef.h(1, 0);
               embeddedViewEnd();
             }
           }
@@ -256,8 +251,6 @@ describe('outputs', () => {
             elementStart(4, DestroyComp);
             elementEnd();
           }
-          ButtonToggle.ngComponentDef.h(3, 2);
-          DestroyComp.ngComponentDef.h(5, 4);
           embeddedViewEnd();
         }
       }
@@ -333,7 +326,6 @@ describe('outputs', () => {
         }
         elementEnd();
       }
-      ButtonToggle.ngComponentDef.h(1, 0);
     }
 
     let counter = 0;
@@ -366,7 +358,6 @@ describe('outputs', () => {
         elementEnd();
       }
       elementProperty(0, 'change', bind(ctx.change));
-      ButtonToggle.ngComponentDef.h(1, 0);
     }
 
     let counter = 0;
@@ -410,7 +401,6 @@ describe('outputs', () => {
             }
             elementEnd();
           }
-          ButtonToggle.ngComponentDef.h(1, 0);
           embeddedViewEnd();
         } else {
           if (embeddedViewStart(1)) {

--- a/packages/core/test/render3/pipe_spec.ts
+++ b/packages/core/test/render3/pipe_spec.ts
@@ -71,7 +71,6 @@ describe('pipe', () => {
         pipe(2, DoublePipe.ngPipeDef);
         elementEnd();
       }
-      MyDir.ngDirectiveDef.h(1, 0);
       elementProperty(0, 'elprop', bind(pipeBind1(2, ctx)));
       directive = load(1);
     }

--- a/packages/core/test/render3/pure_function_spec.ts
+++ b/packages/core/test/render3/pure_function_spec.ts
@@ -35,7 +35,6 @@ describe('array literals', () => {
         elementEnd();
       }
       elementProperty(0, 'names', bind(pureFunction1(e0_ff, ctx.customName)));
-      MyComp.ngComponentDef.h(1, 0);
     }
 
     renderToHtml(Template, {customName: 'Carson'});
@@ -89,7 +88,6 @@ describe('array literals', () => {
       }
       elementProperty(0, 'names1', bind(pureFunction1(e0_ff, ctx.customName)));
       elementProperty(0, 'names2', bind(pureFunction1(e0_ff_1, ctx.customName2)));
-      ManyPropComp.ngComponentDef.h(1, 0);
     }
 
     renderToHtml(Template, {customName: 'Carson', customName2: 'George'});
@@ -126,7 +124,6 @@ describe('array literals', () => {
             elementEnd();
           }
           elementProperty(0, 'names', bind(ctx.someFn(pureFunction1(e0_ff, ctx.customName))));
-          MyComp.ngComponentDef.h(1, 0);
         }
       });
     }
@@ -138,8 +135,6 @@ describe('array literals', () => {
         elementStart(2, ParentComp);
         elementEnd();
       }
-      ParentComp.ngComponentDef.h(1, 0);
-      ParentComp.ngComponentDef.h(3, 2);
     }
 
     renderToHtml(Template, {});
@@ -166,7 +161,6 @@ describe('array literals', () => {
         elementEnd();
       }
       elementProperty(0, 'names', bind(pureFunction2(e0_ff, ctx.customName, ctx.customName2)));
-      MyComp.ngComponentDef.h(1, 0);
     }
 
     renderToHtml(Template, {customName: 'Carson', customName2: 'Hannah'});
@@ -243,12 +237,6 @@ describe('array literals', () => {
           8, 'names', bind(pureFunction7(e8_ff, c[1], c[2], c[3], c[4], c[5], c[6], c[7])));
       elementProperty(
           10, 'names', bind(pureFunction8(e10_ff, c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7])));
-      MyComp.ngComponentDef.h(1, 0);
-      MyComp.ngComponentDef.h(3, 2);
-      MyComp.ngComponentDef.h(5, 4);
-      MyComp.ngComponentDef.h(7, 6);
-      MyComp.ngComponentDef.h(9, 8);
-      MyComp.ngComponentDef.h(11, 10);
     }
 
     renderToHtml(Template, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']);
@@ -295,7 +283,6 @@ describe('array literals', () => {
       elementProperty(0, 'names', bind(pureFunctionV(e0_ff, [
                         c[0], c[1], c[2], c[3], pureFunction1(e0_ff_1, c[4]), c[5], c[6], c[7], c[8]
                       ])));
-      MyComp.ngComponentDef.h(1, 0);
     }
 
     expect(myComp !.names).toEqual([
@@ -339,7 +326,6 @@ describe('object literals', () => {
         elementEnd();
       }
       elementProperty(0, 'config', bind(pureFunction1(e0_ff, ctx.name)));
-      ObjectComp.ngComponentDef.h(1, 0);
     }
 
     renderToHtml(Template, {name: 'slide'});
@@ -376,7 +362,6 @@ describe('object literals', () => {
           0, 'config',
           bind(pureFunction2(
               e0_ff, ctx.name, pureFunction1(e0_ff_1, pureFunction1(e0_ff_2, ctx.duration)))));
-      ObjectComp.ngComponentDef.h(1, 0);
     }
 
     renderToHtml(Template, {name: 'slide', duration: 100});
@@ -443,7 +428,6 @@ describe('object literals', () => {
           elementProperty(
               0, 'config',
               bind(pureFunction2(e0_ff, ctx.configs[i].opacity, ctx.configs[i].duration)));
-          ObjectComp.ngComponentDef.h(1, 0);
           embeddedViewEnd();
         }
       }

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -67,7 +67,6 @@ describe('renderer factory lifecycle', () => {
       elementStart(1, SomeComponent);
       elementEnd();
     }
-    SomeComponent.ngComponentDef.h(2, 1);
   }
 
   beforeEach(() => { logs = []; });

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -41,7 +41,6 @@ describe('ViewContainerRef', () => {
         }
         containerRefreshStart(0);
         cmp.testDir = load<TestDirective>(1);
-        TestDirective.ngDirectiveDef.h(1, 0);
         containerRefreshEnd();
       },
     });


### PR DESCRIPTION
This PR moves the host bindings call out of the template. e.g.

Before:
```ts
if (cm) {
  E(0, MyComp);
  e();
}
MyComp.ngComponentDef.h(1, 0);
```

After:
```ts
if (cm) {
  E(0, MyComp);
  e();
}
```

This change has two main benefits:

- Removes ~11 bytes per directive instance in generated code
- Improves locality because template no longer needs to refer to directives explicitly to set host bindings. This will pave the way for removing all directive references from templates.