### PR TITLE
build: fix windows scripts

### DIFF
--- a/scripts/windows/create-symlinks.sh
+++ b/scripts/windows/create-symlinks.sh
@@ -2,9 +2,6 @@
 
 cd `dirname $0`
 
-CORE_SRC_ANIMATION_DIR=./../../packages/core/src/animation
 UPGRADE_STATIC_DIR=./../../packages/upgrade/static
-mv ${CORE_SRC_ANIMATION_DIR}/dsl.ts ${CORE_SRC_ANIMATION_DIR}/dsl.ts.old
 mv ${UPGRADE_STATIC_DIR}/src ${UPGRADE_STATIC_DIR}/src.old
-cmd <<< "mklink \"..\\..\\packages\\core\\src\\animation\\dsl.ts\" \"..\\..\\..\\animations\\src\\animation_metadata.ts\""
 cmd <<< "mklink /d \"..\\..\\packages\\upgrade\\static\\src\" \"..\\src\""

--- a/scripts/windows/remove-symlinks.sh
+++ b/scripts/windows/remove-symlinks.sh
@@ -2,9 +2,6 @@
 
 cd `dirname $0`
 
-CORE_SRC_ANIMATION_DIR=./../../packages/core/src/animation
 UPGRADE_STATIC_DIR=./../../packages/upgrade/static
-rm ${CORE_SRC_ANIMATION_DIR}/dsl.ts
 rm ${UPGRADE_STATIC_DIR}/src
-mv ${CORE_SRC_ANIMATION_DIR}/dsl.ts.old ${CORE_SRC_ANIMATION_DIR}/dsl.ts
 mv ${UPGRADE_STATIC_DIR}/src.old ${UPGRADE_STATIC_DIR}/src


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] Build related changes
```


## What is the new behavior?
The `packages/core/src/animation/dsl.ts` symlink ws removed in #22692, so `create-/remove-symlinks.sh` scripts for Windows should not try to "fix" it.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
Follow-up to #22692.
