### PR TITLE
docs(aio): updated wrong property name

### DIFF
--- a/aio/content/guide/reactive-forms.md
+++ b/aio/content/guide/reactive-forms.md
@@ -1069,7 +1069,7 @@ Replace the address `FormGroup` definition with a `secretLairs`  `FormArray` def
 
 </code-example>
 
-In `hero-detail.component.html` change `formArrayName="address"` to `formArrayName="secretLairs"`.
+In `hero-detail.component.html` change `formGroupName="address"` to `formArrayName="secretLairs"`.
 
 <code-example path="reactive-forms/src/app/hero-detail/hero-detail-8.component.html" region="form-array-name" title="src/app/hero-detail/hero-detail.component.ts" linenums="false">
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
In the [Reactive Forms](https://angular.io/guide/reactive-forms#from-address-to-secretlairs) section there is a property name mistake in the explanation.
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
It's ask to change the formArrayName="address"
`
In hero-detail.component.html change formArrayName="address" to formArrayName="secretLairs".
`
Nevertheless the current property is formGroupName="address"

Issue Number: N/A


## What is the new behavior?
So just change to the current property
`
In hero-detail.component.html change formGroupName="address" to formArrayName="secretLairs".
`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
