### PR TITLE
fix(router): make locationSyncBootstrapListener public due to change …

### DIFF
--- a/packages/router/upgrade/src/upgrade.ts
+++ b/packages/router/upgrade/src/upgrade.ts
@@ -38,7 +38,7 @@ import {UpgradeModule} from '@angular/upgrade/static';
 export const RouterUpgradeInitializer = {
   provide: APP_BOOTSTRAP_LISTENER,
   multi: true,
-  useFactory: locationSyncBootstrapListener,
+  useFactory: locationSyncBootstrapListener as (ngUpgrade: UpgradeModule) => () => void,
   deps: [UpgradeModule]
 };
 

--- a/packages/router/upgrade/src/upgrade.ts
+++ b/packages/router/upgrade/src/upgrade.ts
@@ -38,7 +38,7 @@ import {UpgradeModule} from '@angular/upgrade/static';
 export const RouterUpgradeInitializer = {
   provide: APP_BOOTSTRAP_LISTENER,
   multi: true,
-  useFactory: locationSyncBootstrapListener as (ngUpgrade: UpgradeModule) => () => void,
+  useFactory: locationSyncBootstrapListener as(ngUpgrade: UpgradeModule) => () => void,
   deps: [UpgradeModule]
 };
 

--- a/tools/public_api_guard/router/upgrade.d.ts
+++ b/tools/public_api_guard/router/upgrade.d.ts
@@ -2,7 +2,7 @@
 export declare const RouterUpgradeInitializer: {
     provide: InjectionToken<((compRef: ComponentRef<any>) => void)[]>;
     multi: boolean;
-    useFactory: typeof locationSyncBootstrapListener;
+    useFactory: (ngUpgrade: UpgradeModule) => () => void;
     deps: (typeof UpgradeModule)[];
 };
 


### PR DESCRIPTION
…in output after TS 2.7 update in #22669

See build diff on 2.7 here:

https://github.com/angular/router-builds/commit/8788b39a980df2ecb72a316b1e0f991ec8a70a00#diff-068e657ab436c99f423c5ad8d4187c1b