### PR TITLE
fix(elements): fix elements test bootstrap

### DIFF
--- a/packages/elements/test/BUILD.bazel
+++ b/packages/elements/test/BUILD.bazel
@@ -42,6 +42,7 @@ ts_web_test(
     ],
     # do not sort
     deps = [
+        "//:node_modules/tslib/tslib.js",
         "//tools/testing:browser",
         ":test_lib",
     ],


### PR DESCRIPTION
Elements uses a different set of bootstrap scripts, and didn't account for change to tslib.