### PR TITLE
fix(upgrade): downgraded component not always attached to the app

### DIFF
--- a/packages/upgrade/src/common/downgrade_component_adapter.ts
+++ b/packages/upgrade/src/common/downgrade_component_adapter.ts
@@ -76,7 +76,7 @@ export class DowngradeComponentAdapter {
     hookupNgModel(this.ngModel, this.component);
   }
 
-  setupInputs(needsNgZone: boolean, propagateDigest = true): void {
+  setupInputs(attachToApp: boolean, propagateDigest = true): void {
     const attrs = this.attrs;
     const inputs = this.componentFactory.inputs || [];
     for (let i = 0; i < inputs.length; i++) {
@@ -152,7 +152,7 @@ export class DowngradeComponentAdapter {
 
     // If necessary, attach the view so that it will be dirty-checked.
     // (Allow time for the initial input values to be set and `ngOnChanges()` to be called.)
-    if (needsNgZone || !propagateDigest) {
+    if (attachToApp || !propagateDigest) {
       let unwatch: Function|null = this.componentScope.$watch(() => {
         unwatch !();
         unwatch = null;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In a case like `ng1` > `ng2-downgraded` > `ng1-upgraded` > `ng2-downgraded`, the last `ng2-downgraded` component would not be attached to the application and therefore would not be part of change detection

Issue Number: #22581


## What is the new behavior?

The last `ng2-downgraded` component will function as it should

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
