### PR TITLE
test(ivy): fixes in the TodoMVC example

### DIFF
--- a/packages/core/test/bundling/todo/index.ts
+++ b/packages/core/test/bundling/todo/index.ts
@@ -33,7 +33,7 @@ export class AppState {
   // but NgForOf expects creation and binding separate.
   template: `
     <div>
-      <input type="checkbox" [value]="todo && todo.done" (click)="onCheckboxClick()">&ngsp;
+      <input type="checkbox" [checked]="todo && todo.done" (change)="onCheckboxClick()">&ngsp;
       <span [class.done]="todo && todo.done">{{todo && todo.text}}</span>&ngsp;
       <button (click)="onArchiveClick()">archive</button>
     </div>
@@ -71,7 +71,7 @@ export class ToDoAppComponent {
 
   onArchive(item: ToDo) {
     const todos = this.appState.todos;
-    todos.splice(todos.indexOf(item));
+    todos.splice(todos.indexOf(item), 1);
     markDirty(this);
   }
 }


### PR DESCRIPTION
@mhevery here is a small PR with a couple of fixes for the TodoMVC with ngIvy:
- properly display initial checked state
- properly remove a todo

Please note that the 'archive' option still doesn't
work correctly as listening to component outputs doesn't
seem to work (onArchive() is never called).

So, the next blocker is the fact that we don't properly listen to component outputs.
