### PR TITLE
fix(router): workaround issues in closure compiler

### DIFF
--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -89,7 +89,7 @@ export function waitForMap<A, B>(
     }
   });
 
-  const concat$ = concatAll.call(of (...waitHead, ...waitTail));
+  const concat$ = concatAll.call(of.apply(null, waitHead.concat(waitTail)));
   const last$ = l.last.call(concat$);
   return map.call(last$, () => res);
 }


### PR DESCRIPTION
Spread operator in this particular place was throwing off closure(probably because it was thrown off by the `of` in the source).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Current Angular code doesn't compile with certain closure compiler flag

## What is the new behavior?
Works with closure

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
