### PR TITLE
perf(ivy): add performance counters in ngDevMode

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -19,13 +19,14 @@ import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, ViewRef as viewEngine_Vie
 import {Type} from '../type';
 
 import {assertGreaterThan, assertLessThan, assertNotNull} from './assert';
-import {addToViewTree, assertPreviousIsParent, createLContainer, createLNodeObject, getDirectiveInstance, getPreviousOrParentNode, getRenderer, isComponent, renderEmbeddedTemplate, resolveDirective} from './instructions';
+import {addToViewTree, assertPreviousIsParent, createLContainer, createLNodeObject, createTView, getDirectiveInstance, getPreviousOrParentNode, getRenderer, isComponent, renderEmbeddedTemplate, resolveDirective} from './instructions';
+import {LContainer} from './interfaces/container';
 import {ComponentTemplate, DirectiveDef, DirectiveDefList, PipeDefList} from './interfaces/definition';
 import {LInjector} from './interfaces/injector';
 import {LContainerNode, LElementNode, LNode, LNodeType, LViewNode, TNodeFlags} from './interfaces/node';
 import {QueryReadType} from './interfaces/query';
 import {Renderer3} from './interfaces/renderer';
-import {LView} from './interfaces/view';
+import {LView, TView} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
 import {insertView, removeView} from './node_manipulation';
 import {notImplemented, stringify} from './util';
@@ -568,7 +569,6 @@ export function getOrCreateContainerRef(di: LInjector): viewEngine_ViewContainer
     const vcRefHost = di.node;
 
     ngDevMode && assertNodeOfPossibleTypes(vcRefHost, LNodeType.Container, LNodeType.Element);
-
     const lContainer = createLContainer(vcRefHost.parent !, vcRefHost.view);
     const lContainerNode: LContainerNode = createLNodeObject(
         LNodeType.Container, vcRefHost.view, vcRefHost.parent !, undefined, lContainer, null);
