### PR TITLE
fix (printing docs): Added printer friendly code-example background color rule

### DIFF
--- a/aio/content/guide/dynamic-component-loader.md
+++ b/aio/content/guide/dynamic-component-loader.md
@@ -31,8 +31,8 @@ Angular comes with its own API for loading components dynamically.
 Before you can add components you have to define an anchor point
 to tell Angular where to insert components.
 
-In our example you use a custom helper directive called `AdDirective`
-to mark valid insertion points in the template.
+The ad banner uses a helper directive called `AdDirective` to
+mark valid insertion points in the template.
 
 
 <code-example path="dynamic-component-loader/src/app/ad.directive.ts" title="src/app/ad.directive.ts" linenums="false">
@@ -103,42 +103,35 @@ Take it step by step. First, it picks an ad.
 
 <div class="l-sub-section">
 
-  **How _loadComponent()_ chooses an ad**
 
-  The `loadComponent()` method chooses an ad using some math.
 
-  First, it sets the `currentAdIndex` by taking whatever it
-  currently is plus one, dividing that by the length of the `AdItem` array, and
-  using the _remainder_ as the new `currentAdIndex` value. Then, it uses that
-  value to select an `adItem` from the array.
+**How _loadComponent()_ chooses an ad**
+
+The `loadComponent()` method chooses an ad using some math.
+
+First, it sets the `currentAdIndex` by taking whatever it
+currently is plus one, dividing that by the length of the `AdItem` array, and
+using the _remainder_ as the new `currentAdIndex` value. Then, it uses that
+value to select an `adItem` from the array.
+
 
 </div>
+
 
 
 After `loadComponent()` selects an ad, it uses `ComponentFactoryResolver`
-to obtain a `ComponentFactory` for the specific component referred to by
-`adItem`. The `ComponentFactory` then creates an instance of that component.
+to resolve a `ComponentFactory` for each specific component.
+The `ComponentFactory` then creates an instance of each component.
 
-As you may recall, `AdDirective` has `ViewContainerRef` injected
-into its constructor. This is how the directive accesses the component that
-you want to use to host the dynamic components.
+Next, you're targeting the `viewContainerRef` that
+exists on this specific instance of the component. How do you know it's
+this specific instance? Because it's referring to `adHost` and `adHost` is the
+directive you set up earlier to tell Angular where to insert dynamic components.
 
+As you may recall, `AdDirective` injects `ViewContainerRef` into its constructor.
+This is how the directive accesses the element that you want to use to host the dynamic component.
 
-<div class="l-sub-section">
-
-  `AdDirective` features `ViewContainerRef` as a public member, so parent
-  components can have immediate access to the directive's `ViewContainerRef`.
-
-</div>
-
-
-Next, you're targeting the host component using the directive's `viewContainerRef`.
-Remember, `viewContainerRef` is featured by `adHost`, which is the `AdDirective`
-directive you set up earlier.
-
-To add the selected ad component to the template, you first remove all
-existing child components by calling `clear()` and then call
-`createComponent()` on `ViewContainerRef` to add the new component.
+To add the component to the template, you call `createComponent()` on `ViewContainerRef`.
 
 The `createComponent()` method returns a reference to the loaded component.
 Use that reference to interact with the component by assigning to its properties or calling its methods.

--- a/aio/content/guide/dynamic-component-loader.md
+++ b/aio/content/guide/dynamic-component-loader.md
@@ -31,8 +31,8 @@ Angular comes with its own API for loading components dynamically.
 Before you can add components you have to define an anchor point
 to tell Angular where to insert components.
 
-The ad banner uses a helper directive called `AdDirective` to
-mark valid insertion points in the template.
+In our example you use a custom helper directive called `AdDirective`
+to mark valid insertion points in the template.
 
 
 <code-example path="dynamic-component-loader/src/app/ad.directive.ts" title="src/app/ad.directive.ts" linenums="false">
@@ -103,35 +103,42 @@ Take it step by step. First, it picks an ad.
 
 <div class="l-sub-section">
 
+  **How _loadComponent()_ chooses an ad**
 
+  The `loadComponent()` method chooses an ad using some math.
 
