### PR TITLE
refactor(ivy): generate pipe names instead of defs

### DIFF
--- a/packages/compiler/src/render3/r3_pipe_compiler.ts
+++ b/packages/compiler/src/render3/r3_pipe_compiler.ts
@@ -24,7 +24,10 @@ export function compilePipe(
     mode: OutputMode) {
   const definitionMapValues: {key: string, quoted: boolean, value: o.Expression}[] = [];
 
-  // e.g. 'type: MyPipe`
+  // e.g. `name: 'myPipe'`
+  definitionMapValues.push({key: 'name', value: o.literal(pipe.name), quoted: false});
+
+  // e.g. `type: MyPipe`
   definitionMapValues.push(
       {key: 'type', value: outputCtx.importExpr(pipe.type.reference), quoted: false});
 

--- a/packages/compiler/test/render3/r3_compiler_compliance_spec.ts
+++ b/packages/compiler/test/render3/r3_compiler_compliance_spec.ts
@@ -97,7 +97,6 @@ describe('compiler compliance', () => {
           template: function ChildComponent_Template(ctx: IDENT, cm: IDENT) {
             if (cm) {
               $r3$.ɵT(0, 'child-view');
-           
             }
           }
         });`;
@@ -784,7 +783,10 @@ describe('compiler compliance', () => {
                 transform(value: any, ...args: any[]) { return value; }
               }
 
-              @Component({selector: 'my-app', template: '{{name | myPipe:size | myPurePipe:size }}'})
+              @Component({
+                selector: 'my-app', 
+                template: '{{name | myPipe:size | myPurePipe:size }}<p>{{ name | myPurePipe:size }}</p>'
+              })
               export class MyApp {
                 name = 'World';
                 size = 0;
@@ -799,19 +801,18 @@ describe('compiler compliance', () => {
       it('should render pipes', () => {
         const MyPipeDefinition = `
             static ngPipeDef = $r3$.ɵdefinePipe(
-                {type: MyPipe, factory: function MyPipe_Factory() { return new MyPipe(); }});
+                {name: 'myPipe', type: MyPipe, factory: function MyPipe_Factory() { return new MyPipe(); }});
         `;
 
         const MyPurePipeDefinition = `
             static ngPipeDef = $r3$.ɵdefinePipe({
+              name: 'myPurePipe', 
               type: MyPurePipe,
               factory: function MyPurePipe_Factory() { return new MyPurePipe(); },
               pure: true
             });`;
 
         const MyAppDefinition = `
