### PR TITLE
fix(compiler): handle undefined annotation metadata

### DIFF
--- a/packages/compiler/src/aot/static_reflector.ts
+++ b/packages/compiler/src/aot/static_reflector.ts
@@ -163,7 +163,9 @@ export class StaticReflector implements CompileReflector {
       let ownAnnotations: any[] = [];
       if (classMetadata['decorators']) {
         ownAnnotations = simplify(type, classMetadata['decorators']);
-        annotations.push(...ownAnnotations);
+        if (ownAnnotations) {
+          annotations.push(...ownAnnotations);
+        }
       }
       if (parentType && !this.summaryResolver.isLibraryFile(type.filePath) &&
           this.summaryResolver.isLibraryFile(parentType.filePath)) {


### PR DESCRIPTION
In certain cases seen in production, simplify() can returned
undefined when simplifying decorator metadata. This has proven tricky
to reproduce in an isolated test, but the fix is simple and low-risk:
don't attempt to spread an undefined set of annotations in the first
place.

Fixes #23310.