### PR TITLE
build: reorder PACKAGE_GROUP entries to make @angular/core the first one

### DIFF
--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -8,8 +8,8 @@ DEFAULT_TSCONFIG = "//packages:tsconfig-build.json"
 
 # Packages which are versioned together on npm
 ANGULAR_SCOPED_PACKAGES = ["@angular/%s" % p for p in [
-  "bazel",
   "core",
+  "bazel",
   "common",
   "compiler",
   "compiler-cli",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -8,6 +8,9 @@ DEFAULT_TSCONFIG = "//packages:tsconfig-build.json"
 
 # Packages which are versioned together on npm
 ANGULAR_SCOPED_PACKAGES = ["@angular/%s" % p for p in [
+  # core should be the first package because it's the main package in the group
+  # this is significant for Angular CLI and "ng update" specifically, @angular/core
+  # is considered the identifier of the group by these tools.
   "core",
   "bazel",
   "common",


### PR DESCRIPTION
CLI will soon consider the first entry to be the main entry in the package group.

This will then be used to display the main entry in "ng update" listing.

//cc: @hansl 