### PR TITLE
build: fix aio size tracking, we need to use node_modules local to aio

### DIFF
--- a/aio/scripts/payload.sh
+++ b/aio/scripts/payload.sh
@@ -8,5 +8,8 @@ readonly parentDir=$(dirname $thisDir)
 # Track payload size functions
 source ../scripts/ci/payload-size.sh
 
+# Provide node_modules from aio
+NODE_MODULES_BIN=$PROJECT_ROOT/aio/node_modules/.bin/
+
 trackPayloadSize "aio" "dist/*.js" true true "${thisDir}/_payload-limits.json"
 

--- a/scripts/ci/payload-size.sh
+++ b/scripts/ci/payload-size.sh
@@ -3,6 +3,7 @@
 set -eu -o pipefail
 
 readonly PROJECT_NAME="angular-payload-size"
+NODE_MODULES_BIN=$PROJECT_ROOT/node_modules/.bin/
 
 # Calculate the size of target file uncompressed size, gzip7 size, gzip9 size
 # Write to global variable $payloadData, $filename
@@ -88,7 +89,7 @@ uploadData() {
 
     # WARNING: FIREBASE_TOKEN should NOT be printed.
     set +x
-    $PROJECT_ROOT/node_modules/.bin/firebase database:update --data "$payloadData" --project $PROJECT_NAME --confirm --token "$ANGULAR_PAYLOAD_FIREBASE_TOKEN" $dbPath
+    $NODE_MODULES_BIN/firebase database:update --data "$payloadData" --project $PROJECT_NAME --confirm --token "$ANGULAR_PAYLOAD_FIREBASE_TOKEN" $dbPath
   fi
 }
 


### PR DESCRIPTION
This fixes an issue introduced by 4f0cae067656fa4563417542297c67030d911a36 which removed firebase from the root node_modules.