### PR TITLE
feat(bazel): prefix private-export (barred-latin-o) symbols

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -280,6 +280,7 @@ def _write_bundle_index(ctx):
   tsconfig = dict(tsc_wrapped_tsconfig(ctx, ctx.files.srcs, ctx.files.srcs), **{
     "angularCompilerOptions": {
       "flatModuleOutFile": flat_module_out_file,
+      "flatModulePrivateSymbolPrefix": "_".join([ctx.workspace_name] + ctx.label.package.split("/") + [ctx.label.name, ""]),
     },
   })
   if not ctx.attr.module_name:

--- a/packages/compiler-cli/integrationtest/bazel/ng_module/spec.js
+++ b/packages/compiler-cli/integrationtest/bazel/ng_module/spec.js
@@ -15,7 +15,8 @@ describe('flat module index', () => {
           require.resolve(`${PKG}/flat_module_filename.metadata.json`), {encoding: 'utf-8'});
       expect(metadata).toContain('"__symbolic":"module"');
       expect(metadata).toContain('"__symbolic":"reference","module":"@angular/core"');
-      expect(metadata).toContain('"origins":{"Child":"./child","ɵa":"./parent"}');
+      expect(metadata).toContain(
+          '"origins":{"Child":"./child","ɵangular_packages_compiler_cli_integrationtest_bazel_ng_module_test_module_a":"./parent"}');
       expect(metadata).toContain('"importAs":"some_npm_module"');
     });
   });
@@ -25,7 +26,8 @@ describe('flat module index', () => {
           fs.readFileSync(require.resolve(`${PKG}/flat_module_filename.d.ts`), {encoding: 'utf-8'});
 
       expect(dts).toContain('export * from \'./index\';');
-      expect(dts).toContain('export { Parent as ɵa } from \'./parent\';');
+      expect(dts).toContain(
+          'export { Parent as ɵangular_packages_compiler_cli_integrationtest_bazel_ng_module_test_module_a } from \'./parent\';');
     });
   });
 });

--- a/packages/compiler-cli/src/metadata/bundle_index_host.ts
+++ b/packages/compiler-cli/src/metadata/bundle_index_host.ts
@@ -77,8 +77,9 @@ export function createBundleIndexHost<H extends ts.CompilerHost>(
   }
   const file = files[0];
   const indexModule = file.replace(/\.ts$/, '');
-  const bundler =
-      new MetadataBundler(indexModule, ngOptions.flatModuleId, new CompilerHostAdapter(host));
+  const bundler = new MetadataBundler(
+      indexModule, ngOptions.flatModuleId, new CompilerHostAdapter(host),
+      ngOptions.flatModulePrivateSymbolPrefix);
   const metadataBundle = bundler.getMetadataBundle();
   const metadata = JSON.stringify(metadataBundle.metadata);
   const name =

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -99,6 +99,10 @@ export interface CompilerOptions extends ts.CompilerOptions {
   // meaningful when `flatModuleOutFile` is also supplied. It is otherwise ignored.
   flatModuleId?: string;
 
+  // A prefix to insert in generated private symbols, e.g. for "my_prefix_" we
+  // would generate private symbols named like `ɵmy_prefix_a`.
+  flatModulePrivateSymbolPrefix?: string;
+
   // Whether to generate code for library code.
   // If true, produce .ngfactory.ts and .ngstyle.ts files for .d.ts inputs.
   // Default is true.

--- a/packages/compiler-cli/test/metadata/bundler_spec.ts
+++ b/packages/compiler-cli/test/metadata/bundler_spec.ts
@@ -19,10 +19,10 @@ describe('metadata bundler', () => {
 
   it('should be able to bundle a simple library', () => {
     const host = new MockStringBundlerHost('/', SIMPLE_LIBRARY);
-    const bundler = new MetadataBundler('/lib/index', undefined, host);
+    const bundler = new MetadataBundler('/lib/index', undefined, host, 'prfx_');
     const result = bundler.getMetadataBundle();
     expect(Object.keys(result.metadata.metadata).sort()).toEqual([
-      'ONE_CLASSES', 'One', 'OneMore', 'TWO_CLASSES', 'Two', 'TwoMore', 'ɵa', 'ɵb'
+      'ONE_CLASSES', 'One', 'OneMore', 'TWO_CLASSES', 'Two', 'TwoMore', 'ɵprfx_a', 'ɵprfx_b'
     ]);
 
     const originalOne = './src/one';
@@ -34,11 +34,11 @@ describe('metadata bundler', () => {
           {name: 'ONE_CLASSES', value: originalOne}, {name: 'One', value: originalOne},
           {name: 'OneMore', value: originalOne}, {name: 'TWO_CLASSES', value: originalTwo},
           {name: 'Two', value: originalTwo}, {name: 'TwoMore', value: originalTwo},
-          {name: 'ɵa', value: originalOne}, {name: 'ɵb', value: originalTwo}
+          {name: 'ɵprfx_a', value: originalOne}, {name: 'ɵprfx_b', value: originalTwo}
         ]);
     expect(result.privates).toEqual([
-      {privateName: 'ɵa', name: 'PrivateOne', module: originalOne},
-      {privateName: 'ɵb', name: 'PrivateTwo', module: originalTwo}
+      {privateName: 'ɵprfx_a', name: 'PrivateOne', module: originalOne},
+      {privateName: 'ɵprfx_b', name: 'PrivateTwo', module: originalTwo}
     ]);
   });
 


### PR DESCRIPTION
This allows a bundle index to be re-exported by a higher-level module without fear of collisions.
Under bazel, we always set the prefix to be underscore-joined workspace, package, label
