### PR TITLE
docs: lock version of in-memory API

### DIFF
--- a/aio/content/tutorial/toh-pt6.md
+++ b/aio/content/tutorial/toh-pt6.md
@@ -43,10 +43,12 @@ If you're _coding along_ with this tutorial, stay here and add the *In-memory We
 
 </div>
 
-Install the *In-memory Web API* package from _npm_
+Install the *In-memory Web API* package from _npm_.
+
+**Note:** This package's version is locked to `v0.5` to maintain compatibility with the current release of `@angular/cli`.
 
 <code-example language="sh" class="code-shell">
-  npm install angular-in-memory-web-api --save
+  npm install angular-in-memory-web-api@0.5 --save
 </code-example>
 
 Import the `InMemoryWebApiModule` and the `InMemoryDataService` class, 


### PR DESCRIPTION
The in-memory API has been updated for v6 but the Angular CLI has not.

Closes angular/in-memory-web-api#189

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The tutorial currently fails because the in-memory web API has been updated for v6 while the Angular CLI has not yet been updated.

Issue Number: angular/in-memory-web-api#189


## What is the new behavior?

The new behavior matches the tutorial's documented expectations.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

It's possible that this minor change may not be necessary if the rest of Angular updates to v6 soon enough, but until then, new folks like me will get tripped up by this section of the tutorial.

Fixes #22977.
Fixes #23205.