### PR TITLE
fix(animations): properly clean up queried element styles in safari/edge

### DIFF
--- a/packages/animations/browser/src/render/css_keyframes/css_keyframes_driver.ts
+++ b/packages/animations/browser/src/render/css_keyframes/css_keyframes_driver.ts
@@ -9,7 +9,7 @@ import {AnimationPlayer, ɵStyleData} from '@angular/animations';
 
 import {allowPreviousPlayerStylesMerge, balancePreviousStylesIntoKeyframes, computeStyle} from '../../util';
 import {AnimationDriver} from '../animation_driver';
-import {containsElement, invokeQuery, matchesElement, validateStyleProperty} from '../shared';
+import {containsElement, hypenatePropsObject, invokeQuery, matchesElement, validateStyleProperty} from '../shared';
 
 import {CssKeyframesPlayer} from './css_keyframes_player';
 import {DirectStylePlayer} from './direct_style_player';
@@ -135,15 +135,6 @@ function flattenKeyframesIntoStyles(
     });
   }
   return flatKeyframes;
-}
-
-function hypenatePropsObject(object: {[key: string]: any}): {[key: string]: any} {
-  const newObj: {[key: string]: any} = {};
-  Object.keys(object).forEach(prop => {
-    const newProp = prop.replace(/([a-z])([A-Z])/g, '$1-$2');
-    newObj[newProp] = object[prop];
-  });
-  return newObj;
 }
 
 function removeElement(node: any) {

--- a/packages/animations/browser/src/render/css_keyframes/direct_style_player.ts
+++ b/packages/animations/browser/src/render/css_keyframes/direct_style_player.ts
@@ -6,12 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {NoopAnimationPlayer} from '@angular/animations';
+import {hypenatePropsObject} from '../shared';
 
 export class DirectStylePlayer extends NoopAnimationPlayer {
   private _startingStyles: {[key: string]: any}|null = {};
   private __initialized = false;
+  private _styles: {[key: string]: any};
 
-  constructor(public element: any, private _styles: {[key: string]: any}) { super(); }
+  constructor(public element: any, styles: {[key: string]: any}) {
+    super();
+    this._styles = hypenatePropsObject(styles);
+  }
 
   init() {
     if (this.__initialized || !this._startingStyles) return;
@@ -25,7 +30,8 @@ export class DirectStylePlayer extends NoopAnimationPlayer {
   play() {
     if (!this._startingStyles) return;
     this.init();
-    Object.keys(this._styles).forEach(prop => { this.element.style[prop] = this._styles[prop]; });
+    Object.keys(this._styles)
+        .forEach(prop => this.element.style.setProperty(prop, this._styles[prop]));
     super.play();
   }
 
@@ -34,7 +40,7 @@ export class DirectStylePlayer extends NoopAnimationPlayer {
     Object.keys(this._startingStyles).forEach(prop => {
       const value = this._startingStyles ![prop];
       if (value) {
-        this.element.style[prop] = value;
+        this.element.style.setProperty(prop, value);
       } else {
         this.element.style.removeProperty(prop);
       }

--- a/packages/animations/browser/src/render/shared.ts
+++ b/packages/animations/browser/src/render/shared.ts
@@ -203,3 +203,12 @@ export function getBodyNode(): any|null {
 export const matchesElement = _matches;
 export const containsElement = _contains;
 export const invokeQuery = _query;
+
+export function hypenatePropsObject(object: {[key: string]: any}): {[key: string]: any} {
+  const newObj: {[key: string]: any} = {};
+  Object.keys(object).forEach(prop => {
+    const newProp = prop.replace(/([a-z])([A-Z])/g, '$1-$2');
+    newObj[newProp] = object[prop];
+  });
+  return newObj;
+}


### PR DESCRIPTION
Prior to this patch, if an element is queried and animated for 0 seconds
(just a style() call and nothing else) then the styles applied would not
be properly cleaned up due to their camelCased nature.