### PR TITLE
feat(elements): provide module with default strategy

### DIFF
--- a/aio/content/guide/custom-elements.md
+++ b/aio/content/guide/custom-elements.md
@@ -15,6 +15,7 @@ detection APIs.
 ```ts
 //hello-world.ts
 import { Component, Input, NgModule } from '@angular/core';
+import { CustomElementsModule } from '@angular/elements';
 
 @Component({
   selector: 'hello-world',
@@ -25,6 +26,7 @@ export class HelloWorld {
 }
 
 @NgModule({
+  imports: [ CustomElementsModule ]
   declarations: [ HelloWorld ],
   entryComponents: [ HelloWorld ]
 })

--- a/aio/src/app/app.module.ts
+++ b/aio/src/app/app.module.ts
@@ -37,7 +37,7 @@ import { TocService } from 'app/shared/toc.service';
 import { CurrentDateToken, currentDateProvider } from 'app/shared/current-date';
 import { WindowToken, windowProvider } from 'app/shared/window';
 
-import { CustomElementsModule } from 'app/custom-elements/custom-elements.module';
+import { AppCustomElementsModule } from 'app/custom-elements/custom-elements.module';
 import { SharedModule } from 'app/shared/shared.module';
 import { SwUpdatesModule } from 'app/sw-updates/sw-updates.module';
 
@@ -91,7 +91,7 @@ export const svgIconProviders = [
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
-    CustomElementsModule,
+    AppCustomElementsModule,
     HttpClientModule,
     MatButtonModule,
     MatIconModule,

--- a/aio/src/app/custom-elements/custom-elements.module.ts
+++ b/aio/src/app/custom-elements/custom-elements.module.ts
@@ -1,5 +1,6 @@
 import { NgModule, NgModuleFactoryLoader, SystemJsNgModuleLoader } from '@angular/core';
 import { ROUTES} from '@angular/router';
+import { CustomElementsModule } from '@angular/elements';
 import { ElementsLoader } from './elements-loader';
 import {
   ELEMENT_MODULE_PATHS,
@@ -8,6 +9,9 @@ import {
 } from './element-registry';
 
 @NgModule({
+  imports: [
+    CustomElementsModule,
+  ],
   providers: [
     ElementsLoader,
     { provide: NgModuleFactoryLoader, useClass: SystemJsNgModuleLoader },
@@ -19,4 +23,4 @@ import {
     { provide: ROUTES, useValue: ELEMENT_MODULE_PATHS_AS_ROUTES, multi: true },
   ],
 })
-export class CustomElementsModule { }
+export class AppCustomElementsModule { }

--- a/aio/src/app/custom-elements/elements-loader.spec.ts
+++ b/aio/src/app/custom-elements/elements-loader.spec.ts
@@ -126,7 +126,7 @@ describe('ElementsLoader', () => {
 
 // TEST CLASSES/HELPERS
 
-class FakeCustomElementModule implements WithCustomElementComponent {
+class FakeAppCustomElementModule implements WithCustomElementComponent {
   customElementComponent: Type<any>;
 }
 
@@ -141,7 +141,7 @@ class FakeComponentFactoryResolver extends ComponentFactoryResolver {
 class FakeModuleRef extends NgModuleRef<WithCustomElementComponent> {
   injector = jasmine.createSpyObj('injector', ['get']);
   componentFactoryResolver = new FakeComponentFactoryResolver(this.modulePath);
-  instance: WithCustomElementComponent = new FakeCustomElementModule();
+  instance: WithCustomElementComponent = new FakeAppCustomElementModule();
 
   constructor(private modulePath) {
     super();

--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
@@ -6,7 +6,7 @@ import { of } from 'rxjs/observable/of';
 
 import { FILE_NOT_FOUND_ID, FETCHING_ERROR_ID } from 'app/documents/document.service';
 import { Logger } from 'app/shared/logger.service';
-import { CustomElementsModule } from 'app/custom-elements/custom-elements.module';
+import { AppCustomElementsModule } from 'app/custom-elements/custom-elements.module';
 import { TocService } from 'app/shared/toc.service';
 import { ElementsLoader } from 'app/custom-elements/elements-loader';
 import {
@@ -24,7 +24,7 @@ describe('DocViewerComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CustomElementsModule, TestModule],
+      imports: [AppCustomElementsModule, TestModule],
     });
 
     parentFixture = TestBed.createComponent(TestParentComponent);

--- a/packages/elements/public_api.ts
+++ b/packages/elements/public_api.ts
@@ -11,7 +11,7 @@
  * @description
  * Entry point for all public APIs of the `elements` package.
  */
-export {NgElement, NgElementConfig, NgElementConstructor, WithProperties, createCustomElement} from './src/create-custom-element';
+export {CustomElementsModule, NgElement, NgElementConfig, NgElementConstructor, WithProperties, createCustomElement} from './src/create-custom-element';
 export {NgElementStrategy, NgElementStrategyEvent, NgElementStrategyFactory} from './src/element-strategy';
 export {VERSION} from './src/version';
 

--- a/packages/elements/src/element-strategy.ts
+++ b/packages/elements/src/element-strategy.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ComponentFactory, Injector} from '@angular/core';
+import {Injector, Type} from '@angular/core';
 import {Observable} from 'rxjs';
 
 /**
@@ -38,7 +38,7 @@ export interface NgElementStrategy {
  *
  * @experimental
  */
-export interface NgElementStrategyFactory {
+export abstract class NgElementStrategyFactory {
   /** Creates a new instance to be used for an NgElement. */
-  create(injector: Injector): NgElementStrategy;
+  abstract create(component: Type<any>, injector: Injector): NgElementStrategy;
 }

--- a/packages/elements/src/view-engine-strategy.ts
+++ b/packages/elements/src/view-engine-strategy.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, EventEmitter, Injector, OnChanges, SimpleChange, SimpleChanges, Type} from '@angular/core';
+import {ApplicationRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, EventEmitter, Injectable, Injector, OnChanges, SimpleChange, SimpleChanges, Type} from '@angular/core';
 import {Observable, merge} from 'rxjs';
 import {map} from 'rxjs/operators';
 
@@ -18,21 +18,17 @@ import {isFunction, scheduler, strictEquals} from './utils';
 const DESTROY_DELAY = 10;
 
 /**
- * Factory that creates new ComponentNgElementStrategy instance. Gets the component factory with the
- * constructor's injector's factory resolver and passes that factory to each strategy.
+ * Factory that creates new ViewEngineNgElementStrategy instance. Gets the component factory with
+ * the constructor's injector's factory resolver and passes that factory to each strategy.
  *
  * @experimental
  */
-export class ComponentNgElementStrategyFactory implements NgElementStrategyFactory {
-  componentFactory: ComponentFactory<any>;
-
-  constructor(private component: Type<any>, private injector: Injector) {
-    this.componentFactory =
+@Injectable()
+export class ViewEngineNgElementStrategyFactory extends NgElementStrategyFactory {
+  create(component: Type<any>, injector: Injector) {
+    const componentFactory =
         injector.get(ComponentFactoryResolver).resolveComponentFactory(component);
-  }
-
-  create(injector: Injector) {
-    return new ComponentNgElementStrategy(this.componentFactory, injector);
+    return new ViewEngineNgElementStrategy(componentFactory, injector);
   }
 }
 
@@ -42,7 +38,7 @@ export class ComponentNgElementStrategyFactory implements NgElementStrategyFacto
  *
  * @experimental
  */
-export class ComponentNgElementStrategy implements NgElementStrategy {
+export class ViewEngineNgElementStrategy implements NgElementStrategy {
   /** Merged stream of the component's output events. */
   events: Observable<NgElementStrategyEvent>;
 

--- a/packages/elements/test/create-custom-element_spec.ts
+++ b/packages/elements/test/create-custom-element_spec.ts
@@ -50,6 +50,12 @@ if (typeof customElements !== 'undefined') {
       expect(NgElementCtor.observedAttributes).toEqual(['foo-foo', 'barbar']);
     });
 
+    it('should throw an error if no strategy is provided', () => {
+      expect(() => createCustomElement(TestComponent, {injector}))
+        .toThrowError('Could not find custom element strategy factory. ' +
+            'Please include "CustomElementsModule" in your application.');
+    });
+
     it('should send input values from attributes when connected', () => {
       const element = new NgElementCtor(injector);
       element.setAttribute('foo-foo', 'value-foo-foo');

--- a/packages/elements/test/view-engine-strategy_spec.ts
+++ b/packages/elements/test/view-engine-strategy_spec.ts
@@ -10,12 +10,12 @@ import {ComponentFactory, ComponentRef, Injector, NgModuleRef, SimpleChange, Sim
 import {fakeAsync, tick} from '@angular/core/testing';
 import {Subject} from 'rxjs';
 
-import {ComponentNgElementStrategy, ComponentNgElementStrategyFactory} from '../src/component-factory-strategy';
 import {NgElementStrategyEvent} from '../src/element-strategy';
+import {ViewEngineNgElementStrategy, ViewEngineNgElementStrategyFactory} from '../src/view-engine-strategy';
 
-describe('ComponentFactoryNgElementStrategy', () => {
+describe('ViewEngineNgElementStrategyFactory', () => {
   let factory: FakeComponentFactory;
-  let strategy: ComponentNgElementStrategy;
+  let strategy: ViewEngineNgElementStrategy;
 
   let injector: any;
   let componentRef: any;
@@ -27,7 +27,7 @@ describe('ComponentFactoryNgElementStrategy', () => {
 
     applicationRef = jasmine.createSpyObj('applicationRef', ['attachView']);
 
-    strategy = new ComponentNgElementStrategy(factory, injector);
+    strategy = new ViewEngineNgElementStrategy(factory, injector);
   });
 
   it('should create a new strategy from the factory', () => {
@@ -36,8 +36,8 @@ describe('ComponentFactoryNgElementStrategy', () => {
     injector = jasmine.createSpyObj('injector', ['get']);
     injector.get.and.returnValue(factoryResolver);
 
-    const strategyFactory = new ComponentNgElementStrategyFactory(FakeComponent, injector);
-    expect(strategyFactory.create(injector)).toBeTruthy();
+    const strategyFactory = new ViewEngineNgElementStrategyFactory();
+    expect(strategyFactory.create(FakeComponent, injector)).toBeTruthy();
   });
 
   describe('after connected', () => {

--- a/tools/public_api_guard/elements/elements.d.ts
+++ b/tools/public_api_guard/elements/elements.d.ts
@@ -2,6 +2,10 @@
 export declare function createCustomElement<P>(component: Type<any>, config: NgElementConfig): NgElementConstructor<P>;
 
 /** @experimental */
+export declare class CustomElementsModule {
+}
+
+/** @experimental */
 export declare abstract class NgElement extends HTMLElement {
     protected ngElementEventsSubscription: Subscription | null;
     protected ngElementStrategy: NgElementStrategy;
@@ -38,8 +42,8 @@ export interface NgElementStrategyEvent {
 }
 
 /** @experimental */
-export interface NgElementStrategyFactory {
-    create(injector: Injector): NgElementStrategy;
+export declare abstract class NgElementStrategyFactory {
+    abstract create(component: Type<any>, injector: Injector): NgElementStrategy;
 }
 
 /** @experimental */


### PR DESCRIPTION
Up for bikeshedding - what should we name this initial pass of the module providing the default strategy? Right it is `CustomElementsModule` but I think it may be too broad and won't help us when we want to switch to a different default (it's a good name, should be reserved for when we are sure it will last for the near future)


## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

`createCustomElement` defaults to using a particular strategy

## What is the new behavior?
 - if/when we want to support a different strategy (by default or not), we want this default to be tree-shakable. By providing it through a module, this is possible so that that the function itself does not directly depend on the code.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Elements was released last week in experimental and RC. This is to resolve a future issue by making this breaking change now before it is fully released.