### PR TITLE
fix(compiler-cli): shorten resolved module name in fileNameToModuleName to npm package name for typings

### DIFF
--- a/integration/bazel/BUILD.bazel
+++ b/integration/bazel/BUILD.bazel
@@ -4,9 +4,12 @@ filegroup(
     name = "node_modules",
     srcs = glob(
         ["node_modules/**/*"],
-        # Exclude directories that commonly contain filenames which are
-        # illegal bazel labels
         exclude = [
+            # Exclude rxjs because we build it from sources using the label @rxjs//:rxjs
+            "node_modules/rxjs/**",
+
+            # Exclude directories that commonly contain filenames which are
+            # illegal bazel labels
             # e.g. node_modules/adm-zip/test/assets/attributes_test/New folder/hidden.txt
             "node_modules/**/test/**",
             # e.g. node_modules/xpath/docs/function resolvers.md

--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -57,6 +57,7 @@ function assert<T>(condition: T | null | undefined) {
 export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHost, AotCompilerHost,
     TypeCheckHost {
   private metadataReaderCache = createMetadataReaderCache();
+  private fileNameToModuleNameCache = new Map<string, string>();
   private flatModuleIndexCache = new Map<string, boolean>();
   private flatModuleIndexNames = new Set<string>();
   private flatModuleIndexRedirectNames = new Set<string>();
@@ -187,6 +188,12 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
    *    import project sources.
    */
   fileNameToModuleName(importedFile: string, containingFile: string): string {
+    const cacheKey = `${importedFile}:${containingFile}`;
+    let moduleName = this.fileNameToModuleNameCache.get(cacheKey);
+    if (moduleName != null) {
+      return moduleName;
+    }
+
     const originalImportedFile = importedFile;
     if (this.options.traceResolution) {
       console.error(
@@ -196,11 +203,10 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
 
     // drop extension
     importedFile = importedFile.replace(EXT, '');
-    const importedFilePackagName = getPackageName(importedFile);
+    const importedFilePackageName = getPackageName(importedFile);
     const containingFilePackageName = getPackageName(containingFile);
 
-    let moduleName: string;
-    if (importedFilePackagName === containingFilePackageName ||
+    if (importedFilePackageName === containingFilePackageName ||
         GENERATED_FILES.test(originalImportedFile)) {
       const rootedContainingFile = relativeToRootDirs(containingFile, this.rootDirs);
       const rootedImportedFile = relativeToRootDirs(importedFile, this.rootDirs);
@@ -211,12 +217,31 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
         importedFile = rootedImportedFile;
       }
       moduleName = dotRelative(path.dirname(containingFile), importedFile);
-    } else if (importedFilePackagName) {
+    } else if (importedFilePackageName) {
       moduleName = stripNodeModulesPrefix(importedFile);
+      if (originalImportedFile.endsWith('.d.ts')) {
+        // the moduleName for these typings could be shortented to the npm package name
+        // if the npm package typings matches the importedFile
+        try {
+          const modulePath = importedFile.substring(0, importedFile.length - moduleName.length) +
+              importedFilePackageName;
+          const packageJson = require(modulePath + '/package.json');
+          const packageTypings = path.posix.join(modulePath, packageJson.typings);
+          if (packageTypings === originalImportedFile) {
+            moduleName = importedFilePackageName;
+          }
+        } catch (e) {
+          // the above require() will throw if there is no package.json file
+          // and this is safe to ignore and correct to keep the longer
+          // moduleName in this case
+        }
+      }
     } else {
       throw new Error(
           `Trying to import a source file from a node_modules package: import ${originalImportedFile} from ${containingFile}`);
     }
+
+    this.fileNameToModuleNameCache.set(cacheKey, moduleName);
     return moduleName;
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently fileNameToModuleName resolves typings files to module names as such: `.../node_modules/@angular/core/core.d.ts` => `@angular/core/core`, `.../node_modules/rxjs/index.d.ts` => `rxjs/index`.

Issue Number: N/A


## What is the new behavior?
If the typings in the npm package matches the imported file then the module name is resolved to the npm package name as such: `.../node_modules/@angular/core/core.d.ts` => `@angular/core`, `.../node_modules/rxjs/index.d.ts` => `rxjs`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
