### PR TITLE
ci(aio): fix `deploy-to-firebase` script

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -13,10 +13,11 @@
     "aio-check-local": "node tools/ng-packages-installer check .",
     "ng": "yarn check-env && ng",
     "start": "yarn check-env && ng serve",
-    "prebuild": "yarn setup",
-    "build": "yarn ~~build",
+    "build": "yarn build-for stable",
+    "prebuild-for": "yarn setup",
+    "build-for": "yarn ~~build --configuration",
     "prebuild-local": "yarn setup-local",
-    "build-local": "yarn ~~build",
+    "build-local": "yarn ~~build --configuration=stable",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",
@@ -60,7 +61,7 @@
     "build-ie-polyfills": "yarn webpack-cli src/ie-polyfills.js -o src/generated/ie-polyfills.min.js --mode production",
     "update-webdriver": "webdriver-manager update --standalone false --gecko false $CHROMEDRIVER_VERSION_ARG",
     "~~check-env": "node scripts/check-environment",
-    "~~build": "ng build --configuration=stable",
+    "~~build": "ng build",
     "post~~build": "yarn sw-manifest && yarn sw-copy"
   },
   "engines": {

--- a/aio/scripts/deploy-to-firebase.sh
+++ b/aio/scripts/deploy-to-firebase.sh
@@ -87,7 +87,7 @@ fi
   cd "`dirname $0`/.."
 
   # Build the app
-  yarn build --configuration=$deployEnv
+  yarn build-for $deployEnv
 
   # Include any mode-specific files
   cp -rf src/extra-files/$deployEnv/. dist/


### PR DESCRIPTION
Temporary workaround for angular/angular-cli#10398.
The behavior of `yarn build` remains the same, but building for a specific deployment env (e.g. archive, next) requires `yarn build-for $deployEnv`.
