### PR TITLE
build: update Bazel dependency to 0.11.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@
 ## IMPORTANT
 # If you change the `docker_image` version, also change the `cache_key` suffix and the version of
 # `com_github_bazelbuild_buildtools` in the `/WORKSPACE` file.
-var_1: &docker_image angular/ngcontainer:0.1.0
-var_2: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.1.0
+var_1: &docker_image angular/ngcontainer:0.2.0
+var_2: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.2.0
 
 # See remote cache documentation in /docs/BAZEL.md
 var_3: &setup-bazel-remote-cache
@@ -47,8 +47,10 @@ jobs:
       - run: 'buildifier -mode=check $(find . -type f \( -name BUILD.bazel -or -name BUILD \)) ||
               (echo "BUILD files not formatted. Please run ''yarn buildifier''" ; exit 1)'
       # Run the skylark linter to check our Bazel rules
+      # deprecated-api is disabled because we use actions.new_file(genfiles_dir)
+      # which has no replacement, see https://github.com/bazelbuild/bazel/issues/4858
       - run: 'find . -type f -name "*.bzl" |
-              xargs java -jar /usr/local/bin/Skylint_deploy.jar ||
+              xargs java -jar /usr/local/bin/Skylint_deploy.jar --disable-checks=deprecated-api ||
               (echo -e "\n.bzl files have lint errors. Please run ''yarn skylint''"; exit 1)'
 
       - restore_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ pubspec.lock
 .settings/
 *.swo
 modules/.settings
