### PR TITLE
fix(compiler-cli): strip /index from resolved module name in compiler_host

### DIFF
--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -212,7 +212,8 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
       }
       moduleName = dotRelative(path.dirname(containingFile), importedFile);
     } else if (importedFilePackagName) {
-      moduleName = stripNodeModulesPrefix(importedFile);
+      // if filename is of form package/index then strip the '/index' portion
+      moduleName = stripNodeModulesPrefix(importedFile).replace(/\/index$/, '');
     } else {
       throw new Error(
           `Trying to import a source file from a node_modules package: import ${originalImportedFile} from ${containingFile}`);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

When compiling the angular packages with ngc in a downstream project that uses Bazel (such as angular-bazel-example), the `core.ngsummary.json` file ends up with an `rxjs/index` entry that looks like this:

```
{
 "__symbol":199,
 "name":"Subject",
 "filePath":"rxjs/index"
},
```

This causes a build failure when building with Bazel as `rxjs/index` does not match up to the expected AMD module `rxjs`:

```
ERROR: /Users/greg/google/gregmagolan/angular-bazel-example/src/hello-world/BUILD.bazel:16:1: Compiling Angular templates (ngc) //src/hello-world:hello-world failed (Exit 1)
: Error: Could not resolve rxjs/index from /private/var/tmp/_bazel_greg/2c2a834fcea131eff2d962ffe20e1c87/bazel-sandbox/6352718279340737278/execroot/angular_bazel_example/node_modules/@angular/core/core.d.ts
    at TsCompilerAotCompilerTypeCheckHostAdapter.fromSummaryFileName (/Users/greg/google/gregmagolan/angular-bazel-example/packages/compiler-cli/src/transformers/compiler_host.ts:249:13)
    at AotSummaryResolver.fromSummaryFileName (/Users/greg/google/gregmagolan/angular-bazel-example/node_modules/@angular/compiler/bundles/compiler.umd.js:36029:26)
    at /Users/greg/google/gregmagolan/angular-bazel-example/node_modules/packages/compiler/esm5/src/aot/summary_serializer.js:634:47
    at Array.map (<anonymous>)
    at FromJsonDeserializer.deserialize (/Users/greg/google/gregmagolan/angular-bazel-example/node_modules/packages/compiler/esm5/src/aot/summary_serializer.js:633:34)
    at deserializeSummaries (/Users/greg/google/gregmagolan/angular-bazel-example/node_modules/@angular/compiler/bundles/compiler.umd.js:32788:25)
    at AotSummaryResolver._loadSummaryFile (/Users/greg/google/gregmagolan/angular-bazel-example/node_modules/packages/compiler/esm5/src/aot/summary_resolver.js:198:22)
    at AotSummaryResolver.resolveSummary (/Users/greg/google/gregmagolan/angular-bazel-example/node_modules/@angular/compiler/bundles/compiler.umd.js:36045:18)
    at StaticSymbolResolver._resolveSymbolFromSummary (/Users/greg/google/gregmagolan/angular-bazel-example/node_modules/@angular/compiler/bundles/compiler.umd.js:32297:61)
    at StaticSymbolResolver.resolveSymbol (/Users/greg/google/gregmagolan/angular-bazel-example/node_modules/packages/compiler/esm5/src/aot/static_symbol_resolver.js:116:30)
```

Issue is reproducible on the `rxjs-repro` branch of my angular-bazel-example fork: https://github.com/gregmagolan/angular-bazel-example/tree/rxjs-repro

Run `yarn` and then `bazel run src/devserver`. To test the fix, compiler_host.js is patched with the fix using `yarn angular-fix` and then `bazel run src/devserver` works.


Related issue: #23005

## What is the new behavior?

The `/index` portion is stripped from the resolved moduleName in `fileNameToModuleName` in `compiler_host.ts` and the generated `core.ngsummary.json` now contains:

```
{
 "__symbol":199,
 "name":"Subject",
 "filePath":"rxjs"
},
```

Downstream angular-bazel-example Bazel build now works.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

Most likely will not break anything, but someone on the compiler team should verify.


## Other information
