### PR TITLE
fix(ivy): local directives and pipes should be applied to TemplateRef

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -20,7 +20,7 @@ import {Type} from '../type';
 
 import {assertGreaterThan, assertLessThan, assertNotNull} from './assert';
 import {addToViewTree, assertPreviousIsParent, createLContainer, createLNodeObject, getDirectiveInstance, getPreviousOrParentNode, getRenderer, isComponent, renderEmbeddedTemplate, resolveDirective} from './instructions';
-import {ComponentTemplate, DirectiveDef} from './interfaces/definition';
+import {ComponentTemplate, DirectiveDef, DirectiveDefList, PipeDefList} from './interfaces/definition';
 import {LInjector} from './interfaces/injector';
 import {LContainerNode, LElementNode, LNode, LNodeType, LViewNode, TNodeFlags} from './interfaces/node';
 import {QueryReadType} from './interfaces/query';
@@ -704,8 +704,10 @@ class ViewContainerRef implements viewEngine_ViewContainerRef {
 export function getOrCreateTemplateRef<T>(di: LInjector): viewEngine_TemplateRef<T> {
   ngDevMode && assertNodeType(di.node, LNodeType.Container);
   const data = (di.node as LContainerNode).data;
+  const tView = di.node.view.tView;
   return di.templateRef || (di.templateRef = new TemplateRef<any>(
-                                getOrCreateElementRef(di), data.template !, getRenderer()));
+                                getOrCreateElementRef(di), data.template !, getRenderer(),
+                                tView.directiveRegistry, tView.pipeRegistry));
 }
 
 class TemplateRef<T> implements viewEngine_TemplateRef<T> {
@@ -714,13 +716,15 @@ class TemplateRef<T> implements viewEngine_TemplateRef<T> {
 
   constructor(
       elementRef: viewEngine_ElementRef, template: ComponentTemplate<T>,
-      private _renderer: Renderer3) {
+      private _renderer: Renderer3, private _directives: DirectiveDefList|null,
+      private _pipes: PipeDefList|null) {
     this.elementRef = elementRef;
     this._template = template;
   }
 
   createEmbeddedView(context: T): viewEngine_EmbeddedViewRef<T> {
-    const viewNode = renderEmbeddedTemplate(null, this._template, context, this._renderer);
+    const viewNode = renderEmbeddedTemplate(
+        null, this._template, context, this._renderer, this._directives, this._pipes);
     return addDestroyable(new EmbeddedViewRef(viewNode, this._template, context));
   }
 }

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -19,7 +19,7 @@ import {LContainerNode, LElementNode, LNode, LNodeType, TNodeFlags, LProjectionN
 import {assertNodeType} from './node_assert';
 import {appendChild, insertChild, insertView, appendProjectedNode, removeView, canInsertNativeNode, createTextNode} from './node_manipulation';
 import {isNodeMatchingSelectorList, matchingSelectorIndex} from './node_selector_matcher';
-import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefList, DirectiveDefListOrFactory, DirectiveType, PipeDef, PipeDefListOrFactory, RenderFlags} from './interfaces/definition';
+import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefList, DirectiveDefListOrFactory, DirectiveType, PipeDef, PipeDefList, PipeDefListOrFactory, RenderFlags} from './interfaces/definition';
 import {RElement, RText, Renderer3, RendererFactory3, ProceduralRenderer3, ObjectOrientedRenderer3, RendererStyleFlags3, isProceduralRenderer} from './interfaces/renderer';
 import {isDifferent, stringify} from './util';
 import {executeHooks, queueLifecycleHooks, queueInitHooks, executeInitHooks} from './hooks';
@@ -450,8 +450,8 @@ export function renderTemplate<T>(
 }
 
 export function renderEmbeddedTemplate<T>(
-    viewNode: LViewNode | null, template: ComponentTemplate<T>, context: T,
-    renderer: Renderer3): LViewNode {
+    viewNode: LViewNode | null, template: ComponentTemplate<T>, context: T, renderer: Renderer3,
+    directives?: DirectiveDefList | null, pipes?: PipeDefList | null): LViewNode {
   const _isParent = isParent;
   const _previousOrParentNode = previousOrParentNode;
   let oldView: LView;
@@ -460,11 +460,7 @@ export function renderEmbeddedTemplate<T>(
     previousOrParentNode = null !;
     let rf: RenderFlags = RenderFlags.Update;
     if (viewNode == null) {
-      // TODO: revisit setting currentView when re-writing view containers
-      const directives = currentView && currentView.tView.directiveRegistry;
-      const pipes = currentView && currentView.tView.pipeRegistry;
-
-      const tView = getOrCreateTView(template, directives, pipes);
+      const tView = getOrCreateTView(template, directives || null, pipes || null);
       const lView = createLView(-1, renderer, tView, template, context, LViewFlags.CheckAlways);
 
       viewNode = createLNode(null, LNodeType.View, null, lView);
@@ -1462,6 +1458,7 @@ function refreshDynamicChildren() {
       const container = current as LContainer;
       for (let i = 0; i < container.views.length; i++) {
         const view = container.views[i];
+        // The directives and pipes are not needed here as an existing view is only being refreshed.
         renderEmbeddedTemplate(view, view.data.template !, view.data.context !, renderer);
       }
     }


### PR DESCRIPTION
Currently, templateRefs are ignoring the directives and pipes which are defined at component level. It should not be the case.