### PR TITLE
build: disambiguate rollup progress message

### DIFF
--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -109,7 +109,7 @@ def _rollup(ctx, rollup_config, entry_point, inputs, js_output, format = "es", p
   if ctx.version_file:
     other_inputs.append(ctx.version_file)
   ctx.actions.run(
-      progress_message = "Angular Packaging: rolling up %s" % ctx.label.name,
+      progress_message = "ng_package: Rollup %s" % ctx.label,
       mnemonic = "AngularPackageRollup",
       inputs = inputs.to_list() + other_inputs,
       outputs = [js_output, map_output],


### PR DESCRIPTION
All our package labels are `npm_package` so the bazel build reports a bunch of identical actions running, like

```
    Angular Packaging: rolling up npm_package; 31s darwin-sandbox
    Angular Packaging: rolling up npm_package; 30s darwin-sandbox
    Angular Packaging: rolling up npm_package; 29s darwin-sandbox
    Angular Packaging: rolling up npm_package; 27s darwin-sandbox
    Angular Packaging: rolling up npm_package; 26s darwin-sandbox
    Angular Packaging: rolling up npm_package; 23s darwin-sandbox
    Angular Packaging: rolling up npm_package; 19s darwin-sandbox
    Angular Packaging: rolling up npm_package; 11s darwin-sandbox
```