@@ -696,28 +696,34 @@ class ViewContainerRef implements viewEngine_ViewContainerRef {
  */
 export function getOrCreateTemplateRef<T>(di: LInjector): viewEngine_TemplateRef<T> {
   ngDevMode && assertNodeType(di.node, LNodeType.Container);
-  const data = (di.node as LContainerNode).data;
-  const tView = di.node.view.tView;
-  return di.templateRef || (di.templateRef = new TemplateRef<any>(
-                                getOrCreateElementRef(di), data.template !, getRenderer(),
-                                tView.directiveRegistry, tView.pipeRegistry));
+  const hostNode = di.node as LContainerNode;
+  const hostTNode = hostNode.tNode !;
+  const hostTView = hostNode.view.tView;
+  let templateTView: TView = hostTNode.tViews as TView;
+  if (templateTView == null) {
+    templateTView = hostTNode.tViews =
+        createTView(hostTView.directiveRegistry, hostTView.pipeRegistry);
+  }
+  ngDevMode && assertNotNull(templateTView, 'TView must be allocated');
+  return di.templateRef ||
+      (di.templateRef = new TemplateRef<any>(
+           getOrCreateElementRef(di), templateTView, hostNode.data.template !, getRenderer(),
+           hostTView.directiveRegistry, hostTView.pipeRegistry));
 }
 
 class TemplateRef<T> implements viewEngine_TemplateRef<T> {
   readonly elementRef: viewEngine_ElementRef;
-  private _template: ComponentTemplate<T>;
 
   constructor(
-      elementRef: viewEngine_ElementRef, template: ComponentTemplate<T>,
-      private _renderer: Renderer3, private _directives: DirectiveDefList|null,
-      private _pipes: PipeDefList|null) {
+      elementRef: viewEngine_ElementRef, private _tView: TView,
+      private _template: ComponentTemplate<T>, private _renderer: Renderer3,
+      private _directives: DirectiveDefList|null, private _pipes: PipeDefList|null) {
     this.elementRef = elementRef;
-    this._template = template;
   }
 
   createEmbeddedView(context: T): viewEngine_EmbeddedViewRef<T> {
     const viewNode = renderEmbeddedTemplate(
-        null, this._template, context, this._renderer, this._directives, this._pipes);
+        null, this._tView, this._template, context, this._renderer, this._directives, this._pipes);
     return addDestroyable(new EmbeddedViewRef(viewNode, this._template, context));
   }
 }

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -695,18 +695,20 @@ class ViewContainerRef implements viewEngine_ViewContainerRef {
  * @returns The TemplateRef instance to use
  */
 export function getOrCreateTemplateRef<T>(di: LInjector): viewEngine_TemplateRef<T> {
-  ngDevMode && assertNodeType(di.node, LNodeType.Container);
-  const hostNode = di.node as LContainerNode;
-  const hostTNode = hostNode.tNode !;
-  const hostTView = hostNode.view.tView;
-  if (!hostTNode.tViews) {
-    hostTNode.tViews = createTView(hostTView.directiveRegistry, hostTView.pipeRegistry);
+  if (!di.templateRef) {
+    ngDevMode && assertNodeType(di.node, LNodeType.Container);
+    const hostNode = di.node as LContainerNode;
+    const hostTNode = hostNode.tNode !;
+    const hostTView = hostNode.view.tView;
+    if (!hostTNode.tViews) {
+      hostTNode.tViews = createTView(hostTView.directiveRegistry, hostTView.pipeRegistry);
+    }
+    ngDevMode && assertNotNull(hostTNode.tViews, 'TView must be allocated');
+    di.templateRef = new TemplateRef<any>(
+        getOrCreateElementRef(di), hostTNode.tViews as TView, hostNode.data.template !,
+        getRenderer(), hostTView.directiveRegistry, hostTView.pipeRegistry);
   }
-  ngDevMode && assertNotNull(hostTNode.tViews, 'TView must be allocated');
-  return di.templateRef ||
-      (di.templateRef = new TemplateRef<any>(
-           getOrCreateElementRef(di), hostTNode.tViews as TView, hostNode.data.template !,
-           getRenderer(), hostTView.directiveRegistry, hostTView.pipeRegistry));
+  return di.templateRef;
 }
 
 class TemplateRef<T> implements viewEngine_TemplateRef<T> {

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -699,16 +699,14 @@ export function getOrCreateTemplateRef<T>(di: LInjector): viewEngine_TemplateRef
   const hostNode = di.node as LContainerNode;
   const hostTNode = hostNode.tNode !;
   const hostTView = hostNode.view.tView;
-  let templateTView: TView = hostTNode.tViews as TView;
-  if (templateTView == null) {
-    templateTView = hostTNode.tViews =
-        createTView(hostTView.directiveRegistry, hostTView.pipeRegistry);
+  if (!hostTNode.tViews) {
+    hostTNode.tViews = createTView(hostTView.directiveRegistry, hostTView.pipeRegistry);
   }
-  ngDevMode && assertNotNull(templateTView, 'TView must be allocated');
+  ngDevMode && assertNotNull(hostTNode.tViews, 'TView must be allocated');
   return di.templateRef ||
       (di.templateRef = new TemplateRef<any>(
-           getOrCreateElementRef(di), templateTView, hostNode.data.template !, getRenderer(),
-           hostTView.directiveRegistry, hostTView.pipeRegistry));
+           getOrCreateElementRef(di), hostTNode.tViews as TView, hostNode.data.template !,
+           getRenderer(), hostTView.directiveRegistry, hostTView.pipeRegistry));
 }
 
 class TemplateRef<T> implements viewEngine_TemplateRef<T> {

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -566,6 +566,7 @@ export function elementStart(
       assertEqual(
           currentView.bindingStartIndex, -1, 'elements should be created before any bindings');
 
+  ngDevMode && ngDevMode.rendererCreateElement++;
   const native: RElement = renderer.createElement(name);
   const node: LElementNode = createLNode(index, LNodeType.Element, native !, null);
 
@@ -580,6 +581,7 @@ function createDirectivesAndLocals(
     localRefs: string[] | null | undefined, containerData: TView[] | null) {
   const node = previousOrParentNode;
   if (firstTemplatePass) {
+    ngDevMode && ngDevMode.firstTemplatePass++;
     ngDevMode && assertDataInRange(index - 1);
     node.tNode = tData[index] = createTNode(name, attrs || null, containerData);
     cacheMatchingDirectivesForNode(node.tNode, currentView.tView, localRefs || null);
@@ -756,6 +758,7 @@ function getOrCreateTView(
 /** Creates a TView instance */
 export function createTView(
     defs: DirectiveDefListOrFactory | null, pipes: PipeDefListOrFactory | null): TView {
+  ngDevMode && ngDevMode.tView++;
   return {
     data: [],
     directives: null,
@@ -784,6 +787,7 @@ function setUpAttributes(native: RElement, attrs: string[]): void {
     const attrName = attrs[i];
     if (attrName !== NG_PROJECT_AS_ATTR_NAME) {
       const attrVal = attrs[i + 1];
+      ngDevMode && ngDevMode.rendererSetAttribute++;
       isProc ? (renderer as ProceduralRenderer3).setAttribute(native, attrName, attrVal) :
                native.setAttribute(attrName, attrVal);
     }
@@ -867,6 +871,7 @@ export function listener(
   // In order to match current behavior, native DOM event listeners must be added for all
   // events (including outputs).
   const cleanupFns = cleanup || (cleanup = currentView.cleanup = []);
+  ngDevMode && ngDevMode.rendererAddEventListener++;
   if (isProceduralRenderer(renderer)) {
     const wrappedListener = wrapListenerWithDirtyLogic(currentView, listenerFn);
     const cleanupFn = renderer.listen(native, eventName, wrappedListener);
@@ -931,9 +936,11 @@ export function elementAttribute(
   if (value !== NO_CHANGE) {
     const element: LElementNode = data[index];
     if (value == null) {
+      ngDevMode && ngDevMode.rendererRemoveAttribute++;
       isProceduralRenderer(renderer) ? renderer.removeAttribute(element.native, name) :
                                        element.native.removeAttribute(name);
     } else {
+      ngDevMode && ngDevMode.rendererSetAttribute++;
       const strValue = sanitizer == null ? stringify(value) : sanitizer(value);
       isProceduralRenderer(renderer) ? renderer.setAttribute(element.native, name, strValue) :
                                        element.native.setAttribute(name, strValue);
@@ -977,6 +984,7 @@ export function elementProperty<T>(
     // is risky, so sanitization can be done without further checks.
     value = sanitizer != null ? (sanitizer(value) as any) : value;
     const native = node.native;
+    ngDevMode && ngDevMode.rendererSetProperty++;
     isProceduralRenderer(renderer) ? renderer.setProperty(native, propName, value) :
                                      (native.setProperty ? native.setProperty(propName, value) :
                                                            (native as any)[propName] = value);
@@ -994,6 +1002,7 @@ export function elementProperty<T>(
  */
 function createTNode(
     tagName: string | null, attrs: string[] | null, data: TContainer | null): TNode {
+  ngDevMode && ngDevMode.tNode++;
   return {
     flags: 0,
     tagName: tagName,
@@ -1067,10 +1076,12 @@ export function elementClassNamed<T>(index: number, className: string, value: T 
   if (value !== NO_CHANGE) {
     const lElement = data[index] as LElementNode;
     if (value) {
+      ngDevMode && ngDevMode.rendererAddClass++;
       isProceduralRenderer(renderer) ? renderer.addClass(lElement.native, className) :
                                        lElement.native.classList.add(className);
 
     } else {
+      ngDevMode && ngDevMode.rendererRemoveClass++;
       isProceduralRenderer(renderer) ? renderer.removeClass(lElement.native, className) :
                                        lElement.native.classList.remove(className);
     }
@@ -1095,6 +1106,7 @@ export function elementClass<T>(index: number, value: T | NO_CHANGE): void {
     // future
     // we will add logic here which would work with the animation code.
     const lElement: LElementNode = data[index];
+    ngDevMode && ngDevMode.rendererSetClassName++;
     isProceduralRenderer(renderer) ? renderer.setProperty(lElement.native, 'className', value) :
                                      lElement.native['className'] = stringify(value);
   }
@@ -1121,6 +1133,7 @@ export function elementStyleNamed<T>(
   if (value !== NO_CHANGE) {
     const lElement: LElementNode = data[index];
     if (value == null) {
+      ngDevMode && ngDevMode.rendererRemoveStyle++;
       isProceduralRenderer(renderer) ?
           renderer.removeStyle(lElement.native, styleName, RendererStyleFlags3.DashCase) :
           lElement.native['style'].removeProperty(styleName);
@@ -1128,6 +1141,7 @@ export function elementStyleNamed<T>(
       let strValue =
           typeof suffixOrSanitizer == 'function' ? suffixOrSanitizer(value) : stringify(value);
       if (typeof suffixOrSanitizer == 'string') strValue = strValue + suffixOrSanitizer;
+      ngDevMode && ngDevMode.rendererSetStyle++;
       isProceduralRenderer(renderer) ?
           renderer.setStyle(lElement.native, styleName, strValue, RendererStyleFlags3.DashCase) :
           lElement.native['style'].setProperty(styleName, strValue);
@@ -1155,14 +1169,20 @@ export function elementStyle<T>(
     // we will add logic here which would work with the animation code.
     const lElement = data[index] as LElementNode;
     if (isProceduralRenderer(renderer)) {
+      ngDevMode && ngDevMode.rendererSetStyle++;
       renderer.setProperty(lElement.native, 'style', value);
     } else {
       const style = lElement.native['style'];
       for (let i = 0, keys = Object.keys(value); i < keys.length; i++) {
         const styleName: string = keys[i];
         const styleValue: any = (value as any)[styleName];
-        styleValue == null ? style.removeProperty(styleName) :
-                             style.setProperty(styleName, styleValue);
+        if (styleValue == null) {
+          ngDevMode && ngDevMode.rendererRemoveStyle++;
+          style.removeProperty(styleName);
+        } else {
+          ngDevMode && ngDevMode.rendererSetStyle++;
+          style.setProperty(styleName, styleValue);
+        }
       }
     }
   }
@@ -1184,6 +1204,7 @@ export function text(index: number, value?: any): void {
   ngDevMode &&
       assertEqual(
           currentView.bindingStartIndex, -1, 'text nodes should be created before bindings');
+  ngDevMode && ngDevMode.rendererCreateTextNode++;
   const textNode = createTextNode(value, renderer);
   const node = createLNode(index, LNodeType.Element, textNode);
   // Text nodes are self closing.
@@ -1203,9 +1224,18 @@ export function textBinding<T>(index: number, value: T | NO_CHANGE): void {
   let existingNode = data[index] as LTextNode;
   ngDevMode && assertNotNull(existingNode, 'LNode should exist');
   ngDevMode && assertNotNull(existingNode.native, 'native element should exist');
-  value !== NO_CHANGE &&
-      (isProceduralRenderer(renderer) ? renderer.setValue(existingNode.native, stringify(value)) :
-                                        existingNode.native.textContent = stringify(value));
+  if (existingNode.native) {
+    // If DOM node exists and value changed, update textContent
+    ngDevMode && ngDevMode.rendererSetText++;
+    value !== NO_CHANGE &&
+        (isProceduralRenderer(renderer) ? renderer.setValue(existingNode.native, stringify(value)) :
+                                          existingNode.native.textContent = stringify(value));
+  } else {
+    // Node was created but DOM node creation was delayed. Create and append now.
+    ngDevMode && ngDevMode.rendererCreateTextNode++;
+    existingNode.native = createTextNode(value, renderer);
+    insertChild(existingNode, currentView);
+  }
 }
 
 //////////////////////////
@@ -1407,7 +1437,7 @@ export function createLContainer(
  * @param localRefs A set of local reference bindings on the element.
  */
 export function container(
-    index: number, template?: ComponentTemplate<any>, tagName?: string, attrs?: string[],
+    index: number, template?: ComponentTemplate<any>, tagName?: string | null, attrs?: string[],
     localRefs?: string[] | null): void {
   ngDevMode && assertEqual(
                    currentView.bindingStartIndex, -1,

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -82,24 +82,6 @@ export interface LContainer {
   queries: LQueries|null;
 }
 
-/**
- * The static equivalent of LContainer, used in TContainerNode.
- *
- * The container needs to store static data for each of its embedded views
- * (TViews). Otherwise, nodes in embedded views with the same index as nodes
- * in their parent views will overwrite each other, as they are in
- * the same template.
- *
- * Each index in this array corresponds to the static data for a certain
- * view. So if you had V(0) and V(1) in a container, you might have:
- *
- * [
- *   [{tagName: 'div', attrs: ...}, null],     // V(0) TView
- *   [{tagName: 'button', attrs ...}, null]    // V(1) TView
- * ]
- */
-export type TContainer = TView[];
-
 // Note: This hack is necessary so we don't erroneously get a circular dependency
 // failure based on types.
 export const unusedValueExportToPlacateAjd = 1;

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -283,11 +283,11 @@ export interface TNode {
   outputs: PropertyAliases|null|undefined;
 
   /**
-   * The static data equivalent of LNode.data.
+   * The TView or TViews attached to this node.
    *
    * If this TNode corresponds to an LContainerNode with inline views, the container will
    * need to store separate static data for each of its view blocks (TView[]). Otherwise,
-   * nodes in embedded views with the same index as nodes in their parent views will overwrite
+   * nodes in inline views with the same index as nodes in their parent views will overwrite
    * each other, as they are in the same template.
    *
    * Each index in this array corresponds to the static data for a certain
@@ -300,7 +300,7 @@ export interface TNode {
    * If this TNode corresponds to an LContainerNode with a template (e.g. structural
    * directive), the template's TView will be stored here.
    *
-   * If this TNode corresponds to an LElementNode, data will be null .
+   * If this TNode corresponds to an LElementNode, tViews will be null .
    */
   tViews: TView|TView[]|null;
 }
@@ -309,7 +309,7 @@ export interface TNode {
 export interface TElementNode extends TNode { tViews: null; }
 
 /** Static data for an LContainerNode */
-export interface TContainerNode extends TNode { tViews: TView|TView[]; }
+export interface TContainerNode extends TNode { tViews: TView|TView[]|null; }
 
 /**
  * This mapping is necessary so we can set input properties and output listeners

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {LContainer, TContainer} from './container';
+import {LContainer} from './container';
 import {LInjector} from './injector';
 import {LProjection} from './projection';
 import {LQueries} from './query';
@@ -285,19 +285,31 @@ export interface TNode {
   /**
    * The static data equivalent of LNode.data.
    *
-   * If this TNode corresponds to an LContainerNode, the container will
-   * need to store separate static data for each of its views (TContainer).
+   * If this TNode corresponds to an LContainerNode with inline views, the container will
+   * need to store separate static data for each of its view blocks (TView[]). Otherwise,
+   * nodes in embedded views with the same index as nodes in their parent views will overwrite
+   * each other, as they are in the same template.
    *
-   * If this TNode corresponds to an LElementNode, data will be null.
+   * Each index in this array corresponds to the static data for a certain
+   * view. So if you had V(0) and V(1) in a container, you might have:
+   *
+   * [
+   *   [{tagName: 'div', attrs: ...}, null],     // V(0) TView
+   *   [{tagName: 'button', attrs ...}, null]    // V(1) TView
+   *
+   * If this TNode corresponds to an LContainerNode with a template (e.g. structural
+   * directive), the template's TView will be stored here.
+   *
+   * If this TNode corresponds to an LElementNode, data will be null .
    */
-  data: TContainer|null;
+  tViews: TView|TView[]|null;
 }
 
 /** Static data for an LElementNode  */
-export interface TElementNode extends TNode { data: null; }
+export interface TElementNode extends TNode { tViews: null; }
 
 /** Static data for an LContainerNode */
-export interface TContainerNode extends TNode { data: TContainer; }
+export interface TContainerNode extends TNode { tViews: TView|TView[]; }
 
 /**
  * This mapping is necessary so we can set input properties and output listeners

--- a/packages/core/src/render3/ng_dev_mode.ts
+++ b/packages/core/src/render3/ng_dev_mode.ts
@@ -8,15 +8,51 @@
 
 
 declare global {
-  const ngDevMode: boolean;
+  const ngDevMode: null|NgDevModePerfCounters;
+  interface NgDevModePerfCounters {
+    firstTemplatePass: number;
+    tNode: number;
+    tView: number;
+    rendererCreateTextNode: number;
+    rendererSetText: number;
+    rendererCreateElement: number;
+    rendererAddEventListener: number;
+    rendererSetAttribute: number;
+    rendererRemoveAttribute: number;
+    rendererSetProperty: number;
+    rendererSetClassName: number;
+    rendererAddClass: number;
+    rendererRemoveClass: number;
+    rendererSetStyle: number;
+    rendererRemoveStyle: number;
+  }
 }
+
+
 
 declare let global: any;
-
-if (typeof ngDevMode == 'undefined') {
-  if (typeof window != 'undefined') (window as any).ngDevMode = true;
-  if (typeof self != 'undefined') (self as any).ngDevMode = true;
-  if (typeof global != 'undefined') (global as any).ngDevMode = true;
-}
-
-export const _ngDevMode = true;
+export const ngDevModeResetPerfCounters: () => void =
+    (typeof ngDevMode == 'undefined' && (function(global: {ngDevMode: NgDevModePerfCounters}) {
+       function ngDevModeResetPerfCounters() {
+         global.ngDevMode = {
+           firstTemplatePass: 0,
+           tNode: 0,
+           tView: 0,
+           rendererCreateTextNode: 0,
+           rendererSetText: 0,
+           rendererCreateElement: 0,
+           rendererAddEventListener: 0,
+           rendererSetAttribute: 0,
+           rendererRemoveAttribute: 0,
+           rendererSetProperty: 0,
+           rendererSetClassName: 0,
+           rendererAddClass: 0,
+           rendererRemoveClass: 0,
+           rendererSetStyle: 0,
+           rendererRemoveStyle: 0,
+         };
+       }
+       ngDevModeResetPerfCounters();
+       return ngDevModeResetPerfCounters;
+     })(typeof window != 'undefined' && window || typeof self != 'undefined' && self ||
+        typeof global != 'undefined' && global)) as() => void;

--- a/packages/core/src/render3/ng_dev_mode.ts
+++ b/packages/core/src/render3/ng_dev_mode.ts
@@ -34,7 +34,7 @@ declare let global: any;
 export const ngDevModeResetPerfCounters: () => void =
     (typeof ngDevMode == 'undefined' && (function(global: {ngDevMode: NgDevModePerfCounters}) {
        function ngDevModeResetPerfCounters() {
-         global.ngDevMode = {
+         global['ngDevMode'] = {
            firstTemplatePass: 0,
            tNode: 0,
            tView: 0,

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -102,18 +102,18 @@ describe('instructions', () => {
       elementStart(0, 'div', ['style', 'height: 10px']);
       elementEnd();
     }
-    const fixture = new TemplateFixture(createDivWithStyle);
 
     it('should add style', () => {
+      const fixture = new TemplateFixture(createDivWithStyle);
       fixture.update(() => elementStyle(0, {'background-color': 'red'}));
       expect(fixture.html).toEqual('<div style="height: 10px; background-color: red;"></div>');
     });
   });
 
   describe('elementClass', () => {
-    const fixture = new TemplateFixture(createDiv);
 
     it('should add class', () => {
+      const fixture = new TemplateFixture(createDiv);
       fixture.update(() => elementClass(0, 'multiple classes'));
       expect(fixture.html).toEqual('<div class="multiple classes"></div>');
     });
@@ -132,34 +132,34 @@ describe('instructions', () => {
 
         static ngComponentDef = defineComponent({
           type: NestedLoops,
-          selectors: [['todo-app']],
+          selectors: [['nested-loops']],
           factory: function ToDoAppComponent_Factory() { return new NestedLoops(); },
           template: function ToDoAppComponent_Template(rf: RenderFlags, ctx: NestedLoops) {
-            if (rf & 1) {
+            if (rf & RenderFlags.Create) {
               container(0, ToDoAppComponent_NgForOf_Template_0, null, _c0);
             }
-            if (rf & 2) {
+            if (rf & RenderFlags.Update) {
               elementProperty(0, 'ngForOf', bind(ctx.rows));
             }
             function ToDoAppComponent_NgForOf_Template_0(
                 rf: RenderFlags, ctx0: NgForOfContext<any>) {
-              if (rf & 1) {
+              if (rf & RenderFlags.Create) {
                 elementStart(0, 'ul');
                 container(1, ToDoAppComponent_NgForOf_NgForOf_Template_1, null, _c0);
                 elementEnd();
               }
-              if (rf & 2) {
+              if (rf & RenderFlags.Update) {
                 const row_r2 = ctx0.$implicit;
                 elementProperty(1, 'ngForOf', bind(row_r2));
               }
               function ToDoAppComponent_NgForOf_NgForOf_Template_1(
                   rf: RenderFlags, ctx1: NgForOfContext<any>) {
-                if (rf & 1) {
+                if (rf & RenderFlags.Create) {
                   elementStart(0, 'li');
                   text(1);
                   elementEnd();
                 }
-                if (rf & 2) {
+                if (rf & RenderFlags.Update) {
                   const col_r3 = ctx1.$implicit;
                   textBinding(1, interpolation1('', col_r3, ''));
                 }
@@ -171,8 +171,8 @@ describe('instructions', () => {
       }
       const fixture = new ComponentFixture(NestedLoops);
       expect(ngDevMode).toHaveProperties({
-        // Expect: host view + component + *ngForRow + *ngForCol
-        tView: 7,  // should be: 4,
+        // Expect: fixture view/Host view + component + ngForRow + ngForCol
+        tView: 4,  // should be: 4,
       });
 
     });

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -28,6 +28,12 @@ describe('render3 integration test', () => {
           elementEnd();
         }
       }
+      expect(ngDevMode).toHaveProperties({
+        firstTemplatePass: 1,
+        tNode: 1,
+        tView: 1,
+        rendererCreateElement: 1,
+      });
     });
 
     it('should render and update basic "Hello, World" template', () => {

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -830,7 +830,7 @@ describe('render3 integration test', () => {
 
       const oldTemplateData = (Template as any).ngPrivateData;
       const oldContainerData = (oldTemplateData as any).data[0];
-      const oldElementData = oldContainerData.data[0][0];
+      const oldElementData = oldContainerData.tViews[0][0];
       expect(oldContainerData).not.toBeNull();
       expect(oldElementData).not.toBeNull();
 
@@ -839,7 +839,7 @@ describe('render3 integration test', () => {
 
       const newTemplateData = (Template as any).ngPrivateData;
       const newContainerData = (oldTemplateData as any).data[0];
-      const newElementData = oldContainerData.data[0][0];
+      const newElementData = oldContainerData.tViews[0][0];
       expect(newTemplateData === oldTemplateData).toBe(true);
       expect(newContainerData === oldContainerData).toBe(true);
       expect(newElementData === oldElementData).toBe(true);

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -19,7 +19,7 @@ function testLStaticData(tagName: string, attrs: string[] | null): TNode {
     initialInputs: undefined,
     inputs: undefined,
     outputs: undefined,
-    data: null,
+    tViews: null,
   };
 }
 

--- a/packages/core/test/render3/perfCounter_spec.ts
+++ b/packages/core/test/render3/perfCounter_spec.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ngDevModeResetPerfCounters} from '../../src/render3/ng_dev_mode';
+
+beforeEach(ngDevModeResetPerfCounters);
+beforeEach(() => {
+  jasmine.addMatchers({
+    toHaveProperties: function(util, customEqualityTesters) {
+      return {compare: toHavePropertiesCompare};
+    }
+  });
+});
+function toHavePropertiesCompare(actual: {[k: string]: number}, expected: {[k: string]: number}) {
+  let pass = true;
+  let errors = [];
+  for (let key of Object.keys(actual)) {
+    if (expected.hasOwnProperty(key)) {
+      if (actual[key] !== expected[key]) {
+        pass = false;
+        errors.push(`Expected '${key}' to be '${expected[key]}' but was '${actual[key]}'.`);
+      }
+    }
+  }
+  return {pass: pass, message: errors.join('\n')};
+}
+
+describe('toHaveProperties', () => {
+  it('should pass', () => {
+    expect({tNode: 1}).toHaveProperties({});
+    expect({tNode: 2}).toHaveProperties({tNode: 2});
+  });
+
+  it('should fail', () => {
+    expect(toHavePropertiesCompare({tNode: 2, tView: 4}, {tNode: 3, tView: 5})).toEqual({
+      pass: false,
+      message:
+          'Expected \'tNode\' to be \'3\' but was \'2\'.\nExpected \'tView\' to be \'5\' but was \'4\'.'
+    });
+  });
+});

--- a/packages/core/test/render3/perfCounter_spec.ts
+++ b/packages/core/test/render3/perfCounter_spec.ts
@@ -16,7 +16,7 @@ beforeEach(() => {
     }
   });
 });
-function toHavePropertiesCompare(actual: {[k: string]: number}, expected: {[k: string]: number}) {
+function toHavePropertiesCompare(actual: any, expected: any) {
   let pass = true;
   let errors = [];
   for (let key of Object.keys(actual)) {

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -147,30 +147,24 @@ describe('ViewContainerRef', () => {
           const tplRef = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(0)));
           elementProperty(0, 'tplRef', bind(tplRef));
           containerRefreshStart(0);
-          let rf1 = embeddedViewStart(1);
-          if (rf1 & RenderFlags.Create) {
-            elementStart(0, 'header');
-            elementEnd();
-          }
-          embeddedViewEnd();
           containerRefreshEnd();
         }
 
         const fixture = new TemplateFixture(createTemplate, updateTemplate, [DirectiveWithVCRef]);
-        expect(fixture.html).toEqual('<header></header><footer></footer>');
+        expect(fixture.html).toEqual('<footer></footer>');
 
         createView('A');
         fixture.update();
-        expect(fixture.html).toEqual('<header></header>A<footer></footer>');
+        expect(fixture.html).toEqual('A<footer></footer>');
 
         createView('B');
         createView('C');
         fixture.update();
-        expect(fixture.html).toEqual('<header></header>ABC<footer></footer>');
+        expect(fixture.html).toEqual('ABC<footer></footer>');
 
         createView('Y', 0);
         fixture.update();
-        expect(fixture.html).toEqual('<header></header>YABC<footer></footer>');
+        expect(fixture.html).toEqual('YABC<footer></footer>');
 
         expect(() => { createView('Z', -1); }).toThrow();
         expect(() => { createView('Z', 5); }).toThrow();

--- a/packages/types.d.ts
+++ b/packages/types.d.ts
@@ -19,3 +19,9 @@
 
 declare let isNode: boolean;
 declare let isBrowser: boolean;
+
+declare namespace jasmine {
+  interface Matchers {
+    toHaveProperties(perfCounts: Partial<NgDevModePerfCounters>): boolean;
+  }
+}

--- a/packages/types.d.ts
+++ b/packages/types.d.ts
@@ -22,6 +22,6 @@ declare let isBrowser: boolean;
 
 declare namespace jasmine {
   interface Matchers {
-    toHaveProperties(perfCounts: Partial<NgDevModePerfCounters>): boolean;
+    toHaveProperties(obj: any): boolean;
   }
 }


### PR DESCRIPTION
This PR has two main changes:

1 - Performance counters in dev mode to improve perf testing
2 - Reduce TViews created by moving away from storing embedded TViews on template functions (instead storing them on the TNode)