### PR TITLE
feat(ivy): implement some of the ViewContainerRef API

### DIFF
--- a/packages/core/src/render3/assert.ts
+++ b/packages/core/src/render3/assert.ts
@@ -40,6 +40,12 @@ export function assertLessThan<T>(actual: T, expected: T, msg: string) {
   }
 }
 
+export function assertGreaterThan<T>(actual: T, expected: T, msg: string) {
+  if (actual <= expected) {
+    throwError(msg);
+  }
+}
+
 export function assertNull<T>(actual: T, msg: string) {
   if (actual != null) {
     throwError(msg);

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -311,6 +311,7 @@ export function removeView(container: LContainerNode, removeIndex: number): LVie
     setViewNext(views[removeIndex - 1], viewNode.next);
   }
   views.splice(removeIndex, 1);
+  viewNode.next = null;
   destroyViewTree(viewNode.data);
   addRemoveViewFromContainer(container, viewNode, false);
   // Notify query that view has been removed

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -48,6 +48,8 @@ function noop() {}
  */
 export class TemplateFixture extends BaseFixture {
   hostNode: LElementNode;
+  private _directiveDefs: DirectiveDefList|null;
+  private _pipeDefs: PipeDefList|null;
   /**
    *
    * @param createBlock Instructions which go into the creation block:
@@ -55,15 +57,18 @@ export class TemplateFixture extends BaseFixture {
    * @param updateBlock Optional instructions which go after the creation block:
    *          `if (creationMode) { ... } __here__`.
    */
-  constructor(private createBlock: () => void, private updateBlock: () => void = noop) {
+  constructor(
+      private createBlock: () => void, private updateBlock: () => void = noop,
+      directives?: DirectiveTypesOrFactory|null, pipes?: PipeTypesOrFactory|null) {
     super();
-    this.updateBlock = updateBlock || function() {};
+    this._directiveDefs = toDefs(directives, extractDirectiveDef);
+    this._pipeDefs = toDefs(pipes, extractPipeDef);
     this.hostNode = renderTemplate(this.hostElement, (ctx: any, cm: boolean) => {
       if (cm) {
         this.createBlock();
       }
       this.updateBlock();
-    }, null !, domRendererFactory3, null);
+    }, null !, domRendererFactory3, null, this._directiveDefs, this._pipeDefs);
   }
 
   /**
@@ -74,7 +79,7 @@ export class TemplateFixture extends BaseFixture {
   update(updateBlock?: () => void): void {
     renderTemplate(
         this.hostNode.native, updateBlock || this.updateBlock, null !, domRendererFactory3,
-        this.hostNode);
+        this.hostNode, this._directiveDefs, this._pipeDefs);
   }
 }
 


### PR DESCRIPTION
This PR implements some of the API of the `ViewContainerRef` and adds more tests.

In scope:
- createEmbeddedView
- insert
- detach
- length
- get
- indexOf
- move

Out of scope:
- createComponent
- remove & clear (destroy part needs to be implemented)
