### PR TITLE
fix(ivy): store local variables in data instead of calling loadDirective

### DIFF
--- a/packages/core/test/render3/compiler_canonical/elements_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/elements_spec.ts
@@ -53,6 +53,60 @@ describe('elements', () => {
         .toEqual('<div class="my-app" title="Hello">Hello <b>World</b>!</div>');
   });
 
+  it('should support local refs', () => {
+    type $LocalRefComp$ = LocalRefComp;
+
+    class Dir {
+      value = 'one';
+
+      static ngDirectiveDef = $r3$.ɵdefineDirective({
+        type: Dir,
+        selector: [[['', 'dir', ''], null]],
+        factory: function DirA_Factory() { return new Dir(); },
+        exportAs: 'dir'
+      });
+    }
+
+    // NORMATIVE
+    const $e0_attrs$ = ['dir', ''];
+    const $e0_locals$ = ['dir', 'dir', 'foo', ''];
+    // /NORMATIVE
+
+    @Component({
+      selector: 'local-ref-comp',
+      template: `
+        <div dir #dir="dir" #foo></div>
+        {{ dir.value }} - {{ foo.tagName }}
+      `
+    })
+    class LocalRefComp {
+      // NORMATIVE
+      static ngComponentDef = $r3$.ɵdefineComponent({
+        type: LocalRefComp,
+        selector: [[['local-ref-comp'], null]],
+        factory: function LocalRefComp_Factory() { return new LocalRefComp(); },
+        template: function LocalRefComp_Template(ctx: $LocalRefComp$, cm: $boolean$) {
+          if (cm) {
+            $r3$.ɵE(0, 'div', $e0_attrs$, $e0_locals$);
+            $r3$.ɵe();
+            $r3$.ɵT(3);
+          }
+          const $tmp$ = $r3$.ɵld(1) as any;
+          const $tmp_2$ = $r3$.ɵld(2) as any;
+          $r3$.ɵt(3, $r3$.ɵi2(' ', $tmp$.value, ' - ', $tmp_2$.tagName, ''));
+        }
+      });
+      // /NORMATIVE
+    }
+
+    // NON-NORMATIVE
+    LocalRefComp.ngComponentDef.directiveDefs = () => [Dir.ngDirectiveDef];
+    // /NON-NORMATIVE
+
+    const fixture = new ComponentFixture(LocalRefComp);
+    expect(fixture.html).toEqual(`<div dir=""></div> one - DIV`);
+  });
+
   it('should support listeners', () => {
     type $ListenerComp$ = ListenerComp;
 

--- a/packages/core/test/render3/properties_spec.ts
+++ b/packages/core/test/render3/properties_spec.ts
@@ -9,9 +9,9 @@
 import {EventEmitter} from '@angular/core';
 
 import {defineComponent, defineDirective, tick} from '../../src/render3/index';
-import {NO_CHANGE, bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, interpolation1, listener, loadDirective, text, textBinding} from '../../src/render3/instructions';
+import {NO_CHANGE, bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, interpolation1, listener, load, loadDirective, text, textBinding} from '../../src/render3/instructions';
 
-import {ComponentFixture, TemplateFixture, createComponent, renderToHtml} from './render_util';
+import {ComponentFixture, renderToHtml} from './render_util';
 
 describe('elementProperty', () => {
 
@@ -533,10 +533,10 @@ describe('elementProperty', () => {
             if (cm) {
               elementStart(0, 'div', ['role', 'button', 'myDir', ''], ['dir', 'myDir']);
               elementEnd();
-              text(1);
+              text(2);
             }
-            // TODO: remove this loadDirective when removing MyDir
-            textBinding(1, bind(loadDirective<MyDir>(0).role));
+            const tmp = load(1) as any;
+            textBinding(2, bind(tmp.role));
           },
           factory: () => new Comp(),
           directiveDefs: () => [MyDir.ngDirectiveDef]

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -179,7 +179,7 @@ describe('query', () => {
           query(0, ['foo'], false, QUERY_READ_FROM_NODE);
           elToQuery = elementStart(1, 'div', null, ['foo', '']);
           elementEnd();
-          elementStart(2, 'div');
+          elementStart(3, 'div');
           elementEnd();
         }
         queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -209,7 +209,7 @@ describe('query', () => {
           query(1, ['bar'], false, QUERY_READ_FROM_NODE);
           elToQuery = elementStart(2, 'div', null, ['foo', '', 'bar', '']);
           elementEnd();
-          elementStart(3, 'div');
+          elementStart(5, 'div');
           elementEnd();
         }
         queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.fooQuery = tmp as QueryList<any>);
@@ -245,9 +245,9 @@ describe('query', () => {
           query(0, ['foo', 'bar'], undefined, QUERY_READ_FROM_NODE);
           el1ToQuery = elementStart(1, 'div', null, ['foo', '']);
           elementEnd();
-          elementStart(2, 'div');
+          elementStart(3, 'div');
           elementEnd();
-          el2ToQuery = elementStart(3, 'div', null, ['bar', '']);
+          el2ToQuery = elementStart(4, 'div', null, ['bar', '']);
           elementEnd();
         }
         queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -276,7 +276,7 @@ describe('query', () => {
           query(0, ['foo'], false, QUERY_READ_ELEMENT_REF);
           elToQuery = elementStart(1, 'div', null, ['foo', '']);
           elementEnd();
-          elementStart(2, 'div');
+          elementStart(3, 'div');
           elementEnd();
         }
         queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
@@ -708,11 +708,11 @@ describe('query', () => {
              query(0, ['foo'], true, QUERY_READ_FROM_NODE);
              firstEl = elementStart(1, 'span', null, ['foo', '']);
              elementEnd();
-             container(2);
-             lastEl = elementStart(3, 'span', null, ['foo', '']);
+             container(3);
+             lastEl = elementStart(4, 'span', null, ['foo', '']);
              elementEnd();
            }
-           containerRefreshStart(2);
+           containerRefreshStart(3);
            {
              if (ctx.exp) {
                let cm1 = embeddedViewStart(1);
@@ -838,9 +838,9 @@ describe('query', () => {
               if (cm1) {
                 firstEl = elementStart(0, 'div', null, ['foo', '']);
                 elementEnd();
-                container(1);
+                container(2);
               }
-              containerRefreshStart(1);
+              containerRefreshStart(2);
               {
                 if (ctx.exp2) {
                   let cm2 = embeddedViewStart(0);


### PR DESCRIPTION
Previously, local refs were retrieved with calls to `loadDirective` and `elementStart`. However, this no longer works if we want component and directives to be matched at runtime. The parent template shouldn't know at compile time whether the local ref resolves to an element or a component.

This PR replaces the `loadDirective` and `elementStart` calls with generic `load` instructions. Local refs will be resolved into values as directives are created, then stored in `data[]` at the same index as the `load` instruction.

Original template:
```html
<comp #foo></comp>
{{ foo.value}}
```

Generated (before):
```ts
if (cm) {
   E(0, 'comp', null, ['foo', '']);
   e();
   T(1);
}
let foo = loadDirective(0);
t(1, b(foo.value));
```

Generated (after): 
```ts
if (cm) {
   E(0, 'comp', null, ['foo', '']);
   e();
   T(2);
}
let foo = load(1);
t(2, b(foo.value));
```

Notes:
- Now that we are matching local refs to slots in `data[]`, order matters in `tNode.localNames`. Values must be pushed to `data[]` in the same order the matching local refs were defined and loaded in the template. 
    - Previously, the local refs were pushed to `localNames` in the order the directive defs were defined on the host component. The new implementation builds up a temporary export map as the directives are created and then iterates once through local refs to set `tNode.localNames` in the correct order. This has the added benefit of looping through local refs just once instead of 1x per directive, as it was before.

