### PR TITLE
feat(ivy): support generation of flags for directive injection

### DIFF
--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -2257,7 +2257,7 @@ describe('ngc transformer command-line', () => {
           constructor(e: Existing) {}
         }
       `);
-      expect(source).toMatch(/ngInjectableDef.*return ..\(..\.inject\(Existing, undefined, 1\)/);
+      expect(source).toMatch(/ngInjectableDef.*return ..\(..\.inject\(Existing, undefined, 4\)/);
     });
 
     it('compiles a service that depends on a token', () => {

--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -2237,7 +2237,7 @@ describe('ngc transformer command-line', () => {
           constructor(e: Existing|null) {}
         }
       `);
-      expect(source).toMatch(/ngInjectableDef.*return ..\(..\.inject\(Existing, null, 0\)/);
+      expect(source).toMatch(/ngInjectableDef.*return ..\(..\.inject\(Existing, 8\)/);
     });
 
     it('compiles a useFactory InjectableDef with skip-self dep', () => {
@@ -2257,7 +2257,7 @@ describe('ngc transformer command-line', () => {
           constructor(e: Existing) {}
         }
       `);
-      expect(source).toMatch(/ngInjectableDef.*return ..\(..\.inject\(Existing, undefined, 4\)/);
+      expect(source).toMatch(/ngInjectableDef.*return ..\(..\.inject\(Existing, 4\)/);
     });
 
     it('compiles a service that depends on a token', () => {

--- a/packages/compiler/src/core.ts
+++ b/packages/compiler/src/core.ts
@@ -217,14 +217,23 @@ export const enum DepFlags {
   Value = 1 << 3,
 }
 
-/** Injection flags for DI. */
+/**
+ * Injection flags for DI.
+ */
 export const enum InjectFlags {
   Default = 0,
 
-  /** Skip the node that is requesting injection. */
-  SkipSelf = 1 << 0,
+  /**
+   * Specifies that an injector should retrieve a dependency from any injector until reaching the
+   * host element of the current component. (Only used with Element Injector)
+   */
+  Host = 1 << 0,
   /** Don't descend into ancestors of the node requesting injection. */
   Self = 1 << 1,
+  /** Skip the node that is requesting injection. */
+  SkipSelf = 1 << 2,
+  /** Inject `defaultValue` instead if token not found. */
+  Optional = 1 << 3,
 }
 
 export const enum ArgumentType {Inline = 0, Dynamic = 1}

--- a/packages/compiler/src/injectable_compiler.ts
+++ b/packages/compiler/src/injectable_compiler.ts
@@ -38,7 +38,6 @@ export class InjectableCompiler {
   private depsArray(deps: any[], ctx: OutputContext): o.Expression[] {
     return deps.map(dep => {
       let token = dep;
-      let defaultValue = undefined;
       let args = [token];
       let flags: InjectFlags = InjectFlags.Default;
       if (Array.isArray(dep)) {
@@ -46,7 +45,7 @@ export class InjectableCompiler {
           const v = dep[i];
           if (v) {
             if (v.ngMetadataName === 'Optional') {
-              defaultValue = null;
+              flags |= InjectFlags.Optional;
             } else if (v.ngMetadataName === 'SkipSelf') {
               flags |= InjectFlags.SkipSelf;
             } else if (v.ngMetadataName === 'Self') {
@@ -69,8 +68,8 @@ export class InjectableCompiler {
         tokenExpr = ctx.importExpr(token);
       }
 
-      if (flags !== InjectFlags.Default || defaultValue !== undefined) {
-        args = [tokenExpr, o.literal(defaultValue), o.literal(flags)];
+      if (flags !== InjectFlags.Default) {
+        args = [tokenExpr, o.literal(flags)];
       } else {
         args = [tokenExpr];
       }

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -81,6 +81,8 @@ export class Identifiers {
 
   static directiveLifeCycle: o.ExternalReference = {name: 'ɵl', moduleName: CORE};
 
+  static injectAttribute: o.ExternalReference = {name: 'ɵinjectAttribute', moduleName: CORE};
+
   static injectElementRef: o.ExternalReference = {name: 'ɵinjectElementRef', moduleName: CORE};
 
   static injectTemplateRef: o.ExternalReference = {name: 'ɵinjectTemplateRef', moduleName: CORE};
@@ -88,7 +90,7 @@ export class Identifiers {
   static injectViewContainerRef:
       o.ExternalReference = {name: 'ɵinjectViewContainerRef', moduleName: CORE};
 
-  static inject: o.ExternalReference = {name: 'ɵinject', moduleName: CORE};
+  static directiveInject: o.ExternalReference = {name: 'ɵdirectiveInject', moduleName: CORE};
 
   static defineComponent: o.ExternalReference = {name: 'ɵdefineComponent', moduleName: CORE};
 

--- a/packages/compiler/src/render3/r3_view_compiler.ts
+++ b/packages/compiler/src/render3/r3_view_compiler.ts
@@ -948,7 +948,7 @@ export function createFactory(
         const flags = extractFlags(dependency);
         if (flags != InjectFlags.Default) {
           // Append flag information if other than default.
-          directiveInjectArgs.push(o.literal(undefined), o.literal(flags));
+          directiveInjectArgs.push(o.literal(flags));
         }
         args.push(o.importExpr(R3.directiveInject).callFn(directiveInjectArgs));
       }

--- a/packages/compiler/test/render3/r3_view_compiler_di_spec.ts
+++ b/packages/compiler/test/render3/r3_view_compiler_di_spec.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {MockDirectory, setup} from '../aot/test_util';
+import {compile, expectEmit} from './mock_compile';
+
+describe('compiler compliance: dependency injection', () => {
+  const angularFiles = setup({
+    compileAngular: true,
+    compileAnimations: false,
+    compileCommon: true,
+  });
+
+  it('should create factory methods', () => {
+    const files = {
+      app: {
+        'spec.ts': `
+              import {Component, NgModule, Injectable, Attribute, Host, SkipSelf, Self, Optional} from '@angular/core';
+              import {CommonModule} from '@angular/common';
+
+              @Injectable()
+              export class MyService {}
+
+              @Component({
+                selector: 'my-component',
+                template: \`\`
+              })
+              export class MyComponent {
+                constructor(
+                  @Attribute('name') name:string,
+                  s1: MyService, 
+                  @Host() s2: MyService,
+                  @Self() s4: MyService,
+                  @SkipSelf() s3: MyService,
+                  @Optional() s5: MyService,
+                  @Self() @Optional() s6: MyService,
+                ) {}
+              }
+
+              @NgModule({declarations: [MyComponent], imports: [CommonModule], providers: [MyService]})
+              export class MyModule {}
+          `
+      }
+    };
+
+    const factory = `
+      factory: function MyComponent_Factory() {
+        return new MyComponent(
+          $r3$.ɵinjectAttribute('name'),
+          $r3$.ɵdirectiveInject(MyService), 
+          $r3$.ɵdirectiveInject(MyService, (undefined as any), 1),
+          $r3$.ɵdirectiveInject(MyService, (undefined as any), 2),
+          $r3$.ɵdirectiveInject(MyService, (undefined as any), 4),
+          $r3$.ɵdirectiveInject(MyService, (undefined as any), 8),
+          $r3$.ɵdirectiveInject(MyService, (undefined as any), 10)
+        );
+      }`;
+
+
+    const result = compile(files, angularFiles);
+
+    expectEmit(result.source, factory, 'Incorrect factory');
+  });
+
+});

