### PR TITLE
build(common): mark locales files as side-effect-full

### DIFF
--- a/packages/common/locales/package.json
+++ b/packages/common/locales/package.json
@@ -1,4 +1,4 @@
 {
   "description": "This directory contains UMD files which by its nature are not side-effect free. The parent package.json marks the whole @angular/common package as side-effect free, so if this directory is not excluded from that, build-optimizer will mark the contents as side-effect free and uglify will incorrectly remove all needed localization code.",
-  "sideEffects": false
+  "sideEffects": true
 }


### PR DESCRIPTION
Fixes https://github.com/angular/angular-cli/issues/10322

The PR https://github.com/angular/angular/pull/23366 marked the locale files as side-effect free, instead of full.
