### PR TITLE
fix(service-worker): deprecate `versionedFiles` in asset-group resources

### DIFF
--- a/aio/content/examples/service-worker-getting-started/src/ngsw-config.json
+++ b/aio/content/examples/service-worker-getting-started/src/ngsw-config.json
@@ -7,12 +7,9 @@
     "resources": {
       "files": [
         "/favicon.ico",
-        "/index.html"
-      ],
-      "versionedFiles": [
-        "/*.bundle.css",
-        "/*.bundle.js",
-        "/*.chunk.js"
+        "/index.html",
+        "/*.css",
+        "/*.js"
       ]
     }
   }, {

--- a/aio/content/guide/service-worker-config.md
+++ b/aio/content/guide/service-worker-config.md
@@ -70,7 +70,7 @@ interface AssetGroup {
   updateMode?: 'prefetch' | 'lazy';
   resources: {
     files?: string[];
-    versionedFiles?: string[];
+    versionedFiles?: string[];  // deprecated
     urls?: string[];
   };
 }
@@ -102,7 +102,7 @@ This section describes the resources to cache, broken up into three groups.
 
 * `files` lists patterns that match files in the distribution directory. These can be single files or glob-like patterns that match a number of files.
 
-* `versionedFiles` is like `files` but should be used for build artifacts that already include a hash in the filename, which is used for cache busting. The Angular service worker can optimize some aspects of its operation if it can assume file contents are immutable.
+* `versionedFiles` has been deprecated. It is exactly the same as `files`, so use that instead.
 
 * `urls` includes both URLs and URL patterns that will be matched at runtime. These resources are not fetched directly and do not have content hashes, but they will be cached according to their HTTP headers. This is most useful for CDNs such as the Google Fonts service.<br>
   _(Negative glob patterns are not supported.)_

--- a/aio/content/guide/service-worker-config.md
+++ b/aio/content/guide/service-worker-config.md
@@ -70,7 +70,8 @@ interface AssetGroup {
   updateMode?: 'prefetch' | 'lazy';
   resources: {
     files?: string[];
-    versionedFiles?: string[];  // deprecated
+    /** @deprecated As of v6 `versionedFiles` and `files` options have the same behavior. Use `files` instead. */
+    versionedFiles?: string[];
     urls?: string[];
   };
 }
@@ -102,7 +103,7 @@ This section describes the resources to cache, broken up into three groups.
 
 * `files` lists patterns that match files in the distribution directory. These can be single files or glob-like patterns that match a number of files.
 
-* `versionedFiles` has been deprecated. It is exactly the same as `files`, so use that instead.
+* `versionedFiles` has been deprecated. As of v6 `versionedFiles` and `files` options have the same behavior. Use `files` instead.
 
 * `urls` includes both URLs and URL patterns that will be matched at runtime. These resources are not fetched directly and do not have content hashes, but they will be cached according to their HTTP headers. This is most useful for CDNs such as the Google Fonts service.<br>
   _(Negative glob patterns are not supported.)_

--- a/packages/service-worker/config/src/generator.ts
+++ b/packages/service-worker/config/src/generator.ts
@@ -44,6 +44,12 @@ export class Generator {
       Promise<Object[]> {
     const seenMap = new Set<string>();
     return Promise.all((config.assetGroups || []).map(async(group) => {
+      if (group.resources.versionedFiles) {
+        console.warn(
+            `Asset-group '${group.name}' in 'ngsw-config.json' uses the deprecated ` +
+            '\'versionedFiles\' property. Please, use \'files\' instead.');
+      }
+
       const fileMatcher = globListToMatcher(group.resources.files || []);
       const versionedMatcher = globListToMatcher(group.resources.versionedFiles || []);
 

--- a/packages/service-worker/config/src/generator.ts
+++ b/packages/service-worker/config/src/generator.ts
@@ -46,8 +46,9 @@ export class Generator {
     return Promise.all((config.assetGroups || []).map(async(group) => {
       if (group.resources.versionedFiles) {
         console.warn(
-            `Asset-group '${group.name}' in 'ngsw-config.json' uses the deprecated ` +
-            '\'versionedFiles\' property. Please, use \'files\' instead.');
+            `Asset-group '${group.name}' in 'ngsw-config.json' uses the 'versionedFiles' option.\n` +
+            'As of v6 \'versionedFiles\' and \'files\' options have the same behavior. ' +
+            'Use \'files\' instead.');
       }
 
       const fileMatcher = globListToMatcher(group.resources.files || []);

--- a/packages/service-worker/config/src/in.ts
+++ b/packages/service-worker/config/src/in.ts
@@ -38,7 +38,12 @@ export interface AssetGroup {
   name: string;
   installMode?: 'prefetch'|'lazy';
   updateMode?: 'prefetch'|'lazy';
-  resources: {files?: Glob[]; versionedFiles?: Glob[]; urls?: Glob[];};
+  resources: {
+    files?: Glob[];
+    /** @deprecated */
+    versionedFiles?: Glob[];
+    urls?: Glob[];
+  };
 }
 
 /**

--- a/packages/service-worker/config/src/in.ts
+++ b/packages/service-worker/config/src/in.ts
@@ -40,7 +40,8 @@ export interface AssetGroup {
   updateMode?: 'prefetch'|'lazy';
   resources: {
     files?: Glob[];
-    /** @deprecated */
+    /** @deprecated As of v6 `versionedFiles` and `files` options have the same behavior. Use
+       `files` instead. */
     versionedFiles?: Glob[];
     urls?: Glob[];
   };

--- a/tools/public_api_guard/service-worker/config.d.ts
+++ b/tools/public_api_guard/service-worker/config.d.ts
@@ -4,7 +4,7 @@ export interface AssetGroup {
     name: string;
     resources: {
         files?: Glob[];
-        versionedFiles?: Glob[];
+        /** @deprecated */ versionedFiles?: Glob[];
         urls?: Glob[];
     };
     updateMode?: 'prefetch' | 'lazy';


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] Bugfix
```


## What is the current behavior?
An asset-group's resources can have a `files` and a `versionedFiles` property. Both properties behave in the exact same way.


## What is the new behavior?
Since `versionedFiles` behaves in the exact same way as `files`, there is no reaason to have both. Users should use `files` instead.

This commit deprecates the property and prints a warning when coming across an asset-group that uses it. It should be completely removed in a future version.

Note, it has also been removed from the default `ngsw-config.json` template in angular/devkit#754.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
