### PR TITLE
build(aio): add support for faster, unoptimized `serve`

### DIFF
--- a/aio/angular.json
+++ b/aio/angular.json
@@ -75,10 +75,12 @@
                 "input": "src/styles.scss"
               }
             ],
-            "scripts": [],
-
+            "scripts": []
           },
           "configurations": {
+            "fast": {
+              "optimization": false
+            },
             "next": {
               "fileReplacements": [
                 {
@@ -111,6 +113,9 @@
             "browserTarget": "site:build"
           },
           "configurations": {
+            "fast": {
+              "browserTarget": "site:build:fast"
+            },
             "next": {
               "browserTarget": "site:build:next"
             },

--- a/aio/package.json
+++ b/aio/package.json
@@ -12,7 +12,7 @@
     "aio-use-npm": "node tools/ng-packages-installer restore .",
     "aio-check-local": "node tools/ng-packages-installer check .",
     "ng": "yarn check-env && ng",
-    "start": "yarn check-env && ng serve",
+    "start": "yarn check-env && ng serve --configuration=fast",
     "build": "yarn build-for stable",
     "prebuild-for": "yarn setup",
     "build-for": "yarn ~~build --configuration",


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?
```
[x] Build related changes
```


## What is the current behavior?
When running `yarn start` and `yarn serve-and-sync`, we are usually more interested in faster re-build times than optimized builds. This was also the behavior, before upgrading to @angular/cli@6 (fc5af69fb).


## What is the new behavior?
This commit introduces a new configuration (`fast`), which is used by `yarn start` and `yarn serve-and-sync` to restore the faster, unoptimized builds.
Other commands, such as `ng serve` and `ng e2e`, remain unchanged (using slower, optimized builds).


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
