### PR TITLE
build: rm --noimplicit_deps from bazel query

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -38,9 +38,6 @@ build --workspace_status_command=./tools/bazel_stamp_vars.sh
 # Prints eg. "ng_module rule //foo:bar" rather than just "//foo:bar"
 query --output=label_kind
 
-# Don't print every dependency in :node_modules, for example
-query --noimplicit_deps
-
 # By default, failing tests don't print any output, it goes to the log file
 test --test_output=errors
 


### PR DESCRIPTION
I added this option for demos, so that it would be easier to see a graphviz graph of the dependency structure without all the node_modules edges.

However, `ibazel` picks up this option as well, and means it doesn't trigger on changes that only appear through an implicit dependency.

