### PR TITLE
fix(benchpress): Fix promise chain in chrome_driver_extension

### DIFF
--- a/packages/benchpress/src/webdriver/chrome_driver_extension.ts
+++ b/packages/benchpress/src/webdriver/chrome_driver_extension.ts
@@ -51,12 +51,12 @@ export class ChromeDriverExtension extends WebDriverExtension {
 
   gc() { return this._driver.executeScript('window.gc()'); }
 
-  timeBegin(name: string): Promise<any> {
+  async timeBegin(name: string): Promise<any> {
     if (this._firstRun) {
       this._firstRun = false;
       // Before the first run, read out the existing performance logs
       // so that the chrome buffer does not fill up.
-      this._driver.logs('performance');
+      await this._driver.logs('performance');
     }
     return this._driver.executeScript(`console.time('${name}');`);
   }


### PR DESCRIPTION
Occasionally the promise to clear the chrome buffer resolves after the subsequent call to start the
timer. This problem causes flakiness in our tests that rely on benchpress, usually manifesting
itself as a "Tried too often to get the ending mark: 21" error thrown by this line:

https://github.com/angular/angular/blob/master/packages/benchpress/src/metric/perflog_metric.ts#L162

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
