### PR TITLE
feat(ivy): first steps towards ngtsc mode

### DIFF
--- a/packages/compiler-cli/src/ngtsc/compiler_host.ts
+++ b/packages/compiler-cli/src/ngtsc/compiler_host.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+export interface CompilerHost extends ts.CompilerHost {
+  getResource(file: string): Promise<string>|undefined;
+}
+
+export class NgtscCompilerHost implements CompilerHost {
+  constructor(private delegate: ts.CompilerHost) {}
+
+  getSourceFile(
+      fileName: string, languageVersion: ts.ScriptTarget,
+      onError?: ((message: string) => void)|undefined,
+      shouldCreateNewSourceFile?: boolean|undefined): ts.SourceFile|undefined {
+    return this.delegate.getSourceFile(
+        fileName, languageVersion, onError, shouldCreateNewSourceFile);
+  }
+
+  getDefaultLibFileName(options: ts.CompilerOptions): string {
+    return this.delegate.getDefaultLibFileName(options);
+  }
+
+  writeFile(
+      fileName: string, data: string, writeByteOrderMark: boolean,
+      onError: ((message: string) => void)|undefined,
+      sourceFiles: ReadonlyArray<ts.SourceFile>): void {
+    return this.delegate.writeFile(fileName, data, writeByteOrderMark, onError, sourceFiles);
+  }
+
+  getCurrentDirectory(): string { return this.delegate.getCurrentDirectory(); }
+
+  getDirectories(path: string): string[] { return this.delegate.getDirectories(path); }
+
+  getCanonicalFileName(fileName: string): string {
+    return this.delegate.getCanonicalFileName(fileName);
+  }
+
+  useCaseSensitiveFileNames(): boolean { return this.delegate.useCaseSensitiveFileNames(); }
+
+  getNewLine(): string { return this.delegate.getNewLine(); }
+
+  fileExists(fileName: string): boolean { return this.delegate.fileExists(fileName); }
+
+  readFile(fileName: string): string|undefined { return this.delegate.readFile(fileName); }
+
+  getResource(file: string): Promise<string>|undefined {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {GeneratedFile} from '@angular/compiler';
+import * as ts from 'typescript';
+
+import * as api from '../transformers/api';
+
+import {CompilerHost} from './compiler_host';
+
+export class NgtscProgram implements api.Program {
+  private tsProgram: ts.Program;
+
+  constructor(
+      rootNames: ReadonlyArray<string>, private options: api.CompilerOptions,
+      private host: api.CompilerHost, oldProgram?: api.Program) {
+    this.tsProgram =
+        ts.createProgram(rootNames, options, host, oldProgram && oldProgram.getTsProgram());
+  }
+
+  getTsProgram(): ts.Program { return this.tsProgram; }
+
+  getTsOptionDiagnostics(cancellationToken?: ts.CancellationToken|
+                         undefined): ReadonlyArray<ts.Diagnostic> {
+    return this.tsProgram.getOptionsDiagnostics(cancellationToken);
+  }
+
+  getNgOptionDiagnostics(cancellationToken?: ts.CancellationToken|
+                         undefined): ReadonlyArray<api.Diagnostic> {
+    return [];
+  }
+
+  getTsSyntacticDiagnostics(
+      sourceFile?: ts.SourceFile|undefined,
+      cancellationToken?: ts.CancellationToken|undefined): ReadonlyArray<ts.Diagnostic> {
+    return this.tsProgram.getSyntacticDiagnostics(sourceFile, cancellationToken);
+  }
+
+  getNgStructuralDiagnostics(cancellationToken?: ts.CancellationToken|
+                             undefined): ReadonlyArray<api.Diagnostic> {
+    return [];
+  }
+
+  getTsSemanticDiagnostics(
+      sourceFile?: ts.SourceFile|undefined,
+      cancellationToken?: ts.CancellationToken|undefined): ReadonlyArray<ts.Diagnostic> {
+    return this.tsProgram.getSemanticDiagnostics(sourceFile, cancellationToken);
+  }
+
+  getNgSemanticDiagnostics(
+      fileName?: string|undefined,
+      cancellationToken?: ts.CancellationToken|undefined): ReadonlyArray<api.Diagnostic> {
+    return [];
+  }
+
+  loadNgStructureAsync(): Promise<void> { return Promise.resolve(); }
+
+  listLazyRoutes(entryRoute?: string|undefined): api.LazyRoute[] {
+    throw new Error('Method not implemented.');
+  }
+
+  getLibrarySummaries(): Map<string, api.LibrarySummary> {
+    throw new Error('Method not implemented.');
+  }
+
+  getEmittedGeneratedFiles(): Map<string, GeneratedFile> {
+    throw new Error('Method not implemented.');
+  }
+
+  getEmittedSourceFiles(): Map<string, ts.SourceFile> {
+    throw new Error('Method not implemented.');
+  }
+
+  emit(opts?: {
+    emitFlags?: api.EmitFlags,
+    cancellationToken?: ts.CancellationToken,
+    customTransformers?: api.CustomTransformers,
+    emitCallback?: api.TsEmitCallback,
+    mergeEmitResultsCallback?: api.TsMergeEmitResultsCallback
+  }): ts.EmitResult {
+    const emitCallback = opts && opts.emitCallback || defaultEmitCallback;
+    const mergeEmitResultsCallback = opts && opts.mergeEmitResultsCallback || mergeEmitResults;
+
+    const emitResult = emitCallback({
+      program: this.tsProgram,
+      host: this.host,
+      options: this.options,
+      emitOnlyDtsFiles: false,
+    });
+    return emitResult;
+  }
+}
+
+const defaultEmitCallback: api.TsEmitCallback =
+    ({program, targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles,
+      customTransformers}) =>
+        program.emit(
+            targetSourceFile, writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers);
+
+function mergeEmitResults(emitResults: ts.EmitResult[]): ts.EmitResult {
+  const diagnostics: ts.Diagnostic[] = [];
+  let emitSkipped = false;
+  const emittedFiles: string[] = [];
+  for (const er of emitResults) {
+    diagnostics.push(...er.diagnostics);
+    emitSkipped = emitSkipped || er.emitSkipped;
+    emittedFiles.push(...(er.emittedFiles || []));
+  }
+  return {diagnostics, emitSkipped, emittedFiles};
+}

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -182,9 +182,12 @@ export interface CompilerOptions extends ts.CompilerOptions {
    * Not all features are supported with this option enabled. It is only supported
    * for experimentation and testing of Render3 style code generation.
    *
+   * There are two options for running the Render3 compiler. Setting `enableIvy` to `true` enables
+   * the ngc-based code path, and setting it to `ngtsc` enables the new experimental compiler.
+   *
    * @experimental
    */
-  enableIvy?: boolean;
+  enableIvy?: boolean|'ngtsc';
 
   /** @internal */
   collectAllErrors?: boolean;

--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -12,6 +12,7 @@ import * as ts from 'typescript';
 
 import {TypeCheckHost} from '../diagnostics/translate_diagnostics';
 import {METADATA_VERSION, ModuleMetadata} from '../metadata/index';
+import {NgtscCompilerHost} from '../ngtsc/compiler_host';
 
 import {CompilerHost, CompilerOptions, LibrarySummary} from './api';
 import {MetadataReaderHost, createMetadataReaderCache, readMetadata} from './metadata_reader';
@@ -23,6 +24,9 @@ const EXT = /(\.ts|\.d\.ts|\.js|\.jsx|\.tsx)$/;
 export function createCompilerHost(
     {options, tsHost = ts.createCompilerHost(options, true)}:
         {options: CompilerOptions, tsHost?: ts.CompilerHost}): CompilerHost {
+  if (options.enableIvy === 'ngtsc') {
+    return new NgtscCompilerHost(tsHost);
+  }
   return tsHost;
 }
 

--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -15,6 +15,7 @@ import * as ts from 'typescript';
 import {TypeCheckHost, translateDiagnostics} from '../diagnostics/translate_diagnostics';
 import {compareVersions} from '../diagnostics/typescript_version';
 import {MetadataCollector, ModuleMetadata, createBundleIndexHost} from '../metadata/index';
+import {NgtscProgram} from '../ngtsc/program';
 
 import {CompilerHost, CompilerOptions, CustomTransformers, DEFAULT_ERROR_CODE, Diagnostic, DiagnosticMessageChain, EmitFlags, LazyRoute, LibrarySummary, Program, SOURCE, TsEmitArguments, TsEmitCallback, TsMergeEmitResultsCallback} from './api';
 import {CodeGenerator, TsCompilerAotCompilerTypeCheckHostAdapter, getOriginalReferences} from './compiler_host';
@@ -286,6 +287,9 @@ class AngularCompilerProgram implements Program {
     emitCallback?: TsEmitCallback,
     mergeEmitResultsCallback?: TsMergeEmitResultsCallback,
   } = {}): ts.EmitResult {
+    if (this.options.enableIvy === 'ngtsc') {
+      throw new Error('Cannot run legacy compiler in ngtsc mode');
+    }
     return this.options.enableIvy === true ? this._emitRender3(parameters) :
                                              this._emitRender2(parameters);
   }
@@ -903,6 +907,9 @@ export function createProgram({rootNames, options, host, oldProgram}: {
   options: CompilerOptions,
   host: CompilerHost, oldProgram?: Program
 }): Program {
+  if (options.enableIvy === 'ngtsc') {
+    return new NgtscProgram(rootNames, options, host, oldProgram);
+  }
   return new AngularCompilerProgram(rootNames, options, host, oldProgram);
 }
 

--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -1,0 +1,29 @@
+load("//tools:defaults.bzl", "ts_library", "ts_web_test")
+load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
+
+# ngc_spec
+ts_library(
+    name = "test_lib",
+    testonly = 1,
+    srcs = glob([
+        "**/*.ts",
+    ]),
+    deps = [
+        "//packages/compiler",
+        "//packages/compiler-cli",
+        "//packages/compiler-cli/test:test_utils",
+    ],
+)
+
+jasmine_node_test(
+    name = "test",
+    bootstrap = ["angular/tools/testing/init_node_spec.js"],
+    data = [
+        "//packages/core:npm_package",
+    ],
+    deps = [
+        ":test_lib",
+        "//packages/core",
+        "//tools/testing:node",
+    ],
+)

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ts from 'typescript';
+
+import {main, readCommandLineAndConfiguration, watchMode} from '../../src/main';
+
+import {isInBazel, makeTempDir, setup} from '../test_support';
+
+function getNgRootDir() {
+  const moduleFilename = module.filename.replace(/\\/g, '/');
+  const distIndex = moduleFilename.indexOf('/dist/all');
+  return moduleFilename.substr(0, distIndex);
+}
+
+describe('ngc transformer command-line', () => {
+  let basePath: string;
+  let outDir: string;
+  let write: (fileName: string, content: string) => void;
+  let errorSpy: jasmine.Spy&((s: string) => void);
+
+  function shouldExist(fileName: string) {
+    if (!fs.existsSync(path.resolve(outDir, fileName))) {
+      throw new Error(`Expected ${fileName} to be emitted (outDir: ${outDir})`);
+    }
+  }
+
+  function shouldNotExist(fileName: string) {
+    if (fs.existsSync(path.resolve(outDir, fileName))) {
+      throw new Error(`Did not expect ${fileName} to be emitted (outDir: ${outDir})`);
+    }
+  }
+
+  function getContents(fileName: string): string {
+    shouldExist(fileName);
+    const modulePath = path.resolve(outDir, fileName);
+    return fs.readFileSync(modulePath, 'utf8');
+  }
+
+  function writeConfig(
+      tsconfig: string =
+          '{"extends": "./tsconfig-base.json", "angularCompilerOptions": {"enableIvy": "ngtsc"}}') {
+    write('tsconfig.json', tsconfig);
+  }
+
+  beforeEach(() => {
+    errorSpy = jasmine.createSpy('consoleError').and.callFake(console.error);
+    if (isInBazel) {
+      const support = setup();
+      basePath = support.basePath;
+      outDir = path.join(basePath, 'built');
+      process.chdir(basePath);
+      write = (fileName: string, content: string) => { support.write(fileName, content); };
+    } else {
+      basePath = makeTempDir();
+      process.chdir(basePath);
+      write = (fileName: string, content: string) => {
+        const dir = path.dirname(fileName);
+        if (dir != '.') {
+          const newDir = path.join(basePath, dir);
+          if (!fs.existsSync(newDir)) fs.mkdirSync(newDir);
+        }
+        fs.writeFileSync(path.join(basePath, fileName), content, {encoding: 'utf-8'});
+      };
+      outDir = path.resolve(basePath, 'built');
+      const ngRootDir = getNgRootDir();
+      const nodeModulesPath = path.resolve(basePath, 'node_modules');
+      fs.mkdirSync(nodeModulesPath);
+      fs.symlinkSync(
+          path.resolve(ngRootDir, 'dist', 'all', '@angular'),
+          path.resolve(nodeModulesPath, '@angular'));
+      fs.symlinkSync(
+          path.resolve(ngRootDir, 'node_modules', 'rxjs'), path.resolve(nodeModulesPath, 'rxjs'));
+    }
+    write('tsconfig-base.json', `{
+      "compilerOptions": {
+        "experimentalDecorators": true,
+        "skipLibCheck": true,
+        "noImplicitAny": true,
+        "types": [],
+        "outDir": "built",
+        "rootDir": ".",
+        "baseUrl": ".",
+        "declaration": true,
+        "target": "es5",
+        "module": "es2015",
+        "moduleResolution": "node",
+        "lib": ["es6", "dom"],
+        "typeRoots": ["node_modules/@types"]
+      },
+      "angularCompilerOptions": {
+        "enableIvy": "ngtsc"
+      }
+    }`);
+  });
+
+  it('should compile without errors', () => {
+    writeConfig();
+    write('test.ts', 'export const A = 1;');
+
+    const exitCode = main(['-p', basePath], errorSpy);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(exitCode).toBe(0);
+
+    const contents = getContents('test.js');
+    expect(contents).toContain('A = 1');
+    shouldExist('testc.d.ts');
+  });
+});

--- a/packages/compiler/src/aot/compiler_options.ts
+++ b/packages/compiler/src/aot/compiler_options.ts
@@ -18,5 +18,5 @@ export interface AotCompilerOptions {
   fullTemplateTypeCheck?: boolean;
   allowEmptyCodegenFiles?: boolean;
   strictInjectionParameters?: boolean;
-  enableIvy?: boolean;
+  enableIvy?: boolean|'ngtsc';
 }


### PR DESCRIPTION
This commit adds a new compiler pipeline that isn't dependent on global
analysis, referred to as 'ngtsc'. This new compiler is accessed by
running ngc with "enableIvy" set to "ngtsc". It reuses the same initialization
logic but creates a new implementation of Program which does not perform the
global-level analysis that AngularCompilerProgram does. It will be the
foundation for the production Ivy compiler.