+.bazelrc
 .vscode
 modules/.vscode
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,7 +9,7 @@ http_archive(
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories", "yarn_install")
 
-check_bazel_version("0.9.0")
+check_bazel_version("0.11.1")
 node_repositories(package_json = ["//:package.json"])
 
 yarn_install(
@@ -44,19 +44,19 @@ local_repository(
 # This commit matches the version of buildifier in angular/ngcontainer
 # If you change this, also check if it matches the version in the angular/ngcontainer
 # version in /.circleci/config.yml
-BAZEL_BUILDTOOLS_VERSION = "b3b620e8bcff18ed3378cd3f35ebeb7016d71f71"
+BAZEL_BUILDTOOLS_VERSION = "70bc7843bb9950fece2bc014ed16de03419e36e2"
 
 http_archive(
     name = "com_github_bazelbuild_buildtools",
     url = "https://github.com/bazelbuild/buildtools/archive/%s.zip" % BAZEL_BUILDTOOLS_VERSION,
     strip_prefix = "buildtools-%s" % BAZEL_BUILDTOOLS_VERSION,
-    sha256 = "dad19224258ed67cbdbae9b7befb785c3b966e5a33b04b3ce58ddb7824b97d73",
+    sha256 = "367c23a5fe7fc2a7cb57863d3718b4149f0e57426c48c8ad54c45348a0b53cc1",
 )
 
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.7.1/rules_go-0.7.1.tar.gz",
-    sha256 = "341d5eacef704415386974bc82a1783a8b7ffbff2ab6ba02375e1ca20d9b031c",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.10.3/rules_go-0.10.3.tar.gz",
+    sha256 = "feba3278c13cde8d67e341a837f69a029f698d7a27ddbb2a202be7a10b22142a",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
@@ -68,9 +68,9 @@ go_register_toolchains()
 # Fetching the Bazel source code allows us to compile the Skylark linter
 http_archive(
     name = "io_bazel",
-    url = "https://github.com/bazelbuild/bazel/archive/9755c72b48866ed034bd28aa033e9abd27431b1e.zip",
-    strip_prefix = "bazel-9755c72b48866ed034bd28aa033e9abd27431b1e",
-    sha256 = "5b8443fc3481b5fcd9e7f348e1dd93c1397f78b223623c39eb56494c55f41962",
+    url = "https://github.com/bazelbuild/bazel/archive/5a35e72f9e97c06540c479f8c31512fb4656202f.zip",
+    strip_prefix = "bazel-5a35e72f9e97c06540c479f8c31512fb4656202f",
+    sha256 = "ed33a52874c14e3b487fb50f390c541fab9c81a33d986d38fb01766a66dbcd21",
 )
 
 # We have a source dependency on the Devkit repository, because it's built with

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "preskylint": "bazel build --noshow_progress @io_bazel//src/tools/skylark/java/com/google/devtools/skylark/skylint:Skylint",
-    "skylint": "find . -type f -name \"*.bzl\" ! -path \"*/node_modules/*\" ! -path \"./dist/*\" | xargs $(bazel info bazel-bin)/external/io_bazel/src/tools/skylark/java/com/google/devtools/skylark/skylint/Skylint",
+    "skylint": "find . -type f -name \"*.bzl\" ! -path \"*/node_modules/*\" ! -path \"./dist/*\" | xargs $(bazel info bazel-bin)/external/io_bazel/src/tools/skylark/java/com/google/devtools/skylark/skylint/Skylint --disable-checks=deprecated-api",
     "prebuildifier": "bazel build --noshow_progress @com_github_bazelbuild_buildtools//buildifier",
     "buildifier": "find . -type f \\( -name BUILD -or -name BUILD.bazel \\) ! -path \"*/node_modules/*\" | xargs $(bazel info bazel-bin)/external/com_github_bazelbuild_buildtools/buildifier/buildifier",
     "preinstall": "node tools/yarn/check-yarn.js",

--- a/packages/bazel/src/esm5.bzl
+++ b/packages/bazel/src/esm5.bzl
@@ -70,7 +70,7 @@ def _esm5_outputs_aspect(target, ctx):
       ],
   )
 
-  ctx.action(
+  ctx.actions.run(
       progress_message = "Compiling TypeScript (ES5 with ES Modules) %s" % target.label,
       inputs = target.typescript.replay_params.inputs + [tsconfig],
       outputs = outputs,

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -239,7 +239,7 @@ def ngc_compile_action(ctx, label, inputs, outputs, messages_out, tsconfig_file,
 
   arguments += i18n_args
 
-  ctx.action(
+  ctx.actions.run(
       progress_message = progress_message,
       mnemonic = mnemonic,
       inputs = inputs,
@@ -252,17 +252,18 @@ def ngc_compile_action(ctx, label, inputs, outputs, messages_out, tsconfig_file,
   )
 
   if messages_out != None:
-    ctx.action(inputs = list(inputs),
-               outputs = messages_out,
-               executable = ctx.executable._ng_xi18n,
-               arguments = (_EXTRA_NODE_OPTIONS_FLAGS +
-                            [tsconfig_file.path] +
-                            # The base path is bin_dir because of the way the ngc
-                            # compiler host is configured. So we need to explicitly
-                            # point to genfiles/ to redirect the output.
-                            ["../genfiles/" + messages_out[0].short_path]),
-               progress_message = "Extracting Angular 2 messages (ng_xi18n)",
-               mnemonic = "Angular2MessageExtractor")
+    ctx.actions.run(
+        inputs = list(inputs),
+        outputs = messages_out,
+        executable = ctx.executable._ng_xi18n,
+        arguments = (_EXTRA_NODE_OPTIONS_FLAGS +
+                     [tsconfig_file.path] +
+                     # The base path is bin_dir because of the way the ngc
+                     # compiler host is configured. So we need to explicitly
+                     # point to genfiles/ to redirect the output.
+                     ["../genfiles/" + messages_out[0].short_path]),
+        progress_message = "Extracting Angular 2 messages (ng_xi18n)",
+        mnemonic = "Angular2MessageExtractor")
 
   if not locale and not ctx.attr.no_i18n:
     return struct(

--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -298,9 +298,9 @@ def _ng_package_impl(ctx):
       ctx,
       devfiles.to_list(),
       [npm_package_directory] + ctx.files.packages)
-  return struct(
+  return [DefaultInfo(
     files = depset([package_dir])
-  )
+  )]
 
 NG_PACKAGE_ATTRS = dict(NPM_PACKAGE_ATTRS, **dict(ROLLUP_ATTRS, **{
     "srcs": attr.label_list(allow_files = True),

--- a/packages/bazel/src/ng_rollup_bundle.bzl
+++ b/packages/bazel/src/ng_rollup_bundle.bzl
@@ -28,7 +28,7 @@ BO_ROLLUP="angular_devkit/packages/angular_devkit/build_optimizer/src/build-opti
 BO_PLUGIN="require('%s').default(%s)" % (BO_ROLLUP, PLUGIN_CONFIG)
 
 def run_brotli(ctx, input, output):
-  ctx.action(
+  ctx.actions.run(
       executable = ctx.executable._brotli,
       inputs = [input],
       outputs = [output],
@@ -77,7 +77,7 @@ ng_rollup_bundle = rule(
             executable = True,
             cfg = "host",
             default = Label("@angular//packages/bazel/src:rollup_with_build_optimizer")),
-	    "_brotli": attr.label(
+        "_brotli": attr.label(
             executable = True,
             cfg = "host",
             default = Label("@org_brotli//:brotli")),

--- a/scripts/ci/env.sh
+++ b/scripts/ci/env.sh
@@ -40,7 +40,7 @@ setEnvVar YARN_VERSION 1.3.2
 # Revision 494239 (which was part of Chrome 62.0.3186.0) is the last version that does not cause flakes. (Latest revision checked: 508578)
 setEnvVar CHROMIUM_VERSION 494239 # Chrome 62 linux stable, see https://www.chromium.org/developers/calendar
 setEnvVar CHROMEDRIVER_VERSION_ARG "--versions.chrome 2.33"
-setEnvVar BAZEL_VERSION 0.9.0
+setEnvVar BAZEL_VERSION 0.11.1
 setEnvVar SAUCE_CONNECT_VERSION 4.4.9
 setEnvVar ANGULAR_CLI_VERSION 1.6.3
 setEnvVar PROJECT_ROOT $(cd ${thisDir}/../..; pwd)


### PR DESCRIPTION
This fixes some minor issues we've seen, and ensures that we report issues against the current release.