### PR TITLE
feat(ivy): ViewContainerRef basic scenarios support

### DIFF
--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -7,7 +7,7 @@
  */
 
 import {ComponentTemplate} from './definition';
-import {LElementNode, LViewNode} from './node';
+import {LContainerNode, LElementNode, LViewNode} from './node';
 import {LQueries} from './query';
 import {LView, TView} from './view';
 
@@ -80,6 +80,13 @@ export interface LContainer {
    * this container are reported to queries referenced here.
    */
   queries: LQueries|null;
+
+  /**
+   * If a LContainer is created dynamically (by a directive requesting ViewContainerRef) this fields
+   * keeps a reference to a node on which a ViewContainerRef was requested. We need to store this
+   * information to find a next render sibling node.
+   */
+  host: LContainerNode|LElementNode|null;
 }
 
 /**

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -281,7 +281,10 @@ export function insertView(
     if (!beforeNode) {
       let containerNextNativeNode = container.native;
       if (containerNextNativeNode === undefined) {
-        containerNextNativeNode = container.native = findNextRNodeSibling(container, null);
+        // TODO(pk): this is probably too simplistic, add more tests for various host placements
+        // (dynamic view, projection, ...)
+        containerNextNativeNode = container.native =
+            findNextRNodeSibling(container.data.host ? container.data.host : container, null);
       }
       beforeNode = containerNextNativeNode;
     }

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -171,6 +171,9 @@
     "name": "createLNode"
   },
   {
+    "name": "createLNodeObject"
+  },
+  {
     "name": "createLView"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -345,6 +345,9 @@
     "name": "checkNoChangesMode"
   },
   {
+    "name": "cleanUpView"
+  },
+  {
     "name": "componentRefresh"
   },
   {
@@ -360,7 +363,13 @@
     "name": "createInjector"
   },
   {
+    "name": "createLContainer"
+  },
+  {
     "name": "createLNode"
+  },
+  {
+    "name": "createLNodeObject"
   },
   {
     "name": "createLView"
@@ -394,6 +403,9 @@
   },
   {
     "name": "defineInjector"
+  },
+  {
+    "name": "destroyViewTree"
   },
   {
     "name": "detectChanges"
@@ -474,6 +486,12 @@
     "name": "executeInitHooks"
   },
   {
+    "name": "executeOnDestroys"
+  },
+  {
+    "name": "executePipeOnDestroys"
+  },
+  {
     "name": "extendStatics"
   },
   {
@@ -541,6 +559,9 @@
   },
   {
     "name": "getOrCreateTemplateRef"
+  },
+  {
+    "name": "getParentState"
   },
   {
     "name": "getPreviousIndex"
@@ -766,6 +787,12 @@
   },
   {
     "name": "refreshDynamicChildren"
+  },
+  {
+    "name": "removeListeners"
+  },
+  {
+    "name": "removeView"
   },
   {
     "name": "renderComponent"

--- a/packages/core/test/render3/common_integration_spec.ts
+++ b/packages/core/test/render3/common_integration_spec.ts
@@ -9,12 +9,13 @@
 import {NgForOfContext} from '@angular/common';
 
 import {defineComponent} from '../../src/render3/index';
-import {bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, text, textBinding} from '../../src/render3/instructions';
+import {bind, container, elementEnd, elementProperty, elementStart, interpolation3, text, textBinding, tick} from '../../src/render3/instructions';
 
 import {NgForOf} from './common_with_def';
-import {renderComponent, toHtml} from './render_util';
+import {ComponentFixture} from './render_util';
 
 describe('@angular/common integration', () => {
+
   describe('NgForOf', () => {
     it('should update a loop', () => {
       class MyApp {
@@ -34,8 +35,6 @@ describe('@angular/common integration', () => {
               elementEnd();
             }
             elementProperty(1, 'ngForOf', bind(myApp.items));
-            containerRefreshStart(1);
-            containerRefreshEnd();
 
             function liTemplate(row: NgForOfContext<string>, cm: boolean) {
               if (cm) {
@@ -50,9 +49,71 @@ describe('@angular/common integration', () => {
         });
       }
 
-      const myApp = renderComponent(MyApp);
-      expect(toHtml(myApp)).toEqual('<ul><li>first</li><li>second</li></ul>');
+      const fixture = new ComponentFixture(MyApp);
+      expect(fixture.html).toEqual('<ul><li>first</li><li>second</li></ul>');
+
+      // change detection cycle, no model changes
+      fixture.update();
+      expect(fixture.html).toEqual('<ul><li>first</li><li>second</li></ul>');
+
+      // remove the last item
+      fixture.component.items.length = 1;
+      fixture.update();
+      expect(fixture.html).toEqual('<ul><li>first</li></ul>');
+
+      // change an item
+      fixture.component.items[0] = 'one';
+      fixture.update();
+      expect(fixture.html).toEqual('<ul><li>one</li></ul>');
+
+      // add an item
+      fixture.component.items.push('two');
+      fixture.update();
+      expect(fixture.html).toEqual('<ul><li>one</li><li>two</li></ul>');
     });
-    // TODO: Test inheritance
+
+    it('should support ngForOf context variables', () => {
+
+      class MyApp {
+        items: string[] = ['first', 'second'];
+
+        static ngComponentDef = defineComponent({
+          type: MyApp,
+          factory: () => new MyApp(),
+          selectors: [['my-app']],
+          // <ul>
+          //   <li *ngFor="let item of items">{{index}} of {{count}}: {{item}}</li>
+          // </ul>
+          template: (myApp: MyApp, cm: boolean) => {
+            if (cm) {
+              elementStart(0, 'ul');
+              { container(1, liTemplate, undefined, ['ngForOf', '']); }
+              elementEnd();
+            }
+            elementProperty(1, 'ngForOf', bind(myApp.items));
+
+            function liTemplate(row: NgForOfContext<string>, cm: boolean) {
+              if (cm) {
+                elementStart(0, 'li');
+                { text(1); }
+                elementEnd();
+              }
+              textBinding(
+                  1, interpolation3('', row.index, ' of ', row.count, ': ', row.$implicit, ''));
+            }
+          },
+          directives: () => [NgForOf]
+        });
+      }
+
+      const fixture = new ComponentFixture(MyApp);
+      expect(fixture.html).toEqual('<ul><li>0 of 2: first</li><li>1 of 2: second</li></ul>');
+
+      fixture.component.items.splice(1, 0, 'middle');
+      fixture.update();
+      expect(fixture.html)
+          .toEqual('<ul><li>0 of 3: first</li><li>1 of 3: middle</li><li>2 of 3: second</li></ul>');
+    });
+
   });
 });


### PR DESCRIPTION
This PR adds support for basic `ViewContainerRef` usage scenarios.
This PR is _not_ the full implementation of the `ViewContainerRef` logic - remaining methods will be implemented in subsequent PRs.