### PR TITLE
docs(aio): updates doc error in guide/http

### DIFF
--- a/aio/content/examples/http/src/testing/http-client.spec.ts
+++ b/aio/content/examples/http/src/testing/http-client.spec.ts
@@ -150,7 +150,7 @@ describe('HttpClient testing', () => {
 
     // Create mock ErrorEvent, raised when something goes wrong at the network level.
     // Connection timeout, DNS error, offline, etc
-    const errorEvent = new ErrorEvent('so sad', {
+    const mockError = new ErrorEvent('Network error', {
       message: emsg,
       // #enddocregion network-error
       // The rest of this is optional and not used.
@@ -162,7 +162,7 @@ describe('HttpClient testing', () => {
     });
 
     // Respond with mock error
-    req.error(errorEvent);
+    req.error(mockError);
   });
   // #enddocregion network-error
 

--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -1030,10 +1030,18 @@ you are responsible for flushing and verifying them.
 
 You should test the app's defenses against HTTP requests that fail.
 
-Call `request.error()` with an `ErrorEvent` instead of `request.flush()`, as in this example.
+Call `request.flush()` with an error message, as seen in the following example.
 
 <code-example 
   path="http/src/testing/http-client.spec.ts"
   region="404" 
+  linenums="false">
+</code-example>
+
+Alternatively, you can call `request.error()` with an `ErrorEvent`.
+
+<code-example
+  path="http/src/testing/http-client.spec.ts"
+  region="network-error"
   linenums="false">
 </code-example>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
https://angular.io/guide/http#testing-for-errors

Currently the documentation says to call `req.error` when forcing a network failure, but instead gives an example using `req.flush`.

Issue Number: #23453


## What is the new behavior?
The documentation now shows two correct examples. One using `req.error`, simulating a network failure, and one using `req.flush`, simulating a 404.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
