### PR TITLE
feat(common): introduce PushPipe

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -21,7 +21,7 @@ export {parseCookieValue as ɵparseCookieValue} from './cookie';
 export {CommonModule, DeprecatedI18NPipesModule} from './common_module';
 export {NgClass, NgForOf, NgForOfContext, NgIf, NgIfContext, NgPlural, NgPluralCase, NgStyle, NgSwitch, NgSwitchCase, NgSwitchDefault, NgTemplateOutlet, NgComponentOutlet} from './directives/index';
 export {DOCUMENT} from './dom_tokens';
-export {AsyncPipe, DatePipe, I18nPluralPipe, I18nSelectPipe, JsonPipe, LowerCasePipe, CurrencyPipe, DecimalPipe, PercentPipe, SlicePipe, UpperCasePipe, TitleCasePipe} from './pipes/index';
+export {AsyncPipe, PushPipe, DatePipe, I18nPluralPipe, I18nSelectPipe, JsonPipe, LowerCasePipe, CurrencyPipe, DecimalPipe, PercentPipe, SlicePipe, UpperCasePipe, TitleCasePipe} from './pipes/index';
 export {DeprecatedDatePipe, DeprecatedCurrencyPipe, DeprecatedDecimalPipe, DeprecatedPercentPipe} from './pipes/deprecated/index';
 export {PLATFORM_BROWSER_ID as ɵPLATFORM_BROWSER_ID, PLATFORM_SERVER_ID as ɵPLATFORM_SERVER_ID, PLATFORM_WORKER_APP_ID as ɵPLATFORM_WORKER_APP_ID, PLATFORM_WORKER_UI_ID as ɵPLATFORM_WORKER_UI_ID, isPlatformBrowser, isPlatformServer, isPlatformWorkerApp, isPlatformWorkerUi} from './platform_id';
 export {VERSION} from './version';

--- a/packages/common/src/pipes/index.ts
+++ b/packages/common/src/pipes/index.ts
@@ -18,6 +18,7 @@ import {I18nPluralPipe} from './i18n_plural_pipe';
 import {I18nSelectPipe} from './i18n_select_pipe';
 import {JsonPipe} from './json_pipe';
 import {CurrencyPipe, DecimalPipe, PercentPipe} from './number_pipe';
