### PR TITLE
fix(animations): treat numeric state name values as strings

### DIFF
--- a/packages/animations/browser/src/dsl/animation_ast_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_ast_builder.ts
@@ -96,7 +96,7 @@ export class AnimationAstBuilderVisitor implements AnimationDslVisitor {
       if (def.type == AnimationMetadataType.State) {
         const stateDef = def as AnimationStateMetadata;
         const name = stateDef.name;
-        name.split(/\s*,\s*/).forEach(n => {
+        name.toString().split(/\s*,\s*/).forEach(n => {
           stateDef.name = n;
           states.push(this.visitState(stateDef, context));
         });

--- a/packages/animations/browser/test/dsl/animation_trigger_spec.ts
+++ b/packages/animations/browser/test/dsl/animation_trigger_spec.ts
@@ -203,6 +203,17 @@ import {makeTrigger} from '../shared';
            ]);
          });
 
+      it('should treat numeric values (disguised as strings) as proper state values', () => {
+        const result = makeTrigger('name', [
+          state(1 as any as string, style({opacity: 0})),
+          state(0 as any as string, style({opacity: 0})), transition('* => *', animate(1000))
+        ]);
+
+        expect(() => {
+          const trans = buildTransition(result, element, false, true) !;
+        }).not.toThrow();
+      });
+
       describe('aliases', () => {
         it('should alias the :enter transition as void => *', () => {
           const result = makeTrigger('name', [transition(':enter', animate(3333))]);


### PR DESCRIPTION
This patch ensures that if a numeric state name value in an animation
is detected then it will not throw an error. Normally this wouldn't
occur, but some JS optimizers may convert a quoted numeric value
(like "1" to 1) in some cases to save space. This patch makes sure
that Angular doesn't throw an error when this occurs.