### PR TITLE
fix(service-worker): correctly handle requests with empty `clientId`

### DIFF
--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -543,10 +543,10 @@ export class Driver implements Debuggable, UpdateSource {
    * Decide which version of the manifest to use for the event.
    */
   private async assignVersion(event: FetchEvent): Promise<AppVersion|null> {
-    // First, check whether the event has a client ID. If it does, the version may
+    // First, check whether the event has a (non empty) client ID. If it does, the version may
     // already be associated.
     const clientId = event.clientId;
-    if (clientId !== null) {
+    if (clientId) {
       // Check if there is an assigned client id.
       if (this.clientVersionMap.has(clientId)) {
         // There is an assignment for this client already.

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -483,7 +483,6 @@ const manifestUpdateHash = sha1(JSON.stringify(manifestUpdate));
     async_it('shows notifications for push notifications', async() => {
       expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
       await driver.initialized;
-      scope.clients.add('default');
       await scope.handlePush({
         notification: {
           title: 'This is a test',
@@ -665,7 +664,7 @@ const manifestUpdateHash = sha1(JSON.stringify(manifestUpdate));
         server.assertSawRequestFor('/baz');
       });
 
-      async_it('does not redirect to index on a request that does not expect HTML', async() => {
+      async_it('does not redirect to index on a request that does not accept HTML', async() => {
         expect(await navRequest('/baz', {headers: {}})).toBeNull();
         server.assertSawRequestFor('/baz');
 
@@ -793,7 +792,6 @@ async function makeRequest(
   const [resPromise, done] = scope.handleFetch(new MockRequest(url, init), clientId);
   await done;
   const res = await resPromise;
-  scope.clients.add(clientId);
   if (res !== undefined && res.ok) {
     return res.text();
   }

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -320,6 +320,27 @@ const manifestUpdateHash = sha1(JSON.stringify(manifestUpdate));
       expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo v2');
     });
 
+    async_it('handles empty client ID', async() => {
+      const navRequest = (url: string, clientId: string | null) =>
+          makeRequest(scope, url, clientId, {
+            headers: {Accept: 'text/plain, text/html, text/css'},
+            mode: 'navigate',
+          });
+
+      // Initialize the SW.
+      expect(await navRequest('/foo/file1', '')).toEqual('this is foo');
+      expect(await navRequest('/bar/file2', null)).toEqual('this is foo');
+      await driver.initialized;
+
+      // Update to a new version.
+      scope.updateServerState(serverUpdate);
+      expect(await driver.checkForUpdate()).toEqual(true);
+
+      // Correctly handle navigation requests, even if `clientId` is null/empty.
+      expect(await navRequest('/foo/file1', '')).toEqual('this is foo v2');
+      expect(await navRequest('/bar/file2', null)).toEqual('this is foo v2');
+    });
+
     async_it('checks for updates on restart', async() => {
       expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
       await driver.initialized;

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -788,7 +788,8 @@ const manifestUpdateHash = sha1(JSON.stringify(manifestUpdate));
 })();
 
 async function makeRequest(
-    scope: SwTestHarness, url: string, clientId = 'default', init?: Object): Promise<string|null> {
+    scope: SwTestHarness, url: string, clientId: string | null = 'default',
+    init?: Object): Promise<string|null> {
   const [resPromise, done] = scope.handleFetch(new MockRequest(url, init), clientId);
   await done;
   const res = await resPromise;

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -63,7 +63,6 @@ export class MockClients implements Clients {
   remove(clientId: string): void { this.clients.delete(clientId); }
 
   async get(id: string): Promise<Client> {
-    this.add(id);
     return this.clients.get(id) !as any as Client;
   }
 
@@ -196,6 +195,10 @@ export class SwTestHarness implements ServiceWorkerGlobalScope, Adapter, Context
     }
     const event = new MockFetchEvent(req, clientId || null);
     this.eventHandlers.get('fetch') !.call(this, event);
+
+    if (clientId) {
+      this.clients.add(clientId);
+    }
 
     return [event.response, event.ready];
   }

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -62,9 +62,7 @@ export class MockClients implements Clients {
 
   remove(clientId: string): void { this.clients.delete(clientId); }
 
-  async get(id: string): Promise<Client> {
-    return this.clients.get(id) !as any as Client;
-  }
+  async get(id: string): Promise<Client> { return this.clients.get(id) !as any as Client; }
 
   getMock(id: string): MockClient|undefined { return this.clients.get(id); }
 

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -189,11 +189,12 @@ export class SwTestHarness implements ServiceWorkerGlobalScope, Adapter, Context
 
   waitUntil(promise: Promise<void>): void {}
 
-  handleFetch(req: Request, clientId?: string): [Promise<Response|undefined>, Promise<void>] {
+  handleFetch(req: Request, clientId: string|null = null):
+      [Promise<Response|undefined>, Promise<void>] {
     if (!this.eventHandlers.has('fetch')) {
       throw new Error('No fetch handler registered');
     }
-    const event = new MockFetchEvent(req, clientId || null);
+    const event = new MockFetchEvent(req, clientId);
     this.eventHandlers.get('fetch') !.call(this, event);
 
     if (clientId) {
@@ -212,7 +213,7 @@ export class SwTestHarness implements ServiceWorkerGlobalScope, Adapter, Context
       event = new MockMessageEvent(data, null);
     } else {
       this.clients.add(clientId);
-      event = new MockMessageEvent(data, this.clients.getMock(clientId) as any);
+      event = new MockMessageEvent(data, this.clients.getMock(clientId) || null);
     }
     this.eventHandlers.get('message') !.call(this, event);
     return event.ready;


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] Bugfix
```

## What is the current behavior?
Requests from clients that are not assigned a client ID by the browser will produce `fetch` events with `null` or empty (`''`) `clientId`s.

The ServiceWorker only handles `null` values correctly. Yet empty strings are also valid (see for example [here][1] and [there][2]).

Related Chromium issue/discussion: [#832105][3]

Issue Number: #23526

## What is the new behavior?
The SW will interpret _all_ falsy `clientId` valuesthe same (i.e. "no client ID assigned") and handle them appropriately.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
Fixes #23526.

[1]: https://github.com/w3c/ServiceWorker/blob/4cc72bd0f13359f16cc733d88bed4ea52ee063c0/docs/index.bs#L1392
[2]: https://w3c.github.io/ServiceWorker/#fetchevent-interface
[3]: https://bugs.chromium.org/p/chromium/issues/detail?id=832105