### PR TITLE
feat(compiler): lower @NgModule ids if needed

### DIFF
--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -68,7 +68,7 @@ const MAX_FILE_COUNT_FOR_SINGLE_FILE_EMIT = 20;
 /**
  * Fields to lower within metadata in render2 mode.
  */
-const LOWER_FIELDS = ['useValue', 'useFactory', 'data'];
+const LOWER_FIELDS = ['useValue', 'useFactory', 'data', 'id'];
 
 /**
  * Fields to lower within metadata in render3 mode.

--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -826,6 +826,23 @@ describe('ngc transformer command-line', () => {
         expect(mymoduleSource).not.toContain('ɵ0');
       });
 
+      it('should lower an NgModule id', () => {
+        write('mymodule.ts', `
+          import {NgModule} from '@angular/core';
+
+          @NgModule({
+            id: (() => 'test')(),
+          })
+          export class MyModule {}
+        `);
+        expect(compile()).toEqual(0);
+
+        const mymodulejs = path.resolve(outDir, 'mymodule.js');
+        const mymoduleSource = fs.readFileSync(mymodulejs, 'utf8');
+        expect(mymoduleSource).toContain('id: ɵ0');
+        expect(mymoduleSource).toMatch(/ɵ0 = .*'test'/);
+      });
+
       it('should be able to lower supported expressions', () => {
         writeConfig(`{
           "extends": "./tsconfig-base.json",

--- a/packages/compiler/src/aot/static_reflector.ts
+++ b/packages/compiler/src/aot/static_reflector.ts
@@ -28,7 +28,7 @@ const IGNORE = {
 
 const USE_VALUE = 'useValue';
 const PROVIDE = 'provide';
-const REFERENCE_SET = new Set([USE_VALUE, 'useFactory', 'data']);
+const REFERENCE_SET = new Set([USE_VALUE, 'useFactory', 'data', 'id']);
 const TYPEGUARD_POSTFIX = 'TypeGuard';
 const USE_IF = 'UseIf';
 

--- a/packages/compiler/src/ng_module_compiler.ts
+++ b/packages/compiler/src/ng_module_compiler.ts
@@ -55,10 +55,11 @@ export class NgModuleCompiler {
         ]));
 
     if (ngModuleMeta.id) {
-      const registerFactoryStmt =
-          o.importExpr(Identifiers.RegisterModuleFactoryFn)
-              .callFn([o.literal(ngModuleMeta.id), o.variable(ngModuleFactoryVar)])
-              .toStmt();
+      const id = typeof ngModuleMeta.id === 'string' ? o.literal(ngModuleMeta.id) :
+                                                       ctx.importExpr(ngModuleMeta.id);
+      const registerFactoryStmt = o.importExpr(Identifiers.RegisterModuleFactoryFn)
+                                      .callFn([id, o.variable(ngModuleFactoryVar)])
+                                      .toStmt();
       ctx.statements.push(registerFactoryStmt);
     }
 


### PR DESCRIPTION
This change allows the id of an NgModule to be dynamically computed if
needed.