### PR TITLE
fix(compiler): don't typecheck all inputs

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -238,8 +238,12 @@ export function compile({allowNonHermeticReads, allDepsCompiledWithBazel = true,
     gatherDiagnostics = (program) =>
         gatherDiagnosticsForInputsOnly(compilerOpts, bazelOpts, program);
   }
-  const {diagnostics, emitResult, program} = ng.performCompilation(
-      {rootNames: files, options: compilerOpts, host: ngHost, emitCallback, gatherDiagnostics});
+  const {diagnostics, emitResult, program} = ng.performCompilation({
+    rootNames: files,
+    options: compilerOpts,
+    host: ngHost, emitCallback,
+    mergeEmitResultsCallback: tsickle.mergeEmitResults, gatherDiagnostics
+  });
   const tsickleEmitResult = emitResult as tsickle.EmitResult;
   let externs = '/** @externs */\n';
   if (!diagnostics.length) {

--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -186,6 +186,7 @@ export function exitCodeFromResult(diags: Diagnostics | undefined): number {
 }
 
 export function performCompilation({rootNames, options, host, oldProgram, emitCallback,
+                                    mergeEmitResultsCallback,
                                     gatherDiagnostics = defaultGatherDiagnostics,
                                     customTransformers, emitFlags = api.EmitFlags.Default}: {
   rootNames: string[],
@@ -193,6 +194,7 @@ export function performCompilation({rootNames, options, host, oldProgram, emitCa
   host?: api.CompilerHost,
   oldProgram?: api.Program,
   emitCallback?: api.TsEmitCallback,
+  mergeEmitResultsCallback?: api.TsMergeEmitResultsCallback,
   gatherDiagnostics?: (program: api.Program) => Diagnostics,
   customTransformers?: api.CustomTransformers,
   emitFlags?: api.EmitFlags
@@ -216,7 +218,8 @@ export function performCompilation({rootNames, options, host, oldProgram, emitCa
     }
 
     if (!hasErrors(allDiagnostics)) {
-      emitResult = program !.emit({emitCallback, customTransformers, emitFlags});
+      emitResult =
+          program !.emit({emitCallback, mergeEmitResultsCallback, customTransformers, emitFlags});
       allDiagnostics.push(...emitResult.diagnostics);
       return {diagnostics: allDiagnostics, program, emitResult};
     }

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -260,6 +260,7 @@ export interface TsEmitArguments {
 }
 
 export interface TsEmitCallback { (args: TsEmitArguments): ts.EmitResult; }
+export interface TsMergeEmitResultsCallback { (results: ts.EmitResult[]): ts.EmitResult; }
 
 /**
  * @internal
@@ -353,11 +354,13 @@ export interface Program {
    *
    * Angular structural information is required to emit files.
    */
-  emit({emitFlags, cancellationToken, customTransformers, emitCallback}?: {
+  emit({emitFlags, cancellationToken, customTransformers, emitCallback,
+        mergeEmitResultsCallback}?: {
     emitFlags?: EmitFlags,
     cancellationToken?: ts.CancellationToken,
     customTransformers?: CustomTransformers,
-    emitCallback?: TsEmitCallback
+    emitCallback?: TsEmitCallback,
+    mergeEmitResultsCallback?: TsMergeEmitResultsCallback
   }): ts.EmitResult;
 
   /**


### PR DESCRIPTION
ngc knows to filter out d.ts inputs, but the logic accidentally
depended on whether it had a previous Program lying around.

Fixing that logic puts ngc on the fast code path, but in that code
path it must be able to merge tsickle EmitResults, so we need to
plumb the tsickle.mergeEmitResults function through all the intervening
APIs.  The bulk of this change is that plumbing.