### PR TITLE
fix(ivy): support separate creation mode and update mode execution

### DIFF
--- a/modules/benchmarks/src/largetable/render3/table.ts
+++ b/modules/benchmarks/src/largetable/render3/table.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵC as C, ɵE as E, ɵT as T, ɵV as V, ɵb as b, ɵcR as cR, ɵcr as cr, ɵdefineComponent as defineComponent, ɵdetectChanges as detectChanges, ɵe as e, ɵsn as sn, ɵt as t, ɵv as v} from '@angular/core';
+import {ɵC as C, ɵE as E, ɵRenderFlags as RenderFlags, ɵT as T, ɵV as V, ɵb as b, ɵcR as cR, ɵcr as cr, ɵdefineComponent as defineComponent, ɵdetectChanges as detectChanges, ɵe as e, ɵsn as sn, ɵt as t, ɵv as v} from '@angular/core';
 import {ComponentDef} from '@angular/core/src/render3/interfaces/definition';
 
 import {TableCell, buildTable, emptyTable} from '../util';
@@ -18,8 +18,8 @@ export class LargeTableComponent {
   static ngComponentDef: ComponentDef<LargeTableComponent> = defineComponent({
     type: LargeTableComponent,
     selectors: [['largetable']],
-    template: function(ctx: LargeTableComponent, cm: boolean) {
-      if (cm) {
+    template: function(rf: RenderFlags, ctx: LargeTableComponent) {
+      if (rf & RenderFlags.Create) {
         E(0, 'table');
         {
           E(1, 'tbody');
@@ -28,38 +28,44 @@ export class LargeTableComponent {
         }
         e();
       }
-      cR(2);
-      {
-        for (let row of ctx.data) {
-          let cm1 = V(1);
-          {
-            if (cm1) {
-              E(0, 'tr');
-              C(1);
-              e();
-            }
-            cR(1);
+      if (rf & RenderFlags.Update) {
+        cR(2);
+        {
+          for (let row of ctx.data) {
+            let rf1 = V(1);
             {
-              for (let cell of row) {
-                let cm2 = V(2);
+              if (rf1 & RenderFlags.Create) {
+                E(0, 'tr');
+                C(1);
+                e();
+              }
+              if (rf1 & RenderFlags.Update) {
+                cR(1);
                 {
-                  if (cm2) {
-                    E(0, 'td');
-                    { T(1); }
-                    e();
+                  for (let cell of row) {
+                    let rf2 = V(2);
+                    {
+                      if (rf2 & RenderFlags.Create) {
+                        E(0, 'td');
+                        { T(1); }
+                        e();
+                      }
+                      if (rf2 & RenderFlags.Update) {
+                        sn(0, 'background-color', b(cell.row % 2 ? '' : 'grey'));
+                        t(1, b(cell.value));
+                      }
+                    }
+                    v();
                   }
-                  sn(0, 'background-color', b(cell.row % 2 ? '' : 'grey'));
-                  t(1, b(cell.value));
                 }
-                v();
+                cr();
               }
             }
-            cr();
+            v();
           }
-          v();
         }
+        cr();
       }
-      cr();
     },
     factory: () => new LargeTableComponent(),
     inputs: {data: 'data'}

--- a/modules/benchmarks/src/tree/render3/tree.ts
+++ b/modules/benchmarks/src/tree/render3/tree.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵC as C, ɵE as E, ɵT as T, ɵV as V, ɵb as b, ɵcR as cR, ɵcr as cr, ɵdefineComponent as defineComponent, ɵdetectChanges as _detectChanges, ɵe as e, ɵi1 as i1, ɵp as p, ɵsn as sn, ɵt as t, ɵv as v} from '@angular/core';
+import {ɵC as C, ɵE as E, ɵRenderFlags as RenderFlags, ɵT as T, ɵV as V, ɵb as b, ɵcR as cR, ɵcr as cr, ɵdefineComponent as defineComponent, ɵdetectChanges as _detectChanges, ɵe as e, ɵi1 as i1, ɵp as p, ɵsn as sn, ɵt as t, ɵv as v} from '@angular/core';
 import {ComponentDef} from '@angular/core/src/render3/interfaces/definition';
 
 import {TreeNode, buildTree, emptyTree} from '../util';
@@ -38,46 +38,52 @@ export class TreeComponent {
   static ngComponentDef: ComponentDef<TreeComponent> = defineComponent({
     type: TreeComponent,
     selectors: [['tree']],
-    template: function(ctx: TreeComponent, cm: boolean) {
-      if (cm) {
+    template: function(rf: RenderFlags, ctx: TreeComponent) {
+      if (rf & RenderFlags.Create) {
         E(0, 'span');
         { T(1); }
         e();
         C(2);
         C(3);
       }
-      sn(0, 'background-color', b(ctx.data.depth % 2 ? '' : 'grey'));
-      t(1, i1(' ', ctx.data.value, ' '));
-      cR(2);
-      {
-        if (ctx.data.left != null) {
-          let cm0 = V(0);
-          {
-            if (cm0) {
-              E(0, 'tree');
-              e();
+      if (rf & RenderFlags.Update) {
+        sn(0, 'background-color', b(ctx.data.depth % 2 ? '' : 'grey'));
+        t(1, i1(' ', ctx.data.value, ' '));
+        cR(2);
+        {
+          if (ctx.data.left != null) {
+            let rf0 = V(0);
+            {
+              if (rf0 & RenderFlags.Create) {
+                E(0, 'tree');
+                e();
+              }
+              if (rf0 & RenderFlags.Update) {
+                p(0, 'data', b(ctx.data.left));
+              }
             }
-            p(0, 'data', b(ctx.data.left));
+            v();
           }
-          v();
         }
-      }
-      cr();
-      cR(3);
-      {
-        if (ctx.data.right != null) {
-          let cm0 = V(0);
-          {
-            if (cm0) {
-              E(0, 'tree');
-              e();
+        cr();
+        cR(3);
+        {
+          if (ctx.data.right != null) {
+            let rf0 = V(0);
+            {
+              if (rf0 & RenderFlags.Create) {
+                E(0, 'tree');
+                e();
+              }
+              if (rf0 & RenderFlags.Update) {
+                p(0, 'data', b(ctx.data.right));
+              }
             }
-            p(0, 'data', b(ctx.data.right));
+            v();
           }
-          v();
         }
+        cr();
       }
-      cr();
     },
     factory: () => new TreeComponent,
     inputs: {data: 'data'},
@@ -92,17 +98,17 @@ export class TreeFunction {
   static ngComponentDef: ComponentDef<TreeFunction> = defineComponent({
     type: TreeFunction,
     selectors: [['tree']],
-    template: function(ctx: TreeFunction, cm: boolean) {
+    template: function(rf: RenderFlags, ctx: TreeFunction) {
       // bit of a hack
-      TreeTpl(ctx.data, cm);
+      TreeTpl(rf, ctx.data);
     },
     factory: () => new TreeFunction,
     inputs: {data: 'data'}
   });
 }
 
-export function TreeTpl(ctx: TreeNode, cm: boolean) {
-  if (cm) {
+export function TreeTpl(rf: RenderFlags, ctx: TreeNode) {
+  if (rf & RenderFlags.Create) {
     E(0, 'tree');
     {
       E(1, 'span');
@@ -113,24 +119,26 @@ export function TreeTpl(ctx: TreeNode, cm: boolean) {
     }
     e();
   }
-  sn(1, 'background-color', b(ctx.depth % 2 ? '' : 'grey'));
-  t(2, i1(' ', ctx.value, ' '));
-  cR(3);
-  {
-    if (ctx.left != null) {
-      let cm0 = V(0);
-      { TreeTpl(ctx.left, cm0); }
-      v();
+  if (rf & RenderFlags.Update) {
+    sn(1, 'background-color', b(ctx.depth % 2 ? '' : 'grey'));
+    t(2, i1(' ', ctx.value, ' '));
+    cR(3);
+    {
+      if (ctx.left != null) {
+        let rf0 = V(0);
+        { TreeTpl(rf0, ctx.left); }
+        v();
+      }
     }
-  }
-  cr();
-  cR(4);
-  {
-    if (ctx.right != null) {
-      let cm0 = V(0);
-      { TreeTpl(ctx.right, cm0); }
-      v();
+    cr();
+    cR(4);
+    {
+      if (ctx.right != null) {
+        let rf0 = V(0);
+        { TreeTpl(rf0, ctx.right); }
+        v();
+      }
     }
+    cr();
   }
-  cr();
 }

--- a/packages/compiler-cli/src/transformers/node_emitter.ts
+++ b/packages/compiler-cli/src/transformers/node_emitter.ts
@@ -566,11 +566,15 @@ class _NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
                   /* type */ undefined, this._visitStatements(expr.statements)));
   }
 
-  visitBinaryOperatorExpr(expr: BinaryOperatorExpr): RecordedNode<ts.ParenthesizedExpression> {
+  visitBinaryOperatorExpr(expr: BinaryOperatorExpr):
+      RecordedNode<ts.BinaryExpression|ts.ParenthesizedExpression> {
     let binaryOperator: ts.BinaryOperator;
     switch (expr.operator) {
       case BinaryOperator.And:
         binaryOperator = ts.SyntaxKind.AmpersandAmpersandToken;
+        break;
+      case BinaryOperator.BitwiseAnd:
+        binaryOperator = ts.SyntaxKind.AmpersandToken;
         break;
       case BinaryOperator.Bigger:
         binaryOperator = ts.SyntaxKind.GreaterThanToken;
@@ -617,10 +621,9 @@ class _NodeEmitterVisitor implements StatementVisitor, ExpressionVisitor {
       default:
         throw new Error(`Unknown operator: ${expr.operator}`);
     }
-    return this.record(
-        expr, ts.createParen(ts.createBinary(
-                  expr.lhs.visitExpression(this, null), binaryOperator,
-                  expr.rhs.visitExpression(this, null))));
+    const binary = ts.createBinary(
+        expr.lhs.visitExpression(this, null), binaryOperator, expr.rhs.visitExpression(this, null));
+    return this.record(expr, expr.parens ? ts.createParen(binary) : binary);
   }
 
   visitReadPropExpr(expr: ReadPropExpr): RecordedNode<ts.PropertyAccessExpression> {

--- a/packages/compiler/design/architecture.md
+++ b/packages/compiler/design/architecture.md
@@ -85,13 +85,15 @@ GreetComponent.ngComponentDef = i0.ɵdefineComponent({
     type: GreetComponent,
     tag: 'greet',
     factory: () => new GreetComponent(),
-    template: function (ctx, cm) {
-        if (cm) {
+    template: function (rf, ctx) {
+        if (rf & RenderFlags.Create) {
             i0.ɵE(0, 'div');
             i0.ɵT(1);
             i0.ɵe();
         }
-        i0.ɵt(1, i0.ɵi1('Hello ', ctx.name, '!'));
+        if (rf & RenderFlags.Update) {
+            i0.ɵt(1, i0.ɵi1('Hello ', ctx.name, '!'));
+        }
     }
 });
 ```

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -396,6 +396,9 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
       case o.BinaryOperator.And:
         opStr = '&&';
         break;
+      case o.BinaryOperator.BitwiseAnd:
+        opStr = '&';
+        break;
       case o.BinaryOperator.Or:
         opStr = '||';
         break;
@@ -429,11 +432,11 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
       default:
         throw new Error(`Unknown operator ${ast.operator}`);
     }
-    ctx.print(ast, `(`);
+    if (ast.parens) ctx.print(ast, `(`);
     ast.lhs.visitExpression(this, ctx);
     ctx.print(ast, ` ${opStr} `);
     ast.rhs.visitExpression(this, ctx);
-    ctx.print(ast, `)`);
+    if (ast.parens) ctx.print(ast, `)`);
     return null;
   }
 

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -99,6 +99,7 @@ export enum BinaryOperator {
   Modulo,
   And,
   Or,
+  BitwiseAnd,
   Lower,
   LowerEquals,
   Bigger,
@@ -206,6 +207,10 @@ export abstract class Expression {
   }
   and(rhs: Expression, sourceSpan?: ParseSourceSpan|null): BinaryOperatorExpr {
     return new BinaryOperatorExpr(BinaryOperator.And, this, rhs, null, sourceSpan);
+  }
+  bitwiseAnd(rhs: Expression, sourceSpan?: ParseSourceSpan|null, parens: boolean = true):
+      BinaryOperatorExpr {
+    return new BinaryOperatorExpr(BinaryOperator.BitwiseAnd, this, rhs, null, sourceSpan, parens);
   }
   or(rhs: Expression, sourceSpan?: ParseSourceSpan|null): BinaryOperatorExpr {
     return new BinaryOperatorExpr(BinaryOperator.Or, this, rhs, null, sourceSpan);
@@ -569,7 +574,7 @@ export class BinaryOperatorExpr extends Expression {
   public lhs: Expression;
   constructor(
       public operator: BinaryOperator, lhs: Expression, public rhs: Expression, type?: Type|null,
-      sourceSpan?: ParseSourceSpan|null) {
+      sourceSpan?: ParseSourceSpan|null, public parens: boolean = true) {
     super(type || lhs.type, sourceSpan);
     this.lhs = lhs;
   }

--- a/packages/compiler/test/render3/r3_compiler_compliance_spec.ts
+++ b/packages/compiler/test/render3/r3_compiler_compliance_spec.ts
@@ -13,6 +13,7 @@ import {compile, expectEmit} from './mock_compile';
   * test in compiler_canonical_spec.ts should have a corresponding test here.
   */
 describe('compiler compliance', () => {
+
   const angularFiles = setup({
     compileAngular: true,
     compileAnimations: false,
@@ -45,8 +46,8 @@ describe('compiler compliance', () => {
       const template = `
         const $c1$ = ['class', 'my-app', 'title', 'Hello'];
         …
-        template: function MyComponent_Template(ctx: IDENT, cm: IDENT) {
-          if (cm) {
+        template: function MyComponent_Template(rf: IDENT, ctx: IDENT) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'div', $c1$);
             $r3$.ɵT(1, 'Hello ');
             $r3$.ɵE(2, 'b');
@@ -94,8 +95,8 @@ describe('compiler compliance', () => {
           type: ChildComponent,
           selectors: [['child']],
           factory: function ChildComponent_Factory() { return new ChildComponent(); },
-          template: function ChildComponent_Template(ctx: IDENT, cm: IDENT) {
-            if (cm) {
+          template: function ChildComponent_Template(rf: IDENT, ctx: IDENT) {
+            if (rf & 1) {
               $r3$.ɵT(0, 'child-view');
             }
           }
@@ -118,8 +119,8 @@ describe('compiler compliance', () => {
           type: MyComponent,
           selectors: [['my-component']],
           factory: function MyComponent_Factory() { return new MyComponent(); },
-          template: function MyComponent_Template(ctx: IDENT, cm: IDENT) {
-            if (cm) {
+          template: function MyComponent_Template(rf: IDENT, ctx: IDENT) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'child', $c1$);
               $r3$.ɵe();
               $r3$.ɵT(1, '!');
@@ -255,21 +256,22 @@ describe('compiler compliance', () => {
           type: MyComponent,
           selectors: [['my-component']],
           factory: function MyComponent_Factory() { return new MyComponent(); },
-          template: function MyComponent_Template(ctx: IDENT, cm: IDENT) {
-            if (cm) {
+          template: function MyComponent_Template(rf: IDENT, ctx: IDENT) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'ul', null, $c1$);
               $r3$.ɵC(2, MyComponent_IfDirective_Template_2, null, $c2$);
               $r3$.ɵe();
             }
             const $foo$ = $r3$.ɵld(1);
-
-            function MyComponent_IfDirective_Template_2(ctx0: IDENT, cm: IDENT) {
-              if (cm) {
+            function MyComponent_IfDirective_Template_2(rf: IDENT, ctx0: IDENT) {
+              if (rf & 1) {
                 $r3$.ɵE(0, 'li');
                 $r3$.ɵT(1);
                 $r3$.ɵe();
               }
-              $r3$.ɵt(1, $r3$.ɵi2('', ctx.salutation, ' ', $foo$, ''));
+              if (rf & 2) {
+                $r3$.ɵt(1, $r3$.ɵi2('', ctx.salutation, ' ', $foo$, ''));
+              }
             }
           },
           directives: [IfDirective]
@@ -324,12 +326,14 @@ describe('compiler compliance', () => {
             type: MyApp,
             selectors: [['my-app']],
             factory: function MyApp_Factory() { return new MyApp(); },
-            template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-              if (cm) {
+            template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+              if (rf & 1) {
                 $r3$.ɵE(0, 'my-comp');
                 $r3$.ɵe();
               }
-              $r3$.ɵp(0, 'names', $r3$.ɵb($r3$.ɵf1($e0_ff$, ctx.customName)));
+              if (rf & 2) {
+                $r3$.ɵp(0, 'names', $r3$.ɵb($r3$.ɵf1($e0_ff$, ctx.customName)));
+              }
             },
             directives: [MyComp]
           });
@@ -401,14 +405,16 @@ describe('compiler compliance', () => {
             type: MyApp,
             selectors: [['my-app']],
             factory: function MyApp_Factory() { return new MyApp(); },
-            template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-              if (cm) {
+            template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+              if (rf & 1) {
                 $r3$.ɵE(0, 'my-comp');
                 $r3$.ɵe();
               }
-              $r3$.ɵp(
-                  0, 'names',
-                  $r3$.ɵb($r3$.ɵfV($e0_ff$, ctx.n0, ctx.n1, ctx.n2, ctx.n3, ctx.n4, ctx.n5, ctx.n6, ctx.n7, ctx.n8)));
+              if (rf & 2) {
+                $r3$.ɵp(
+                    0, 'names',
+                    $r3$.ɵb($r3$.ɵfV($e0_ff$, ctx.n0, ctx.n1, ctx.n2, ctx.n3, ctx.n4, ctx.n5, ctx.n6, ctx.n7, ctx.n8)));
+              }
             },
             directives: [MyComp]
           });
@@ -460,12 +466,14 @@ describe('compiler compliance', () => {
             type: MyApp,
             selectors: [['my-app']],
             factory: function MyApp_Factory() { return new MyApp(); },
-            template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-              if (cm) {
+            template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+              if (rf & 1) {
                 $r3$.ɵE(0, 'object-comp');
                 $r3$.ɵe();
               }
-              $r3$.ɵp(0, 'config', $r3$.ɵb($r3$.ɵf1($e0_ff$, ctx.name)));
+              if (rf & 2) {
+                $r3$.ɵp(0, 'config', $r3$.ɵb($r3$.ɵf1($e0_ff$, ctx.name)));
+              }
             },
             directives: [ObjectComp]
           });
@@ -523,15 +531,17 @@ describe('compiler compliance', () => {
             type: MyApp,
             selectors: [['my-app']],
             factory: function MyApp_Factory() { return new MyApp(); },
-            template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-              if (cm) {
+            template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+              if (rf & 1) {
                 $r3$.ɵE(0, 'nested-comp');
                 $r3$.ɵe();
               }
-              $r3$.ɵp(
-                  0, 'config',
-                  $r3$.ɵb($r3$.ɵf2(
-                      $e0_ff_2$, ctx.name, $r3$.ɵf1($e0_ff_1$, $r3$.ɵf1($e0_ff$, ctx.duration)))));
+              if (rf & 2) {
+                $r3$.ɵp(
+                    0, 'config',
+                    $r3$.ɵb($r3$.ɵf2(
+                        $e0_ff_2$, ctx.name, $r3$.ɵf1($e0_ff_1$, $r3$.ɵf1($e0_ff$, ctx.duration)))));
+              }
             },
             directives: [NestedComp]
           });
@@ -579,8 +589,8 @@ describe('compiler compliance', () => {
           type: SimpleComponent,
           selectors: [['simple']],
           factory: function SimpleComponent_Factory() { return new SimpleComponent(); },
-          template: function SimpleComponent_Template(ctx: IDENT, cm: IDENT) {
-            if (cm) {
+          template: function SimpleComponent_Template(rf: IDENT, ctx: IDENT) {
+            if (rf & 1) {
               $r3$.ɵpD(0);
               $r3$.ɵE(1, 'div');
               $r3$.ɵP(2, 0);
@@ -598,8 +608,8 @@ describe('compiler compliance', () => {
           type: ComplexComponent,
           selectors: [['complex']],
           factory: function ComplexComponent_Factory() { return new ComplexComponent(); },
-          template: function ComplexComponent_Template(ctx: IDENT, cm: IDENT) {
-            if (cm) {
+          template: function ComplexComponent_Template(rf: IDENT, ctx: IDENT) {
+            if (rf & 1) {
               $r3$.ɵpD(0, $c1$);
               $r3$.ɵE(1, 'div', $c2$);
               $r3$.ɵP(2, 0, 1);
@@ -663,14 +673,16 @@ describe('compiler compliance', () => {
             type: ViewQueryComponent,
             selectors: [['view-query-component']],
             factory: function ViewQueryComponent_Factory() { return new ViewQueryComponent(); },
-            template: function ViewQueryComponent_Template(ctx: $ViewQueryComponent$, cm: $boolean$) {
+            template: function ViewQueryComponent_Template(rf: $RenderFlags$, ctx: $ViewQueryComponent$) {
               var $tmp$: $any$;
-              if (cm) {
+              if (rf & 1) {
                 $r3$.ɵQ(0, SomeDirective, true);
                 $r3$.ɵE(1, 'div', $e0_attrs$);
                 $r3$.ɵe();
               }
-              ($r3$.ɵqR(($tmp$ = $r3$.ɵld(0))) && (ctx.someDir = $tmp$.first));
+              if (rf & 2) {
+                ($r3$.ɵqR(($tmp$ = $r3$.ɵld(0))) && (ctx.someDir = $tmp$.first));
+              }
             },
             directives:[SomeDirective]
           });`;
@@ -728,8 +740,8 @@ describe('compiler compliance', () => {
               ($r3$.ɵqR(($tmp$ = $r3$.ɵld(dirIndex)[1])) && ($r3$.ɵld(dirIndex)[0].someDir = $tmp$.first));
             },
             template: function ContentQueryComponent_Template(
-                ctx: $ContentQueryComponent$, cm: $boolean$) {
-              if (cm) {
+                rf: $RenderFlags$, ctx: $ContentQueryComponent$) {
+              if (rf & 1) {
                 $r3$.ɵpD(0);
                 $r3$.ɵE(1, 'div');
                 $r3$.ɵP(2, 0);
@@ -805,8 +817,8 @@ describe('compiler compliance', () => {
               type: MyApp,
               selectors: [['my-app']],
               factory: function MyApp_Factory() { return new MyApp(); },
-              template: function MyApp_Template(ctx: IDENT, cm: IDENT) {
-                if (cm) {
+              template: function MyApp_Template(rf: IDENT, ctx: IDENT) {
+                if (rf & 1) {
                   $r3$.ɵT(0);
                   $r3$.ɵPp(1, 'myPurePipe');
                   $r3$.ɵPp(2, 'myPipe');
@@ -815,8 +827,10 @@ describe('compiler compliance', () => {
                   $r3$.ɵPp(5, 'myPurePipe');
                   $r3$.ɵe();
                 }
-                $r3$.ɵt(0, $r3$.ɵi1('', $r3$.ɵpb2(1, $r3$.ɵpb2(2,ctx.name, ctx.size), ctx.size), ''));
-                $r3$.ɵt(4, $r3$.ɵi1('', $r3$.ɵpb2(5, ctx.name, ctx.size), ''));
+                if (rf & 2) {
+                  $r3$.ɵt(0, $r3$.ɵi1('', $r3$.ɵpb2(1, $r3$.ɵpb2(2,ctx.name, ctx.size), ctx.size), ''));
+                  $r3$.ɵt(4, $r3$.ɵi1('', $r3$.ɵpb2(5, ctx.name, ctx.size), ''));
+                }
               },
               pipes: [MyPurePipe, MyPipe]
             });`;
@@ -852,14 +866,16 @@ describe('compiler compliance', () => {
           type: MyComponent,
           selectors: [['my-component']],
           factory: function MyComponent_Factory() { return new MyComponent(); },
-          template: function MyComponent_Template(ctx: IDENT, cm: IDENT) {
-            if (cm) {
+          template: function MyComponent_Template(rf: IDENT, ctx: IDENT) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'input', null, $c1$);
               $r3$.ɵe();
               $r3$.ɵT(2);
             }
             const $user$ = $r3$.ɵld(1);
-            $r3$.ɵt(2, $r3$.ɵi1('Hello ', $user$.value, '!'));
+            if (rf & 2) {
+              $r3$.ɵt(2, $r3$.ɵi1('Hello ', $user$.value, '!'));
+            }
           }
         });
       `;
@@ -920,7 +936,7 @@ describe('compiler compliance', () => {
             type: LifecycleComp,
             selectors: [['lifecycle-comp']],
             factory: function LifecycleComp_Factory() { return new LifecycleComp(); },
-            template: function LifecycleComp_Template(ctx: IDENT, cm: IDENT) {},
+            template: function LifecycleComp_Template(rf: IDENT, ctx: IDENT) {},
             inputs: {nameMin: 'name'},
             features: [$r3$.ɵNgOnChangesFeature(LifecycleComp)]
           });`;
@@ -930,15 +946,17 @@ describe('compiler compliance', () => {
             type: SimpleLayout,
             selectors: [['simple-layout']],
             factory: function SimpleLayout_Factory() { return new SimpleLayout(); },
-            template: function SimpleLayout_Template(ctx: IDENT, cm: IDENT) {
-              if (cm) {
+            template: function SimpleLayout_Template(rf: IDENT, ctx: IDENT) {
+              if (rf & 1) {
                 $r3$.ɵE(0, 'lifecycle-comp');
                 $r3$.ɵe();
                 $r3$.ɵE(1, 'lifecycle-comp');
                 $r3$.ɵe();
               }
-              $r3$.ɵp(0, 'name', $r3$.ɵb(ctx.name1));
-              $r3$.ɵp(1, 'name', $r3$.ɵb(ctx.name2));
+              if (rf & 2) {
+                $r3$.ɵp(0, 'name', $r3$.ɵb(ctx.name1));
+                $r3$.ɵp(1, 'name', $r3$.ɵb(ctx.name2));
+              }
             },
             directives: [LifecycleComp]
           });`;
@@ -1049,22 +1067,26 @@ describe('compiler compliance', () => {
             type: MyComponent,
             selectors: [['my-component']],
             factory: function MyComponent_Factory() { return new MyComponent(); },
-            template: function MyComponent_Template(ctx: IDENT, cm: IDENT) {
-              if (cm) {
+            template: function MyComponent_Template(rf: IDENT, ctx: IDENT) {
+              if (rf & 1) {
                 $r3$.ɵE(0, 'ul');
                 $r3$.ɵC(1, MyComponent_ForOfDirective_Template_1, null, $_c0$);
                 $r3$.ɵe();
               }
-              $r3$.ɵp(1, 'forOf', $r3$.ɵb(ctx.items));
+              if (rf & 2) {
+                $r3$.ɵp(1, 'forOf', $r3$.ɵb(ctx.items));
+              }
 
-              function MyComponent_ForOfDirective_Template_1(ctx0: IDENT, cm: IDENT) {
-                if (cm) {
+              function MyComponent_ForOfDirective_Template_1(rf: IDENT, ctx0: IDENT) {
+                if (rf & 1) {
                   $r3$.ɵE(0, 'li');
                   $r3$.ɵT(1);
                   $r3$.ɵe();
                 }
-                const $item$ = ctx0.$implicit;
-                $r3$.ɵt(1, $r3$.ɵi1('', $item$.name, ''));
+                if (rf & 2) {
+                  const $item$ = ctx0.$implicit;
+                  $r3$.ɵt(1, $r3$.ɵi1('', $item$.name, ''));
+                }
               }
             },
             directives: [ForOfDirective]
@@ -1123,16 +1145,18 @@ describe('compiler compliance', () => {
             type: MyComponent,
             selectors: [['my-component']],
             factory: function MyComponent_Factory() { return new MyComponent(); },
-            template: function MyComponent_Template(ctx: IDENT, cm: IDENT) {
-              if (cm) {
+            template: function MyComponent_Template(rf: IDENT, ctx: IDENT) {
+              if (rf & 1) {
                 $r3$.ɵE(0, 'ul');
                 $r3$.ɵC(1, MyComponent_ForOfDirective_Template_1, null, $c1$);
                 $r3$.ɵe();
               }
-              $r3$.ɵp(1, 'forOf', $r3$.ɵb(ctx.items));
+              if (rf & 2) {
+                $r3$.ɵp(1, 'forOf', $r3$.ɵb(ctx.items));
+              }
 
-              function MyComponent_ForOfDirective_Template_1(ctx0: IDENT, cm: IDENT) {
-                if (cm) {
+              function MyComponent_ForOfDirective_Template_1(rf: IDENT, ctx0: IDENT) {
+                if (rf & 1) {
                   $r3$.ɵE(0, 'li');
                   $r3$.ɵE(1, 'div');
                   $r3$.ɵT(2);
@@ -1142,20 +1166,24 @@ describe('compiler compliance', () => {
                   $r3$.ɵe();
                   $r3$.ɵe();
                 }
-                const $item$ = ctx0.$implicit;
-                $r3$.ɵp(4, 'forOf', $r3$.ɵb(IDENT.infos));
-                $r3$.ɵt(2, $r3$.ɵi1('', IDENT.name, ''));
+                if (rf & 2) {
+                  const $item$ = ctx0.$implicit;
+                  $r3$.ɵt(2, $r3$.ɵi1('', IDENT.name, ''));
+                  $r3$.ɵp(4, 'forOf', $r3$.ɵb(IDENT.infos));
+                }
 
                 function MyComponent_ForOfDirective_ForOfDirective_Template_4(
-                    ctx1: IDENT, cm: IDENT) {
-                  if (cm) {
+                    rf: IDENT, ctx1: IDENT) {
+                  if (rf & 1) {
                     $r3$.ɵE(0, 'li');
                     $r3$.ɵT(1);
                     $r3$.ɵe();
                   }
-                  const $item$ = ctx0.$implicit;
-                  const $info$ = ctx1.$implicit;
-                  $r3$.ɵt(1, $r3$.ɵi2(' ', $item$.name, ': ', $info$.description, ' '));
+                  if (rf & 2) {
+                    const $item$ = ctx0.$implicit;
+                    const $info$ = ctx1.$implicit;
+                    $r3$.ɵt(1, $r3$.ɵi2(' ', $item$.name, ': ', $info$.description, ' '));
+                  }
                 }
               }
             },

--- a/packages/compiler/test/render3/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler/test/render3/r3_view_compiler_i18n_spec.ts
@@ -46,8 +46,8 @@ describe('i18n support in the view compiler', () => {
       const $msg_1$ = goog.getMsg('Hello world');
       const $msg_2$ = goog.getMsg('farewell');
       …
-      template: function MyComponent_Template(ctx: IDENT, cm: IDENT) {
-        if (cm) {
+      template: function MyComponent_Template(rf: IDENT, ctx: IDENT) {
+        if (rf & 1) {
           …
           $r3$.ɵT(1, $msg_1$);
           …
@@ -104,8 +104,8 @@ describe('i18n support in the view compiler', () => {
        */
       const $msg_2$ = goog.getMsg('Hello world');
       …
-      template: function MyComponent_Template(ctx: IDENT, cm: IDENT) {
-        if (cm) {
+      template: function MyComponent_Template(rf: IDENT, ctx: IDENT) {
+        if (rf & 1) {
           $r3$.ɵE(0, 'div', $r3$.ɵf1($c1$, $msg_1$));
           $r3$.ɵT(1, $msg_2$);
           $r3$.ɵe();
@@ -152,8 +152,8 @@ describe('i18n support in the view compiler', () => {
         return ['id', 'static', 'title', $a1$];
       };
       …
-      template: function MyComponent_Template(ctx: IDENT, cm: IDENT) {
-        if (cm) {
+      template: function MyComponent_Template(rf: IDENT, ctx: IDENT) {
+        if (rf & 1) {
           $r3$.ɵE(0, 'div', $r3$.ɵf1($c1$, $msg_1$));
           $r3$.ɵe();
         }

--- a/packages/compiler/test/render3/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler/test/render3/r3_view_compiler_listener_spec.ts
@@ -41,8 +41,8 @@ describe('compiler compliance: listen()', () => {
 
     // The template should look like this (where IDENT is a wild card for an identifier):
     const template = `
-        template: function MyComponent_Template(ctx: $MyComponent$, cm: $boolean$) {
-          if (cm) {
+        template: function MyComponent_Template(rf: $RenderFlags$, ctx: $MyComponent$) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'div');
             $r3$.ɵL('click', function MyComponent_Template_div_click_listener($event: $any$) { 
               ctx.onClick($event);

--- a/packages/compiler/test/render3/r3_view_compiler_template_spec.ts
+++ b/packages/compiler/test/render3/r3_view_compiler_template_spec.ts
@@ -51,28 +51,35 @@ describe('compiler compliance: template', () => {
 
     // The template should look like this (where IDENT is a wild card for an identifier):
     const template = `
-      template:function MyComponent_Template(ctx:any, cm:boolean){
-        if (cm) { 
+      template:function MyComponent_Template(rf: IDENT, ctx: IDENT){
+        if (rf & 1) { 
           $i0$.ɵC(0, MyComponent_NgForOf_Template_0, null, _c0); 
         }
-        $i0$.ɵp(0, 'ngForOf', $i0$.ɵb(ctx.items));
-        function MyComponent_NgForOf_Template_0(ctx0:any, cm:boolean) {
-          if (cm) {
+        if (rf & 2) {
+          $i0$.ɵp(0, 'ngForOf', $i0$.ɵb(ctx.items));
+        }
+        
+        function MyComponent_NgForOf_Template_0(rf: IDENT, ctx0: IDENT) {
+          if (rf & 1) {
             $i0$.ɵE(0, 'ul');
             $i0$.ɵC(1, MyComponent_NgForOf_NgForOf_Template_1, null, _c0);
             $i0$.ɵe();
           }
-          const $outer$ = ctx0.$implicit;
-          $i0$.ɵp(1, 'ngForOf', $i0$.ɵb($outer$.items));
-          function MyComponent_NgForOf_NgForOf_Template_1(ctx1:any, cm:boolean) {
-            if (cm) {
+          if (rf & 2) {
+            const $outer$ = ctx0.$implicit;
+            $i0$.ɵp(1, 'ngForOf', $i0$.ɵb($outer$.items));
+          }
+          function MyComponent_NgForOf_NgForOf_Template_1(rf: IDENT, ctx1: IDENT) {
+            if (rf & 1) {
               $i0$.ɵE(0, 'li');
               $i0$.ɵC(1, MyComponent_NgForOf_NgForOf_NgForOf_Template_1, null, _c0);
               $i0$.ɵe();
             }
-            $i0$.ɵp(1, 'ngForOf', $i0$.ɵb(ctx.items));
-            function MyComponent_NgForOf_NgForOf_NgForOf_Template_1(ctx2:any, cm:boolean) {
-              if (cm) {
+            if (rf & 2) {
+              $i0$.ɵp(1, 'ngForOf', $i0$.ɵb(ctx.items));
+            }
+            function MyComponent_NgForOf_NgForOf_NgForOf_Template_1(rf: IDENT, ctx2: IDENT) {
+              if (rf & 1) {
                 $i0$.ɵE(0, 'div');
                 $i0$.ɵL('click', function MyComponent_NgForOf_NgForOf_NgForOf_Template_1_div_click_listener($event:any){
                   const $outer$ = ctx0.$implicit;
@@ -83,11 +90,13 @@ describe('compiler compliance: template', () => {
                 $i0$.ɵT(1);
                 $i0$.ɵe();
               }
-              const $outer$ = ctx0.$implicit;
-              const $middle$ = ctx1.$implicit;
-              const $inner$ = ctx2.$implicit;
-              $i0$.ɵp(0, 'title', ctx.format($outer$, $middle$, $inner$, ctx.component));
-              $i0$.ɵt(1, $i0$.ɵi1(' ', ctx.format($outer$, $middle$, $inner$, ctx.component), ' '));
+              if (rf & 2) {
+                const $outer$ = ctx0.$implicit;
+                const $middle$ = ctx1.$implicit;
+                const $inner$ = ctx2.$implicit;
+                $i0$.ɵp(0, 'title', ctx.format($outer$, $middle$, $inner$, ctx.component));
+                $i0$.ɵt(1, $i0$.ɵi1(' ', ctx.format($outer$, $middle$, $inner$, ctx.component), ' '));
+              }
             }
           }
         }

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -15,6 +15,7 @@ export {
   renderComponent as ɵrenderComponent,
   ComponentType as ɵComponentType,
   DirectiveType as ɵDirectiveType,
+  RenderFlags as ɵRenderFlags,
   directiveInject as ɵdirectiveInject,
   injectTemplateRef as ɵinjectTemplateRef,
   injectViewContainerRef as ɵinjectViewContainerRef,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -12,6 +12,7 @@ import {InjectFlags} from './di';
 import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefFlags, DirectiveType, PipeDef} from './interfaces/definition';
 
 export {InjectFlags, QUERY_READ_CONTAINER_REF, QUERY_READ_ELEMENT_REF, QUERY_READ_FROM_NODE, QUERY_READ_TEMPLATE_REF, directiveInject, injectAttribute, injectChangeDetectorRef, injectElementRef, injectTemplateRef, injectViewContainerRef} from './di';
+export {RenderFlags} from './interfaces/definition';
 export {CssSelectorList} from './interfaces/projection';
 
 

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -206,7 +206,7 @@ export function enterView(newView: LView, host: LElementNode | LViewNode | null)
   cleanup = newView && newView.cleanup;
   renderer = newView && newView.renderer;
 
-  if (newView && newView.bindingIndex == null) {
+  if (newView && newView.bindingIndex < 0) {
     newView.bindingIndex = newView.bindingStartIndex || 0;
   }
 
@@ -233,7 +233,7 @@ export function leaveView(newView: LView): void {
   // Views should be clean and in update mode after being checked, so these bits are cleared
   currentView.flags &= ~(LViewFlags.CreationMode | LViewFlags.Dirty);
   currentView.lifecycleStage = LifecycleStage.INIT;
-  currentView.bindingIndex = null !;
+  currentView.bindingIndex = -1;
   enterView(newView, null);
 }
 
@@ -295,7 +295,7 @@ export function createLView<T>(
     tail: null,
     next: null,
     bindingStartIndex: null,
-    bindingIndex: null !,
+    bindingIndex: -1,
     template: template,
     context: context,
     dynamicViewCount: 0,
@@ -1976,6 +1976,9 @@ export const NO_CHANGE = {} as NO_CHANGE;
  *  (ie `bind()`, `interpolationX()`, `pureFunctionX()`)
  */
 function initBindings() {
+  ngDevMode &&
+      assertNull(
+          currentView.bindingStartIndex, 'Binding start index should only be set once, when null');
   currentView.bindingIndex = currentView.bindingStartIndex = data.length;
 }
 

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -207,7 +207,7 @@ export function enterView(newView: LView, host: LElementNode | LViewNode | null)
   renderer = newView && newView.renderer;
 
   if (newView && newView.bindingIndex < 0) {
-    newView.bindingIndex = newView.bindingStartIndex || 0;
+    newView.bindingIndex = newView.bindingStartIndex || -1;
   }
 
   if (host != null) {
@@ -1979,6 +1979,9 @@ function initBindings() {
   ngDevMode &&
       assertNull(
           currentView.bindingStartIndex, 'Binding start index should only be set once, when null');
+  ngDevMode && assertEqual(
+                   currentView.bindingIndex, -1,
+                   'Binding index should not yet be set ' + currentView.bindingIndex);
   currentView.bindingIndex = currentView.bindingStartIndex = data.length;
 }
 

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -6,21 +6,33 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectionStrategy} from '../../change_detection/constants';
-import {PipeTransform} from '../../change_detection/pipe_transform';
 import {Provider} from '../../core';
 import {RendererType2} from '../../render/api';
 import {Type} from '../../type';
-import {resolveRendererType2} from '../../view/util';
 import {CssSelectorList} from './projection';
-
 
 /**
  * Definition of what a template rendering function should look like.
  */
 export type ComponentTemplate<T> = {
-  (ctx: T, creationMode: boolean): void; ngPrivateData?: never;
+  (rf: RenderFlags, ctx: T): void; ngPrivateData?: never;
 };
+
+/**
+ * Flags passed into template functions to determine which blocks (i.e. creation, update)
+ * should be executed.
+ *
+ * Typically, a template runs both the creation block and the update block on initialization and
+ * subsequent runs only execute the update block. However, dynamically created views require that
+ * the creation block be executed separately from the update block (for backwards compat).
+ */
+export const enum RenderFlags {
+  /* Whether to run the creation block (e.g. create elements and directives) */
+  Create = 0b01,
+
+  /* Whether to run the update block (e.g. refresh bindings) */
+  Update = 0b10
+}
 
 /**
  * A subclass of `Type` which has a static `ngComponentDef`:`ComponentDef` field making it

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -61,7 +61,7 @@ export interface LView {
    * will begin reading bindings at the correct point in the array when
    * we are in update mode.
    */
-  bindingStartIndex: number|null;
+  bindingStartIndex: number;
 
   /**
    * The binding index we should access next.

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -64,6 +64,15 @@ export interface LView {
   bindingStartIndex: number|null;
 
   /**
+   * The binding index we should access next.
+   *
+   * This is stored so that bindings can continue where they left off
+   * if a view is left midway through processing bindings (e.g. if there is
+   * a setter that creates an embedded view, like in ngIf).
+   */
+  bindingIndex: number;
+
+  /**
    * When a view is destroyed, listeners need to be released and outputs need to be
    * unsubscribed. This cleanup array stores both listener data (in chunks of 4)
    * and output data (in chunks of 2) for a particular view. Combining the arrays

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -63,6 +63,9 @@
     "name": "createTView"
   },
   {
+    "name": "createTextNode"
+  },
+  {
     "name": "currentView"
   },
   {
@@ -103,6 +106,9 @@
   },
   {
     "name": "getOrCreateTView"
+  },
+  {
+    "name": "getRenderFlags"
   },
   {
     "name": "hostElement"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -270,6 +270,9 @@
     "name": "createTView"
   },
   {
+    "name": "createTextNode"
+  },
+  {
     "name": "currentView"
   },
   {
@@ -397,6 +400,9 @@
   },
   {
     "name": "getPreviousOrParentNode"
+  },
+  {
+    "name": "getRenderFlags"
   },
   {
     "name": "getRenderer"

--- a/packages/core/test/bundling/todo/index.ts
+++ b/packages/core/test/bundling/todo/index.ts
@@ -56,8 +56,6 @@ export class TodoStore {
 
 @Component({
   selector: 'todo-app',
-  // TODO(misko) remove all `foo && foo.something` once `ViewContainerRef` can separate creation and
-  // update block.
   // TODO(misko): make this work with `[(ngModel)]`
   template: `
   <section class="todoapp">
@@ -74,18 +72,18 @@ export class TodoStore {
              (click)="todoStore.setAllTo(toggleall.checked)">
       <ul class="todo-list">
         <li *ngFor="let todo of todoStore.todos" 
-            [class.completed]="todo && todo.completed" 
-            [class.editing]="todo && todo.editing">
+            [class.completed]="todo.completed" 
+            [class.editing]="todo.editing">
           <div class="view">
             <input class="toggle" type="checkbox" 
                    (click)="toggleCompletion(todo)" 
-                   [checked]="todo && todo.completed">
-            <label (dblclick)="editTodo(todo)">{{todo && todo.title}}</label>
+                   [checked]="todo.completed">
+            <label (dblclick)="editTodo(todo)">{{todo.title}}</label>
             <button class="destroy" (click)="remove(todo)"></button>
           </div>
-          <input *ngIf="todo && todo.editing" 
+          <input *ngIf="todo.editing" 
                  class="edit" #editedtodo
-                 [value]="todo && todo.title" 
+                 [value]="todo.title" 
                  (blur)="stopEditing(todo, editedtodo.value)"
                  (keyup)="todo.title = $event.target.value" 
                  (keyup)="$event.code == 'Enter' && updateEditingTodo(todo, editedtodo.value)" 
@@ -106,7 +104,7 @@ export class TodoStore {
     </footer>
   </section>
   `,
-  // TODO(misko): switch oven to OnPush
+  // TODO(misko): switch over to OnPush
   // changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ToDoAppComponent {

--- a/packages/core/test/render3/basic_perf.ts
+++ b/packages/core/test/render3/basic_perf.ts
@@ -8,7 +8,7 @@
 
 import {defineComponent} from '../../src/render3/index';
 import {container, containerRefreshEnd, containerRefreshStart, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, text} from '../../src/render3/instructions';
-
+import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {document, renderComponent} from './render_util';
 
 describe('iv perf test', () => {
@@ -35,25 +35,27 @@ describe('iv perf test', () => {
           static ngComponentDef = defineComponent({
             type: Component,
             selectors: [['div']],
-            template: function Template(ctx: any, cm: any) {
-              if (cm) {
+            template: function Template(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
                 container(0);
               }
-              containerRefreshStart(0);
-              {
-                for (let i = 0; i < count; i++) {
-                  let cm0 = embeddedViewStart(0);
-                  {
-                    if (cm0) {
-                      elementStart(0, 'div');
-                      text(1, '-');
-                      elementEnd();
+              if (rf & RenderFlags.Update) {
+                containerRefreshStart(0);
+                {
+                  for (let i = 0; i < count; i++) {
+                    let rf0 = embeddedViewStart(0);
+                    {
+                      if (rf0 & RenderFlags.Create) {
+                        elementStart(0, 'div');
+                        text(1, '-');
+                        elementEnd();
+                      }
                     }
+                    embeddedViewEnd();
                   }
-                  embeddedViewEnd();
                 }
+                containerRefreshEnd();
               }
-              containerRefreshEnd();
             },
             factory: () => new Component
           });

--- a/packages/core/test/render3/common_integration_spec.ts
+++ b/packages/core/test/render3/common_integration_spec.ts
@@ -10,7 +10,7 @@ import {NgForOfContext} from '@angular/common';
 
 import {defineComponent} from '../../src/render3/index';
 import {bind, container, elementEnd, elementProperty, elementStart, interpolation3, text, textBinding, tick} from '../../src/render3/instructions';
-
+import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {NgForOf} from './common_with_def';
 import {ComponentFixture} from './render_util';
 
@@ -28,21 +28,25 @@ describe('@angular/common integration', () => {
           // <ul>
           //   <li *ngFor="let item of items">{{item}}</li>
           // </ul>
-          template: (myApp: MyApp, cm: boolean) => {
-            if (cm) {
+          template: (rf: RenderFlags, myApp: MyApp) => {
+            if (rf & RenderFlags.Create) {
               elementStart(0, 'ul');
               { container(1, liTemplate, undefined, ['ngForOf', '']); }
               elementEnd();
             }
-            elementProperty(1, 'ngForOf', bind(myApp.items));
+            if (rf & RenderFlags.Update) {
+              elementProperty(1, 'ngForOf', bind(myApp.items));
+            }
 
-            function liTemplate(row: NgForOfContext<string>, cm: boolean) {
-              if (cm) {
+            function liTemplate(rf1: RenderFlags, row: NgForOfContext<string>) {
+              if (rf1 & RenderFlags.Create) {
                 elementStart(0, 'li');
                 { text(1); }
                 elementEnd();
               }
-              textBinding(1, bind(row.$implicit));
+              if (rf1 & RenderFlags.Update) {
+                textBinding(1, bind(row.$implicit));
+              }
             }
           },
           directives: () => [NgForOf]
@@ -84,22 +88,26 @@ describe('@angular/common integration', () => {
           // <ul>
           //   <li *ngFor="let item of items">{{index}} of {{count}}: {{item}}</li>
           // </ul>
-          template: (myApp: MyApp, cm: boolean) => {
-            if (cm) {
+          template: (rf: RenderFlags, myApp: MyApp) => {
+            if (rf & RenderFlags.Create) {
               elementStart(0, 'ul');
               { container(1, liTemplate, undefined, ['ngForOf', '']); }
               elementEnd();
             }
-            elementProperty(1, 'ngForOf', bind(myApp.items));
+            if (rf & RenderFlags.Update) {
+              elementProperty(1, 'ngForOf', bind(myApp.items));
+            }
 
-            function liTemplate(row: NgForOfContext<string>, cm: boolean) {
-              if (cm) {
+            function liTemplate(rf1: RenderFlags, row: NgForOfContext<string>) {
+              if (rf1 & RenderFlags.Create) {
                 elementStart(0, 'li');
                 { text(1); }
                 elementEnd();
               }
-              textBinding(
-                  1, interpolation3('', row.index, ' of ', row.count, ': ', row.$implicit, ''));
+              if (rf1 & RenderFlags.Update) {
+                textBinding(
+                    1, interpolation3('', row.index, ' of ', row.count, ': ', row.$implicit, ''));
+              }
             }
           },
           directives: () => [NgForOf]

--- a/packages/core/test/render3/common_integration_spec.ts
+++ b/packages/core/test/render3/common_integration_spec.ts
@@ -11,7 +11,7 @@ import {NgForOfContext} from '@angular/common';
 import {defineComponent} from '../../src/render3/index';
 import {bind, container, elementEnd, elementProperty, elementStart, interpolation3, text, textBinding, tick} from '../../src/render3/instructions';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
-import {NgForOf} from './common_with_def';
+import {NgForOf, NgIf} from './common_with_def';
 import {ComponentFixture} from './render_util';
 
 describe('@angular/common integration', () => {
@@ -121,6 +121,67 @@ describe('@angular/common integration', () => {
       fixture.update();
       expect(fixture.html)
           .toEqual('<ul><li>0 of 3: first</li><li>1 of 3: middle</li><li>2 of 3: second</li></ul>');
+    });
+
+  });
+
+  describe('ngIf', () => {
+    it('should support sibling ngIfs', () => {
+      class MyApp {
+        showing = true;
+        valueOne = 'one';
+        valueTwo = 'two';
+
+        static ngComponentDef = defineComponent({
+          type: MyApp,
+          factory: () => new MyApp(),
+          selectors: [['my-app']],
+          /**
+           * <div *ngIf="showing">{{ valueOne }}</div>
+           * <div *ngIf="showing">{{ valueTwo }}</div>
+           */
+          template: (rf: RenderFlags, myApp: MyApp) => {
+            if (rf & RenderFlags.Create) {
+              container(0, templateOne, undefined, ['ngIf', '']);
+              container(1, templateTwo, undefined, ['ngIf', '']);
+            }
+            if (rf & RenderFlags.Update) {
+              elementProperty(0, 'ngIf', bind(myApp.showing));
+              elementProperty(1, 'ngIf', bind(myApp.showing));
+            }
+
+            function templateOne(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                elementStart(0, 'div');
+                { text(1); }
+                elementEnd();
+              }
+              if (rf & RenderFlags.Update) {
+                textBinding(1, bind(myApp.valueOne));
+              }
+            }
+            function templateTwo(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                elementStart(0, 'div');
+                { text(1); }
+                elementEnd();
+              }
+              if (rf & RenderFlags.Update) {
+                textBinding(1, bind(myApp.valueTwo));
+              }
+            }
+          },
+          directives: () => [NgIf]
+        });
+      }
+
+      const fixture = new ComponentFixture(MyApp);
+      expect(fixture.html).toEqual('<div>one</div><div>two</div>');
+
+      fixture.component.valueOne = '$$one$$';
+      fixture.component.valueTwo = '$$two$$';
+      fixture.update();
+      expect(fixture.html).toEqual('<div>$$one$$</div><div>$$two$$</div>');
     });
 
   });

--- a/packages/core/test/render3/common_with_def.ts
+++ b/packages/core/test/render3/common_with_def.ts
@@ -6,13 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgForOf as NgForOfDef} from '@angular/common';
+import {NgForOf as NgForOfDef, NgIf as NgIfDef} from '@angular/common';
 import {IterableDiffers} from '@angular/core';
 
 import {defaultIterableDiffers} from '../../src/change_detection/change_detection';
 import {DirectiveType, InjectFlags, NgOnChangesFeature, defineDirective, directiveInject, injectTemplateRef, injectViewContainerRef} from '../../src/render3/index';
 
 export const NgForOf: DirectiveType<NgForOfDef<any>> = NgForOfDef as any;
+export const NgIf: DirectiveType<NgIfDef> = NgIfDef as any;
 
 NgForOf.ngDirectiveDef = defineDirective({
   type: NgForOfDef,
@@ -26,4 +27,11 @@ NgForOf.ngDirectiveDef = defineDirective({
     ngForTrackBy: 'ngForTrackBy',
     ngForTemplate: 'ngForTemplate',
   }
+});
+
+(NgIf as any).ngDirectiveDef = defineDirective({
+  type: NgIfDef,
+  selectors: [['', 'ngIf', '']],
+  factory: () => new NgIfDef(injectViewContainerRef(), injectTemplateRef()),
+  inputs: {ngIf: 'ngIf', ngIfThen: 'ngIfThen', ngIfElse: 'ngIfElse'}
 });

--- a/packages/core/test/render3/compiler_canonical/component_directives_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/component_directives_spec.ts
@@ -12,10 +12,9 @@ import {renderComponent, toHtml} from '../render_util';
 
 /// See: `normative.md`
 describe('components & directives', () => {
-  type $boolean$ = boolean;
+  type $RenderFlags$ = $r3$.ɵRenderFlags;
   type $any$ = any;
   type $number$ = number;
-
 
   it('should instantiate directives', () => {
     type $ChildComponent$ = ChildComponent;
@@ -29,9 +28,9 @@ describe('components & directives', () => {
       static ngComponentDef = $r3$.ɵdefineComponent({
         type: ChildComponent,
         selectors: [['child']],
-        factory: () => new ChildComponent(),
-        template: function(ctx: $ChildComponent$, cm: $boolean$) {
-          if (cm) {
+        factory: function ChildComponent_Factory() { return new ChildComponent(); },
+        template: function ChildComponent_Template(rf: $RenderFlags$, ctx: $ChildComponent$) {
+          if (rf & 1) {
             $r3$.ɵT(0, 'child-view');
           }
         }
@@ -65,8 +64,8 @@ describe('components & directives', () => {
         type: MyComponent,
         selectors: [['my-component']],
         factory: () => new MyComponent(),
-        template: function(ctx: $MyComponent$, cm: $boolean$) {
-          if (cm) {
+        template: function(rf: $RenderFlags$, ctx: $MyComponent$) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'child', $e0_attrs$);
             $r3$.ɵe();
             $r3$.ɵT(1, '!');
@@ -117,8 +116,8 @@ describe('components & directives', () => {
         type: MyApp,
         selectors: [['my-app']],
         factory: function MyApp_Factory() { return new MyApp(); },
-        template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-          if (cm) {
+        template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'div', $e0_attrs$);
             $r3$.ɵe();
           }
@@ -167,8 +166,8 @@ describe('components & directives', () => {
         type: MyApp,
         selectors: [['my-app']],
         factory: function MyApp_Factory() { return new MyApp(); },
-        template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-          if (cm) {
+        template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'button', $e0_attrs$);
             $r3$.ɵT(1, 'Click');
             $r3$.ɵe();
@@ -213,8 +212,8 @@ describe('components & directives', () => {
         type: MyApp,
         selectors: [['my-app']],
         factory: function MyApp_Factory() { return new MyApp(); },
-        template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-          if (cm) {
+        template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'div', $e0_attrs$);
             $r3$.ɵe();
           }
@@ -261,8 +260,8 @@ describe('components & directives', () => {
         type: MyApp,
         selectors: [['my-app']],
         factory: function MyApp_Factory() { return new MyApp(); },
-        template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-          if (cm) {
+        template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'div', $e0_attrs$);
             $r3$.ɵe();
           }
@@ -296,8 +295,8 @@ describe('components & directives', () => {
         type: MyComp,
         selectors: [['my-comp']],
         factory: function MyComp_Factory() { return new MyComp(); },
-        template: function MyComp_Template(ctx: $MyComp$, cm: $boolean$) {
-          if (cm) {
+        template: function MyComp_Template(rf: $RenderFlags$, ctx: $MyComp$) {
+          if (rf & 1) {
             $r3$.ɵT(0);
           }
           $r3$.ɵt(0, $r3$.ɵb(ctx.name));
@@ -321,12 +320,14 @@ describe('components & directives', () => {
         type: MyApp,
         selectors: [['my-app']],
         factory: function MyApp_Factory() { return new MyApp(); },
-        template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-          if (cm) {
+        template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'my-comp');
             $r3$.ɵe();
           }
-          $r3$.ɵp(0, 'name', $r3$.ɵb(ctx.name));
+          if (rf & 2) {
+            $r3$.ɵp(0, 'name', $r3$.ɵb(ctx.name));
+          }
         }
       });
     }
@@ -370,23 +371,27 @@ describe('components & directives', () => {
         type: MyComponent,
         selectors: [['my-component']],
         factory: () => new MyComponent(),
-        template: function(ctx: $MyComponent$, cm: $boolean$) {
-          if (cm) {
+        template: function(rf: $RenderFlags$, ctx: $MyComponent$) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'ul', null, $e0_locals$);
             $r3$.ɵC(2, C1, '', ['if', '']);
             $r3$.ɵe();
           }
           let $foo$ = $r3$.ɵld<any>(1);
-          $r3$.ɵcR(2);
-          $r3$.ɵcr();
+          if (rf & 2) {
+            $r3$.ɵcR(2);
+            $r3$.ɵcr();
+          }
 
-          function C1(ctx1: $any$, cm: $boolean$) {
-            if (cm) {
+          function C1(rf1: $RenderFlags$, ctx1: $any$) {
+            if (rf1 & 1) {
               $r3$.ɵE(0, 'li');
               $r3$.ɵT(1);
               $r3$.ɵe();
             }
-            $r3$.ɵt(1, $r3$.ɵi2('', ctx.salutation, ' ', $foo$, ''));
+            if (rf1 & 2) {
+              $r3$.ɵt(1, $r3$.ɵi2('', ctx.salutation, ' ', $foo$, ''));
+            }
           }
         }
       });
@@ -413,11 +418,13 @@ describe('components & directives', () => {
         type: MyArrayComp,
         selectors: [['my-array-comp']],
         factory: function MyArrayComp_Factory() { return new MyArrayComp(); },
-        template: function MyArrayComp_Template(ctx: $MyArrayComp$, cm: $boolean$) {
-          if (cm) {
+        template: function MyArrayComp_Template(rf: $RenderFlags$, ctx: $MyArrayComp$) {
+          if (rf & 1) {
             $r3$.ɵT(0);
           }
-          $r3$.ɵt(0, $r3$.ɵi2('', ctx.names[0], ' ', ctx.names[1], ''));
+          if (rf & 2) {
+            $r3$.ɵt(0, $r3$.ɵi2('', ctx.names[0], ' ', ctx.names[1], ''));
+          }
         },
         inputs: {names: 'names'}
       });
@@ -442,12 +449,14 @@ describe('components & directives', () => {
           type: MyApp,
           selectors: [['my-app']],
           factory: function MyApp_Factory() { return new MyApp(); },
-          template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-            if (cm) {
+          template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'my-array-comp');
               $r3$.ɵe();
             }
-            $r3$.ɵp(0, 'names', cm ? $e0_arr$ : $r3$.ɵNC);
+            if (rf & 2) {
+              $r3$.ɵp(0, 'names', rf & 1 ? $e0_arr$ : $r3$.ɵNC);
+            }
           }
         });
         // /NORMATIVE
@@ -484,12 +493,14 @@ describe('components & directives', () => {
           type: MyApp,
           selectors: [['my-app']],
           factory: function MyApp_Factory() { return new MyApp(); },
-          template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-            if (cm) {
+          template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'my-array-comp');
               $r3$.ɵe();
             }
-            $r3$.ɵp(0, 'names', $r3$.ɵb(ctx.someFn($r3$.ɵf0($e0_ff$))));
+            if (rf & 2) {
+              $r3$.ɵp(0, 'names', $r3$.ɵb(ctx.someFn($r3$.ɵf0($e0_ff$))));
+            }
           }
         });
         // /NORMATIVE
@@ -514,11 +525,13 @@ describe('components & directives', () => {
           type: MyComp,
           selectors: [['my-comp']],
           factory: function MyComp_Factory() { return new MyComp(); },
-          template: function MyComp_Template(ctx: $MyComp$, cm: $boolean$) {
-            if (cm) {
+          template: function MyComp_Template(rf: $RenderFlags$, ctx: $MyComp$) {
+            if (rf & 1) {
               $r3$.ɵT(0);
             }
-            $r3$.ɵt(0, $r3$.ɵb(ctx.num));
+            if (rf & 2) {
+              $r3$.ɵt(0, $r3$.ɵb(ctx.num));
+            }
           },
           inputs: {num: 'num'}
         });
@@ -540,12 +553,14 @@ describe('components & directives', () => {
           type: MyApp,
           selectors: [['my-app']],
           factory: function MyApp_Factory() { return new MyApp(); },
-          template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-            if (cm) {
+          template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'my-comp');
               $r3$.ɵe();
             }
-            $r3$.ɵp(0, 'num', $r3$.ɵb($r3$.ɵf0($e0_ff$).length + 1));
+            if (rf & 2) {
+              $r3$.ɵp(0, 'num', $r3$.ɵb($r3$.ɵf0($e0_ff$).length + 1));
+            }
           }
         });
         // /NORMATIVE
@@ -580,12 +595,14 @@ describe('components & directives', () => {
           type: MyApp,
           selectors: [['my-app']],
           factory: function MyApp_Factory() { return new MyApp(); },
-          template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-            if (cm) {
+          template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'my-array-comp');
               $r3$.ɵe();
             }
-            $r3$.ɵp(0, 'names', $r3$.ɵb($r3$.ɵf1($e0_ff$, ctx.customName)));
+            if (rf & 2) {
+              $r3$.ɵp(0, 'names', $r3$.ɵb($r3$.ɵf1($e0_ff$, ctx.customName)));
+            }
           }
         });
         // /NORMATIVE
@@ -624,8 +641,8 @@ describe('components & directives', () => {
           type: MyComp,
           selectors: [['my-comp']],
           factory: function MyComp_Factory() { return new MyComp(); },
-          template: function MyComp_Template(ctx: $MyComp$, cm: $boolean$) {
-            if (cm) {
+          template: function MyComp_Template(rf: $RenderFlags$, ctx: $MyComp$) {
+            if (rf & 1) {
               $r3$.ɵT(0);
               $r3$.ɵT(1);
               $r3$.ɵT(2);
@@ -639,18 +656,20 @@ describe('components & directives', () => {
               $r3$.ɵT(10);
               $r3$.ɵT(11);
             }
-            $r3$.ɵt(0, $r3$.ɵb(ctx.names[0]));
-            $r3$.ɵt(1, $r3$.ɵb(ctx.names[1]));
-            $r3$.ɵt(2, $r3$.ɵb(ctx.names[2]));
-            $r3$.ɵt(3, $r3$.ɵb(ctx.names[3]));
-            $r3$.ɵt(4, $r3$.ɵb(ctx.names[4]));
-            $r3$.ɵt(5, $r3$.ɵb(ctx.names[5]));
-            $r3$.ɵt(6, $r3$.ɵb(ctx.names[6]));
-            $r3$.ɵt(7, $r3$.ɵb(ctx.names[7]));
-            $r3$.ɵt(8, $r3$.ɵb(ctx.names[8]));
-            $r3$.ɵt(9, $r3$.ɵb(ctx.names[9]));
-            $r3$.ɵt(10, $r3$.ɵb(ctx.names[10]));
-            $r3$.ɵt(11, $r3$.ɵb(ctx.names[11]));
+            if (rf & 2) {
+              $r3$.ɵt(0, $r3$.ɵb(ctx.names[0]));
+              $r3$.ɵt(1, $r3$.ɵb(ctx.names[1]));
+              $r3$.ɵt(2, $r3$.ɵb(ctx.names[2]));
+              $r3$.ɵt(3, $r3$.ɵb(ctx.names[3]));
+              $r3$.ɵt(4, $r3$.ɵb(ctx.names[4]));
+              $r3$.ɵt(5, $r3$.ɵb(ctx.names[5]));
+              $r3$.ɵt(6, $r3$.ɵb(ctx.names[6]));
+              $r3$.ɵt(7, $r3$.ɵb(ctx.names[7]));
+              $r3$.ɵt(8, $r3$.ɵb(ctx.names[8]));
+              $r3$.ɵt(9, $r3$.ɵb(ctx.names[9]));
+              $r3$.ɵt(10, $r3$.ɵb(ctx.names[10]));
+              $r3$.ɵt(11, $r3$.ɵb(ctx.names[11]));
+            }
           },
           inputs: {names: 'names'}
         });
@@ -685,14 +704,17 @@ describe('components & directives', () => {
           type: MyApp,
           selectors: [['my-app']],
           factory: function MyApp_Factory() { return new MyApp(); },
-          template: function MyApp_Template(c: MyApp, cm: boolean) {
-            if (cm) {
+          template: function MyApp_Template(rf: $RenderFlags$, c: $any$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'my-comp');
               $r3$.ɵe();
             }
-            $r3$.ɵp(
-                0, 'names',
-                $r3$.ɵb($r3$.ɵfV($e0_ff$, [c.n0, c.n1, c.n2, c.n3, c.n4, c.n5, c.n6, c.n7, c.n8])));
+            if (rf & 2) {
+              $r3$.ɵp(
+                  0, 'names',
+                  $r3$.ɵb(
+                      $r3$.ɵfV($e0_ff$, [c.n0, c.n1, c.n2, c.n3, c.n4, c.n5, c.n6, c.n7, c.n8])));
+            }
           }
         });
         // /NORMATIVE
@@ -723,8 +745,8 @@ describe('components & directives', () => {
           type: ObjectComp,
           selectors: [['object-comp']],
           factory: function ObjectComp_Factory() { return new ObjectComp(); },
-          template: function ObjectComp_Template(ctx: $ObjectComp$, cm: $boolean$) {
-            if (cm) {
+          template: function ObjectComp_Template(rf: $RenderFlags$, ctx: $ObjectComp$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'p');
               $r3$.ɵT(1);
               $r3$.ɵe();
@@ -732,8 +754,10 @@ describe('components & directives', () => {
               $r3$.ɵT(3);
               $r3$.ɵe();
             }
-            $r3$.ɵt(1, $r3$.ɵb(ctx.config['duration']));
-            $r3$.ɵt(3, $r3$.ɵb(ctx.config.animation));
+            if (rf & 2) {
+              $r3$.ɵt(1, $r3$.ɵb(ctx.config['duration']));
+              $r3$.ɵt(3, $r3$.ɵb(ctx.config.animation));
+            }
           },
           inputs: {config: 'config'}
         });
@@ -757,12 +781,14 @@ describe('components & directives', () => {
           type: MyApp,
           selectors: [['my-app']],
           factory: function MyApp_Factory() { return new MyApp(); },
-          template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-            if (cm) {
+          template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'object-comp');
               $r3$.ɵe();
             }
-            $r3$.ɵp(0, 'config', $r3$.ɵb($r3$.ɵf1($e0_ff$, ctx.name)));
+            if (rf & 2) {
+              $r3$.ɵp(0, 'config', $r3$.ɵb($r3$.ɵf1($e0_ff$, ctx.name)));
+            }
           }
         });
         // /NORMATIVE
@@ -794,8 +820,8 @@ describe('components & directives', () => {
           type: NestedComp,
           selectors: [['nested-comp']],
           factory: function NestedComp_Factory() { return new NestedComp(); },
-          template: function NestedComp_Template(ctx: $NestedComp$, cm: $boolean$) {
-            if (cm) {
+          template: function NestedComp_Template(rf: $RenderFlags$, ctx: $NestedComp$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'p');
               $r3$.ɵT(1);
               $r3$.ɵe();
@@ -806,9 +832,11 @@ describe('components & directives', () => {
               $r3$.ɵT(5);
               $r3$.ɵe();
             }
-            $r3$.ɵt(1, $r3$.ɵb(ctx.config.animation));
-            $r3$.ɵt(3, $r3$.ɵb(ctx.config.actions[0].opacity));
-            $r3$.ɵt(5, $r3$.ɵb(ctx.config.actions[1].duration));
+            if (rf & 2) {
+              $r3$.ɵt(1, $r3$.ɵb(ctx.config.animation));
+              $r3$.ɵt(3, $r3$.ɵb(ctx.config.actions[0].opacity));
+              $r3$.ɵt(5, $r3$.ɵb(ctx.config.actions[1].duration));
+            }
           },
           inputs: {config: 'config'}
         });
@@ -837,15 +865,17 @@ describe('components & directives', () => {
           type: MyApp,
           selectors: [['my-app']],
           factory: function MyApp_Factory() { return new MyApp(); },
-          template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-            if (cm) {
+          template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'nested-comp');
               $r3$.ɵe();
             }
-            $r3$.ɵp(
-                0, 'config', $r3$.ɵf2(
-                                 $e0_ff_2$, ctx.name,
-                                 $r3$.ɵb($r3$.ɵf1($e0_ff_1$, $r3$.ɵf1($e0_ff$, ctx.duration)))));
+            if (rf & 2) {
+              $r3$.ɵp(
+                  0, 'config', $r3$.ɵf2(
+                                   $e0_ff_2$, ctx.name,
+                                   $r3$.ɵb($r3$.ɵf1($e0_ff_1$, $r3$.ɵf1($e0_ff$, ctx.duration)))));
+            }
           }
         });
         // /NORMATIVE

--- a/packages/core/test/render3/compiler_canonical/content_projection_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/content_projection_spec.ts
@@ -8,11 +8,10 @@
 
 import {ChangeDetectionStrategy, ChangeDetectorRef, Component, ContentChild, ContentChildren, Directive, HostBinding, HostListener, Injectable, Input, NgModule, OnDestroy, Optional, Pipe, PipeTransform, QueryList, SimpleChanges, TemplateRef, ViewChild, ViewChildren, ViewContainerRef} from '../../../src/core';
 import * as $r3$ from '../../../src/core_render3_private_export';
-import {renderComponent, toHtml} from '../render_util';
 
 /// See: `normative.md`
 describe('content projection', () => {
-  type $boolean$ = boolean;
+  type $RenderFlags$ = $r3$.ɵRenderFlags;
 
   it('should support content projection', () => {
     type $SimpleComponent$ = SimpleComponent;
@@ -26,8 +25,8 @@ describe('content projection', () => {
         type: SimpleComponent,
         selectors: [['simple']],
         factory: () => new SimpleComponent(),
-        template: function(ctx: $SimpleComponent$, cm: $boolean$) {
-          if (cm) {
+        template: function(rf: $RenderFlags$, ctx: $SimpleComponent$) {
+          if (rf & 1) {
             $r3$.ɵpD(0);
             $r3$.ɵE(1, 'div');
             $r3$.ɵP(2, 0);
@@ -56,8 +55,8 @@ describe('content projection', () => {
         type: ComplexComponent,
         selectors: [['complex']],
         factory: () => new ComplexComponent(),
-        template: function(ctx: $ComplexComponent$, cm: $boolean$) {
-          if (cm) {
+        template: function(rf: $RenderFlags$, ctx: $ComplexComponent$) {
+          if (rf & 1) {
             $r3$.ɵpD(0, $pD_0P$, $pD_0R$);
             $r3$.ɵE(1, 'div', ['id', 'first']);
             $r3$.ɵP(2, 0, 1);
@@ -81,8 +80,8 @@ describe('content projection', () => {
         type: MyApp,
         selectors: [['my-app']],
         factory: () => new MyApp(),
-        template: function(ctx: $MyApp$, cm: $boolean$) {
-          if (cm) {
+        template: function(rf: $RenderFlags$, ctx: $MyApp$) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'simple');
             $r3$.ɵT(1, 'content');
             $r3$.ɵe();

--- a/packages/core/test/render3/compiler_canonical/elements_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/elements_spec.ts
@@ -13,10 +13,9 @@ import {ComponentFixture, renderComponent, toHtml} from '../render_util';
 
 /// See: `normative.md`
 describe('elements', () => {
-  // Saving type as $boolean$, etc to simplify testing for compiler, as types aren't saved
-  type $boolean$ = boolean;
+  // Saving type as $any$, etc to simplify testing for compiler, as types aren't saved
   type $any$ = any;
-  type $number$ = number;
+  type $RenderFlags$ = $r3$.ɵRenderFlags;
 
   it('should translate DOM structure', () => {
     type $MyComponent$ = MyComponent;
@@ -34,8 +33,8 @@ describe('elements', () => {
         type: MyComponent,
         selectors: [['my-component']],
         factory: () => new MyComponent(),
-        template: function(ctx: $MyComponent$, cm: $boolean$) {
-          if (cm) {
+        template: function(rf: $RenderFlags$, ctx: $MyComponent$) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'div', $e0_attrs$);
             $r3$.ɵT(1, 'Hello ');
             $r3$.ɵE(2, 'b');
@@ -85,15 +84,19 @@ describe('elements', () => {
         type: LocalRefComp,
         selectors: [['local-ref-comp']],
         factory: function LocalRefComp_Factory() { return new LocalRefComp(); },
-        template: function LocalRefComp_Template(ctx: $LocalRefComp$, cm: $boolean$) {
-          if (cm) {
+        template: function LocalRefComp_Template(rf: $RenderFlags$, ctx: $LocalRefComp$) {
+          let $tmp$: any;
+          let $tmp_2$: any;
+          if (rf & 1) {
             $r3$.ɵE(0, 'div', $e0_attrs$, $e0_locals$);
             $r3$.ɵe();
             $r3$.ɵT(3);
           }
-          const $tmp$ = $r3$.ɵld(1) as any;
-          const $tmp_2$ = $r3$.ɵld(2) as any;
-          $r3$.ɵt(3, $r3$.ɵi2(' ', $tmp$.value, ' - ', $tmp_2$.tagName, ''));
+          if (rf & 2) {
+            $tmp$ = $r3$.ɵld(1);
+            $tmp_2$ = $r3$.ɵld(2);
+            $r3$.ɵt(3, $r3$.ɵi2(' ', $tmp$.value, ' - ', $tmp_2$.tagName, ''));
+          }
         }
       });
       // /NORMATIVE
@@ -125,8 +128,8 @@ describe('elements', () => {
         type: ListenerComp,
         selectors: [['listener-comp']],
         factory: function ListenerComp_Factory() { return new ListenerComp(); },
-        template: function ListenerComp_Template(ctx: $ListenerComp$, cm: $boolean$) {
-          if (cm) {
+        template: function ListenerComp_Template(rf: $RenderFlags$, ctx: $ListenerComp$) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'button');
             $r3$.ɵL('click', function ListenerComp_click_Handler() { return ctx.onClick(); });
             $r3$.ɵL('keypress', function ListenerComp_keypress_Handler($event: $any$) {
@@ -157,12 +160,14 @@ describe('elements', () => {
           type: MyComponent,
           selectors: [['my-component']],
           factory: function MyComponent_Factory() { return new MyComponent(); },
-          template: function MyComponent_Template(ctx: $MyComponent$, cm: $boolean$) {
-            if (cm) {
+          template: function MyComponent_Template(rf: $RenderFlags$, ctx: $MyComponent$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'div');
               $r3$.ɵe();
             }
-            $r3$.ɵp(0, 'id', $r3$.ɵb(ctx.someProperty));
+            if (rf & 2) {
+              $r3$.ɵp(0, 'id', $r3$.ɵb(ctx.someProperty));
+            }
           }
         });
         // /NORMATIVE
@@ -187,12 +192,14 @@ describe('elements', () => {
           type: MyComponent,
           selectors: [['my-component']],
           factory: function MyComponent_Factory() { return new MyComponent(); },
-          template: function MyComponent_Template(ctx: $MyComponent$, cm: $boolean$) {
-            if (cm) {
+          template: function MyComponent_Template(rf: $RenderFlags$, ctx: $MyComponent$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'div');
               $r3$.ɵe();
             }
-            $r3$.ɵa(0, 'title', $r3$.ɵb(ctx.someAttribute));
+            if (rf & 2) {
+              $r3$.ɵa(0, 'title', $r3$.ɵb(ctx.someAttribute));
+            }
           }
         });
         // /NORMATIVE
@@ -217,12 +224,14 @@ describe('elements', () => {
           type: MyComponent,
           selectors: [['my-component']],
           factory: function MyComponent_Factory() { return new MyComponent(); },
-          template: function MyComponent_Template(ctx: $MyComponent$, cm: $boolean$) {
-            if (cm) {
+          template: function MyComponent_Template(rf: $RenderFlags$, ctx: $MyComponent$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'div');
               $r3$.ɵe();
             }
-            $r3$.ɵkn(0, 'foo', $r3$.ɵb(ctx.someFlag));
+            if (rf & 2) {
+              $r3$.ɵkn(0, 'foo', $r3$.ɵb(ctx.someFlag));
+            }
           }
         });
         // /NORMATIVE
@@ -251,13 +260,15 @@ describe('elements', () => {
           type: MyComponent,
           selectors: [['my-component']],
           factory: function MyComponent_Factory() { return new MyComponent(); },
-          template: function MyComponent_Template(ctx: $MyComponent$, cm: $boolean$) {
-            if (cm) {
+          template: function MyComponent_Template(rf: $RenderFlags$, ctx: $MyComponent$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'div');
               $r3$.ɵe();
             }
-            $r3$.ɵsn(0, 'color', $r3$.ɵb(ctx.someColor));
-            $r3$.ɵsn(0, 'width', $r3$.ɵb(ctx.someWidth), 'px');
+            if (rf & 2) {
+              $r3$.ɵsn(0, 'color', $r3$.ɵb(ctx.someColor));
+              $r3$.ɵsn(0, 'width', $r3$.ɵb(ctx.someWidth), 'px');
+            }
           }
         });
         // /NORMATIVE
@@ -299,13 +310,15 @@ describe('elements', () => {
           type: MyComponent,
           selectors: [['my-component']],
           factory: function MyComponent_Factory() { return new MyComponent(); },
-          template: function MyComponent_Template(ctx: $MyComponent$, cm: $boolean$) {
-            if (cm) {
+          template: function MyComponent_Template(rf: $RenderFlags$, ctx: $MyComponent$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'div', $e0_attrs$);
               $r3$.ɵe();
             }
-            $r3$.ɵp(0, 'id', $r3$.ɵb(ctx.someString + 1));
-            $r3$.ɵkn(0, 'foo', $r3$.ɵb(ctx.someString == 'initial'));
+            if (rf & 2) {
+              $r3$.ɵp(0, 'id', $r3$.ɵb(ctx.someString + 1));
+              $r3$.ɵkn(0, 'foo', $r3$.ɵb(ctx.someString == 'initial'));
+            }
           }
         });
         // /NORMATIVE
@@ -333,13 +346,15 @@ describe('elements', () => {
           type: StyleComponent,
           selectors: [['style-comp']],
           factory: function StyleComponent_Factory() { return new StyleComponent(); },
-          template: function StyleComponent_Template(ctx: $StyleComponent$, cm: $boolean$) {
-            if (cm) {
+          template: function StyleComponent_Template(rf: $RenderFlags$, ctx: $StyleComponent$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'div');
               $r3$.ɵe();
             }
-            $r3$.ɵk(0, $r3$.ɵb(ctx.classExp));
-            $r3$.ɵs(0, $r3$.ɵb(ctx.styleExp));
+            if (rf & 2) {
+              $r3$.ɵk(0, $r3$.ɵb(ctx.classExp));
+              $r3$.ɵs(0, $r3$.ɵb(ctx.styleExp));
+            }
           }
         });
         // /NORMATIVE

--- a/packages/core/test/render3/compiler_canonical/injection_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/injection_spec.ts
@@ -14,7 +14,7 @@ import {renderComponent, toHtml} from '../render_util';
 
 /// See: `normative.md`
 describe('injection', () => {
-  type $boolean$ = boolean;
+  type $RenderFlags$ = $r3$.ɵRenderFlags;
 
   describe('directives', () => {
     // Directives (and Components) should use `directiveInject`
@@ -34,11 +34,13 @@ describe('injection', () => {
           factory: function MyComp_Factory() {
             return new MyComp($r3$.ɵinjectChangeDetectorRef());
           },
-          template: function MyComp_Template(ctx: $MyComp$, cm: $boolean$) {
-            if (cm) {
+          template: function MyComp_Template(rf: $RenderFlags$, ctx: $MyComp$) {
+            if (rf & 1) {
               $r3$.ɵT(0);
             }
-            $r3$.ɵt(0, $r3$.ɵb(ctx.value));
+            if (rf & 2) {
+              $r3$.ɵt(0, $r3$.ɵb(ctx.value));
+            }
           }
         });
         // /NORMATIVE
@@ -50,8 +52,8 @@ describe('injection', () => {
           selectors: [['my-app']],
           factory: function MyApp_Factory() { return new MyApp(); },
           /** <my-comp></my-comp> */
-          template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-            if (cm) {
+          template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'my-comp');
               $r3$.ɵe();
             }
@@ -79,11 +81,13 @@ describe('injection', () => {
           type: MyComp,
           selectors: [['my-comp']],
           factory: function MyComp_Factory() { return new MyComp($r3$.ɵinjectAttribute('title')); },
-          template: function MyComp_Template(ctx: $MyComp$, cm: $boolean$) {
-            if (cm) {
+          template: function MyComp_Template(rf: $RenderFlags$, ctx: $MyComp$) {
+            if (rf & 1) {
               $r3$.ɵT(0);
             }
-            $r3$.ɵt(0, $r3$.ɵb(ctx.title));
+            if (rf & 2) {
+              $r3$.ɵt(0, $r3$.ɵb(ctx.title));
+            }
           }
         });
         // /NORMATIVE
@@ -95,8 +99,8 @@ describe('injection', () => {
           selectors: [['my-app']],
           factory: function MyApp_Factory() { return new MyApp(); },
           /** <my-comp></my-comp> */
-          template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-            if (cm) {
+          template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'my-comp', e0_attrs);
               $r3$.ɵe();
             }
@@ -148,7 +152,7 @@ describe('injection', () => {
                 $r3$.ɵdirectiveInject(ServiceA), $r3$.ɵdirectiveInject(ServiceB), inject(INJECTOR));
           },
           /**  */
-          template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {},
+          template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {},
           providers: [ServiceA],
           viewProviders: [ServiceB],
         });

--- a/packages/core/test/render3/compiler_canonical/life_cycle_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/life_cycle_spec.ts
@@ -15,7 +15,7 @@ describe('lifecycle hooks', () => {
   let events: string[] = [];
   let simpleLayout: SimpleLayout;
 
-  type $boolean$ = boolean;
+  type $RenderFlags$ = $r3$.ɵRenderFlags;
   type $LifecycleComp$ = LifecycleComp;
   type $SimpleLayout$ = SimpleLayout;
 
@@ -43,7 +43,7 @@ describe('lifecycle hooks', () => {
       type: LifecycleComp,
       selectors: [['lifecycle-comp']],
       factory: function LifecycleComp_Factory() { return new LifecycleComp(); },
-      template: function LifecycleComp_Template(ctx: $LifecycleComp$, cm: $boolean$) {},
+      template: function LifecycleComp_Template(rf: $RenderFlags$, ctx: $LifecycleComp$) {},
       inputs: {nameMin: 'name'},
       features: [$r3$.ɵNgOnChangesFeature({nameMin: 'nameMin'})]
     });
@@ -66,15 +66,17 @@ describe('lifecycle hooks', () => {
       type: SimpleLayout,
       selectors: [['simple-layout']],
       factory: function SimpleLayout_Factory() { return simpleLayout = new SimpleLayout(); },
-      template: function SimpleLayout_Template(ctx: $SimpleLayout$, cm: $boolean$) {
-        if (cm) {
+      template: function SimpleLayout_Template(rf: $RenderFlags$, ctx: $SimpleLayout$) {
+        if (rf & 1) {
           $r3$.ɵE(0, 'lifecycle-comp');
           $r3$.ɵe();
           $r3$.ɵE(1, 'lifecycle-comp');
           $r3$.ɵe();
         }
-        $r3$.ɵp(0, 'name', $r3$.ɵb(ctx.name1));
-        $r3$.ɵp(1, 'name', $r3$.ɵb(ctx.name2));
+        if (rf & 2) {
+          $r3$.ɵp(0, 'name', $r3$.ɵb(ctx.name1));
+          $r3$.ɵp(1, 'name', $r3$.ɵb(ctx.name2));
+        }
       }
     });
     // /NORMATIVE

--- a/packages/core/test/render3/compiler_canonical/local_reference_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/local_reference_spec.ts
@@ -12,7 +12,7 @@ import {renderComponent, toHtml} from '../render_util';
 
 /// See: `normative.md`
 describe('local references', () => {
-  type $boolean$ = boolean;
+  type $RenderFlags$ = $r3$.ɵRenderFlags;
 
   // TODO(misko): currently disabled until local refs are working
   xit('should translate DOM structure', () => {
@@ -25,14 +25,17 @@ describe('local references', () => {
         type: MyComponent,
         selectors: [['my-component']],
         factory: () => new MyComponent,
-        template: function(ctx: $MyComponent$, cm: $boolean$) {
-          if (cm) {
+        template: function(rf: $RenderFlags$, ctx: $MyComponent$) {
+          let l1_user: any;
+          if (rf & 1) {
             $r3$.ɵE(0, 'input', null, ['user', '']);
             $r3$.ɵe();
             $r3$.ɵT(2);
           }
-          const l1_user = $r3$.ɵld<any>(1);
-          $r3$.ɵt(2, $r3$.ɵi1('Hello ', l1_user.value, '!'));
+          if (rf & 2) {
+            l1_user = $r3$.ɵld<any>(1);
+            $r3$.ɵt(2, $r3$.ɵi1('Hello ', l1_user.value, '!'));
+          }
         }
       });
       // NORMATIVE

--- a/packages/core/test/render3/compiler_canonical/pipes_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/pipes_spec.ts
@@ -13,7 +13,7 @@ import {containerEl, renderComponent, toHtml} from '../render_util';
 /// See: `normative.md`
 describe('pipes', () => {
   type $any$ = any;
-  type $boolean$ = boolean;
+  type $RenderFlags$ = $r3$.ɵRenderFlags;
 
   let myPipeTransformCalls = 0;
   let myPurePipeTransformCalls = 0;
@@ -81,13 +81,15 @@ describe('pipes', () => {
         type: MyApp,
         selectors: [['my-app']],
         factory: function MyApp_Factory() { return new MyApp(); },
-        template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-          if (cm) {
+        template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+          if (rf & 1) {
             $r3$.ɵT(0);
             $r3$.ɵPp(1, 'myPipe');
             $r3$.ɵPp(2, 'myPurePipe');
           }
-          $r3$.ɵt(0, $r3$.ɵi1('', $r3$.ɵpb2(1, $r3$.ɵpb2(2, ctx.name, ctx.size), ctx.size), ''));
+          if (rf & 2) {
+            $r3$.ɵt(0, $r3$.ɵi1('', $r3$.ɵpb2(1, $r3$.ɵpb2(2, ctx.name, ctx.size), ctx.size), ''));
+          }
         }
       });
       // /NORMATIVE
@@ -154,28 +156,32 @@ describe('pipes', () => {
         type: MyApp,
         selectors: [['my-app']],
         factory: function MyApp_Factory() { return new MyApp(); },
-        template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-          if (cm) {
+        template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+          if (rf & 1) {
             $r3$.ɵT(0);
             $r3$.ɵPp(1, 'myPurePipe');
             $r3$.ɵT(2);
             $r3$.ɵPp(3, 'myPurePipe');
             $r3$.ɵC(4, C4, '', ['oneTimeIf', '']);
           }
-          $r3$.ɵt(0, $r3$.ɵi1('', $r3$.ɵpb2(1, ctx.name, ctx.size), ''));
-          $r3$.ɵt(2, $r3$.ɵi1('', $r3$.ɵpb2(3, ctx.name, ctx.size), ''));
-          $r3$.ɵp(4, 'oneTimeIf', $r3$.ɵb(ctx.more));
-          $r3$.ɵcR(4);
-          $r3$.ɵcr();
+          if (rf & 2) {
+            $r3$.ɵt(0, $r3$.ɵi1('', $r3$.ɵpb2(1, ctx.name, ctx.size), ''));
+            $r3$.ɵt(2, $r3$.ɵi1('', $r3$.ɵpb2(3, ctx.name, ctx.size), ''));
+            $r3$.ɵp(4, 'oneTimeIf', $r3$.ɵb(ctx.more));
+            $r3$.ɵcR(4);
+            $r3$.ɵcr();
+          }
 
-          function C4(ctx1: $any$, cm: $boolean$) {
-            if (cm) {
+          function C4(rf: $RenderFlags$, ctx1: $any$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'div');
               $r3$.ɵT(1);
               $r3$.ɵPp(2, 'myPurePipe');
               $r3$.ɵe();
             }
-            $r3$.ɵt(1, $r3$.ɵi1('', $r3$.ɵpb2(2, ctx.name, ctx.size), ''));
+            if (rf & 2) {
+              $r3$.ɵt(1, $r3$.ɵi1('', $r3$.ɵpb2(2, ctx.name, ctx.size), ''));
+            }
           }
         }
       });

--- a/packages/core/test/render3/compiler_canonical/query_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/query_spec.ts
@@ -12,7 +12,7 @@ import {renderComponent, toHtml} from '../render_util';
 
 /// See: `normative.md`
 describe('queries', () => {
-  type $boolean$ = boolean;
+  type $RenderFlags$ = $r3$.ɵRenderFlags;
   type $number$ = number;
   let someDir: SomeDirective;
 
@@ -50,18 +50,20 @@ describe('queries', () => {
         type: ViewQueryComponent,
         selectors: [['view-query-component']],
         factory: function ViewQueryComponent_Factory() { return new ViewQueryComponent(); },
-        template: function ViewQueryComponent_Template(ctx: $ViewQueryComponent$, cm: $boolean$) {
+        template: function ViewQueryComponent_Template(
+            rf: $RenderFlags$, ctx: $ViewQueryComponent$) {
           let $tmp$: any;
-          if (cm) {
+          if (rf & 1) {
             $r3$.ɵQ(0, SomeDirective, false);
             $r3$.ɵQ(1, SomeDirective, false);
             $r3$.ɵE(2, 'div', $e1_attrs$);
             $r3$.ɵe();
           }
-
-          $r3$.ɵqR($tmp$ = $r3$.ɵld<QueryList<any>>(0)) && (ctx.someDir = $tmp$.first);
-          $r3$.ɵqR($tmp$ = $r3$.ɵld<QueryList<any>>(1)) &&
-              (ctx.someDirList = $tmp$ as QueryList<any>);
+          if (rf & 2) {
+            $r3$.ɵqR($tmp$ = $r3$.ɵld<QueryList<any>>(0)) && (ctx.someDir = $tmp$.first);
+            $r3$.ɵqR($tmp$ = $r3$.ɵld<QueryList<any>>(1)) &&
+                (ctx.someDirList = $tmp$ as QueryList<any>);
+          }
         }
       });
       // /NORMATIVE
@@ -110,8 +112,8 @@ describe('queries', () => {
           $r3$.ɵqR($tmp$ = $r3$.ɵd<any[]>(dirIndex)[2]) && ($instance$.someDirList = $tmp$);
         },
         template: function ContentQueryComponent_Template(
-            ctx: $ContentQueryComponent$, cm: $boolean$) {
-          if (cm) {
+            rf: $number$, ctx: $ContentQueryComponent$) {
+          if (rf & 1) {
             $r3$.ɵpD(0);
             $r3$.ɵE(1, 'div');
             $r3$.ɵP(2, 0);
@@ -138,8 +140,8 @@ describe('queries', () => {
         type: MyApp,
         selectors: [['my-app']],
         factory: function MyApp_Factory() { return new MyApp(); },
-        template: function MyApp_Template(ctx: $MyApp$, cm: $boolean$) {
-          if (cm) {
+        template: function MyApp_Template(rf: $RenderFlags$, ctx: $MyApp$) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'content-query-component');
             contentQueryComp = $r3$.ɵd<any[]>(0)[0];
             $r3$.ɵE(1, 'div', $e2_attrs$);

--- a/packages/core/test/render3/compiler_canonical/sanitize_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/sanitize_spec.ts
@@ -19,7 +19,8 @@ import {renderComponent, toHtml} from '../render_util';
  */
 
 describe('compiler sanitization', () => {
-  type $boolean$ = boolean;
+  type $RenderFlags$ = $r3$.ɵRenderFlags;
+
   it('should translate DOM structure', () => {
     type $MyComponent$ = MyComponent;
 
@@ -40,18 +41,20 @@ describe('compiler sanitization', () => {
         type: MyComponent,
         selectors: [['my-component']],
         factory: function MyComponent_Factory() { return new MyComponent(); },
-        template: function MyComponent_Template(ctx: $MyComponent$, cm: $boolean$) {
-          if (cm) {
+        template: function MyComponent_Template(rf: $RenderFlags$, ctx: $MyComponent$) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'div');
             $r3$.ɵe();
             $r3$.ɵE(1, 'img');
             $r3$.ɵe();
           }
-          $r3$.ɵp(0, 'innerHTML', $r3$.ɵb(ctx.innerHTML), $r3$.ɵsanitizeHtml);
-          $r3$.ɵp(0, 'hidden', $r3$.ɵb(ctx.hidden));
-          $r3$.ɵsn(1, 'background-image', $r3$.ɵb(ctx.style), $r3$.ɵsanitizeStyle);
-          $r3$.ɵp(1, 'src', $r3$.ɵb(ctx.url), $r3$.ɵsanitizeUrl);
-          $r3$.ɵa(1, 'srcset', $r3$.ɵb(ctx.url), $r3$.ɵsanitizeUrl);
+          if (rf & 2) {
+            $r3$.ɵp(0, 'innerHTML', $r3$.ɵb(ctx.innerHTML), $r3$.ɵsanitizeHtml);
+            $r3$.ɵp(0, 'hidden', $r3$.ɵb(ctx.hidden));
+            $r3$.ɵsn(1, 'background-image', $r3$.ɵb(ctx.style), $r3$.ɵsanitizeStyle);
+            $r3$.ɵp(1, 'src', $r3$.ɵb(ctx.url), $r3$.ɵsanitizeUrl);
+            $r3$.ɵa(1, 'srcset', $r3$.ɵb(ctx.url), $r3$.ɵsanitizeUrl);
+          }
         }
       });
       // /NORMATIVE

--- a/packages/core/test/render3/compiler_canonical/small_app_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/small_app_spec.ts
@@ -21,6 +21,8 @@ interface ToDo {
   done: boolean;
 }
 
+type $RenderFlags$ = r3.RenderFlags;
+
 @Injectable()
 class AppState {
   todos: ToDo[] = [
@@ -62,16 +64,18 @@ class ToDoAppComponent {
     factory: function ToDoAppComponent_Factory() {
       return new ToDoAppComponent(r3.directiveInject(AppState));
     },
-    template: function ToDoAppComponent_Template(ctx: ToDoAppComponent, cm: boolean) {
-      if (cm) {
+    template: function ToDoAppComponent_Template(rf: $RenderFlags$, ctx: ToDoAppComponent) {
+      if (rf & 1) {
         const ToDoAppComponent_NgForOf_Template = function ToDoAppComponent_NgForOf_Template(
-            ctx1: NgForOfContext<ToDo>, cm: boolean) {
-          if (cm) {
+            rf: $RenderFlags$, ctx1: NgForOfContext<ToDo>) {
+          if (rf & 1) {
             r3.E(0, 'todo');
             r3.L('archive', ctx.onArchive.bind(ctx));
             r3.e();
           }
-          r3.p(0, 'todo', r3.b(ctx1.$implicit));
+          if (rf & 2) {
+            r3.p(0, 'todo', r3.b(ctx1.$implicit));
+          }
         };
         r3.E(0, 'h1');
         r3.T(1, 'ToDo Application');
@@ -83,7 +87,9 @@ class ToDoAppComponent {
         r3.T(5);
         r3.e();
       }
-      r3.t(5, r3.i1('count: ', ctx.appState.todos.length, ''));
+      if (rf & 2) {
+        r3.t(5, r3.i1('count: ', ctx.appState.todos.length, ''));
+      }
     }
   });
   // /NORMATIVE
@@ -125,8 +131,8 @@ class ToDoItemComponent {
     type: ToDoItemComponent,
     selectors: [['todo']],
     factory: function ToDoItemComponent_Factory() { return new ToDoItemComponent(); },
-    template: function ToDoItemComponent_Template(ctx: ToDoItemComponent, cm: boolean) {
-      if (cm) {
+    template: function ToDoItemComponent_Template(rf: $RenderFlags$, ctx: ToDoItemComponent) {
+      if (rf & 1) {
         r3.E(0, 'div');
         r3.E(1, 'input', e1_attrs);
         r3.L('click', ctx.onCheckboxClick.bind(ctx));
@@ -140,8 +146,10 @@ class ToDoItemComponent {
         r3.e();
         r3.e();
       }
-      r3.p(1, 'value', r3.b(ctx.todo.done));
-      r3.t(3, r3.b(ctx.todo.text));
+      if (rf & 2) {
+        r3.p(1, 'value', r3.b(ctx.todo.done));
+        r3.t(3, r3.b(ctx.todo.text));
+      }
     },
     inputs: {todo: 'todo'},
   });

--- a/packages/core/test/render3/compiler_canonical/template_variables_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/template_variables_spec.ts
@@ -12,9 +12,9 @@ import {renderComponent, toHtml} from '../render_util';
 
 /// See: `normative.md`
 describe('template variables', () => {
-  type $boolean$ = boolean;
   type $any$ = any;
   type $number$ = number;
+  type $RenderFlags$ = $r3$.ɵRenderFlags;
 
   interface ForOfContext {
     $implicit: any;
@@ -93,24 +93,29 @@ describe('template variables', () => {
         type: MyComponent,
         selectors: [['my-component']],
         factory: function MyComponent_Factory() { return new MyComponent(); },
-        template: function MyComponent_Template(ctx: $MyComponent$, cm: $boolean$) {
-          if (cm) {
+        template: function MyComponent_Template(rf: $RenderFlags$, ctx: $MyComponent$) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'ul');
             $r3$.ɵC(1, MyComponent_ForOfDirective_Template_1, '', ['forOf', '']);
             $r3$.ɵe();
           }
-          $r3$.ɵp(1, 'forOf', $r3$.ɵb(ctx.items));
-          $r3$.ɵcR(1);
-          $r3$.ɵcr();
+          if (rf & 2) {
+            $r3$.ɵp(1, 'forOf', $r3$.ɵb(ctx.items));
+            $r3$.ɵcR(1);
+            $r3$.ɵcr();
+          }
 
-          function MyComponent_ForOfDirective_Template_1(ctx1: $any$, cm: $boolean$) {
-            if (cm) {
+          function MyComponent_ForOfDirective_Template_1(rf: $RenderFlags$, ctx1: $any$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'li');
               $r3$.ɵT(1);
               $r3$.ɵe();
             }
-            const $l0_item$ = ctx1.$implicit;
-            $r3$.ɵt(1, $r3$.ɵi1('', $l0_item$.name, ''));
+            let $l0_item$: any;
+            if (rf & 2) {
+              $l0_item$ = ctx1.$implicit;
+              $r3$.ɵt(1, $r3$.ɵi1('', $l0_item$.name, ''));
+            }
           }
         }
       });
@@ -161,18 +166,20 @@ describe('template variables', () => {
         type: MyComponent,
         selectors: [['my-component']],
         factory: function MyComponent_Factory() { return new MyComponent(); },
-        template: function MyComponent_Template(ctx: $MyComponent$, cm: $boolean$) {
-          if (cm) {
+        template: function MyComponent_Template(rf: $RenderFlags$, ctx: $MyComponent$) {
+          if (rf & 1) {
             $r3$.ɵE(0, 'ul');
             $r3$.ɵC(1, MyComponent_ForOfDirective_Template_1, '', ['forOf', '']);
             $r3$.ɵe();
           }
-          $r3$.ɵp(1, 'forOf', $r3$.ɵb(ctx.items));
-          $r3$.ɵcR(1);
-          $r3$.ɵcr();
+          if (rf & 2) {
+            $r3$.ɵp(1, 'forOf', $r3$.ɵb(ctx.items));
+            $r3$.ɵcR(1);
+            $r3$.ɵcr();
+          }
 
-          function MyComponent_ForOfDirective_Template_1(ctx1: $any$, cm: $boolean$) {
-            if (cm) {
+          function MyComponent_ForOfDirective_Template_1(rf1: $RenderFlags$, ctx1: $any$) {
+            if (rf & 1) {
               $r3$.ɵE(0, 'li');
               $r3$.ɵE(1, 'div');
               $r3$.ɵT(2);
@@ -182,21 +189,27 @@ describe('template variables', () => {
               $r3$.ɵe();
               $r3$.ɵe();
             }
-            const $l0_item$ = ctx1.$implicit;
-            $r3$.ɵp(4, 'forOf', $r3$.ɵb($l0_item$.infos));
-            $r3$.ɵt(2, $r3$.ɵi1('', $l0_item$.name, ''));
-            $r3$.ɵcR(4);
-            $r3$.ɵcr();
+            let $l0_item$: any;
+            if (rf & 2) {
+              $l0_item$ = ctx1.$implicit;
+              $r3$.ɵp(4, 'forOf', $r3$.ɵb($l0_item$.infos));
+              $r3$.ɵt(2, $r3$.ɵi1('', $l0_item$.name, ''));
+              $r3$.ɵcR(4);
+              $r3$.ɵcr();
+            }
 
             function MyComponent_ForOfDirective_ForOfDirective_Template_3(
-                ctx2: $any$, cm: $boolean$) {
-              if (cm) {
+                rf2: $number$, ctx2: $any$) {
+              if (rf & 1) {
                 $r3$.ɵE(0, 'li');
                 $r3$.ɵT(1);
                 $r3$.ɵe();
               }
-              const $l0_info$ = ctx2.$implicit;
-              $r3$.ɵt(1, $r3$.ɵi2(' ', $l0_item$.name, ': ', $l0_info$.description, ' '));
+              let $l0_info$: any;
+              if (rf & 2) {
+                $l0_info$ = ctx2.$implicit;
+                $r3$.ɵt(1, $r3$.ɵi2(' ', $l0_item$.name, ': ', $l0_info$.description, ' '));
+              }
             }
           }
         }

--- a/packages/core/test/render3/directive_spec.ts
+++ b/packages/core/test/render3/directive_spec.ts
@@ -8,7 +8,7 @@
 
 import {defineDirective} from '../../src/render3/index';
 import {bind, elementEnd, elementProperty, elementStart, loadDirective} from '../../src/render3/instructions';
-
+import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {renderToHtml} from './render_util';
 
 describe('directive', () => {
@@ -31,8 +31,8 @@ describe('directive', () => {
         });
       }
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'span', ['dir', '']);
           elementEnd();
         }

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -9,18 +9,20 @@
 import {SimpleChanges} from '../../src/core';
 import {ComponentTemplate, LifecycleHooksFeature, NgOnChangesFeature, defineComponent, defineDirective} from '../../src/render3/index';
 import {bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, listener, markDirty, projection, projectionDef, store, text} from '../../src/render3/instructions';
-
+import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {containerEl, renderComponent, renderToHtml, requestAnimationFrame} from './render_util';
 
 describe('lifecycles', () => {
 
   function getParentTemplate(name: string) {
-    return (ctx: any, cm: boolean) => {
-      if (cm) {
+    return (rf: RenderFlags, ctx: any) => {
+      if (rf & RenderFlags.Create) {
         elementStart(0, name);
         elementEnd();
       }
-      elementProperty(0, 'val', bind(ctx.val));
+      if (rf & RenderFlags.Update) {
+        elementProperty(0, 'val', bind(ctx.val));
+      }
     };
   }
 
@@ -29,8 +31,8 @@ describe('lifecycles', () => {
 
     beforeEach(() => { events = []; });
 
-    let Comp = createOnInitComponent('comp', (ctx: any, cm: boolean) => {
-      if (cm) {
+    let Comp = createOnInitComponent('comp', (rf: RenderFlags, ctx: any) => {
+      if (rf & RenderFlags.Create) {
         projectionDef(0);
         elementStart(1, 'div');
         { projection(2, 0); }
@@ -38,8 +40,8 @@ describe('lifecycles', () => {
       }
     });
     let Parent = createOnInitComponent('parent', getParentTemplate('comp'), [Comp]);
-    let ProjectedComp = createOnInitComponent('projected', (ctx: any, cm: boolean) => {
-      if (cm) {
+    let ProjectedComp = createOnInitComponent('projected', (rf: RenderFlags, ctx: any) => {
+      if (rf & RenderFlags.Create) {
         text(0, 'content');
       }
     });
@@ -72,12 +74,14 @@ describe('lifecycles', () => {
     it('should call onInit method after inputs are set in creation mode (and not in update mode)',
        () => {
          /** <comp [val]="val"></comp> */
-         function Template(ctx: any, cm: boolean) {
-           if (cm) {
+         function Template(rf: RenderFlags, ctx: any) {
+           if (rf & RenderFlags.Create) {
              elementStart(0, 'comp');
              elementEnd();
            }
-           elementProperty(0, 'val', bind(ctx.val));
+           if (rf & RenderFlags.Update) {
+             elementProperty(0, 'val', bind(ctx.val));
+           }
          }
 
          renderToHtml(Template, {val: '1'}, directives);
@@ -102,8 +106,8 @@ describe('lifecycles', () => {
        * parent temp: <comp></comp>
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           elementEnd();
         }
@@ -121,15 +125,17 @@ describe('lifecycles', () => {
        * parent temp: <comp [val]="val"></comp>
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           elementEnd();
           elementStart(1, 'parent');
           elementEnd();
         }
-        elementProperty(0, 'val', 1);
-        elementProperty(1, 'val', 2);
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', 1);
+          elementProperty(1, 'val', 2);
+        }
       }
 
       renderToHtml(Template, {}, directives);
@@ -144,21 +150,24 @@ describe('lifecycles', () => {
        * % }
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           container(0);
         }
-        containerRefreshStart(0);
-        {
-          if (ctx.condition) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'comp');
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(0);
+          {
+            if (ctx.condition) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'comp');
+                elementEnd();
+              }
+              embeddedViewEnd();
             }
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {condition: true}, directives);
@@ -177,8 +186,8 @@ describe('lifecycles', () => {
        *   <projected></projected>
        * </comp>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           { elementStart(1, 'projected'); }
           elementEnd();
@@ -198,8 +207,8 @@ describe('lifecycles', () => {
        *   <projected [val]="1"></projected>
        * </comp>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           { elementStart(1, 'projected'); }
           elementEnd();
@@ -207,10 +216,12 @@ describe('lifecycles', () => {
           { elementStart(3, 'projected'); }
           elementEnd();
         }
-        elementProperty(0, 'val', 1);
-        elementProperty(1, 'val', 1);
-        elementProperty(2, 'val', 2);
-        elementProperty(3, 'val', 2);
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', 1);
+          elementProperty(1, 'val', 1);
+          elementProperty(2, 'val', 2);
+          elementProperty(3, 'val', 2);
+        }
       }
 
       renderToHtml(Template, {}, directives);
@@ -219,8 +230,8 @@ describe('lifecycles', () => {
 
     it('should be called on directives after component', () => {
       /** <comp directive></comp> */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp', ['dir', '']);
           elementEnd();
         }
@@ -236,8 +247,8 @@ describe('lifecycles', () => {
 
     it('should be called on directives on an element', () => {
       /** <div directive></div> */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'div', ['dir', '']);
           elementEnd();
         }
@@ -259,28 +270,33 @@ describe('lifecycles', () => {
        *  <comp [val]="5"></comp>
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           elementEnd();
           container(1);
           elementStart(2, 'comp');
           elementEnd();
         }
-        elementProperty(0, 'val', 1);
-        elementProperty(2, 'val', 5);
-        containerRefreshStart(1);
-        {
-          for (let j = 2; j < 5; j++) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'comp');
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', 1);
+          elementProperty(2, 'val', 5);
+          containerRefreshStart(1);
+          {
+            for (let j = 2; j < 5; j++) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'comp');
+                elementEnd();
+              }
+              if (rf1 & RenderFlags.Update) {
+                elementProperty(0, 'val', j);
+              }
+              embeddedViewEnd();
             }
-            elementProperty(0, 'val', j);
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {}, directives);
@@ -299,28 +315,33 @@ describe('lifecycles', () => {
        *  <parent [val]="5"></parent>
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           elementEnd();
           container(1);
           elementStart(2, 'parent');
           elementEnd();
         }
-        elementProperty(0, 'val', 1);
-        elementProperty(2, 'val', 5);
-        containerRefreshStart(1);
-        {
-          for (let j = 2; j < 5; j++) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'parent');
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', 1);
+          elementProperty(2, 'val', 5);
+          containerRefreshStart(1);
+          {
+            for (let j = 2; j < 5; j++) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'parent');
+                elementEnd();
+              }
+              if (rf1 & RenderFlags.Update) {
+                elementProperty(0, 'val', j);
+              }
+              embeddedViewEnd();
             }
-            elementProperty(0, 'val', j);
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {}, directives);
@@ -344,7 +365,7 @@ describe('lifecycles', () => {
       allEvents = [];
     });
 
-    let Comp = createDoCheckComponent('comp', (ctx: any, cm: boolean) => {});
+    let Comp = createDoCheckComponent('comp', (rf: RenderFlags, ctx: any) => {});
     let Parent = createDoCheckComponent('parent', getParentTemplate('comp'), [Comp]);
 
     function createDoCheckComponent(
@@ -377,8 +398,8 @@ describe('lifecycles', () => {
 
     it('should call doCheck on every refresh', () => {
       /** <comp></comp> */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           elementEnd();
         }
@@ -406,8 +427,8 @@ describe('lifecycles', () => {
        * parent temp: <comp></comp>
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           elementEnd();
         }
@@ -419,8 +440,8 @@ describe('lifecycles', () => {
 
     it('should call ngOnInit before ngDoCheck if creation mode', () => {
       /** <comp></comp> */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           elementEnd();
         }
@@ -435,8 +456,8 @@ describe('lifecycles', () => {
 
     it('should be called on directives after component', () => {
       /** <comp directive></comp> */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp', ['dir', '']);
           elementEnd();
         }
@@ -452,8 +473,8 @@ describe('lifecycles', () => {
 
     it('should be called on directives on an element', () => {
       /** <div directive></div> */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'div', ['dir', '']);
           elementEnd();
         }
@@ -477,25 +498,27 @@ describe('lifecycles', () => {
       allEvents = [];
     });
 
-    let Comp = createAfterContentInitComp('comp', function(ctx: any, cm: boolean) {
-      if (cm) {
+    let Comp = createAfterContentInitComp('comp', function(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         projectionDef(0);
         projection(1, 0);
       }
     });
 
-    let Parent = createAfterContentInitComp('parent', function(ctx: any, cm: boolean) {
-      if (cm) {
+    let Parent = createAfterContentInitComp('parent', function(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         projectionDef(0);
         elementStart(1, 'comp');
         { projection(2, 0); }
         elementEnd();
       }
-      elementProperty(1, 'val', bind(ctx.val));
+      if (rf & RenderFlags.Update) {
+        elementProperty(1, 'val', bind(ctx.val));
+      }
     }, [Comp]);
 
-    let ProjectedComp = createAfterContentInitComp('projected', (ctx: any, cm: boolean) => {
-      if (cm) {
+    let ProjectedComp = createAfterContentInitComp('projected', (rf: RenderFlags, ctx: any) => {
+      if (rf & RenderFlags.Create) {
         projectionDef(0);
         projection(1, 0);
       }
@@ -530,8 +553,8 @@ describe('lifecycles', () => {
           {type: Directive, selectors: [['', 'dir', '']], factory: () => new Directive()});
     }
 
-    function ForLoopWithChildrenTemplate(ctx: any, cm: boolean) {
-      if (cm) {
+    function ForLoopWithChildrenTemplate(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'parent');
         { text(1, 'content'); }
         elementEnd();
@@ -540,29 +563,34 @@ describe('lifecycles', () => {
         { text(4, 'content'); }
         elementEnd();
       }
-      elementProperty(0, 'val', 1);
-      elementProperty(3, 'val', 4);
-      containerRefreshStart(2);
-      {
-        for (let i = 2; i < 4; i++) {
-          if (embeddedViewStart(0)) {
-            elementStart(0, 'parent');
-            { text(1, 'content'); }
-            elementEnd();
+      if (rf & RenderFlags.Update) {
+        elementProperty(0, 'val', 1);
+        elementProperty(3, 'val', 4);
+        containerRefreshStart(2);
+        {
+          for (let i = 2; i < 4; i++) {
+            let rf1 = embeddedViewStart(0);
+            if (rf1 & RenderFlags.Create) {
+              elementStart(0, 'parent');
+              { text(1, 'content'); }
+              elementEnd();
+            }
+            if (rf1 & RenderFlags.Update) {
+              elementProperty(0, 'val', i);
+            }
+            embeddedViewEnd();
           }
-          elementProperty(0, 'val', i);
-          embeddedViewEnd();
         }
+        containerRefreshEnd();
       }
-      containerRefreshEnd();
     }
 
     const directives = [Comp, Parent, ProjectedComp, Directive];
 
     it('should be called only in creation mode', () => {
       /** <comp>content</comp> */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           { text(1, 'content'); }
           elementEnd();
@@ -591,22 +619,25 @@ describe('lifecycles', () => {
        *   <comp>content</comp>
        * % }
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           container(0);
         }
-        containerRefreshStart(0);
-        {
-          if (ctx.condition) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'comp');
-              { text(1, 'content'); }
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(0);
+          {
+            if (ctx.condition) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'comp');
+                { text(1, 'content'); }
+                elementEnd();
+              }
+              embeddedViewEnd();
             }
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {condition: true}, directives);
@@ -625,8 +656,8 @@ describe('lifecycles', () => {
        *
        * parent template: <comp><ng-content></ng-content></comp>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           { text(1, 'content'); }
           elementEnd();
@@ -644,8 +675,8 @@ describe('lifecycles', () => {
        *
        * parent template: <comp [val]="val"><ng-content></ng-content></comp>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           { text(1, 'content'); }
           elementEnd();
@@ -653,8 +684,10 @@ describe('lifecycles', () => {
           { text(3, 'content'); }
           elementEnd();
         }
-        elementProperty(0, 'val', 1);
-        elementProperty(2, 'val', 2);
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', 1);
+          elementProperty(2, 'val', 2);
+        }
       }
 
       renderToHtml(Template, {}, directives);
@@ -672,8 +705,8 @@ describe('lifecycles', () => {
        *
        * projected comp: <ng-content></ng-content>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           {
             elementStart(1, 'projected');
@@ -702,8 +735,8 @@ describe('lifecycles', () => {
        *
        * projected comp: <ng-content></ng-content>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           {
             elementStart(1, 'projected');
@@ -719,10 +752,12 @@ describe('lifecycles', () => {
           }
           elementEnd();
         }
-        elementProperty(0, 'val', 1);
-        elementProperty(1, 'val', 1);
-        elementProperty(3, 'val', 2);
-        elementProperty(4, 'val', 2);
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', 1);
+          elementProperty(1, 'val', 1);
+          elementProperty(3, 'val', 2);
+          elementProperty(4, 'val', 2);
+        }
       }
 
       renderToHtml(Template, {}, directives);
@@ -737,8 +772,8 @@ describe('lifecycles', () => {
        * % }
        * <comp [val]="4">content</comp>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           { text(1, 'content'); }
           elementEnd();
@@ -747,21 +782,26 @@ describe('lifecycles', () => {
           { text(4, 'content'); }
           elementEnd();
         }
-        elementProperty(0, 'val', 1);
-        elementProperty(3, 'val', 4);
-        containerRefreshStart(2);
-        {
-          for (let i = 2; i < 4; i++) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'comp');
-              { text(1, 'content'); }
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', 1);
+          elementProperty(3, 'val', 4);
+          containerRefreshStart(2);
+          {
+            for (let i = 2; i < 4; i++) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'comp');
+                { text(1, 'content'); }
+                elementEnd();
+              }
+              if (rf1 & RenderFlags.Update) {
+                elementProperty(0, 'val', i);
+              }
+              embeddedViewEnd();
             }
-            elementProperty(0, 'val', i);
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {}, directives);
@@ -786,8 +826,8 @@ describe('lifecycles', () => {
 
       it('should be called every change detection run after afterContentInit', () => {
         /** <comp>content</comp> */
-        function Template(ctx: any, cm: boolean) {
-          if (cm) {
+        function Template(rf: RenderFlags, ctx: any) {
+          if (rf & RenderFlags.Create) {
             elementStart(0, 'comp');
             { text(1, 'content'); }
             elementEnd();
@@ -816,8 +856,8 @@ describe('lifecycles', () => {
     describe('directives', () => {
       it('should be called on directives after component', () => {
         /** <comp directive></comp> */
-        function Template(ctx: any, cm: boolean) {
-          if (cm) {
+        function Template(rf: RenderFlags, ctx: any) {
+          if (rf & RenderFlags.Create) {
             elementStart(0, 'comp', ['dir', '']);
             elementEnd();
           }
@@ -829,8 +869,8 @@ describe('lifecycles', () => {
 
       it('should be called on directives on an element', () => {
         /** <div directive></div> */
-        function Template(ctx: any, cm: boolean) {
-          if (cm) {
+        function Template(rf: RenderFlags, ctx: any) {
+          if (rf & RenderFlags.Create) {
             elementStart(0, 'div', ['dir', '']);
             elementEnd();
           }
@@ -851,8 +891,8 @@ describe('lifecycles', () => {
       allEvents = [];
     });
 
-    let Comp = createAfterViewInitComponent('comp', (ctx: any, cm: boolean) => {
-      if (cm) {
+    let Comp = createAfterViewInitComponent('comp', (rf: RenderFlags, ctx: any) => {
+      if (rf & RenderFlags.Create) {
         projectionDef(0);
         elementStart(1, 'div');
         { projection(2, 0); }
@@ -861,8 +901,8 @@ describe('lifecycles', () => {
     });
     let Parent = createAfterViewInitComponent('parent', getParentTemplate('comp'), [Comp]);
 
-    let ProjectedComp = createAfterViewInitComponent('projected', (ctx: any, cm: boolean) => {
-      if (cm) {
+    let ProjectedComp = createAfterViewInitComponent('projected', (rf: RenderFlags, ctx: any) => {
+      if (rf & RenderFlags.Create) {
         text(0, 'content');
       }
     });
@@ -900,8 +940,8 @@ describe('lifecycles', () => {
 
     it('should be called on init and not in update mode', () => {
       /** <comp></comp> */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           elementEnd();
         }
@@ -929,21 +969,24 @@ describe('lifecycles', () => {
       *   <comp></comp>
       * % }
       */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           container(0);
         }
-        containerRefreshStart(0);
-        {
-          if (ctx.condition) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'comp');
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(0);
+          {
+            if (ctx.condition) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'comp');
+                elementEnd();
+              }
+              embeddedViewEnd();
             }
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {condition: true}, defs);
@@ -963,8 +1006,8 @@ describe('lifecycles', () => {
        *
        * parent temp: <comp></comp>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           elementEnd();
         }
@@ -982,15 +1025,17 @@ describe('lifecycles', () => {
        *
        *  parent temp: <comp [val]="val"></comp>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           elementEnd();
           elementStart(1, 'parent');
           elementEnd();
         }
-        elementProperty(0, 'val', 1);
-        elementProperty(1, 'val', 2);
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', 1);
+          elementProperty(1, 'val', 2);
+        }
       }
       renderToHtml(Template, {}, defs);
       expect(events).toEqual(['comp1', 'comp2', 'parent1', 'parent2']);
@@ -1003,8 +1048,8 @@ describe('lifecycles', () => {
        *   <projected></projected>
        * </comp>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           {
             elementStart(1, 'projected');
@@ -1027,8 +1072,8 @@ describe('lifecycles', () => {
        *   <projected [val]="2"></projected>
        * </comp>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           {
             elementStart(1, 'projected');
@@ -1042,10 +1087,12 @@ describe('lifecycles', () => {
           }
           elementEnd();
         }
-        elementProperty(0, 'val', 1);
-        elementProperty(1, 'val', 1);
-        elementProperty(2, 'val', 2);
-        elementProperty(3, 'val', 2);
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', 1);
+          elementProperty(1, 'val', 1);
+          elementProperty(2, 'val', 2);
+          elementProperty(3, 'val', 2);
+        }
       }
 
       renderToHtml(Template, {}, defs);
@@ -1058,8 +1105,8 @@ describe('lifecycles', () => {
        *   <projected [val]="val"></projected>
        * </comp>
        */
-      const ParentComp = createAfterViewInitComponent('parent', (ctx: any, cm: boolean) => {
-        if (cm) {
+      const ParentComp = createAfterViewInitComponent('parent', (rf: RenderFlags, ctx: any) => {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           {
             elementStart(1, 'projected');
@@ -1067,23 +1114,27 @@ describe('lifecycles', () => {
           }
           elementEnd();
         }
-        elementProperty(0, 'val', bind(ctx.val));
-        elementProperty(1, 'val', bind(ctx.val));
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', bind(ctx.val));
+          elementProperty(1, 'val', bind(ctx.val));
+        }
       }, [Comp, ProjectedComp]);
 
       /**
        * <parent [val]="1"></parent>
        * <parent [val]="2"></parent>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           elementEnd();
           elementStart(1, 'parent');
           elementEnd();
         }
-        elementProperty(0, 'val', 1);
-        elementProperty(1, 'val', 2);
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', 1);
+          elementProperty(1, 'val', 2);
+        }
       }
 
       renderToHtml(Template, {}, [ParentComp]);
@@ -1098,28 +1149,33 @@ describe('lifecycles', () => {
        * % }
        * <comp [val]="4"></comp>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           elementEnd();
           container(1);
           elementStart(2, 'comp');
           elementEnd();
         }
-        elementProperty(0, 'val', 1);
-        elementProperty(2, 'val', 4);
-        containerRefreshStart(1);
-        {
-          for (let i = 2; i < 4; i++) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'comp');
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', 1);
+          elementProperty(2, 'val', 4);
+          containerRefreshStart(1);
+          {
+            for (let i = 2; i < 4; i++) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'comp');
+                elementEnd();
+              }
+              if (rf1 & RenderFlags.Update) {
+                elementProperty(0, 'val', i);
+              }
+              embeddedViewEnd();
             }
-            elementProperty(0, 'val', i);
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {}, defs);
@@ -1135,28 +1191,33 @@ describe('lifecycles', () => {
        * % }
        * <parent [val]="4"></parent>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           elementEnd();
           container(1);
           elementStart(2, 'parent');
           elementEnd();
         }
-        elementProperty(0, 'val', 1);
-        elementProperty(2, 'val', 4);
-        containerRefreshStart(1);
-        {
-          for (let i = 2; i < 4; i++) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'parent');
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', 1);
+          elementProperty(2, 'val', 4);
+          containerRefreshStart(1);
+          {
+            for (let i = 2; i < 4; i++) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'parent');
+                elementEnd();
+              }
+              if (rf1 & RenderFlags.Update) {
+                elementProperty(0, 'val', i);
+              }
+              embeddedViewEnd();
             }
-            elementProperty(0, 'val', i);
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {}, defs);
@@ -1169,8 +1230,8 @@ describe('lifecycles', () => {
 
       it('should call ngAfterViewChecked every update', () => {
         /** <comp></comp> */
-        function Template(ctx: any, cm: boolean) {
-          if (cm) {
+        function Template(rf: RenderFlags, ctx: any) {
+          if (rf & RenderFlags.Create) {
             elementStart(0, 'comp');
             elementEnd();
           }
@@ -1194,12 +1255,14 @@ describe('lifecycles', () => {
 
       it('should call ngAfterViewChecked with bindings', () => {
         /** <comp [val]="myVal"></comp> */
-        function Template(ctx: any, cm: boolean) {
-          if (cm) {
+        function Template(rf: RenderFlags, ctx: any) {
+          if (rf & RenderFlags.Create) {
             elementStart(0, 'comp');
             elementEnd();
           }
-          elementProperty(0, 'val', bind(ctx.myVal));
+          if (rf & RenderFlags.Update) {
+            elementProperty(0, 'val', bind(ctx.myVal));
+          }
         }
 
         renderToHtml(Template, {myVal: 5}, defs);
@@ -1217,28 +1280,33 @@ describe('lifecycles', () => {
        * % }
          * <parent [val]="4"></parent>
          */
-        function Template(ctx: any, cm: boolean) {
-          if (cm) {
+        function Template(rf: RenderFlags, ctx: any) {
+          if (rf & RenderFlags.Create) {
             elementStart(0, 'parent');
             elementEnd();
             container(1);
             elementStart(2, 'parent');
             elementEnd();
           }
-          elementProperty(0, 'val', 1);
-          elementProperty(2, 'val', 4);
-          containerRefreshStart(1);
-          {
-            for (let i = 2; i < 4; i++) {
-              if (embeddedViewStart(0)) {
-                elementStart(0, 'parent');
-                elementEnd();
+          if (rf & RenderFlags.Update) {
+            elementProperty(0, 'val', 1);
+            elementProperty(2, 'val', 4);
+            containerRefreshStart(1);
+            {
+              for (let i = 2; i < 4; i++) {
+                let rf1 = embeddedViewStart(0);
+                if (rf1 & RenderFlags.Create) {
+                  elementStart(0, 'parent');
+                  elementEnd();
+                }
+                if (rf1 & RenderFlags.Update) {
+                  elementProperty(0, 'val', i);
+                }
+                embeddedViewEnd();
               }
-              elementProperty(0, 'val', i);
-              embeddedViewEnd();
             }
+            containerRefreshEnd();
           }
-          containerRefreshEnd();
         }
 
         renderToHtml(Template, {}, defs);
@@ -1255,8 +1323,8 @@ describe('lifecycles', () => {
     describe('directives', () => {
       it('should be called on directives after component', () => {
         /** <comp directive></comp> */
-        function Template(ctx: any, cm: boolean) {
-          if (cm) {
+        function Template(rf: RenderFlags, ctx: any) {
+          if (rf & RenderFlags.Create) {
             elementStart(0, 'comp', ['dir', '']);
             elementEnd();
           }
@@ -1268,8 +1336,8 @@ describe('lifecycles', () => {
 
       it('should be called on directives on an element', () => {
         /** <div directive></div> */
-        function Template(ctx: any, cm: boolean) {
-          if (cm) {
+        function Template(rf: RenderFlags, ctx: any) {
+          if (rf & RenderFlags.Create) {
             elementStart(0, 'div', ['dir', '']);
             elementEnd();
           }
@@ -1286,8 +1354,8 @@ describe('lifecycles', () => {
 
     beforeEach(() => { events = []; });
 
-    let Comp = createOnDestroyComponent('comp', (ctx: any, cm: boolean) => {
-      if (cm) {
+    let Comp = createOnDestroyComponent('comp', (rf: RenderFlags, ctx: any) => {
+      if (rf & RenderFlags.Create) {
         projectionDef(0);
         projection(1, 0);
       }
@@ -1311,14 +1379,14 @@ describe('lifecycles', () => {
       };
     }
 
-    let Grandparent = createOnDestroyComponent('grandparent', function(ctx: any, cm: boolean) {
-      if (cm) {
+    let Grandparent = createOnDestroyComponent('grandparent', function(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'parent');
         elementEnd();
       }
     }, [Parent]);
 
-    const ProjectedComp = createOnDestroyComponent('projected', (ctx: any, cm: boolean) => {});
+    const ProjectedComp = createOnDestroyComponent('projected', (rf: RenderFlags, ctx: any) => {});
 
     class Directive {
       ngOnDestroy() { events.push('dir'); }
@@ -1336,21 +1404,24 @@ describe('lifecycles', () => {
        * % }
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           container(0);
         }
-        containerRefreshStart(0);
-        {
-          if (ctx.condition) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'comp');
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(0);
+          {
+            if (ctx.condition) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'comp');
+                elementEnd();
+              }
+              embeddedViewEnd();
             }
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {condition: true}, defs);
@@ -1366,25 +1437,30 @@ describe('lifecycles', () => {
        * % }
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           container(0);
         }
-        containerRefreshStart(0);
-        {
-          if (ctx.condition) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'comp');
-              elementEnd();
-              elementStart(1, 'comp');
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(0);
+          {
+            if (ctx.condition) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'comp');
+                elementEnd();
+                elementStart(1, 'comp');
+                elementEnd();
+              }
+              if (rf1 & RenderFlags.Update) {
+                elementProperty(0, 'val', bind('1'));
+                elementProperty(1, 'val', bind('2'));
+              }
+              embeddedViewEnd();
             }
-            elementProperty(0, 'val', bind('1'));
-            elementProperty(1, 'val', bind('2'));
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {condition: true}, defs);
@@ -1401,21 +1477,24 @@ describe('lifecycles', () => {
        * parent template: <comp></comp>
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           container(0);
         }
-        containerRefreshStart(0);
-        {
-          if (ctx.condition) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'parent');
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(0);
+          {
+            if (ctx.condition) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'parent');
+                elementEnd();
+              }
+              embeddedViewEnd();
             }
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {condition: true}, defs);
@@ -1433,21 +1512,24 @@ describe('lifecycles', () => {
        * parent template: <comp></comp>
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           container(0);
         }
-        containerRefreshStart(0);
-        {
-          if (ctx.condition) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'grandparent');
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(0);
+          {
+            if (ctx.condition) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'grandparent');
+                elementEnd();
+              }
+              embeddedViewEnd();
             }
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {condition: true}, defs);
@@ -1466,35 +1548,40 @@ describe('lifecycles', () => {
        *   </comp>
        * }
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           container(0);
         }
-        containerRefreshStart(0);
-        {
-          if (ctx.showing) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'comp');
-              {
-                elementStart(1, 'projected');
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(0);
+          {
+            if (ctx.showing) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'comp');
+                {
+                  elementStart(1, 'projected');
+                  elementEnd();
+                }
+                elementEnd();
+                elementStart(2, 'comp');
+                {
+                  elementStart(3, 'projected');
+                  elementEnd();
+                }
                 elementEnd();
               }
-              elementEnd();
-              elementStart(2, 'comp');
-              {
-                elementStart(3, 'projected');
-                elementEnd();
+              if (rf1 & RenderFlags.Update) {
+                elementProperty(0, 'val', 1);
+                elementProperty(1, 'val', 1);
+                elementProperty(2, 'val', 2);
+                elementProperty(3, 'val', 2);
               }
-              elementEnd();
+              embeddedViewEnd();
             }
-            elementProperty(0, 'val', 1);
-            elementProperty(1, 'val', 1);
-            elementProperty(2, 'val', 2);
-            elementProperty(3, 'val', 2);
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {showing: true}, defs);
@@ -1515,38 +1602,46 @@ describe('lifecycles', () => {
        * % }
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           container(0);
         }
-        containerRefreshStart(0);
-        {
-          if (ctx.condition) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'comp');
-              elementEnd();
-              container(1);
-              elementStart(2, 'comp');
-              elementEnd();
-            }
-            elementProperty(0, 'val', bind('1'));
-            elementProperty(2, 'val', bind('3'));
-            containerRefreshStart(1);
-            {
-              if (ctx.condition2) {
-                if (embeddedViewStart(0)) {
-                  elementStart(0, 'comp');
-                  elementEnd();
-                }
-                elementProperty(0, 'val', bind('2'));
-                embeddedViewEnd();
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(0);
+          {
+            if (ctx.condition) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'comp');
+                elementEnd();
+                container(1);
+                elementStart(2, 'comp');
+                elementEnd();
               }
+              if (rf1 & RenderFlags.Update) {
+                elementProperty(0, 'val', bind('1'));
+                elementProperty(2, 'val', bind('3'));
+                containerRefreshStart(1);
+                {
+                  if (ctx.condition2) {
+                    let rf2 = embeddedViewStart(0);
+                    if (rf2 & RenderFlags.Create) {
+                      elementStart(0, 'comp');
+                      elementEnd();
+                    }
+                    if (rf2 & RenderFlags.Update) {
+                      elementProperty(0, 'val', bind('2'));
+                    }
+                    embeddedViewEnd();
+                  }
+                }
+                containerRefreshEnd();
+              }
+              embeddedViewEnd();
             }
-            containerRefreshEnd();
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {condition: true, condition2: true}, defs);
@@ -1585,38 +1680,46 @@ describe('lifecycles', () => {
        *   <comp [val]="5"></comp>
        * % }
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           container(0);
         }
-        containerRefreshStart(0);
-        {
-          if (ctx.condition) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'comp');
-              elementEnd();
-              container(1);
-              elementStart(2, 'comp');
-              elementEnd();
-            }
-            elementProperty(0, 'val', bind('1'));
-            elementProperty(2, 'val', bind('5'));
-            containerRefreshStart(1);
-            {
-              for (let j = 2; j < ctx.len; j++) {
-                if (embeddedViewStart(0)) {
-                  elementStart(0, 'comp');
-                  elementEnd();
-                }
-                elementProperty(0, 'val', bind(j));
-                embeddedViewEnd();
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(0);
+          {
+            if (ctx.condition) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'comp');
+                elementEnd();
+                container(1);
+                elementStart(2, 'comp');
+                elementEnd();
               }
+              if (rf1 & RenderFlags.Update) {
+                elementProperty(0, 'val', bind('1'));
+                elementProperty(2, 'val', bind('5'));
+                containerRefreshStart(1);
+                {
+                  for (let j = 2; j < ctx.len; j++) {
+                    let rf2 = embeddedViewStart(0);
+                    if (rf2 & RenderFlags.Create) {
+                      elementStart(0, 'comp');
+                      elementEnd();
+                    }
+                    if (rf2 & RenderFlags.Update) {
+                      elementProperty(0, 'val', bind(j));
+                    }
+                    embeddedViewEnd();
+                  }
+                }
+                containerRefreshEnd();
+              }
+              embeddedViewEnd();
             }
-            containerRefreshEnd();
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       /**
@@ -1657,33 +1760,36 @@ describe('lifecycles', () => {
        * % }
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           container(0);
         }
-        containerRefreshStart(0);
-        {
-          if (ctx.condition) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'button');
-              {
-                listener('click', ctx.onClick.bind(ctx));
-                text(1, 'Click me');
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(0);
+          {
+            if (ctx.condition) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'button');
+                {
+                  listener('click', ctx.onClick.bind(ctx));
+                  text(1, 'Click me');
+                }
+                elementEnd();
+                elementStart(2, 'comp');
+                elementEnd();
+                elementStart(3, 'button');
+                {
+                  listener('click', ctx.onClick.bind(ctx));
+                  text(4, 'Click me');
+                }
+                elementEnd();
               }
-              elementEnd();
-              elementStart(2, 'comp');
-              elementEnd();
-              elementStart(3, 'button');
-              {
-                listener('click', ctx.onClick.bind(ctx));
-                text(4, 'Click me');
-              }
-              elementEnd();
+              embeddedViewEnd();
             }
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       class App {
@@ -1716,21 +1822,24 @@ describe('lifecycles', () => {
        * % }
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           container(0);
         }
-        containerRefreshStart(0);
-        {
-          if (ctx.condition) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'comp', ['dir', '']);
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(0);
+          {
+            if (ctx.condition) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'comp', ['dir', '']);
+                elementEnd();
+              }
+              embeddedViewEnd();
             }
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {condition: true}, defs);
@@ -1748,21 +1857,24 @@ describe('lifecycles', () => {
        * % }
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           container(0);
         }
-        containerRefreshStart(0);
-        {
-          if (ctx.condition) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'div', ['dir', '']);
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(0);
+          {
+            if (ctx.condition) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'div', ['dir', '']);
+                elementEnd();
+              }
+              embeddedViewEnd();
             }
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {condition: true}, defs);
@@ -1779,24 +1891,26 @@ describe('lifecycles', () => {
 
     beforeEach(() => { events = []; });
 
-    const Comp = createOnChangesComponent('comp', (ctx: any, cm: boolean) => {
-      if (cm) {
+    const Comp = createOnChangesComponent('comp', (rf: RenderFlags, ctx: any) => {
+      if (rf & RenderFlags.Create) {
         projectionDef(0);
         elementStart(1, 'div');
         { projection(2, 0); }
         elementEnd();
       }
     });
-    const Parent = createOnChangesComponent('parent', (ctx: any, cm: boolean) => {
-      if (cm) {
+    const Parent = createOnChangesComponent('parent', (rf: RenderFlags, ctx: any) => {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'comp');
         elementEnd();
       }
-      elementProperty(0, 'val1', bind(ctx.a));
-      elementProperty(0, 'publicName', bind(ctx.b));
+      if (rf & RenderFlags.Update) {
+        elementProperty(0, 'val1', bind(ctx.a));
+        elementProperty(0, 'publicName', bind(ctx.b));
+      }
     }, [Comp]);
-    const ProjectedComp = createOnChangesComponent('projected', (ctx: any, cm: boolean) => {
-      if (cm) {
+    const ProjectedComp = createOnChangesComponent('projected', (rf: RenderFlags, ctx: any) => {
+      if (rf & RenderFlags.Create) {
         text(0, 'content');
       }
     });
@@ -1848,13 +1962,15 @@ describe('lifecycles', () => {
 
     it('should call onChanges method after inputs are set in creation and update mode', () => {
       /** <comp [val1]="val1" [publicName]="val2"></comp> */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           elementEnd();
         }
-        elementProperty(0, 'val1', bind(ctx.val1));
-        elementProperty(0, 'publicName', bind(ctx.val2));
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val1', bind(ctx.val1));
+          elementProperty(0, 'publicName', bind(ctx.val2));
+        }
       }
 
       renderToHtml(Template, {val1: '1', val2: 'a'}, defs);
@@ -1873,13 +1989,15 @@ describe('lifecycles', () => {
        * parent temp: <comp></comp>
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           elementEnd();
         }
-        elementProperty(0, 'val1', bind(ctx.val1));
-        elementProperty(0, 'publicName', bind(ctx.val2));
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val1', bind(ctx.val1));
+          elementProperty(0, 'publicName', bind(ctx.val2));
+        }
       }
 
       renderToHtml(Template, {val1: '1', val2: 'a'}, defs);
@@ -1897,17 +2015,19 @@ describe('lifecycles', () => {
        * parent temp: <comp [val]="val"></comp>
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           elementEnd();
           elementStart(1, 'parent');
           elementEnd();
         }
-        elementProperty(0, 'val1', bind(1));
-        elementProperty(0, 'publicName', bind(1));
-        elementProperty(1, 'val1', bind(2));
-        elementProperty(1, 'publicName', bind(2));
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val1', bind(1));
+          elementProperty(0, 'publicName', bind(1));
+          elementProperty(1, 'val1', bind(2));
+          elementProperty(1, 'publicName', bind(2));
+        }
       }
 
       renderToHtml(Template, {}, defs);
@@ -1927,23 +2047,28 @@ describe('lifecycles', () => {
        * % }
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           container(0);
         }
-        containerRefreshStart(0);
-        {
-          if (ctx.condition) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'comp');
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(0);
+          {
+            if (ctx.condition) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'comp');
+                elementEnd();
+              }
+              if (rf1 & RenderFlags.Update) {
+                elementProperty(0, 'val1', bind(1));
+                elementProperty(0, 'publicName', bind(1));
+              }
+              embeddedViewEnd();
             }
-            elementProperty(0, 'val1', bind(1));
-            elementProperty(0, 'publicName', bind(1));
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {condition: true}, defs);
@@ -1965,16 +2090,18 @@ describe('lifecycles', () => {
        *   <projected></projected>
        * </comp>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           { elementStart(1, 'projected'); }
           elementEnd();
         }
-        elementProperty(0, 'val1', bind(1));
-        elementProperty(0, 'publicName', bind(1));
-        elementProperty(1, 'val1', bind(2));
-        elementProperty(1, 'publicName', bind(2));
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val1', bind(1));
+          elementProperty(0, 'publicName', bind(1));
+          elementProperty(1, 'val1', bind(2));
+          elementProperty(1, 'publicName', bind(2));
+        }
       }
 
       renderToHtml(Template, {}, defs);
@@ -1993,8 +2120,8 @@ describe('lifecycles', () => {
        *   <projected [val]="1"></projected>
        * </comp>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           { elementStart(1, 'projected'); }
           elementEnd();
@@ -2002,14 +2129,16 @@ describe('lifecycles', () => {
           { elementStart(3, 'projected'); }
           elementEnd();
         }
-        elementProperty(0, 'val1', bind(1));
-        elementProperty(0, 'publicName', bind(1));
-        elementProperty(1, 'val1', bind(2));
-        elementProperty(1, 'publicName', bind(2));
-        elementProperty(2, 'val1', bind(3));
-        elementProperty(2, 'publicName', bind(3));
-        elementProperty(3, 'val1', bind(4));
-        elementProperty(3, 'publicName', bind(4));
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val1', bind(1));
+          elementProperty(0, 'publicName', bind(1));
+          elementProperty(1, 'val1', bind(2));
+          elementProperty(1, 'publicName', bind(2));
+          elementProperty(2, 'val1', bind(3));
+          elementProperty(2, 'publicName', bind(3));
+          elementProperty(3, 'val1', bind(4));
+          elementProperty(3, 'publicName', bind(4));
+        }
       }
 
       renderToHtml(Template, {}, defs);
@@ -2023,13 +2152,15 @@ describe('lifecycles', () => {
 
     it('should be called on directives after component', () => {
       /** <comp directive></comp> */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp', ['dir', '']);
           elementEnd();
         }
-        elementProperty(0, 'val1', bind(1));
-        elementProperty(0, 'publicName', bind(1));
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val1', bind(1));
+          elementProperty(0, 'publicName', bind(1));
+        }
       }
 
       renderToHtml(Template, {}, defs);
@@ -2046,13 +2177,15 @@ describe('lifecycles', () => {
 
     it('should be called on directives on an element', () => {
       /** <div directive></div> */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'div', ['dir', '']);
           elementEnd();
         }
-        elementProperty(0, 'val1', bind(1));
-        elementProperty(0, 'publicName', bind(1));
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val1', bind(1));
+          elementProperty(0, 'publicName', bind(1));
+        }
       }
 
       renderToHtml(Template, {}, defs);
@@ -2071,31 +2204,36 @@ describe('lifecycles', () => {
        *  <comp [val]="5"></comp>
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           elementEnd();
           container(1);
           elementStart(2, 'comp');
           elementEnd();
         }
-        elementProperty(0, 'val1', bind(1));
-        elementProperty(0, 'publicName', bind(1));
-        elementProperty(2, 'val1', bind(5));
-        elementProperty(2, 'publicName', bind(5));
-        containerRefreshStart(1);
-        {
-          for (let j = 2; j < 5; j++) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'comp');
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val1', bind(1));
+          elementProperty(0, 'publicName', bind(1));
+          elementProperty(2, 'val1', bind(5));
+          elementProperty(2, 'publicName', bind(5));
+          containerRefreshStart(1);
+          {
+            for (let j = 2; j < 5; j++) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'comp');
+                elementEnd();
+              }
+              if (rf1 & RenderFlags.Update) {
+                elementProperty(0, 'val1', bind(j));
+                elementProperty(0, 'publicName', bind(j));
+              }
+              embeddedViewEnd();
             }
-            elementProperty(0, 'val1', bind(j));
-            elementProperty(0, 'publicName', bind(j));
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {}, defs);
@@ -2120,31 +2258,36 @@ describe('lifecycles', () => {
        *  <parent [val]="5"></parent>
        */
 
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           elementEnd();
           container(1);
           elementStart(2, 'parent');
           elementEnd();
         }
-        elementProperty(0, 'val1', bind(1));
-        elementProperty(0, 'publicName', bind(1));
-        elementProperty(2, 'val1', bind(5));
-        elementProperty(2, 'publicName', bind(5));
-        containerRefreshStart(1);
-        {
-          for (let j = 2; j < 5; j++) {
-            if (embeddedViewStart(0)) {
-              elementStart(0, 'parent');
-              elementEnd();
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val1', bind(1));
+          elementProperty(0, 'publicName', bind(1));
+          elementProperty(2, 'val1', bind(5));
+          elementProperty(2, 'publicName', bind(5));
+          containerRefreshStart(1);
+          {
+            for (let j = 2; j < 5; j++) {
+              let rf1 = embeddedViewStart(0);
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'parent');
+                elementEnd();
+              }
+              if (rf1 & RenderFlags.Update) {
+                elementProperty(0, 'val1', bind(j));
+                elementProperty(0, 'publicName', bind(j));
+              }
+              embeddedViewEnd();
             }
-            elementProperty(0, 'val1', bind(j));
-            elementProperty(0, 'publicName', bind(j));
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
         }
-        containerRefreshEnd();
       }
 
       renderToHtml(Template, {}, defs);
@@ -2200,22 +2343,24 @@ describe('lifecycles', () => {
     }
 
     it('should call all hooks in correct order', () => {
-      const Comp = createAllHooksComponent('comp', (ctx: any, cm: boolean) => {});
+      const Comp = createAllHooksComponent('comp', (rf: RenderFlags, ctx: any) => {});
 
 
       /**
        * <comp [val]="1"></comp>
        * <comp [val]="2"></comp>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           elementEnd();
           elementStart(1, 'comp');
           elementEnd();
         }
-        elementProperty(0, 'val', 1);
-        elementProperty(1, 'val', 2);
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', 1);
+          elementProperty(1, 'val', 2);
+        }
       }
 
       const defs = [Comp];
@@ -2235,30 +2380,34 @@ describe('lifecycles', () => {
     });
 
     it('should call all hooks in correct order with children', () => {
-      const Comp = createAllHooksComponent('comp', (ctx: any, cm: boolean) => {});
+      const Comp = createAllHooksComponent('comp', (rf: RenderFlags, ctx: any) => {});
 
       /** <comp [val]="val"></comp> */
-      const Parent = createAllHooksComponent('parent', (ctx: any, cm: boolean) => {
-        if (cm) {
+      const Parent = createAllHooksComponent('parent', (rf: RenderFlags, ctx: any) => {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'comp');
           elementEnd();
         }
-        elementProperty(0, 'val', bind(ctx.val));
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', bind(ctx.val));
+        }
       }, [Comp]);
 
       /**
        * <parent [val]="1"></parent>
        * <parent [val]="2"></parent>
        */
-      function Template(ctx: any, cm: boolean) {
-        if (cm) {
+      function Template(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'parent');
           elementEnd();
           elementStart(1, 'parent');
           elementEnd();
         }
-        elementProperty(0, 'val', 1);
-        elementProperty(1, 'val', 2);
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, 'val', 1);
+          elementProperty(1, 'val', 2);
+        }
       }
 
       const defs = [Parent];

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -8,7 +8,7 @@
 
 import {defineComponent, defineDirective} from '../../src/render3/index';
 import {container, containerRefreshEnd, containerRefreshStart, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, listener, text} from '../../src/render3/instructions';
-
+import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {getRendererFactory2} from './imported_renderer2';
 import {containerEl, renderComponent, renderToHtml} from './render_util';
 
@@ -26,8 +26,8 @@ describe('event listeners', () => {
       type: MyComp,
       selectors: [['comp']],
       /** <button (click)="onClick()"> Click me </button> */
-      template: function CompTemplate(ctx: any, cm: boolean) {
-        if (cm) {
+      template: function CompTemplate(rf: RenderFlags, ctx: any) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'button');
           {
             listener('click', function() { return ctx.onClick(); });
@@ -64,8 +64,8 @@ describe('event listeners', () => {
       selectors: [['prevent-default-comp']],
       factory: () => new PreventDefaultComp(),
       /** <button (click)="onClick($event)">Click</button> */
-      template: (ctx: PreventDefaultComp, cm: boolean) => {
-        if (cm) {
+      template: (rf: RenderFlags, ctx: PreventDefaultComp) => {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'button');
           {
             listener('click', function($event: any) { return ctx.onClick($event); });
@@ -124,8 +124,8 @@ describe('event listeners', () => {
 
   it('should call function chain on event emit', () => {
     /** <button (click)="onClick(); onClick2(); "> Click me </button> */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'button');
         {
           listener('click', function() {
@@ -159,8 +159,8 @@ describe('event listeners', () => {
   it('should evaluate expression on event emit', () => {
 
     /** <button (click)="showing=!showing"> Click me </button> */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'button');
         {
           listener('click', function() { return ctx.showing = !ctx.showing; });
@@ -188,25 +188,27 @@ describe('event listeners', () => {
        *  <button (click)="onClick()"> Click me </button>
        * % }
      */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         container(0);
       }
-      containerRefreshStart(0);
-      {
-        if (ctx.showing) {
-          if (embeddedViewStart(1)) {
-            elementStart(0, 'button');
-            {
-              listener('click', function() { return ctx.onClick(); });
-              text(1, 'Click me');
+      if (rf & RenderFlags.Update) {
+        containerRefreshStart(0);
+        {
+          if (ctx.showing) {
+            if (embeddedViewStart(1)) {
+              elementStart(0, 'button');
+              {
+                listener('click', function() { return ctx.onClick(); });
+                text(1, 'Click me');
+              }
+              elementEnd();
             }
-            elementEnd();
+            embeddedViewEnd();
           }
-          embeddedViewEnd();
         }
+        containerRefreshEnd();
       }
-      containerRefreshEnd();
     }
 
     let comp = new MyComp();
@@ -244,8 +246,8 @@ describe('event listeners', () => {
       });
     }
 
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'button', ['hostListenerDir', '']);
         text(1, 'Click');
         elementEnd();
@@ -271,36 +273,42 @@ describe('event listeners', () => {
        *    % }
        * % }
      */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         container(0);
       }
-      containerRefreshStart(0);
-      {
-        if (ctx.showing) {
-          if (embeddedViewStart(0)) {
-            text(0, 'Hello');
-            container(1);
-          }
-          containerRefreshStart(1);
-          {
-            if (ctx.button) {
-              if (embeddedViewStart(0)) {
-                elementStart(0, 'button');
-                {
-                  listener('click', function() { return ctx.onClick(); });
-                  text(1, 'Click');
-                }
-                elementEnd();
-              }
-              embeddedViewEnd();
+      if (rf & RenderFlags.Update) {
+        containerRefreshStart(0);
+        {
+          if (ctx.showing) {
+            let rf1 = embeddedViewStart(0);
+            if (rf1 & RenderFlags.Create) {
+              text(0, 'Hello');
+              container(1);
             }
+            if (rf1 & RenderFlags.Update) {
+              containerRefreshStart(1);
+              {
+                if (ctx.button) {
+                  let rf1 = embeddedViewStart(0);
+                  if (rf1 & RenderFlags.Create) {
+                    elementStart(0, 'button');
+                    {
+                      listener('click', function() { return ctx.onClick(); });
+                      text(1, 'Click');
+                    }
+                    elementEnd();
+                  }
+                  embeddedViewEnd();
+                }
+              }
+              containerRefreshEnd();
+            }
+            embeddedViewEnd();
           }
-          containerRefreshEnd();
-          embeddedViewEnd();
         }
+        containerRefreshEnd();
       }
-      containerRefreshEnd();
     }
 
     const comp = {showing: true, counter: 0, button: true, onClick: function() { this.counter++; }};
@@ -329,24 +337,27 @@ describe('event listeners', () => {
      * comp:
      * <button (click)="onClick()"> Click </button>
      */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         container(0);
       }
-      containerRefreshStart(0);
-      {
-        if (ctx.showing) {
-          if (embeddedViewStart(0)) {
-            text(0, 'Hello');
-            elementStart(1, 'comp');
-            elementEnd();
-            elementStart(2, 'comp');
-            elementEnd();
+      if (rf & RenderFlags.Update) {
+        containerRefreshStart(0);
+        {
+          if (ctx.showing) {
+            let rf1 = embeddedViewStart(0);
+            if (rf1 & RenderFlags.Create) {
+              text(0, 'Hello');
+              elementStart(1, 'comp');
+              elementEnd();
+              elementStart(2, 'comp');
+              elementEnd();
+            }
+            embeddedViewEnd();
           }
-          embeddedViewEnd();
         }
+        containerRefreshEnd();
       }
-      containerRefreshEnd();
     }
 
     const ctx = {showing: true};
@@ -381,52 +392,59 @@ describe('event listeners', () => {
      *   % }
      * % }
      */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         container(0);
       }
-      containerRefreshStart(0);
-      {
-        if (ctx.condition) {
-          if (embeddedViewStart(0)) {
-            text(0, 'Hello');
-            container(1);
-            container(2);
-          }
-          containerRefreshStart(1);
-          {
-            if (ctx.sub1) {
-              if (embeddedViewStart(0)) {
-                elementStart(0, 'button');
-                {
-                  listener('click', function() { return ctx.counter1++; });
-                  text(1, 'Click');
-                }
-                elementEnd();
-              }
-              embeddedViewEnd();
+      if (rf & RenderFlags.Update) {
+        containerRefreshStart(0);
+        {
+          if (ctx.condition) {
+            let rf1 = embeddedViewStart(0);
+            if (rf1 & RenderFlags.Create) {
+              text(0, 'Hello');
+              container(1);
+              container(2);
             }
-          }
-          containerRefreshEnd();
-          containerRefreshStart(2);
-          {
-            if (ctx.sub2) {
-              if (embeddedViewStart(0)) {
-                elementStart(0, 'button');
-                {
-                  listener('click', function() { return ctx.counter2++; });
-                  text(1, 'Click');
+            if (rf1 & RenderFlags.Update) {
+              containerRefreshStart(1);
+              {
+                if (ctx.sub1) {
+                  let rf1 = embeddedViewStart(0);
+                  if (rf1 & RenderFlags.Create) {
+                    elementStart(0, 'button');
+                    {
+                      listener('click', function() { return ctx.counter1++; });
+                      text(1, 'Click');
+                    }
+                    elementEnd();
+                  }
+                  embeddedViewEnd();
                 }
-                elementEnd();
               }
-              embeddedViewEnd();
+              containerRefreshEnd();
+              containerRefreshStart(2);
+              {
+                if (ctx.sub2) {
+                  let rf1 = embeddedViewStart(0);
+                  if (rf1 & RenderFlags.Create) {
+                    elementStart(0, 'button');
+                    {
+                      listener('click', function() { return ctx.counter2++; });
+                      text(1, 'Click');
+                    }
+                    elementEnd();
+                  }
+                  embeddedViewEnd();
+                }
+              }
+              containerRefreshEnd();
             }
+            embeddedViewEnd();
           }
-          containerRefreshEnd();
-          embeddedViewEnd();
         }
+        containerRefreshEnd();
       }
-      containerRefreshEnd();
     }
 
     const ctx = {condition: true, counter1: 0, counter2: 0, sub1: true, sub2: true};

--- a/packages/core/test/render3/outputs_spec.ts
+++ b/packages/core/test/render3/outputs_spec.ts
@@ -10,7 +10,7 @@ import {EventEmitter} from '@angular/core';
 
 import {defineComponent, defineDirective} from '../../src/render3/index';
 import {bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, listener, text} from '../../src/render3/instructions';
-
+import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {containerEl, renderToHtml} from './render_util';
 
 describe('outputs', () => {
@@ -25,7 +25,7 @@ describe('outputs', () => {
     static ngComponentDef = defineComponent({
       type: ButtonToggle,
       selectors: [['button-toggle']],
-      template: function(ctx: any, cm: boolean) {},
+      template: function(rf: RenderFlags, ctx: any) {},
       factory: () => buttonToggle = new ButtonToggle(),
       outputs: {change: 'change', resetStream: 'reset'}
     });
@@ -51,7 +51,7 @@ describe('outputs', () => {
     static ngComponentDef = defineComponent({
       type: DestroyComp,
       selectors: [['destroy-comp']],
-      template: function(ctx: any, cm: boolean) {},
+      template: function(rf: RenderFlags, ctx: any) {},
       factory: () => destroyComp = new DestroyComp()
     });
   }
@@ -73,8 +73,8 @@ describe('outputs', () => {
 
   it('should call component output function when event is emitted', () => {
     /** <button-toggle (change)="onChange()"></button-toggle> */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'button-toggle');
         {
           listener('change', function() { return ctx.onChange(); });
@@ -96,8 +96,8 @@ describe('outputs', () => {
 
   it('should support more than 1 output function on the same node', () => {
     /** <button-toggle (change)="onChange()" (reset)="onReset()"></button-toggle> */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'button-toggle');
         {
           listener('change', function() { return ctx.onChange(); });
@@ -121,8 +121,8 @@ describe('outputs', () => {
 
   it('should eval component output expression when event is emitted', () => {
     /** <button-toggle (change)="counter++"></button-toggle> */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'button-toggle');
         {
           listener('change', function() { return ctx.counter++; });
@@ -149,24 +149,27 @@ describe('outputs', () => {
      * % }
      */
 
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         container(0);
       }
-      containerRefreshStart(0);
-      {
-        if (ctx.condition) {
-          if (embeddedViewStart(0)) {
-            elementStart(0, 'button-toggle');
-            {
-              listener('change', function() { return ctx.onChange(); });
+      if (rf & RenderFlags.Update) {
+        containerRefreshStart(0);
+        {
+          if (ctx.condition) {
+            let rf1 = embeddedViewStart(0);
+            if (rf1 & RenderFlags.Create) {
+              elementStart(0, 'button-toggle');
+              {
+                listener('change', function() { return ctx.onChange(); });
+              }
+              elementEnd();
             }
-            elementEnd();
+            embeddedViewEnd();
           }
-          embeddedViewEnd();
         }
+        containerRefreshEnd();
       }
-      containerRefreshEnd();
     }
 
     let counter = 0;
@@ -193,34 +196,38 @@ describe('outputs', () => {
      * % }
      */
 
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         container(0);
       }
-      containerRefreshStart(0);
-      {
-        if (ctx.condition) {
-          if (embeddedViewStart(0)) {
-            container(0);
-          }
-          containerRefreshStart(0);
-          {
-            if (ctx.condition2) {
-              if (embeddedViewStart(0)) {
-                elementStart(0, 'button-toggle');
-                {
-                  listener('change', function() { return ctx.onChange(); });
-                }
-                elementEnd();
-              }
-              embeddedViewEnd();
+      if (rf & RenderFlags.Update) {
+        containerRefreshStart(0);
+        {
+          if (ctx.condition) {
+            let rf1 = embeddedViewStart(0);
+            if (rf1 & RenderFlags.Create) {
+              container(0);
             }
+            containerRefreshStart(0);
+            {
+              if (ctx.condition2) {
+                let rf1 = embeddedViewStart(0);
+                if (rf1 & RenderFlags.Create) {
+                  elementStart(0, 'button-toggle');
+                  {
+                    listener('change', function() { return ctx.onChange(); });
+                  }
+                  elementEnd();
+                }
+                embeddedViewEnd();
+              }
+            }
+            containerRefreshEnd();
+            embeddedViewEnd();
           }
-          containerRefreshEnd();
-          embeddedViewEnd();
         }
+        containerRefreshEnd();
       }
-      containerRefreshEnd();
     }
 
     let counter = 0;
@@ -245,32 +252,35 @@ describe('outputs', () => {
      *   <destroy-comp></destroy-comp>
      * % }
      */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         container(0);
       }
-      containerRefreshStart(0);
-      {
-        if (ctx.condition) {
-          if (embeddedViewStart(0)) {
-            elementStart(0, 'button');
-            {
-              listener('click', function() { return ctx.onClick(); });
-              text(1, 'Click me');
+      if (rf & RenderFlags.Update) {
+        containerRefreshStart(0);
+        {
+          if (ctx.condition) {
+            let rf1 = embeddedViewStart(0);
+            if (rf1 & RenderFlags.Create) {
+              elementStart(0, 'button');
+              {
+                listener('click', function() { return ctx.onClick(); });
+                text(1, 'Click me');
+              }
+              elementEnd();
+              elementStart(2, 'button-toggle');
+              {
+                listener('change', function() { return ctx.onChange(); });
+              }
+              elementEnd();
+              elementStart(3, 'destroy-comp');
+              elementEnd();
             }
-            elementEnd();
-            elementStart(2, 'button-toggle');
-            {
-              listener('change', function() { return ctx.onChange(); });
-            }
-            elementEnd();
-            elementStart(3, 'destroy-comp');
-            elementEnd();
+            embeddedViewEnd();
           }
-          embeddedViewEnd();
         }
+        containerRefreshEnd();
       }
-      containerRefreshEnd();
     }
 
     let clickCounter = 0;
@@ -299,8 +309,8 @@ describe('outputs', () => {
   });
 
   it('should fire event listeners along with outputs if they match', () => {
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'button', ['myButton', '']);
         {
           listener('click', function() { return ctx.onClick(); });
@@ -324,8 +334,8 @@ describe('outputs', () => {
 
   it('should work with two outputs of the same name', () => {
     /** <button-toggle (change)="onChange()" otherDir></button-toggle> */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'button-toggle', ['otherDir', '']);
         {
           listener('change', function() { return ctx.onChange(); });
@@ -359,15 +369,17 @@ describe('outputs', () => {
     }
 
     /** <button-toggle (change)="onChange()" otherChangeDir [change]="change"></button-toggle> */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'button-toggle', ['otherChangeDir', '']);
         {
           listener('change', function() { return ctx.onChange(); });
         }
         elementEnd();
       }
-      elementProperty(0, 'change', bind(ctx.change));
+      if (rf & RenderFlags.Update) {
+        elementProperty(0, 'change', bind(ctx.change));
+      }
     }
 
     let counter = 0;
@@ -392,8 +404,8 @@ describe('outputs', () => {
      * 'changeStream']}
      * % }
      */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'button');
         {
           listener('click', function() { return ctx.onClick(); });
@@ -402,29 +414,32 @@ describe('outputs', () => {
         elementEnd();
         container(2);
       }
-      containerRefreshStart(2);
-      {
-        if (ctx.condition) {
-          if (embeddedViewStart(0)) {
-            elementStart(0, 'button-toggle');
-            {
-              listener('change', function() { return ctx.onChange(); });
+      if (rf & RenderFlags.Update) {
+        containerRefreshStart(2);
+        {
+          if (ctx.condition) {
+            let rf1 = embeddedViewStart(0);
+            if (rf1 & RenderFlags.Create) {
+              elementStart(0, 'button-toggle');
+              {
+                listener('change', function() { return ctx.onChange(); });
+              }
+              elementEnd();
             }
-            elementEnd();
-          }
-          embeddedViewEnd();
-        } else {
-          if (embeddedViewStart(1)) {
-            elementStart(0, 'div', ['otherDir', '']);
-            {
-              listener('change', function() { return ctx.onChange(); });
+            embeddedViewEnd();
+          } else {
+            if (embeddedViewStart(1)) {
+              elementStart(0, 'div', ['otherDir', '']);
+              {
+                listener('change', function() { return ctx.onChange(); });
+              }
+              elementEnd();
             }
-            elementEnd();
+            embeddedViewEnd();
           }
-          embeddedViewEnd();
         }
+        containerRefreshEnd();
       }
-      containerRefreshEnd();
     }
 
     let counter = 0;

--- a/packages/core/test/render3/pure_function_spec.ts
+++ b/packages/core/test/render3/pure_function_spec.ts
@@ -7,6 +7,7 @@
  */
 import {defineComponent} from '../../src/render3/index';
 import {bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, load, loadDirective} from '../../src/render3/instructions';
+import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {pureFunction1, pureFunction2, pureFunction3, pureFunction4, pureFunction5, pureFunction6, pureFunction7, pureFunction8, pureFunctionV} from '../../src/render3/pure_function';
 import {renderToHtml} from '../../test/render3/render_util';
 
@@ -20,7 +21,7 @@ describe('array literals', () => {
       type: MyComp,
       selectors: [['my-comp']],
       factory: function MyComp_Factory() { return myComp = new MyComp(); },
-      template: function MyComp_Template(ctx: MyComp, cm: boolean) {},
+      template: function MyComp_Template(rf: RenderFlags, ctx: MyComp) {},
       inputs: {names: 'names'}
     });
   }
@@ -31,12 +32,14 @@ describe('array literals', () => {
     const e0_ff = (v: any) => ['Nancy', v, 'Bess'];
 
     /** <my-comp [names]="['Nancy', customName, 'Bess']"></my-comp> */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'my-comp');
         elementEnd();
       }
-      elementProperty(0, 'names', bind(pureFunction1(e0_ff, ctx.customName)));
+      if (rf & RenderFlags.Update) {
+        elementProperty(0, 'names', bind(pureFunction1(e0_ff, ctx.customName)));
+      }
     }
 
     renderToHtml(Template, {customName: 'Carson'}, directives);
@@ -71,7 +74,7 @@ describe('array literals', () => {
         type: ManyPropComp,
         selectors: [['many-prop-comp']],
         factory: function ManyPropComp_Factory() { return manyPropComp = new ManyPropComp(); },
-        template: function ManyPropComp_Template(ctx: ManyPropComp, cm: boolean) {},
+        template: function ManyPropComp_Template(rf: RenderFlags, ctx: ManyPropComp) {},
         inputs: {names1: 'names1', names2: 'names2'}
       });
     }
@@ -83,13 +86,15 @@ describe('array literals', () => {
      * <many-prop-comp [names1]="['Nancy', customName]" [names2]="[customName2]">
      * </many-prop-comp>
      */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'many-prop-comp');
         elementEnd();
       }
-      elementProperty(0, 'names1', bind(pureFunction1(e0_ff, ctx.customName)));
-      elementProperty(0, 'names2', bind(pureFunction1(e0_ff_1, ctx.customName2)));
+      if (rf & RenderFlags.Update) {
+        elementProperty(0, 'names1', bind(pureFunction1(e0_ff, ctx.customName)));
+        elementProperty(0, 'names2', bind(pureFunction1(e0_ff_1, ctx.customName2)));
+      }
     }
 
     const defs = [ManyPropComp];
@@ -120,20 +125,22 @@ describe('array literals', () => {
         type: ParentComp,
         selectors: [['parent-comp']],
         factory: () => new ParentComp(),
-        template: function(ctx: any, cm: boolean) {
-          if (cm) {
+        template: function(rf: RenderFlags, ctx: any) {
+          if (rf & RenderFlags.Create) {
             elementStart(0, 'my-comp');
             myComps.push(loadDirective(0));
             elementEnd();
           }
-          elementProperty(0, 'names', bind(ctx.someFn(pureFunction1(e0_ff, ctx.customName))));
+          if (rf & RenderFlags.Update) {
+            elementProperty(0, 'names', bind(ctx.someFn(pureFunction1(e0_ff, ctx.customName))));
+          }
         },
         directives: directives
       });
     }
 
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'parent-comp');
         elementEnd();
         elementStart(1, 'parent-comp');
@@ -159,12 +166,14 @@ describe('array literals', () => {
     const e0_ff = (v1: any, v2: any) => ['Nancy', v1, 'Bess', v2];
 
     /** <my-comp [names]="['Nancy', customName, 'Bess', customName2]"></my-comp> */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'my-comp');
         elementEnd();
       }
-      elementProperty(0, 'names', bind(pureFunction2(e0_ff, ctx.customName, ctx.customName2)));
+      if (rf & RenderFlags.Update) {
+        elementProperty(0, 'names', bind(pureFunction2(e0_ff, ctx.customName, ctx.customName2)));
+      }
     }
 
     renderToHtml(Template, {customName: 'Carson', customName2: 'Hannah'}, directives);
@@ -212,8 +221,8 @@ describe('array literals', () => {
         (v1: any, v2: any, v3: any, v4: any, v5: any, v6: any, v7: any,
          v8: any) => [v1, v2, v3, v4, v5, v6, v7, v8];
 
-    function Template(c: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, c: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'my-comp');
         f3Comp = loadDirective(0);
         elementEnd();
@@ -233,14 +242,17 @@ describe('array literals', () => {
         f8Comp = loadDirective(5);
         elementEnd();
       }
-      elementProperty(0, 'names', bind(pureFunction3(e0_ff, c[5], c[6], c[7])));
-      elementProperty(1, 'names', bind(pureFunction4(e2_ff, c[4], c[5], c[6], c[7])));
-      elementProperty(2, 'names', bind(pureFunction5(e4_ff, c[3], c[4], c[5], c[6], c[7])));
-      elementProperty(3, 'names', bind(pureFunction6(e6_ff, c[2], c[3], c[4], c[5], c[6], c[7])));
-      elementProperty(
-          4, 'names', bind(pureFunction7(e8_ff, c[1], c[2], c[3], c[4], c[5], c[6], c[7])));
-      elementProperty(
-          5, 'names', bind(pureFunction8(e10_ff, c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7])));
+      if (rf & RenderFlags.Update) {
+        elementProperty(0, 'names', bind(pureFunction3(e0_ff, c[5], c[6], c[7])));
+        elementProperty(1, 'names', bind(pureFunction4(e2_ff, c[4], c[5], c[6], c[7])));
+        elementProperty(2, 'names', bind(pureFunction5(e4_ff, c[3], c[4], c[5], c[6], c[7])));
+        elementProperty(3, 'names', bind(pureFunction6(e6_ff, c[2], c[3], c[4], c[5], c[6], c[7])));
+        elementProperty(
+            4, 'names', bind(pureFunction7(e8_ff, c[1], c[2], c[3], c[4], c[5], c[6], c[7])));
+        elementProperty(
+            5, 'names',
+            bind(pureFunction8(e10_ff, c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7])));
+      }
     }
 
     renderToHtml(Template, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'], directives);
@@ -279,14 +291,17 @@ describe('array literals', () => {
      * <my-comp [names]="['start', v0, v1, v2, v3, {name: v4}, v5, v6, v7, v8, 'end']">
      * </my-comp>
      */
-    function Template(c: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, c: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'my-comp');
         elementEnd();
       }
-      elementProperty(0, 'names', bind(pureFunctionV(e0_ff, [
-                        c[0], c[1], c[2], c[3], pureFunction1(e0_ff_1, c[4]), c[5], c[6], c[7], c[8]
-                      ])));
+      if (rf & RenderFlags.Update) {
+        elementProperty(
+            0, 'names', bind(pureFunctionV(e0_ff, [
+              c[0], c[1], c[2], c[3], pureFunction1(e0_ff_1, c[4]), c[5], c[6], c[7], c[8]
+            ])));
+      }
     }
 
     expect(myComp !.names).toEqual([
@@ -315,7 +330,7 @@ describe('object literals', () => {
       type: ObjectComp,
       selectors: [['object-comp']],
       factory: function ObjectComp_Factory() { return objectComp = new ObjectComp(); },
-      template: function ObjectComp_Template(ctx: ObjectComp, cm: boolean) {},
+      template: function ObjectComp_Template(rf: RenderFlags, ctx: ObjectComp) {},
       inputs: {config: 'config'}
     });
   }
@@ -326,12 +341,14 @@ describe('object literals', () => {
     const e0_ff = (v: any) => { return {duration: 500, animation: v}; };
 
     /** <object-comp [config]="{duration: 500, animation: name}"></object-comp> */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'object-comp');
         elementEnd();
       }
-      elementProperty(0, 'config', bind(pureFunction1(e0_ff, ctx.name)));
+      if (rf & RenderFlags.Update) {
+        elementProperty(0, 'config', bind(pureFunction1(e0_ff, ctx.name)));
+      }
     }
 
     renderToHtml(Template, {name: 'slide'}, defs);
@@ -359,15 +376,17 @@ describe('object literals', () => {
      * duration: duration }]}">
      * </object-comp>
      */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         elementStart(0, 'object-comp');
         elementEnd();
       }
-      elementProperty(
-          0, 'config',
-          bind(pureFunction2(
-              e0_ff, ctx.name, pureFunction1(e0_ff_1, pureFunction1(e0_ff_2, ctx.duration)))));
+      if (rf & RenderFlags.Update) {
+        elementProperty(
+            0, 'config',
+            bind(pureFunction2(
+                e0_ff, ctx.name, pureFunction1(e0_ff_1, pureFunction1(e0_ff_2, ctx.duration)))));
+      }
     }
 
     renderToHtml(Template, {name: 'slide', duration: 100}, defs);
@@ -419,25 +438,30 @@ describe('object literals', () => {
      *   </object-comp>
      * % }
      */
-    function Template(ctx: any, cm: boolean) {
-      if (cm) {
+    function Template(rf: RenderFlags, ctx: any) {
+      if (rf & RenderFlags.Create) {
         container(0);
       }
-      containerRefreshStart(0);
-      {
-        for (let i = 0; i < 2; i++) {
-          if (embeddedViewStart(0)) {
-            elementStart(0, 'object-comp');
-            objectComps.push(loadDirective(0));
-            elementEnd();
+      if (rf & RenderFlags.Update) {
+        containerRefreshStart(0);
+        {
+          for (let i = 0; i < 2; i++) {
+            let rf1 = embeddedViewStart(0);
+            if (rf1 & RenderFlags.Create) {
+              elementStart(0, 'object-comp');
+              objectComps.push(loadDirective(0));
+              elementEnd();
+            }
+            if (rf1 & RenderFlags.Update) {
+              elementProperty(
+                  0, 'config',
+                  bind(pureFunction2(e0_ff, ctx.configs[i].opacity, ctx.configs[i].duration)));
+            }
+            embeddedViewEnd();
           }
-          elementProperty(
-              0, 'config',
-              bind(pureFunction2(e0_ff, ctx.configs[i].opacity, ctx.configs[i].duration)));
-          embeddedViewEnd();
         }
+        containerRefreshEnd();
       }
-      containerRefreshEnd();
     }
 
     const e0_ff = (v1: any, v2: any) => { return {opacity: v1, duration: v2}; };

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -8,6 +8,7 @@
 import {QUERY_READ_CONTAINER_REF, QUERY_READ_ELEMENT_REF, QUERY_READ_FROM_NODE, QUERY_READ_TEMPLATE_REF} from '../../src/render3/di';
 import {QueryList, defineComponent, detectChanges} from '../../src/render3/index';
 import {container, containerRefreshEnd, containerRefreshStart, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, load, loadDirective} from '../../src/render3/instructions';
+import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {query, queryRefresh} from '../../src/render3/query';
 
 import {createComponent, createDirective, renderComponent} from './render_util';
@@ -43,11 +44,11 @@ function isViewContainerRef(candidate: any): boolean {
 
 describe('query', () => {
   it('should project query children', () => {
-    const Child = createComponent('child', function(ctx: any, cm: boolean) {});
+    const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {});
 
     let child1 = null;
     let child2 = null;
-    const Cmp = createComponent('cmp', function(ctx: any, cm: boolean) {
+    const Cmp = createComponent('cmp', function(rf: RenderFlags, ctx: any) {
       /**
        * <child>
        *   <child>
@@ -59,7 +60,7 @@ describe('query', () => {
        * }
        */
       let tmp: any;
-      if (cm) {
+      if (rf & RenderFlags.Create) {
         query(0, Child, false);
         query(1, Child, true);
         elementStart(2, 'child');
@@ -71,8 +72,10 @@ describe('query', () => {
         }
         elementEnd();
       }
-      queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query0 = tmp as QueryList<any>);
-      queryRefresh(tmp = load<QueryList<any>>(1)) && (ctx.query1 = tmp as QueryList<any>);
+      if (rf & RenderFlags.Update) {
+        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query0 = tmp as QueryList<any>);
+        queryRefresh(tmp = load<QueryList<any>>(1)) && (ctx.query1 = tmp as QueryList<any>);
+      }
     }, [Child]);
 
     const parent = renderComponent(Cmp);
@@ -91,14 +94,16 @@ describe('query', () => {
        *  @ViewChildren(Child, {read: ElementRef}) query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, Child, false, QUERY_READ_ELEMENT_REF);
           elToQuery = elementStart(1, 'div', ['child', '']);
           elementEnd();
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       }, [Child]);
 
       const cmptInstance = renderComponent(Cmpt);
@@ -119,15 +124,17 @@ describe('query', () => {
        *  @ViewChildren(Child, {read: OtherChild}) query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, Child, false, OtherChild);
           elementStart(1, 'div', ['child', '', 'otherChild', '']);
           { otherChildInstance = loadDirective(1); }
           elementEnd();
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       }, [Child, OtherChild]);
 
       const cmptInstance = renderComponent(Cmpt);
@@ -145,14 +152,16 @@ describe('query', () => {
        *  @ViewChildren(Child, {read: OtherChild}) query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, Child, false, OtherChild);
           elementStart(1, 'div', ['child', '']);
           elementEnd();
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       }, [Child, OtherChild]);
 
       const cmptInstance = renderComponent(Cmpt);
@@ -173,16 +182,18 @@ describe('query', () => {
        *  @ViewChildren('foo') query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], false, QUERY_READ_FROM_NODE);
           elToQuery = elementStart(1, 'div', null, ['foo', '']);
           elementEnd();
           elementStart(3, 'div');
           elementEnd();
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       });
 
       const cmptInstance = renderComponent(Cmpt);
@@ -202,9 +213,9 @@ describe('query', () => {
        *  @ViewChildren('bar') barQuery;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], false, QUERY_READ_FROM_NODE);
           query(1, ['bar'], false, QUERY_READ_FROM_NODE);
           elToQuery = elementStart(2, 'div', null, ['foo', '', 'bar', '']);
@@ -212,8 +223,10 @@ describe('query', () => {
           elementStart(5, 'div');
           elementEnd();
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.fooQuery = tmp as QueryList<any>);
-        queryRefresh(tmp = load<QueryList<any>>(1)) && (ctx.barQuery = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.fooQuery = tmp as QueryList<any>);
+          queryRefresh(tmp = load<QueryList<any>>(1)) && (ctx.barQuery = tmp as QueryList<any>);
+        }
       });
 
       const cmptInstance = renderComponent(Cmpt);
@@ -239,9 +252,9 @@ describe('query', () => {
        *  @ViewChildren('foo,bar') query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo', 'bar'], undefined, QUERY_READ_FROM_NODE);
           el1ToQuery = elementStart(1, 'div', null, ['foo', '']);
           elementEnd();
@@ -250,7 +263,9 @@ describe('query', () => {
           el2ToQuery = elementStart(4, 'div', null, ['bar', '']);
           elementEnd();
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       });
 
       const cmptInstance = renderComponent(Cmpt);
@@ -270,16 +285,18 @@ describe('query', () => {
        *  @ViewChildren('foo', {read: ElementRef}) query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], false, QUERY_READ_ELEMENT_REF);
           elToQuery = elementStart(1, 'div', null, ['foo', '']);
           elementEnd();
           elementStart(3, 'div');
           elementEnd();
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       });
 
       const cmptInstance = renderComponent(Cmpt);
@@ -296,14 +313,16 @@ describe('query', () => {
        *  @ViewChildren('foo', {read: ViewContainerRef}) query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], false, QUERY_READ_CONTAINER_REF);
           elementStart(1, 'div', null, ['foo', '']);
           elementEnd();
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       });
 
       const cmptInstance = renderComponent(Cmpt);
@@ -319,13 +338,15 @@ describe('query', () => {
        *  @ViewChildren('foo', {read: ViewContainerRef}) query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], false, QUERY_READ_CONTAINER_REF);
           container(1, undefined, undefined, undefined, ['foo', '']);
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       });
 
       const cmptInstance = renderComponent(Cmpt);
@@ -342,13 +363,15 @@ describe('query', () => {
           *  @ViewChildren('foo', {read: ElementRef}) query;
           * }
           */
-         const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+         const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
            let tmp: any;
-           if (cm) {
+           if (rf & RenderFlags.Create) {
              query(0, ['foo'], false, QUERY_READ_ELEMENT_REF);
              container(1, undefined, undefined, undefined, ['foo', '']);
            }
-           queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+           if (rf & RenderFlags.Update) {
+             queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+           }
          });
 
          const cmptInstance = renderComponent(Cmpt);
@@ -365,13 +388,15 @@ describe('query', () => {
        *  @ViewChildren('foo') query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], undefined, QUERY_READ_FROM_NODE);
           container(1, undefined, undefined, undefined, ['foo', '']);
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       });
 
       const cmptInstance = renderComponent(Cmpt);
@@ -388,13 +413,15 @@ describe('query', () => {
        *  @ViewChildren('foo', {read: TemplateRef}) query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], false, QUERY_READ_TEMPLATE_REF);
           container(1, undefined, undefined, undefined, ['foo', '']);
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       });
 
       const cmptInstance = renderComponent(Cmpt);
@@ -404,7 +431,7 @@ describe('query', () => {
     });
 
     it('should read component instance if element queried for is a component host', () => {
-      const Child = createComponent('child', function(ctx: any, cm: boolean) {});
+      const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {});
 
       let childInstance;
       /**
@@ -413,15 +440,17 @@ describe('query', () => {
        *  @ViewChildren('foo') query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], true, QUERY_READ_FROM_NODE);
           elementStart(1, 'child', null, ['foo', '']);
           { childInstance = loadDirective(0); }
           elementEnd();
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       }, [Child]);
 
       const cmptInstance = renderComponent(Cmpt);
@@ -438,7 +467,7 @@ describe('query', () => {
           type: Child,
           selectors: [['child']],
           factory: () => childInstance = new Child(),
-          template: (ctx: Child, cm: boolean) => {},
+          template: (rf: RenderFlags, ctx: Child) => {},
           exportAs: 'child'
         });
       }
@@ -449,14 +478,16 @@ describe('query', () => {
        *  @ViewChildren('foo') query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], true, QUERY_READ_FROM_NODE);
           elementStart(1, 'child', null, ['foo', 'child']);
           elementEnd();
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       }, [Child]);
 
       const cmptInstance = renderComponent(Cmpt);
@@ -476,15 +507,17 @@ describe('query', () => {
           *  @ViewChildren('foo') query;
           * }
           */
-         const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+         const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
            let tmp: any;
-           if (cm) {
+           if (rf & RenderFlags.Create) {
              query(0, ['foo'], true, QUERY_READ_FROM_NODE);
              elementStart(1, 'div', ['child', ''], ['foo', 'child']);
              childInstance = loadDirective(0);
              elementEnd();
            }
-           queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+           if (rf & RenderFlags.Update) {
+             queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+           }
          }, [Child]);
 
          const cmptInstance = renderComponent(Cmpt);
@@ -504,9 +537,9 @@ describe('query', () => {
        *  @ViewChildren('foo, bar') query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo', 'bar'], true, QUERY_READ_FROM_NODE);
           elementStart(1, 'div', ['child1', '', 'child2', ''], ['foo', 'child1', 'bar', 'child2']);
           {
@@ -515,7 +548,9 @@ describe('query', () => {
           }
           elementEnd();
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       }, [Child1, Child2]);
 
       const cmptInstance = renderComponent(Cmpt);
@@ -536,17 +571,19 @@ describe('query', () => {
        *  @ViewChildren('bar') barQuery;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], true, QUERY_READ_FROM_NODE);
           query(1, ['bar'], true, QUERY_READ_FROM_NODE);
           elementStart(2, 'div', ['child', ''], ['foo', 'child', 'bar', 'child']);
           { childInstance = loadDirective(0); }
           elementEnd();
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.fooQuery = tmp as QueryList<any>);
-        queryRefresh(tmp = load<QueryList<any>>(1)) && (ctx.barQuery = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.fooQuery = tmp as QueryList<any>);
+          queryRefresh(tmp = load<QueryList<any>>(1)) && (ctx.barQuery = tmp as QueryList<any>);
+        }
       }, [Child]);
 
       const cmptInstance = renderComponent(Cmpt);
@@ -570,14 +607,16 @@ describe('query', () => {
        *  @ViewChildren('foo', {read: ElementRef}) query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], undefined, QUERY_READ_ELEMENT_REF);
           div = elementStart(1, 'div', ['child', ''], ['foo', 'child']);
           elementEnd();
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       }, [Child]);
 
       const cmptInstance = renderComponent(Cmpt);
@@ -596,15 +635,17 @@ describe('query', () => {
        *  @ViewChildren('foo, bar') query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo', 'bar'], undefined, QUERY_READ_FROM_NODE);
           div = elementStart(1, 'div', ['child', ''], ['foo', '', 'bar', 'child']);
           { childInstance = loadDirective(0); }
           elementEnd();
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       }, [Child]);
 
       const cmptInstance = renderComponent(Cmpt);
@@ -623,14 +664,16 @@ describe('query', () => {
        *  @ViewChildren('foo', {read: Child}) query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], false, Child);
           elementStart(1, 'div', ['foo', '']);
           elementEnd();
         }
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        if (rf & RenderFlags.Update) {
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+        }
       }, [Child]);
 
       const cmptInstance = renderComponent(Cmpt);
@@ -652,27 +695,29 @@ describe('query', () => {
        *  @ViewChildren('foo') query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], true, QUERY_READ_FROM_NODE);
           container(1);
         }
-        containerRefreshStart(1);
-        {
-          if (ctx.exp) {
-            let cm1 = embeddedViewStart(1);
-            {
-              if (cm1) {
-                firstEl = elementStart(0, 'div', null, ['foo', '']);
-                elementEnd();
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(1);
+          {
+            if (ctx.exp) {
+              let rf1 = embeddedViewStart(1);
+              {
+                if (rf1 & RenderFlags.Create) {
+                  firstEl = elementStart(0, 'div', null, ['foo', '']);
+                  elementEnd();
+                }
               }
+              embeddedViewEnd();
             }
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
         }
-        containerRefreshEnd();
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
       });
 
       const cmptInstance = renderComponent(Cmpt);
@@ -702,9 +747,9 @@ describe('query', () => {
           *  @ViewChildren('foo') query;
           * }
           */
-         const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+         const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
            let tmp: any;
-           if (cm) {
+           if (rf & RenderFlags.Create) {
              query(0, ['foo'], true, QUERY_READ_FROM_NODE);
              firstEl = elementStart(1, 'span', null, ['foo', '']);
              elementEnd();
@@ -712,21 +757,23 @@ describe('query', () => {
              lastEl = elementStart(4, 'span', null, ['foo', '']);
              elementEnd();
            }
-           containerRefreshStart(3);
-           {
-             if (ctx.exp) {
-               let cm1 = embeddedViewStart(1);
-               {
-                 if (cm1) {
-                   viewEl = elementStart(0, 'div', null, ['foo', '']);
-                   elementEnd();
+           if (rf & RenderFlags.Update) {
+             containerRefreshStart(3);
+             {
+               if (ctx.exp) {
+                 let rf1 = embeddedViewStart(1);
+                 {
+                   if (rf1 & RenderFlags.Create) {
+                     viewEl = elementStart(0, 'div', null, ['foo', '']);
+                     elementEnd();
+                   }
                  }
+                 embeddedViewEnd();
                }
-               embeddedViewEnd();
              }
+             containerRefreshEnd();
+             queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
            }
-           containerRefreshEnd();
-           queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
          });
 
          const cmptInstance = renderComponent(Cmpt);
@@ -762,37 +809,39 @@ describe('query', () => {
        *  @ViewChildren('foo') query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], true, QUERY_READ_FROM_NODE);
           container(1);
         }
-        containerRefreshStart(1);
-        {
-          if (ctx.exp1) {
-            let cm1 = embeddedViewStart(0);
-            {
-              if (cm1) {
-                firstEl = elementStart(0, 'div', null, ['foo', '']);
-                elementEnd();
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(1);
+          {
+            if (ctx.exp1) {
+              let rf0 = embeddedViewStart(0);
+              {
+                if (rf0 & RenderFlags.Create) {
+                  firstEl = elementStart(0, 'div', null, ['foo', '']);
+                  elementEnd();
+                }
               }
+              embeddedViewEnd();
             }
-            embeddedViewEnd();
-          }
-          if (ctx.exp2) {
-            let cm1 = embeddedViewStart(1);
-            {
-              if (cm1) {
-                lastEl = elementStart(0, 'span', null, ['foo', '']);
-                elementEnd();
+            if (ctx.exp2) {
+              let rf1 = embeddedViewStart(1);
+              {
+                if (rf1 & RenderFlags.Create) {
+                  lastEl = elementStart(0, 'span', null, ['foo', '']);
+                  elementEnd();
+                }
               }
+              embeddedViewEnd();
             }
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
         }
-        containerRefreshEnd();
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
       });
 
       const cmptInstance = renderComponent(Cmpt);
@@ -824,42 +873,46 @@ describe('query', () => {
        *  @ViewChildren('foo') query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], true, QUERY_READ_FROM_NODE);
           container(1);
         }
-        containerRefreshStart(1);
-        {
-          if (ctx.exp1) {
-            let cm1 = embeddedViewStart(0);
-            {
-              if (cm1) {
-                firstEl = elementStart(0, 'div', null, ['foo', '']);
-                elementEnd();
-                container(2);
-              }
-              containerRefreshStart(2);
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(1);
+          {
+            if (ctx.exp1) {
+              let rf0 = embeddedViewStart(0);
               {
-                if (ctx.exp2) {
-                  let cm2 = embeddedViewStart(0);
+                if (rf0 & RenderFlags.Create) {
+                  firstEl = elementStart(0, 'div', null, ['foo', '']);
+                  elementEnd();
+                  container(2);
+                }
+                if (rf0 & RenderFlags.Update) {
+                  containerRefreshStart(2);
                   {
-                    if (cm2) {
-                      lastEl = elementStart(0, 'span', null, ['foo', '']);
-                      elementEnd();
+                    if (ctx.exp2) {
+                      let rf2 = embeddedViewStart(0);
+                      {
+                        if (rf2) {
+                          lastEl = elementStart(0, 'span', null, ['foo', '']);
+                          elementEnd();
+                        }
+                      }
+                      embeddedViewEnd();
                     }
                   }
-                  embeddedViewEnd();
+                  containerRefreshEnd();
                 }
               }
-              containerRefreshEnd();
+              embeddedViewEnd();
             }
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
         }
-        containerRefreshEnd();
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
       });
 
       const cmptInstance = renderComponent(Cmpt);
@@ -888,31 +941,33 @@ describe('query', () => {
        *  @ViewChildren('foo') query;
        * }
        */
-      const Cmpt = createComponent('cmpt', function(ctx: any, cm: boolean) {
+      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
         let tmp: any;
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           query(0, ['foo'], true, QUERY_READ_FROM_NODE);
           query(1, ['foo'], false, QUERY_READ_FROM_NODE);
           container(2);
           elementStart(3, 'span', null, ['foo', '']);
           elementEnd();
         }
-        containerRefreshStart(2);
-        {
-          if (ctx.exp) {
-            let cm1 = embeddedViewStart(0);
-            {
-              if (cm1) {
-                elementStart(0, 'div', null, ['foo', '']);
-                elementEnd();
+        if (rf & RenderFlags.Update) {
+          containerRefreshStart(2);
+          {
+            if (ctx.exp) {
+              let rf0 = embeddedViewStart(0);
+              {
+                if (rf0 & RenderFlags.Create) {
+                  elementStart(0, 'div', null, ['foo', '']);
+                  elementEnd();
+                }
               }
+              embeddedViewEnd();
             }
-            embeddedViewEnd();
           }
+          containerRefreshEnd();
+          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.deep = tmp as QueryList<any>);
+          queryRefresh(tmp = load<QueryList<any>>(1)) && (ctx.shallow = tmp as QueryList<any>);
         }
-        containerRefreshEnd();
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.deep = tmp as QueryList<any>);
-        queryRefresh(tmp = load<QueryList<any>>(1)) && (ctx.shallow = tmp as QueryList<any>);
       });
 
       const cmptInstance = renderComponent(Cmpt);

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -10,7 +10,7 @@ import {stringifyElement} from '@angular/platform-browser/testing/src/browser_ut
 
 import {CreateComponentOptions} from '../../src/render3/component';
 import {extractDirectiveDef, extractPipeDef} from '../../src/render3/definition';
-import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveType, PublicFeature, defineComponent, defineDirective, renderComponent as _renderComponent, tick} from '../../src/render3/index';
+import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveType, PublicFeature, RenderFlags, defineComponent, defineDirective, renderComponent as _renderComponent, tick} from '../../src/render3/index';
 import {NG_HOST_SYMBOL, renderTemplate} from '../../src/render3/instructions';
 import {DirectiveDefList, DirectiveDefListOrFactory, DirectiveTypesOrFactory, PipeDef, PipeDefList, PipeDefListOrFactory, PipeTypesOrFactory} from '../../src/render3/interfaces/definition';
 import {LElementNode} from '../../src/render3/interfaces/node';
@@ -63,11 +63,13 @@ export class TemplateFixture extends BaseFixture {
     super();
     this._directiveDefs = toDefs(directives, extractDirectiveDef);
     this._pipeDefs = toDefs(pipes, extractPipeDef);
-    this.hostNode = renderTemplate(this.hostElement, (ctx: any, cm: boolean) => {
-      if (cm) {
+    this.hostNode = renderTemplate(this.hostElement, (rf: RenderFlags, ctx: any) => {
+      if (rf & RenderFlags.Create) {
         this.createBlock();
       }
-      this.updateBlock();
+      if (rf & RenderFlags.Update) {
+        this.updateBlock();
+      }
     }, null !, domRendererFactory3, null, this._directiveDefs, this._pipeDefs);
   }
 

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -12,6 +12,7 @@ import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/brow
 import {RendererType2, ViewEncapsulation} from '../../src/core';
 import {defineComponent, detectChanges} from '../../src/render3/index';
 import {bind, elementEnd, elementProperty, elementStart, listener, text, tick} from '../../src/render3/instructions';
+import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {createRendererType2} from '../../src/view/index';
 
 import {getAnimationRendererFactory2, getRendererFactory2} from './imported_renderer2';
@@ -32,9 +33,9 @@ describe('renderer factory lifecycle', () => {
     static ngComponentDef = defineComponent({
       type: SomeComponent,
       selectors: [['some-component']],
-      template: function(ctx: SomeComponent, cm: boolean) {
+      template: function(rf: RenderFlags, ctx: SomeComponent) {
         logs.push('component');
-        if (cm) {
+        if (rf & RenderFlags.Create) {
           text(0, 'foo');
         }
       },
@@ -46,25 +47,25 @@ describe('renderer factory lifecycle', () => {
     static ngComponentDef = defineComponent({
       type: SomeComponentWhichThrows,
       selectors: [['some-component-with-Error']],
-      template: function(ctx: SomeComponentWhichThrows, cm: boolean) {
+      template: function(rf: RenderFlags, ctx: SomeComponentWhichThrows) {
         throw(new Error('SomeComponentWhichThrows threw'));
       },
       factory: () => new SomeComponentWhichThrows
     });
   }
 
-  function Template(ctx: any, cm: boolean) {
+  function Template(rf: RenderFlags, ctx: any) {
     logs.push('function');
-    if (cm) {
+    if (rf & RenderFlags.Create) {
       text(0, 'bar');
     }
   }
 
   const directives = [SomeComponent, SomeComponentWhichThrows];
 
-  function TemplateWithComponent(ctx: any, cm: boolean) {
+  function TemplateWithComponent(rf: RenderFlags, ctx: any) {
     logs.push('function_with_component');
-    if (cm) {
+    if (rf & RenderFlags.Create) {
       text(0, 'bar');
       elementStart(1, 'some-component');
       elementEnd();
@@ -125,8 +126,8 @@ describe('animation renderer factory', () => {
     static ngComponentDef = defineComponent({
       type: SomeComponent,
       selectors: [['some-component']],
-      template: function(ctx: SomeComponent, cm: boolean) {
-        if (cm) {
+      template: function(rf: RenderFlags, ctx: SomeComponent) {
+        if (rf & RenderFlags.Create) {
           text(0, 'foo');
         }
       },
@@ -142,8 +143,8 @@ describe('animation renderer factory', () => {
     static ngComponentDef = defineComponent({
       type: SomeComponentWithAnimation,
       selectors: [['some-component']],
-      template: function(ctx: SomeComponentWithAnimation, cm: boolean) {
-        if (cm) {
+      template: function(rf: RenderFlags, ctx: SomeComponentWithAnimation) {
+        if (rf & RenderFlags.Create) {
           elementStart(0, 'div');
           {
             listener('@myAnimation.start', ctx.callback.bind(ctx));
@@ -152,7 +153,9 @@ describe('animation renderer factory', () => {
           }
           elementEnd();
         }
-        elementProperty(0, '@myAnimation', bind(ctx.exp));
+        if (rf & RenderFlags.Update) {
+          elementProperty(0, '@myAnimation', bind(ctx.exp));
+        }
       },
       factory: () => new SomeComponentWithAnimation,
       rendererType: createRendererType2({


### PR DESCRIPTION
Currently, the update block (i.e. binding refresh) always runs with the creation block (i.e. creating elements / directives) because of the way template functions are constructed. While this is the correct behavior for most templates, this limitation breaks dynamically created views because structural directives like `ngFor` expect that the creation block runs separately from the update block, as it does in render2.

This PR separates the execution of the creation block and update block, so they can run together or separately depending on what's appropriate. This is accomplished by replacing the boolean `cm` parameter in template functions with an enum called `RenderFlags`. Note that the order of the parameters has also been switched.

Before:

```ts
function Template(ctx: any, cm: boolean) {
  if (cm) {
    E(0, 'div');
    e();
  }
  p(0, 'title', b(ctx.title));
}
```

After (flags written out for clarity):

```ts
function Template(rf: RenderFlags, ctx: any) {
  if (rf & RenderFlags.Create) {
    E(0, 'div');
    e();
  }
  if (rf & RenderFlags.Update) {
    p(0, 'title', b(ctx.title));
  }
}
```

After (actual output):
```ts
function Template(rf: RenderFlags, ctx: any) {
  if (rf & 1) {
    E(0, 'div');
    e();
  }
  if (rf & 2) {
    p(0, 'title', b(ctx.title));
  }
}
```

Notes:
- For now, normal views and inline embedded views default to running the creation block and the update block together, while dynamically created views default to running them separately. 
   - For dynamically created views, this means that when `createEmbeddedView` is called, only the creation block is run. The update block isn't executed until `renderEmbeddedTemplate` is called by `refreshDynamicChildren` at the end of the parent view's execution.
- Local variables that were previously declared outside of the creation block are now declared outside of either block (to support references in later container templates).

Before:
```ts
if (cm) {
  E(0, 'input', null, ['foo', '']);
  e();
  T(2);
}
const tmp = ld(1) as any;
t(2, b(tmp.value));
```

After:
```ts

if (rf & RenderFlags.Create) {
  E(0, 'input', null, ['foo', '']);
  e();
  T(2);
}
const tmp = ld(1) as any;
if (rf & RenderFlags.Update) {
  t(2, b(tmp.value));
}

```

- Previously, we would check if it was creation mode before setting `bindingStartIndex`. This doesn't work anymore because bindings won't always run with creation mode, so the `bindingStartIndex` might not be set. Now we have an explicit check to `bindingStartIndex`.
- Normally, text nodes with bindings are not created until their bound value becomes available in update mode (for performance reasons). So if there is a bound text node that is a root node of a dynamically created view, `ViewContainerRef` will try to insert it into the view before the text node has actually been created (update mode has not yet run at this point). In these cases, we have to create the text node at insertion, then update the value later.