### PR TITLE
Correct spelling of "ambient" in AOT Compiler docs.

### DIFF
--- a/aio/content/guide/aot-compiler.md
+++ b/aio/content/guide/aot-compiler.md
@@ -987,7 +987,7 @@ import { configuration } from './configuration';
 The compiler encountered a type and can't determine which module exports that type.
 
 This can happen if you refer to an ambient type.
-For example, the `Window` type is an ambiant type declared in the global `.d.ts` file.
+For example, the `Window` type is an ambient type declared in the global `.d.ts` file.
 
 You'll get an error if you reference it in the component constructor,
 which the compiler must statically analyze.
@@ -999,17 +999,17 @@ export class MyComponent {
   constructor (private win: Window) { ... }
 }
 ```
-TypeScript understands ambiant types so you don't import them.
+TypeScript understands ambient types so you don't import them.
 The Angular compiler does not understand a type that you neglect to export or import.
 
 In this case, the compiler doesn't understand how to inject something with the `Window` token.
 
 Do not refer to ambient types in metadata expressions.
 
-If you must inject an instance of an ambiant type,
+If you must inject an instance of an ambient type,
 you can finesse the problem in four steps:
 
-1. Create an injection token for an instance of the ambiant type.
+1. Create an injection token for an instance of the ambient type.
 1. Create a factory function that returns that instance.
 1. Add a `useFactory` provider with that factory function.
 1. Use `@Inject` to inject the instance.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features) (N/A)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

"ambient" is misspelled as "ambiant".

Issue Number: N/A


## What is the new behavior?

"ambient" is spelled correctly.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
