### PR TITLE
WIP: update to latest jasmine typings and fix compilation errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/diff": "^3.2.2",
     "@types/fs-extra": "4.0.2",
     "@types/hammerjs": "2.0.35",
-    "@types/jasmine": "2.2.22-alpha",
+    "@types/jasmine": "2.8.6",
     "@types/minimist": "^1.2.0",
     "@types/node": "6.0.88",
     "@types/selenium-webdriver": "3.0.7",

--- a/packages/bazel/test/ngc-wrapped/test_support.ts
+++ b/packages/bazel/test/ngc-wrapped/test_support.ts
@@ -30,7 +30,7 @@ export interface TestSupport {
   writeFiles(...mockDirs: {[fileName: string]: string}[]): void;
   shouldExist(fileName: string): void;
   shouldNotExist(fileName: string): void;
-  runOneBuild(): void;
+  runOneBuild(): boolean;
 }
 
 export function setup(

--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -166,7 +166,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
          fixture.componentInstance.currentComponent = Module2InjectedComponent;
          fixture.detectChanges();
 
-         const moduleRef = fixture.componentInstance.ngComponentOutlet['_moduleRef'];
+         const moduleRef = fixture.componentInstance.ngComponentOutlet['_moduleRef']!;
          spyOn(moduleRef, 'destroy').and.callThrough();
 
          expect(moduleRef !.destroy).not.toHaveBeenCalled();

--- a/packages/compiler-cli/test/metadata/collector_spec.ts
+++ b/packages/compiler-cli/test/metadata/collector_spec.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 
 import {MetadataCollector} from '../../src/metadata/collector';
-import {ClassMetadata, ConstructorMetadata, METADATA_VERSION, MetadataEntry, ModuleMetadata, isClassMetadata, isMetadataGlobalReferenceExpression} from '../../src/metadata/schema';
+import {ClassMetadata, ConstructorMetadata, MemberMetadata, METADATA_VERSION, MetadataEntry, ModuleMetadata, isClassMetadata, isMetadataGlobalReferenceExpression} from '../../src/metadata/schema';
 
 import {Directory, Host, expectValidSources} from './typescript.mocks';
 
@@ -269,7 +269,7 @@ describe('Collector', () => {
   it('should provide any reference for an any ctor parameter type', () => {
     const casesAny = <ClassMetadata>casesMetadata.metadata['CaseAny'];
     expect(casesAny).toBeTruthy();
-    const ctorData = casesAny.members !['__ctor__'];
+    const ctorData = <ConstructorMetadata[]>casesAny.members !['__ctor__'];
     expect(ctorData).toEqual(
         [{__symbolic: 'constructor', parameters: [{__symbolic: 'reference', name: 'any'}]}]);
   });
@@ -316,9 +316,9 @@ describe('Collector', () => {
             name: 'ClassReference',
             arguments: [{__symbolic: 'reference', name: 'NgForRow'}]
           }]
-        }]
+        }] as ConstructorMetadata[]
       }
-    });
+    } as ClassMetadata);
   });
 
   it('should report errors for destructured imports', () => {
@@ -763,7 +763,7 @@ describe('Collector', () => {
           arguments: ['a']
         }]],
         parameters: [{__symbolic: 'reference', name: 'any'}]
-      }]
+      }] as ConstructorMetadata[]
     });
   });
 
@@ -857,6 +857,7 @@ describe('Collector', () => {
         constructor (a: Foo, b: Foo | null, c: Foo | undefined, d: Foo | undefined | null, e: Foo | undefined | null | Foo) {}
       }
     `);
+
     expect((metadata.metadata['SomeClass'] as ClassMetadata).members).toEqual({
       __ctor__: [{
         __symbolic: 'constructor',
@@ -867,7 +868,7 @@ describe('Collector', () => {
           {__symbolic: 'reference', module: './foo', name: 'Foo', line: 3, character: 24},
           {__symbolic: 'reference', module: './foo', name: 'Foo', line: 3, character: 24}
         ]
-      }]
+      }] as ConstructorMetadata[]
     });
   });
 

--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -1698,7 +1698,7 @@ describe('ngc transformer command-line', () => {
       const exitCode =
           main(['-p', path.join(basePath, 'src/tsconfig.json')], message => messages.push(message));
       expect(exitCode).toBe(1, 'Compile was expected to fail');
-      expect(messages[0]).toContain(['Tagged template expressions are not supported in metadata']);
+      expect(messages[0]).toContain('Tagged template expressions are not supported in metadata');
     });
 
     // Regression: #20076
@@ -2323,7 +2323,7 @@ describe('ngc transformer command-line', () => {
         }
       }`);
       write('service.ts', `
-        import {Injectable, Self} from '@angular/core';  
+        import {Injectable, Self} from '@angular/core';
 
         @Injectable()
         export class ServiceA {}

--- a/packages/core/testing/src/testing_internal.ts
+++ b/packages/core/testing/src/testing_internal.ts
@@ -23,7 +23,7 @@ export const proxy: ClassDecorator = (t: any) => t;
 const _global = <any>(typeof window === 'undefined' ? global : window);
 
 export const afterEach: Function = _global.afterEach;
-export const expect: (actual: any) => jasmine.Matchers = _global.expect;
+export const expect: (actual: any) => jasmine.Matchers<any> = _global.expect;
 
 const jsmBeforeEach = _global.beforeEach;
 const jsmDescribe = _global.describe;

--- a/packages/platform-browser/testing/src/matchers.ts
+++ b/packages/platform-browser/testing/src/matchers.ts
@@ -15,7 +15,7 @@ import {ɵgetDOM as getDOM} from '@angular/platform-browser';
 /**
  * Jasmine matchers that check Angular specific conditions.
  */
-export interface NgMatchers extends jasmine.Matchers {
+export interface NgMatchers extends jasmine.Matchers<any> {
   /**
    * Expect the value to be a `Promise`.
    *

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,9 +50,9 @@
   version "2.0.35"
   resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.35.tgz#7b7c950c7d54593e23bffc8d2b4feba9866a7277"
 
-"@types/jasmine@2.2.22-alpha":
-  version "2.2.22-alpha"
-  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.2.22-alpha.tgz#eecaee43fe42ef6b5cfefad1bcc370c433f485bf"
+"@types/jasmine@2.8.6":
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.6.tgz#14445b6a1613cf4e05dd61c3c3256d0e95c0421e"
 
 "@types/minimatch@*":
   version "3.0.3"


### PR DESCRIPTION
Updates to the latest `@types/jasmine` and fixes a couple of errors that are the result of a new generic param being added to `jasmine.Matchers`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```