### PR TITLE
styles(topMenu):space between .home and .hamburger

### DIFF
--- a/aio/src/styles/1-layouts/_top-menu.scss
+++ b/aio/src/styles/1-layouts/_top-menu.scss
@@ -1,6 +1,6 @@
 // VARIABLES
-$hamburgerShownMargin: 0;
-$hamburgerHiddenMargin: 0 24px 0 -88px;
+$hamburgerShownMargin: 0 8px 0 0;
+$hamburgerHiddenMargin: 0 16px 0 -88px;
 
 
 // DOCS PAGE / STANDARD: TOPNAV TOOLBAR FIXED

--- a/aio/src/styles/1-layouts/_top-menu.scss
+++ b/aio/src/styles/1-layouts/_top-menu.scss
@@ -96,7 +96,6 @@ aio-shell.folder-tutorial mat-toolbar.mat-toolbar {
 .nav-link.home img {
   position: relative;
   margin-top: -21px;
-  margin-right: 20px;
   top: 12px;
   height: 40px;
 
@@ -144,6 +143,10 @@ aio-top-menu {
     padding: 24px 16px;
     cursor: pointer;
 
+    &.home{
+      margin-right: 20px;
+    }
+    
     &:focus {
       background: rgba($white, 0.15);
       border-radius: 4px;


### PR DESCRIPTION
when hamburger menu is clicked, it's ripple background is drawn until the very edge of home's image, leaving no space. this adds a tiny space there

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
On the top header, when hamburger menu button is present, when clicked on it, a ripple background is drawn and is extended just to very edge of the main `Angular` image in home link.

Issue Number: N/A


## What is the new behavior?
I added a tiny space, and in my opinion it just looks nicer


## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
this is just self-opinionated. I just saw it on website and felt like there needs to be a small space there