### PR TITLE
fix(compiler): do not emit line/char in ngsummary files.

### DIFF
--- a/packages/compiler/src/aot/summary_serializer.ts
+++ b/packages/compiler/src/aot/summary_serializer.ts
@@ -222,6 +222,24 @@ class ToJsonSerializer extends ValueTransformer {
   }
 
   /**
+   * Strip line and character numbers from ngsummaries.
+   * Emitting them causes white spaces changes to retrigger upstream
+   * recompilations in bazel.
+   * TODO: find out a way to have line and character numbers in errors without
+   * excessive recompilation in bazel.
+   */
+  visitStringMap(map: {[key: string]: any}, context: any): any {
+    if (map['__symbolic'] === 'resolved') {
+      return visitValue(map.symbol, this, context);
+    }
+    if (map['__symbolic'] === 'error') {
+      delete map['line'];
+      delete map['character'];
+    }
+    return super.visitStringMap(map, context);
+  }
+
+  /**
    * Returns null if the options.resolveValue is true, and the summary for the symbol
    * resolved to a type or could not be resolved.
    */


### PR DESCRIPTION
Having ngsummaries emit line/char numbers causes white space change to
retrigger upstream recompilations.