### PR TITLE
fix(compiler-cli): change traceResolution to trace

### DIFF
--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -188,7 +188,7 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
    */
   fileNameToModuleName(importedFile: string, containingFile: string): string {
     const originalImportedFile = importedFile;
-    if (this.options.traceResolution) {
+    if (this.options.trace) {
       console.error(
           'fileNameToModuleName from containingFile', containingFile, 'to importedFile',
           importedFile);


### PR DESCRIPTION
options.traceResolution does not exist and should be options.trace according to the docs

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Compiler-cli uses options.traceResolution which is a property that does not exist on angularCompilerOptions.


## What is the new behavior?
Now it uses the documented trace option.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
