### PR TITLE
perf(compiler-cli):  use previously cached program for 2nd time compi…

### DIFF
--- a/packages/compiler-cli/src/perform_watch.ts
+++ b/packages/compiler-cli/src/perform_watch.ts
@@ -200,7 +200,7 @@ export function performWatchCompilation(host: PerformWatchHost):
       rootNames: cachedOptions.rootNames,
       options: cachedOptions.options,
       host: cachedCompilerHost,
-      oldProgram: oldProgram,
+      oldProgram,
       emitCallback: host.createEmitCallback(cachedOptions.options)
     });
 

--- a/packages/compiler-cli/src/perform_watch.ts
+++ b/packages/compiler-cli/src/perform_watch.ts
@@ -210,7 +210,6 @@ export function performWatchCompilation(host: PerformWatchHost):
 
     const endTime = Date.now();
     if (cachedOptions.options.diagnostics) {
-      const totalTime = (endTime - startTime) / 1000;
       host.reportDiagnostics([totalCompilationTimeDiagnostic(endTime - startTime)]);
     }
     const exitCode = exitCodeFromResult(compileResult.diagnostics);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[X] Other... Please describe:
```

## What is the current behavior?
At the moment `cachedProgram` / `oldProgram` program is never used in watch mode. The `oldProgram` should be used in the 2nd compilation to provide a faster build. 

`cachedProgram` here will would `undefined` https://github.com/alan-agius4/angular/blob/abcd9169ed1ef0c8a93e39f7b858b98565425483/packages/compiler-cli/src/perform_watch.ts#L198 thus `oldProgram` should be used.


//cc: @alxhub 

Issue Number: N/A


## What is the new behavior?
Use `cachedProgram`  for second compilation

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
