### PR TITLE
 ci(language-service): enable language service tests in bazel

### DIFF
--- a/packages/compiler-cli/src/diagnostics/typescript_symbols.ts
+++ b/packages/compiler-cli/src/diagnostics/typescript_symbols.ts
@@ -513,7 +513,7 @@ class PipesTable implements SymbolTable {
 }
 
 // This matches .d.ts files that look like ".../<package-name>/<package-name>.d.ts",
-const INDEX_PATTERN = /[\\|/](\w+)[\\|/]\1\.d\.ts$/;
+const INDEX_PATTERN = /[\\/]([^\\/]+)[\\/]\1\.d\.ts$/;
 
 class PipeSymbol implements Symbol {
   private _tsType: ts.Type;
@@ -611,7 +611,7 @@ function findClassSymbolInContext(type: StaticSymbol, context: TypeContext): ts.
     const p = type.filePath as string;
     const m = p.match(INDEX_PATTERN);
     if (m) {
-      const indexVersion = path.join(p.substr(0, m.index ! + m[1].length + 1), 'index.d.ts');
+      const indexVersion = path.join(path.dirname(p), 'index.d.ts');
       sourceFile = context.program.getSourceFile(indexVersion);
     }
   }

--- a/packages/compiler-cli/test/BUILD.bazel
+++ b/packages/compiler-cli/test/BUILD.bazel
@@ -10,7 +10,10 @@ ts_library(
         "mocks.ts",
         "test_support.ts",
     ],
-    visibility = [":__subpackages__"],
+    visibility = [
+        ":__subpackages__",
+        "//packages/language-service/test:__subpackages__",
+    ],
     deps = [
         "//packages:types",
         "//packages/compiler",

--- a/packages/language-service/test/BUILD.bazel
+++ b/packages/language-service/test/BUILD.bazel
@@ -8,6 +8,7 @@ ts_library(
     deps = [
         "//packages:types",
         "//packages/compiler",
+        "//packages/compiler-cli/test:test_utils",
         "//packages/language-service",
     ],
 )
@@ -15,9 +16,14 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
+    data = [
+        "//packages/common:npm_package",
+        "//packages/core:npm_package",
+        "//packages/forms:npm_package",
+    ],
     # disable since tests are running but not yet passing
-    tags = ["manual"],
     deps = [
+        ":test_lib",
         "//tools/testing:node",
     ],
 )

--- a/packages/language-service/test/test_utils.ts
+++ b/packages/language-service/test/test_utils.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {isInBazel, setup} from '@angular/compiler-cli/test/test_support';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
@@ -75,12 +76,19 @@ export class MockTypescriptHost implements ts.LanguageServiceHost {
       private scriptNames: string[], private data: MockData,
       private node_modules: string = 'node_modules', private myPath: typeof path = path) {
     const moduleFilename = module.filename.replace(/\\/g, '/');
-    let angularIndex = moduleFilename.indexOf('@angular');
-    if (angularIndex >= 0)
-      this.angularPath = moduleFilename.substr(0, angularIndex).replace('/all/', '/all/@angular/');
-    let distIndex = moduleFilename.indexOf('/dist/all');
-    if (distIndex >= 0)
-      this.nodeModulesPath = myPath.join(moduleFilename.substr(0, distIndex), 'node_modules');
+    if (isInBazel()) {
+      const support = setup();
+      this.angularPath = path.join(support.basePath, 'node_modules/@angular');
+      this.nodeModulesPath = path.join(support.basePath, 'node_modules');
+    } else {
+      let angularIndex = moduleFilename.indexOf('@angular');
+      if (angularIndex >= 0)
+        this.angularPath =
+            moduleFilename.substr(0, angularIndex).replace('/all/', '/all/@angular/');
+      let distIndex = moduleFilename.indexOf('/dist/all');
+      if (distIndex >= 0)
+        this.nodeModulesPath = myPath.join(moduleFilename.substr(0, distIndex), 'node_modules');
+    }
     this.options = {
       target: ts.ScriptTarget.ES5,
       module: ts.ModuleKind.CommonJS,

--- a/packages/language-service/test/test_utils.ts
+++ b/packages/language-service/test/test_utils.ts
@@ -78,14 +78,14 @@ export class MockTypescriptHost implements ts.LanguageServiceHost {
     const moduleFilename = module.filename.replace(/\\/g, '/');
     if (isInBazel()) {
       const support = setup();
-      this.angularPath = path.join(support.basePath, 'node_modules/@angular');
       this.nodeModulesPath = path.join(support.basePath, 'node_modules');
+      this.angularPath = path.join(this.nodeModulesPath, '@angular');
     } else {
-      let angularIndex = moduleFilename.indexOf('@angular');
+      const angularIndex = moduleFilename.indexOf('@angular');
       if (angularIndex >= 0)
         this.angularPath =
             moduleFilename.substr(0, angularIndex).replace('/all/', '/all/@angular/');
-      let distIndex = moduleFilename.indexOf('/dist/all');
+      const distIndex = moduleFilename.indexOf('/dist/all');
       if (distIndex >= 0)
         this.nodeModulesPath = myPath.join(moduleFilename.substr(0, distIndex), 'node_modules');
     }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] CI related changes
```

## What is the current behavior?

Tests for `@angular/language-service` only run in `test.sh`.

## What is the new behavior?

Tests  for `@angular/language-service` in `bazel test`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
