### PR TITLE
remove redundant override of robots meta

### DIFF
--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.ts
@@ -155,10 +155,8 @@ export class DocViewerComponent implements OnDestroy {
    */
   private setNoIndex(val: boolean) {
     if (val) {
-      this.metaService.addTag({ name: 'googlebot', content: 'noindex' });
       this.metaService.addTag({ name: 'robots', content: 'noindex' });
     } else {
-      this.metaService.removeTag('name="googlebot"');
       this.metaService.removeTag('name="robots"');
     }
   }

--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -33,8 +33,6 @@
 
   <script>
     // Dynamically, pre-emptively, add `noindex`, which will be removed when the doc is ready and valid
-    var tag = document.createElement('meta'); tag.name = 'googlebot'; tag.content = 'noindex';
-    document.head.appendChild(tag);
     tag = document.createElement('meta'); tag.name = 'robots'; tag.content = 'noindex';
     document.head.appendChild(tag);
   </script>


### PR DESCRIPTION
according to https://developers.google.com/search/reference/robots_meta_tag
googlebot is only used as a google specific override of 'robots'- there's no need for override in this case

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[X] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
