### PR TITLE
ci: update ngbot config for g3

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -19,10 +19,12 @@ merge:
     disabled: false
     # the name of the status
     context: "google3"
-    # text to show when the status is pending
-    pendingDesc: "Googler: test this change in google3 http://go/angular-g3sync"
+    # text to show when the status is pending, {{PRNumber}} will be replaced by the PR number
+    pendingDesc: "Googler: run g3sync presubmit {{PRNumber}}"
     # text to show when the status is success
     successDesc: "Does not affect google3"
+    # link to use for the details
+    url: "http://go/angular-g3sync"
     # list of patterns to check for the files changed by the PR
     # this list must be manually kept in sync with google3/third_party/javascript/angular2/copy.bara.sky
     include:


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] CI related changes
```

## What is the current behavior?
The command to type for g3 sync is not listed, and the link is not clickable


## What is the new behavior?
Updated status desc to add the command to run g3 sync & added a clickable link to g3 sync


## Does this PR introduce a breaking change?
```
[x] No
```