### PR TITLE
ci: add config for size plugin of the github rebot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,9 +89,10 @@ jobs:
 
       # CircleCI will allow us to go back and view/download these artifacts from past builds.
       # Also we can use a service like https://buildsize.org/ to automatically track binary size of these artifacts.
-      # These destination keys need to fit the format {projectName}/{context}/{fileName}
+      # The destination keys need be format {projectName}/{context}/{fileName} so that the github-robot can process them for size calculations
       # projectName should remain consistant to group files
       # context and fileName can be almost anything (within usual URI rules)
+      # There should only be exactly 2 forward slashes in the path
       # This is so they're backwards compatiable with the existing data we have on bundle sizes
       - store_artifacts:
           path: dist/bin/packages/core/test/bundling/hello_world/bundle.min.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,17 +91,16 @@ jobs:
       # Also we can use a service like https://buildsize.org/ to automatically track binary size of these artifacts.
       - store_artifacts:
           path: dist/bin/packages/core/test/bundling/hello_world/bundle.min.js
-          destination: packages/core/test/bundling/hello_world/bundle.min.js
+          destination: core/hello_world/bundle
       - store_artifacts:
           path: dist/bin/packages/core/test/bundling/todo/bundle.min.js
-          destination: packages/core/test/bundling/todo/bundle.min.js
+          destination: core/todo/bundle
       - store_artifacts:
           path: dist/bin/packages/core/test/bundling/hello_world/bundle.min.js.br
-          destination: packages/core/test/bundling/hello_world/bundle.min.js.br
+          destination: core/hello_world/br/bundle
       - store_artifacts:
           path: dist/bin/packages/core/test/bundling/todo/bundle.min.js.br
-          destination: packages/core/test/bundling/todo/bundle.min.js.br
-
+          destination: core/todo/br/bundle
       - save_cache:
           key: *cache_key
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,10 @@ jobs:
 
       # CircleCI will allow us to go back and view/download these artifacts from past builds.
       # Also we can use a service like https://buildsize.org/ to automatically track binary size of these artifacts.
+      # These destination keys need to fit the format {projectName}/{context}/{fileName}
+      # projectName should remain consistant to group files
+      # context and fileName can be almost anything (within usual URI rules)
+      # This is so they're backwards compatiable with the existing data we have on bundle sizes
       - store_artifacts:
           path: dist/bin/packages/core/test/bundling/hello_world/bundle.min.js
           destination: core/hello_world/bundle
@@ -97,10 +101,10 @@ jobs:
           destination: core/todo/bundle
       - store_artifacts:
           path: dist/bin/packages/core/test/bundling/hello_world/bundle.min.js.br
-          destination: core/hello_world/br/bundle
+          destination: core/hello_world/bundle.br
       - store_artifacts:
           path: dist/bin/packages/core/test/bundling/todo/bundle.min.js.br
-          destination: core/todo/br/bundle
+          destination: core/todo/bundle.br
       - save_cache:
           key: *cache_key
           paths:

--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -1,5 +1,13 @@
 # Configuration for angular-robot
 
+#options for the size plugin
+size:
+  disabled: false
+  maxSizeIncrease: 1000
+  status:
+    disabled: false
+    context: "ci/angular: size"
+
 # options for the merge plugin
 merge:
   # the status will be added to your pull requests


### PR DESCRIPTION
see: https://github.com/angular/github-robot/pull/2

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
```
[x] CI related changes
```

## What is the current behavior?
Config that allows the size bot to operate on this repo

## What is the new behavior?
The size bot will be able to track the sizes of artifacts from circleci and figure out if they've increassed during a PR.
If the increase is larger than the configured size of 1000 then the bot will put up a failure status on the PR.

## Does this PR introduce a breaking change?
```
[x] No
```
