### PR TITLE
fix(router): fix lazy loading of aux routes

### DIFF
--- a/packages/router/src/components/empty_outlet.ts
+++ b/packages/router/src/components/empty_outlet.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+
+/**
+ * This component is used internally within the router to be a placeholder when an empty
+ * router-outlet is needed. For example, with a config such as:
+ *
+ * `{path: 'parent', outlet: 'nav', children: [...]}`
+ *
+ * In order to render, there needs to be a component on this config, which will default
+ * to this `EmptyOutletComponent`.
+ */
+@Component({template: `<router-outlet></router-outlet>`})
+export class EmptyOutletComponent {
+}

--- a/packages/router/src/private_export.ts
+++ b/packages/router/src/private_export.ts
@@ -7,5 +7,6 @@
  */
 
 
+export {EmptyOutletComponent as ɵEmptyOutletComponent} from './components/empty_outlet';
 export {ROUTER_PROVIDERS as ɵROUTER_PROVIDERS} from './router_module';
 export {flatten as ɵflatten} from './utils/collection';

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -12,7 +12,7 @@ import {BehaviorSubject, Observable, Subject, Subscription, of } from 'rxjs';
 import {concatMap, map, mergeMap} from 'rxjs/operators';
 
 import {applyRedirects} from './apply_redirects';
-import {LoadedRouterConfig, QueryParamsHandling, Route, Routes, copyConfig, validateConfig} from './config';
+import {LoadedRouterConfig, QueryParamsHandling, Route, Routes, standardizeConfig, validateConfig} from './config';
 import {createRouterState} from './create_router_state';
 import {createUrlTree} from './create_url_tree';
 import {ActivationEnd, ChildActivationEnd, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, NavigationTrigger, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RoutesRecognized} from './events';
@@ -357,7 +357,7 @@ export class Router {
    */
   resetConfig(config: Routes): void {
     validateConfig(config);
-    this.config = config.map(copyConfig);
+    this.config = config.map(standardizeConfig);
     this.navigated = false;
     this.lastSuccessfulId = -1;
   }

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -10,7 +10,7 @@ import {Compiler, InjectionToken, Injector, NgModuleFactory, NgModuleFactoryLoad
 // TODO(i): switch to fromPromise once it's expored in rxjs
 import {Observable, from, of } from 'rxjs';
 import {map, mergeMap} from 'rxjs/operators';
-import {LoadChildren, LoadedRouterConfig, Route, copyConfig} from './config';
+import {LoadChildren, LoadedRouterConfig, Route, standardizeConfig} from './config';
 import {flatten, wrapIntoObservable} from './utils/collection';
 
 /**
@@ -39,7 +39,8 @@ export class RouterConfigLoader {
 
       const module = factory.create(parentInjector);
 
-      return new LoadedRouterConfig(flatten(module.injector.get(ROUTES)).map(copyConfig), module);
+      return new LoadedRouterConfig(
+          flatten(module.injector.get(ROUTES)).map(standardizeConfig), module);
     }));
   }
 

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -11,6 +11,7 @@ import {ANALYZE_FOR_ENTRY_COMPONENTS, APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, A
 import {ɵgetDOM as getDOM} from '@angular/platform-browser';
 import {Subject, of } from 'rxjs';
 
+import {EmptyOutletComponent} from './components/empty_outlet';
 import {Route, Routes} from './config';
 import {RouterLink, RouterLinkWithHref} from './directives/router_link';
 import {RouterLinkActive} from './directives/router_link_active';
@@ -35,7 +36,8 @@ import {flatten} from './utils/collection';
  *
  *
  */
-const ROUTER_DIRECTIVES = [RouterOutlet, RouterLink, RouterLinkWithHref, RouterLinkActive];
+const ROUTER_DIRECTIVES =
+    [RouterOutlet, RouterLink, RouterLinkWithHref, RouterLinkActive, EmptyOutletComponent];
 
 /**
  * @description
@@ -127,7 +129,11 @@ export function routerNgProbeToken() {
  *
  *
  */
-@NgModule({declarations: ROUTER_DIRECTIVES, exports: ROUTER_DIRECTIVES})
+@NgModule({
+  declarations: ROUTER_DIRECTIVES,
+  exports: ROUTER_DIRECTIVES,
+  entryComponents: [EmptyOutletComponent]
+})
 export class RouterModule {
   // Note: We are injecting the Router so it gets created eagerly...
   constructor(@Optional() @Inject(ROUTER_FORROOT_GUARD) guard: any, @Optional() router: Router) {}

--- a/packages/router/test/config.spec.ts
+++ b/packages/router/test/config.spec.ts
@@ -123,20 +123,26 @@ describe('config', () => {
          }).toThrowError(/Invalid configuration of route '{path: "", redirectTo: "b"}'/);
        });
 
-    it('should throw when pathPatch is invalid', () => {
+    it('should throw when pathMatch is invalid', () => {
       expect(() => { validateConfig([{path: 'a', pathMatch: 'invalid', component: ComponentB}]); })
           .toThrowError(
               /Invalid configuration of route 'a': pathMatch can only be set to 'prefix' or 'full'/);
     });
 
-    it('should throw when pathPatch is invalid', () => {
-      expect(() => { validateConfig([{path: 'a', outlet: 'aux', children: []}]); })
+    it('should throw when path/outlet combination is invalid', () => {
+      expect(() => { validateConfig([{path: 'a', outlet: 'aux'}]); })
           .toThrowError(
-              /Invalid configuration of route 'a': a componentless route cannot have a named outlet set/);
-
+              /Invalid configuration of route 'a': a componentless route without children or loadChildren cannot have a named outlet set/);
       expect(() => validateConfig([{path: 'a', outlet: '', children: []}])).not.toThrow();
       expect(() => validateConfig([{path: 'a', outlet: PRIMARY_OUTLET, children: []}]))
           .not.toThrow();
+    });
+
+    it('should not throw when path/outlet combination is valid', () => {
+      expect(() => { validateConfig([{path: 'a', outlet: 'aux', children: []}]); }).not.toThrow();
+      expect(() => {
+        validateConfig([{path: 'a', outlet: 'aux', loadChildren: 'child'}]);
+      }).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
Fixes #10981

This PR adds an `EmptyOutletComponent` that becomes the default in the case of a route config with a `path`, `outlet`, and `children` defined, but no `Component`. In the past, this would throw an error. The workaround was to define an empty component.

This PR makes that workaround the default for this scenario.