### PR TITLE
fix(compiler-cli): don't lower expressions in flat module metadata

### DIFF
--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -1040,7 +1040,6 @@ describe('ngc transformer command-line', () => {
           exports: [
             FlatComponent,
           ],
-          providers: [{provide: 'test', useFactory: () => true}],
         })
         export class FlatModule {
         }`);
@@ -1055,7 +1054,7 @@ describe('ngc transformer command-line', () => {
       shouldExist('index.metadata.json');
     });
 
-    it('should downlevel flat module metadata', () => {
+    it('should downlevel templates in flat module metadata', () => {
       writeFlatModule('index.js');
 
       const exitCode = main(['-p', path.join(basePath, 'tsconfig.json')], errorSpy);
@@ -1066,7 +1065,7 @@ describe('ngc transformer command-line', () => {
       const metadataPath = path.resolve(outDir, 'index.metadata.json');
       const metadataSource = fs.readFileSync(metadataPath, 'utf8');
       expect(metadataSource).not.toContain('templateUrl');
-      expect(metadataSource).toContain('"useFactory":{"__symbolic":"reference","name":"ɵ0"}');
+      expect(metadataSource).toContain('<div>flat module component</div>');
     });
 
     describe('with tree example', () => {


### PR DESCRIPTION
Lowering expressions in flat module metadata is desirable, but it won't
work without some rearchitecting. Currently the flat module index source
is added to the Program and therefore must be determined before the rest
of the transforms run. Since the lowering transform changes the set of
exports needed in the index, this creates a catch-22 in the index
generation.

This commit causes the flat module index metadata to be generated using
only those transforms which are "safe" (don't modify the index).