-**How _loadComponent()_ chooses an ad**
-
-The `loadComponent()` method chooses an ad using some math.
-
-First, it sets the `currentAdIndex` by taking whatever it
-currently is plus one, dividing that by the length of the `AdItem` array, and
-using the _remainder_ as the new `currentAdIndex` value. Then, it uses that
-value to select an `adItem` from the array.
-
+  First, it sets the `currentAdIndex` by taking whatever it
+  currently is plus one, dividing that by the length of the `AdItem` array, and
+  using the _remainder_ as the new `currentAdIndex` value. Then, it uses that
+  value to select an `adItem` from the array.
 
 </div>
 
 
-
 After `loadComponent()` selects an ad, it uses `ComponentFactoryResolver`
-to resolve a `ComponentFactory` for each specific component.
-The `ComponentFactory` then creates an instance of each component.
+to obtain a `ComponentFactory` for the specific component referred to by
+`adItem`. The `ComponentFactory` then creates an instance of that component.
 
-Next, you're targeting the `viewContainerRef` that
-exists on this specific instance of the component. How do you know it's
-this specific instance? Because it's referring to `adHost` and `adHost` is the
-directive you set up earlier to tell Angular where to insert dynamic components.
+As you may recall, `AdDirective` has `ViewContainerRef` injected
+into its constructor. This is how the directive accesses the component that
+you want to use to host the dynamic components.
 
-As you may recall, `AdDirective` injects `ViewContainerRef` into its constructor.
-This is how the directive accesses the element that you want to use to host the dynamic component.
 
-To add the component to the template, you call `createComponent()` on `ViewContainerRef`.
+<div class="l-sub-section">
+
+  `AdDirective` features `ViewContainerRef` as a public member, so parent
+  components can have immediate access to the directive's `ViewContainerRef`.
+
+</div>
+
+
+Next, you're targeting the host component using the directive's `viewContainerRef`.
+Remember, `viewContainerRef` is featured by `adHost`, which is the `AdDirective`
+directive you set up earlier.
+
+To add the selected ad component to the template, you first remove all
+existing child components by calling `clear()` and then call
+`createComponent()` on `ViewContainerRef` to add the new component.
 
 The `createComponent()` method returns a reference to the loaded component.
 Use that reference to interact with the component by assigning to its properties or calling its methods.

--- a/aio/src/styles/1-layouts/_print-layout.scss
+++ b/aio/src/styles/1-layouts/_print-layout.scss
@@ -66,6 +66,11 @@
     }
 
     code-example {
+
+        .code-shell {
+            background-color: gainsboro !important;
+        }
+
         pre.lang-bash code span {
             color: $mediumgray !important;
         }

--- a/aio/src/styles/1-layouts/_print-layout.scss
+++ b/aio/src/styles/1-layouts/_print-layout.scss
@@ -67,7 +67,9 @@
 
     code-example {
 
-        background-color: gainsboro !important;
+        .code-shell {
+            background-color: gainsboro !important;
+        }
 
         pre.lang-bash code span {
             color: $mediumgray !important;

--- a/aio/src/styles/1-layouts/_print-layout.scss
+++ b/aio/src/styles/1-layouts/_print-layout.scss
@@ -66,6 +66,8 @@
     }
 
     code-example {
+        background-color: gainsboro !important;
+
         pre.lang-bash code span {
             color: $mediumgray !important;
         }

--- a/aio/src/styles/1-layouts/_print-layout.scss
+++ b/aio/src/styles/1-layouts/_print-layout.scss
@@ -66,6 +66,7 @@
     }
 
     code-example {
+
         background-color: gainsboro !important;
 
         pre.lang-bash code span {


### PR DESCRIPTION
The original SCSS file for printing the documentation is missing a background-color rule for printing, so color/background-color happen to be the same.

I added a light grey background color rule that saves toner and still is immediately recognizable as distinct code example token to the reader.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, CSS color/background-color on the printed version of code examples in the documentation happen to be the same, so the code examples are plain invisible to the reader.
Issue Number: #23431


## What is the new behavior?

I added a light grey background color rule to the SCSS file for printing that saves toner and still is immediately recognizable as distinct code example token to the reader:

![updated code-example scss](https://user-images.githubusercontent.com/9283914/39094387-ca5c8068-462e-11e8-9a85-c67e5d5138b8.png)

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```