### PR TITLE
feat(platform-browser): add token marking which the type of animation…

### DIFF
--- a/packages/core/test/animation/animation_integration_spec.ts
+++ b/packages/core/test/animation/animation_integration_spec.ts
@@ -8,9 +8,9 @@
 import {AUTO_STYLE, AnimationEvent, AnimationOptions, AnimationPlayer, NoopAnimationPlayer, animate, animateChild, group, keyframes, query, state, style, transition, trigger, ɵPRE_STYLE as PRE_STYLE} from '@angular/animations';
 import {AnimationDriver, ɵAnimationEngine, ɵNoopAnimationDriver as NoopAnimationDriver} from '@angular/animations/browser';
 import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/browser/testing';
-import {ChangeDetectorRef, Component, HostBinding, HostListener, RendererFactory2, ViewChild} from '@angular/core';
+import {ChangeDetectorRef, Component, HostBinding, HostListener, Inject, RendererFactory2, ViewChild} from '@angular/core';
 import {ɵDomRendererFactory2} from '@angular/platform-browser';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {ANIMATION_MODULE_TYPE, BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
 import {TestBed, fakeAsync, flushMicrotasks} from '../../testing';
@@ -36,6 +36,34 @@ const DEFAULT_COMPONENT_ID = '1';
         imports: [BrowserAnimationsModule]
       });
     });
+
+    describe('animation modules', function() {
+      it('should hint at BrowserAnimationsModule being used', () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule(
+            {declarations: [SharedAnimationCmp], imports: [BrowserAnimationsModule]});
+
+        const fixture = TestBed.createComponent(SharedAnimationCmp);
+        const cmp = fixture.componentInstance;
+        expect(cmp.animationType).toEqual('BrowserAnimations');
+      });
+
+      it('should hint at NoopAnimationsModule being used', () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule(
+            {declarations: [SharedAnimationCmp], imports: [NoopAnimationsModule]});
+
+        const fixture = TestBed.createComponent(SharedAnimationCmp);
+        const cmp = fixture.componentInstance;
+        expect(cmp.animationType).toEqual('NoopAnimations');
+      });
+    });
+
+    @Component({template: '<p>template text</p>'})
+    class SharedAnimationCmp {
+      constructor(@Inject(ANIMATION_MODULE_TYPE) public animationType: 'NoopAnimations'|
+                  'BrowserAnimations') {}
+    }
 
     describe('fakeAsync testing', () => {
       it('should only require one flushMicrotasks call to kick off animation callbacks',

--- a/packages/platform-browser/animations/src/animations.ts
+++ b/packages/platform-browser/animations/src/animations.ts
@@ -13,4 +13,6 @@
  */
 export {BrowserAnimationsModule, NoopAnimationsModule} from './module';
 
+export {ANIMATION_MODULE_TYPE} from './providers';
+
 export * from './private_export';

--- a/packages/platform-browser/animations/src/providers.ts
+++ b/packages/platform-browser/animations/src/providers.ts
@@ -8,7 +8,7 @@
 
 import {AnimationBuilder} from '@angular/animations';
 import {AnimationDriver, ɵAnimationEngine as AnimationEngine, ɵAnimationStyleNormalizer as AnimationStyleNormalizer, ɵCssKeyframesDriver as CssKeyframesDriver, ɵNoopAnimationDriver as NoopAnimationDriver, ɵWebAnimationsDriver as WebAnimationsDriver, ɵWebAnimationsStyleNormalizer as WebAnimationsStyleNormalizer, ɵsupportsWebAnimations as supportsWebAnimations} from '@angular/animations/browser';
-import {Injectable, NgZone, Provider, RendererFactory2} from '@angular/core';
+import {Injectable, InjectionToken, NgZone, Provider, RendererFactory2} from '@angular/core';
 import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
 
 import {BrowserAnimationBuilder} from './animation_builder';
@@ -34,6 +34,12 @@ export function instantiateRendererFactory(
   return new AnimationRendererFactory(renderer, engine, zone);
 }
 
+/**
+ * @experimental Animation support is experimental.
+ */
+export const ANIMATION_MODULE_TYPE =
+    new InjectionToken<'NoopAnimations'|'BrowserAnimations'>('AnimationModuleType');
+
 const SHARED_ANIMATION_PROVIDERS: Provider[] = [
   {provide: AnimationBuilder, useClass: BrowserAnimationBuilder},
   {provide: AnimationStyleNormalizer, useFactory: instantiateDefaultStyleNormalizer},
@@ -50,12 +56,14 @@ const SHARED_ANIMATION_PROVIDERS: Provider[] = [
  */
 export const BROWSER_ANIMATIONS_PROVIDERS: Provider[] = [
   {provide: AnimationDriver, useFactory: instantiateSupportedAnimationDriver},
-  ...SHARED_ANIMATION_PROVIDERS
+  {provide: ANIMATION_MODULE_TYPE, useValue: 'BrowserAnimations'}, ...SHARED_ANIMATION_PROVIDERS
 ];
 
 /**
  * Separate providers from the actual module so that we can do a local modification in Google3 to
  * include them in the BrowserTestingModule.
  */
-export const BROWSER_NOOP_ANIMATIONS_PROVIDERS: Provider[] =
-    [{provide: AnimationDriver, useClass: NoopAnimationDriver}, ...SHARED_ANIMATION_PROVIDERS];
+export const BROWSER_NOOP_ANIMATIONS_PROVIDERS: Provider[] = [
+  {provide: AnimationDriver, useClass: NoopAnimationDriver},
+  {provide: ANIMATION_MODULE_TYPE, useValue: 'NoopAnimations'}, ...SHARED_ANIMATION_PROVIDERS
+];

--- a/tools/public_api_guard/platform-browser/animations.d.ts
+++ b/tools/public_api_guard/platform-browser/animations.d.ts
@@ -1,4 +1,7 @@
 /** @experimental */
+export declare const ANIMATION_MODULE_TYPE: InjectionToken<"NoopAnimations" | "BrowserAnimations">;
+
+/** @experimental */
 export declare class BrowserAnimationsModule {
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, it is not possible to determine if a component is running in a `BrowserAnimationsModule` or `NoopAnimationsModule` context at runtime.
Issue Number: N/A


## What is the new behavior?
An token is provided as a marker to be able to determine which animation context is being used for the component at runtime.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
