### PR TITLE
fix(platform-browser): Make transfer state key typesafe. 

### DIFF
--- a/goldens/public-api/platform-browser/platform-browser.md
+++ b/goldens/public-api/platform-browser/platform-browser.md
@@ -193,6 +193,7 @@ export interface SafeValue {
 // @public
 export type StateKey<T> = string & {
     __not_a_string: never;
+    __value_type?: T;
 };
 
 // @public

--- a/packages/platform-browser/src/browser/transfer_state.ts
+++ b/packages/platform-browser/src/browser/transfer_state.ts
@@ -45,7 +45,10 @@ export function unescapeHtml(text: string): string {
  *
  * @publicApi
  */
-export type StateKey<T> = string&{__not_a_string: never};
+export type StateKey<T> = string&{
+  __not_a_string: never,
+  __value_type?: T,
+};
 
 /**
  * Create a `StateKey<T>` that can be used to store value of type T with `TransferState`.


### PR DESCRIPTION
Make `StateKey` typesafe by narrowing the type.

BREAKING CHANGE: This may break invalid calls to `TransferState` methods.

This tightens parameter types of `TransferState` usage, and is a minor breaking change which may reveal existing problematic calls.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
```

## What is the current behavior?

The methods of `TransferState` class allow wrongly typed usage, even thought their signature imply they are typesafe. Actually, the type parameter of StateKey is not used at all, which makes `StateKey<number>` equals to `StateKey<string>` .
```typescript
const KEY_FOR_NUMBER = makeStateKey<number>('keyForNumber');
transferState.get(KEY_FOR_NUMBER, 'string'); // no compile time error
const value = transferState.get(KEY_FOR_NUMBER, null); // type of value is any
```

## What is the new behavior?
```typescript
const KEY_FOR_NUMBER = makeStateKey<number>('keyForNumber');
transferState.get(KEY_FOR_NUMBER, 'abc'); // compile error: Argument of type '"abc"' is not assignable to parameter of type 'number'.
const value = transferState.get(KEY_FOR_NUMBER, null); // type of value is number
```

## Does this PR introduce a breaking change?

In an `@experimental` API and in a sense that a wrongly typed usage won't compile anymore without errors.

```
[x] Yes
[ ] No
```

If you see compile errors after this fix, that means you very likely have a bug. If you do not want to correct the types, you can have the old behavior just by changing your `makeStateKey<T>` calls to `makeStateKey<any>`.

## Other information
