### PR TITLE
fix (printing docs): Added printer friendly code-example background color rule

### DIFF
--- a/aio/src/styles/1-layouts/_print-layout.scss
+++ b/aio/src/styles/1-layouts/_print-layout.scss
@@ -66,6 +66,8 @@
     }
 
     code-example {
+        background-color: gainsboro !important;
+
         pre.lang-bash code span {
             color: $mediumgray !important;
         }

--- a/aio/src/styles/1-layouts/_print-layout.scss
+++ b/aio/src/styles/1-layouts/_print-layout.scss
@@ -66,6 +66,7 @@
     }
 
     code-example {
+
         background-color: gainsboro !important;
 
         pre.lang-bash code span {


### PR DESCRIPTION
The original SCSS file for printing the documentation is missing a background-color rule for printing, so color/background-color happen to be the same.

I added a light grey background color rule that saves toner and still is immediately recognizable as distinct code example token to the reader.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, CSS color/background-color on the printed version of code examples in the documentation happen to be the same, so the code examples are plain invisible to the reader.
Issue Number: #23431


## What is the new behavior?

I added a light grey background color rule to the SCSS file for printing that saves toner and still is immediately recognizable as distinct code example token to the reader.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```