### PR TITLE
 feat(common): allow async pipe to use detectChanges when using NoopZone

### DIFF
--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -7,7 +7,8 @@
  */
 
 import {AsyncPipe} from '@angular/common';
-import {EventEmitter, WrappedValue} from '@angular/core';
+import {EventEmitter, NgZone, WrappedValue, ɵNoopNgZone} from '@angular/core';
+import {async} from '@angular/core/testing';
 import {AsyncTestCompleter, beforeEach, describe, expect, inject, it} from '@angular/core/testing/src/testing_internal';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
@@ -27,6 +28,34 @@ import {SpyChangeDetectorRef} from '../spies';
         emitter = new EventEmitter();
         ref = new SpyChangeDetectorRef();
         pipe = new AsyncPipe(ref);
+      });
+
+      describe('noop zone', () => {
+        let zone: NgZone;
+        beforeEach(() => {
+          zone = new ɵNoopNgZone();
+          pipe = new AsyncPipe(ref, zone);
+        });
+        it('should be in push mode when NoopNgZone is injected',
+           () => { expect(pipe['_usePush']).toBe(true); });
+        it('should not be in push mode when NoopNgZone is injected', () => {
+          pipe = new AsyncPipe(ref);
+          expect(pipe['_usePush']).toBe(false);
+        });
+        it('should not be in push mode when NoopNgZone is injected', () => {
+          zone = new NgZone({});
+          pipe = new AsyncPipe(ref, zone);
+          expect(pipe['_usePush']).toBe(false);
+        });
+        it('should call detectChanges when in push', async(() => {
+             pipe.transform(emitter);
+             emitter.emit(message);
+
+             setTimeout(() => {
+               expect(ref.spy('detectChanges')).toHaveBeenCalled();
+               expect(ref.spy('markForCheck')).not.toHaveBeenCalled();
+             }, 0);
+           }));
       });
 
       describe('transform', () => {
@@ -119,6 +148,34 @@ import {SpyChangeDetectorRef} from '../spies';
         });
         ref = new SpyChangeDetectorRef();
         pipe = new AsyncPipe(<any>ref);
+      });
+
+      describe('noop zone', () => {
+        let zone: NgZone;
+        beforeEach(() => {
+          zone = new ɵNoopNgZone();
+          pipe = new AsyncPipe(<any>ref, zone);
+        });
+        it('should be in push mode when NoopNgZone is injected',
+           () => { expect(pipe['_usePush']).toBe(true); });
+        it('should not be in push mode when NoopNgZone is injected', () => {
+          pipe = new AsyncPipe(<any>ref);
+          expect(pipe['_usePush']).toBe(false);
+        });
+        it('should not be in push mode when NoopNgZone is injected', () => {
+          zone = new NgZone({});
+          pipe = new AsyncPipe(<any>ref, zone);
+          expect(pipe['_usePush']).toBe(false);
+        });
+        it('should call detectChanges when in push', async(() => {
+             pipe.transform(promise);
+             resolve(message);
+
+             setTimeout(() => {
+               expect(ref.spy('detectChanges')).toHaveBeenCalled();
+               expect(ref.spy('markForCheck')).not.toHaveBeenCalled();
+             }, 0);
+           }));
       });
 
       describe('transform', () => {

--- a/packages/common/test/spies.ts
+++ b/packages/common/test/spies.ts
@@ -13,6 +13,7 @@ export class SpyChangeDetectorRef extends SpyObject {
   constructor() {
     super(ChangeDetectorRef);
     this.spy('markForCheck');
+    this.spy('detectChanges');
   }
 }
 

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -27,3 +27,4 @@ export {makeDecorator as ɵmakeDecorator} from './util/decorators';
 export {isObservable as ɵisObservable, isPromise as ɵisPromise} from './util/lang';
 export {clearOverrides as ɵclearOverrides, overrideComponentView as ɵoverrideComponentView, overrideProvider as ɵoverrideProvider} from './view/index';
 export {NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as ɵNOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from './view/provider';
+export {NoopNgZone as ɵNoopNgZone} from './zone/ng_zone';

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -3,7 +3,7 @@ export declare const APP_BASE_HREF: InjectionToken<string>;
 
 /** @stable */
 export declare class AsyncPipe implements OnDestroy, PipeTransform {
-    constructor(_ref: ChangeDetectorRef);
+    constructor(_ref: ChangeDetectorRef, zone?: NgZone);
     ngOnDestroy(): void;
     transform<T>(obj: Promise<T> | null | undefined): T | null;
     transform<T>(obj: Observable<T> | null | undefined): T | null;


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Feature
```

## What is the current behavior?
The async pipe cannot push changes when using NoopZone

## What is the new behavior?
Allows async pipe to be used with NoopZone.
This will be especially helpful when using it with Angualr Elements since it's much easier to not include zone.js

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
