### PR TITLE
build: improve the publish-next script

### DIFF
--- a/scripts/release/publish-next
+++ b/scripts/release/publish-next
@@ -5,6 +5,13 @@ set -u -e -o pipefail
 # Use for BETA and RC releases
 # Query Bazel for npm_package and ng_package rules with tags=["release-with-framework"]
 # Publish them to npm (tagged next)
-for p in $(bazel query --output=label 'attr("tags", "\[.*release-with-framework.*\]", //...) intersect kind(".*_package", //...) except //dist/...'); do
-  bazel run -- $p.publish --access public --tag next
+
+# query for all npm packages to be released as part of the framework release
+NPM_PACKAGE_LABELS=`bazel query --output=label 'attr("tags", "\[.*release-with-framework.*\]", //packages/...) intersect kind(".*_package", //...)'`
+# build all npm packages in parallel
+bazel build $NPM_PACKAGE_LABELS
+# publish all packages in sequence to make it easier to spot any errors or warnings
+for packageLabel in $NPM_PACKAGE_LABELS; do
+  echo "publishing $packageLabel"
+  bazel run -- ${packageLabel}.publish --access public --tag next
 done


### PR DESCRIPTION
- add paralelization of the build
- correct issues with picking up targets from /dist and /aio/node_modules/
- add logging during the publish process