### PR TITLE
fix(compiler-cli): Reading empty metadata.json should not be fatal

### DIFF
--- a/packages/compiler-cli/src/transformers/metadata_reader.ts
+++ b/packages/compiler-cli/src/transformers/metadata_reader.ts
@@ -83,7 +83,7 @@ function readMetadataFile(host: MetadataReaderHost, dtsFilePath: string): Module
     return metadatas;
   } catch (e) {
     console.error(`Failed to read JSON file ${metadataPath}`);
-    throw e;
+    return undefined;
   }
 }
 


### PR DESCRIPTION
The compiler will crash if it tries to read an empty metadata.json. This
should not be fatal, as the compiler can generate a subset of necessary
information from the corresponding .d.ts file instead. This commit
modifies the function that reads the metadata.json file to return
undefined if the file is empty, as if the file does not exist.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
compiler crashes when trying to read empty metadata.json file.

Issue Number: N/A


## What is the new behavior?
compiler acts as if the metadata.json file does not exist.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
