### PR TITLE
fix(router): support null response in UrlMatcher

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -287,7 +287,7 @@ export type UrlMatchResult = {
  * @experimental
  */
 export type UrlMatcher = (segments: UrlSegment[], group: UrlSegmentGroup, route: Route) =>
-    UrlMatchResult;
+    UrlMatchResult | null;
 
 /**
  * @whatItDoes Represents the static data associated with a particular route.

--- a/packages/router/test/config.spec.ts
+++ b/packages/router/test/config.spec.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {validateConfig} from '../src/config';
+import {Route, validateConfig} from '../src/config';
 import {PRIMARY_OUTLET} from '../src/shared';
+import {UrlSegment, UrlSegmentGroup} from '../src/url_tree';
 
 describe('config', () => {
   describe('validateConfig', () => {
@@ -20,6 +21,11 @@ describe('config', () => {
     it('should not throw when a matcher is provided', () => {
       expect(() => validateConfig([{matcher: <any>'someFunc', component: ComponentA}]))
           .not.toThrow();
+    });
+
+    it('should not throw when a null matcher is provided', () => {
+      const matcher = (segments: UrlSegment[], group: UrlSegmentGroup, route: Route) => null;
+      expect(() => validateConfig([{matcher, component: ComponentA}])).not.toThrow();
     });
 
     it('should throw for undefined route', () => {

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -512,7 +512,7 @@ export declare abstract class UrlHandlingStrategy {
 }
 
 /** @experimental */
-export declare type UrlMatcher = (segments: UrlSegment[], group: UrlSegmentGroup, route: Route) => UrlMatchResult;
+export declare type UrlMatcher = (segments: UrlSegment[], group: UrlSegmentGroup, route: Route) => UrlMatchResult | null;
 
 /** @experimental */
 export declare type UrlMatchResult = {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) (updated router golden)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
This allows UrlMatcher responses to be null.

## What is the new behavior?
The example (in the documentation) UrlMatcher supports returning null.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```