### PR TITLE
docs(http): update deprecation comments in JSDoc to escape @ symbol

### DIFF
--- a/packages/http/src/backends/browser_xhr.ts
+++ b/packages/http/src/backends/browser_xhr.ts
@@ -13,7 +13,7 @@ import {Injectable} from '@angular/core';
  *
  * Take care not to evaluate this in non-browser contexts.
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 @Injectable()
 export class BrowserXhr {

--- a/packages/http/src/backends/jsonp_backend.ts
+++ b/packages/http/src/backends/jsonp_backend.ts
@@ -23,7 +23,7 @@ const JSONP_ERR_WRONG_METHOD = 'JSONP requests must use GET request method.';
 /**
  * Base class for an in-flight JSONP request.
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export class JSONPConnection implements Connection {
   private _id: string;
@@ -136,7 +136,7 @@ export class JSONPConnection implements Connection {
 /**
  * A {@link ConnectionBackend} that uses the JSONP strategy of making requests.
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 @Injectable()
 export class JSONPBackend extends ConnectionBackend {

--- a/packages/http/src/backends/xhr_backend.ts
+++ b/packages/http/src/backends/xhr_backend.ts
@@ -28,7 +28,7 @@ const XSSI_PREFIX = /^\)\]\}',?\n/;
  * This class would typically not be created or interacted with directly inside applications, though
  * the {@link MockConnection} may be interacted with in tests.
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export class XHRConnection implements Connection {
   request: Request;
@@ -187,7 +187,7 @@ export class XHRConnection implements Connection {
  * with different `cookieName` and `headerName` values. See the main HTTP documentation for more
  * details.
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export class CookieXSRFStrategy implements XSRFStrategy {
   constructor(
@@ -225,7 +225,7 @@ export class CookieXSRFStrategy implements XSRFStrategy {
  *   }
  * }
  * ```
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 @Injectable()
 export class XHRBackend implements ConnectionBackend {

--- a/packages/http/src/base_request_options.ts
+++ b/packages/http/src/base_request_options.ts
@@ -37,7 +37,7 @@ import {URLSearchParams} from './url_search_params';
  * console.log('options.url:', options.url); // https://google.com
  * ```
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export class RequestOptions {
   /**
@@ -200,7 +200,7 @@ export class RequestOptions {
  * console.log('req.url:', req.url); // https://google.com
  * ```
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 @Injectable()
 export class BaseRequestOptions extends RequestOptions {

--- a/packages/http/src/base_response_options.ts
+++ b/packages/http/src/base_response_options.ts
@@ -39,7 +39,7 @@ import {ResponseOptionsArgs} from './interfaces';
  * console.log('res.json():', res.json()); // Object {name: "Jeff"}
  * ```
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export class ResponseOptions {
   // TODO: FormData | Blob
@@ -156,7 +156,7 @@ export class ResponseOptions {
  * console.log('res.text():', res.text()); // Angular;
  * ```
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 @Injectable()
 export class BaseResponseOptions extends ResponseOptions {

--- a/packages/http/src/enums.ts
+++ b/packages/http/src/enums.ts
@@ -8,7 +8,7 @@
 
 /**
  * Supported http methods.
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export enum RequestMethod {
   Get,
@@ -24,7 +24,7 @@ export enum RequestMethod {
  * All possible states in which a connection can be, based on
  * [States](http://www.w3.org/TR/XMLHttpRequest/#states) from the `XMLHttpRequest` spec, but with an
  * additional "CANCELLED" state.
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export enum ReadyState {
   Unsent,
@@ -38,7 +38,7 @@ export enum ReadyState {
 /**
  * Acceptable response types to be associated with a {@link Response}, based on
  * [ResponseType](https://fetch.spec.whatwg.org/#responsetype) from the Fetch spec.
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export enum ResponseType {
   Basic,
@@ -50,7 +50,7 @@ export enum ResponseType {
 
 /**
  * Supported content type to be automatically associated with a {@link Request}.
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export enum ContentType {
   NONE,
@@ -64,7 +64,7 @@ export enum ContentType {
 
 /**
  * Define which buffer to use to store the response
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export enum ResponseContentType {
   Text,

--- a/packages/http/src/headers.ts
+++ b/packages/http/src/headers.ts
@@ -32,7 +32,7 @@
  * console.log(thirdHeaders.get('X-My-Custom-Header')); //'Angular'
  * ```
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export class Headers {
   /** @internal header names are lower case */

--- a/packages/http/src/http.ts
+++ b/packages/http/src/http.ts
@@ -99,7 +99,7 @@ function mergeOptions(
  * http.get('request-from-mock-backend.json').subscribe((res:Response) => doSomething(res));
  * ```
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 @Injectable()
 export class Http {
@@ -187,7 +187,7 @@ export class Http {
 
 
 /**
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 @Injectable()
 export class Jsonp extends Http {

--- a/packages/http/src/http_module.ts
+++ b/packages/http/src/http_module.ts
@@ -40,7 +40,7 @@ export function jsonpFactory(jsonpBackend: JSONPBackend, requestOptions: Request
 /**
  * The module that includes http's providers
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 @NgModule({
   providers: [
@@ -60,7 +60,7 @@ export class HttpModule {
 /**
  * The module that includes jsonp's providers
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 @NgModule({
   providers: [

--- a/packages/http/src/interfaces.ts
+++ b/packages/http/src/interfaces.ts
@@ -17,14 +17,14 @@ import {URLSearchParams} from './url_search_params';
  * The primary purpose of a `ConnectionBackend` is to create new connections to fulfill a given
  * {@link Request}.
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export abstract class ConnectionBackend { abstract createConnection(request: any): Connection; }
 
 /**
  * Abstract class from which real connections are derived.
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export abstract class Connection {
   readyState: ReadyState;
@@ -35,7 +35,7 @@ export abstract class Connection {
 /**
  * An XSRFStrategy configures XSRF protection (e.g. via headers) on an HTTP request.
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export abstract class XSRFStrategy { abstract configureRequest(req: Request): void; }
 
@@ -43,7 +43,7 @@ export abstract class XSRFStrategy { abstract configureRequest(req: Request): vo
  * Interface for options to construct a RequestOptions, based on
  * [RequestInit](https://fetch.spec.whatwg.org/#requestinit) from the Fetch spec.
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export interface RequestOptionsArgs {
   url?: string|null;
@@ -66,7 +66,7 @@ export interface RequestArgs extends RequestOptionsArgs { url: string|null; }
  * Interface for options to construct a Response, based on
  * [ResponseInit](https://fetch.spec.whatwg.org/#responseinit) from the Fetch spec.
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export interface ResponseOptionsArgs {
   body?: string|Object|FormData|ArrayBuffer|Blob|null;

--- a/packages/http/src/static_request.ts
+++ b/packages/http/src/static_request.ts
@@ -52,7 +52,7 @@ import {URLSearchParams} from './url_search_params';
  * });
  * ```
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export class Request extends Body {
   /**

--- a/packages/http/src/static_response.ts
+++ b/packages/http/src/static_response.ts
@@ -32,7 +32,7 @@ import {Headers} from './headers';
  * can be accessed many times. There are other differences in the implementation, but this is the
  * most significant.
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export class Response extends Body {
   /**

--- a/packages/http/src/url_search_params.ts
+++ b/packages/http/src/url_search_params.ts
@@ -22,7 +22,7 @@ function paramParser(rawParams: string = ''): Map<string, string[]> {
   return map;
 }
 /**
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  **/
 export class QueryEncoder {
   encodeKey(k: string): string { return standardEncoding(k); }
@@ -76,7 +76,7 @@ function standardEncoding(v: string): string {
  *
  * let params = new URLSearchParams('', new MyQueryEncoder());
  * ```
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export class URLSearchParams {
   paramsMap: Map<string, string[]>;

--- a/packages/http/src/version.ts
+++ b/packages/http/src/version.ts
@@ -14,6 +14,6 @@
 
 import {Version} from '@angular/core';
 /**
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export const VERSION = new Version('0.0.0-PLACEHOLDER');

--- a/packages/http/testing/src/mock_backend.ts
+++ b/packages/http/testing/src/mock_backend.ts
@@ -16,7 +16,7 @@ import {take} from 'rxjs/operators';
  *
  * Mock Connection to represent a {@link Connection} for tests.
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 export class MockConnection implements Connection {
   // TODO Name `readyState` should change to be more generic, and states could be made to be more
@@ -189,7 +189,7 @@ export class MockConnection implements Connection {
  *
  * This method only exists in the mock implementation, not in real Backends.
  *
- * @deprecated use @angular/common/http instead
+ * @deprecated use \@angular/common/http instead
  */
 @Injectable()
 export class MockBackend implements ConnectionBackend {


### PR DESCRIPTION
<body>
@angular/http is being treated as a new tag, rather than belonging to the @deprecated tag.
<footer>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
@angular is treated as a tag rather than a part of @deprecated
Issue Number: N/A


## What is the new behavior?
@angular is escaped so documentation parsers understand it belongs to @deprecated

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
