### PR TITLE
ci(compiler): run compiler tests in bazel

### DIFF
--- a/packages/compiler/test/BUILD.bazel
+++ b/packages/compiler/test/BUILD.bazel
@@ -1,18 +1,24 @@
 load("//tools:defaults.bzl", "ts_library", "ts_web_test")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
+# Test that should only be run in node
+NODE_ONLY = [
+    "**/*_node_only_spec.ts",
+    "aot/**/*.ts",
+    "render3/**/*.ts",
+]
+
 ts_library(
     name = "test_lib",
     testonly = 1,
     srcs = glob(
         ["**/*.ts"],
-        exclude = ["**/*_node_only_spec.ts"],
+        exclude = NODE_ONLY,
     ),
     deps = [
         "//packages:types",
         "//packages/common",
         "//packages/compiler",
-        "//packages/compiler-cli",
         "//packages/compiler/testing",
         "//packages/core",
         "//packages/core/testing",
@@ -25,19 +31,25 @@ ts_library(
 ts_library(
     name = "test_node_only_lib",
     testonly = 1,
-    srcs = glob(["**/*_node_only_spec.ts"]),
+    srcs = glob(NODE_ONLY),
     deps = [
         ":test_lib",
         "//packages/compiler",
+        "//packages/compiler-cli",
         "//packages/compiler/testing",
+        "//packages/core",
     ],
 )
 
 jasmine_node_test(
     name = "test",
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
+    data = [
+        "//packages/animations:npm_package",
+        "//packages/common:npm_package",
+        "//packages/core:npm_package",
+    ],
     # dissable since tests are running but not yet passing
-    tags = ["manual"],
     deps = [
         ":test_lib",
         ":test_node_only_lib",
@@ -49,7 +61,6 @@ jasmine_node_test(
 ts_web_test(
     name = "test_web",
     # disable since tests are running but not yet passing
-    tags = ["manual"],
     deps = [
         ":test_lib",
     ],

--- a/packages/compiler/test/aot/compiler_spec.ts
+++ b/packages/compiler/test/aot/compiler_spec.ts
@@ -924,7 +924,7 @@ describe('compiler (bundled Angular)', () => {
           new EmittingCompilerHost(['/bolder/index.ts'], {emitMetadata: false, mockData: LIBRARY});
 
       if (isInBazel()) {
-        // In bazel we need can just add the angular files from the ones read during setup.
+        // In bazel we can just add the angular files from the ones read during setup.
         emittingHost.addFiles(angularFiles);
       }
 

--- a/packages/compiler/test/aot/compiler_spec.ts
+++ b/packages/compiler/test/aot/compiler_spec.ts
@@ -13,7 +13,7 @@ import {extractSourceMap, originalPositionFor} from '@angular/compiler/testing/s
 import {NodeFlags} from '@angular/core/src/view/index';
 import * as ts from 'typescript';
 
-import {EmittingCompilerHost, MockAotCompilerHost, MockCompilerHost, MockDirectory, MockMetadataBundlerHost, arrayToMockDir, compile, expectNoDiagnostics, settings, setup, toMockFileArray} from './test_util';
+import {EmittingCompilerHost, MockAotCompilerHost, MockCompilerHost, MockDirectory, MockMetadataBundlerHost, arrayToMockDir, compile, expectNoDiagnostics, isInBazel, settings, setup, toMockFileArray} from './test_util';
 
 describe('compiler (unbundled Angular)', () => {
   let angularFiles = setup();
@@ -872,30 +872,31 @@ describe('compiler (unbundled Angular)', () => {
 });
 
 describe('compiler (bundled Angular)', () => {
-  setup({compileAngular: false, compileAnimations: false});
-
-  let angularFiles: Map<string, string>;
+  let angularFiles: Map<string, string> = setup();
 
   beforeAll(() => {
-    const emittingHost = new EmittingCompilerHost(['@angular/core/index'], {emitMetadata: false});
+    if (!isInBazel()) {
+      // If we are not using Bazel then we need to build these files explicitly
+      const emittingHost = new EmittingCompilerHost(['@angular/core/index'], {emitMetadata: false});
 
-    // Create the metadata bundled
-    const indexModule = emittingHost.effectiveName('@angular/core/index');
-    const bundler = new MetadataBundler(
-        indexModule, '@angular/core', new MockMetadataBundlerHost(emittingHost));
-    const bundle = bundler.getMetadataBundle();
-    const metadata = JSON.stringify(bundle.metadata, null, ' ');
-    const bundleIndexSource = privateEntriesToIndex('./index', bundle.privates);
-    emittingHost.override('@angular/core/bundle_index.ts', bundleIndexSource);
-    emittingHost.addWrittenFile(
-        '@angular/core/package.json', JSON.stringify({typings: 'bundle_index.d.ts'}));
-    emittingHost.addWrittenFile('@angular/core/bundle_index.metadata.json', metadata);
+      // Create the metadata bundled
+      const indexModule = emittingHost.effectiveName('@angular/core/index');
+      const bundler = new MetadataBundler(
+          indexModule, '@angular/core', new MockMetadataBundlerHost(emittingHost));
+      const bundle = bundler.getMetadataBundle();
+      const metadata = JSON.stringify(bundle.metadata, null, ' ');
+      const bundleIndexSource = privateEntriesToIndex('./index', bundle.privates);
+      emittingHost.override('@angular/core/bundle_index.ts', bundleIndexSource);
+      emittingHost.addWrittenFile(
+          '@angular/core/package.json', JSON.stringify({typings: 'bundle_index.d.ts'}));
+      emittingHost.addWrittenFile('@angular/core/bundle_index.metadata.json', metadata);
 
-    // Emit the sources
-    const bundleIndexName = emittingHost.effectiveName('@angular/core/bundle_index.ts');
-    const emittingProgram = ts.createProgram([bundleIndexName], settings, emittingHost);
-    emittingProgram.emit();
-    angularFiles = emittingHost.writtenAngularFiles();
+      // Emit the sources
+      const bundleIndexName = emittingHost.effectiveName('@angular/core/bundle_index.ts');
+      const emittingProgram = ts.createProgram([bundleIndexName], settings, emittingHost);
+      emittingProgram.emit();
+      angularFiles = emittingHost.writtenAngularFiles();
+    }
   });
 
   describe('Quickstart', () => {
@@ -921,6 +922,11 @@ describe('compiler (bundled Angular)', () => {
       // Emit the library bundle
       const emittingHost =
           new EmittingCompilerHost(['/bolder/index.ts'], {emitMetadata: false, mockData: LIBRARY});
+
+      if (isInBazel()) {
+        // In bazel we need can just add the angular files from the ones read during setup.
+        emittingHost.addFiles(angularFiles);
+      }
 
       // Create the metadata bundled
       const indexModule = '/bolder/public-api';


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] CI related changes
```

## What is the current behavior?

The `@angular/compiler` tests only ran under `./test.sh`

## What is the new behavior?

The `@angular/compiler` tests run with `bazel test packages/...`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```