### PR TITLE
test(ivy): fix flaky tests

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -572,9 +572,6 @@ class ViewContainerRef implements viewEngine_ViewContainerRef {
   createEmbeddedView<C>(
       templateRef: viewEngine_TemplateRef<C>, context?: C|undefined,
       index?: number|undefined): viewEngine_EmbeddedViewRef<C> {
-    // set current view to container node's view
-    enterView(this._node.view, null);
-
     const viewRef = templateRef.createEmbeddedView(context !);
     this.insert(viewRef, index);
     return viewRef;

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -431,9 +431,10 @@ export function renderEmbeddedTemplate<T>(
     previousOrParentNode = null !;
     let cm: boolean = false;
     if (viewNode == null) {
+      // TODO: revisit setting currentView when re-writing view containers
       const view = createLView(
-          -1, renderer, createTView(currentView.tView.directiveRegistry), template, context,
-          LViewFlags.CheckAlways);
+          -1, renderer, createTView(currentView && currentView.tView.directiveRegistry), template,
+          context, LViewFlags.CheckAlways);
       viewNode = createLNode(null, LNodeType.View, null, view);
       cm = true;
     }
@@ -443,7 +444,7 @@ export function renderEmbeddedTemplate<T>(
     refreshDynamicChildren();
     refreshDirectives();
   } finally {
-    leaveView(currentView !.parent !);
+    leaveView(currentView && currentView !.parent !);
     isParent = _isParent;
     previousOrParentNode = _previousOrParentNode;
   }


### PR DESCRIPTION
Some lifecycle hook tests are failing on Travis because of the new `enterView` call in `ViewContainerRef`. 