### PR TITLE
docs: remove old elements item from navigation

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -463,11 +463,6 @@
           ]
         },
         {
-          "url": "guide/custom-elements",
-          "title": "Custom Elements",
-          "tooltip": "Using Angular Components as Custom Elements."
-        },
-        {
           "title": "Service Workers",
           "tooltip": "Angular service workers: Controlling caching of application resources.",
           "children": [


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[X ] Other... Please describe: Docs navigation change
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is an extra old "Custom Elements" item in the navigation, with no associated file. This change removes that old entry. (new nav entry was in the elements doc PR)

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
