### PR TITLE
fix(router): get method of ParamsAsMap should always return a string

### DIFF
--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -80,7 +80,7 @@ class ParamsAsMap implements ParamMap {
   get(name: string): string|null {
     if (this.has(name)) {
       const v = this.params[name];
-      return Array.isArray(v) ? v[0] : v;
+      return Array.isArray(v) ? v[0].toString() : v.toString();
     }
 
     return null;


### PR DESCRIPTION
The get method of ParamsAsMap should return a string but array could contain number.

Fixes #23165

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #23165


## What is the new behavior?
Always returns a string now

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
