### PR TITLE
build(common): mark locales files as side-effect-full

### DIFF
--- a/packages/common/locales/BUILD.bazel
+++ b/packages/common/locales/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
 
 npm_package(
     name = "package",
+    srcs = [ "package.json" ],
     replacements = {
         # Workaround for https://github.com/angular/angular/issues/23217
         # Webpack will detect that the UMD outputs from TypeScript pass the

--- a/packages/common/locales/BUILD.bazel
+++ b/packages/common/locales/BUILD.bazel
@@ -13,7 +13,7 @@ ts_library(
 
 npm_package(
     name = "package",
-    srcs = [ "package.json" ],
+    srcs = ["package.json"],
     replacements = {
         # Workaround for https://github.com/angular/angular/issues/23217
         # Webpack will detect that the UMD outputs from TypeScript pass the

--- a/packages/common/locales/package.json
+++ b/packages/common/locales/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/packages/common/locales/package.json
+++ b/packages/common/locales/package.json
@@ -1,3 +1,4 @@
 {
+  "description": "This directory contains UMD files which by its nature are not side-effect free. The parent package.json marks the whole @angular/common package as side-effect free, so if this directory is not excluded from that, build-optimizer will mark the contents as side-effect free and uglify will incorrectly remove all needed localization code.",
   "sideEffects": false
 }


### PR DESCRIPTION
These files are in the UMD format for greater portablity, and as such
can't be marked as side-effect-free by webpack/build-optimizer/uglify.