### PR TITLE
docs: add missing link to BAZEL.md in DEVELOPER.md

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -29,7 +29,7 @@ following products on your development machine:
 * [Java Development Kit](http://www.oracle.com/technetwork/es/java/javase/downloads/index.html) which is used
   to execute the selenium standalone server for e2e testing.
 
-* (Optional for now) [Bazel](https://bazel.build/), please follow instructions in [Bazel.md]
+* (Optional for now) [Bazel](https://bazel.build/), please follow instructions in [Bazel.md](BAZEL.md)
 
 ## Getting the Sources
 


### PR DESCRIPTION
PR Close #23047

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The developer documentation page  has a missing link to BAZEL.md
https://github.com/angular/angular/blob/master/docs/DEVELOPER.md

Here is what is displayed
```
(Optional for now) Bazel, please follow instructions in [Bazel.md]
```

Issue Number: N/A
 #23047

## What is the new behavior?
```
(Optional for now) [Bazel](https://bazel.build/), please follow instructions in [Bazel.md](BAZEL.md)
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information