### PR TITLE
docs(forms): Fixed a typo in the reactive form 

### DIFF
--- a/aio/content/guide/reactive-forms.md
+++ b/aio/content/guide/reactive-forms.md
@@ -1068,7 +1068,7 @@ Replace the address `FormGroup` definition with a `secretLairs`  `FormArray` def
 
 </code-example>
 
-In `hero-detail.component.html` change `formArrayName="address"` to `formArrayName="secretLairs"`.
+In `hero-detail.component.html` change `formGroupName="address"` to `formArrayName="secretLairs"`.
 
 <code-example path="reactive-forms/src/app/hero-detail/hero-detail-8.component.html" region="form-array-name" title="src/app/hero-detail/hero-detail.component.ts" linenums="false">
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[X] Documentation content changes
```

## What is the current behavior?
Looks like there is an issue in the From address to secretLairs. Now we have 
```
In hero-detail.component.html change formArrayName="address" to formArrayName="secretLairs"
```
Issue Number: [23207](https://github.com/angular/angular/issues/23207)


## What is the new behavior?
It is now
```
In hero-detail.component.html change formGroupName="address" to formArrayName="secretLairs"
```

## Does this PR introduce a breaking change?
```
[X] No
```