### PR TITLE
fix(compiler-cli): Use typescript to resolve modules for metadata generation

### DIFF
--- a/packages/compiler-cli/src/metadata/bundle_index_host.ts
+++ b/packages/compiler-cli/src/metadata/bundle_index_host.ts
@@ -103,7 +103,7 @@ export function createBundleIndexHost<H extends ts.CompilerHost>(
   // etc.
   const getMetadataBundle = (cache: MetadataCache | null) => {
     const bundler = new MetadataBundler(
-        indexModule, ngOptions.flatModuleId, new CompilerHostAdapter(host, cache),
+        indexModule, ngOptions.flatModuleId, new CompilerHostAdapter(host, cache, ngOptions),
         ngOptions.flatModulePrivateSymbolPrefix);
     return bundler.getMetadataBundle();
   };

--- a/packages/compiler-cli/src/metadata/bundler.ts
+++ b/packages/compiler-cli/src/metadata/bundler.ts
@@ -72,7 +72,7 @@ export interface BundledModule {
 }
 
 export interface MetadataBundlerHost {
-  getMetadataFor(moduleName: string): ModuleMetadata|undefined;
+  getMetadataFor(moduleName: string, containingFile: string): ModuleMetadata|undefined;
 }
 
 type StaticsMetadata = {
@@ -136,7 +136,7 @@ export class MetadataBundler {
     if (!result) {
       if (moduleName.startsWith('.')) {
         const fullModuleName = resolveModule(moduleName, this.root);
-        result = this.host.getMetadataFor(fullModuleName);
+        result = this.host.getMetadataFor(fullModuleName, this.root);
       }
       this.metadataCache.set(moduleName, result);
     }
@@ -598,11 +598,27 @@ export class MetadataBundler {
 export class CompilerHostAdapter implements MetadataBundlerHost {
   private collector = new MetadataCollector();
 
-  constructor(private host: ts.CompilerHost, private cache: MetadataCache|null) {}
+  constructor(
+      private host: ts.CompilerHost, private cache: MetadataCache|null,
+      private options: ts.CompilerOptions) {}
 
-  getMetadataFor(fileName: string): ModuleMetadata|undefined {
-    if (!this.host.fileExists(fileName + '.ts')) return undefined;
-    const sourceFile = this.host.getSourceFile(fileName + '.ts', ts.ScriptTarget.Latest);
+  getMetadataFor(fileName: string, containingFile: string): ModuleMetadata|undefined {
+    const {resolvedModule} =
+        ts.resolveModuleName(fileName, containingFile, this.options, this.host);
+
+    let sourceFile: ts.SourceFile|undefined;
+    if (resolvedModule) {
+      let {resolvedFileName} = resolvedModule;
+      if (resolvedModule.extension !== '.ts') {
+        resolvedFileName = resolvedFileName.replace(/(\.d\.ts|\.js)$/, '.ts');
+      }
+      sourceFile = this.host.getSourceFile(resolvedFileName, ts.ScriptTarget.Latest);
+    } else {
+      // If typescript is unable to resolve the file, fallback on old behavior
+      if (!this.host.fileExists(fileName + '.ts')) return undefined;
+      sourceFile = this.host.getSourceFile(fileName + '.ts', ts.ScriptTarget.Latest);
+    }
+
     // If there is a metadata cache, use it to get the metadata for this source file. Otherwise,
     // fall back on the locally created MetadataCollector.
     if (!sourceFile) {

--- a/packages/compiler-cli/test/metadata/BUILD.bazel
+++ b/packages/compiler-cli/test/metadata/BUILD.bazel
@@ -9,6 +9,7 @@ ts_library(
         "//packages:types",
         "//packages/compiler",
         "//packages/compiler-cli",
+        "//packages/compiler-cli/test:test_utils",
         "//packages/core",
     ],
 )

--- a/packages/compiler-cli/test/mocks.ts
+++ b/packages/compiler-cli/test/mocks.ts
@@ -19,7 +19,9 @@ export class MockAotContext {
 
   fileExists(fileName: string): boolean { return typeof this.getEntry(fileName) === 'string'; }
 
-  directoryExists(path: string): boolean { return typeof this.getEntry(path) === 'object'; }
+  directoryExists(path: string): boolean {
+    return path === this.currentDirectory || typeof this.getEntry(path) === 'object';
+  }
 
   readFile(fileName: string): string {
     const data = this.getEntry(fileName);


### PR DESCRIPTION
The current module resolution for the metadata collector simply attaches `.ts` to the import/export path, which does not work if the path is using Node / CommonJS behavior to resolve to an index.ts file. This patch uses typescript's module resolution logic, and will attempt to load the original typescript file if this resolution returns a `.js` or `.d.ts` file

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

The metadata collector does not generate correct metadata when a file uses an implied "index" in an import or export path. In the following example, the `import` refers to a path `../tools` that will be resolved by typescript as `../tools/index.ts`. The metadata collector, however, simply appends `.ts` directly to the path string before attempting to find it to generate metadata, thus looking for `../tools.ts`, which doesn't exist. This results in the metadata having no information for named entry `ɵb`, despite having it listed in imports and origins.

```ts
// app.component.ts
import { BrowserModule } from '@angular/platform-browser';
import { NgModule } from '@angular/core';

import { ToolModule } from '../tools';
import { AppComponent } from './app.component';


@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    BrowserModule,
    ToolModule,
  ],
  providers: [],
  bootstrap: [AppComponent]
})
export class AppModule { }
```

```ts
// ../tools/index.ts
import { NgModule } from '@angular/core';

@NgModule({
  declarations: [],
  exports: [],
  imports: [],
  providers: [],
})
export class ToolModule {

}
```

```js
{
  "__symbolic": "module",
  "version": 4,
  "metadata": {
    "AppModule": {
      "__symbolic": "class",
      "decorators": [
        {
          "__symbolic": "call",
          ...
          "arguments": [
            {
              ...
              "imports": [
                {
                  "__symbolic": "reference",
                  "module": "@angular/platform-browser",
                  "name": "BrowserModule",
                  "line": 13,
                  "character": 4
                },
                {
                  "__symbolic": "reference",
                  "name": "ɵb"
                }
              ],
              ...
            }
          ]
        }
      ],
      "members": {}
    },
    "ɵa": {
      "__symbolic": "class",
      ...
    }
  },
  "origins": {
    "AppModule": "./src/app/app.module",
    "ɵa": "./src/app/app.component",
    "ɵb": "./src/tools"
  },
  ...
}
```

Issue Number: N/A


## What is the new behavior?

This PR introduces a change to use the typescript module resolver to find files for metadata instead of just appending `.ts` to the input path name. This has the benefit that it will follow the same conventions that the runtime module resolution will use, and supports correctly finding files in all existing situations, as well as all situations where the path actually points to an index file (i.e. `../tools` will find `../tools.ts` or `../tools/index.ts` depending on how the project is structured).

With this change, correct metadata is generated for the same project as defined above - as seen below, `ɵb` now has metadata properly generated:

```js
{
  "__symbolic": "module",
  "version": 4,
  "metadata": {
    "AppModule": {
      "__symbolic": "class",
      "decorators": [
        {
          "__symbolic": "call",
          ...
          "arguments": [
            {
              ...
              "imports": [
                {
                  "__symbolic": "reference",
                  "module": "@angular/platform-browser",
                  "name": "BrowserModule",
                  "line": 13,
                  "character": 4
                },
                {
                  "__symbolic": "reference",
                  "name": "ɵb"
                }
              ],
              ...
            }
          ]
        }
      ],
      "members": {}
    },
    "ɵa": {
      "__symbolic": "class",
      ...
    },
    "ɵb": {
      "__symbolic": "class",
      "decorators": [
        {
          "__symbolic": "call",
          "expression": {
            "__symbolic": "reference",
            "module": "@angular/core",
            "name": "NgModule",
            "line": 2,
            "character": 1
          },
          "arguments": [
            {
              "declarations": [],
              "exports": [],
              "imports": [],
              "providers": []
            }
          ]
        }
      ],
      "members": {}
    }
  },
  "origins": {
    "AppModule": "./src/app/app.module",
    "ɵa": "./src/app/app.component",
    "ɵb": "./src/tools"
  },
  ...
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I don't believe this closes any open issue with this repo currently, although it is possibly a start for angular/angular#21082. However, I believe this is part of the root cause behind a range of issues in other libraries, including [ng-packagr](https://github.com/dherges/ng-packagr):

- dherges/ng-packagr#195
- dherges/ng-packagr#382
