### PR TITLE
refactor(service-worker): public API/docs fixes and minor refactoring

### DIFF
--- a/packages/service-worker/src/index.ts
+++ b/packages/service-worker/src/index.ts
@@ -14,6 +14,7 @@
 * found in the LICENSE file at https://angular.io/license
 */
 
+export {UpdateActivatedEvent, UpdateAvailableEvent} from './low_level';
 export {ServiceWorkerModule} from './module';
 export {SwPush} from './push';
 export {SwUpdate} from './update';

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -61,19 +61,10 @@ function errorObservable(message: string): Observable<any> {
  * @experimental
  */
 export class NgswCommChannel {
-  /**
-   * @internal
-   */
   readonly worker: Observable<ServiceWorker>;
 
-  /**
-   * @internal
-   */
   readonly registration: Observable<ServiceWorkerRegistration>;
 
-  /**
-   * @internal
-   */
   readonly events: Observable<TypedEvent>;
 
   constructor(private serviceWorker: ServiceWorkerContainer|undefined) {
@@ -100,9 +91,6 @@ export class NgswCommChannel {
     }
   }
 
-  /**
-   * @internal
-   */
   postMessage(action: string, payload: Object): Promise<void> {
     return this.worker
         .pipe(take(1), tap((sw: ServiceWorker) => {
@@ -114,38 +102,23 @@ export class NgswCommChannel {
         .then(() => undefined);
   }
 
-  /**
-   * @internal
-   */
   postMessageWithStatus(type: string, payload: Object, nonce: number): Promise<void> {
     const waitForStatus = this.waitForStatus(nonce);
     const postMessage = this.postMessage(type, payload);
     return Promise.all([waitForStatus, postMessage]).then(() => undefined);
   }
 
-  /**
-   * @internal
-   */
   generateNonce(): number { return Math.round(Math.random() * 10000000); }
 
-  /**
-   * @internal
-   */
   eventsOfType<T extends TypedEvent>(type: T['type']): Observable<T> {
     const filterFn = (event: TypedEvent): event is T => event.type === type;
     return this.events.pipe(filter(filterFn));
   }
 
-  /**
-   * @internal
-   */
   nextEventOfType<T extends TypedEvent>(type: T['type']): Observable<T> {
     return this.eventsOfType(type).pipe(take(1));
   }
 
-  /**
-   * @internal
-   */
   waitForStatus(nonce: number): Promise<void> {
     return this.eventsOfType<StatusEvent>('STATUS')
         .pipe(filter(event => event.nonce === nonce), take(1), map(event => {

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -11,27 +11,26 @@ import {filter, map, publish, switchMap, take, tap} from 'rxjs/operators';
 
 export const ERR_SW_NOT_SUPPORTED = 'Service workers are disabled or not supported by this browser';
 
-export interface Version {
-  hash: string;
-  appData?: Object;
-}
-
 /**
+ * An event emitted when a new version of the app is available.
+ *
  * @experimental
  */
 export interface UpdateAvailableEvent {
   type: 'UPDATE_AVAILABLE';
-  current: Version;
-  available: Version;
+  current: {hash: string, appData?: Object};
+  available: {hash: string, appData?: Object};
 }
 
 /**
+ * An event emitted when a new version of the app has been downloaded and activated.
+ *
  * @experimental
  */
 export interface UpdateActivatedEvent {
   type: 'UPDATE_ACTIVATED';
-  previous?: Version;
-  current: Version;
+  previous?: {hash: string, appData?: Object};
+  current: {hash: string, appData?: Object};
 }
 
 export type IncomingEvent = UpdateAvailableEvent | UpdateActivatedEvent;
@@ -52,7 +51,7 @@ function errorObservable(message: string): Observable<any> {
 
 /**
  * @experimental
-*/
+ */
 export class NgswCommChannel {
   /**
    * @internal

--- a/packages/service-worker/src/push.ts
+++ b/packages/service-worker/src/push.ts
@@ -10,7 +10,7 @@ import {Injectable} from '@angular/core';
 import {NEVER, Observable, Subject, merge} from 'rxjs';
 import {map, switchMap, take} from 'rxjs/operators';
 
-import {ERR_SW_NOT_SUPPORTED, NgswCommChannel} from './low_level';
+import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, PushEvent} from './low_level';
 
 
 /**
@@ -34,7 +34,7 @@ export class SwPush {
       this.subscription = NEVER;
       return;
     }
-    this.messages = this.sw.eventsOfType('PUSH').pipe(map((message: any) => message.data));
+    this.messages = this.sw.eventsOfType<PushEvent>('PUSH').pipe(map(message => message.data));
 
     this.pushManager = this.sw.registration.pipe(
         map((registration: ServiceWorkerRegistration) => { return registration.pushManager; }));

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -21,8 +21,21 @@ import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, UpdateActivatedEvent, UpdateAvail
  */
 @Injectable()
 export class SwUpdate {
+  /**
+   * Emits an `UpdateAvailableEvent` event whenever a new app version is available.
+   */
   readonly available: Observable<UpdateAvailableEvent>;
+
+  /**
+   * Emits an `UpdateActivatedEvent` event whenever the app has been updated to a new version.
+   */
   readonly activated: Observable<UpdateActivatedEvent>;
+
+  /**
+   * True if the Service Worker is enabled (supported by the browser and enabled via
+   * `ServiceWorkerModule`).
+   */
+  get isEnabled(): boolean { return this.sw.isEnabled; }
 
   constructor(private sw: NgswCommChannel) {
     if (!sw.isEnabled) {
@@ -33,12 +46,6 @@ export class SwUpdate {
     this.available = this.sw.eventsOfType<UpdateAvailableEvent>('UPDATE_AVAILABLE');
     this.activated = this.sw.eventsOfType<UpdateActivatedEvent>('UPDATE_ACTIVATED');
   }
-
-  /**
-   * Returns true if the Service Worker is enabled (supported by the browser and enabled via
-   * ServiceWorkerModule).
-   */
-  get isEnabled(): boolean { return this.sw.isEnabled; }
 
   checkForUpdate(): Promise<void> {
     if (!this.sw.isEnabled) {

--- a/tools/public_api_guard/service-worker/service-worker.d.ts
+++ b/tools/public_api_guard/service-worker/service-worker.d.ts
@@ -27,3 +27,29 @@ export declare class SwUpdate {
     activateUpdate(): Promise<void>;
     checkForUpdate(): Promise<void>;
 }
+
+/** @experimental */
+export interface UpdateActivatedEvent {
+    current: {
+        hash: string;
+        appData?: Object;
+    };
+    previous?: {
+        hash: string;
+        appData?: Object;
+    };
+    type: 'UPDATE_ACTIVATED';
+}
+
+/** @experimental */
+export interface UpdateAvailableEvent {
+    available: {
+        hash: string;
+        appData?: Object;
+    };
+    current: {
+        hash: string;
+        appData?: Object;
+    };
+    type: 'UPDATE_AVAILABLE';
+}


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
```


## What is the current behavior?
`NgswCommChannel`, `UpdateAvailableEvent`, `UpdateActivatedEvent` are mentioned in the docs without being part of the public API. 
The constructors of `SwPush`/`SwUpdate` are shown in the docs, making it look like they could be manually constructed.

## What is the new behavior?
`UpdateAvailableEvent`, `UpdateActivatedEvent` are added to the public API.
`SwPush`/`SwUpdate` are changed to abstract classes, so their constructors (including the `NgswCommChannel`) are not shown in the docs.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No (afaict :D)
```
