### PR TITLE
fix(service-worker): handle offline mode and ignore invalid `only-if-cached` requests

### DIFF
--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -95,6 +95,12 @@ export class Driver implements Debuggable, UpdateSource {
   private scheduledNavUpdateCheck: boolean = false;
 
   /**
+   * Keep track of whether we have logged an invalid `only-if-cached` request.
+   * (See `.onFetch()` for details.)
+   */
+  private loggedInvalidOnlyIfCachedRequest: boolean = false;
+
+  /**
    * A scheduler which manages a queue of tasks that need to be executed when the SW is
    * not doing any other work (not processing any other requests).
    */
@@ -178,13 +184,21 @@ export class Driver implements Debuggable, UpdateSource {
       return;
     }
 
-    // Under some circumstances (possibly related to opening Chrome DevTools), requests are made
-    // with `cache: 'only-if-cached'` and `mode: 'no-cors'`. These request will eventually fail,
-    // because `only-if-cached` is only allowed to be used with `mode: 'same-origin'`.
+    // When opening DevTools in Chrome, a request is made for the current URL (and possibly related
+    // resources, e.g. scripts) with `cache: 'only-if-cached'` and `mode: 'no-cors'`. These request
+    // will eventually fail, because `only-if-cached` is only allowed to be used with
+    // `mode: 'same-origin'`.
     // This is likely a bug in Chrome DevTools. Avoid handling such requests.
     // (See also https://github.com/angular/angular/issues/22362.)
     // TODO(gkalpak): Remove once no longer necessary (i.e. fixed in Chrome DevTools).
     if ((req.cache as string) === 'only-if-cached' && req.mode !== 'same-origin') {
+      // Log the incident only the first time it happens, to avoid spamming the logs.
+      if (!this.loggedInvalidOnlyIfCachedRequest) {
+        this.loggedInvalidOnlyIfCachedRequest = true;
+        this.debugger.log(
+            `Ignoring invalid request: 'only-if-cached' can be set only with 'same-origin' mode`,
+            `Driver.fetch(${req.url}, cache: ${req.cache}, mode: ${req.mode})`);
+      }
       return;
     }
 
@@ -622,8 +636,8 @@ export class Driver implements Debuggable, UpdateSource {
    * offline (detected as response status 504).
    */
   private async fetchLatestManifest(ignoreOfflineError?: false): Promise<Manifest>;
-  private async fetchLatestManifest(ignoreOfflineError: true): Promise<Manifest | null>;
-  private async fetchLatestManifest(ignoreOfflineError = false): Promise<Manifest | null> {
+  private async fetchLatestManifest(ignoreOfflineError: true): Promise<Manifest|null>;
+  private async fetchLatestManifest(ignoreOfflineError = false): Promise<Manifest|null> {
     const res =
         await this.safeFetch(this.adapter.newRequest('ngsw.json?ngsw-cache-bust=' + Math.random()));
     if (!res.ok) {

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -708,6 +708,15 @@ const manifestUpdateHash = sha1(JSON.stringify(manifestUpdate));
 
         expect(driver.state).toEqual(DriverReadyState.EXISTING_CLIENTS_ONLY);
       });
+
+      async_it('ignores invalid `only-if-cached` requests ', async() => {
+        const requestFoo = (cache: RequestCache | 'only-if-cached', mode: RequestMode) =>
+            makeRequest(scope, '/foo.txt', undefined, {cache, mode});
+
+        expect(await requestFoo('default', 'no-cors')).toBe('this is foo');
+        expect(await requestFoo('only-if-cached', 'same-origin')).toBe('this is foo');
+        expect(await requestFoo('only-if-cached', 'no-cors')).toBeNull();
+      });
     });
   });
 })();

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -516,6 +516,17 @@ const manifestUpdateHash = sha1(JSON.stringify(manifestUpdate));
       expect(await scope.caches.keys()).toEqual([]);
     });
 
+    async_it('does not unregister or change state when offline (i.e. manifest 504s)', async() => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+      server.online = false;
+
+      expect(await driver.checkForUpdate()).toEqual(false);
+      expect(driver.state).toEqual(DriverReadyState.NORMAL);
+      expect(scope.unregistered).toBeFalsy();
+      expect(await scope.caches.keys()).not.toEqual([]);
+    });
+
     describe('unhashed requests', () => {
       async_beforeEach(async() => {
         expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');

--- a/packages/service-worker/worker/testing/fetch.ts
+++ b/packages/service-worker/worker/testing/fetch.ts
@@ -110,6 +110,9 @@ export class MockRequest extends MockBody implements Request {
         Object.keys(headers).forEach(header => { this.headers.set(header, headers[header]); });
       }
     }
+    if (init.cache !== undefined) {
+      this.cache = init.cache;
+    }
     if (init.mode !== undefined) {
       this.mode = init.mode;
     }

--- a/packages/service-worker/worker/testing/mock.ts
+++ b/packages/service-worker/worker/testing/mock.ts
@@ -96,6 +96,7 @@ export class MockServerState {
   private gate: Promise<void> = Promise.resolve();
   private resolve: Function|null = null;
   private resolveNextRequest: Function;
+  online = true;
   nextRequest: Promise<Request>;
 
   constructor(private resources: Map<string, Response>, private errors: Set<string>) {
@@ -107,6 +108,10 @@ export class MockServerState {
     this.nextRequest = new Promise(resolve => { this.resolveNextRequest = resolve; });
 
     await this.gate;
+
+    if (!this.online) {
+      throw new Error('Offline.');
+    }
 
     if (req.credentials === 'include') {
       return new MockResponse(null, {status: 0, statusText: '', type: 'opaque'});
@@ -171,6 +176,7 @@ export class MockServerState {
     this.nextRequest = new Promise(resolve => { this.resolveNextRequest = resolve; });
     this.gate = Promise.resolve();
     this.resolve = null;
+    this.online = true;
   }
 }
 


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] Bugfix
```

## What is the current behavior?
This PR fixes two issues:
1. When trying to fetch `ngsw.json` (e.g. during `checkForUpdate()`) while either the client or the server are offline, the ServiceWorker would enter a degrade mode, where only existing clients would be served. This essentially means that the ServiceWorker doesn't work offline.
2. Under some circumstances (possibly related to opening Chrome DevTools), requests are made with `cache: 'only-if-cached'` and `mode: 'no-cors'`. These request will eventually fail, because `only-if-cached` is only allowed to be [used with `mode: 'same-origin'`](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache).
This is likely a bug in Chrome DevTools. See also https://github.com/angular/angular/issues/22362#issuecomment-369116888.

Issue Number: #21636, #22362


## What is the new behavior?
1. Offline errors (status: 504) are treated differently than other fetch errors and the SW doesn't enter degraded mode. The ServiceWorker will remain in the current mode until connectivity to the server is restored.
2. Invalid `only-if-cached` requests (i.e. with `mode !== 'same-origin'`) are not handled by the SW.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
Fixes #21636 and #22362.
