### PR TITLE
ci: fix snapshot publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,8 +192,12 @@ workflows:
           # We'd really like to filter out pull requests here, but not yet available:
           # https://discuss.circleci.com/t/workflows-pull-request-filter/14396/4
           # Instead, the publish-build-artifacts.sh script just terminates when
-          # CIRCLE_PULL_REQUEST is set.
+          # CIRCLE_PR_NUMBER is set.
           requires:
+            # Only publish if tests pass
+            - test
+            # Get the artifacts to publish from the build-packages-dist job
+            # since the publishing script expects the legacy outputs layout.
             - build-packages-dist
 
   aio_monitoring:

--- a/scripts/ci/publish-build-artifacts.sh
+++ b/scripts/ci/publish-build-artifacts.sh
@@ -126,7 +126,7 @@ if [ $# -gt 0 ]; then
 elif [[ \
     "$CIRCLE_PROJECT_USERNAME" == "angular" && \
     "$CIRCLE_PROJECT_REPONAME" == "angular" && \
-    ! -v CIRCLE_PULL_REQUEST ]]; then
+    ! -v CIRCLE_PR_NUMBER ]]; then
   ORG="angular"
   # $KEY is set on CI only for non-PR builds. See /.circleci/README.md
   openssl aes-256-cbc -d -in .circleci/github_token -k "${KEY}" -out "${HOME}/.git_credentials"


### PR DESCRIPTION
Seems like a bug: by ssh'ing into a job, I see that `CIRCLE_PULL_REQUEST` is set to a bogus value on non-pull-request builds.