### PR TITLE
build: remove unnecessary stability check

### DIFF
--- a/tools/ts-api-guardian/index.bzl
+++ b/tools/ts-api-guardian/index.bzl
@@ -31,7 +31,6 @@ def ts_api_guardian_test(name, golden, actual, data = [], **kwargs):
       # From there, the relative imports would point to .ts files.
       "--node_options=--preserve-symlinks",
       "--stripExportPattern", "^\(__\|ɵ\)",
-      "--onStabilityMissing", "error",
   ]
   for i in COMMON_MODULE_IDENTIFIERS:
     args += ["--allowModuleIdentifiers", i]

--- a/tools/ts-api-guardian/lib/cli.ts
+++ b/tools/ts-api-guardian/lib/cli.ts
@@ -24,13 +24,7 @@ export function startCli() {
   const options: SerializationOptions = {
     stripExportPattern: argv['stripExportPattern'],
     allowModuleIdentifiers: [].concat(argv['allowModuleIdentifiers']),
-    onStabilityMissing: argv['onStabilityMissing'] || 'none'
   };
-
-  if (['warn', 'error', 'none'].indexOf(options.onStabilityMissing as string) < 0) {
-    throw new Error(
-        'Argument for "--onStabilityMissing" option must be one of: "warn", "error", "none"');
-  }
 
   for (const error of errors) {
     console.warn(error);
@@ -85,7 +79,7 @@ export function parseArguments(input: string[]):
   const argv = minimist(input, {
     string: [
       'out', 'outDir', 'verify', 'verifyDir', 'rootDir', 'stripExportPattern',
-      'allowModuleIdentifiers', 'onStabilityMissing'
+      'allowModuleIdentifiers'
     ],
     boolean: [
       'help',
@@ -161,10 +155,7 @@ Options:
 
         --stripExportPattern <regexp>   Do not output exports matching the pattern
         --allowModuleIdentifiers <identifier>
-                                        Whitelist identifier for "* as foo" imports
-        --onStabilityMissing <warn|error|none>
-                                        Warn or error if an export has no stability
-                                        annotation`);
+                                        Whitelist identifier for "* as foo" imports`);
   process.exit(error ? 1 : 0);
 }
 

--- a/tools/ts-api-guardian/lib/serializer.ts
+++ b/tools/ts-api-guardian/lib/serializer.ts
@@ -31,11 +31,6 @@ export interface SerializationOptions {
    * whitelisting angular.
    */
   allowModuleIdentifiers?: string[];
-  /**
-   * Warns or errors if stability annotations are missing on an export.
-   * Supports experimental, stable and deprecated.
-   */
-  onStabilityMissing?: DiagnosticSeverity;
 }
 
 export type DiagnosticSeverity = 'warn' | 'error' | 'none';
@@ -124,12 +119,6 @@ class ResolvedDeclarationEmitter {
         const match = stabilityAnnotationPattern.exec(trivia);
         if (match) {
           output += `/** @${match[1]} */\n`;
-        } else if (['warn', 'error'].indexOf(this.options.onStabilityMissing as string) >= 0) {
-          this.diagnostics.push({
-            type: this.options.onStabilityMissing,
-            message: createErrorMessage(
-                decl, `No stability annotation found for symbol "${symbol.name}"`)
-          });
         }
 
         output += stripEmptyLines(this.emitNode(decl)) + '\n';

--- a/tools/ts-api-guardian/test/cli_e2e_test.ts
+++ b/tools/ts-api-guardian/test/cli_e2e_test.ts
@@ -114,19 +114,6 @@ describe('cli: e2e test', () => {
     chai.assert.equal(stdout, '');
     chai.assert.equal(status, 0);
   });
-
-  it('should respect --onStabilityMissing', () => {
-    const {stdout, stderr, status} = execute([
-      '--verify', 'test/fixtures/simple_expected.d.ts', '--onStabilityMissing', 'warn',
-      'test/fixtures/simple.d.ts'
-    ]);
-    chai.assert.equal(stdout, '');
-    chai.assert.equal(
-        stderr,
-        'test/fixtures/simple.d.ts(1,1): error: No stability annotation found for symbol "A"\n' +
-            'test/fixtures/simple.d.ts(2,1): error: No stability annotation found for symbol "B"\n');
-    chai.assert.equal(status, 0, stderr);
-  });
 });
 
 function copyFile(sourceFile: string, targetFile: string) {

--- a/tools/ts-api-guardian/test/unit_test.ts
+++ b/tools/ts-api-guardian/test/unit_test.ts
@@ -460,22 +460,6 @@ describe('unit test', () => {
     `;
     check({'file.d.ts': input}, expected);
   });
-
-  it('should warn on onStabilityMissing: warn', () => {
-    const input = `
-      export declare class A {
-        constructor();
-      }
-    `;
-    const expected = `
-      export declare class A {
-        constructor();
-      }
-    `;
-    check({'file.d.ts': input}, expected, {onStabilityMissing: 'warn'});
-    chai.assert.deepEqual(
-        warnings, ['file.d.ts(1,1): error: No stability annotation found for symbol "A"']);
-  });
 });
 
 function getMockHost(files: {[name: string]: string}): ts.CompilerHost {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been ~~added~~ / removed (for bug fixes / features)
- [x] Docs have been ~~added~~ / removed (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The doc-gen now assumes that a code item is stable if
it does not contain neither `@experimental` nor `@deprecated` tags.

## What is the new behavior?

The ts-api-guardian no longer warns if the `@stable` tag is missing.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Discussed with @IgorMinar 
