### PR TITLE
Typo fix, ContentChildred => ContentChildren

### DIFF
--- a/packages/core/src/render3/STATUS.md
+++ b/packages/core/src/render3/STATUS.md
@@ -175,7 +175,7 @@ The goal is for the `@Component` (and friends) to be the compiler of template. S
 | `@Query(read)`                  |  ✅     |  ✅      |  n/a      |
 | `@Query(selector)`              |  ✅     |  ✅      |  n/a      |
 | `@Query(Type)`                  |  ✅     |  ✅      |  n/a      |
-| `@ContentChildred`              |  ✅     |  ✅      |  ❌       |
+| `@ContentChildren`              |  ✅     |  ✅      |  ❌       |
 | `@ContentChild`                 |  ✅     |  ✅      |  ✅       |
 | `@ViewChildren`                 |  ✅     |  ✅      |  ❌       |
 | `@ViewChild`                    |  ✅     |  ✅      |  ✅       |


### PR DESCRIPTION
This PR corrected typo on ngIvy Status page.

## PR Type
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```