### PR TITLE
refactor: add a commit-msg git hook to check commit messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,10 @@
     "postinstall": "yarn update-webdriver && node ./tools/postinstall-patches.js",
     "update-webdriver": "webdriver-manager update --gecko false $CHROMEDRIVER_VERSION_ARG",
     "check-env": "gulp check-env",
-    "commitmsg": "./scripts/git/commit-msg.js"
+    "commitmsg": "node ./scripts/git/commit-msg.js"
   },
   "dependencies": {
     "core-js": "^2.4.1",
-    "husky": "^0.14.3",
     "reflect-metadata": "^0.1.3",
     "rxjs": "6.0.0-beta.0",
     "tslib": "^1.7.1",
@@ -81,6 +80,7 @@
     "gulp-conventional-changelog": "1.1.0",
     "gulp-tslint": "8.1.2",
     "hammerjs": "2.0.8",
+    "husky": "^0.14.3",
     "incremental-dom": "0.4.1",
     "jasmine": "2.4.1",
     "jasmine-core": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
     "preinstall": "node tools/yarn/check-yarn.js",
     "postinstall": "yarn update-webdriver && node ./tools/postinstall-patches.js",
     "update-webdriver": "webdriver-manager update --gecko false $CHROMEDRIVER_VERSION_ARG",
-    "check-env": "gulp check-env"
+    "check-env": "gulp check-env",
+    "commitmsg": "./scripts/git/commit-msg.js"
   },
   "dependencies": {
     "core-js": "^2.4.1",
+    "husky": "^0.14.3",
     "reflect-metadata": "^0.1.3",
     "rxjs": "6.0.0-beta.0",
     "tslib": "^1.7.1",

--- a/scripts/git/commit-msg.js
+++ b/scripts/git/commit-msg.js
@@ -1,0 +1,31 @@
+#! /usr/bin/env node
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// git commit-msg hook to check the commit message against Angular conventions
+// see `/CONTRIBUTING.md` for mode details.
+
+'use strict';
+
+const fs = require('fs');
+const checkMsg = require('../../tools/validate-commit-message');
+const msgFile = process.env['GIT_PARAMS'];
+
+let isValid = true;
+
+if (msgFile) {
+    const commitMsg = fs.readFileSync(msgFile, {encoding: 'utf-8'});
+    const firstLine = commitMsg.split('\n')[0];
+    isValid = checkMsg(firstLine);
+
+    if (!isValid) {
+        console.error('\nCheck CONTRIBUTING.md at the root of the repo for more information.')
+    }
+}
+
+process.exit(isValid ? 0 : 1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,6 +855,10 @@ chokidar@1.7.0, chokidar@^1.0.0, chokidar@^1.4.1:
   optionalDependencies:
     fsevents "^1.0.0"
 
+ci-info@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
+
 clang-format@1.0.41:
   version "1.0.41"
   resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.0.41.tgz#28552e50b0c9e44d23f85aebe3d2fbd06c93620c"
@@ -2854,6 +2858,14 @@ https-proxy-agent@^1.0.0:
     debug "2"
     extend "3"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 iconv-lite@0.4.11:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.11.tgz#2ecb42fd294744922209a2e7c404dac8793d8ade"
@@ -2959,6 +2971,12 @@ is-builtin-module@^1.0.0:
 is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
+is-ci@^1.0.10:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
+  dependencies:
+    ci-info "^1.0.0"
 
 is-date-object@^1.0.1:
   version "1.0.1"
@@ -4135,6 +4153,10 @@ normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
+
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
 normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.1.1"
@@ -5576,6 +5598,10 @@ strip-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
The commit command will fail if the commit message header does not follow the
Angular conventions as defined in /CONTRIBUTING.md.

You can force the commit by adding the `--no-verify` option.

NOTE:
You should remove all unused hooks (in <angular>/.git/hooks) before running
`yarn` so that husky hooks are installed correctly.

---

The idea is to merge this one first and then I can work on the formatting hook to be merged after a few days (when we get feedback about how this one work for everybody).

---

Exemple output (success/fail)

```
$ git commit -m 'feat(compiler): blabla'
Found '/Users/berchet/Code/angular/.nvmrc' with version <8.9>
Now using node v8.9.4 (npm v5.6.0)
Found '/Users/berchet/Code/angular/.nvmrc' with version <8.9>
Now using node v8.9.4 (npm v5.6.0)
husky > npm run -s commitmsg (node v8.9.4)

[0323-checkMsgHook 214d6eb1c8] feat(compiler): blabla
 3 files changed, 55 insertions(+), 1 deletion(-)
 create mode 100644 scripts/git/commit-msg.js
```

```
$ git commit --amend -m 'sdfkjghfsdkj'
Found '/Users/berchet/Code/angular/.nvmrc' with version <8.9>
Now using node v8.9.4 (npm v5.6.0)
Found '/Users/berchet/Code/angular/.nvmrc' with version <8.9>
Now using node v8.9.4 (npm v5.6.0)
husky > npm run -s commitmsg (node v8.9.4)

INVALID COMMIT MSG: "sdfkjghfsdkj"
 => ERROR: The commit message does not match the format of '<type>(<scope>): <subject>' OR 'Revert: "type(<scope>): <subject>"'

husky > commit-msg hook failed (add --no-verify to bypass)
```