### PR TITLE
fix(core): don't override ngInjectableDef in the decorator if present on the type

### DIFF
--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/test/app_spec.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/test/app_spec.ts
@@ -124,4 +124,22 @@ describe('ngInjectableDef Bazel Integration', () => {
 
     expect(TestBed.get(Service).value).toEqual('overridden');
   });
+
+  it('does not override existing ngInjectableDef', () => {
+    @Injectable({
+      providedIn: 'root',
+      useValue: new Service(false),
+    })
+    class Service {
+      constructor(public value: boolean) {}
+      static ngInjectableDef = {
+        providedIn: 'root',
+        factory: () => new Service(true),
+        token: Service,
+      };
+    }
+
+    TestBed.configureTestingModule({});
+    expect(TestBed.get(Service).value).toEqual(true);
+  });
 });

--- a/packages/core/src/di/injectable.ts
+++ b/packages/core/src/di/injectable.ts
@@ -119,7 +119,8 @@ export const Injectable: InjectableDecorator = makeDecorator(
     'Injectable', undefined, undefined, undefined,
     (injectableType: InjectableType<any>,
      options: {providedIn?: Type<any>| 'root' | null} & InjectableProvider) => {
-      if (options && options.providedIn !== undefined) {
+      if (options && options.providedIn !== undefined &&
+          injectableType.ngInjectableDef === undefined) {
         injectableType.ngInjectableDef = defineInjectable({
           providedIn: options.providedIn,
           factory: convertInjectableProviderToFactory(injectableType, options)


### PR DESCRIPTION
Previously, @Injectable() would generate an ngInjectableDef on the type it was
decorating, even if that type already had a compiled ngInjectableDef, overwriting
the compiled version.