### PR TITLE
fix(common): make HttpParams default encoder changeable

### DIFF
--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -97,13 +97,18 @@ export interface HttpParamsOptions {
  * @stable
  */
 export class HttpParams {
+  /**
+   * Can override default encoder.
+   */
+  static defaultEncoderClass = HttpUrlEncodingCodec;
+
   private map: Map<string, string[]>|null;
   private encoder: HttpParameterCodec;
   private updates: Update[]|null = null;
   private cloneFrom: HttpParams|null = null;
 
   constructor(options: HttpParamsOptions = {} as HttpParamsOptions) {
-    this.encoder = options.encoder || new HttpUrlEncodingCodec();
+    this.encoder = options.encoder || new HttpParams.defaultEncoderClass();
     if (!!options.fromString) {
       if (!!options.fromObject) {
         throw new Error(`Cannot specify both fromString and fromObject.`);

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -6,10 +6,26 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpParams} from '../src/params';
+import {HttpParams, HttpUrlEncodingCodec} from '../src/params';
 
 {
   describe('HttpUrlEncodedParams', () => {
+    describe('change default encoder', () => {
+      it('should replace default parameter encoder', () => {
+        HttpParams.defaultEncoderClass = class CustomEncoder extends HttpUrlEncodingCodec {
+          encodeKey(key: string): string { return key + 'a'; }
+          encodeValue(value: string): string { return value + 'b'; }
+          decodeKey(key: string): string { return key + 'a'; }
+          decodeValue(value: string): string { return value + 'b'; }
+        };
+
+        const body = new HttpParams({fromString: 'a=b'});
+        expect(body.has('aa')).toBe(true);
+        expect(body.getAll('aa')).toEqual(['bb']);
+      });
+
+      afterEach(() => { HttpParams.defaultEncoderClass = HttpUrlEncodingCodec; });
+    });
     describe('initialization', () => {
       it('should be empty at construction', () => {
         const body = new HttpParams();


### PR DESCRIPTION
Some case parameter encoding strategy needs to change because of API server settings.

I can use HttpClient method options, but it is very annoying things.

This change make way to override default parameter encoder for HttpParams

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Default `HttpParameterEncoder` of `HttpParams` isn't changeable.

Issue Number: N/A

## What is the new behavior?

Developer can change default `HttpParameterEncoder`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
