### PR TITLE
docs: add link to cli and material docs for ng add options

### DIFF
--- a/aio/content/guide/quickstart.md
+++ b/aio/content/guide/quickstart.md
@@ -40,7 +40,7 @@ Older versions produce errors, but newer versions are fine.
 
 
 
-Then **install the [Angular CLI](https://github.com/angular/angular-cli)** globally.
+Then install the [Angular CLI](https://github.com/angular/angular-cli) globally.
 
 
 <code-example language="sh" class="code-shell">
@@ -60,7 +60,7 @@ Then **install the [Angular CLI](https://github.com/angular/angular-cli)** globa
 Open a terminal window.
 
 
-Generate a new project and skeleton application by running the following commands:
+Generate a new project and default app by running the following command:
 
 
 <code-example language="sh" class="code-shell">
@@ -69,18 +69,22 @@ Generate a new project and skeleton application by running the following command
 </code-example>
 
 
+The Angular CLI installs the necessary npm packages, creates the project files, and populates the project with a simple default app. This can take some time.  
+
+
 
 <div class="l-sub-section">
 
 
 
-Patience, please.
-It takes time to set up a new project; most of it is spent installing npm packages.
+You can generate a more complex app at project creation by specifying a package and schematics collection to the `ng new` command. You can add packages and schematics collections to an existing project by using the `ng add` command. 
+For more information, see the [Angular CLI documentation.](https://github.com/angular/angular-cli/wiki/ "Angular CLI documentation") 
+
+Angular Material provides schematics for typical app layouts. 
+See the [Angular Material documentation](https://material.angular.io/guides "Angular Material documentation") for details.
 
 
 </div>
-
-
 
 
 <h2 id='serve'>

--- a/aio/content/tutorial/toh-pt0.md
+++ b/aio/content/tutorial/toh-pt0.md
@@ -18,6 +18,20 @@ Create a new project named `angular-tour-of-heroes` with this CLI command.
 
 The Angular CLI generated a new project with a default application and supporting files. 
 
+
+<div class="l-sub-section">
+
+
+
+You can generate a more complex app at project creation by specifying a package and schematics collection to the `ng new` command. You can add packages and schematics collections to an existing project by using the `ng add` command. 
+For more information, see the [Angular CLI documentation.](https://github.com/angular/angular-cli/wiki/ "Angular CLI documentation") 
+
+Angular Material provides schematics for typical app layouts. 
+See the [Angular Material documentation](https://material.angular.io/guides "Angular Material documentation") for details.
+
+</div>
+
+
 ## Serve the application
 
 Go to the project directory and launch the application.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ X] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Tutorial and Getting Started currently describe how to use ng new to create a default skeleton app that displays a welcome page.

Issue Number: N/A


## What is the new behavior?
Tutorial and Getting Started now have a note box that introduces the idea of creating more sophisticated apps at project creation by specifying a package and schematics. Included links to CLI doc for ng new and to Material guides for info about materials schematics that are available. 

Did not change main flow of the example being created by Tutorial or Getting Started. That larger change should be considered for a future update. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
