### PR TITLE
refactor(ivy): speed up bound text nodes

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1157,7 +1157,6 @@ export function elementStyle<T>(
  *
  * @param index Index of the node in the data array.
  * @param value Value to write. This value will be stringified.
- *   If value is not provided than the actual creation of the text node is delayed.
  */
 export function text(index: number, value?: any): void {
   ngDevMode &&
@@ -1180,13 +1179,11 @@ export function text(index: number, value?: any): void {
 export function textBinding<T>(index: number, value: T | NO_CHANGE): void {
   ngDevMode && assertDataInRange(index);
   let existingNode = data[index] as LTextNode;
-  ngDevMode && assertNotNull(existingNode, 'existing node');
-  if (existingNode.native) {
-    // If DOM node exists and value changed, update textContent
-    value !== NO_CHANGE &&
-        (isProceduralRenderer(renderer) ? renderer.setValue(existingNode.native, stringify(value)) :
-                                          existingNode.native.textContent = stringify(value));
-  }
+  ngDevMode && assertNotNull(existingNode, 'LNode should exist');
+  ngDevMode && assertNotNull(existingNode.native, 'native element should exist');
+  value !== NO_CHANGE &&
+      (isProceduralRenderer(renderer) ? renderer.setValue(existingNode.native, stringify(value)) :
+                                        existingNode.native.textContent = stringify(value));
 }
 
 //////////////////////////

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1163,7 +1163,7 @@ export function text(index: number, value?: any): void {
   ngDevMode &&
       assertEqual(
           currentView.bindingStartIndex, -1, 'text nodes should be created before bindings');
-  const textNode = value != null ? createTextNode(value, renderer) : null;
+  const textNode = createTextNode(value, renderer);
   const node = createLNode(index, LNodeType.Element, textNode);
   // Text nodes are self closing.
   isParent = false;
@@ -1186,10 +1186,6 @@ export function textBinding<T>(index: number, value: T | NO_CHANGE): void {
     value !== NO_CHANGE &&
         (isProceduralRenderer(renderer) ? renderer.setValue(existingNode.native, stringify(value)) :
                                           existingNode.native.textContent = stringify(value));
-  } else {
-    // Node was created but DOM node creation was delayed. Create and append now.
-    existingNode.native = createTextNode(value, renderer);
-    insertChild(existingNode, currentView);
   }
 }
 

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -180,12 +180,6 @@ export function addRemoveViewFromContainer(
       const renderer = container.view.renderer;
       if (node.type === LNodeType.Element) {
         if (insertMode) {
-          if (!node.native) {
-            // If the native element doesn't exist, this is a bound text node that hasn't yet been
-            // created because update mode has not run (occurs when a bound text node is a root
-            // node of a dynamically created view). See textBinding() in instructions for ctx.
-            (node as LTextNode).native = createTextNode('', renderer);
-          }
           isProceduralRenderer(renderer) ?
               renderer.insertBefore(parent, node.native !, beforeNode as RNode | null) :
               parent.insertBefore(node.native !, beforeNode as RNode | null, true);

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -459,9 +459,6 @@
     "name": "injectViewContainerRef"
   },
   {
-    "name": "insertChild"
-  },
-  {
     "name": "insertView"
   },
   {


### PR DESCRIPTION
We were previously delaying creation of bound text nodes until their values were known, so we could create them with the correct value (rather than creating, then setting value later). However, by the time values are known, other nodes have been created, so it's necessary to find the correct node to insert before. We found that this search process is actually slower than creating and setting separately. 

Creating text nodes eagerly and appending them in order shaves about 30% off render time for a large table of bound text nodes.