### PR TITLE
fix(router): don't use spread operator to workaround an issue in clos…

### DIFF
--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -84,7 +84,8 @@ export function waitForMap<A, B>(
     }
   });
 
-  return of (...waitHead, ...waitTail).pipe(concatAll(), lastValue(), map(() => res));
+  // Closure compiler has problem with using spread operator here. So just using Array.concat.
+  return of .apply(null, waitHead.concat(waitTail)).pipe(concatAll(), lastValue(), map(() => res));
 }
 
 /**


### PR DESCRIPTION
…ure compiler

Closure compiler could not handle the spread operator in this one place. Working around it by removing the use of spread operator.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Closure compiler throws an error for the use of the spread operator for one of the binaries 

## What is the new behavior?
No error from closure

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
