### PR TITLE
ci: update ngbot config file for RFC triage

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -108,4 +108,3 @@ triage:
       - "comp: *"
     -
       - "type: RFC / Discussion / question"
-      - "comp: *"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] CI related changes
```

## What is the current behavior?
RFC issues require a "comp" label to go into backlog

Issue Number: https://github.com/angular/angular/issues/23072#issuecomment-380270234


## What is the new behavior?
As @manughub requested, RFC issues don't need any other label to go into the backlog

## Does this PR introduce a breaking change?
```
[x] No
```