### PR TITLE
fix(common): make `HttpParameterCodec` injectable

### DIFF
--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -57,6 +57,9 @@ export type HttpObserve = 'body' | 'events' | 'response';
 export class HttpClient {
   constructor(
     private handler: HttpHandler,
+    /**
+     * You can also provide custom `HttpParameterCodec`.
+     */
     @Optional() private httpParameterCodec?: HttpParameterCodec,
   ) {}
 

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -12,9 +12,10 @@ import {concatMap, filter, map} from 'rxjs/operators';
 
 import {HttpHandler} from './backend';
 import {HttpHeaders} from './headers';
-import {HttpParams, HttpParamsOptions, HttpParameterCodec} from './params';
+import {HttpParameterCodec, HttpParams, HttpParamsOptions} from './params';
 import {HttpRequest} from './request';
 import {HttpEvent, HttpResponse} from './response';
+
 
 
 /**
@@ -56,12 +57,11 @@ export type HttpObserve = 'body' | 'events' | 'response';
 @Injectable()
 export class HttpClient {
   constructor(
-    private handler: HttpHandler,
-    /**
-     * You can also provide custom `HttpParameterCodec`.
-     */
-    @Optional() private httpParameterCodec?: HttpParameterCodec,
-  ) {}
+      private handler: HttpHandler,
+      /**
+       * You can also provide custom `HttpParameterCodec`.
+       */
+      @Optional() private httpParameterCodec?: HttpParameterCodec, ) {}
 
   /**
    * Send the given `HttpRequest` and return a stream of `HttpEvents`.
@@ -365,8 +365,7 @@ export class HttpClient {
           params = options.params;
         } else {
           params = new HttpParams({
-            fromObject: options.params,
-            encoder: this.httpParameterCodec,
+            fromObject: options.params, encoder: this.httpParameterCodec,
           } as HttpParamsOptions);
         }
       }

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable} from '@angular/core';
+import {Injectable, Optional} from '@angular/core';
 import {Observable, of } from 'rxjs';
 import {concatMap, filter, map} from 'rxjs/operators';
 
 import {HttpHandler} from './backend';
 import {HttpHeaders} from './headers';
-import {HttpParams, HttpParamsOptions} from './params';
+import {HttpParams, HttpParamsOptions, HttpParameterCodec} from './params';
 import {HttpRequest} from './request';
 import {HttpEvent, HttpResponse} from './response';
 
@@ -55,7 +55,10 @@ export type HttpObserve = 'body' | 'events' | 'response';
  */
 @Injectable()
 export class HttpClient {
-  constructor(private handler: HttpHandler) {}
+  constructor(
+    private handler: HttpHandler,
+    @Optional() private httpParameterCodec?: HttpParameterCodec,
+  ) {}
 
   /**
    * Send the given `HttpRequest` and return a stream of `HttpEvents`.
@@ -358,7 +361,10 @@ export class HttpClient {
         if (options.params instanceof HttpParams) {
           params = options.params;
         } else {
-          params = new HttpParams({ fromObject: options.params } as HttpParamsOptions);
+          params = new HttpParams({
+            fromObject: options.params,
+            encoder: this.httpParameterCodec,
+          } as HttpParamsOptions);
         }
       }
 

--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -13,12 +13,12 @@
  *
  *
  **/
-export interface HttpParameterCodec {
-  encodeKey(key: string): string;
-  encodeValue(value: string): string;
+export abstract class HttpParameterCodec {
+  abstract encodeKey(key: string): string;
+  abstract encodeValue(value: string): string;
 
-  decodeKey(key: string): string;
-  decodeValue(value: string): string;
+  abstract decodeKey(key: string): string;
+  abstract decodeValue(value: string): string;
 }
 
 /**
@@ -27,7 +27,7 @@ export interface HttpParameterCodec {
  *
  *
  */
-export class HttpUrlEncodingCodec implements HttpParameterCodec {
+export class HttpUrlEncodingCodec extends HttpParameterCodec {
   encodeKey(k: string): string { return standardEncoding(k); }
 
   encodeValue(v: string): string { return standardEncoding(v); }

--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -12,6 +12,7 @@ import {toArray} from 'rxjs/operators';
 import {HttpClient} from '../src/client';
 import {HttpErrorResponse, HttpEventType, HttpResponse} from '../src/response';
 import {HttpClientTestingBackend} from '../testing/src/backend';
+import {HttpParameterCodec} from '../src/params';
 
 {
   describe('HttpClient', () => {
@@ -160,6 +161,27 @@ import {HttpClientTestingBackend} from '../testing/src/backend';
         });
         backend.expectOne('/test').flush(
             {'data': 'hello world'}, {status: 500, statusText: 'Server error'});
+      });
+    });
+    describe('should change default http parameter encoder', () => {
+      class TestHttpParameterEncoder extends HttpParameterCodec {
+        encodeKey(key: string): string { return key + 'a'; }
+        encodeValue(value: string): string { return value + 'b'; }
+        decodeKey(key: string): string { return key + 'a'; }
+        decodeValue(value: string): string { return value + 'b'; }
+      }
+
+      beforeEach(() => {
+        client = new HttpClient(backend, new TestHttpParameterEncoder());
+      });
+      afterEach(() => { backend.verify(); });
+
+      it('should test', (done: DoneFn) => {
+        client.get('/test', {observe: 'response', params: {a: 'b'}}).subscribe(res => {
+          expect(res.ok).toBeTruthy();
+          done();
+        });
+        backend.expectOne('/test?aa=bb').flush('hello world');
       });
     });
   });

