### PR TITLE
test: remove gulp public-api:update docs

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -111,17 +111,6 @@ All the tests are executed on our Continuous Integration infrastructure and a PR
 - CircleCI fails if your code is not formatted properly,
 - Travis CI fails if any of the test suites described above fails.
 
-## Update the public API tests
-
-If you happen to modify the public API of Angular, API golden files must be updated using:
-
-``` shell
-$ gulp public-api:update
-```
-
-Note: The command `gulp public-api:enforce` fails when the API doesn't match the golden files. Make sure to rebuild
-the project before trying to verify after an API change.
-
 ## <a name="clang-format"></a> Formatting your source code
 
 Angular uses [clang-format](http://clang.llvm.org/docs/ClangFormat.html) to format the source code. If the source code


### PR DESCRIPTION
Since #22639, the command is no longer provided.