### PR TITLE
docs: fixed live example for the lifecycle hooks.

### DIFF
--- a/aio/content/examples/lifecycle-hooks/src/app/peek-a-boo-parent.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/peek-a-boo-parent.component.ts
@@ -43,6 +43,7 @@ export class PeekABooParentComponent {
       this.heroName = 'Windstorm';
       this.logger.clear(); // clear log on create
     }
+    this.hookLog = this.logger.logs;
     this.logger.tick();
   }
 


### PR DESCRIPTION
## PR Type
Docs

<!-- Please check the one that applies to this PR using "x". -->
```
Documentation content changes
```

## What is the current behavior?
**https://angular.io/guide/lifecycle-hooks
Live example for lifecycle hooks in documentation is not working as expected.

Below is the example link
https://stackblitz.com/angular/jlqeyrgaoaq

Clicking the 'Create PeekABooComponent' not logging the lifecycle hooks below it on UI.**

Issue Number: 22279


## What is the new behavior?
After clicking the 'Create PeekABooComponent' the logs should be viewed below it.


## Does this PR introduce a breaking change?
```
No
```