--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -10,9 +10,9 @@ import {ddescribe, describe, iit, it} from '@angular/core/testing/src/testing_in
 import {toArray} from 'rxjs/operators';
 
 import {HttpClient} from '../src/client';
+import {HttpParameterCodec} from '../src/params';
 import {HttpErrorResponse, HttpEventType, HttpResponse} from '../src/response';
 import {HttpClientTestingBackend} from '../testing/src/backend';
-import {HttpParameterCodec} from '../src/params';
 
 {
   describe('HttpClient', () => {
@@ -171,9 +171,7 @@ import {HttpParameterCodec} from '../src/params';
         decodeValue(value: string): string { return value + 'b'; }
       }
 
-      beforeEach(() => {
-        client = new HttpClient(backend, new TestHttpParameterEncoder());
-      });
+      beforeEach(() => { client = new HttpClient(backend, new TestHttpParameterEncoder()); });
       afterEach(() => { backend.verify(); });
 
       it('should test', (done: DoneFn) => {

--- a/packages/common/http/test/module_spec.ts
+++ b/packages/common/http/test/module_spec.ts
@@ -14,12 +14,12 @@ import {map} from 'rxjs/operators';
 import {HttpHandler} from '../src/backend';
 import {HttpClient} from '../src/client';
 import {HTTP_INTERCEPTORS, HttpInterceptor} from '../src/interceptor';
+import {HttpParameterCodec} from '../src/params';
 import {HttpRequest} from '../src/request';
 import {HttpEvent, HttpResponse} from '../src/response';
 import {HttpTestingController} from '../testing/src/api';
 import {HttpClientTestingModule} from '../testing/src/module';
 import {TestRequest} from '../testing/src/request';
-import {HttpParameterCodec} from '../src/params';
 
 class TestInterceptor implements HttpInterceptor {
   constructor(private value: string) {}
@@ -116,9 +116,7 @@ class ReentrantInterceptor implements HttpInterceptor {
       TestBed.resetTestingModule();
       injector = TestBed.configureTestingModule({
         imports: [HttpClientTestingModule],
-        providers: [
-          {provide: HttpParameterCodec, useClass: TestHttpParameterEncoder}
-        ]
+        providers: [{provide: HttpParameterCodec, useClass: TestHttpParameterEncoder}]
       });
 
       expect(injector.get(HttpParameterCodec).encodeKey('a')).toBe('aa');


### PR DESCRIPTION
You can inject custom `HttpParameterCodec` for avoid to not use default encoder.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
User can't avoid receive request error related with default http parameter encoder uses.

for example some API server can't accept character `+` but standard encoder make that.

https://github.com/angular/angular/blob/5298b2bda34a8766b28c8425e447f94598b23901/packages/common/http/src/params.ts#L64

Issue Number: #19710, #23157


## What is the new behavior?

User can provide custom http parameter codec.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
