### PR TITLE
fix(compiler-cli): no exported member 'NgTools_InternalApi_NG_2'

### DIFF
--- a/packages/compiler-cli/index.ts
+++ b/packages/compiler-cli/index.ts
@@ -21,6 +21,5 @@ export * from './src/perform_compile';
 // TODO(tbosch): remove this once cli 1.5 is fully released,
 // and usages in G3 are changed to `CompilerOptions`.
 export {CompilerOptions as AngularCompilerOptions} from './src/transformers/api';
-export {NgTools_InternalApi_NG_2 as __NGTOOLS_PRIVATE_API_2} from './src/ngtools_api';
 
 export {ngToTsDiagnostic} from './src/transformers/util';


### PR DESCRIPTION
Module '"/node_modules/@angular/compiler-cli/src/ngtools_api"' has no exported member 'NgTools_InternalApi_NG_2'.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Build fails due to Module '"/node_modules/@angular/compiler-cli/src/ngtools_api"' has no exported member 'NgTools_InternalApi_NG_2'.

Issue Number: N/A


## What is the new behavior?
No error

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
