### PR TITLE
build: upgrade zone.js

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -40,12 +40,8 @@ filegroup(
     srcs = [
         "//:node_modules/reflect-metadata/Reflect.js",
         "//:node_modules/zone.js/dist/zone.js",
-        "//:node_modules/zone.js/dist/async-test.js",
-        "//:node_modules/zone.js/dist/sync-test.js",
-        "//:node_modules/zone.js/dist/fake-async-test.js",
+        "//:node_modules/zone.js/dist/zone-testing.js",
         "//:node_modules/zone.js/dist/task-tracking.js",
-        "//:node_modules/zone.js/dist/proxy.js",
-        "//:node_modules/zone.js/dist/jasmine-patch.js",
     ],
 )
 

--- a/aio/content/examples/http/src/main-specs.ts
+++ b/aio/content/examples/http/src/main-specs.ts
@@ -6,12 +6,7 @@ declare var jasmine;
 
 import './polyfills';
 
-import 'zone.js/dist/async-test';
-import 'zone.js/dist/fake-async-test';
-import 'zone.js/dist/long-stack-trace-zone';
-import 'zone.js/dist/proxy.js';
-import 'zone.js/dist/sync-test';
-import 'zone.js/dist/jasmine-patch';
+import 'zone.js/dist/zone-testing';
 
 import { getTestBed } from '@angular/core/testing';
 import {

--- a/aio/content/examples/setup/src/quickstart-specs.html
+++ b/aio/content/examples/setup/src/quickstart-specs.html
@@ -21,12 +21,7 @@
   <script src="node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
 
   <script src="node_modules/zone.js/dist/zone.js"></script>
-  <script src="node_modules/zone.js/dist/long-stack-trace-zone.js"></script>
-  <script src="node_modules/zone.js/dist/proxy.js"></script>
-  <script src="node_modules/zone.js/dist/sync-test.js"></script>
-  <script src="node_modules/zone.js/dist/jasmine-patch.js"></script>
-  <script src="node_modules/zone.js/dist/async-test.js"></script>
-  <script src="node_modules/zone.js/dist/fake-async-test.js"></script>
+  <script src="node_modules/zone.js/dist/zone-testing.js"></script>
 
   <!-- #docregion files -->
   <script>

--- a/aio/content/examples/testing/src/main-specs.ts
+++ b/aio/content/examples/testing/src/main-specs.ts
@@ -6,12 +6,7 @@ declare var jasmine;
 
 import './polyfills';
 
-import 'zone.js/dist/async-test';
-import 'zone.js/dist/fake-async-test';
-import 'zone.js/dist/long-stack-trace-zone';
-import 'zone.js/dist/proxy.js';
-import 'zone.js/dist/sync-test';
-import 'zone.js/dist/jasmine-patch';
+import 'zone.js/dist/zone-testing';
 
 import { getTestBed } from '@angular/core/testing';
 import {

--- a/aio/content/examples/testing/src/tests.html
+++ b/aio/content/examples/testing/src/tests.html
@@ -22,12 +22,7 @@
   <script src="node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
 
   <script src="node_modules/zone.js/dist/zone.js"></script>
-  <script src="node_modules/zone.js/dist/long-stack-trace-zone.js"></script>
-  <script src="node_modules/zone.js/dist/proxy.js"></script>
-  <script src="node_modules/zone.js/dist/sync-test.js"></script>
-  <script src="node_modules/zone.js/dist/jasmine-patch.js"></script>
-  <script src="node_modules/zone.js/dist/async-test.js"></script>
-  <script src="node_modules/zone.js/dist/fake-async-test.js"></script>
+  <script src="node_modules/zone.js/dist/zone-testing.js"></script>
 
   <script>
     var __spec_files__ = [

--- a/aio/content/examples/upgrade-phonecat-2-hybrid/karma.conf.ajs.js
+++ b/aio/content/examples/upgrade-phonecat-2-hybrid/karma.conf.ajs.js
@@ -22,12 +22,7 @@ module.exports = function(config) {
 
       // zone.js
       'node_modules/zone.js/dist/zone.js',
-      'node_modules/zone.js/dist/long-stack-trace-zone.js',
-      'node_modules/zone.js/dist/proxy.js',
-      'node_modules/zone.js/dist/sync-test.js',
-      'node_modules/zone.js/dist/jasmine-patch.js',
-      'node_modules/zone.js/dist/async-test.js',
-      'node_modules/zone.js/dist/fake-async-test.js',
+      'node_modules/zone.js/dist/zone-testing.js',
 
       // RxJs.
       { pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false },

--- a/aio/content/examples/upgrade-phonecat-2-hybrid/karma.conf.js
+++ b/aio/content/examples/upgrade-phonecat-2-hybrid/karma.conf.js
@@ -41,12 +41,7 @@ module.exports = function(config) {
 
       // zone.js
       'node_modules/zone.js/dist/zone.js',
-      'node_modules/zone.js/dist/long-stack-trace-zone.js',
-      'node_modules/zone.js/dist/proxy.js',
-      'node_modules/zone.js/dist/sync-test.js',
-      'node_modules/zone.js/dist/jasmine-patch.js',
-      'node_modules/zone.js/dist/async-test.js',
-      'node_modules/zone.js/dist/fake-async-test.js',
+      'node_modules/zone.js/dist/zone-testing.js',
 
       // RxJs
       { pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false },

--- a/aio/content/examples/upgrade-phonecat-3-final/karma.conf.js
+++ b/aio/content/examples/upgrade-phonecat-3-final/karma.conf.js
@@ -41,12 +41,7 @@ module.exports = function(config) {
 
       // zone.js
       'node_modules/zone.js/dist/zone.js',
-      'node_modules/zone.js/dist/long-stack-trace-zone.js',
-      'node_modules/zone.js/dist/proxy.js',
-      'node_modules/zone.js/dist/sync-test.js',
-      'node_modules/zone.js/dist/jasmine-patch.js',
-      'node_modules/zone.js/dist/async-test.js',
-      'node_modules/zone.js/dist/fake-async-test.js',
+      'node_modules/zone.js/dist/zone-testing.js',
 
       // RxJs
       { pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false },

--- a/aio/content/examples/webpack/config/karma-test-shim.js
+++ b/aio/content/examples/webpack/config/karma-test-shim.js
@@ -5,12 +5,7 @@ require('core-js/es6');
 require('core-js/es7/reflect');
 
 require('zone.js/dist/zone');
-require('zone.js/dist/long-stack-trace-zone');
-require('zone.js/dist/proxy');
-require('zone.js/dist/sync-test');
-require('zone.js/dist/jasmine-patch');
-require('zone.js/dist/async-test');
-require('zone.js/dist/fake-async-test');
+require('zone.js/dist/zone-testing');
 
 var appContext = require.context('../src', true, /\.spec\.ts/);
 

--- a/aio/package.json
+++ b/aio/package.json
@@ -93,7 +93,7 @@
     "rxjs-compat": "6.0.0-rc.0",
     "tslib": "^1.9.0",
     "web-animations-js": "^2.2.5",
-    "zone.js": "^0.8.19"
+    "zone.js": "^0.8.25"
   },
   "devDependencies": {
     "@angular/cli": "^1.7.3",

--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -4,7 +4,7 @@
       "uncompressed": {
         "inline": 1971,
         "main": 565539,
-        "polyfills": 40272,
+        "polyfills": 38514,
         "prettify": 14886
       }
     }

--- a/aio/src/test.ts
+++ b/aio/src/test.ts
@@ -1,11 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/long-stack-trace-zone';
-import 'zone.js/dist/proxy.js';
-import 'zone.js/dist/sync-test';
-import 'zone.js/dist/jasmine-patch';
-import 'zone.js/dist/async-test';
-import 'zone.js/dist/fake-async-test';
+import 'zone.js/dist/zone-testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,

--- a/aio/tools/examples/shared/boilerplate/cli/src/test.ts
+++ b/aio/tools/examples/shared/boilerplate/cli/src/test.ts
@@ -1,11 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/long-stack-trace-zone';
-import 'zone.js/dist/proxy.js';
-import 'zone.js/dist/sync-test';
-import 'zone.js/dist/jasmine-patch';
-import 'zone.js/dist/async-test';
-import 'zone.js/dist/fake-async-test';
+import 'zone.js/dist/zone-testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -9827,6 +9827,6 @@ zip-stream@~0.6.0:
     lodash "~3.10.1"
     readable-stream "~1.0.26"
 
-zone.js@^0.8.19:
-  version "0.8.19"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.19.tgz#a4b522cd9e8b7b616a638c297d720d4c7f292f71"
+zone.js@^0.8.25:
+  version "0.8.25"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.25.tgz#e20e5e85b881e2e66352612b5f238e8309e5badd"

--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -5,7 +5,7 @@
         "inline": 1508,
         "main": "TODO(i): temporarily increase the payload size limit to 257298 from 155112, we need CLI v6 to bring the size down",
         "main": 257298,
-        "polyfills": 59483
+        "polyfills": 60187
       }
     }
   },

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -29,13 +29,8 @@ module.exports = function(config) {
 
       'node_modules/core-js/client/core.js',
       'node_modules/zone.js/dist/zone.js',
-      'node_modules/zone.js/dist/long-stack-trace-zone.js',
+      'node_modules/zone.js/dist/zone-testing.js',
       'node_modules/zone.js/dist/task-tracking.js',
-      'node_modules/zone.js/dist/proxy.js',
-      'node_modules/zone.js/dist/sync-test.js',
-      'node_modules/zone.js/dist/jasmine-patch.js',
-      'node_modules/zone.js/dist/async-test.js',
-      'node_modules/zone.js/dist/fake-async-test.js',
 
       // Including systemjs because it defines `__eval`, which produces correct stack traces.
       'test-events.js',

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "reflect-metadata": "^0.1.3",
     "rxjs": "6.0.0-rc.0",
     "tslib": "^1.7.1",
-    "zone.js": "^0.8.12"
+    "zone.js": "^0.8.25"
   },
   "optionalDependencies": {
     "fsevents": "1.1.2"

--- a/packages/core/testing/src/async.ts
+++ b/packages/core/testing/src/async.ts
@@ -6,9 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-declare var global: any;
-
-const _global = <any>(typeof window === 'undefined' ? global : window);
+import {asyncFallback} from './async_fallback';
 
 /**
  * Wraps a test function in an asynchronous test zone. The test will automatically
@@ -28,85 +26,20 @@ const _global = <any>(typeof window === 'undefined' ? global : window);
  * @stable
  */
 export function async(fn: Function): (done: any) => any {
-  // If we're running using the Jasmine test framework, adapt to call the 'done'
-  // function when asynchronous activity is finished.
-  if (_global.jasmine) {
-    // Not using an arrow function to preserve context passed from call site
-    return function(done: any) {
-      if (!done) {
-        // if we run beforeEach in @angular/core/testing/testing_internal then we get no done
-        // fake it here and assume sync.
-        done = function() {};
-        done.fail = function(e: any) { throw e; };
-      }
-      runInTestZone(fn, this, done, (err: any) => {
-        if (typeof err === 'string') {
-          return done.fail(new Error(<string>err));
-        } else {
-          done.fail(err);
-        }
-      });
+  const _Zone: any = typeof Zone !== 'undefined' ? Zone : null;
+  if (!_Zone) {
+    return function() {
+      return Promise.reject(
+          'Zone is needed for the async() test helper but could not be found. ' +
+          'Please make sure that your environment includes zone.js/dist/zone.js');
     };
   }
-  // Otherwise, return a promise which will resolve when asynchronous activity
-  // is finished. This will be correctly consumed by the Mocha framework with
-  // it('...', async(myFn)); or can be used in a custom framework.
-  // Not using an arrow function to preserve context passed from call site
-  return function() {
-    return new Promise<void>((finishCallback, failCallback) => {
-      runInTestZone(fn, this, finishCallback, failCallback);
-    });
-  };
-}
-
-function runInTestZone(
-    fn: Function, context: any, finishCallback: Function, failCallback: Function) {
-  const currentZone = Zone.current;
-  const AsyncTestZoneSpec = (Zone as any)['AsyncTestZoneSpec'];
-  if (AsyncTestZoneSpec === undefined) {
-    throw new Error(
-        'AsyncTestZoneSpec is needed for the async() test helper but could not be found. ' +
-        'Please make sure that your environment includes zone.js/dist/async-test.js');
+  const asyncTest = _Zone && _Zone[_Zone.__symbol__('asyncTest')];
+  if (typeof asyncTest === 'function') {
+    return asyncTest(fn);
   }
-  const ProxyZoneSpec = (Zone as any)['ProxyZoneSpec'] as {
-    get(): {setDelegate(spec: ZoneSpec): void; getDelegate(): ZoneSpec;};
-    assertPresent: () => void;
-  };
-  if (ProxyZoneSpec === undefined) {
-    throw new Error(
-        'ProxyZoneSpec is needed for the async() test helper but could not be found. ' +
-        'Please make sure that your environment includes zone.js/dist/proxy.js');
-  }
-  const proxyZoneSpec = ProxyZoneSpec.get();
-  ProxyZoneSpec.assertPresent();
-  // We need to create the AsyncTestZoneSpec outside the ProxyZone.
-  // If we do it in ProxyZone then we will get to infinite recursion.
-  const proxyZone = Zone.current.getZoneWith('ProxyZoneSpec');
-  const previousDelegate = proxyZoneSpec.getDelegate();
-  proxyZone.parent.run(() => {
-    const testZoneSpec: ZoneSpec = new AsyncTestZoneSpec(
-        () => {
-          // Need to restore the original zone.
-          currentZone.run(() => {
-            if (proxyZoneSpec.getDelegate() == testZoneSpec) {
-              // Only reset the zone spec if it's sill this one. Otherwise, assume it's OK.
-              proxyZoneSpec.setDelegate(previousDelegate);
-            }
-            finishCallback();
-          });
-        },
-        (error: any) => {
-          // Need to restore the original zone.
-          currentZone.run(() => {
-            if (proxyZoneSpec.getDelegate() == testZoneSpec) {
-              // Only reset the zone spec if it's sill this one. Otherwise, assume it's OK.
-              proxyZoneSpec.setDelegate(previousDelegate);
-            }
-            failCallback(error);
-          });
-        },
-        'test');
-    proxyZoneSpec.setDelegate(testZoneSpec);
-  });
-  return Zone.current.runGuarded(fn, context);
+  // not using new version of zone.js
+  // TODO @JiaLiPassion, remove this after all library updated to
+  // newest version of zone.js(0.8.25)
+  return asyncFallback(fn);
 }

--- a/packages/core/testing/src/async_fallback.ts
+++ b/packages/core/testing/src/async_fallback.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * async has been moved to zone.js
+ * this file is for fallback in case old version of zone.js is used
+ */
+declare var global: any;
+
+const _global = <any>(typeof window === 'undefined' ? global : window);
+
+/**
+ * Wraps a test function in an asynchronous test zone. The test will automatically
+ * complete when all asynchronous calls within this zone are done. Can be used
+ * to wrap an {@link inject} call.
+ *
+ * Example:
+ *
+ * ```
+ * it('...', async(inject([AClass], (object) => {
+ *   object.doSomething.then(() => {
+ *     expect(...);
+ *   })
+ * });
+ * ```
+ *
+ * @stable
+ */
+export function asyncFallback(fn: Function): (done: any) => any {
+  // If we're running using the Jasmine test framework, adapt to call the 'done'
+  // function when asynchronous activity is finished.
+  if (_global.jasmine) {
+    // Not using an arrow function to preserve context passed from call site
+    return function(done: any) {
+      if (!done) {
+        // if we run beforeEach in @angular/core/testing/testing_internal then we get no done
+        // fake it here and assume sync.
+        done = function() {};
+        done.fail = function(e: any) { throw e; };
+      }
+      runInTestZone(fn, this, done, (err: any) => {
+        if (typeof err === 'string') {
+          return done.fail(new Error(<string>err));
+        } else {
+          done.fail(err);
+        }
+      });
+    };
+  }
+  // Otherwise, return a promise which will resolve when asynchronous activity
+  // is finished. This will be correctly consumed by the Mocha framework with
+  // it('...', async(myFn)); or can be used in a custom framework.
+  // Not using an arrow function to preserve context passed from call site
+  return function() {
+    return new Promise<void>((finishCallback, failCallback) => {
+      runInTestZone(fn, this, finishCallback, failCallback);
+    });
+  };
+}
+
+function runInTestZone(
+    fn: Function, context: any, finishCallback: Function, failCallback: Function) {
+  const currentZone = Zone.current;
+  const AsyncTestZoneSpec = (Zone as any)['AsyncTestZoneSpec'];
+  if (AsyncTestZoneSpec === undefined) {
+    throw new Error(
+        'AsyncTestZoneSpec is needed for the async() test helper but could not be found. ' +
+        'Please make sure that your environment includes zone.js/dist/async-test.js');
+  }
+  const ProxyZoneSpec = (Zone as any)['ProxyZoneSpec'] as {
+    get(): {setDelegate(spec: ZoneSpec): void; getDelegate(): ZoneSpec;};
+    assertPresent: () => void;
+  };
+  if (ProxyZoneSpec === undefined) {
+    throw new Error(
+        'ProxyZoneSpec is needed for the async() test helper but could not be found. ' +
+        'Please make sure that your environment includes zone.js/dist/proxy.js');
+  }
+  const proxyZoneSpec = ProxyZoneSpec.get();
+  ProxyZoneSpec.assertPresent();
+  // We need to create the AsyncTestZoneSpec outside the ProxyZone.
+  // If we do it in ProxyZone then we will get to infinite recursion.
+  const proxyZone = Zone.current.getZoneWith('ProxyZoneSpec');
+  const previousDelegate = proxyZoneSpec.getDelegate();
+  proxyZone.parent.run(() => {
+    const testZoneSpec: ZoneSpec = new AsyncTestZoneSpec(
+        () => {
+          // Need to restore the original zone.
+          currentZone.run(() => {
+            if (proxyZoneSpec.getDelegate() == testZoneSpec) {
+              // Only reset the zone spec if it's sill this one. Otherwise, assume it's OK.
+              proxyZoneSpec.setDelegate(previousDelegate);
+            }
+            finishCallback();
+          });
+        },
+        (error: any) => {
+          // Need to restore the original zone.
+          currentZone.run(() => {
+            if (proxyZoneSpec.getDelegate() == testZoneSpec) {
+              // Only reset the zone spec if it's sill this one. Otherwise, assume it's OK.
+              proxyZoneSpec.setDelegate(previousDelegate);
+            }
+            failCallback(error);
+          });
+        },
+        'test');
+    proxyZoneSpec.setDelegate(testZoneSpec);
+  });
+  return Zone.current.runGuarded(fn, context);
+}

--- a/packages/core/testing/src/fake_async_fallback.ts
+++ b/packages/core/testing/src/fake_async_fallback.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * fakeAsync has been moved to zone.js
+ * this file is for fallback in case old version of zone.js is used
+ */
+const _Zone: any = typeof Zone !== 'undefined' ? Zone : null;
+const FakeAsyncTestZoneSpec = _Zone && _Zone['FakeAsyncTestZoneSpec'];
+type ProxyZoneSpec = {
+  setDelegate(delegateSpec: ZoneSpec): void; getDelegate(): ZoneSpec; resetDelegate(): void;
+};
+const ProxyZoneSpec: {get(): ProxyZoneSpec; assertPresent: () => ProxyZoneSpec} =
+    _Zone && _Zone['ProxyZoneSpec'];
+
+let _fakeAsyncTestZoneSpec: any = null;
+
+/**
+ * Clears out the shared fake async zone for a test.
+ * To be called in a global `beforeEach`.
+ *
+ * @experimental
+ */
+export function resetFakeAsyncZoneFallback() {
+  _fakeAsyncTestZoneSpec = null;
+  // in node.js testing we may not have ProxyZoneSpec in which case there is nothing to reset.
+  ProxyZoneSpec && ProxyZoneSpec.assertPresent().resetDelegate();
+}
+
+let _inFakeAsyncCall = false;
+
+/**
+ * Wraps a function to be executed in the fakeAsync zone:
+ * - microtasks are manually executed by calling `flushMicrotasks()`,
+ * - timers are synchronous, `tick()` simulates the asynchronous passage of time.
+ *
+ * If there are any pending timers at the end of the function, an exception will be thrown.
+ *
+ * Can be used to wrap inject() calls.
+ *
+ * ## Example
+ *
+ * {@example core/testing/ts/fake_async.ts region='basic'}
+ *
+ * @param fn
+ * @returns The function wrapped to be executed in the fakeAsync zone
+ *
+ * @experimental
+ */
+export function fakeAsyncFallback(fn: Function): (...args: any[]) => any {
+  // Not using an arrow function to preserve context passed from call site
+  return function(...args: any[]) {
+    const proxyZoneSpec = ProxyZoneSpec.assertPresent();
+    if (_inFakeAsyncCall) {
+      throw new Error('fakeAsync() calls can not be nested');
+    }
+    _inFakeAsyncCall = true;
+    try {
+      if (!_fakeAsyncTestZoneSpec) {
+        if (proxyZoneSpec.getDelegate() instanceof FakeAsyncTestZoneSpec) {
+          throw new Error('fakeAsync() calls can not be nested');
+        }
+
+        _fakeAsyncTestZoneSpec = new FakeAsyncTestZoneSpec();
+      }
+
+      let res: any;
+      const lastProxyZoneSpec = proxyZoneSpec.getDelegate();
+      proxyZoneSpec.setDelegate(_fakeAsyncTestZoneSpec);
+      try {
+        res = fn.apply(this, args);
+        flushMicrotasksFallback();
+      } finally {
+        proxyZoneSpec.setDelegate(lastProxyZoneSpec);
+      }
+
+      if (_fakeAsyncTestZoneSpec.pendingPeriodicTimers.length > 0) {
+        throw new Error(
+            `${_fakeAsyncTestZoneSpec.pendingPeriodicTimers.length} ` +
+            `periodic timer(s) still in the queue.`);
+      }
+
+      if (_fakeAsyncTestZoneSpec.pendingTimers.length > 0) {
+        throw new Error(
+            `${_fakeAsyncTestZoneSpec.pendingTimers.length} timer(s) still in the queue.`);
+      }
+      return res;
+    } finally {
+      _inFakeAsyncCall = false;
+      resetFakeAsyncZoneFallback();
+    }
+  };
+}
+
+function _getFakeAsyncZoneSpec(): any {
+  if (_fakeAsyncTestZoneSpec == null) {
+    throw new Error('The code should be running in the fakeAsync zone to call this function');
+  }
+  return _fakeAsyncTestZoneSpec;
+}
+
+/**
+ * Simulates the asynchronous passage of time for the timers in the fakeAsync zone.
+ *
+ * The microtasks queue is drained at the very start of this function and after any timer callback
+ * has been executed.
+ *
+ * ## Example
+ *
+ * {@example core/testing/ts/fake_async.ts region='basic'}
+ *
+ * @experimental
+ */
+export function tickFallback(millis: number = 0): void {
+  _getFakeAsyncZoneSpec().tick(millis);
+}
+
+/**
+ * Simulates the asynchronous passage of time for the timers in the fakeAsync zone by
+ * draining the macrotask queue until it is empty. The returned value is the milliseconds
+ * of time that would have been elapsed.
+ *
+ * @param maxTurns
+ * @returns The simulated time elapsed, in millis.
+ *
+ * @experimental
+ */
+export function flushFallback(maxTurns?: number): number {
+  return _getFakeAsyncZoneSpec().flush(maxTurns);
+}
+
+/**
+ * Discard all remaining periodic tasks.
+ *
+ * @experimental
+ */
+export function discardPeriodicTasksFallback(): void {
+  const zoneSpec = _getFakeAsyncZoneSpec();
+  const pendingTimers = zoneSpec.pendingPeriodicTimers;
+  zoneSpec.pendingPeriodicTimers.length = 0;
+}
+
+/**
+ * Flush any pending microtasks.
+ *
+ * @experimental
+ */
+export function flushMicrotasksFallback(): void {
+  _getFakeAsyncZoneSpec().flushMicrotasks();
+}

--- a/packages/elements/test/BUILD.bazel
+++ b/packages/elements/test/BUILD.bazel
@@ -27,11 +27,7 @@ filegroup(
         "//:node_modules/@webcomponents/custom-elements/src/native-shim.js",
         "//:node_modules/reflect-metadata/Reflect.js",
         "//:node_modules/zone.js/dist/zone.js",
-        "//:node_modules/zone.js/dist/async-test.js",
-        "//:node_modules/zone.js/dist/sync-test.js",
-        "//:node_modules/zone.js/dist/fake-async-test.js",
-        "//:node_modules/zone.js/dist/proxy.js",
-        "//:node_modules/zone.js/dist/jasmine-patch.js",
+        "//:node_modules/zone.js/dist/zone-testing.js",
     ],
 )
 

--- a/packages/router/karma.conf.js
+++ b/packages/router/karma.conf.js
@@ -28,12 +28,7 @@ module.exports = function(config) {
 
       // Zone.js dependencies
       'node_modules/zone.js/dist/zone.js',
-      'node_modules/zone.js/dist/long-stack-trace-zone.js',
-      'node_modules/zone.js/dist/proxy.js',
-      'node_modules/zone.js/dist/sync-test.js',
-      'node_modules/zone.js/dist/jasmine-patch.js',
-      'node_modules/zone.js/dist/async-test.js',
-      'node_modules/zone.js/dist/fake-async-test.js',
+      'node_modules/zone.js/dist/zone-testing.js',
 
       {pattern: 'node_modules/rxjs/**/*', included: false, watched: false},
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6475,6 +6475,6 @@ zip-stream@~0.5.0:
     lodash "~3.2.0"
     readable-stream "~1.0.26"
 
-zone.js@^0.8.12:
-  version "0.8.20"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.20.tgz#a218c48db09464b19ff6fc8f0d4bb5b1046e185d"
+zone.js@^0.8.25:
+  version "0.8.25"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.25.tgz#e20e5e85b881e2e66352612b5f238e8309e5badd"


### PR DESCRIPTION
based on #23100
Upgrade `zone.js` to latest version, currently  this PR is just for test, because it depends on my `zone.js branch`.
in `zone.js` 0.8.21, there are several feature which break `angular` test.

1.  move `async/fakeAsync` from angular to zone.js
2.  support `jasmine.clock()` to be auto jump into `fakeAsync` 

```
beforeEach(() => {
      jasmine.clock().install();
    });

    afterEach(() => {
      jasmine.clock().uninstall();
    });

    it('should get date diff correctly', () => {  // we don't need fakeAsync here.
      // automatically run into fake async zone, because jasmine.clock() is installed.
      const start = Date.now();
      jasmine.clock().tick(100);
      const end = Date.now();
      expect(end - start).toBe(100);
    });
```

this feature break the test cases in `aio`. https://github.com/angular/angular/blob/master/aio/src/app/app.component.spec.ts#L1110
which use `jasmine.clock()` to simulate `timer`, but still use `async/await`, so it will be `TIMEOUT`, in this PR, just remove `async/await` and use `tick`.

3.  several test cases in `angular` will be timeout, https://travis-ci.org/angular/angular/jobs/360448001
the reason is because `zone.js AsyncTestZoneSpec` add a new feature to be able to wait `non resolved promise.then`, it seems this feature will have a big impact to current `angular` test cases, for example, in the following case, 
https://github.com/angular/angular/blob/master/packages/compiler/test/metadata_resolver_spec.ts#L87
current test case seems have some error, that the `promise.then` never invoked, but in earlier version of `zone.js`, this test case will pass, but in `zone.js 0.8.21`, this will fail. there are several similar cases, so I just disable this feature in https://github.com/angular/zone.js/pull/1051, and I will check all related test cases in angular later.

