### PR TITLE
test(upgrade): increase timeout to reduce flaky-ness

### DIFF
--- a/packages/upgrade/test/common/test_helpers.ts
+++ b/packages/upgrade/test/common/test_helpers.ts
@@ -22,7 +22,13 @@ const ng1Versions = [
 export function createWithEachNg1VersionFn(setNg1: typeof setAngularJSGlobal) {
   return (specSuite: () => void) => ng1Versions.forEach(({label, files}) => {
     describe(`[AngularJS v${label}]`, () => {
+      let originalTimeout: typeof jasmine.DEFAULT_TIMEOUT_INTERVAL;
+
       beforeAll(done => {
+        // Increase the timeout, because these tests need to load the AngularJS files first.
+        originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+        jasmine.DEFAULT_TIMEOUT_INTERVAL =20000;
+
         // Load AngularJS before running tests.
         files
             .reduce(
@@ -42,6 +48,9 @@ export function createWithEachNg1VersionFn(setNg1: typeof setAngularJSGlobal) {
       });
 
       afterAll(() => {
+        // Restore the default timeout.
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+
         // In these tests we are loading different versions of AngularJS on the same window.
         // AngularJS leaves an "expandoId" property on `document`, which can trick subsequent
         // `window.angular` instances into believing an app is already bootstrapped.


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] CI related changes
```

## What is the current behavior?
Some `ngUpgrade` tests need to load AngularJS scripts before running the actual tests. On slow machines (e.g. CI) these tests can sometimes timeout.


## What is the new behavior?
Increased jasmine's timeout interval for these tests to reduce flaky-ness.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
