### PR TITLE
feat(service-worker): add support for ignoring specific URLs

### DIFF
--- a/aio/content/guide/service-worker-config.md
+++ b/aio/content/guide/service-worker-config.md
@@ -1,5 +1,3 @@
-{@a glob}
-
 # Service worker configuration
 
 #### Prerequisites
@@ -9,9 +7,9 @@ A basic understanding of the following:
 
 <hr />
 
-The `src/ngsw-config.json` configuration file specifies which files and data URLs the Angular 
-service worker should cache and how it should update the cached files and data. The 
-CLI processes the configuration file during `ng build --prod`. Manually, you can process 
+The `src/ngsw-config.json` configuration file specifies which files and data URLs the Angular
+service worker should cache and how it should update the cached files and data. The
+CLI processes the configuration file during `ng build --prod`. Manually, you can process
 it with the `ngsw-config` tool:
 
 ```sh
@@ -32,7 +30,7 @@ Example patterns:
 * `/*.html` specifies only HTML files in the root.
 * `!/**/*.map` exclude all sourcemaps.
 
-Each section of the configuration file is described below. 
+Each section of the configuration file is described below.
 
 ## `appData`
 
@@ -42,6 +40,17 @@ The `SwUpdate` service includes that data in the update notifications. Many apps
 ## `index`
 
 Specifies the file that serves as the index page to satisfy navigation requests. Usually this is `/index.html`.
+
+## `ignoredUrlPatterns`
+
+This section enables you to specify URLs that will not be handled by the service worker. The service
+worker will forward matching requests to the server and neither try to retrieve responses from the
+cache nor serve the index page (even for navigation requests). This is useful for routes that are
+not part of the Angular app, but should always be handled by the server.
+
+This field contains an array of URLs and glob-like URL patterns that will be matched at runtime.
+
+**Note**: Currently, negative patterns (i.e. patterns beginning with `!`) are _not_ supported.
 
 ## `assetGroups`
 
@@ -92,7 +101,7 @@ The `installMode` determines how these resources are initially cached. The `inst
 
 For resources already in the cache, the `updateMode` determines the caching behavior when a new version of the app is discovered. Any resources in the group that have changed since the previous version are updated in accordance with `updateMode`.
 
-* `prefetch` tells the service worker to download and cache the changed resources immediately. 
+* `prefetch` tells the service worker to download and cache the changed resources immediately.
 
 * `lazy` tells the service worker to not cache those resources. Instead, it treats them as unrequested and waits until they're requested again before updating them. An `updateMode` of `lazy` is only valid if the `installMode` is also `lazy`.
 
@@ -135,7 +144,7 @@ A list of URL patterns. URLs that match these patterns will be cached according 
 ### `version`
 Occasionally APIs change formats in a way that is not backward-compatible. A new version of the app may not be compatible with the old API format and thus may not be compatible with existing cached resources from that API.
 
-`version` provides a mechanism to indicate that the resources being cached have been updated in a backwards-incompatible way, and that the old cache entries&mdash;those from previous versions&mdash;should be discarded. 
+`version` provides a mechanism to indicate that the resources being cached have been updated in a backwards-incompatible way, and that the old cache entries&mdash;those from previous versions&mdash;should be discarded.
 
 `version` is an integer field and defaults to `0`.
 
@@ -166,4 +175,3 @@ The Angular service worker can use either of two caching strategies for data res
 * `performance`, the default, optimizes for responses that are as fast as possible. If a resource exists in the cache, the cached version is used. This allows for some staleness, depending on the `maxAge`, in exchange for better performance. This is suitable for resources that don't change often; for example, user avatar images.
 
 * `freshness` optimizes for currency of data, preferentially fetching requested data from the network. Only if the network times out, according to `timeout`, does the request fall back to the cache. This is useful for resources that change frequently; for example, account balances.
-

--- a/aio/content/guide/service-worker-devops.md
+++ b/aio/content/guide/service-worker-devops.md
@@ -21,20 +21,20 @@ In the context of an Angular service worker, a "version" is a collection of reso
 
 To preserve app integrity, the Angular service worker groups all files into a version together. The files grouped into a version usually include HTML, JS, and CSS files. Grouping of these files is essential for integrity because HTML, JS, and CSS files frequently refer to each other and depend on specific content. For example, an `index.html` file might have a `<script>` tag that references `bundle.js` and it might attempt to call a function `startApp()` from within that script. Any time this version of `index.html` is served, the corresponding `bundle.js` must be served with it. For example, assume that the `startApp()` function is renamed to `runApp()` in both files. In this scenario, it is not valid to serve the old `index.html`, which calls `startApp()`, along with the new bundle, which defines `runApp()`.
 
