### PR TITLE
 refactor(service-worker): sort manifest `url`/`hashTable` entries

### DIFF
--- a/packages/service-worker/config/test/generator_spec.ts
+++ b/packages/service-worker/config/test/generator_spec.ts
@@ -74,8 +74,8 @@ import {MockFilesystem} from '../testing/mock';
                installMode: 'prefetch',
                updateMode: 'prefetch',
                urls: [
-                 '/test/index.html',
                  '/test/foo/test.html',
+                 '/test/index.html',
                  '/test/test.txt',
                ],
                patterns: [
@@ -102,9 +102,9 @@ import {MockFilesystem} from '../testing/mock';
                {positive: false, regex: '^http:\\/\\/example\\.com\\/excluded$'},
              ],
              hashTable: {
-               '/test/test.txt': '18f6f8eb7b1c23d2bb61bff028b83d867a9e4643',
+               '/test/foo/test.html': '18f6f8eb7b1c23d2bb61bff028b83d867a9e4643',
                '/test/index.html': 'a54d88e06612d820bc3be72877c74f257b561b19',
-               '/test/foo/test.html': '18f6f8eb7b1c23d2bb61bff028b83d867a9e4643'
+               '/test/test.txt': '18f6f8eb7b1c23d2bb61bff028b83d867a9e4643'
              }
            });
            done();


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] Refactoring (no functional changes, no api changes)
```


## What is the current behavior?
Entries (e.g. `hashTable` entries, asset-group `urls`) in the SW manifest are in the order in which they where matched by the various globs.


## What is the new behavior?
The `urls`/`hashTable` entries are sorted in alphabetic order. This makes it easier to quickly check whether a specific file ended up in the manifest, for example when debugging.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