-            const $MyPurePipe_ngPipeDef$ = MyPurePipe.ngPipeDef;
-            const $MyPipe_ngPipeDef$ = MyPipe.ngPipeDef;
             …
             static ngComponentDef = $r3$.ɵdefineComponent({
               type: MyApp,
@@ -820,11 +821,17 @@ describe('compiler compliance', () => {
               template: function MyApp_Template(ctx: IDENT, cm: IDENT) {
                 if (cm) {
                   $r3$.ɵT(0);
-                  $r3$.ɵPp(1, $MyPurePipe_ngPipeDef$, $MyPurePipe_ngPipeDef$.n());
-                  $r3$.ɵPp(2, $MyPipe_ngPipeDef$, $MyPipe_ngPipeDef$.n());
+                  $r3$.ɵPp(1, 'myPurePipe');
+                  $r3$.ɵPp(2, 'myPipe');
+                  $r3$.ɵE(3, 'p');
+                  $r3$.ɵT(4);
+                  $r3$.ɵPp(5, 'myPurePipe');
+                  $r3$.ɵe();
                 }
                 $r3$.ɵt(0, $r3$.ɵi1('', $r3$.ɵpb2(1, $r3$.ɵpb2(2,ctx.name, ctx.size), ctx.size), ''));
-              }
+                $r3$.ɵt(4, $r3$.ɵi1('', $r3$.ɵpb2(5, ctx.name, ctx.size), ''));
+              },
+              pipes: [MyPurePipe, MyPipe]
             });`;
 
         const result = compile(files, angularFiles);

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -16,11 +16,10 @@ import {pureFunction1, pureFunction2, pureFunction3, pureFunction4, pureFunction
  * Create a pipe.
  *
  * @param index Pipe index where the pipe will be stored.
- * @param pipeDef Pipe definition object for registering life cycle hooks.
- * @param firstInstance (optional) The first instance of the pipe that can be reused for pure pipes.
+ * @param pipeName The name of the pipe
  * @returns T the instance of the pipe.
  */
-export function pipe(index: number, pipeName: string, firstInstance?: any): any {
+export function pipe(index: number, pipeName: string): any {
   const tView = getTView();
   let pipeDef: PipeDef<any>;
 
@@ -34,7 +33,7 @@ export function pipe(index: number, pipeName: string, firstInstance?: any): any 
     pipeDef = tView.data[index] as PipeDef<any>;
   }
 
-  const pipeInstance = pipeDef.pure && firstInstance ? firstInstance : pipeDef.n();
+  const pipeInstance = pipeDef.n();
   store(index, pipeInstance);
   return pipeInstance;
 }

--- a/packages/core/test/render3/compiler_canonical/pipes_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/pipes_spec.ts
@@ -155,12 +155,11 @@ describe('pipes', () => {
         selectors: [['my-app']],
         factory: function MyApp_Factory() { return new MyApp(); },
         template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-          let $pi$: $any$;
           if (cm) {
             $r3$.ɵT(0);
-            $pi$ = $r3$.ɵPp(1, 'myPurePipe');
+            $r3$.ɵPp(1, 'myPurePipe');
             $r3$.ɵT(2);
-            $r3$.ɵPp(3, 'myPurePipe', $pi$);
+            $r3$.ɵPp(3, 'myPurePipe');
             $r3$.ɵC(4, C4, '', ['oneTimeIf', '']);
           }
           $r3$.ɵt(0, $r3$.ɵi1('', $r3$.ɵpb2(1, ctx.name, ctx.size), ''));
@@ -173,7 +172,7 @@ describe('pipes', () => {
             if (cm) {
               $r3$.ɵE(0, 'div');
               $r3$.ɵT(1);
-              $r3$.ɵPp(2, 'myPurePipe', $pi$);
+              $r3$.ɵPp(2, 'myPurePipe');
               $r3$.ɵe();
             }
             $r3$.ɵt(1, $r3$.ɵi1('', $r3$.ɵpb2(2, ctx.name, ctx.size), ''));

--- a/packages/core/test/render3/pipe_spec.ts
+++ b/packages/core/test/render3/pipe_spec.ts
@@ -183,49 +183,6 @@ describe('pipe', () => {
       expect(renderToHtml(Template, person, null, defs)).toEqual('bart state:2');
       expect(renderToHtml(Template, person, null, defs)).toEqual('bart state:2');
     });
-
-    it('should cache pure pipes', () => {
-      function Template(ctx: any, cm: boolean) {
-        let pipeInstance: any;
-        if (cm) {
-          elementStart(0, 'div');
-          pipeInstance = pipe(1, 'countingPipe');
-          elementEnd();
-          elementStart(2, 'div');
-          pipe(3, 'countingPipe', pipeInstance);
-          elementEnd();
-          container(4);
-        }
-        elementProperty(0, 'someProp', bind(pipeBind1(1, true)));
-        elementProperty(2, 'someProp', bind(pipeBind1(3, true)));
-        pipeInstances.push(load<CountingPipe>(1), load(3));
-        containerRefreshStart(4);
-        {
-          for (let i of [1, 2]) {
-            let cm1 = embeddedViewStart(1);
-            {
-              if (cm1) {
-                elementStart(0, 'div');
-                pipe(1, 'countingPipe', pipeInstance);
-                elementEnd();
-              }
-              elementProperty(0, 'someProp', bind(pipeBind1(1, true)));
-              pipeInstances.push(load<CountingPipe>(1));
-            }
-            embeddedViewEnd();
-          }
-        }
-        containerRefreshEnd();
-      }
-
-      const pipeInstances: CountingPipe[] = [];
-      renderToHtml(Template, {}, null, defs, rendererFactory2);
-      expect(pipeInstances.length).toEqual(4);
-      expect(pipeInstances[0]).toBeAnInstanceOf(CountingPipe);
-      expect(pipeInstances[1]).toBe(pipeInstances[0]);
-      expect(pipeInstances[2]).toBe(pipeInstances[0]);
-      expect(pipeInstances[3]).toBe(pipeInstances[0]);
-    });
   });
 
   describe('impure', () => {


### PR DESCRIPTION
This PR updates the Ivy compiler to generate pipe names instead of defs.

Original template:
```html
{{ name | myPipe }}
```

Before:
```ts
class MyPipe {
   static ngPipeDef = definePipe({
      type: MyPipe,
      ...
   });
}

...
template: (ctx: SomeComp, cm: boolean) {
   if (cm) {
      T(0);
      Pp(1, MyPipe.ngPipeDef);
   }
   t(0, i1('', pb1(1, ctx.name), ''));
}
```

After:
```ts
class MyPipe {
   static ngPipeDef = definePipe({
      name: 'myPipe',
      type: MyPipe,
      ...
   });
}

...
template: (ctx: SomeComp, cm: boolean) {
   if (cm) {
      T(0);
      Pp(1, 'myPipe');
   }
   t(0, i1('', pb1(1, ctx.name), ''));
}
```

Notes:
- We used to have an optimization where we passed the first instance of a pure pipe to any subsequent invocations of that pipe, to avoid having to instantiate it multiple times. Now that the compiler is generating code as if it doesn't know which pipes are present in the template (and thus which ones are pure and should get an instance), it no longer makes sense to generate this extra argument.

- Once #22921 goes in, we'll want to refactor to share the `addDependencyToComponent` logic.