-This file integrity is especially important when lazy loading modules. 
-A JS bundle may reference many lazy chunks, and the filenames of the 
-lazy chunks are unique to the particular build of the app. If a running 
-app at version `X` attempts to load a lazy chunk, but the server has 
+This file integrity is especially important when lazy loading modules.
+A JS bundle may reference many lazy chunks, and the filenames of the
+lazy chunks are unique to the particular build of the app. If a running
+app at version `X` attempts to load a lazy chunk, but the server has
 updated to version `X + 1` already, the lazy loading operation will fail.
 
-The version identifier of the app is determined by the contents of all 
-resources, and it changes if any of them change. In practice, the version 
-is determined by the contents of the `ngsw.json` file, which includes 
-hashes for all known content. If any of the cached files change, the file's 
-hash will change in `ngsw.json`, causing the Angular service worker to 
-treat the active set of files as a new version. 
+The version identifier of the app is determined by the contents of all
+resources, and it changes if any of them change. In practice, the version
+is determined by the contents of the `ngsw.json` file, which includes
+hashes for all known content. If any of the cached files change, the file's
+hash will change in `ngsw.json`, causing the Angular service worker to
+treat the active set of files as a new version.
 
-With the versioning behavior of the Angular service worker, an application 
+With the versioning behavior of the Angular service worker, an application
 server can ensure that the Angular app always has a consistent set of files.
 
 #### Update checks
@@ -46,25 +46,25 @@ the next time the application is loaded.
 
 ### Resource integrity
 
-One of the potential side effects of long caching is inadvertently 
-caching an invalid resource. In a normal HTTP cache, a hard refresh 
-or cache expiration limits the negative effects of caching an invalid 
-file. A service worker ignores such constraints and effectively long 
-caches the entire app. Consequently, it is essential that the service worker 
-get the correct content.
+One of the potential side effects of long caching is inadvertently
+caching an invalid resource. In a normal HTTP cache, a hard refresh
+or cache expiration limits the negative effects of caching an invalid
+file. A service worker ignores such constraints and effectively long
+caches the entire app. Consequently, it is essential that the service worker
+gets the correct content.
 
-To ensure resource integrity, the Angular service worker validates 
-the hashes of all resources for which it has a hash. Typically for 
-a CLI app, this is everything in the `dist` directory covered by 
+To ensure resource integrity, the Angular service worker validates
+the hashes of all resources for which it has a hash. Typically for
+a CLI app, this is everything in the `dist` directory covered by
 the user's `src/ngsw-config.json` configuration.
 
-If a particular file fails validation, the Angular service worker 
-attempts to re-fetch the content using a "cache-busting" URL 
-parameter to eliminate the effects of browser or intermediate 
-caching. If that content also fails validation, the service worker 
-considers the entire version of the app to be invalid and it stops 
-serving the app. If necessary, the service worker enters a safe mode 
-where requests fall back on the network, opting not to use its cache 
+If a particular file fails validation, the Angular service worker
+attempts to re-fetch the content using a "cache-busting" URL
+parameter to eliminate the effects of browser or intermediate
+caching. If that content also fails validation, the service worker
+considers the entire version of the app to be invalid and it stops
+serving the app. If necessary, the service worker enters a safe mode
+where requests fall back on the network, opting not to use its cache
 if the risk of serving invalid, broken, or outdated content is high.
 
 Hash mismatches can occur for a variety of reasons:
@@ -75,57 +75,57 @@ Hash mismatches can occur for a variety of reasons:
 
 #### Unhashed content
 
-The only resources that have hashes in the `ngsw.json` 
-manifest are resources that were present in the `dist` 
-directory at the time the manifest was built. Other 
-resources, especially those loaded from CDNs, have 
-content that is unknown at build time or are updated 
+The only resources that have hashes in the `ngsw.json`
+manifest are resources that were present in the `dist`
+directory at the time the manifest was built. Other
+resources, especially those loaded from CDNs, have
+content that is unknown at build time or are updated
 more frequently than the app is deployed.
 
