### PR TITLE
fix(ivy): fix issue with refreshing embedded views

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -442,6 +442,7 @@ export function renderEmbeddedTemplate<T>(
     renderer: Renderer3): LViewNode {
   const _isParent = isParent;
   const _previousOrParentNode = previousOrParentNode;
+  let oldView: LView;
   try {
     isParent = true;
     previousOrParentNode = null !;
@@ -456,14 +457,14 @@ export function renderEmbeddedTemplate<T>(
       viewNode = createLNode(null, LNodeType.View, null, view);
       cm = true;
     }
-    enterView(viewNode.data, viewNode);
+    oldView = enterView(viewNode.data, viewNode);
 
     template(context, cm);
     refreshDirectives();
     refreshDynamicChildren();
 
   } finally {
-    leaveView(currentView && currentView !.parent !);
+    leaveView(oldView !);
     isParent = _isParent;
     previousOrParentNode = _previousOrParentNode;
   }

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -119,6 +119,10 @@ describe('ViewContainerRef', () => {
     directiveInstance !.insertTpl();
     expect(fixture.html).toEqual('before<div testdir=""></div>From a template.after');
 
+    // run change-detection cycle with no template insertion / removal
+    fixture.update();
+    expect(fixture.html).toEqual('before<div testdir=""></div>From a template.after');
+
     directiveInstance !.insertTpl();
     expect(fixture.html)
         .toEqual('before<div testdir=""></div>From a template.From a template.after');
@@ -176,6 +180,10 @@ describe('ViewContainerRef', () => {
     expect(fixture.html).toEqual('before||after');
 
     directiveInstance !.insertTpl({name: 'World'});
+    expect(fixture.html).toEqual('before|Hello, World|after');
+
+    // run change-detection cycle with no template insertion / removal
+    fixture.update();
     expect(fixture.html).toEqual('before|Hello, World|after');
 
     directiveInstance !.remove(0);


### PR DESCRIPTION
This PR fixes an issue where running a CD cycle after inserting an embedded view through `ViewContainerRef` was failing (due to the incorrect value of the global `currentView` being set in the process).

This is one of few steps that should allow us to remove references to the global state in the `renderEmbeddedTemplate` function. 