### PR TITLE
fix(core): use addCustomEqualityTester instead of overriding toEqual

### DIFF
--- a/packages/core/test/testing_internal_spec.ts
+++ b/packages/core/test/testing_internal_spec.ts
@@ -21,6 +21,18 @@ class SpyTestObj extends SpyObject {
 
 {
   describe('testing', () => {
+    describe('should respect custom equality tester', () => {
+      beforeEach(() => {
+        const equalIfMarried =
+            (first: any, second: any) => { return first === 'kevin' && second === 'patricia'; };
+        jasmine.addCustomEqualityTester(equalIfMarried);
+      });
+
+      it('for positive test', () => { expect('kevin').toEqual('patricia'); });
+
+      it('for negative test', () => { expect('kevin').not.toEqual('kevin'); });
+    });
+
     describe('equality', () => {
       it('should structurally compare objects', () => {
         const expected = new TestObj(new TestObj({'one': [1, 2]}));

--- a/packages/platform-browser/testing/src/matchers.ts
+++ b/packages/platform-browser/testing/src/matchers.ts
@@ -96,12 +96,19 @@ const _global = <any>(typeof window === 'undefined' ? global : window);
  */
 export const expect: (actual: any) => NgMatchers = <any>_global.expect;
 
+/**
+ * Jasmine matching utilities. These are added in the a more recent version of
+ * the Jasmine typedefs than what we are using:
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20771
+ */
+declare global{namespace jasmine{const matchersUtil: MatchersUtil;}}
 
 // Some Map polyfills don't polyfill Map.toString correctly, which
 // gives us bad error messages in tests.
 // The only way to do this in Jasmine is to monkey patch a method
 // to the object :-(
-(Map as any).prototype['jasmineToString'] = function() {
+(Map as any)
+    .prototype['jasmineToString'] = function() {
   const m = this;
   if (!m) {
     return '' + m;
@@ -112,29 +119,23 @@ export const expect: (actual: any) => NgMatchers = <any>_global.expect;
 };
 
 _global.beforeEach(function() {
-  jasmine.addMatchers({
-    // Custom handler for Map as Jasmine does not support it yet
-    toEqual: function(util) {
-      return {
-        compare: function(actual: any, expected: any) {
-          return {pass: util.equals(actual, expected, [compareMap])};
-        }
-      };
-
-      function compareMap(actual: any, expected: any): boolean {
-        if (actual instanceof Map) {
-          let pass = actual.size === expected.size;
-          if (pass) {
-            actual.forEach((v: any, k: any) => { pass = pass && util.equals(v, expected.get(k)); });
-          }
-          return pass;
-        } else {
-          // TODO(misko): we should change the return, but jasmine.d.ts is not null safe
-          return undefined !;
-        }
+  // Custom handler for Map as we use Jasmine 2.4, and support for maps is not
+  // added until Jasmine 2.6.
+  jasmine.addCustomEqualityTester(function compareMap(actual: any, expected: any): boolean {
+    if (actual instanceof Map) {
+      let pass = actual.size === expected.size;
+      if (pass) {
+        actual.forEach((v: any, k: any) => {
+          pass = pass && jasmine.matchersUtil.equals(v, expected.get(k));
+        });
       }
-    },
-
+      return pass;
+    } else {
+      // TODO(misko): we should change the return, but jasmine.d.ts is not null safe
+      return undefined !;
+    }
+  });
+  jasmine.addMatchers({
     toBePromise: function() {
       return {
         compare: function(actual: any) {

--- a/packages/platform-browser/testing/src/matchers.ts
+++ b/packages/platform-browser/testing/src/matchers.ts
@@ -96,19 +96,12 @@ const _global = <any>(typeof window === 'undefined' ? global : window);
  */
 export const expect: (actual: any) => NgMatchers = <any>_global.expect;
 
-/**
- * Jasmine matching utilities. These are added in the a more recent version of
- * the Jasmine typedefs than what we are using:
- * https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20771
- */
-declare global{namespace jasmine{const matchersUtil: MatchersUtil;}}
 
 // Some Map polyfills don't polyfill Map.toString correctly, which
 // gives us bad error messages in tests.
 // The only way to do this in Jasmine is to monkey patch a method
 // to the object :-(
-(Map as any)
-    .prototype['jasmineToString'] = function() {
+(Map as any).prototype['jasmineToString'] = function() {
   const m = this;
   if (!m) {
     return '' + m;

--- a/packages/types.d.ts
+++ b/packages/types.d.ts
@@ -25,3 +25,12 @@ declare namespace jasmine {
     toHaveProperties(obj: any): boolean;
   }
 }
+
+/**
+*Jasmine matching utilities. These are added in the a more recent version of
+*the Jasmine typedefs than what we are using:
+*https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20771
+*/
+declare namespace jasmine {
+  const matchersUtil: MatchersUtil;
+}


### PR DESCRIPTION
This propagates other custom equality testers added by users. Additionally, if
an Angular project is using jasmine 2.6+, it will allow Jasmine's custom object
differ to print out pretty test error messages.

fixes #22939

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
[x] Kind of?
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
It may break (well, fix) tests that add matchers which were not being invoked. Now that those matchers will be invoked, some tests that weren't testing things correctly will start to do so, and that could cause test failures.

## Other information