-If the Angular service worker does not have a hash to validate 
-a given resource, it still caches its contents but it honors 
-the HTTP caching headers by using a policy of "stale while 
-revalidate." That is, when HTTP caching headers for a cached 
-resource indicate that the resource has expired, the Angular 
-service worker continues to serve the content and it attempts 
-to refresh the resource in the background. This way, broken 
-unhashed resources do not remain in the cache beyond their 
+If the Angular service worker does not have a hash to validate
+a given resource, it still caches its contents but it honors
+the HTTP caching headers by using a policy of "stale while
+revalidate." That is, when HTTP caching headers for a cached
+resource indicate that the resource has expired, the Angular
+service worker continues to serve the content and it attempts
+to refresh the resource in the background. This way, broken
+unhashed resources do not remain in the cache beyond their
 configured lifetimes.
 
 {@a tabs}
 
 ### App tabs
 
-It can be problematic for an app if the version of resources 
-it's receiving changes suddenly or without warning. See the 
-[Versions](guide/service-worker-devops#versions) section above 
+It can be problematic for an app if the version of resources
+it's receiving changes suddenly or without warning. See the
+[Versions](guide/service-worker-devops#versions) section above
 for a description of such issues.
 
-The Angular service worker provides a guarantee: a running app 
-will continue to run the same version of the app. If another 
-instance of the app is opened in a new web browser tab, then 
-the most current version of the app is served. As a result, 
-that new tab can be running a different version of the app 
+The Angular service worker provides a guarantee: a running app
+will continue to run the same version of the app. If another
+instance of the app is opened in a new web browser tab, then
+the most current version of the app is served. As a result,
+that new tab can be running a different version of the app
 than the original tab.
 
-It's important to note that this guarantee is **stronger** 
-than that provided by the normal web deployment model. Without 
-a service worker, there is no guarantee that code lazily loaded 
-later in a running app is from the same version as the initial 
+It's important to note that this guarantee is **stronger**
+than that provided by the normal web deployment model. Without
+a service worker, there is no guarantee that code lazily loaded
+later in a running app is from the same version as the initial
 code for the app.
 
-There are a few limited reasons why the Angular service worker 
-might change the version of a running app. Some of them are 
+There are a few limited reasons why the Angular service worker
+might change the version of a running app. Some of them are
 error conditions:
 
 * The current version becomes invalid due to a failed hash.
 * An unrelated error causes the service worker to enter safe mode; that is, temporary deactivation.
 
-The Angular service worker is aware of which versions are in 
-use at any given moment and it cleans up versions when 
+The Angular service worker is aware of which versions are in
+use at any given moment and it cleans up versions when
 no tab is using them.
 
-Other reasons the Angular service worker might change the version 
+Other reasons the Angular service worker might change the version
 of a running app are normal events:
 
 * The page is reloaded/refreshed.
@@ -133,33 +133,33 @@ of a running app are normal events:
 
 ### Service worker updates
 
-The Angular service worker is a small script that runs in web browsers. 
-From time to time, the service worker will be updated with bug 
-fixes and feature improvements. 
+The Angular service worker is a small script that runs in web browsers.
+From time to time, the service worker will be updated with bug
+fixes and feature improvements.
 
-The Angular service worker is downloaded when the app is first opened 
-and when the app is accessed after a period of inactivity. If the 
-service worker has changed, the service worker will be updated in the background.  
+The Angular service worker is downloaded when the app is first opened
+and when the app is accessed after a period of inactivity. If the
+service worker has changed, the service worker will be updated in the background.
 
-Most updates to the Angular service worker are transparent to the 
-app&mdash;the old caches are still valid and content is still served 
-normally. However, occasionally a bugfix or feature in the Angular 
-service worker requires the invalidation of old caches. In this case, 
+Most updates to the Angular service worker are transparent to the
+app&mdash;the old caches are still valid and content is still served
+normally. However, occasionally a bugfix or feature in the Angular
+service worker requires the invalidation of old caches. In this case,
 the app will be refreshed transparently from the network.
 
 
 ## Debugging the Angular service worker
 
-Occasionally, it may be necessary to examine the Angular service 
-worker in a running state to investigate issues or to ensure that 
-it is operating as designed. Browsers provide built-in tools for 
-debugging service workers and the Angular service worker itself 
+Occasionally, it may be necessary to examine the Angular service
+worker in a running state to investigate issues or to ensure that
+it is operating as designed. Browsers provide built-in tools for
+debugging service workers and the Angular service worker itself
 includes useful debugging features.
 
 ### Locating and analyzing debugging information
 
-The Angular service worker exposes debugging information under 
-the `ngsw/` virtual directory. Currently, the single exposed URL 
+The Angular service worker exposes debugging information under
+the `ngsw/` virtual directory. Currently, the single exposed URL
 is `ngsw/state`. Here is an example of this debug page's contents:
 
 ```
@@ -184,27 +184,27 @@ Debug log:
 
 #### Driver state
 
-The first line indicates the driver state: 
+The first line indicates the driver state:
 
 ```
 Driver state: NORMAL ((nominal))
 ```
 
-`NORMAL` indicates that the service worker is operating normally and is not in a degraded state. 
+`NORMAL` indicates that the service worker is operating normally and is not in a degraded state.
 
 There are two possible degraded states:
 
-* `EXISTING_CLIENTS_ONLY`: the service worker does not have a 
-clean copy of the latest known version of the app. Older cached 
-versions are safe to use, so existing tabs continue to run from 
+* `EXISTING_CLIENTS_ONLY`: the service worker does not have a
+clean copy of the latest known version of the app. Older cached
+versions are safe to use, so existing tabs continue to run from
 cache, but new loads of the app will be served from the network.
 
-* `SAFE_MODE`: the service worker cannot guarantee the safety of 
-using cached data. Either an unexpected error occurred or all 
-cached versions are invalid. All traffic will be served from the 
+* `SAFE_MODE`: the service worker cannot guarantee the safety of
+using cached data. Either an unexpected error occurred or all
+cached versions are invalid. All traffic will be served from the
 network, running as little service worker code as possible.
 
-In both cases, the parenthetical annotation provides the 
+In both cases, the parenthetical annotation provides the
 error that caused the service worker to enter the degraded state.
 
 
@@ -223,7 +223,7 @@ This is the SHA1 hash of the most up-to-date version of the app that the service
 Last update check: never
 ```
 
-This indicates the last time the service worker checked for a new version, or update, of the app. `never` indicates that the service worker has never checked for an update. 
+This indicates the last time the service worker checked for a new version, or update, of the app. `never` indicates that the service worker has never checked for an update.
 
 In this example debug file, the update check is currently scheduled, as explained the next section.
 
@@ -235,10 +235,10 @@ In this example debug file, the update check is currently scheduled, as explaine
 Clients: 7b79a015-69af-4d3d-9ae6-95ba90c79486, 5bc08295-aaf2-42f3-a4cc-9e4ef9100f65
 ```
 
-In this example, the service worker has one version of the app cached and 
-being used to serve two different tabs. Note that this version hash 
-is the "latest manifest hash" listed above. Both clients are on the 
-latest version. Each client is listed by its ID from the `Clients` 
+In this example, the service worker has one version of the app cached and
+being used to serve two different tabs. Note that this version hash
+is the "latest manifest hash" listed above. Both clients are on the
+latest version. Each client is listed by its ID from the `Clients`
 API in the browser.
 
 
@@ -252,16 +252,16 @@ Task queue:
  * init post-load (update, cleanup)
 ```
 
-The Idle Task Queue is the queue of all pending tasks that happen 
-in the background in the service worker. If there are any tasks 
-in the queue, they are listed with a description. In this example, 
-the service worker has one such task scheduled, a post-initialization 
+The Idle Task Queue is the queue of all pending tasks that happen
+in the background in the service worker. If there are any tasks
+in the queue, they are listed with a description. In this example,
+the service worker has one such task scheduled, a post-initialization
 operation involving an update check and cleanup of stale caches.
 
-The last update tick/run counters give the time since specific 
-events happened related to the idle queue. The "Last update run" 
-counter shows the last time idle tasks were actually executed. 
-"Last update tick" shows the time since the last event after 
+The last update tick/run counters give the time since specific
+events happened related to the idle queue. The "Last update run"
+counter shows the last time idle tasks were actually executed.
+"Last update tick" shows the time since the last event after
 which the queue might be processed.
 
 
@@ -276,34 +276,34 @@ Errors that occur within the service worker will be logged here.
 
 ### Developer Tools
 
-Browsers such as Chrome provide developer tools for interacting 
-with service workers. Such tools can be powerful when used properly, 
+Browsers such as Chrome provide developer tools for interacting
+with service workers. Such tools can be powerful when used properly,
 but there are a few things to keep in mind.
 
-* When using developer tools, the service worker is kept running 
+* When using developer tools, the service worker is kept running
 in the background and never restarts. This can cause behavior with Dev
 Tools open to differ from behavior a user might experience.
 
-* If you look in the Cache Storage viewer, the cache is frequently 
+* If you look in the Cache Storage viewer, the cache is frequently
 out of date. Right click the Cache Storage title and refresh the caches.
 
-Stopping and starting the service worker in the Service Worker 
+Stopping and starting the service worker in the Service Worker
 pane triggers a check for updates.
 
 ## Service Worker Safety
 
-Like any complex system, bugs or broken configurations can cause 
-the Angular service worker to act in unforeseen ways. While its 
-design attempts to minimize the impact of such problems, the 
-Angular service worker contains several failsafe mechanisms in case 
+Like any complex system, bugs or broken configurations can cause
+the Angular service worker to act in unforeseen ways. While its
+design attempts to minimize the impact of such problems, the
+Angular service worker contains several failsafe mechanisms in case
 an administrator ever needs to deactivate the service worker quickly.
 
-## Fail-safe
+### Fail-safe
 
-To deactivate the service worker, remove or rename the 
-`ngsw-config.json` file. When the service worker's request 
-for `ngsw.json` returns a `404`, then the service worker 
-removes all of its caches and de-registers itself, 
+To deactivate the service worker, remove or rename the
+`ngsw-config.json` file. When the service worker's request
+for `ngsw.json` returns a `404`, then the service worker
+removes all of its caches and de-registers itself,
 essentially self-destructing.
 
 ### Safety Worker

--- a/aio/content/guide/service-worker-getting-started.md
+++ b/aio/content/guide/service-worker-getting-started.md
@@ -8,21 +8,21 @@ A basic understanding of the following:
 <hr />
 
 
-Beginning in Angular 5.0.0, you can easily enable Angular service worker support in any CLI project. This document explains how to enable Angular service worker support in new and existing projects. It then uses a simple example to show you a service worker in action, demonstrating loading and basic caching.  
+Beginning in Angular 5.0.0, you can easily enable Angular service worker support in any CLI project. This document explains how to enable Angular service worker support in new and existing projects. It then uses a simple example to show you a service worker in action, demonstrating loading and basic caching.
 
 ## Adding a service worker to a new application
 
 If you're generating a new CLI project, you can use the CLI to set up the Angular service worker as part of creating the project. To do so, add the `--service-worker` flag to the `ng new`  command:
 
 ```sh
-ng new my-project --service-worker 
+ng new my-project --service-worker
 ```
 
-The `--service-worker` flag takes care of configuring your app to 
-use service workers by adding the `service-worker` package along 
-with setting up the necessary files to support service workers. 
-For information on the details, see the following section 
-which covers the process in detail as it shows you how to add a 
+The `--service-worker` flag takes care of configuring your app to
+use service workers by adding the `service-worker` package along
+with setting up the necessary files to support service workers.
+For information on the details, see the following section
+which covers the process in detail as it shows you how to add a
 service worker manually to an existing app.
 
 
@@ -34,7 +34,7 @@ To add a service worker to an existing app:
 1. Add the service worker package.
 2. Enable service worker build support in the CLI.
 3. Import and register the service worker.
-4. Create the service worker configuration file, which specifies the caching behaviors and other settings. 
+4. Create the service worker configuration file, which specifies the caching behaviors and other settings.
 5. Build the project.
 
 ### Step 1: Add the service worker package
@@ -70,7 +70,7 @@ The file `ngsw-worker.js` is the name of the prebuilt service worker script, whi
 
 ### Step 4: Create the configuration file, `ngsw-config.json`
 
-The Angular CLI needs a service worker configuration file, called `ngsw-config.json`. The configuration file controls how the service worker caches files and data 
+The Angular CLI needs a service worker configuration file, called `ngsw-config.json`. The configuration file controls how the service worker caches files and data
 resources.
 
 You can begin with the boilerplate version from the CLI, which configures sensible defaults for most applications.
@@ -81,7 +81,7 @@ Alternately, save the following as `src/ngsw-config.json`:
 
 ### Step 5: Build the project
 
-Finally, build the project: 
+Finally, build the project:
 
 ```sh
 ng build --prod
@@ -92,18 +92,17 @@ The CLI project is now set up to use the Angular service worker.
 
 ## Service worker in action: a tour
 
-This section demonstrates a service worker in action, 
-using an example application. 
+This section demonstrates a service worker in action,
+using an example application.
 
 ### Serving with `http-server`
 
 Because `ng serve` does not work with service workers, you must use a separate HTTP server to test your project locally. You can use any HTTP server. The example below uses the [http-server](https://www.npmjs.com/package/http-server) package from npm. To reduce the possibility of conflicts, test on a dedicated port.
 
-To serve with `http-server`, change to the directory containing your web files and start the web server: 
+To serve the app, start `http-server` and specify the directory containing your web files and the port:
 
 ```sh
-cd dist
-http-server -p 8080
+http-server dist -p 8080
 ```
 
 ### Initial load
@@ -114,7 +113,7 @@ With the server running, you can point your browser at http://localhost:8080/. Y
 
 ### Simulating a network issue
 
-To simulate a network issue, disable network interaction for your application. In Chrome: 
+To simulate a network issue, disable network interaction for your application. In Chrome:
 
 1. Select **Tools** > **Developer Tools** (from the Chrome menu located at the top right corner).
 2. Go to the **Network tab**.
@@ -126,9 +125,9 @@ To simulate a network issue, disable network interaction for your application. I
 
 Now the app has no access to network interaction.
 
-For applications that do not use the Angular service worker, refreshing now would display Chrome's Internet disconnected page that says "There is no Internet connection". 
+For applications that do not use the Angular service worker, refreshing now would display Chrome's Internet disconnected page that says "There is no Internet connection".
 
-With the addition of an Angular service worker, the application behavior changes. On a refresh, the page loads normally. 
+With the addition of an Angular service worker, the application behavior changes. On a refresh, the page loads normally.
 
 If you look at the Network tab, you can verify that the service worker is active.
 
@@ -150,12 +149,12 @@ Notice that all of the files the browser needs to render this application are ca
 
 ### Making changes to your application
 
-Now that you've seen how service workers cache your application, the 
-next step is understanding how updates work. 
+Now that you've seen how service workers cache your application, the
+next step is understanding how updates work.
 
 1. If you're testing in an incognito window, open a second blank tab. This will keep the incognito and the cache state alive during your test.
 
-2. Close the application tab, but not the window. This should also close the Developer Tools. 
+2. Close the application tab, but not the window. This should also close the Developer Tools.
 
 3. Shut down `http-server`.
 
@@ -169,8 +168,7 @@ next step is understanding how updates work.
 
 ```sh
 ng build --prod
-cd dist
-http-server -p 8080
+http-server dist -p 8080
 ```
 
 ### Updating your application in the browser

--- a/packages/service-worker/config/src/in.ts
+++ b/packages/service-worker/config/src/in.ts
@@ -24,6 +24,7 @@ export type Duration = string;
 export interface Config {
   appData?: {};
   index: string;
+  ignoredUrlPatterns?: string[];
   assetGroups?: AssetGroup[];
   dataGroups?: DataGroup[];
 }

--- a/packages/service-worker/config/test/generator_spec.ts
+++ b/packages/service-worker/config/test/generator_spec.ts
@@ -20,10 +20,16 @@ import {MockFilesystem} from '../testing/mock';
       });
       const gen = new Generator(fs, '/test');
       const res = gen.process({
-        index: '/index.html',
         appData: {
           test: true,
         },
+        index: '/index.html',
+        ignoredUrlPatterns: [
+          '/ignored/absolute/**',
+          '/ignored/some/url?with+escaped+chars',
+          'ignored/relative/*.txt',
+          'http://example.com/ignored',
+        ],
         assetGroups: [{
           name: 'test',
           resources: {
@@ -56,36 +62,42 @@ import {MockFilesystem} from '../testing/mock';
       });
       res.then(config => {
            expect(config).toEqual({
-             'configVersion': 1,
-             'index': '/test/index.html',
-             'appData': {
-               'test': true,
+             configVersion: 1,
+             appData: {
+               test: true,
              },
-             'assetGroups': [{
-               'name': 'test',
-               'installMode': 'prefetch',
-               'updateMode': 'prefetch',
-               'urls': [
+             index: '/test/index.html',
+             ignoredUrlPatterns: [
+               '^\\/ignored\\/absolute\\/.*',
+               '^\\/ignored\\/some\\/url\\?with\\+escaped\\+chars',
+               '^\\/test\\/ignored\\/relative\\/[^\\/]+\\.txt',
+               '^http:\\/\\/example\\.com\\/ignored',
+             ],
+             assetGroups: [{
+               name: 'test',
+               installMode: 'prefetch',
+               updateMode: 'prefetch',
+               urls: [
                  '/test/index.html',
                  '/test/foo/test.html',
                  '/test/test.txt',
                ],
-               'patterns': [
+               patterns: [
                  '\\/absolute\\/.*',
                  '\\/some\\/url\\?with\\+escaped\\+chars',
                  '\\/test\\/relative\\/[^\\/]+\\.txt',
                ]
              }],
-             'dataGroups': [{
-               'name': 'other',
-               'patterns': ['\\/api\\/.*', '\\/test\\/relapi\\/.*'],
-               'strategy': 'performance',
-               'maxSize': 100,
-               'maxAge': 259200000,
-               'timeoutMs': 60000,
-               'version': 1,
+             dataGroups: [{
+               name: 'other',
+               patterns: ['\\/api\\/.*', '\\/test\\/relapi\\/.*'],
+               strategy: 'performance',
+               maxSize: 100,
+               maxAge: 259200000,
+               timeoutMs: 60000,
+               version: 1,
              }],
-             'hashTable': {
+             hashTable: {
                '/test/test.txt': '18f6f8eb7b1c23d2bb61bff028b83d867a9e4643',
                '/test/index.html': 'a54d88e06612d820bc3be72877c74f257b561b19',
                '/test/foo/test.html': '18f6f8eb7b1c23d2bb61bff028b83d867a9e4643'

--- a/packages/service-worker/config/test/generator_spec.ts
+++ b/packages/service-worker/config/test/generator_spec.ts
@@ -68,10 +68,10 @@ import {MockFilesystem} from '../testing/mock';
              },
              index: '/test/index.html',
              ignoredUrlPatterns: [
-               '^\\/ignored\\/absolute\\/.*',
-               '^\\/ignored\\/some\\/url\\?with\\+escaped\\+chars',
-               '^\\/test\\/ignored\\/relative\\/[^\\/]+\\.txt',
-               '^http:\\/\\/example\\.com\\/ignored',
+               '^\\/ignored\\/absolute\\/.*$',
+               '^\\/ignored\\/some\\/url\\?with\\+escaped\\+chars$',
+               '^\\/test\\/ignored\\/relative\\/[^\\/]+\\.txt$',
+               '^http:\\/\\/example\\.com\\/ignored$',
              ],
              assetGroups: [{
                name: 'test',

--- a/packages/service-worker/worker/src/manifest.ts
+++ b/packages/service-worker/worker/src/manifest.ts
@@ -14,6 +14,7 @@ export interface Manifest {
   configVersion: number;
   appData?: {[key: string]: string};
   index: string;
+  ignoredUrlPatterns?: string[];
   assetGroups?: AssetGroupConfig[];
   dataGroups?: DataGroupConfig[];
   hashTable: {[url: string]: string};

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -63,8 +63,8 @@ const manifest: Manifest = {
   },
   index: '/foo.txt',
   ignoredUrlPatterns: [
-    '^\\/ignored\\/file',
-    '^\\/ignored\\/dir\\/.*',
+    '^\\/ignored\\/file$',
+    '^\\/ignored\\/dir\\/.*$',
   ],
   assetGroups: [
     {

--- a/tools/public_api_guard/service-worker/config.d.ts
+++ b/tools/public_api_guard/service-worker/config.d.ts
@@ -15,6 +15,7 @@ export interface Config {
     appData?: {};
     assetGroups?: AssetGroup[];
     dataGroups?: DataGroup[];
+    ignoredUrlPatterns?: string[];
     index: string;
 }
 


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] Feature
```

## What is the current behavior?
The ServiceWorker will redirect navigation requests that don't match any `asset` or `data` group to the specified index file. Yet, sometimes it is desirable to configure the SW to ignore specific URLs (even for navigation requests) and pass them through to the server.

Issue Number: #20404


## What is the new behavior?
This commit adds support for specifying an optional `ignoredUrlPatterns` list in `ngsw-config.json`, which contains URLs or simple globs (currently only recognizing `*` and `**`). Requests matching these URLs or patterns will not be handled by the SW.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
Fixes #20404.