### PR TITLE
docs: fix typo in tag name (`my-child` --> `app-child`)

### DIFF
--- a/aio/content/guide/lifecycle-hooks.md
+++ b/aio/content/guide/lifecycle-hooks.md
@@ -561,7 +561,7 @@ the `AfterContentComponent`'s parent. Here's the parent's template:
 
 <code-example path="lifecycle-hooks/src/app/after-content.component.ts" region="parent-template" title="AfterContentParentComponent (template excerpt)" linenums="false"></code-example>
 
-Notice that the `<my-child>` tag is tucked between the `<after-content>` tags.
+Notice that the `<app-child>` tag is tucked between the `<after-content>` tags.
 Never put content between a component's element tags *unless you intend to project that content
 into the component*.
 
@@ -571,7 +571,7 @@ Now look at the component's template:
 
 The `<ng-content>` tag is a *placeholder* for the external content.
 It tells Angular where to insert that content.
-In this case, the projected content is the `<my-child>` from the parent.
+In this case, the projected content is the `<app-child>` from the parent.
 
 <figure>
   <img src='generated/images/guide/lifecycle-hooks/projected-child-view.png' alt="Projected Content">


### PR DESCRIPTION
Fixes #23599.
