### PR TITLE
docs(aio): update HTTP error test example

### DIFF
--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -1040,6 +1040,6 @@ Call `request.error()` with an `ErrorEvent` instead of `request.flush()`, as in 
 
 <code-example 
   path="http/src/testing/http-client.spec.ts"
-  region="404" 
+  region="network-error"
   linenums="false">
 </code-example>


### PR DESCRIPTION
Update the example to match the description preceding it, which refers to the
use of the error method and ErrorEvent rather than the flush method with a
non-2xx status as shown previously.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the [Testing for errors][1] section of the HTTP docs, the explanatory text reads:

 > Call `request.error()` with an `ErrorEvent` instead of `request.flush()`, as in this example.

However, the example that follows this text does not show the behaviour described.

 [1]: https://angular.io/guide/http#testing-for-errors

Issue Number: N/A


## What is the new behavior?

The example is now switched to the network error example, which does use `request.error`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
