### PR TITLE
docs(aio): Fixed typo in 'comparing observables -> Observable compared to arrays' section.

### DIFF
--- a/aio/content/guide/comparing-observables.md
+++ b/aio/content/guide/comparing-observables.md
@@ -249,7 +249,7 @@ An observable produces values over time. An array is created as a static set of 
       <pre>➞5</pre>
     </td>
     <td>
-      <pre>arr.find((v) => v>10)</pre>
+      <pre>arr.find((v) => v>3)</pre>
       <pre>5</pre>
     </td>
   </tr>
@@ -273,8 +273,8 @@ An observable produces values over time. An array is created as a static set of 
 1
 2
 3
-4
-5</pre>
+5
+7</pre>
     </td>
     <td>
       <pre>arr.forEach((v) => {
@@ -283,8 +283,8 @@ An observable produces values over time. An array is created as a static set of 
 1
 2
 3
-4
-5</pre>
+5
+7</pre>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
In the section "Observables compared to arrays" of "Observables compared to other techniques"
(https://angular.io/guide/comparing-observables), there are some errors in the table.
(1) the content of the cell of row "find()" and column "Array":
arr.find((v) => v>10)
5
(2) the content of the cell of the row "forEach()" and column "Observable":
obs.forEach((v) => {
console.log(v);
})
1
2
3
4
5
(3) the content of the cell of the row "forEach()" and column "Array":
arr.forEach((v) => {
console.log(v);
})
1
2
3
4
5

Issue Number: 23405


## What is the new behavior?
(1) the content of the cell of row "find()" and column "Array":
arr.find((v) => v>3)
5
(2) the content of the cell of the row "forEach()" and column "Observable":
obs.forEach((v) => {
console.log(v);
})
1
2
3
5
7
(3) the content of the cell of the row "forEach()" and column "Array":
arr.forEach((v) => {
console.log(v);
})
1
2
3
5
7


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
