### PR TITLE
fix(core): avoid eager providers re-initialization

### DIFF
--- a/packages/core/src/view/ng_module.ts
+++ b/packages/core/src/view/ng_module.ts
@@ -68,7 +68,10 @@ export function initNgModule(data: NgModuleData) {
   for (let i = 0; i < def.providers.length; i++) {
     const provDef = def.providers[i];
     if (!(provDef.flags & NodeFlags.LazyProvider)) {
-      providers[i] = _createProviderInstance(data, provDef);
+      // Make sure the provider has not been already initialized outside this loop.
+      if (providers[i] === undefined) {
+        providers[i] = _createProviderInstance(data, provDef);
+      }
     }
   }
 }


### PR DESCRIPTION
Fix a corner case where eager providers were getting constructed twice if the provider was requested before the initialization of the NgModule is complete.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```
## Does this PR introduce a breaking change?
```
[] Yes
[x] No
```
