### PR TITLE
fix(compiler): avoid a crash in ngc-wrapped.

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -267,6 +267,10 @@ export function compile({allowNonHermeticReads, allDepsCompiledWithBazel = true,
       fs.writeFileSync(bazelOpts.manifest, manifest);
     }
   }
+  
+  // If compilation fails unexpectedly, performCompilation returns no program.
+  // Make sure not to crash but report the diagnostics.
+  if (!program) return {program, diagnostics};
 
   if (!bazelOpts.nodeModulesPrefix) {
     // If there is no node modules, then metadata.json should be emitted since


### PR DESCRIPTION
`ng.performCompilation` can return an `undefined` program, which is not handled by ngc-wrapped.

Avoid crashing by checking for the error return and returning the diagnostics.