+import {PushPipe} from './push_pipe';
 import {SlicePipe} from './slice_pipe';
 
 export {
@@ -30,6 +31,7 @@ export {
   JsonPipe,
   LowerCasePipe,
   PercentPipe,
+  PushPipe,
   SlicePipe,
   TitleCasePipe,
   UpperCasePipe
@@ -41,6 +43,7 @@ export {
  */
 export const COMMON_PIPES = [
   AsyncPipe,
+  PushPipe,
   UpperCasePipe,
   LowerCasePipe,
   JsonPipe,

--- a/packages/common/src/pipes/push_pipe.ts
+++ b/packages/common/src/pipes/push_pipe.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ChangeDetectorRef, EventEmitter, OnDestroy, Pipe, PipeTransform, WrappedValue, ɵisObservable, ɵisPromise} from '@angular/core';
+import {Observable, SubscriptionLike} from 'rxjs';
+import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
+
+/**
+ * @ngModule CommonModule
+ * @whatItDoes Unwraps a value from an Observable and runs local Change Detection.
+ * @howToUse `observable$ | push`
+ * @description
+ * The `push` pipe subscribes to an `Observable` and returns the latest value it has
+ * emitted. When a new value is emitted, the `push` pipe runs local Change Detection on the
+ * component.
+ * When the component gets destroyed, the `push` pipe unsubscribes automatically to avoid
+ * potential memory leaks.
+ *
+ * @experimental
+ */
+@Pipe({name: 'push', pure: false})
+export class PushPipe implements OnDestroy, PipeTransform {
+  private _latestValue: any = null;
+  private _latestReturnedValue: any = null;
+
+  private _subscription: SubscriptionLike|null = null;
+  private _obj: Observable<any>|EventEmitter<any>|null = null;
+
+  constructor(private _ref: ChangeDetectorRef) {}
+
+  ngOnDestroy(): void {
+    if (this._subscription) {
+      this._dispose();
+    }
+  }
+
+  transform<T>(obj: null): null;
+  transform<T>(obj: undefined): undefined;
+  transform<T>(obj: Observable<T>|null|undefined): T|null;
+  transform(obj: Observable<any>|null|undefined): any {
+    if (!this._obj) {
+      if (obj) {
+        this._obj = obj;
+        this._subscription =
+            obj.subscribe({next: (value: Object) => this._updateLatestValue(obj, value)});
+      }
+      this._latestReturnedValue = this._latestValue;
+      return this._latestValue;
+    }
+
+    if (obj !== this._obj) {
+      this._dispose();
+      return this.transform(obj as any);
+    }
+
+    if (this._latestValue === this._latestReturnedValue) {
+      return this._latestReturnedValue;
+    }
+
+    this._latestReturnedValue = this._latestValue;
+    return WrappedValue.wrap(this._latestValue);
+  }
+
+  private _dispose(): void {
+    if (this._subscription) {
+      this._subscription.unsubscribe();
+    }
+    this._latestValue = null;
+    this._latestReturnedValue = null;
+    this._subscription = null;
+    this._obj = null;
+  }
+
+  private _updateLatestValue(async: any, value: Object): void {
+    if (async === this._obj) {
+      this._latestValue = value;
+      this._ref.detectChanges();
+    }
+  }
+}

--- a/packages/common/test/pipes/push_pipe_spec.ts
+++ b/packages/common/test/pipes/push_pipe_spec.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {PushPipe} from '@angular/common';
+import {EventEmitter, WrappedValue} from '@angular/core';
+import {AsyncTestCompleter, beforeEach, describe, expect, inject, it} from '@angular/core/testing/src/testing_internal';
+import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
+import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
+
+import {SpyChangeDetectorRef} from '../spies';
+
+{
+  describe('PushPipe', () => {
+
+    let emitter: EventEmitter<any>;
+    let pipe: PushPipe;
+    let ref: any;
+    const message = {};
+
+    beforeEach(() => {
+      emitter = new EventEmitter();
+      ref = new SpyChangeDetectorRef();
+      pipe = new PushPipe(ref);
+    });
+
+    describe('transform', () => {
+      it('should return null when subscribing to an observable',
+         () => { expect(pipe.transform(emitter)).toBe(null); });
+
+      it('should return the latest available value wrapped',
+         inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+           pipe.transform(emitter);
+           emitter.emit(message);
+
+           setTimeout(() => {
+             expect(pipe.transform(emitter)).toEqual(new WrappedValue(message));
+             async.done();
+           }, 0);
+         }));
+
+
+      it('should return same value when nothing has changed since the last call',
+         inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+           pipe.transform(emitter);
+           emitter.emit(message);
+
+           setTimeout(() => {
+             pipe.transform(emitter);
+             expect(pipe.transform(emitter)).toBe(message);
+             async.done();
+           }, 0);
+         }));
+
+      it('should dispose of the existing subscription when subscribing to a new observable',
+         inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+           pipe.transform(emitter);
+
+           const newEmitter = new EventEmitter();
+           expect(pipe.transform(newEmitter)).toBe(null);
+           emitter.emit(message);
+
+           // this should not affect the pipe
+           setTimeout(() => {
+             expect(pipe.transform(newEmitter)).toBe(null);
+             async.done();
+           }, 0);
+         }));
+
+      it('should request a change detection check upon receiving a new value',
+         inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+           pipe.transform(emitter);
+           emitter.emit(message);
+
+           setTimeout(() => {
+             expect(ref.spy('detectChanges')).toHaveBeenCalled();
+             async.done();
+           }, 10);
+         }));
+    });
+
+    describe('ngOnDestroy', () => {
+      it('should do nothing when no subscription',
+         () => { expect(() => pipe.ngOnDestroy()).not.toThrow(); });
+
+      it('should dispose of the existing subscription',
+         inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+           pipe.transform(emitter);
+           pipe.ngOnDestroy();
+           emitter.emit(message);
+
+           setTimeout(() => {
+             expect(pipe.transform(emitter)).toBe(null);
+             async.done();
+           }, 0);
+         }));
+    });
+  });
+
+  describe('null', () => {
+    it('should return null when given null', () => {
+      const pipe = new PushPipe(null as any);
+      expect(pipe.transform(null)).toEqual(null);
+    });
+  });
+
+  describe('other types', () => {
+    it('should throw when given an invalid object', () => {
+      const pipe = new PushPipe(null as any);
+      expect(() => pipe.transform(<any>'some bogus object')).toThrowError();
+    });
+  });
+}

--- a/packages/common/test/spies.ts
+++ b/packages/common/test/spies.ts
@@ -13,6 +13,7 @@ export class SpyChangeDetectorRef extends SpyObject {
   constructor() {
     super(ChangeDetectorRef);
     this.spy('markForCheck');
+    this.spy('detectChanges');
   }
 }
 

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -437,6 +437,15 @@ export interface PopStateEvent {
 }
 
 /** @experimental */
+export declare class PushPipe implements OnDestroy, PipeTransform {
+    constructor(_ref: ChangeDetectorRef);
+    ngOnDestroy(): void;
+    transform<T>(obj: undefined): undefined;
+    transform<T>(obj: Observable<T> | null | undefined): T | null;
+    transform<T>(obj: null): null;
+}
+
+/** @experimental */
 export declare function registerLocaleData(data: any, localeId?: string | any, extraData?: any): void;
 
 /** @stable */


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
```
[x] Feature
```

## What is the current behavior?
It is not easy to handle Change Detection when using `ngZone: 'noop'`

## What is the new behavior?
A new pipe which can run local change detection for use in Angular when using `ngZone: 'noop'`
This can be especially helpful when using Angular Elements since zone.js is often difficult to use in other environments

This pipe is very similar to the `async` pipe but with 2 major differences.
- It called `detectChanges` instead of `markForCheck` which means it runs local Change Detection on that component it's used on.
- It only accepts Observables as input.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```