### PR TITLE
fix(ivy): workaround for tsickle bug

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -574,7 +574,8 @@ function createDirectivesAndLocals(
  */
 function cacheMatchingDirectivesForNode(
     tNode: TNode, tView: TView, localRefs: string[] | null): void {
-  const exportsMap = localRefs ? {'': -1} : null;
+  // Please make sure to have explicit type for `exportsMap`. Inferred type triggers bug in tsickle.
+  const exportsMap: ({[key: string]: number} | null) = localRefs ? {'': -1} : null;
   const matches = tView.currentMatches = findDirectiveMatches(tNode);
   if (matches) {
     for (let i = 0; i < matches.length; i += 2) {


### PR DESCRIPTION
The issue is with tsickle type inference and the bug should be assigned to them.

The offending code is:
```
function cacheMatchingDirectivesForNode(
    tNode: TNode, tView: TView, localRefs: string[] | null): void {
  const exportsMap = localRefs ? {'': -1} : null;     // <<<<< ===== OFFENDING LINE
  const matches = tView.currentMatches = findDirectiveMatches(tNode);
  if (matches) {
    for (let i = 0; i < matches.length; i += 2) {
      const def = matches[i] as DirectiveDef<any>;
      const valueIndex = i + 1;
      resolveDirective(def, valueIndex, matches, tView);
      saveNameToExportMap(matches[valueIndex] as number, def, exportsMap);
    }
  }
  if (exportsMap) cacheMatchingLocalNames(tNode, localRefs, exportsMap);
}

```

because it generates invalid js closure code:
```
function cacheMatchingDirectivesForNode(tNode, tView, localRefs) {
    const /** @type {(null|{: number})} */ exportsMap = localRefs ? { '': -1 } : null;      // <<<<< ===== OFFENDING LINE
    const /** @type {(null|!Array<?>)} */ matches = tView.currentMatches = findDirectiveMatches(tNode);
    if (matches) {
        for (let /** @type {number} */ i = 0; i < matches.length; i += 2) {
            const /** @type {!tsickle_forward_declare_11.DirectiveDef<?>} */ def = /** @type {!tsickle_forward_declare_11.DirectiveDef<?>} */ (matches[i]);
            const /** @type {number} */ valueIndex = i + 1;
            resolveDirective(def, valueIndex, matches, tView);
            saveNameToExportMap(/** @type {number} */ (matches[valueIndex]), def, exportsMap);
        }
    }
    if (exportsMap)
        cacheMatchingLocalNames(tNode, localRefs, exportsMap);
}
```

The workaround is to declare the type explicitly such as:

```
const exportsMap: ({[key:string]:number}|null) = localRefs ? {'': -1} : null;
```

which than generates valid closure code:

```
const /** @type {(null|!Object<string,number>)} */ exportsMap = localRefs ? { '': -1 } : null;
```
