### PR TITLE
docs(common): add `HttpParamsOptions` to the public API (#20332)

### DIFF
--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -12,7 +12,7 @@ import {concatMap, filter, map} from 'rxjs/operators';
 
 import {HttpHandler} from './backend';
 import {HttpHeaders} from './headers';
-import {HttpParams, HttpParamsOptions} from './params';
+import {HttpParams} from './params';
 import {HttpRequest} from './request';
 import {HttpEvent, HttpResponse} from './response';
 
@@ -466,7 +466,7 @@ export class HttpClient {
         if (options.params instanceof HttpParams) {
           params = options.params;
         } else {
-          params = new HttpParams({ fromObject: options.params } as HttpParamsOptions);
+          params = new HttpParams({fromObject: options.params});
         }
       }
 

--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -97,24 +97,6 @@ interface Update {
   op: 'a'|'d'|'s';
 }
 
-/** Options used to construct an `HttpParams` instance.
- *
- * @publicApi
- */
-export interface HttpParamsOptions {
-  /**
-   * String representation of the HTTP parameters in URL-query-string format.
-   * Mutually exclusive with `fromObject`.
-   */
-  fromString?: string;
-
-  /** Object map of the HTTP parameters. Mutually exclusive with `fromString`. */
-  fromObject?: {[param: string]: string | string[]};
-
-  /** Encoding codec used to parse and serialize the parameters. */
-  encoder?: HttpParameterCodec;
-}
-
 /**
  * An HTTP request/response body that represents serialized parameters,
  * per the MIME type `application/x-www-form-urlencoded`.
@@ -129,7 +111,19 @@ export class HttpParams {
   private updates: Update[]|null = null;
   private cloneFrom: HttpParams|null = null;
 
-  constructor(options: HttpParamsOptions = {} as HttpParamsOptions) {
+  constructor(options = {} as {
+    /**
+     * String representation of the HTTP parameters in URL-query-string format.
+     * Mutually exclusive with `fromObject`.
+     */
+    fromString?: string;
+
+    /** Object map of the HTTP parameters. Mutally exclusive with `fromString`. */
+    fromObject?: {[param: string]: string | string[]};
+
+    /** Encoding codec used to parse and serialize the parameters. */
+    encoder?: HttpParameterCodec;
+  }) {
     this.encoder = options.encoder || new HttpUrlEncodingCodec();
     if (!!options.fromString) {
       if (!!options.fromObject) {
@@ -231,7 +225,7 @@ export class HttpParams {
   }
 
   private clone(update: Update): HttpParams {
-    const clone = new HttpParams({ encoder: this.encoder } as HttpParamsOptions);
+    const clone = new HttpParams({encoder: this.encoder});
     clone.cloneFrom = this.cloneFrom || this;
     clone.updates = (this.updates || []).concat([update]);
     return clone;

--- a/tools/public_api_guard/common/http.d.ts
+++ b/tools/public_api_guard/common/http.d.ts
@@ -1564,7 +1564,13 @@ export interface HttpParameterCodec {
 }
 
 export declare class HttpParams {
-    constructor(options?: HttpParamsOptions);
+    constructor(options?: {
+        fromString?: string | undefined;
+        fromObject?: {
+            [param: string]: string | string[];
+        } | undefined;
+        encoder?: HttpParameterCodec | undefined;
+    });
     append(param: string, value: string): HttpParams;
     delete(param: string, value?: string): HttpParams;
     get(param: string): string | null;


### PR DESCRIPTION
Resubmitting #20332, since it was reverted (due to an [error in g3][1]).


## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] Documentation content changes
```

## What is the current behavior?
`HttpParamsOptions` is not documented as part of the public API.
Issue Number: #20276


## What is the new behavior?
`HttpParamsOptions` is documented as part of the public API.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
Fixes #20276.

[1]: https://github.com/angular/angular/pull/20332#issuecomment-364574160