--- a/packages/compiler/test/render3/r3_view_compiler_di_spec.ts
+++ b/packages/compiler/test/render3/r3_view_compiler_di_spec.ts
@@ -53,11 +53,11 @@ describe('compiler compliance: dependency injection', () => {
         return new MyComponent(
           $r3$.ɵinjectAttribute('name'),
           $r3$.ɵdirectiveInject(MyService), 
-          $r3$.ɵdirectiveInject(MyService, (undefined as any), 1),
-          $r3$.ɵdirectiveInject(MyService, (undefined as any), 2),
-          $r3$.ɵdirectiveInject(MyService, (undefined as any), 4),
-          $r3$.ɵdirectiveInject(MyService, (undefined as any), 8),
-          $r3$.ɵdirectiveInject(MyService, (undefined as any), 10)
+          $r3$.ɵdirectiveInject(MyService, 1),
+          $r3$.ɵdirectiveInject(MyService, 2),
+          $r3$.ɵdirectiveInject(MyService, 4),
+          $r3$.ɵdirectiveInject(MyService, 8),
+          $r3$.ɵdirectiveInject(MyService, 10)
         );
       }`;
 

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {InjectableDef, defineInjectable} from '../../di/defs';
 import {Optional, SkipSelf} from '../../di/metadata';
 import {StaticProvider} from '../../di/provider';
+import {DefaultIterableDifferFactory} from '../differs/default_iterable_differ';
 
 
 /**
@@ -135,6 +137,11 @@ export interface IterableDifferFactory {
  *
  */
 export class IterableDiffers {
+  static ngInjectableDef: InjectableDef<IterableDiffers> = defineInjectable({
+    providedIn: 'root',
+    factory: () => new IterableDiffers([new DefaultIterableDifferFactory()])
+  });
+
   /**
    * @deprecated v4.0.0 - Should be private
    */

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -13,7 +13,7 @@ export {devModeEqual as ɵdevModeEqual} from './change_detection/change_detectio
 export {isListLikeIterable as ɵisListLikeIterable} from './change_detection/change_detection_util';
 export {ChangeDetectorStatus as ɵChangeDetectorStatus, isDefaultChangeDetectionStrategy as ɵisDefaultChangeDetectionStrategy} from './change_detection/constants';
 export {Console as ɵConsole} from './console';
-export {setCurrentInjector as ɵsetCurrentInjector} from './di/injector';
+export {inject as ɵinject, setCurrentInjector as ɵsetCurrentInjector} from './di/injector';
 export {APP_ROOT as ɵAPP_ROOT} from './di/scope';
 export {ComponentFactory as ɵComponentFactory} from './linker/component_factory';
 export {CodegenComponentFactoryResolver as ɵCodegenComponentFactoryResolver} from './linker/component_factory_resolver';

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -21,7 +21,6 @@ export {
   injectViewContainerRef as ɵinjectViewContainerRef,
   injectChangeDetectorRef as ɵinjectChangeDetectorRef,
   injectAttribute as ɵinjectAttribute,
-  InjectFlags as ɵInjectFlags,
   PublicFeature as ɵPublicFeature,
   NgOnChangesFeature as ɵNgOnChangesFeature,
   CssSelectorList as ɵCssSelectorList,

--- a/packages/core/src/di/defs.ts
+++ b/packages/core/src/di/defs.ts
@@ -25,8 +25,25 @@ import {ClassProvider, ClassSansProvider, ConstructorProvider, ConstructorSansPr
  * @experimental
  */
 export interface InjectableDef<T> {
+  /**
+   * Specifies that the given type belongs to a particular injector:
+   * - `InjectorType` such as `NgModule`,
+   * - `'root'` the root injector
+   * - `'any'` all injectors.
+   * - `null`, does not belong to any injector. Must be explicitly listed in the injector
+   *   `providers`.
+   */
   providedIn: InjectorType<any>|'root'|'any'|null;
+
+  /**
+   * Factory method to execute to create an instance of the injectable.
+   */
   factory: () => T;
+
+  /**
+   * In a case of no explicit injector, a location where the instance of the injectable is stored.
+   */
+  value: T|undefined;
 }
 
 /**
@@ -101,12 +118,13 @@ export interface InjectorTypeWithProviders<T> {
  * @experimental
  */
 export function defineInjectable<T>(opts: {
-  providedIn?: Type<any>| 'root' | null,
+  providedIn?: Type<any>| 'root' | 'any' | null,
   factory: () => T,
 }): InjectableDef<T> {
   return {
-    providedIn: (opts.providedIn as InjectorType<any>| 'root' | null | undefined) || null,
+    providedIn: opts.providedIn as any || null,
     factory: opts.factory,
+    value: undefined,
   };
 }
 

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -411,16 +411,21 @@ function getClosureSafeProperty<T>(objWithPropertyToExtract: T): string {
 
 /**
  * Injection flags for DI.
- *
- *
  */
 export const enum InjectFlags {
   Default = 0,
 
-  /** Skip the node that is requesting injection. */
-  SkipSelf = 1 << 0,
+  /**
+   * Specifies that an injector should retrieve a dependency from any injector until reaching the
+   * host element of the current component. (Only used with Element Injector)
+   */
+  Host = 1 << 0,
   /** Don't descend into ancestors of the node requesting injection. */
   Self = 1 << 1,
+  /** Skip the node that is requesting injection. */
+  SkipSelf = 1 << 2,
+  /** Inject `defaultValue` instead if token not found. */
+  Optional = 1 << 3,
 }
 
 let _currentInjector: Injector|null = null;

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -428,9 +428,15 @@ export const enum InjectFlags {
   Optional = 1 << 3,
 }
 
-let _currentInjector: Injector|null = null;
+/**
+ * Current injector value used by `inject`.
+ * - `undefined`: it is an error to call `inject`
+ * - `null`: `inject` can be called but there is no injector (limp-mode).
+ * - Injector instance: Use the injector for resolution.
+ */
+let _currentInjector: Injector|undefined|null = undefined;
 
-export function setCurrentInjector(injector: Injector | null): Injector|null {
+export function setCurrentInjector(injector: Injector | null | undefined): Injector|undefined|null {
   const former = _currentInjector;
   _currentInjector = injector;
   return former;
@@ -450,19 +456,21 @@ export function setCurrentInjector(injector: Injector | null): Injector|null {
  *
  * @experimental
  */
-export function inject<T>(
-    token: Type<T>| InjectionToken<T>, notFoundValue?: undefined, flags?: InjectFlags): T;
-export function inject<T>(
-    token: Type<T>| InjectionToken<T>, notFoundValue: T, flags?: InjectFlags): T;
-export function inject<T>(
-    token: Type<T>| InjectionToken<T>, notFoundValue: null, flags?: InjectFlags): T|null;
-export function inject<T>(
-    token: Type<T>| InjectionToken<T>, notFoundValue?: T | null, flags = InjectFlags.Default): T|
-    null {
-  if (_currentInjector === null) {
+export function inject<T>(token: Type<T>| InjectionToken<T>): T;
+export function inject<T>(token: Type<T>| InjectionToken<T>, flags?: InjectFlags): T|null;
+export function inject<T>(token: Type<T>| InjectionToken<T>, flags = InjectFlags.Default): T|null {
+  if (_currentInjector === undefined) {
     throw new Error(`inject() must be called from an injection context`);
+  } else if (_currentInjector === null) {
+    const injectableDef: InjectableDef<T> = (token as any).ngInjectableDef;
+    if (injectableDef && injectableDef.providedIn == 'root') {
+      return injectableDef.value === undefined ? injectableDef.value = injectableDef.factory() :
+                                                 injectableDef.value;
+    }
+    throw new Error(`Injector: NOT_FOUND [${stringify(token)}]`);
+  } else {
+    return _currentInjector.get(token, flags & InjectFlags.Optional ? null : undefined, flags);
   }
-  return _currentInjector.get(token, notFoundValue, flags);
 }
 
 export function injectArgs(types: (Type<any>| InjectionToken<any>| any[])[]): any[] {
@@ -474,13 +482,12 @@ export function injectArgs(types: (Type<any>| InjectionToken<any>| any[])[]): an
         throw new Error('Arguments array must have arguments.');
       }
       let type: Type<any>|undefined = undefined;
-      let defaultValue: null|undefined = undefined;
       let flags: InjectFlags = InjectFlags.Default;
 
       for (let j = 0; j < arg.length; j++) {
         const meta = arg[j];
         if (meta instanceof Optional || meta.__proto__.ngMetadataName === 'Optional') {
-          defaultValue = null;
+          flags |= InjectFlags.Optional;
         } else if (meta instanceof SkipSelf || meta.__proto__.ngMetadataName === 'SkipSelf') {
           flags |= InjectFlags.SkipSelf;
         } else if (meta instanceof Self || meta.__proto__.ngMetadataName === 'Self') {
@@ -492,7 +499,7 @@ export function injectArgs(types: (Type<any>| InjectionToken<any>| any[])[]): an
         }
       }
 
-      args.push(inject(type !, defaultValue, InjectFlags.Default));
+      args.push(inject(type !, flags));
     } else {
       args.push(inject(arg));
     }

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -64,12 +64,12 @@ interface Record<T> {
 }
 
 /**
- * Create a new `Injector` which is configured using `InjectorDefType`s.
+ * Create a new `Injector` which is configured using `InjectorType`s.
  *
  * @experimental
  */
 export function createInjector(
-    defType: /* InjectorDefType<any> */ any, parent: Injector | null = null): Injector {
+    defType: /* InjectorType<any> */ any, parent: Injector | null = null): Injector {
   parent = parent || getNullInjector();
   return new R3Injector(defType, parent);
 }
@@ -81,7 +81,7 @@ export class R3Injector {
   private records = new Map<Type<any>|InjectionToken<any>, Record<any>>();
 
   /**
-   * The transitive set of `InjectorDefType`s which define this injector.
+   * The transitive set of `InjectorType`s which define this injector.
    */
   private injectorDefTypes = new Set<InjectorType<any>>();
 
@@ -102,7 +102,7 @@ export class R3Injector {
   private destroyed = false;
 
   constructor(def: InjectorType<any>, readonly parent: Injector) {
-    // Start off by creating Records for every provider declared in every InjectorDefType
+    // Start off by creating Records for every provider declared in every InjectorType
     // included transitively in `def`.
     deepForEach(
         [def], injectorDef => this.processInjectorType(injectorDef, new Set<InjectorType<any>>()));
@@ -114,7 +114,7 @@ export class R3Injector {
     // any injectable scoped to APP_ROOT_SCOPE.
     this.isRootInjector = this.records.has(APP_ROOT);
 
-    // Eagerly instantiate the InjectorDefType classes themselves.
+    // Eagerly instantiate the InjectorType classes themselves.
     this.injectorDefTypes.forEach(defType => this.get(defType));
   }
 
@@ -187,7 +187,7 @@ export class R3Injector {
   }
 
   /**
-   * Add an `InjectorDefType` or `InjectorDefTypeWithProviders` and all of its transitive providers
+   * Add an `InjectorType` or `InjectorDefTypeWithProviders` and all of its transitive providers
    * to this injector.
    */
   private processInjectorType(
@@ -195,7 +195,7 @@ export class R3Injector {
       parents: Set<InjectorType<any>>) {
     defOrWrappedDef = resolveForwardRef(defOrWrappedDef);
 
-    // Either the defOrWrappedDef is an InjectorDefType (with ngInjectorDef) or an
+    // Either the defOrWrappedDef is an InjectorType (with ngInjectorDef) or an
     // InjectorDefTypeWithProviders (aka ModuleWithProviders). Detecting either is a megamorphic
     // read, so care is taken to only do the read once.
 
@@ -206,7 +206,7 @@ export class R3Injector {
     const ngModule =
         (def == null) && (defOrWrappedDef as InjectorTypeWithProviders<any>).ngModule || undefined;
 
-    // Determine the InjectorDefType. In the case where `defOrWrappedDef` is an `InjectorDefType`,
+    // Determine the InjectorType. In the case where `defOrWrappedDef` is an `InjectorType`,
     // then this is easy. In the case of an InjectorDefTypeWithProviders, then the definition type
     // is the `ngModule`.
     const defType: InjectorType<any> =
@@ -234,7 +234,7 @@ export class R3Injector {
       throw new Error(`Circular dependency: type ${stringify(defType)} ends up importing itself.`);
     }
 
-    // Track the InjectorDefType and add a provider for it.
+    // Track the InjectorType and add a provider for it.
     this.injectorDefTypes.add(defType);
     this.records.set(defType, makeRecord(def.factory));
 

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -132,10 +132,11 @@ export function renderComponent<T>(
     scheduler: opts.scheduler || requestAnimationFrame.bind(window),
     clean: CLEAN_PROMISE,
   };
-  const rootView = createLView(
+  const rootView: LView = createLView(
       -1, rendererFactory.createRenderer(hostNode, componentDef.rendererType),
       createTView(null, null), null, rootContext,
       componentDef.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways);
+  rootView.injector = opts.injector || null;
 
   const oldView = enterView(rootView, null !);
   let elementNode: LElementNode;

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -8,10 +8,9 @@
 
 import {LifecycleHooksFeature, createComponentRef, getHostElement, getRenderedText, renderComponent, whenRendered} from './component';
 import {NgOnChangesFeature, PublicFeature, defineComponent, defineDirective, definePipe} from './definition';
-import {InjectFlags} from './di';
 import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefFlags, DirectiveType, PipeDef} from './interfaces/definition';
 
-export {InjectFlags, QUERY_READ_CONTAINER_REF, QUERY_READ_ELEMENT_REF, QUERY_READ_FROM_NODE, QUERY_READ_TEMPLATE_REF, directiveInject, injectAttribute, injectChangeDetectorRef, injectElementRef, injectTemplateRef, injectViewContainerRef} from './di';
+export {QUERY_READ_CONTAINER_REF, QUERY_READ_ELEMENT_REF, QUERY_READ_FROM_NODE, QUERY_READ_TEMPLATE_REF, directiveInject, injectAttribute, injectChangeDetectorRef, injectElementRef, injectTemplateRef, injectViewContainerRef} from './di';
 export {RenderFlags} from './interfaces/definition';
 export {CssSelectorList} from './interfaces/projection';
 

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -301,6 +301,7 @@ export function createLView<T>(
     dynamicViewCount: 0,
     lifecycleStage: LifecycleStage.Init,
     queries: null,
+    injector: currentView && currentView.injector,
   };
 
   return newView;

--- a/packages/core/src/render3/interfaces/injector.ts
+++ b/packages/core/src/render3/interfaces/injector.ts
@@ -7,7 +7,6 @@
  */
 
 import {ChangeDetectorRef} from '../../change_detection/change_detector_ref';
-import {Injector} from '../../di/injector';
 import {ElementRef} from '../../linker/element_ref';
 import {TemplateRef} from '../../linker/template_ref';
 import {ViewContainerRef} from '../../linker/view_container_ref';
@@ -68,8 +67,6 @@ export interface LInjector {
   cbf5: number;
   cbf6: number;
   cbf7: number;
-
-  injector: Injector|null;
 
   /** Stores the TemplateRef so subsequent injections of the TemplateRef get the same instance. */
   templateRef: TemplateRef<any>|null;

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Injector} from '../../di/injector';
 import {LContainer} from './container';
 import {ComponentTemplate, DirectiveDef, DirectiveDefList, PipeDef, PipeDefList} from './definition';
 import {LElementNode, LViewNode, TNode} from './node';
@@ -189,6 +190,11 @@ export interface LView {
    * Queries active for this view - nodes from a view are reported to those queries
    */
   queries: LQueries|null;
+
+  /**
+   * An optional Module Injector to be used as fall back after Element Injectors are consulted.
+   */
+  injector: Injector|null;
 }
 
 /** Flags associated with an LView (saved in LView.flags) */

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1,5 +1,8 @@
 [
   {
+    "name": "BLOOM_SIZE"
+  },
+  {
     "name": "CIRCULAR$2"
   },
   {
@@ -28,6 +31,12 @@
   },
   {
     "name": "IterableChangeRecord_"
+  },
+  {
+    "name": "IterableDiffers"
+  },
+  {
+    "name": "NG_ELEMENT_ID"
   },
   {
     "name": "NG_HOST_SYMBOL"
@@ -177,6 +186,9 @@
     "name": "_c9"
   },
   {
+    "name": "_currentInjector"
+  },
+  {
     "name": "_devMode"
   },
   {
@@ -217,6 +229,12 @@
   },
   {
     "name": "bindingUpdated"
+  },
+  {
+    "name": "bloomFindPossibleInjector"
+  },
+  {
+    "name": "bloomHashBit"
   },
   {
     "name": "cacheMatchingDirectivesForNode"
@@ -276,9 +294,6 @@
     "name": "currentView"
   },
   {
-    "name": "defaultIterableDiffers"
-  },
-  {
     "name": "defineComponent"
   },
   {
@@ -301,6 +316,9 @@
   },
   {
     "name": "directiveCreate"
+  },
+  {
+    "name": "directiveInject"
   },
   {
     "name": "domRendererFactory3"
@@ -381,6 +399,9 @@
     "name": "getOrCreateElementRef"
   },
   {
+    "name": "getOrCreateInjectable"
+  },
+  {
     "name": "getOrCreateNodeInjector"
   },
   {
@@ -427,6 +448,9 @@
   },
   {
     "name": "initChangeDetectorIfExisting"
+  },
+  {
+    "name": "inject"
   },
   {
     "name": "injectTemplateRef"
@@ -571,6 +595,12 @@
   },
   {
     "name": "scheduleTick"
+  },
+  {
+    "name": "searchMatchesQueuedForCreation"
+  },
+  {
+    "name": "setCurrentInjector"
   },
   {
     "name": "setHostBindings"

--- a/packages/core/test/bundling/todo/index.ts
+++ b/packages/core/test/bundling/todo/index.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule, NgForOf, NgIf} from '@angular/common';
-import {ChangeDetectionStrategy, Component, EventEmitter, InjectFlags, Injectable, Input, IterableDiffers, NgModule, Output, createInjector, defineInjector, inject, ɵComponentDef as ComponentDef, ɵComponentType as ComponentType, ɵDirectiveDef as DirectiveDef, ɵDirectiveType as DirectiveType, ɵNgOnChangesFeature as NgOnChangesFeature, ɵdefaultIterableDiffers as defaultIterableDiffers, ɵdefineDirective as defineDirective, ɵinjectTemplateRef as injectTemplateRef, ɵinjectViewContainerRef as injectViewContainerRef, ɵmarkDirty as markDirty, ɵrenderComponent as renderComponent} from '@angular/core';
+import {ChangeDetectionStrategy, Component, EventEmitter, InjectFlags, Injectable, Input, IterableDiffers, NgModule, Output, createInjector, defineInjector, inject, ɵComponentDef as ComponentDef, ɵComponentType as ComponentType, ɵDirectiveDef as DirectiveDef, ɵDirectiveType as DirectiveType, ɵNgOnChangesFeature as NgOnChangesFeature, ɵdefaultIterableDiffers as defaultIterableDiffers, ɵdefineDirective as defineDirective, ɵdirectiveInject as directiveInject, ɵinjectTemplateRef as injectTemplateRef, ɵinjectViewContainerRef as injectViewContainerRef, ɵmarkDirty as markDirty, ɵrenderComponent as renderComponent} from '@angular/core';
 
 
 export class Todo {
@@ -23,7 +23,7 @@ export class Todo {
   }
 }
 
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class TodoStore {
   todos: Array<Todo> = [
     new Todo('Demonstrate Components'),
@@ -108,12 +108,9 @@ export class TodoStore {
   // changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ToDoAppComponent {
-  todoStore: TodoStore;
   newTodoText = '';
 
-  // TODO(misko) Fix injection
-  // constructor(todoStore: TodoStore) { this.todoStore = todoStore; }
-  constructor() { this.todoStore = new TodoStore(); }
+  constructor(public todoStore: TodoStore) {}
 
   stopEditing(todo: Todo, editedTitle: string) {
     todo.title = editedTitle;
@@ -157,10 +154,7 @@ export class ToDoAppComponent {
   type: NgForOf,
   selectors: [['', 'ngFor', '', 'ngForOf', '']],
   factory: () => new NgForOf(
-               injectViewContainerRef(), injectTemplateRef(),
-               // TODO(misko): inject does not work since it needs to be directiveInject
-               // inject(IterableDiffers, defaultIterableDiffers)
-               defaultIterableDiffers),
+               injectViewContainerRef(), injectTemplateRef(), directiveInject(IterableDiffers)),
   features: [NgOnChangesFeature({
     ngForOf: 'ngForOf',
     ngForTrackBy: 'ngForTrackBy',

--- a/packages/core/test/render3/common_with_def.ts
+++ b/packages/core/test/render3/common_with_def.ts
@@ -19,8 +19,7 @@ NgForOf.ngDirectiveDef = defineDirective({
   type: NgForOfDef,
   selectors: [['', 'ngForOf', '']],
   factory: () => new NgForOfDef(
-               injectViewContainerRef(), injectTemplateRef(),
-               directiveInject(IterableDiffers, defaultIterableDiffers, InjectFlags.Default)),
+               injectViewContainerRef(), injectTemplateRef(), directiveInject(IterableDiffers)),
   features: [NgOnChangesFeature()],
   inputs: {
     ngForOf: 'ngForOf',

--- a/packages/core/test/render3/common_with_def.ts
+++ b/packages/core/test/render3/common_with_def.ts
@@ -7,10 +7,10 @@
  */
 
 import {NgForOf as NgForOfDef, NgIf as NgIfDef} from '@angular/common';
-import {IterableDiffers} from '@angular/core';
+import {InjectFlags, IterableDiffers} from '@angular/core';
 
 import {defaultIterableDiffers} from '../../src/change_detection/change_detection';
-import {DirectiveType, InjectFlags, NgOnChangesFeature, defineDirective, directiveInject, injectTemplateRef, injectViewContainerRef} from '../../src/render3/index';
+import {DirectiveType, NgOnChangesFeature, defineDirective, directiveInject, injectTemplateRef, injectViewContainerRef} from '../../src/render3/index';
 
 export const NgForOf: DirectiveType<NgForOfDef<any>> = NgForOfDef as any;
 export const NgIf: DirectiveType<NgIfDef> = NgIfDef as any;
@@ -20,7 +20,7 @@ NgForOf.ngDirectiveDef = defineDirective({
   selectors: [['', 'ngForOf', '']],
   factory: () => new NgForOfDef(
                injectViewContainerRef(), injectTemplateRef(),
-               directiveInject(IterableDiffers, InjectFlags.Default, defaultIterableDiffers)),
+               directiveInject(IterableDiffers, defaultIterableDiffers, InjectFlags.Default)),
   features: [NgOnChangesFeature()],
   inputs: {
     ngForOf: 'ngForOf',

--- a/packages/core/test/render3/compiler_canonical/injection_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/injection_spec.ts
@@ -185,7 +185,7 @@ describe('injection', () => {
       // NORMATIVE
       static ngInjectableDef = defineInjectable({
         factory: function ServiceA_Factory() {
-          return new ServiceB(inject(ServiceA), inject(INJECTOR, undefined, InjectFlags.SkipSelf));
+          return new ServiceB(inject(ServiceA), inject(INJECTOR, InjectFlags.SkipSelf) !);
         },
       });
       // /NORMATIVE

--- a/packages/core/test/render3/compiler_canonical/ng_module_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/ng_module_spec.ts
@@ -71,7 +71,7 @@ xdescribe('NgModule', () => {
       static ngInjectableDef = defineInjectable({
         providedIn: MyModule,
         factory: () => new BurntToast(
-                     $r3$.ɵdirectiveInject(Toast, undefined, $core$.InjectFlags.Optional),
+                     $r3$.ɵdirectiveInject(Toast, $core$.InjectFlags.Optional),
                      $r3$.ɵdirectiveInject(String)),
       });
       // /NORMATIVE

--- a/packages/core/test/render3/compiler_canonical/ng_module_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/ng_module_spec.ts
@@ -6,9 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as $core$ from '../../../index';
 import {ChangeDetectionStrategy, ChangeDetectorRef, Component, ContentChild, ContentChildren, Directive, HostBinding, HostListener, Injectable, Input, NgModule, OnDestroy, Optional, Pipe, PipeTransform, QueryList, SimpleChanges, TemplateRef, ViewChild, ViewChildren, ViewContainerRef} from '../../../src/core';
 import * as $r3$ from '../../../src/core_render3_private_export';
 import {renderComponent, toHtml} from '../render_util';
+
 
 /// See: `normative.md`
 xdescribe('NgModule', () => {
@@ -69,7 +71,7 @@ xdescribe('NgModule', () => {
       static ngInjectableDef = defineInjectable({
         providedIn: MyModule,
         factory: () => new BurntToast(
-                     $r3$.ɵdirectiveInject(Toast, $r3$.ɵInjectFlags.Optional),
+                     $r3$.ɵdirectiveInject(Toast, undefined, $core$.InjectFlags.Optional),
                      $r3$.ɵdirectiveInject(String)),
       });
       // /NORMATIVE

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, ElementRef, TemplateRef, ViewContainerRef} from '@angular/core';
+import {ChangeDetectorRef, ElementRef, InjectFlags, TemplateRef, ViewContainerRef} from '@angular/core';
 import {RenderFlags} from '@angular/core/src/render3/interfaces/definition';
 
 import {defineComponent} from '../../src/render3/definition';
-import {InjectFlags, bloomAdd, bloomFindPossibleInjector, getOrCreateNodeInjector, injectAttribute} from '../../src/render3/di';
+import {bloomAdd, bloomFindPossibleInjector, getOrCreateNodeInjector, injectAttribute} from '../../src/render3/di';
 import {NgOnChangesFeature, PublicFeature, defineDirective, directiveInject, injectChangeDetectorRef, injectElementRef, injectTemplateRef, injectViewContainerRef} from '../../src/render3/index';
 import {bind, container, containerRefreshEnd, containerRefreshStart, createLNode, createLView, createTView, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, enterView, interpolation2, leaveView, load, projection, projectionDef, text, textBinding} from '../../src/render3/instructions';
 import {LInjector} from '../../src/render3/interfaces/injector';
@@ -1019,7 +1019,7 @@ describe('di', () => {
             type: MyApp,
             selectors: [['my-app']],
             factory: () => new MyApp(
-                         directiveInject(String as any, InjectFlags.Default, 'DefaultValue')),
+                         directiveInject(String as any, 'DefaultValue', InjectFlags.Default)),
             template: () => null
           });
         }

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, ElementRef, InjectFlags, TemplateRef, ViewContainerRef} from '@angular/core';
+import {ChangeDetectorRef, ElementRef, InjectFlags, TemplateRef, ViewContainerRef, defineInjectable} from '@angular/core';
 import {RenderFlags} from '@angular/core/src/render3/interfaces/definition';
 
 import {defineComponent} from '../../src/render3/definition';
@@ -397,6 +397,35 @@ describe('di', () => {
       expect(log).toEqual(['DirB', 'DirB', 'DirA (dep: DirB - 2)']);
     });
 
+    it('should create instance even when no injector present', () => {
+      class MyService {
+        value = 'MyService';
+        static ngInjectableDef =
+            defineInjectable({providedIn: 'root', factory: () => new MyService()});
+      }
+
+      class MyComponent {
+        constructor(public myService: MyService) {}
+        static ngComponentDef = defineComponent({
+          type: MyComponent,
+          selectors: [['my-component']],
+          factory: () => new MyComponent(directiveInject(MyService)),
+          template: function(rf: RenderFlags, ctx: MyComponent) {
+            if (rf & RenderFlags.Create) {
+              text(0);
+            }
+            if (rf & RenderFlags.Update) {
+              textBinding(0, bind(ctx.myService.value));
+            }
+          }
+        });
+      }
+
+      const fixture = new ComponentFixture(MyComponent);
+      fixture.update();
+      expect(fixture.html).toEqual('MyService');
+    });
+
     it('should throw if directive is not found', () => {
       class Dir {
         constructor(siblingDir: OtherDir) {}
@@ -426,8 +455,7 @@ describe('di', () => {
         }
       }, [Dir, OtherDir]);
 
-      expect(() => new ComponentFixture(App))
-          .toThrowError(/ElementInjector: NotFound \[OtherDir\]/);
+      expect(() => new ComponentFixture(App)).toThrowError(/Injector: NOT_FOUND \[OtherDir\]/);
     });
 
     it('should throw if directives try to inject each other', () => {
@@ -1007,24 +1035,6 @@ describe('di', () => {
         expect(bloomFindPossibleInjector(di, 188)).toEqual(di);
         expect(bloomFindPossibleInjector(di, 223)).toEqual(di);
         expect(bloomFindPossibleInjector(di, 255)).toEqual(di);
-      });
-    });
-
-    describe('flags', () => {
-      it('should return defaultValue not found', () => {
-        class MyApp {
-          constructor(public value: string) {}
-
-          static ngComponentDef = defineComponent({
-            type: MyApp,
-            selectors: [['my-app']],
-            factory: () => new MyApp(
-                         directiveInject(String as any, 'DefaultValue', InjectFlags.Default)),
-            template: () => null
-          });
-        }
-        const myApp = renderComponent(MyApp);
-        expect(myApp.value).toEqual('DefaultValue');
       });
     });
 

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -8,6 +8,7 @@
 
 import {stringifyElement} from '@angular/platform-browser/testing/src/browser_util';
 
+import {Injector} from '../../src/di/injector';
 import {CreateComponentOptions} from '../../src/render3/component';
 import {extractDirectiveDef, extractPipeDef} from '../../src/render3/definition';
 import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveType, PublicFeature, RenderFlags, defineComponent, defineDirective, renderComponent as _renderComponent, tick} from '../../src/render3/index';
@@ -93,7 +94,7 @@ export class ComponentFixture<T> extends BaseFixture {
   component: T;
   requestAnimationFrame: {(fn: () => void): void; flush(): void; queue: (() => void)[];};
 
-  constructor(private componentType: ComponentType<T>) {
+  constructor(private componentType: ComponentType<T>, opts: {injector?: Injector} = {}) {
     super();
     this.requestAnimationFrame = function(fn: () => void) {
       requestAnimationFrame.queue.push(fn);
@@ -105,10 +106,9 @@ export class ComponentFixture<T> extends BaseFixture {
       }
     };
 
-    this.component = _renderComponent(componentType, {
-      host: this.hostElement,
-      scheduler: this.requestAnimationFrame,
-    });
+    this.component = _renderComponent(
+        componentType,
+        {host: this.hostElement, scheduler: this.requestAnimationFrame, injector: opts.injector});
   }
 
   update(): void {

--- a/packages/core/test/view/ng_module_spec.ts
+++ b/packages/core/test/view/ng_module_spec.ts
@@ -59,7 +59,7 @@ class HasOptionalDep {
   constructor(public baz: Baz|null) {}
 
   static ngInjectableDef: InjectableDef<HasOptionalDep> = defineInjectable({
-    factory: () => new HasOptionalDep(inject(Baz, null)),
+    factory: () => new HasOptionalDep(inject(Baz, InjectFlags.Optional)),
     providedIn: MyModule,
   });
 }
@@ -74,7 +74,7 @@ class ChildDep {
 class FromChildWithOptionalDep {
   constructor(public baz: Baz|null) {}
   static ngInjectableDef: InjectableDef<FromChildWithOptionalDep> = defineInjectable({
-    factory: () => new FromChildWithOptionalDep(inject(Baz, null, InjectFlags.Default)),
+    factory: () => new FromChildWithOptionalDep(inject(Baz, InjectFlags.Default)),
     providedIn: MyChildModule,
   });
 }
@@ -83,7 +83,8 @@ class FromChildWithSkipSelfDep {
   constructor(public depFromParent: ChildDep|null, public depFromChild: Bar|null) {}
   static ngInjectableDef: InjectableDef<FromChildWithSkipSelfDep> = defineInjectable({
     factory: () => new FromChildWithSkipSelfDep(
-                 inject(ChildDep, null, InjectFlags.SkipSelf), inject(Bar, null, InjectFlags.Self)),
+                 inject(ChildDep, InjectFlags.SkipSelf|InjectFlags.Optional),
+                 inject(Bar, InjectFlags.Self|InjectFlags.Optional)),
     providedIn: MyChildModule,
   });
 }

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -242,7 +242,7 @@ export declare class DefaultIterableDiffer<V> implements IterableDiffer<V>, Iter
 
 /** @experimental */
 export declare function defineInjectable<T>(opts: {
-    providedIn?: Type<any> | 'root' | null;
+    providedIn?: Type<any> | 'root' | 'any' | null;
     factory: () => T;
 }): InjectableDef<T>;
 
@@ -336,9 +336,8 @@ export interface HostDecorator {
 export declare const HostListener: HostListenerDecorator;
 
 /** @experimental */
-export declare function inject<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: undefined, flags?: InjectFlags): T;
-export declare function inject<T>(token: Type<T> | InjectionToken<T>, notFoundValue: T, flags?: InjectFlags): T;
-export declare function inject<T>(token: Type<T> | InjectionToken<T>, notFoundValue: null, flags?: InjectFlags): T | null;
+export declare function inject<T>(token: Type<T> | InjectionToken<T>): T;
+export declare function inject<T>(token: Type<T> | InjectionToken<T>, flags?: InjectFlags): T | null;
 
 export declare const Inject: InjectDecorator;
 
@@ -359,6 +358,7 @@ export interface InjectableDecorator {
 export interface InjectableDef<T> {
     factory: () => T;
     providedIn: InjectorType<any> | 'root' | 'any' | null;
+    value: T | undefined;
 }
 
 /** @experimental */
@@ -462,6 +462,7 @@ export declare class IterableDiffers {
     /** @deprecated */ factories: IterableDifferFactory[];
     constructor(factories: IterableDifferFactory[]);
     find(iterable: any): IterableDifferFactory;
+    static ngInjectableDef: InjectableDef<IterableDiffers>;
     static create(factories: IterableDifferFactory[], parent?: IterableDiffers): IterableDiffers;
     static extend(factories: IterableDifferFactory[]): StaticProvider;
 }

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -376,8 +376,10 @@ export interface InjectDecorator {
 
 export declare const enum InjectFlags {
     Default = 0,
-    SkipSelf = 1,
+    Host = 1,
     Self = 2,
+    SkipSelf = 4,
+    Optional = 8,
 }
 
 export declare class InjectionToken<T> {


### PR DESCRIPTION
This change changes:
- compiler uses `directiveInject` instead of `inject` for `Directive`s
- unifies the flags in `di` as well as `render3`
- changes the signature of `directiveInject` to match `inject` In prep for #23330
- compiler now generates flags for injection.

Compiler portion of #23342
Prep for #23330 

feat(ivy): support injection even if no injector present

- Remove default injection value from `inject` / `directiveInject` since
  it is not possible to set using annotations.
- Module `Injector` is stored on `LView` instead of `LInjector` data 
  structure because it can change only at `LView` level. (More efficient)
- Add `ngInjectableDef` to `IterableDiffers` so that existing tests can 
  pass as well as enable `IterableDiffers` to be injectable without 
  `Injector`