### PR TITLE
docs(core): fix content errors

### DIFF
--- a/aio/tools/transforms/angular-api-package/processors/mergeDecoratorDocs.js
+++ b/aio/tools/transforms/angular-api-package/processors/mergeDecoratorDocs.js
@@ -92,6 +92,8 @@ module.exports = function mergeDecoratorDocs(log) {
           decoratorDoc.description = callMember.description;
           decoratorDoc.howToUse = callMember.howToUse;
           decoratorDoc.whatItDoes = callMember.whatItDoes;
+          decoratorDoc.usageNotes = callMember.usageNotes;
+          decoratorDoc.examples = callMember.examples;
 
           // remove doc from its module doc's exports
           doc.moduleDoc.exports =

--- a/aio/tools/transforms/angular-api-package/tag-defs/example.js
+++ b/aio/tools/transforms/angular-api-package/tag-defs/example.js
@@ -1,0 +1,7 @@
+module.exports = function() {
+  return {
+    name: 'example',
+    multi: true,
+    docProperty: 'examples',
+  };
+};

--- a/aio/tools/transforms/templates/api/includes/description.html
+++ b/aio/tools/transforms/templates/api/includes/description.html
@@ -4,3 +4,10 @@
   {$ doc.description | trimBlankLines | marked $}
 </section>
 {% endif %}
+
+{% for example in doc.examples -%}
+<section class="example">
+  <h3 class="no-anchor no-toc">Example</h3>
+  {$ example | trimBlankLines | marked $}
+</section>
+{% endfor -%}

--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -64,9 +64,18 @@
 
 {% if overload.description and (overload.description != method.description) -%}
 <div class="description">
+  <h4 class="no-anchor">Description</h4>
   {$ overload.description | marked $}
 </div>
 {%- endif %}
+
+{% if overload.examples != method.examples %}
+{%- for example in overload.examples %}
+  <h4 class="no-anchor">Example</h4>
+  {$ example | marked $}
+{%- endfor %}
+{%- endif %}
+
 {%- endmacro -%}
 
 {%- macro renderMethodDetail(method, cssClass) -%}
@@ -154,6 +163,10 @@
           {% if property.shortDescription %}{$ property.shortDescription | marked $}{% endif %}
           {$ (property.description or property.constructorParamDoc.description) | marked $}
           {% if property.constructorParamDoc %} <span class='from-constructor'>Declared in constructor.</span>{% endif %}
+          {% for example in property.examples %}
+            <h5 class="no-anchor">Example</h5>
+            {$ example | marked $}
+          {% endfor %}
         </td>
     </tr>
     {% endfor %}

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -196,8 +196,7 @@ export class PlatformRef {
    * Creates an instance of an `@NgModule` for the given platform
    * for offline compilation.
    *
-   * ## Simple Example
-   *
+   * ** The following example demonstrates calling `bootstrapModuleFactory`:**
    * ```typescript
    * my_module.ts:
    *
@@ -251,8 +250,6 @@ export class PlatformRef {
 
   /**
    * Creates an instance of an `@NgModule` for a given platform using the given runtime compiler.
-   *
-   * ## Simple Example
    *
    * ```typescript
    * @NgModule({
@@ -448,7 +445,7 @@ export class ApplicationRef {
   /**
    * Bootstrap a new component at the root level of the application.
    *
-   * ### Bootstrap process
+   * **Bootstrap process**
    *
    * When bootstrapping a new root component into an application, Angular mounts the
    * specified application component onto DOM elements identified by the [componentType]'s
@@ -457,7 +454,6 @@ export class ApplicationRef {
    * Optionally, a component can be mounted onto a DOM element that does not match the
    * [componentType]'s selector.
    *
-   * ### Example
    * {@example core/ts/platform/platform.ts region='longform'}
    */
   bootstrap<C>(componentOrFactory: ComponentFactory<C>|Type<C>, rootSelectorOrNode?: string|any):

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -197,6 +197,7 @@ export class PlatformRef {
    * for offline compilation.
    *
    * ** The following example demonstrates calling `bootstrapModuleFactory`:**
+   *
    * ```typescript
    * my_module.ts:
    *

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -196,7 +196,8 @@ export class PlatformRef {
    * Creates an instance of an `@NgModule` for the given platform
    * for offline compilation.
    *
-   * ** The following example demonstrates calling `bootstrapModuleFactory`:**
+   * @example
+   * The following example demonstrates calling `bootstrapModuleFactory`:
    *
    * ```typescript
    * my_module.ts:
@@ -252,6 +253,7 @@ export class PlatformRef {
   /**
    * Creates an instance of an `@NgModule` for a given platform using the given runtime compiler.
    *
+   * @example
    * ```typescript
    * @NgModule({
    *   imports: [BrowserModule]
@@ -455,7 +457,9 @@ export class ApplicationRef {
    * Optionally, a component can be mounted onto a DOM element that does not match the
    * [componentType]'s selector.
    *
-   * {@example core/ts/platform/platform.ts region='longform'}
+   * @example
+   *
+   * <code-example path="core/ts/platform/platform.ts" region="longform"></code-example>
    */
   bootstrap<C>(componentOrFactory: ComponentFactory<C>|Type<C>, rootSelectorOrNode?: string|any):
       ComponentRef<C> {

--- a/packages/core/src/change_detection/change_detector_ref.ts
+++ b/packages/core/src/change_detection/change_detector_ref.ts
@@ -19,6 +19,7 @@ export abstract class ChangeDetectorRef {
    *
    * <!-- TODO: Add a link to a chapter on OnPush components -->
    *
+   * @example
    * The following example demonstrates marking a component's template for change detection
    * ([live demo](https://stackblitz.com/edit/angular-kx7rrw)):
    *
@@ -54,6 +55,7 @@ export abstract class ChangeDetectorRef {
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->
    * <!-- TODO: Add a live demo once ref.detectChanges is merged into master -->
    *
+   * @example
    * The following example defines a component with a large list of readonly data.
    * Imagine the data changes constantly, many times per second. For performance reasons,
    * we want to check and update the list every five seconds. We can do that by detaching
@@ -104,7 +106,6 @@ export abstract class ChangeDetectorRef {
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->
    * <!-- TODO: Add a live demo once ref.detectChanges is merged into master -->
    *
-   * The following example defines a component with a large list of readonly data.
    * Imagine, the data changes constantly, many times per second. For performance reasons,
    * we want to check and update the list every five seconds.
    *
@@ -131,6 +132,7 @@ export abstract class ChangeDetectorRef {
    *
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->
    *
+   * @example
    * The following example creates a component displaying `live` data. The component will detach
    * its change detector from the main change detector tree when the component's live property
    * is set to false ([live demo](https://stackblitz.com/edit/angular-ymgsxw)).

--- a/packages/core/src/change_detection/change_detector_ref.ts
+++ b/packages/core/src/change_detection/change_detector_ref.ts
@@ -19,7 +19,8 @@ export abstract class ChangeDetectorRef {
    *
    * <!-- TODO: Add a link to a chapter on OnPush components -->
    *
-   * ### Example ([live demo](https://stackblitz.com/edit/angular-kx7rrw))
+   * The following example demonstrates marking a component's template for change detection
+   * ([live demo](https://stackblitz.com/edit/angular-kx7rrw)):
    *
    * ```typescript
    * @Component({
@@ -52,8 +53,6 @@ export abstract class ChangeDetectorRef {
    *
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->
    * <!-- TODO: Add a live demo once ref.detectChanges is merged into master -->
-   *
-   * ### Example
    *
    * The following example defines a component with a large list of readonly data.
    * Imagine the data changes constantly, many times per second. For performance reasons,
@@ -105,8 +104,6 @@ export abstract class ChangeDetectorRef {
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->
    * <!-- TODO: Add a live demo once ref.detectChanges is merged into master -->
    *
-   * ### Example
-   *
    * The following example defines a component with a large list of readonly data.
    * Imagine, the data changes constantly, many times per second. For performance reasons,
    * we want to check and update the list every five seconds.
@@ -134,11 +131,9 @@ export abstract class ChangeDetectorRef {
    *
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->
    *
-   * ### Example ([live demo](https://stackblitz.com/edit/angular-ymgsxw))
-   *
    * The following example creates a component displaying `live` data. The component will detach
    * its change detector from the main change detector tree when the component's live property
-   * is set to false.
+   * is set to false ([live demo](https://stackblitz.com/edit/angular-ymgsxw)).
    *
    * ```typescript
    * class DataProvider {

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -166,8 +166,6 @@ export class IterableDiffers {
    * which will only be applied to the injector for this component and its children.
    * This step is all that's required to make a new {@link IterableDiffer} available.
    *
-   * ### Example
-   *
    * ```
    * @Component({
    *   viewProviders: [

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -162,6 +162,7 @@ export class IterableDiffers {
    * inherited {@link IterableDiffers} instance with the provided factories and return a new
    * {@link IterableDiffers} instance.
    *
+   * @example
    * The following example shows how to extend an existing list of factories,
    * which will only be applied to the injector for this component and its children.
    * This step is all that's required to make a new {@link IterableDiffer} available.

--- a/packages/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/packages/core/src/change_detection/differs/keyvalue_differs.ts
@@ -135,6 +135,7 @@ export class KeyValueDiffers {
    * inherited {@link KeyValueDiffers} instance with the provided factories and return a new
    * {@link KeyValueDiffers} instance.
    *
+   * @example
    * The following example shows how to extend an existing list of factories,
    * which will only be applied to the injector for this component and its children.
    * This step is all that's required to make a new {@link KeyValueDiffer} available.

--- a/packages/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/packages/core/src/change_detection/differs/keyvalue_differs.ts
@@ -139,8 +139,6 @@ export class KeyValueDiffers {
    * which will only be applied to the injector for this component and its children.
    * This step is all that's required to make a new {@link KeyValueDiffer} available.
    *
-   * ### Example
-   *
    * ```
    * @Component({
    *   viewProviders: [

--- a/packages/core/src/change_detection/pipe_transform.ts
+++ b/packages/core/src/change_detection/pipe_transform.ts
@@ -12,13 +12,14 @@
  * Angular invokes the `transform` method with the value of a binding
  * as the first argument, and any parameters as the second argument in list form.
  *
- * ## Syntax
+ * The syntax of using a pipe in a template is:
  *
  * `value | pipeName[:arg0[:arg1...]]`
  *
- * ### Example ([live demo](http://plnkr.co/edit/f5oyIked9M2cKzvZNKHV?p=preview))
  *
- * The `RepeatPipe` below repeats the value as many times as indicated by the first argument:
+ *
+ * The `RepeatPipe` example below repeats the value as many times as indicated by the first
+ * argument ([live demo](http://plnkr.co/edit/f5oyIked9M2cKzvZNKHV?p=preview)):
  *
  * ```
  * import {Pipe, PipeTransform} from '@angular/core';

--- a/packages/core/src/change_detection/pipe_transform.ts
+++ b/packages/core/src/change_detection/pipe_transform.ts
@@ -16,9 +16,8 @@
  *
  * `value | pipeName[:arg0[:arg1...]]`
  *
- *
- *
- * The `RepeatPipe` example below repeats the value as many times as indicated by the first
+ * @example
+ * This `RepeatPipe` example repeats the value as many times as indicated by the first
  * argument ([live demo](http://plnkr.co/edit/f5oyIked9M2cKzvZNKHV?p=preview)):
  *
  * ```

--- a/packages/core/src/di/forward_ref.ts
+++ b/packages/core/src/di/forward_ref.ts
@@ -14,9 +14,10 @@ import {stringify} from '../util';
 /**
  * An interface that a function passed into {@link forwardRef} has to implement.
  *
- * ### Example
+ * **Usage:**
  *
  * {@example core/di/ts/forward_ref/forward_ref_spec.ts region='forward_ref_fn'}
+ *
  * @experimental
  */
 export interface ForwardRefFn { (): any; }
@@ -25,12 +26,11 @@ export interface ForwardRefFn { (): any; }
  * Allows to refer to references which are not yet defined.
  *
  * For instance, `forwardRef` is used when the `token` which we need to refer to for the purposes of
- * DI is declared,
- * but not yet defined. It is also used when the `token` which we use when creating a query is not
- * yet defined.
+ * DI is declared, but not yet defined.
+ * It is also used when the `token` which we use when creating a query is not yet defined.
  *
- * ### Example
  * {@example core/di/ts/forward_ref/forward_ref_spec.ts region='forward_ref'}
+ *
  * @experimental
  */
 export function forwardRef(forwardRefFn: ForwardRefFn): Type<any> {
@@ -44,11 +44,13 @@ export function forwardRef(forwardRefFn: ForwardRefFn): Type<any> {
  *
  * Acts as the identity function when given a non-forward-ref value.
  *
- * ### Example ([live demo](http://plnkr.co/edit/GU72mJrk1fiodChcmiDR?p=preview))
+ * The following example demonstrates this
+ * ([live demo](http://plnkr.co/edit/GU72mJrk1fiodChcmiDR?p=preview)).
  *
  * {@example core/di/ts/forward_ref/forward_ref_spec.ts region='resolve_forward_ref'}
  *
  * See: {@link forwardRef}
+ *
  * @experimental
  */
 export function resolveForwardRef(type: any): any {

--- a/packages/core/src/di/forward_ref.ts
+++ b/packages/core/src/di/forward_ref.ts
@@ -14,7 +14,7 @@ import {stringify} from '../util';
 /**
  * An interface that a function passed into {@link forwardRef} has to implement.
  *
- * **Usage:**
+ * The following example demonstrates how to use the `forwardRef` interface:
  *
  * {@example core/di/ts/forward_ref/forward_ref_spec.ts region='forward_ref_fn'}
  *

--- a/packages/core/src/di/forward_ref.ts
+++ b/packages/core/src/di/forward_ref.ts
@@ -14,9 +14,10 @@ import {stringify} from '../util';
 /**
  * An interface that a function passed into {@link forwardRef} has to implement.
  *
+ * @example
  * The following example demonstrates how to use the `forwardRef` interface:
  *
- * {@example core/di/ts/forward_ref/forward_ref_spec.ts region='forward_ref_fn'}
+ * <code-example path="core/di/ts/forward_ref/forward_ref_spec.ts" region="forward_ref_fn"></code-example>
  *
  * @experimental
  */
@@ -29,7 +30,8 @@ export interface ForwardRefFn { (): any; }
  * DI is declared, but not yet defined.
  * It is also used when the `token` which we use when creating a query is not yet defined.
  *
- * {@example core/di/ts/forward_ref/forward_ref_spec.ts region='forward_ref'}
+ * @example
+ * <code-example path="core/di/ts/forward_ref/forward_ref_spec.ts" region="forward_ref"></code-example>
  *
  * @experimental
  */
@@ -44,10 +46,11 @@ export function forwardRef(forwardRefFn: ForwardRefFn): Type<any> {
  *
  * Acts as the identity function when given a non-forward-ref value.
  *
+ * @example
  * The following example demonstrates this
  * ([live demo](http://plnkr.co/edit/GU72mJrk1fiodChcmiDR?p=preview)).
  *
- * {@example core/di/ts/forward_ref/forward_ref_spec.ts region='resolve_forward_ref'}
+ * <code-example path="core/di/ts/forward_ref/forward_ref_spec.ts" region="resolve_forward_ref"></code-example>
  *
  * See: {@link forwardRef}
  *

--- a/packages/core/src/di/injectable.ts
+++ b/packages/core/src/di/injectable.ts
@@ -41,18 +41,20 @@ export interface InjectableDecorator {
    * ```
    *
    * @description
-   * A marker metadata that marks a class as available to {@link Injector} for creation.
+   * A marker metadata that marks a class as available to `Injector` for creation.
    *
-   * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+   * For more details, see the [Dependency Injection Guide](/guide/dependency-injection).
    *
-   * **Usage:**
+   * @example
+   * This example shows how to use the `@Injectable` decorator.
    *
-   * {@example core/di/ts/metadata_spec.ts region='Injectable'}
+   * <code-example path="core/di/ts/metadata_spec.ts" region="Injectable"></code-example>
    *
-   * {@link Injector} will throw an error when trying to instantiate a class that
-   * does not have `@Injectable` marker, as shown in the example below.
+   * @example
+   * This example shows that `Injector` will throw an error when trying to instantiate a
+   * class that does not have `@Injectable` marker.
    *
-   * {@example core/di/ts/metadata_spec.ts region='InjectableThrows'}
+   * <code-example path="core/di/ts/metadata_spec.ts" region="InjectableThrows"></code-example>
    *
    */
   (): any;

--- a/packages/core/src/di/injectable.ts
+++ b/packages/core/src/di/injectable.ts
@@ -45,7 +45,7 @@ export interface InjectableDecorator {
    *
    * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
    *
-   * ### Example
+   * **Usage:**
    *
    * {@example core/di/ts/metadata_spec.ts region='Injectable'}
    *
@@ -53,7 +53,6 @@ export interface InjectableDecorator {
    * does not have `@Injectable` marker, as shown in the example below.
    *
    * {@example core/di/ts/metadata_spec.ts region='InjectableThrows'}
-   *
    *
    */
   (): any;

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -36,13 +36,11 @@ import {InjectableDef, defineInjectable} from './defs';
  * overrides the above behavior and marks the token as belonging to a particular `@NgModule`. As
  * mentioned above, `'root'` is the default value for `providedIn`.
  *
- * ### Example
- *
- * #### Tree-shakeable InjectionToken
+ * **Tree-shakeable `InjectionToken` example**
  *
  * {@example core/di/ts/injector_spec.ts region='ShakeableInjectionToken'}
  *
- * #### Plain InjectionToken
+ * **Plain InjectionToken example**
  *
  * {@example core/di/ts/injector_spec.ts region='InjectionToken'}
  *

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -36,14 +36,15 @@ import {InjectableDef, defineInjectable} from './defs';
  * overrides the above behavior and marks the token as belonging to a particular `@NgModule`. As
  * mentioned above, `'root'` is the default value for `providedIn`.
  *
- * **Tree-shakeable `InjectionToken` example**
+ * @example
+ * This example shows how to create a simple `InjectionToken`.
  *
- * {@example core/di/ts/injector_spec.ts region='ShakeableInjectionToken'}
+ * <code-example path="core/di/ts/injector_spec.ts" region="InjectionToken"></code-example>
  *
- * **Plain InjectionToken example**
+ * @example
+ * This examples shows a how to create a tree-shakeable `InjectionToken`.
  *
- * {@example core/di/ts/injector_spec.ts region='InjectionToken'}
- *
+ * <code-example path="core/di/ts/injector_spec.ts" region="ShakeableInjectionToken"></code-example>
  *
  */
 export class InjectionToken<T> {

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -51,11 +51,15 @@ export class NullInjector implements Injector {
  *
  * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
  *
- * {@example core/di/ts/injector_spec.ts region='Injector'}
+ * @example
+ * This example shows how to create and use an `Injector`.
  *
- * `Injector` returns itself when given `Injector` as a token:
- * {@example core/di/ts/injector_spec.ts region='injectInjector'}
+ * <code-example path="core/di/ts/injector_spec.ts" region="Injector"></code-example>
  *
+ * @example
+ * This example shows how an `Injector` returns itself when given `Injector` as a token:
+ *
+ * <code-example path="core/di/ts/injector_spec.ts" region="injectInjector"></code-example>
  *
  */
 export abstract class Injector {
@@ -86,9 +90,10 @@ export abstract class Injector {
   /**
    * Create a new Injector which is configured using `StaticProvider`s.
    *
-   * **Usage**:
+   * @example
+   * This example shows how to use this method to create and use an `Injector`.
    *
-   * {@example core/di/ts/provider_spec.ts region='ConstructorProvider'}
+   * <code-example path="core/di/ts/provider_spec.ts" region="ConstructorProvider"></code-example>
    */
   static create(
       options: StaticProvider[]|{providers: StaticProvider[], parent?: Injector, name?: string},
@@ -446,7 +451,7 @@ export function setCurrentInjector(injector: Injector | null | undefined): Injec
  * This function must be used in the context of a factory function such as one defined for an
  * `InjectionToken`, and will throw an error if not called from such a context. For example:
  *
- * {@example core/di/ts/injector_spec.ts region='ShakeableInjectionToken'}
+ * <code-example path="core/di/ts/injector_spec.ts" region="ShakeableInjectionToken"></code-example>
  *
  * Within such a factory function `inject` is utilized to request injection of a dependency, instead
  * of providing an additional array of dependencies as was common to do with `useFactory` providers.

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -51,8 +51,6 @@ export class NullInjector implements Injector {
  *
  * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
  *
- * ### Example
- *
  * {@example core/di/ts/injector_spec.ts region='Injector'}
  *
  * `Injector` returns itself when given `Injector` as a token:
@@ -86,9 +84,9 @@ export abstract class Injector {
   static create(options: {providers: StaticProvider[], parent?: Injector, name?: string}): Injector;
 
   /**
-   * Create a new Injector which is configure using `StaticProvider`s.
+   * Create a new Injector which is configured using `StaticProvider`s.
    *
-   * ### Example
+   * **Usage**:
    *
    * {@example core/di/ts/provider_spec.ts region='ConstructorProvider'}
    */

--- a/packages/core/src/di/metadata.ts
+++ b/packages/core/src/di/metadata.ts
@@ -20,31 +20,25 @@ import {EMPTY_ARRAY} from '../view/util';
  */
 export interface InjectDecorator {
   /**
-   * @usageNotes
-   * ```
-   * @Injectable()
-   * class Car {
-   *   constructor(@Inject("MyEngine") public engine:Engine) {}
-   * }
-   * ```
-   *
-   * @description
    * A parameter decorator that specifies a dependency.
    *
    * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
-   *
-   * ### Example
    *
    * {@example core/di/ts/metadata_spec.ts region='Inject'}
    *
    * When `@Inject()` is not present, {@link Injector} will use the type annotation of the
    * parameter.
    *
-   * ### Example
-   *
    * {@example core/di/ts/metadata_spec.ts region='InjectWithoutDecorator'}
    *
+   * @usageNotes
    *
+   * ```
+   * @Injectable()
+   * class Car {
+   *   constructor(@Inject("MyEngine") public engine:Engine) {}
+   * }
+   * ```
    */
   (token: any): any;
   new (token: any): Inject;
@@ -52,14 +46,11 @@ export interface InjectDecorator {
 
 /**
  * Type of the Inject metadata.
- *
- *
  */
 export interface Inject { token: any; }
 
 /**
  * Inject decorator and metadata.
- *
  *
  * @Annotation
  */
@@ -68,30 +59,24 @@ export const Inject: InjectDecorator = makeParamDecorator('Inject', (token: any)
 
 /**
  * Type of the Optional decorator / constructor function.
- *
- *
  */
 export interface OptionalDecorator {
   /**
+   * A parameter metadata that marks a dependency as optional.
+   * {@link Injector} provides `null` if the dependency is not found.
+   *
+   * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+   *
+   * {@example core/di/ts/metadata_spec.ts region='Optional'}
+   *
    * @usageNotes
+   *
    * ```
    * @Injectable()
    * class Car {
    *   constructor(@Optional() public engine:Engine) {}
    * }
    * ```
-   *
-   * @description
-   * A parameter metadata that marks a dependency as optional.
-   * {@link Injector} provides `null` if the dependency is not found.
-   *
-   * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
-   *
-   * ### Example
-   *
-   * {@example core/di/ts/metadata_spec.ts region='Optional'}
-   *
-   *
    */
   (): any;
   new (): Optional;
@@ -99,14 +84,11 @@ export interface OptionalDecorator {
 
 /**
  * Type of the Optional metadata.
- *
- *
  */
 export interface Optional {}
 
 /**
  * Optional decorator and metadata.
- *
  *
  * @Annotation
  */
@@ -114,29 +96,23 @@ export const Optional: OptionalDecorator = makeParamDecorator('Optional');
 
 /**
  * Type of the Self decorator / constructor function.
- *
- *
  */
 export interface SelfDecorator {
   /**
+   * Specifies that an {@link Injector} should retrieve a dependency only from itself.
+   *
+   * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+   *
+   * {@example core/di/ts/metadata_spec.ts region='Self'}
+   *
    * @usageNotes
+   *
    * ```
    * @Injectable()
    * class Car {
    *   constructor(@Self() public engine:Engine) {}
    * }
    * ```
-   *
-   * @description
-   * Specifies that an {@link Injector} should retrieve a dependency only from itself.
-   *
-   * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
-   *
-   * ### Example
-   *
-   * {@example core/di/ts/metadata_spec.ts region='Self'}
-   *
-   *
    */
   (): any;
   new (): Self;
@@ -144,14 +120,11 @@ export interface SelfDecorator {
 
 /**
  * Type of the Self metadata.
- *
- *
  */
 export interface Self {}
 
 /**
  * Self decorator and metadata.
- *
  *
  * @Annotation
  */
@@ -160,29 +133,23 @@ export const Self: SelfDecorator = makeParamDecorator('Self');
 
 /**
  * Type of the SkipSelf decorator / constructor function.
- *
- *
  */
 export interface SkipSelfDecorator {
   /**
+   * Specifies that the dependency resolution should start from the parent injector.
+   *
+   * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+   *
+   * {@example core/di/ts/metadata_spec.ts region='SkipSelf'}
+   *
    * @usageNotes
+   *
    * ```
    * @Injectable()
    * class Car {
    *   constructor(@SkipSelf() public engine:Engine) {}
    * }
    * ```
-   *
-   * @description
-   * Specifies that the dependency resolution should start from the parent injector.
-   *
-   * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
-   *
-   * ### Example
-   *
-   * {@example core/di/ts/metadata_spec.ts region='SkipSelf'}
-   *
-   *
    */
   (): any;
   new (): SkipSelf;
@@ -190,14 +157,11 @@ export interface SkipSelfDecorator {
 
 /**
  * Type of the SkipSelf metadata.
- *
- *
  */
 export interface SkipSelf {}
 
 /**
  * SkipSelf decorator and metadata.
- *
  *
  * @Annotation
  */
@@ -205,30 +169,24 @@ export const SkipSelf: SkipSelfDecorator = makeParamDecorator('SkipSelf');
 
 /**
  * Type of the Host decorator / constructor function.
- *
- *
  */
 export interface HostDecorator {
   /**
+   * Specifies that an injector should retrieve a dependency from any injector until
+   * reaching the host element of the current component.
+   *
+   * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+   *
+   * {@example core/di/ts/metadata_spec.ts region='Host'}
+   *
    * @usageNotes
+   *
    * ```
    * @Injectable()
    * class Car {
    *   constructor(@Host() public engine:Engine) {}
    * }
    * ```
-   *
-   * @description
-   * Specifies that an injector should retrieve a dependency from any injector until
-   * reaching the host element of the current component.
-   *
-   * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
-   *
-   * ### Example
-   *
-   * {@example core/di/ts/metadata_spec.ts region='Host'}
-   *
-   *
    */
   (): any;
   new (): Host;
@@ -236,14 +194,11 @@ export interface HostDecorator {
 
 /**
  * Type of the Host metadata.
- *
- *
  */
 export interface Host {}
 
 /**
  * Host decorator and metadata.
- *
  *
  * @Annotation
  */

--- a/packages/core/src/di/metadata.ts
+++ b/packages/core/src/di/metadata.ts
@@ -24,21 +24,17 @@ export interface InjectDecorator {
    *
    * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
    *
-   * {@example core/di/ts/metadata_spec.ts region='Inject'}
+   * @example
+   * This example shows how to use the `@Inject()` decorator.
    *
+   * <code-example path="core/di/ts/metadata_spec.ts" region="Inject"></code-example>
+   *
+   * @example
    * When `@Inject()` is not present, {@link Injector} will use the type annotation of the
    * parameter.
    *
-   * {@example core/di/ts/metadata_spec.ts region='InjectWithoutDecorator'}
+   * <code-example path="core/di/ts/metadata_spec.ts" region="InjectWithoutDecorator"></code-example>
    *
-   * @usageNotes
-   *
-   * ```
-   * @Injectable()
-   * class Car {
-   *   constructor(@Inject("MyEngine") public engine:Engine) {}
-   * }
-   * ```
    */
   (token: any): any;
   new (token: any): Inject;
@@ -67,16 +63,12 @@ export interface OptionalDecorator {
    *
    * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
    *
-   * {@example core/di/ts/metadata_spec.ts region='Optional'}
+   * @example
    *
-   * @usageNotes
+   * This example shows how to use the `@Optional()` decorator.
    *
-   * ```
-   * @Injectable()
-   * class Car {
-   *   constructor(@Optional() public engine:Engine) {}
-   * }
-   * ```
+   * <code-example path="core/di/ts/metadata_spec.ts" region="Optional"></code-example>
+   *
    */
   (): any;
   new (): Optional;
@@ -103,16 +95,11 @@ export interface SelfDecorator {
    *
    * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
    *
-   * {@example core/di/ts/metadata_spec.ts region='Self'}
+   * @example
+   * This example shows how to use the `@Self()` decorator.
    *
-   * @usageNotes
+   * <code-example path="core/di/ts/metadata_spec.ts" region="Self"></code-example>
    *
-   * ```
-   * @Injectable()
-   * class Car {
-   *   constructor(@Self() public engine:Engine) {}
-   * }
-   * ```
    */
   (): any;
   new (): Self;
@@ -140,16 +127,11 @@ export interface SkipSelfDecorator {
    *
    * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
    *
-   * {@example core/di/ts/metadata_spec.ts region='SkipSelf'}
+   * @example
+   * This example shows how to use the `@SkipSelf()` decorotor.
    *
-   * @usageNotes
+   * <code-example path="core/di/ts/metadata_spec.ts" region="SkipSelf"></code-example>
    *
-   * ```
-   * @Injectable()
-   * class Car {
-   *   constructor(@SkipSelf() public engine:Engine) {}
-   * }
-   * ```
    */
   (): any;
   new (): SkipSelf;
@@ -177,16 +159,11 @@ export interface HostDecorator {
    *
    * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
    *
-   * {@example core/di/ts/metadata_spec.ts region='Host'}
+   * @example
+   * This example shows how to use the `@Host()` decorator.
    *
-   * @usageNotes
+   * <code-example path="core/di/ts/metadata_spec.ts" region="Host"></code-example>
    *
-   * ```
-   * @Injectable()
-   * class Car {
-   *   constructor(@Host() public engine:Engine) {}
-   * }
-   * ```
    */
   (): any;
   new (): Host;

--- a/packages/core/src/di/provider.ts
+++ b/packages/core/src/di/provider.ts
@@ -11,9 +11,12 @@ import {Type} from '../type';
 /**
  * Configures the `Injector` to return a value for a token.
  *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ * For more details, see the [Dependency Injection Guide](guide/dependency-injection).
  *
- * {@example core/di/ts/provider_spec.ts region='ValueSansProvider'}
+ * @example
+ * This example shows how to define a provider that matches this interface:
+ *
+ * <code-example path="core/di/ts/provider_spec.ts" region="ValueSansProvider"></code-example>
  *
  * @usageNotes
  *
@@ -34,9 +37,12 @@ export interface ValueSansProvider {
 /**
  * Configures the `Injector` to return a value for a token.
  *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ * For more details, see the [Dependency Injection Guide](guide/dependency-injection).
  *
- * {@example core/di/ts/provider_spec.ts region='ValueProvider'}
+ * @example
+ * This example shows how to define a provider that matches this interface:
+ *
+ * <code-example path="core/di/ts/provider_spec.ts" region="ValueProvider"></code-example>
  *
  * @usageNotes
  *
@@ -54,7 +60,10 @@ export interface ValueProvider extends ValueSansProvider {
    * If true, then injector returns an array of instances. This is useful to allow multiple
    * providers spread across many files to provide configuration information to a common token.
    *
-   * {@example core/di/ts/provider_spec.ts region='MultiProviderAspect'}
+   * @example
+   * This example shows how to define a multiple valued provider:
+   *
+   * <code-example path="core/di/ts/provider_spec.ts" region="MultiProviderAspect"></code-example>
    */
   multi?: boolean;
 }
@@ -62,9 +71,12 @@ export interface ValueProvider extends ValueSansProvider {
 /**
  * Configures the `Injector` to return an instance of `useClass` for a token.
  *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ * For more details, see the [Dependency Injection Guide](guide/dependency-injection).
  *
- * {@example core/di/ts/provider_spec.ts region='StaticClassSansProvider'}
+ * @example
+ * This example shows how to define a provider that matches this interface:
+ *
+ * <code-example path="core/di/ts/provider_spec.ts" region="StaticClassSansProvider"></code-example>
  *
  * @usageNotes
  *
@@ -92,13 +104,17 @@ export interface StaticClassSansProvider {
 /**
  * Configures the `Injector` to return an instance of `useClass` for a token.
  *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ * For more details, see the [Dependency Injection Guide](/guide/dependency-injection).
  *
- * {@example core/di/ts/provider_spec.ts region='StaticClassProvider'}
+ * @example
+ * This example shows how to define a provider that matches this interface:
  *
+ * <code-example path="core/di/ts/provider_spec.ts" region="StaticClassProvider"></code-example>
+ *
+ * @example
  * Note that following two providers are not equal:
  *
- * {@example core/di/ts/provider_spec.ts region='StaticClassProviderDifference'}
+ * <code-example path="core/di/ts/provider_spec.ts" region="StaticClassProviderDifference"></code-example>
  *
  * @usageNotes
  *
@@ -119,7 +135,10 @@ export interface StaticClassProvider extends StaticClassSansProvider {
    * If true, then injector returns an array of instances. This is useful to allow multiple
    * providers spread across many files to provide configuration information to a common token.
    *
-   * {@example core/di/ts/provider_spec.ts region='MultiProviderAspect'}
+   * @example
+   * This example shows how to define a multiple valued provider:
+   *
+   * <code-example path="core/di/ts/provider_spec.ts" region="MultiProviderAspect"></code-example>
    */
   multi?: boolean;
 }
@@ -134,9 +153,12 @@ export interface StaticClassProvider extends StaticClassSansProvider {
  * @description
  * Configures the `Injector` to return an instance of a token.
  *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ * For more details, see the [Dependency Injection Guide](/guide/dependency-injection).
  *
- * {@example core/di/ts/provider_spec.ts region='ConstructorSansProvider'}
+ * @example
+ * This example shows how to define a provider that matches this interface:
+ *
+ * <code-example path="core/di/ts/provider_spec.ts" region="ConstructorSansProvider"></code-example>
  *
  * @experimental
  */
@@ -151,9 +173,12 @@ export interface ConstructorSansProvider {
 /**
  * Configures the `Injector` to return an instance of a token.
  *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ * For more details, see the [Dependency Injection Guide](guide/dependency-injection).
  *
- * {@example core/di/ts/provider_spec.ts region='ConstructorProvider'}
+ * @example
+ * This example shows how to define a provider that matches this interface:
+ *
+ * <code-example path="core/di/ts/provider_spec.ts" region="ConstructorProvider"></code-example>
  *
  * @usageNotes
  *
@@ -174,7 +199,10 @@ export interface ConstructorProvider extends ConstructorSansProvider {
    * If true, then injector returns an array of instances. This is useful to allow multiple
    * providers spread across many files to provide configuration information to a common token.
    *
-   * {@example core/di/ts/provider_spec.ts region='MultiProviderAspect'}
+   * @example
+   * This example shows how to define a multiple valued provider:
+   *
+   * <code-example path="core/di/ts/provider_spec.ts" region="MultiProviderAspect"></code-example>
    */
   multi?: boolean;
 }
@@ -182,9 +210,12 @@ export interface ConstructorProvider extends ConstructorSansProvider {
 /**
  * Configures the `Injector` to return a value of another `useExisting` token.
  *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ * For more details, see the [Dependency Injection Guide](guide/dependency-injection).
  *
- * {@example core/di/ts/provider_spec.ts region='ExistingSansProvider'}
+ * @example
+ * This example shows how to define a provider that matches this interface:
+ *
+ * <code-example path="core/di/ts/provider_spec.ts" region="ExistingSansProvider"></code-example>
  *
  * @usageNotes
  *
@@ -203,9 +234,12 @@ export interface ExistingSansProvider {
 /**
  * Configures the `Injector` to return a value of another `useExisting` token.
  *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ * For more details, see the [Dependency Injection Guide](guide/dependency-injection).
  *
- * {@example core/di/ts/provider_spec.ts region='ExistingProvider'}
+ * @example
+ * This example shows how to define a provider that matches this interface:
+ *
+ * <code-example path="core/di/ts/provider_spec.ts" region="ExistingProvider"></code-example>
  *
  * @usageNotes
  *
@@ -223,7 +257,10 @@ export interface ExistingProvider extends ExistingSansProvider {
    * If true, then injector returns an array of instances. This is useful to allow multiple
    * providers spread across many files to provide configuration information to a common token.
    *
-   * {@example core/di/ts/provider_spec.ts region='MultiProviderAspect'}
+   * @example
+   * This example shows how to define a multiple valued provider:
+   *
+   * <code-example path="core/di/ts/provider_spec.ts" region="MultiProviderAspect"></code-example>
    */
   multi?: boolean;
 }
@@ -231,9 +268,12 @@ export interface ExistingProvider extends ExistingSansProvider {
 /**
  * Configures the `Injector` to return a value by invoking a `useFactory` function.
  *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ * For more details, see the [Dependency Injection Guide](guide/dependency-injection).
  *
- * {@example core/di/ts/provider_spec.ts region='FactorySansProvider'}
+ * @example
+ * This example shows how to define a provider that matches this interface:
+ *
+ * <code-example path="core/di/ts/provider_spec.ts" region="FactorySansProvider"></code-example>
  *
  * @usageNotes
  *
@@ -263,13 +303,18 @@ export interface FactorySansProvider {
 /**
  * Configures the `Injector` to return a value by invoking a `useFactory` function.
  *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ * For more details, see the [Dependency Injection Guide](guide/dependency-injection).
  *
- * {@example core/di/ts/provider_spec.ts region='FactoryProvider'}
+ * @example
+ * This example shows how to define a provider that matches this interface:
  *
+ * <code-example path="core/di/ts/provider_spec.ts" region="FactoryProvider"></code-example>
+ *
+ *
+ * @example
  * Dependencies can also be marked as optional:
  *
- * {@example core/di/ts/provider_spec.ts region='FactoryProviderOptionalDeps'}
+ * <code-example path="core/di/ts/provider_spec.ts" region="FactoryProviderOptionalDeps"></code-example>
  *
  * @usageNotes
  *
@@ -290,7 +335,10 @@ export interface FactoryProvider extends FactorySansProvider {
    * If true, then injector returns an array of instances. This is useful to allow multiple
    * providers spread across many files to provide configuration information to a common token.
    *
-   * {@example core/di/ts/provider_spec.ts region='MultiProviderAspect'}
+   * @example
+   * This example shows how to define a multiple valued provider:
+   *
+   * <code-example path="core/di/ts/provider_spec.ts" region="MultiProviderAspect"></code-example>
    */
   multi?: boolean;
 }
@@ -298,9 +346,9 @@ export interface FactoryProvider extends FactorySansProvider {
 /**
  * Describes how the `Injector` should be configured in a static way (Without reflection).
  *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ * For more details, see the [Dependency Injection Guide](guide/dependency-injection).
  *
- * See {@link ValueProvider}, {@link ExistingProvider}, {@link FactoryProvider}.
+ * See `ValueProvider`, `ExistingProvider`, `FactoryProvider`.
  */
 export type StaticProvider = ValueProvider | ExistingProvider | StaticClassProvider |
     ConstructorProvider | FactoryProvider | any[];
@@ -312,9 +360,12 @@ export type StaticProvider = ValueProvider | ExistingProvider | StaticClassProvi
  * Create an instance by invoking the `new` operator and supplying additional arguments.
  * This form is a short form of `TypeProvider`;
  *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ * For more details, see the [Dependency Injection Guide](guide/dependency-injection).
  *
- * {@example core/di/ts/provider_spec.ts region='TypeProvider'}
+ * @example
+ * This example shows how to define a provider that matches this interface:
+ *
+ * <code-example path="core/di/ts/provider_spec.ts" region="TypeProvider"></code-example>
  *
  * @usageNotes
  *
@@ -330,9 +381,12 @@ export interface TypeProvider extends Type<any> {}
 /**
  * Configures the `Injector` to return a value by invoking a `useClass` function.
  *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ * For more details, see the [Dependency Injection Guide](guide/dependency-injection).
  *
- * {@example core/di/ts/provider_spec.ts region='ClassSansProvider'}
+ * @example
+ * This example shows how to define a provider that matches this interface:
+ *
+ * <code-example path="core/di/ts/provider_spec.ts" region="ClassSansProvider"></code-example>
  *
  * @usageNotes
  *
@@ -355,13 +409,19 @@ export interface ClassSansProvider {
 /**
  * Configures the `Injector` to return an instance of `useClass` for a token.
  *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ * For more details, see the [Dependency Injection Guide](guide/dependency-injection).
  *
- * {@example core/di/ts/provider_spec.ts region='ClassProvider'}
+ * @example
+ * This example shows how to define a provider that matches this interface:
  *
+ * <code-example path="core/di/ts/provider_spec.ts" region="ClassProvider"></code-example>
+ *
+ *
+ * @example
  * Note that following two providers are not equal:
+ * This example shows how to define a provider that matches this interface:
  *
- * {@example core/di/ts/provider_spec.ts region='ClassProviderDifference'}
+ * <code-example path="core/di/ts/provider_spec.ts" region="ClassProviderDifference"></code-example>
  *
  * @usageNotes
  *
@@ -382,7 +442,10 @@ export interface ClassProvider extends ClassSansProvider {
    * If true, then injector returns an array of instances. This is useful to allow multiple
    * providers spread across many files to provide configuration information to a common token.
    *
-   * {@example core/di/ts/provider_spec.ts region='MultiProviderAspect'}
+   * @example
+   * This example shows how to define a provider that matches this interface:
+   *
+   * <code-example path="core/di/ts/provider_spec.ts" region="MultiProviderAspect"></code-example>
    */
   multi?: boolean;
 }
@@ -390,9 +453,9 @@ export interface ClassProvider extends ClassSansProvider {
 /**
  * Describes how the `Injector` should be configured.
  *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ * For more details, see the [Dependency Injection Guide](guide/dependency-injection).
  *
- * See {@link TypeProvider}, {@link ClassProvider}, {@link StaticProvider}.
+ * See `TypeProvider`, `ClassProvider`, `StaticProvider`.
  */
 export type Provider =
     TypeProvider | ValueProvider | ClassProvider | ExistingProvider | FactoryProvider | any[];

--- a/packages/core/src/di/provider.ts
+++ b/packages/core/src/di/provider.ts
@@ -9,20 +9,18 @@
 import {Type} from '../type';
 
 /**
- * @usageNotes
- * ```
- * @Injectable(SomeModule, {useValue: 'someValue'})
- * class SomeClass {}
- * ```
- *
- * @description
  * Configures the `Injector` to return a value for a token.
  *
  * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
  *
- * ### Example
- *
  * {@example core/di/ts/provider_spec.ts region='ValueSansProvider'}
+ *
+ * @usageNotes
+ *
+ * ```
+ * @Injectable(SomeModule, {useValue: 'someValue'})
+ * class SomeClass {}
+ * ```
  *
  * @experimental
  */
@@ -34,21 +32,17 @@ export interface ValueSansProvider {
 }
 
 /**
- * @usageNotes
- * ```
- * const provider: ValueProvider = {provide: 'someToken', useValue: 'someValue'};
- * ```
- *
- * @description
  * Configures the `Injector` to return a value for a token.
  *
  * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
  *
- * ### Example
- *
  * {@example core/di/ts/provider_spec.ts region='ValueProvider'}
  *
+ * @usageNotes
  *
+ * ```
+ * const provider: ValueProvider = {provide: 'someToken', useValue: 'someValue'};
+ * ```
  */
 export interface ValueProvider extends ValueSansProvider {
   /**
@@ -60,28 +54,24 @@ export interface ValueProvider extends ValueSansProvider {
    * If true, then injector returns an array of instances. This is useful to allow multiple
    * providers spread across many files to provide configuration information to a common token.
    *
-   * ### Example
-   *
    * {@example core/di/ts/provider_spec.ts region='MultiProviderAspect'}
    */
   multi?: boolean;
 }
 
 /**
- * @usageNotes
- * ```
- * @Injectable(SomeModule, {useClass: MyService, deps: []})
- * class MyService {}
- * ```
- *
- * @description
  * Configures the `Injector` to return an instance of `useClass` for a token.
  *
  * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
  *
- * ### Example
- *
  * {@example core/di/ts/provider_spec.ts region='StaticClassSansProvider'}
+ *
+ * @usageNotes
+ *
+ * ```
+ * @Injectable(SomeModule, {useClass: MyService, deps: []})
+ * class MyService {}
+ * ```
  *
  * @experimental
  */
@@ -100,27 +90,24 @@ export interface StaticClassSansProvider {
 }
 
 /**
+ * Configures the `Injector` to return an instance of `useClass` for a token.
+ *
+ * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ *
+ * {@example core/di/ts/provider_spec.ts region='StaticClassProvider'}
+ *
+ * Note that following two providers are not equal:
+ *
+ * {@example core/di/ts/provider_spec.ts region='StaticClassProviderDifference'}
+ *
  * @usageNotes
+ *
  * ```
  * @Injectable()
  * class MyService {}
  *
  * const provider: ClassProvider = {provide: 'someToken', useClass: MyService, deps: []};
  * ```
- *
- * @description
- * Configures the `Injector` to return an instance of `useClass` for a token.
- *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
- *
- * ### Example
- *
- * {@example core/di/ts/provider_spec.ts region='StaticClassProvider'}
- *
- * Note that following two providers are not equal:
- * {@example core/di/ts/provider_spec.ts region='StaticClassProviderDifference'}
- *
- *
  */
 export interface StaticClassProvider extends StaticClassSansProvider {
   /**
@@ -131,8 +118,6 @@ export interface StaticClassProvider extends StaticClassSansProvider {
   /**
    * If true, then injector returns an array of instances. This is useful to allow multiple
    * providers spread across many files to provide configuration information to a common token.
-   *
-   * ### Example
    *
    * {@example core/di/ts/provider_spec.ts region='MultiProviderAspect'}
    */
@@ -151,8 +136,6 @@ export interface StaticClassProvider extends StaticClassSansProvider {
  *
  * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
  *
- * ### Example
- *
  * {@example core/di/ts/provider_spec.ts region='ConstructorSansProvider'}
  *
  * @experimental
@@ -166,24 +149,20 @@ export interface ConstructorSansProvider {
 }
 
 /**
+ * Configures the `Injector` to return an instance of a token.
+ *
+ * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ *
+ * {@example core/di/ts/provider_spec.ts region='ConstructorProvider'}
+ *
  * @usageNotes
+ *
  * ```
  * @Injectable()
  * class MyService {}
  *
  * const provider: ClassProvider = {provide: MyClass, deps: []};
  * ```
- *
- * @description
- * Configures the `Injector` to return an instance of a token.
- *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
- *
- * ### Example
- *
- * {@example core/di/ts/provider_spec.ts region='ConstructorProvider'}
- *
- *
  */
 export interface ConstructorProvider extends ConstructorSansProvider {
   /**
@@ -195,30 +174,24 @@ export interface ConstructorProvider extends ConstructorSansProvider {
    * If true, then injector returns an array of instances. This is useful to allow multiple
    * providers spread across many files to provide configuration information to a common token.
    *
-   * ### Example
-   *
    * {@example core/di/ts/provider_spec.ts region='MultiProviderAspect'}
    */
   multi?: boolean;
 }
 
 /**
- * @usageNotes
- * ```
- * @Injectable(SomeModule, {useExisting: 'someOtherToken'})
- * class SomeClass {}
- * ```
- *
- * @description
  * Configures the `Injector` to return a value of another `useExisting` token.
  *
  * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
  *
- * ### Example
- *
  * {@example core/di/ts/provider_spec.ts region='ExistingSansProvider'}
  *
+ * @usageNotes
  *
+ * ```
+ * @Injectable(SomeModule, {useExisting: 'someOtherToken'})
+ * class SomeClass {}
+ * ```
  */
 export interface ExistingSansProvider {
   /**
@@ -228,21 +201,17 @@ export interface ExistingSansProvider {
 }
 
 /**
- * @usageNotes
- * ```
- * const provider: ExistingProvider = {provide: 'someToken', useExisting: 'someOtherToken'};
- * ```
- *
- * @description
  * Configures the `Injector` to return a value of another `useExisting` token.
  *
  * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
  *
- * ### Example
- *
  * {@example core/di/ts/provider_spec.ts region='ExistingProvider'}
  *
+ * @usageNotes
  *
+ * ```
+ * const provider: ExistingProvider = {provide: 'someToken', useExisting: 'someOtherToken'};
+ * ```
  */
 export interface ExistingProvider extends ExistingSansProvider {
   /**
@@ -254,15 +223,20 @@ export interface ExistingProvider extends ExistingSansProvider {
    * If true, then injector returns an array of instances. This is useful to allow multiple
    * providers spread across many files to provide configuration information to a common token.
    *
-   * ### Example
-   *
    * {@example core/di/ts/provider_spec.ts region='MultiProviderAspect'}
    */
   multi?: boolean;
 }
 
 /**
+ * Configures the `Injector` to return a value by invoking a `useFactory` function.
+ *
+ * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ *
+ * {@example core/di/ts/provider_spec.ts region='FactorySansProvider'}
+ *
  * @usageNotes
+ *
  * ```
  * function serviceFactory() { ... }
  *
@@ -270,17 +244,8 @@ export interface ExistingProvider extends ExistingSansProvider {
  * class SomeClass {}
  * ```
  *
- * @description
- * Configures the `Injector` to return a value by invoking a `useFactory` function.
- *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
- *
- * ### Example
- *
- * {@example core/di/ts/provider_spec.ts region='FactorySansProvider'}
- *
  * @experimental
-   */
+ */
 export interface FactorySansProvider {
   /**
    * A function to invoke to create a value for this `token`. The function is invoked with
@@ -296,25 +261,23 @@ export interface FactorySansProvider {
 }
 
 /**
+ * Configures the `Injector` to return a value by invoking a `useFactory` function.
+ *
+ * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ *
+ * {@example core/di/ts/provider_spec.ts region='FactoryProvider'}
+ *
+ * Dependencies can also be marked as optional:
+ *
+ * {@example core/di/ts/provider_spec.ts region='FactoryProviderOptionalDeps'}
+ *
  * @usageNotes
+ *
  * ```
  * function serviceFactory() { ... }
  *
  * const provider: FactoryProvider = {provide: 'someToken', useFactory: serviceFactory, deps: []};
  * ```
- *
- * @description
- * Configures the `Injector` to return a value by invoking a `useFactory` function.
- *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
- *
- * ### Example
- *
- * {@example core/di/ts/provider_spec.ts region='FactoryProvider'}
- *
- * Dependencies can also be marked as optional:
- * {@example core/di/ts/provider_spec.ts region='FactoryProviderOptionalDeps'}
- *
  *
  */
 export interface FactoryProvider extends FactorySansProvider {
@@ -327,38 +290,23 @@ export interface FactoryProvider extends FactorySansProvider {
    * If true, then injector returns an array of instances. This is useful to allow multiple
    * providers spread across many files to provide configuration information to a common token.
    *
-   * ### Example
-   *
    * {@example core/di/ts/provider_spec.ts region='MultiProviderAspect'}
    */
   multi?: boolean;
 }
 
 /**
- * @usageNotes
- * See {@link ValueProvider}, {@link ExistingProvider}, {@link FactoryProvider}.
- *
- * @description
  * Describes how the `Injector` should be configured in a static way (Without reflection).
  *
  * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
  *
- *
+ * See {@link ValueProvider}, {@link ExistingProvider}, {@link FactoryProvider}.
  */
 export type StaticProvider = ValueProvider | ExistingProvider | StaticClassProvider |
     ConstructorProvider | FactoryProvider | any[];
 
 
 /**
- * @usageNotes
- * ```
- * @Injectable()
- * class MyService {}
- *
- * const provider: TypeProvider = MyService;
- * ```
- *
- * @description
  * Configures the `Injector` to return an instance of `Type` when `Type' is used as the token.
  *
  * Create an instance by invoking the `new` operator and supplying additional arguments.
@@ -366,32 +314,34 @@ export type StaticProvider = ValueProvider | ExistingProvider | StaticClassProvi
  *
  * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
  *
- * ### Example
- *
  * {@example core/di/ts/provider_spec.ts region='TypeProvider'}
  *
+ * @usageNotes
  *
+ * ```
+ * @Injectable()
+ * class MyService {}
+ *
+ * const provider: TypeProvider = MyService;
+ * ```
  */
 export interface TypeProvider extends Type<any> {}
 
 /**
- * @usageNotes
- * ```
+ * Configures the `Injector` to return a value by invoking a `useClass` function.
  *
+ * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ *
+ * {@example core/di/ts/provider_spec.ts region='ClassSansProvider'}
+ *
+ * @usageNotes
+ *
+ * ```
  * class SomeClassImpl {}
  *
  * @Injectable(SomeModule, {useClass: SomeClassImpl})
  * class SomeClass {}
  * ```
- *
- * @description
- * Configures the `Injector` to return a value by invoking a `useClass` function.
- *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
- *
- * ### Example
- *
- * {@example core/di/ts/provider_spec.ts region='ClassSansProvider'}
  *
  * @experimental
  */
@@ -403,27 +353,24 @@ export interface ClassSansProvider {
 }
 
 /**
+ * Configures the `Injector` to return an instance of `useClass` for a token.
+ *
+ * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
+ *
+ * {@example core/di/ts/provider_spec.ts region='ClassProvider'}
+ *
+ * Note that following two providers are not equal:
+ *
+ * {@example core/di/ts/provider_spec.ts region='ClassProviderDifference'}
+ *
  * @usageNotes
+ *
  * ```
  * @Injectable()
  * class MyService {}
  *
  * const provider: ClassProvider = {provide: 'someToken', useClass: MyService};
  * ```
- *
- * @description
- * Configures the `Injector` to return an instance of `useClass` for a token.
- *
- * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
- *
- * ### Example
- *
- * {@example core/di/ts/provider_spec.ts region='ClassProvider'}
- *
- * Note that following two providers are not equal:
- * {@example core/di/ts/provider_spec.ts region='ClassProviderDifference'}
- *
- *
  */
 export interface ClassProvider extends ClassSansProvider {
   /**
@@ -435,23 +382,17 @@ export interface ClassProvider extends ClassSansProvider {
    * If true, then injector returns an array of instances. This is useful to allow multiple
    * providers spread across many files to provide configuration information to a common token.
    *
-   * ### Example
-   *
    * {@example core/di/ts/provider_spec.ts region='MultiProviderAspect'}
    */
   multi?: boolean;
 }
 
 /**
- * @usageNotes
- * See {@link TypeProvider}, {@link ClassProvider}, {@link StaticProvider}.
- *
- * @description
  * Describes how the `Injector` should be configured.
  *
  * For more details, see the {@linkDocs guide/dependency-injection "Dependency Injection Guide"}.
  *
- *
+ * See {@link TypeProvider}, {@link ClassProvider}, {@link StaticProvider}.
  */
 export type Provider =
     TypeProvider | ValueProvider | ClassProvider | ExistingProvider | FactoryProvider | any[];

--- a/packages/core/src/di/reflective_errors.ts
+++ b/packages/core/src/di/reflective_errors.ts
@@ -67,10 +67,12 @@ function addKey(this: InjectionError, injector: ReflectiveInjector, key: Reflect
 }
 
 /**
- * Thrown when trying to retrieve a dependency by key from {@link Injector}, but the
- * {@link Injector} does not have a {@link Provider} for the given key.
+ * Thrown when trying to retrieve a dependency by key from `Injector`, but the
+ * `Injector` does not have a `Provider` for the given key.
  *
- * **Example** ([live demo](http://plnkr.co/edit/vq8D3FRB9aGbnWJqtEPE?p=preview))
+ * @example
+ * This example shows what can cause this error to be thrown
+ * ([live demo](http://plnkr.co/edit/vq8D3FRB9aGbnWJqtEPE?p=preview)):
  *
  * ```typescript
  * class A {
@@ -90,7 +92,9 @@ export function noProviderError(injector: ReflectiveInjector, key: ReflectiveKey
 /**
  * Thrown when dependencies form a cycle.
  *
- * **Example** ([live demo](http://plnkr.co/edit/wYQdNos0Tzql3ei1EV9j?p=info))
+ * @example
+ * This example shows what can cause this error to be thrown
+ * ([live demo](http://plnkr.co/edit/wYQdNos0Tzql3ei1EV9j?p=info)):
  *
  * ```typescript
  * var injector = Injector.resolveAndCreate([
@@ -116,7 +120,9 @@ export function cyclicDependencyError(
  * The `InstantiationError` class contains the original error plus the dependency graph which caused
  * this object to be instantiated.
  *
- * **Example** ([live demo](http://plnkr.co/edit/7aWYdcqTQsP0eNqEdUAf?p=preview))
+ * @example
+ * This example shows what can cause this error to be thrown
+ * ([live demo](http://plnkr.co/edit/7aWYdcqTQsP0eNqEdUAf?p=preview)):
  *
  * ```typescript
  * class A {
@@ -146,10 +152,12 @@ export function instantiationError(
 }
 
 /**
- * Thrown when an object other then {@link Provider} (or `Type`) is passed to {@link Injector}
+ * Thrown when an object other then `Provider` (or `Type`) is passed to `Injector`
  * creation.
  *
- * **Example** ([live demo](http://plnkr.co/edit/YatCFbPAMCL0JSSQ4mvH?p=preview))
+ * @example
+ * This example shows what can cause this error to be thrown
+ * ([live demo](http://plnkr.co/edit/YatCFbPAMCL0JSSQ4mvH?p=preview)):
  *
  * ```typescript
  * expect(() => Injector.resolveAndCreate(["not a type"])).toThrowError();
@@ -163,10 +171,12 @@ export function invalidProviderError(provider: any) {
 /**
  * Thrown when the class has no annotation information.
  *
- * Lack of annotation information prevents the {@link Injector} from determining which dependencies
+ * Lack of annotation information prevents the `Injector` from determining which dependencies
  * need to be injected into the constructor.
  *
- * **Example** ([live demo](http://plnkr.co/edit/rHnZtlNS7vJOPQ6pcVkm?p=preview))
+ * @example
+ * This example shows what can cause this error to be thrown
+ * ([live demo](http://plnkr.co/edit/rHnZtlNS7vJOPQ6pcVkm?p=preview)):
  *
  * ```typescript
  * class A {
@@ -176,7 +186,8 @@ export function invalidProviderError(provider: any) {
  * expect(() => Injector.resolveAndCreate([A])).toThrowError();
  * ```
  *
- * This error is also thrown when the class not marked with {@link Injectable} has parameter types.
+ * @example
+ * This error is also thrown when the class not marked with `Injectable` has parameter types.
  *
  * ```typescript
  * class B {}
@@ -209,7 +220,9 @@ export function noAnnotationError(typeOrFunc: Type<any>| Function, params: any[]
 /**
  * Thrown when getting an object by index.
  *
- * **Example** ([live demo](http://plnkr.co/edit/bRs0SX2OTQiJzqvjgl8P?p=preview))
+ * @example
+ * This example shows what can cause this error to be thrown
+ * ([live demo](http://plnkr.co/edit/bRs0SX2OTQiJzqvjgl8P?p=preview)):
  *
  * ```typescript
  * class A {}
@@ -227,6 +240,9 @@ export function outOfBoundsError(index: number) {
 // TODO: add a working example after alpha38 is released
 /**
  * Thrown when a multi provider and a regular provider are bound to the same token.
+ *
+ * @example
+ * This example shows what can cause this error to be thrown
  *
  * ```typescript
  * expect(() => Injector.resolveAndCreate([

--- a/packages/core/src/di/reflective_errors.ts
+++ b/packages/core/src/di/reflective_errors.ts
@@ -70,7 +70,7 @@ function addKey(this: InjectionError, injector: ReflectiveInjector, key: Reflect
  * Thrown when trying to retrieve a dependency by key from {@link Injector}, but the
  * {@link Injector} does not have a {@link Provider} for the given key.
  *
- * ### Example ([live demo](http://plnkr.co/edit/vq8D3FRB9aGbnWJqtEPE?p=preview))
+ * **Example** ([live demo](http://plnkr.co/edit/vq8D3FRB9aGbnWJqtEPE?p=preview))
  *
  * ```typescript
  * class A {
@@ -90,7 +90,7 @@ export function noProviderError(injector: ReflectiveInjector, key: ReflectiveKey
 /**
  * Thrown when dependencies form a cycle.
  *
- * ### Example ([live demo](http://plnkr.co/edit/wYQdNos0Tzql3ei1EV9j?p=info))
+ * **Example** ([live demo](http://plnkr.co/edit/wYQdNos0Tzql3ei1EV9j?p=info))
  *
  * ```typescript
  * var injector = Injector.resolveAndCreate([
@@ -116,7 +116,7 @@ export function cyclicDependencyError(
  * The `InstantiationError` class contains the original error plus the dependency graph which caused
  * this object to be instantiated.
  *
- * ### Example ([live demo](http://plnkr.co/edit/7aWYdcqTQsP0eNqEdUAf?p=preview))
+ * **Example** ([live demo](http://plnkr.co/edit/7aWYdcqTQsP0eNqEdUAf?p=preview))
  *
  * ```typescript
  * class A {
@@ -149,7 +149,7 @@ export function instantiationError(
  * Thrown when an object other then {@link Provider} (or `Type`) is passed to {@link Injector}
  * creation.
  *
- * ### Example ([live demo](http://plnkr.co/edit/YatCFbPAMCL0JSSQ4mvH?p=preview))
+ * **Example** ([live demo](http://plnkr.co/edit/YatCFbPAMCL0JSSQ4mvH?p=preview))
  *
  * ```typescript
  * expect(() => Injector.resolveAndCreate(["not a type"])).toThrowError();
@@ -166,7 +166,7 @@ export function invalidProviderError(provider: any) {
  * Lack of annotation information prevents the {@link Injector} from determining which dependencies
  * need to be injected into the constructor.
  *
- * ### Example ([live demo](http://plnkr.co/edit/rHnZtlNS7vJOPQ6pcVkm?p=preview))
+ * **Example** ([live demo](http://plnkr.co/edit/rHnZtlNS7vJOPQ6pcVkm?p=preview))
  *
  * ```typescript
  * class A {
@@ -209,7 +209,7 @@ export function noAnnotationError(typeOrFunc: Type<any>| Function, params: any[]
 /**
  * Thrown when getting an object by index.
  *
- * ### Example ([live demo](http://plnkr.co/edit/bRs0SX2OTQiJzqvjgl8P?p=preview))
+ * **Example** ([live demo](http://plnkr.co/edit/bRs0SX2OTQiJzqvjgl8P?p=preview))
  *
  * ```typescript
  * class A {}
@@ -227,8 +227,6 @@ export function outOfBoundsError(index: number) {
 // TODO: add a working example after alpha38 is released
 /**
  * Thrown when a multi provider and a regular provider are bound to the same token.
- *
- * ### Example
  *
  * ```typescript
  * expect(() => Injector.resolveAndCreate([

--- a/packages/core/src/di/reflective_injector.ts
+++ b/packages/core/src/di/reflective_injector.ts
@@ -26,7 +26,7 @@ const UNDEFINED = new Object();
  * In typical use, application code asks for the dependencies in the constructor and they are
  * resolved by the `Injector`.
  *
- * ### Example ([live demo](http://plnkr.co/edit/jzjec0?p=preview))
+ * **Example** ([live demo](http://plnkr.co/edit/jzjec0?p=preview))
  *
  * The following example creates an `Injector` configured to create `Engine` and `Car`.
  *
@@ -58,7 +58,7 @@ export abstract class ReflectiveInjector implements Injector {
    * A resolution is a process of flattening multiple nested arrays and converting individual
    * providers into an array of {@link ResolvedReflectiveProvider}s.
    *
-   * ### Example ([live demo](http://plnkr.co/edit/AiXTHi?p=preview))
+   * **Example** ([live demo](http://plnkr.co/edit/AiXTHi?p=preview))
    *
    * ```typescript
    * @Injectable()
@@ -95,7 +95,7 @@ export abstract class ReflectiveInjector implements Injector {
    * The passed-in providers can be an array of `Type`, {@link Provider},
    * or a recursive array of more providers.
    *
-   * ### Example ([live demo](http://plnkr.co/edit/ePOccA?p=preview))
+   * **Example** ([live demo](http://plnkr.co/edit/ePOccA?p=preview))
    *
    * ```typescript
    * @Injectable()
@@ -126,7 +126,7 @@ export abstract class ReflectiveInjector implements Injector {
    *
    * This API is the recommended way to construct injectors in performance-sensitive parts.
    *
-   * ### Example ([live demo](http://plnkr.co/edit/KrSMci?p=preview))
+   * **Example** ([live demo](http://plnkr.co/edit/KrSMci?p=preview))
    *
    * ```typescript
    * @Injectable()
@@ -156,7 +156,7 @@ export abstract class ReflectiveInjector implements Injector {
    * <!-- TODO: Add a link to the section of the user guide talking about hierarchical injection.
    * -->
    *
-   * ### Example ([live demo](http://plnkr.co/edit/eosMGo?p=preview))
+   * **Example** ([live demo](http://plnkr.co/edit/eosMGo?p=preview))
    *
    * ```typescript
    * var parent = ReflectiveInjector.resolveAndCreate([]);
@@ -175,7 +175,7 @@ export abstract class ReflectiveInjector implements Injector {
    * The passed-in providers can be an array of `Type`, {@link Provider},
    * or a recursive array of more providers.
    *
-   * ### Example ([live demo](http://plnkr.co/edit/opB3T4?p=preview))
+   * **Example** ([live demo](http://plnkr.co/edit/opB3T4?p=preview))
    *
    * ```typescript
    * class ParentProvider {}
@@ -204,7 +204,7 @@ export abstract class ReflectiveInjector implements Injector {
    *
    * This API is the recommended way to construct injectors in performance-sensitive parts.
    *
-   * ### Example ([live demo](http://plnkr.co/edit/VhyfjN?p=preview))
+   * **Example** ([live demo](http://plnkr.co/edit/VhyfjN?p=preview))
    *
    * ```typescript
    * class ParentProvider {}
@@ -228,7 +228,7 @@ export abstract class ReflectiveInjector implements Injector {
    *
    * The created object does not get cached by the injector.
    *
-   * ### Example ([live demo](http://plnkr.co/edit/yvVXoB?p=preview))
+   * **Example** ([live demo](http://plnkr.co/edit/yvVXoB?p=preview))
    *
    * ```typescript
    * @Injectable()
@@ -254,7 +254,7 @@ export abstract class ReflectiveInjector implements Injector {
    *
    * The created object does not get cached by the injector.
    *
-   * ### Example ([live demo](http://plnkr.co/edit/ptCImQ?p=preview))
+   * **Example** ([live demo](http://plnkr.co/edit/ptCImQ?p=preview))
    *
    * ```typescript
    * @Injectable()

--- a/packages/core/src/di/reflective_injector.ts
+++ b/packages/core/src/di/reflective_injector.ts
@@ -26,7 +26,8 @@ const UNDEFINED = new Object();
  * In typical use, application code asks for the dependencies in the constructor and they are
  * resolved by the `Injector`.
  *
- * **Example** ([live demo](http://plnkr.co/edit/jzjec0?p=preview))
+ * @example
+ * This example shows how to use this class ([live demo](http://plnkr.co/edit/jzjec0?p=preview)):
  *
  * The following example creates an `Injector` configured to create `Engine` and `Car`.
  *
@@ -56,9 +57,10 @@ export abstract class ReflectiveInjector implements Injector {
    * Turns an array of provider definitions into an array of resolved providers.
    *
    * A resolution is a process of flattening multiple nested arrays and converting individual
-   * providers into an array of {@link ResolvedReflectiveProvider}s.
+   * providers into an array of `ResolvedReflectiveProvider`s.
    *
-   * **Example** ([live demo](http://plnkr.co/edit/AiXTHi?p=preview))
+   * @example
+   * This example shows how to use this method ([live demo](http://plnkr.co/edit/AiXTHi?p=preview)):
    *
    * ```typescript
    * @Injectable()
@@ -92,10 +94,11 @@ export abstract class ReflectiveInjector implements Injector {
   /**
    * Resolves an array of providers and creates an injector from those providers.
    *
-   * The passed-in providers can be an array of `Type`, {@link Provider},
+   * The passed-in providers can be an array of `Type`, `Provider`,
    * or a recursive array of more providers.
    *
-   * **Example** ([live demo](http://plnkr.co/edit/ePOccA?p=preview))
+   * @example
+   * This example shows how to use this method ([live demo](http://plnkr.co/edit/ePOccA?p=preview)):
    *
    * ```typescript
    * @Injectable()
@@ -126,7 +129,8 @@ export abstract class ReflectiveInjector implements Injector {
    *
    * This API is the recommended way to construct injectors in performance-sensitive parts.
    *
-   * **Example** ([live demo](http://plnkr.co/edit/KrSMci?p=preview))
+   * @example
+   * This example shows how to use this method ([live demo](http://plnkr.co/edit/KrSMci?p=preview)):
    *
    * ```typescript
    * @Injectable()
@@ -156,7 +160,8 @@ export abstract class ReflectiveInjector implements Injector {
    * <!-- TODO: Add a link to the section of the user guide talking about hierarchical injection.
    * -->
    *
-   * **Example** ([live demo](http://plnkr.co/edit/eosMGo?p=preview))
+   * @example
+   * This example shows how to use this method ([live demo](http://plnkr.co/edit/eosMGo?p=preview)):
    *
    * ```typescript
    * var parent = ReflectiveInjector.resolveAndCreate([]);
@@ -172,10 +177,11 @@ export abstract class ReflectiveInjector implements Injector {
    * <!-- TODO: Add a link to the section of the user guide talking about hierarchical injection.
    * -->
    *
-   * The passed-in providers can be an array of `Type`, {@link Provider},
+   * The passed-in providers can be an array of `Type`, `Provider`,
    * or a recursive array of more providers.
    *
-   * **Example** ([live demo](http://plnkr.co/edit/opB3T4?p=preview))
+   * @example
+   * This example shows how to use this method ([live demo](http://plnkr.co/edit/opB3T4?p=preview)):
    *
    * ```typescript
    * class ParentProvider {}
@@ -204,7 +210,8 @@ export abstract class ReflectiveInjector implements Injector {
    *
    * This API is the recommended way to construct injectors in performance-sensitive parts.
    *
-   * **Example** ([live demo](http://plnkr.co/edit/VhyfjN?p=preview))
+   * @example
+   * This example shows how to use this method ([live demo](http://plnkr.co/edit/VhyfjN?p=preview)):
    *
    * ```typescript
    * class ParentProvider {}
@@ -228,7 +235,8 @@ export abstract class ReflectiveInjector implements Injector {
    *
    * The created object does not get cached by the injector.
    *
-   * **Example** ([live demo](http://plnkr.co/edit/yvVXoB?p=preview))
+   * @example
+   * This example shows how to use this method ([live demo](http://plnkr.co/edit/yvVXoB?p=preview)):
    *
    * ```typescript
    * @Injectable()
@@ -254,7 +262,8 @@ export abstract class ReflectiveInjector implements Injector {
    *
    * The created object does not get cached by the injector.
    *
-   * **Example** ([live demo](http://plnkr.co/edit/ptCImQ?p=preview))
+   * @example
+   * This example shows how to use this method ([live demo](http://plnkr.co/edit/ptCImQ?p=preview)):
    *
    * ```typescript
    * @Injectable()

--- a/packages/core/src/di/reflective_provider.ts
+++ b/packages/core/src/di/reflective_provider.ts
@@ -42,7 +42,9 @@ const _EMPTY_LIST: any[] = [];
  *
  * It can be created manually, as follows:
  *
- * **Example** ([live demo](http://plnkr.co/edit/RfEnhh8kUEI0G3qsnIeT?p%3Dpreview&p=preview))
+ * @example
+ * This example shows how to specify this type of provider
+ * ([live demo](http://plnkr.co/edit/RfEnhh8kUEI0G3qsnIeT?p%3Dpreview&p=preview)):
  *
  * ```typescript
  * var resolvedProviders = Injector.resolve([{ provide: 'message', useValue: 'Hello' }]);

--- a/packages/core/src/di/reflective_provider.ts
+++ b/packages/core/src/di/reflective_provider.ts
@@ -42,7 +42,7 @@ const _EMPTY_LIST: any[] = [];
  *
  * It can be created manually, as follows:
  *
- * ### Example ([live demo](http://plnkr.co/edit/RfEnhh8kUEI0G3qsnIeT?p%3Dpreview&p=preview))
+ * **Example** ([live demo](http://plnkr.co/edit/RfEnhh8kUEI0G3qsnIeT?p%3Dpreview&p=preview))
  *
  * ```typescript
  * var resolvedProviders = Injector.resolve([{ provide: 'message', useValue: 'Hello' }]);

--- a/packages/core/src/error_handler.ts
+++ b/packages/core/src/error_handler.ts
@@ -11,15 +11,11 @@ import {ERROR_ORIGINAL_ERROR, getDebugContext, getErrorLogger, getOriginalError}
 
 
 /**
- *
- * @description
  * Provides a hook for centralized exception handling.
  *
  * The default implementation of `ErrorHandler` prints error messages to the `console`. To
  * intercept error handling, write a custom exception handler that replaces this default as
  * appropriate for your app.
- *
- * ### Example
  *
  * ```
  * class MyErrorHandler implements ErrorHandler {

--- a/packages/core/src/error_handler.ts
+++ b/packages/core/src/error_handler.ts
@@ -17,6 +17,9 @@ import {ERROR_ORIGINAL_ERROR, getDebugContext, getErrorLogger, getOriginalError}
  * intercept error handling, write a custom exception handler that replaces this default as
  * appropriate for your app.
  *
+ * @example
+ * This example shows show to implement a custom `ErrorHandler`:
+ *
  * ```
  * class MyErrorHandler implements ErrorHandler {
  *   handleError(error) {

--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -11,6 +11,7 @@ import {Subject, Subscription} from 'rxjs';
 /**
  * Use by directives and components to emit custom Events.
  *
+ * @example
  * In the following example, `Zippy` alternatively emits `open` and `close` events when its
  * title gets clicked:
  *
@@ -47,6 +48,7 @@ import {Subject, Subscription} from 'rxjs';
  * <zippy (open)="onOpen($event)" (close)="onClose($event)"></zippy>
  * ```
  *
+ * @usageNotes
  * Uses `Rx.Observable` but provides an adapter to make it work as specified here:
  * https://github.com/jhusain/observable-spec
  *

--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -11,8 +11,6 @@ import {Subject, Subscription} from 'rxjs';
 /**
  * Use by directives and components to emit custom Events.
  *
- * ### Examples
- *
  * In the following example, `Zippy` alternatively emits `open` and `close` events when its
  * title gets clicked:
  *
@@ -49,7 +47,7 @@ import {Subject, Subscription} from 'rxjs';
  * <zippy (open)="onOpen($event)" (close)="onClose($event)"></zippy>
  * ```
  *
- * Uses Rx.Observable but provides an adapter to make it work as specified here:
+ * Uses `Rx.Observable` but provides an adapter to make it work as specified here:
  * https://github.com/jhusain/observable-spec
  *
  * Once a reference implementation of the spec is available, switch to it.

--- a/packages/core/src/i18n/tokens.ts
+++ b/packages/core/src/i18n/tokens.ts
@@ -15,7 +15,7 @@ import {InjectionToken} from '../di/injection_token';
  *
  * See the {@linkDocs guide/i18n#setting-up-locale i18n guide} for more information.
  *
- * ### Example
+ * **Example:**
  *
  * ```typescript
  * import { LOCALE_ID } from '@angular/core';
@@ -37,7 +37,7 @@ export const LOCALE_ID = new InjectionToken<string>('LocaleId');
  *
  * See the {@linkDocs guide/i18n#merge i18n guide} for more information.
  *
- * ### Example
+ * **Example:**
  *
  * ```typescript
  * import { TRANSLATIONS } from '@angular/core';
@@ -62,7 +62,7 @@ export const TRANSLATIONS = new InjectionToken<string>('Translations');
  *
  * See the {@linkDocs guide/i18n#merge i18n guide} for more information.
  *
- * ### Example
+ * **Example:**
  *
  * ```typescript
  * import { TRANSLATIONS_FORMAT } from '@angular/core';
@@ -87,7 +87,8 @@ export const TRANSLATIONS_FORMAT = new InjectionToken<string>('TranslationsForma
  *
  * See the {@linkDocs guide/i18n#missing-translation i18n guide} for more information.
  *
- * ### Example
+ * **Example:**
+ *
  * ```typescript
  * import { MissingTranslationStrategy } from '@angular/core';
  * import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';

--- a/packages/core/src/i18n/tokens.ts
+++ b/packages/core/src/i18n/tokens.ts
@@ -13,9 +13,10 @@ import {InjectionToken} from '../di/injection_token';
  * It is used for i18n extraction, by i18n pipes (DatePipe, I18nPluralPipe, CurrencyPipe,
  * DecimalPipe and PercentPipe) and by ICU expressions.
  *
- * See the {@linkDocs guide/i18n#setting-up-locale i18n guide} for more information.
+ * See the [i18n guide](/guide/i18n#setting-up-locale) for more information.
  *
- * **Example:**
+ * @example
+ * This example shows how you can use this token.
  *
  * ```typescript
  * import { LOCALE_ID } from '@angular/core';
@@ -35,9 +36,10 @@ export const LOCALE_ID = new InjectionToken<string>('LocaleId');
  * Use this token at bootstrap to provide the content of your translation file (`xtb`,
  * `xlf` or `xlf2`) when you want to translate your application in another language.
  *
- * See the {@linkDocs guide/i18n#merge i18n guide} for more information.
+ * See the [i18n guide](/guide/i18n#merge) for more information.
  *
- * **Example:**
+ * @example
+ * This example shows how you can use this token.
  *
  * ```typescript
  * import { TRANSLATIONS } from '@angular/core';
@@ -57,12 +59,13 @@ export const LOCALE_ID = new InjectionToken<string>('LocaleId');
 export const TRANSLATIONS = new InjectionToken<string>('Translations');
 
 /**
- * Provide this token at bootstrap to set the format of your {@link TRANSLATIONS}: `xtb`,
+ * Provide this token at bootstrap to set the format of your `TRANSLATIONS`: `xtb`,
  * `xlf` or `xlf2`.
  *
- * See the {@linkDocs guide/i18n#merge i18n guide} for more information.
+ * See the [i18n guide](/guide/i18n#merge) for more information.
  *
- * **Example:**
+ * @example
+ * This example shows how you can use this token.
  *
  * ```typescript
  * import { TRANSLATIONS_FORMAT } from '@angular/core';
@@ -85,9 +88,10 @@ export const TRANSLATIONS_FORMAT = new InjectionToken<string>('TranslationsForma
  * - Warning (default): show a warning in the console and/or shell.
  * - Ignore: do nothing.
  *
- * See the {@linkDocs guide/i18n#missing-translation i18n guide} for more information.
+ * See the [i18n guide](/guide/i18n#missing-translation) for more information.
  *
- * **Example:**
+ * @example
+ * This example shows how you can use this token.
  *
  * ```typescript
  * import { MissingTranslationStrategy } from '@angular/core';

--- a/packages/core/src/linker/query_list.ts
+++ b/packages/core/src/linker/query_list.ts
@@ -27,7 +27,9 @@ import {getSymbolIterator} from '../util';
  *
  * NOTE: In the future this class will implement an `Observable` interface.
  *
- * ### Example ([live demo](http://plnkr.co/edit/RX8sJnQYl9FWuSCWme5z?p=preview))
+ * The following example shows use of `QueryList`
+ * ([live demo](http://plnkr.co/edit/RX8sJnQYl9FWuSCWme5z?p=preview))
+ *
  * ```typescript
  * @Component({...})
  * class Container {

--- a/packages/core/src/linker/query_list.ts
+++ b/packages/core/src/linker/query_list.ts
@@ -27,6 +27,7 @@ import {getSymbolIterator} from '../util';
  *
  * NOTE: In the future this class will implement an `Observable` interface.
  *
+ * @example
  * The following example shows use of `QueryList`
  * ([live demo](http://plnkr.co/edit/RX8sJnQYl9FWuSCWme5z?p=preview))
  *

--- a/packages/core/src/linker/view_ref.ts
+++ b/packages/core/src/linker/view_ref.ts
@@ -36,8 +36,6 @@ export abstract class ViewRef extends ChangeDetectorRef {
  * removing nested Views via a {@link ViewContainerRef}. Each View can contain many View Containers.
  * <!-- /TODO -->
  *
- * ### Example
- *
  * Given this template...
  *
  * ```

--- a/packages/core/src/linker/view_ref.ts
+++ b/packages/core/src/linker/view_ref.ts
@@ -36,6 +36,7 @@ export abstract class ViewRef extends ChangeDetectorRef {
  * removing nested Views via a {@link ViewContainerRef}. Each View can contain many View Containers.
  * <!-- /TODO -->
  *
+ * @example
  * Given this template...
  *
  * ```

--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -16,6 +16,7 @@ import {makeParamDecorator, makePropDecorator} from '../util/decorators';
  * All components that are referenced in the `useValue` value (either directly
  * or in a nested array or map) will be added to the `entryComponents` property.
  *
+ * @example
  * The following example shows how the router can populate the `entryComponents`
  * field of an NgModule based on the router configuration which refers
  * to components.
@@ -56,6 +57,7 @@ export interface AttributeDecorator {
    *
    * The directive can inject constant string literals of host element attributes.
    *
+   * @example
    * Suppose we have an `<input>` element and want to know its `type`.
    *
    * ```html
@@ -64,13 +66,15 @@ export interface AttributeDecorator {
    *
    * A decorator can inject the string literal `text` like so:
    *
-   * {@example core/ts/metadata/metadata.ts region='attributeMetadata'}
+   * <code-example path="core/ts/metadata/metadata.ts" region="attributeMetadata"></code-example>
    *
-   * **Use as a TypeScript decorator:**
+   * @example
+   * This example shows how to use this as a TypeScript decorator:
    *
-   * {@example core/ts/metadata/metadata.ts region='attributeFactory'}
+   * <code-example path="core/ts/metadata/metadata.ts" region="attributeFactory"></code-example>
    *
-   * **Use as an ES5 annotation:**
+   * @example
+   * This example shows how to use this as an ES5 annotation:
    *
    * ```
    * var MyComponent = function(title) {
@@ -145,13 +149,14 @@ export interface ContentChildrenDecorator {
    * * **descendants** - include only direct children or all descendants.
    * * **read** - read a different token from the queried elements.
    *
+   * @example
    * Let's look at an example:
    *
-   * {@example core/di/ts/contentChildren/content_children_example.ts region='Component'}
+   * <code-example path="core/di/ts/contentChildren/content_children_example.ts" region="Component"></code-example>?
    *
    * @usageNotes
    *
-   * {@example core/di/ts/contentChildren/content_children_howto.ts region='HowTo'}
+   * <code-example path="core/di/ts/contentChildren/content_children_howto.ts" region="HowTo"></code-example>?
    *
    * @Annotation
    */
@@ -195,13 +200,14 @@ export interface ContentChildDecorator {
    * * **selector** - the directive type or the name used for querying.
    * * **read** - read a different token from the queried element.
    *
+   * @example
    * Let's look at an example:
    *
-   * {@example core/di/ts/contentChild/content_child_example.ts region='Component'}
+   * <code-example path="core/di/ts/contentChild/content_child_example.ts" region="Component"></code-example>
    *
    * @usageNotes
    *
-   * {@example core/di/ts/contentChild/content_child_howto.ts region='HowTo'}
+   * <code-example path="core/di/ts/contentChild/content_child_howto.ts" region="HowTo"></code-example>
    *
    * @Annotation
    */
@@ -249,13 +255,14 @@ export interface ViewChildrenDecorator {
    * * **selector** - the directive type or the name used for querying.
    * * **read** - read a different token from the queried elements.
    *
+   * @example
    * Let's look at an example:
    *
-   * {@example core/di/ts/viewChildren/view_children_example.ts region='Component'}
+   * <code-example path="core/di/ts/viewChildren/view_children_example.ts" region="Component"></code-example>
    *
    * @usageNotes
    *
-   * {@example core/di/ts/viewChildren/view_children_howto.ts region='HowTo'}
+   * <code-example path="core/di/ts/viewChildren/view_children_howto.ts" region="HowTo"></code-example>
    *
    * @Annotation
    */
@@ -287,9 +294,9 @@ export interface ViewChildDecorator {
   /**
    * Configures a view query.
    *
-   * You can use ViewChild to get the first element or the directive matching the selector from the
-   * view DOM. If the view DOM changes, and a new child matches the selector,
-   * the property will be updated.
+   * You can use `@ViewChild()` to get the first element or the directive matching the selector
+   * from the view DOM.
+   * If the view DOM changes, and a new child matches the selector, the property will be updated.
    *
    * View queries are set before the `ngAfterViewInit` callback is called.
    *
@@ -298,11 +305,14 @@ export interface ViewChildDecorator {
    * * **selector** - the directive type or the name used for querying.
    * * **read** - read a different token from the queried elements.
    *
-   * {@example core/di/ts/viewChild/view_child_example.ts region='Component'}
+   * @example
+   * This example shows how you can use this decorator.
+   *
+   * <code-example path="core/di/ts/viewChild/view_child_example.ts" region="Component"></code-example>
    *
    * @usageNotes
    *
-   * {@example core/di/ts/viewChild/view_child_howto.ts region='HowTo'}
+   * <code-example path="core/di/ts/viewChild/view_child_howto.ts" region="HowTo"></code-example>
    *
    * @Annotation
    */

--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -16,7 +16,6 @@ import {makeParamDecorator, makePropDecorator} from '../util/decorators';
  * All components that are referenced in the `useValue` value (either directly
  * or in a nested array or map) will be added to the `entryComponents` property.
  *
- * ### Example
  * The following example shows how the router can populate the `entryComponents`
  * field of an NgModule based on the router configuration which refers
  * to components.
@@ -57,23 +56,21 @@ export interface AttributeDecorator {
    *
    * The directive can inject constant string literals of host element attributes.
    *
-   * ### Example
-   *
    * Suppose we have an `<input>` element and want to know its `type`.
    *
    * ```html
    * <input type="text">
    * ```
    *
-   * A decorator can inject string literal `text` like so:
+   * A decorator can inject the string literal `text` like so:
    *
    * {@example core/ts/metadata/metadata.ts region='attributeMetadata'}
    *
-   * ### Example as TypeScript Decorator
+   * **Use as a TypeScript decorator:**
    *
    * {@example core/ts/metadata/metadata.ts region='attributeFactory'}
    *
-   * ### Example as ES5 annotation
+   * **Use as an ES5 annotation:**
    *
    * ```
    * var MyComponent = function(title) {
@@ -87,8 +84,6 @@ export interface AttributeDecorator {
    *   [new ng.Attribute('title')]
    * ]
    * ```
-   *
-   *
    */
   (name: string): any;
   new (name: string): Attribute;
@@ -103,7 +98,6 @@ export interface Attribute { attributeName?: string; }
 /**
  * Attribute decorator and metadata.
  *
- *
  * @Annotation
  */
 export const Attribute: AttributeDecorator =
@@ -111,8 +105,6 @@ export const Attribute: AttributeDecorator =
 
 /**
  * Type of the Query metadata.
- *
- *
  */
 export interface Query {
   descendants: boolean;
@@ -125,9 +117,7 @@ export interface Query {
 /**
  * Base class for query metadata.
  *
- * See {@link ContentChildren}, {@link ContentChild}, {@link ViewChildren}, {@link ViewChild} for
- * more information.
- *
+ * See `ContentChildren`, `ContentChild`, `ViewChildren`, `ViewChild` for more information.
  *
  */
 export abstract class Query {}
@@ -135,21 +125,14 @@ export abstract class Query {}
 /**
  * Type of the ContentChildren decorator / constructor function.
  *
- * See {@link ContentChildren}.
- *
+ * See `ContentChildren`.
  *
  */
 export interface ContentChildrenDecorator {
   /**
-   *
-   * @usageNotes
-   *
-   * {@example core/di/ts/contentChildren/content_children_howto.ts region='HowTo'}
-   *
-   * @description
    * Configures a content query.
    *
-   * You can use ContentChildren to get the {@link QueryList} of elements or directives from the
+   * You can use ContentChildren to get the `QueryList` of elements or directives from the
    * content DOM. Any time a child element is added, removed, or moved, the query list will be
    * updated,
    * and the changes observable of the query list will emit a new value.
@@ -166,8 +149,9 @@ export interface ContentChildrenDecorator {
    *
    * {@example core/di/ts/contentChildren/content_children_example.ts region='Component'}
    *
-   * **npm package**: `@angular/core`
+   * @usageNotes
    *
+   * {@example core/di/ts/contentChildren/content_children_howto.ts region='HowTo'}
    *
    * @Annotation
    */
@@ -178,14 +162,12 @@ export interface ContentChildrenDecorator {
 /**
  * Type of the ContentChildren metadata.
  *
- *
  * @Annotation
  */
 export type ContentChildren = Query;
 
 /**
  * ContentChildren decorator and metadata.
- *
  *
  *  @Annotation
  */
@@ -197,18 +179,9 @@ export const ContentChildren: ContentChildrenDecorator = makePropDecorator(
 
 /**
  * Type of the ContentChild decorator / constructor function.
- *
- *
- *
  */
 export interface ContentChildDecorator {
   /**
-   *
-   * @usageNotes
-   *
-   * {@example core/di/ts/contentChild/content_child_howto.ts region='HowTo'}
-   *
-   * @description
    * Configures a content query.
    *
    * You can use ContentChild to get the first element or the directive matching the selector from
@@ -226,8 +199,9 @@ export interface ContentChildDecorator {
    *
    * {@example core/di/ts/contentChild/content_child_example.ts region='Component'}
    *
-   * **npm package**: `@angular/core`
+   * @usageNotes
    *
+   * {@example core/di/ts/contentChild/content_child_howto.ts region='HowTo'}
    *
    * @Annotation
    */
@@ -238,7 +212,7 @@ export interface ContentChildDecorator {
 /**
  * Type of the ContentChild metadata.
  *
- * See {@link ContentChild}.
+ * See `ContentChild`.
  *
  *
  */
@@ -246,7 +220,6 @@ export type ContentChild = Query;
 
 /**
  * ContentChild decorator and metadata.
- *
  *
  * @Annotation
  */
@@ -258,21 +231,14 @@ export const ContentChild: ContentChildDecorator = makePropDecorator(
 /**
  * Type of the ViewChildren decorator / constructor function.
  *
- * See {@link ViewChildren}.
- *
+ * See `ViewChildren`.
  *
  */
 export interface ViewChildrenDecorator {
   /**
-   *
-   * @usageNotes
-   *
-   * {@example core/di/ts/viewChildren/view_children_howto.ts region='HowTo'}
-   *
-   * @description
    * Configures a view query.
    *
-   * You can use ViewChildren to get the {@link QueryList} of elements or directives from the
+   * You can use `ViewChildren` to get the `QueryList` of elements or directives from the
    * view DOM. Any time a child element is added, removed, or moved, the query list will be updated,
    * and the changes observable of the query list will emit a new value.
    *
@@ -287,8 +253,9 @@ export interface ViewChildrenDecorator {
    *
    * {@example core/di/ts/viewChildren/view_children_example.ts region='Component'}
    *
-   * **npm package**: `@angular/core`
+   * @usageNotes
    *
+   * {@example core/di/ts/viewChildren/view_children_howto.ts region='HowTo'}
    *
    * @Annotation
    */
@@ -298,14 +265,11 @@ export interface ViewChildrenDecorator {
 
 /**
  * Type of the ViewChildren metadata.
- *
- *
  */
 export type ViewChildren = Query;
 
 /**
  * ViewChildren decorator and metadata.
- *
  *
  * @Annotation
  */
@@ -317,18 +281,10 @@ export const ViewChildren: ViewChildrenDecorator = makePropDecorator(
 /**
  * Type of the ViewChild decorator / constructor function.
  *
- * See {@link ViewChild}
- *
- *
+ * See `ViewChild`
  */
 export interface ViewChildDecorator {
   /**
-   *
-   * @usageNotes
-   *
-   * {@example core/di/ts/viewChild/view_child_howto.ts region='HowTo'}
-   *
-   * @description
    * Configures a view query.
    *
    * You can use ViewChild to get the first element or the directive matching the selector from the
@@ -344,8 +300,9 @@ export interface ViewChildDecorator {
    *
    * {@example core/di/ts/viewChild/view_child_example.ts region='Component'}
    *
-   * **npm package**: `@angular/core`
+   * @usageNotes
    *
+   * {@example core/di/ts/viewChild/view_child_howto.ts region='HowTo'}
    *
    * @Annotation
    */
@@ -355,14 +312,11 @@ export interface ViewChildDecorator {
 
 /**
  * Type of the ViewChild metadata.
- *
- *
  */
 export type ViewChild = Query;
 
 /**
  * ViewChild decorator and metadata.
- *
  *
  * @Annotation
  */

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -71,7 +71,7 @@ export interface DirectiveDecorator {
   (obj: Directive): TypeDecorator;
 
   /**
-   * See the {@link Directive} decorator.
+   * See the `Directive` decorator.
    */
   new (obj: Directive): Directive;
 }
@@ -92,8 +92,6 @@ export interface Directive {
    * - `:not(sub_selector)`: select only if the element does not match the `sub_selector`.
    * - `selector1, selector2`: select if either `selector1` or `selector2` matches.
    *
-   *
-   * ### Example
    *
    * Suppose we have a directive with an `input[type=text]` selector.
    *
@@ -124,9 +122,8 @@ export interface Directive {
    *
    * When `bindingProperty` is not provided, it is assumed to be equal to `directiveProperty`.
    *
-   * ### Example ([live demo](http://plnkr.co/edit/ivhfXY?p=preview))
-   *
-   * The following example creates a component with two data-bound properties.
+   * The following example creates a component with two data-bound properties
+   * ([live demo](http://plnkr.co/edit/ivhfXY?p=preview)):
    *
    * ```typescript
    * @Component({
@@ -169,7 +166,8 @@ export interface Directive {
    * - `directiveProperty` specifies the component property that emits events.
    * - `bindingProperty` specifies the DOM property the event handler is attached to.
    *
-   * ### Example ([live demo](http://plnkr.co/edit/d5CNq7?p=preview))
+   * The following example shows how to use the `outputs` property
+   * ([live demo](http://plnkr.co/edit/d5CNq7?p=preview)):
    *
    * ```typescript
    * @Directive({
@@ -205,7 +203,7 @@ export interface Directive {
   /**
    * Specify the events, actions, properties and attributes related to the host element.
    *
-   * ## Host Listeners
+   * **Host Listeners:**
    *
    * Specifies which DOM events a directive listens to via a set of `(event)` to `method`
    * key-value pairs:
@@ -220,10 +218,9 @@ export interface Directive {
    *
    * When writing a directive event binding, you can also refer to the $event local variable.
    *
-   * ### Example ([live demo](http://plnkr.co/edit/DlA5KU?p=preview))
-   *
    * The following example declares a directive that attaches a click listener to the button and
-   * counts clicks.
+   * counts clicks
+   * ([live demo](http://plnkr.co/edit/DlA5KU?p=preview)):
    *
    * ```typescript
    * @Directive({
@@ -247,17 +244,16 @@ export interface Directive {
    * class App {}
    * ```
    *
-   * ## Host Property Bindings
+   * **Host Property Bindings**
    *
    * Specifies which DOM properties a directive updates.
    *
    * Angular automatically checks host property bindings during change detection.
    * If a binding changes, it will update the host element of the directive.
    *
-   * ### Example ([live demo](http://plnkr.co/edit/gNg0ED?p=preview))
-   *
    * The following example creates a directive that sets the `valid` and `invalid` classes
-   * on the DOM element that has ngModel directive on it.
+   * on the DOM element that has ngModel directive on it
+   * ([live demo](http://plnkr.co/edit/gNg0ED?p=preview)):
    *
    * ```typescript
    * @Directive({
@@ -282,14 +278,12 @@ export interface Directive {
    * }
    * ```
    *
-   * ## Attributes
+   * **Attributes**
    *
    * Specifies static attributes that should be propagated to a host element.
    *
-   * ### Example
-   *
-   * In this example using `my-button` directive (ex.: `<div my-button></div>`) on a host element
-   * (here: `<div>` ) will ensure that this element will get the "button" role.
+   * The following example, using `my-button` directive (ex.: `<div my-button></div>`) on a host
+   * element (here: `<div>` ), shows that this element will get the "button" role:
    *
    * ```typescript
    * @Directive({
@@ -307,8 +301,6 @@ export interface Directive {
   /**
    * Defines the set of injectable objects that are visible to a Directive and its light DOM
    * children.
-   *
-   * ## Simple Example
    *
    * Here is an example of a class that can be injected:
    *
@@ -339,7 +331,7 @@ export interface Directive {
   /**
    * Defines the name that can be used in the template to assign this directive to a variable.
    *
-   * ## Simple Example
+   * **Example**:
    *
    * ```
    * @Directive({
@@ -366,7 +358,7 @@ export interface Directive {
    * Content queries are set before the `ngAfterContentInit` callback is called.
    * View queries are set before the `ngAfterViewInit` callback is called.
    *
-   * ### Example
+   * **Example**:
    *
    * ```
    * @Component({
@@ -458,24 +450,21 @@ export interface ComponentDecorator {
    * * **templateUrl** - url to an external file containing a template for the view
    * * **viewProviders** - list of providers available to this component and its view children
    *
-   * ### Example
+   * **Example:**
    *
    * {@example core/ts/metadata/metadata.ts region='component'}
-   *
    *
    * @Annotation
    */
   (obj: Component): TypeDecorator;
   /**
-   * See the {@link Component} decorator.
+   * See the `Component` decorator.
    */
   new (obj: Component): Component;
 }
 
 /**
  * Type of the Component metadata.
- *
- *
  */
 export interface Component extends Directive {
   /**
@@ -491,8 +480,6 @@ export interface Component extends Directive {
 
   /**
    * Defines the set of injectable objects that are visible to its view DOM children.
-   *
-   * ## Simple Example
    *
    * Here is an example of a class that can be injected:
    *
@@ -534,8 +521,7 @@ export interface Component extends Directive {
    * In CommonJS, this can always be set to `module.id`, similarly SystemJS exposes `__moduleName`
    * variable within each module.
    *
-   *
-   * ## Simple Example
+   * **Example**:
    *
    * ```
    * @Directive({
@@ -585,8 +571,7 @@ export interface Component extends Directive {
    *
    * For animations to be available for use, animation state changes are placed within
    * {@link trigger animation triggers} which are housed inside of the `animations` annotation
-   * metadata. Within a trigger both {@link state state} and {@link transition transition} entries
-   * can be placed.
+   * metadata. Within a trigger both `state` and `transition` entries can be placed.
    *
    * ```typescript
    * @Component({
@@ -630,7 +615,7 @@ export interface Component extends Directive {
    * to a change of state between `on` and `off`). The `expression` value attached to the trigger
    * must be something that can be evaluated with the template/component context.
    *
-   * ### DSL Animation Functions
+   * **DSL Animation Functions**
    *
    * Please visit each of the animation DSL functions listed below to gain a better understanding
    * of how and why they are used for crafting animations in Angular:
@@ -656,7 +641,7 @@ export interface Component extends Directive {
    *   encapsulation.
    *
    * When no `encapsulation` is defined for the component, the default value from the
-   * {@link CompilerOptions} is used. The default is `ViewEncapsulation.Emulated`}. Provide a new
+   * `CompilerOptions` is used. The default is `ViewEncapsulation.Emulated`. Provide a new
    * `CompilerOptions` to override this value.
    *
    * If the encapsulation is set to `ViewEncapsulation.Emulated` and the component has no `styles`
@@ -672,8 +657,7 @@ export interface Component extends Directive {
   /**
    * Defines the components that should be compiled as well when
    * this component is defined. For each components listed here,
-   * Angular will create a {@link ComponentFactory} and store it in the
-   * {@link ComponentFactoryResolver}.
+   * Angular will create a `ComponentFactory` and store it in the `ComponentFactoryResolver`.
    */
   entryComponents?: Array<Type<any>|any[]>;
 
@@ -749,7 +733,6 @@ export interface Component extends Directive {
 /**
  * Component decorator and metadata.
  *
- *
  * @Annotation
  */
 export const Component: ComponentDecorator = makeDecorator(
@@ -758,8 +741,6 @@ export const Component: ComponentDecorator = makeDecorator(
 
 /**
  * Type of the Pipe decorator / constructor function.
- *
- *
  */
 export interface PipeDecorator {
   /**
@@ -772,15 +753,13 @@ export interface PipeDecorator {
   (obj: Pipe): TypeDecorator;
 
   /**
-   * See the {@link Pipe} decorator.
+   * See the `Pipe` decorator.
    */
   new (obj: Pipe): Pipe;
 }
 
 /**
  * Type of the Pipe metadata.
- *
- *
  */
 export interface Pipe {
   /**
@@ -808,11 +787,10 @@ export interface Pipe {
  * Pipe decorator and metadata.
  *
  * Use the `@Pipe` annotation to declare that a given class is a pipe. A pipe
- * class must also implement {@link PipeTransform} interface.
+ * class must also implement `PipeTransform` interface.
  *
  * To use the pipe include a reference to the pipe class in
  * {@link NgModule#declarations}.
- *
  *
  * @Annotation
  */
@@ -821,8 +799,6 @@ export const Pipe: PipeDecorator = makeDecorator('Pipe', (p: Pipe) => ({pure: tr
 
 /**
  * Type of the Input decorator / constructor function.
- *
- *
  */
 export interface InputDecorator {
   /**
@@ -833,8 +809,6 @@ export interface InputDecorator {
    * `Input` takes an optional parameter that specifies the name
    * used when instantiating a component in the template. When not provided,
    * the name of the decorated property is used.
-   *
-   * ### Example
    *
    * The following example creates a component with two input properties.
    *
@@ -871,8 +845,6 @@ export interface InputDecorator {
 
 /**
  * Type of the Input metadata.
- *
- *
  */
 export interface Input {
   /**
@@ -884,7 +856,6 @@ export interface Input {
 /**
  * Input decorator and metadata.
  *
- *
  * @Annotation
  */
 export const Input: InputDecorator =
@@ -892,8 +863,6 @@ export const Input: InputDecorator =
 
 /**
  * Type of the Output decorator / constructor function.
- *
- *
  */
 export interface OutputDecorator {
   /**
@@ -905,8 +874,6 @@ export interface OutputDecorator {
    * `Output` takes an optional parameter that specifies the name
    * used when instantiating a component in the template. When not provided,
    * the name of the decorated property is used.
-   *
-   * ### Example
    *
    * ```typescript
    * @Directive({
@@ -942,14 +909,11 @@ export interface OutputDecorator {
 
 /**
  * Type of the Output metadata.
- *
- *
  */
 export interface Output { bindingPropertyName?: string; }
 
 /**
  * Output decorator and metadata.
- *
  *
  * @Annotation
  */
@@ -959,8 +923,6 @@ export const Output: OutputDecorator =
 
 /**
  * Type of the HostBinding decorator / constructor function.
- *
- *
  */
 export interface HostBindingDecorator {
   /**
@@ -972,8 +934,6 @@ export interface HostBindingDecorator {
    * `HostBinding` takes an optional parameter that specifies the property
    * name of the host element that will be updated. When not provided,
    * the class property name is used.
-   *
-   * ### Example
    *
    * The following example creates a directive that sets the `valid` and `invalid` classes
    * on the DOM element that has ngModel directive on it.
@@ -1002,14 +962,11 @@ export interface HostBindingDecorator {
 
 /**
  * Type of the HostBinding metadata.
- *
- *
  */
 export interface HostBinding { hostPropertyName?: string; }
 
 /**
  * HostBinding decorator and metadata.
- *
  *
  * @Annotation
  */
@@ -1019,8 +976,6 @@ export const HostBinding: HostBindingDecorator =
 
 /**
  * Type of the HostListener decorator / constructor function.
- *
- *
  */
 export interface HostListenerDecorator {
   /**
@@ -1029,8 +984,6 @@ export interface HostListenerDecorator {
    * Angular will invoke the decorated method when the host element emits the specified event.
    *
    * If the decorated method returns `false`, then `preventDefault` is applied on the DOM event.
-   *
-   * ### Example
    *
    * The following example declares a directive that attaches a click listener to the button and
    * counts clicks.
@@ -1061,8 +1014,6 @@ export interface HostListenerDecorator {
 
 /**
  * Type of the HostListener metadata.
- *
- *
  */
 export interface HostListener {
   eventName?: string;
@@ -1071,7 +1022,6 @@ export interface HostListener {
 
 /**
  * HostListener decorator and metadata.
- *
  *
  * @Annotation
  */

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -203,7 +203,7 @@ export interface Directive {
   /**
    * Specify the events, actions, properties and attributes related to the host element.
    *
-   * **Host Listeners:**
+   * **Host Listeners**
    *
    * Specifies which DOM events a directive listens to via a set of `(event)` to `method`
    * key-value pairs:

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -331,7 +331,7 @@ export interface Directive {
   /**
    * Defines the name that can be used in the template to assign this directive to a variable.
    *
-   * **Example**:
+   * The following example demonstrates how to specify how a component is exported.
    *
    * ```
    * @Directive({
@@ -358,7 +358,8 @@ export interface Directive {
    * Content queries are set before the `ngAfterContentInit` callback is called.
    * View queries are set before the `ngAfterViewInit` callback is called.
    *
-   * **Example**:
+   * The following example demonstrates how to specify `contentChilden` and
+   * `viewChildren` queries on a component.
    *
    * ```
    * @Component({
@@ -450,7 +451,8 @@ export interface ComponentDecorator {
    * * **templateUrl** - url to an external file containing a template for the view
    * * **viewProviders** - list of providers available to this component and its view children
    *
-   * **Example:**
+   * The following example demonstrates how to define a component using the `@Component`
+   * decorator.
    *
    * {@example core/ts/metadata/metadata.ts region='component'}
    *
@@ -521,7 +523,7 @@ export interface Component extends Directive {
    * In CommonJS, this can always be set to `module.id`, similarly SystemJS exposes `__moduleName`
    * variable within each module.
    *
-   * **Example**:
+   * The following example demonstrates how to specify the module id for a component.
    *
    * ```
    * @Directive({

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -93,6 +93,7 @@ export interface Directive {
    * - `selector1, selector2`: select if either `selector1` or `selector2` matches.
    *
    *
+   * @example
    * Suppose we have a directive with an `input[type=text]` selector.
    *
    * And the following HTML:
@@ -122,6 +123,7 @@ export interface Directive {
    *
    * When `bindingProperty` is not provided, it is assumed to be equal to `directiveProperty`.
    *
+   * @example
    * The following example creates a component with two data-bound properties
    * ([live demo](http://plnkr.co/edit/ivhfXY?p=preview)):
    *
@@ -166,6 +168,7 @@ export interface Directive {
    * - `directiveProperty` specifies the component property that emits events.
    * - `bindingProperty` specifies the DOM property the event handler is attached to.
    *
+   * @example
    * The following example shows how to use the `outputs` property
    * ([live demo](http://plnkr.co/edit/d5CNq7?p=preview)):
    *
@@ -203,21 +206,33 @@ export interface Directive {
   /**
    * Specify the events, actions, properties and attributes related to the host element.
    *
-   * **Host Listeners**
+   * * **Host Listeners**
    *
-   * Specifies which DOM events a directive listens to via a set of `(event)` to `method`
-   * key-value pairs:
+   *   Specifies which DOM events a directive listens to via a set of `(event)` to `method`
+   *   key-value pairs:
    *
-   * - `event`: the DOM event that the directive listens to.
-   * - `statement`: the statement to execute when the event occurs.
-   * If the evaluation of the statement returns `false`, then `preventDefault`is applied on the DOM
-   * event.
+   *   - `event`: the DOM event that the directive listens to.
+   *   - `statement`: the statement to execute when the event occurs.
+   *   If the evaluation of the statement returns `false`, then `preventDefault`is applied on the DOM
+   *   event.
    *
-   * To listen to global events, a target must be added to the event name.
-   * The target can be `window`, `document` or `body`.
+   *   To listen to global events, a target must be added to the event name.
+   *   The target can be `window`, `document` or `body`.
    *
-   * When writing a directive event binding, you can also refer to the $event local variable.
+   *   When writing a directive event binding, you can also refer to the $event local variable.
    *
+   * * **Host Property Bindings**
+   *
+   *   Specifies which DOM properties a directive updates.
+   *
+   *   Angular automatically checks host property bindings during change detection.
+   *   If a binding changes, it will update the host element of the directive.
+   *
+   * * **Attributes**
+   *
+   *   Specifies static attributes that should be propagated to a host element.
+   *
+   * @example
    * The following example declares a directive that attaches a click listener to the button and
    * counts clicks
    * ([live demo](http://plnkr.co/edit/DlA5KU?p=preview)):
@@ -244,13 +259,7 @@ export interface Directive {
    * class App {}
    * ```
    *
-   * **Host Property Bindings**
-   *
-   * Specifies which DOM properties a directive updates.
-   *
-   * Angular automatically checks host property bindings during change detection.
-   * If a binding changes, it will update the host element of the directive.
-   *
+   * @example
    * The following example creates a directive that sets the `valid` and `invalid` classes
    * on the DOM element that has ngModel directive on it
    * ([live demo](http://plnkr.co/edit/gNg0ED?p=preview)):
@@ -278,10 +287,7 @@ export interface Directive {
    * }
    * ```
    *
-   * **Attributes**
-   *
-   * Specifies static attributes that should be propagated to a host element.
-   *
+   * @example
    * The following example, using `my-button` directive (ex.: `<div my-button></div>`) on a host
    * element (here: `<div>` ), shows that this element will get the "button" role:
    *
@@ -302,6 +308,7 @@ export interface Directive {
    * Defines the set of injectable objects that are visible to a Directive and its light DOM
    * children.
    *
+   * @example
    * Here is an example of a class that can be injected:
    *
    * ```
@@ -331,6 +338,7 @@ export interface Directive {
   /**
    * Defines the name that can be used in the template to assign this directive to a variable.
    *
+   * @example
    * The following example demonstrates how to specify how a component is exported.
    *
    * ```
@@ -358,6 +366,7 @@ export interface Directive {
    * Content queries are set before the `ngAfterContentInit` callback is called.
    * View queries are set before the `ngAfterViewInit` callback is called.
    *
+   * @example
    * The following example demonstrates how to specify `contentChilden` and
    * `viewChildren` queries on a component.
    *
@@ -405,7 +414,7 @@ export interface ComponentDecorator {
   /**
    * @usageNotes
    *
-   * {@example core/ts/metadata/metadata.ts region='component'}
+   * <code-example path="core/ts/metadata/metadata.ts" region="component"></code-example>
    *
    * @description
    * Marks a class as an Angular component and collects component configuration
@@ -451,10 +460,11 @@ export interface ComponentDecorator {
    * * **templateUrl** - url to an external file containing a template for the view
    * * **viewProviders** - list of providers available to this component and its view children
    *
+   * @example
    * The following example demonstrates how to define a component using the `@Component`
    * decorator.
    *
-   * {@example core/ts/metadata/metadata.ts region='component'}
+   * <code-example path="core/ts/metadata/metadata.ts" region="component"></code-example>
    *
    * @Annotation
    */
@@ -483,6 +493,7 @@ export interface Component extends Directive {
   /**
    * Defines the set of injectable objects that are visible to its view DOM children.
    *
+   * @example
    * Here is an example of a class that can be injected:
    *
    * ```
@@ -523,6 +534,7 @@ export interface Component extends Directive {
    * In CommonJS, this can always be set to `module.id`, similarly SystemJS exposes `__moduleName`
    * variable within each module.
    *
+   * @example
    * The following example demonstrates how to specify the module id for a component.
    *
    * ```
@@ -812,6 +824,7 @@ export interface InputDecorator {
    * used when instantiating a component in the template. When not provided,
    * the name of the decorated property is used.
    *
+   * @example
    * The following example creates a component with two input properties.
    *
    * ```typescript
@@ -877,6 +890,10 @@ export interface OutputDecorator {
    * used when instantiating a component in the template. When not provided,
    * the name of the decorated property is used.
    *
+   *
+   * @example
+   * The following example shows how you can use the `@Output` decorator.
+   *
    * ```typescript
    * @Directive({
    *   selector: 'interval-dir',
@@ -937,6 +954,7 @@ export interface HostBindingDecorator {
    * name of the host element that will be updated. When not provided,
    * the class property name is used.
    *
+   * @example
    * The following example creates a directive that sets the `valid` and `invalid` classes
    * on the DOM element that has ngModel directive on it.
    *
@@ -987,6 +1005,7 @@ export interface HostListenerDecorator {
    *
    * If the decorated method returns `false`, then `preventDefault` is applied on the DOM event.
    *
+   * @example
    * The following example declares a directive that attaches a click listener to the button and
    * counts clicks.
    *

--- a/packages/core/src/metadata/lifecycle_hooks.ts
+++ b/packages/core/src/metadata/lifecycle_hooks.ts
@@ -18,7 +18,7 @@ export interface SimpleChanges { [propName: string]: SimpleChange; }
 
 /**
  * @usageNotes
- * {@example core/ts/metadata/lifecycle_hooks_spec.ts region='OnChanges'}
+ * <code-example path="core/ts/metadata/lifecycle_hooks_spec.ts" region="OnChanges"></code-example>
  *
  * @description
  * Lifecycle hook that is called when any data-bound property of a directive changes.
@@ -35,7 +35,7 @@ export interface OnChanges { ngOnChanges(changes: SimpleChanges): void; }
 
 /**
  * @usageNotes
- * {@example core/ts/metadata/lifecycle_hooks_spec.ts region='OnInit'}
+ * <code-example path="core/ts/metadata/lifecycle_hooks_spec.ts" region="OnInit"></code-example>
  *
  * @description
  * Lifecycle hook that is called after data-bound properties of a directive are
@@ -53,7 +53,7 @@ export interface OnInit { ngOnInit(): void; }
 
 /**
  * @usageNotes
- * {@example core/ts/metadata/lifecycle_hooks_spec.ts region='DoCheck'}
+ * <code-example path="core/ts/metadata/lifecycle_hooks_spec.ts" region="DoCheck"></code-example>
  *
  * @description
  * Lifecycle hook that is called when Angular dirty checks a directive.
@@ -77,7 +77,7 @@ export interface DoCheck { ngDoCheck(): void; }
 
 /**
  * @usageNotes
- * {@example core/ts/metadata/lifecycle_hooks_spec.ts region='OnDestroy'}
+ * <code-example path="core/ts/metadata/lifecycle_hooks_spec.ts" region="OnDestroy"></code-example>
  *
  * @description
  * Lifecycle hook that is called when a directive, pipe or service is destroyed.
@@ -94,7 +94,7 @@ export interface OnDestroy { ngOnDestroy(): void; }
 /**
  *
  * @usageNotes
- * {@example core/ts/metadata/lifecycle_hooks_spec.ts region='AfterContentInit'}
+ * <code-example path="core/ts/metadata/lifecycle_hooks_spec.ts" region="AfterContentInit"></code-example>
  *
  * @description
  * Lifecycle hook that is called after a directive's content has been fully
@@ -108,7 +108,7 @@ export interface AfterContentInit { ngAfterContentInit(): void; }
 
 /**
  * @usageNotes
- * {@example core/ts/metadata/lifecycle_hooks_spec.ts region='AfterContentChecked'}
+ * <code-example path="core/ts/metadata/lifecycle_hooks_spec.ts" region="AfterContentChecked"></code-example>
  *
  * @description
  * Lifecycle hook that is called after every check of a directive's content.
@@ -121,7 +121,7 @@ export interface AfterContentChecked { ngAfterContentChecked(): void; }
 
 /**
  * @usageNotes
- * {@example core/ts/metadata/lifecycle_hooks_spec.ts region='AfterViewInit'}
+ * <code-example path="core/ts/metadata/lifecycle_hooks_spec.ts" region="AfterViewInit"></code-example>
  *
  * @description
  * Lifecycle hook that is called after a component's view has been fully
@@ -135,7 +135,7 @@ export interface AfterViewInit { ngAfterViewInit(): void; }
 
 /**
  * @usageNotes
- * {@example core/ts/metadata/lifecycle_hooks_spec.ts region='AfterViewChecked'}
+ * <code-example path="core/ts/metadata/lifecycle_hooks_spec.ts" region="AfterViewChecked"></code-example>
  *
  * @description
  * Lifecycle hook that is called after every check of a component's view.

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -103,7 +103,8 @@ export interface NgModule {
   /**
    * Specifies a list of directives/pipes that belong to this module.
    *
-   * **Example**:
+   * The following example demonstrates how declare components with the NgModule
+   * decorator:
    *
    * ```javascript
    * @NgModule({
@@ -120,7 +121,8 @@ export interface NgModule {
    * should be available to templates in this module.
    * This can also contain `ModuleWithProviders`.
    *
-   * **Example**:
+   * The following example demonstrates how specify imports with the NgModule
+   * decorator:
    *
    * ```javascript
    * @NgModule({
@@ -137,7 +139,8 @@ export interface NgModule {
    * of any component that is part of an Angular module
    * that imports this Angular module.
    *
-   * **Example**:
+   * The following example demonstrates how specify exports with the NgModule
+   * decorator:
    *
    * ```javascript
    * @NgModule({

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -75,8 +75,6 @@ export interface NgModule {
    * Defines the set of injectable objects that are available in the injector
    * of this module.
    *
-   * ## Simple Example
-   *
    * Here is an example of a class that can be injected:
    *
    * ```
@@ -105,7 +103,7 @@ export interface NgModule {
   /**
    * Specifies a list of directives/pipes that belong to this module.
    *
-   * ### Example
+   * **Example**:
    *
    * ```javascript
    * @NgModule({
@@ -120,9 +118,9 @@ export interface NgModule {
   /**
    * Specifies a list of modules whose exported directives/pipes
    * should be available to templates in this module.
-   * This can also contain {@link ModuleWithProviders}.
+   * This can also contain `ModuleWithProviders`.
    *
-   * ### Example
+   * **Example**:
    *
    * ```javascript
    * @NgModule({
@@ -139,7 +137,7 @@ export interface NgModule {
    * of any component that is part of an Angular module
    * that imports this Angular module.
    *
-   * ### Example
+   * **Example**:
    *
    * ```javascript
    * @NgModule({
@@ -153,8 +151,8 @@ export interface NgModule {
 
   /**
    * Specifies a list of components that should be compiled when this module is defined.
-   * For each component listed here, Angular will create a {@link ComponentFactory}
-   * and store it in the {@link ComponentFactoryResolver}.
+   * For each component listed here, Angular will create a `ComponentFactory`
+   * and store it in the `ComponentFactoryResolver`.
    */
   entryComponents?: Array<Type<any>|any[]>;
 

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -103,6 +103,7 @@ export interface NgModule {
   /**
    * Specifies a list of directives/pipes that belong to this module.
    *
+   * @example
    * The following example demonstrates how declare components with the NgModule
    * decorator:
    *
@@ -121,6 +122,7 @@ export interface NgModule {
    * should be available to templates in this module.
    * This can also contain `ModuleWithProviders`.
    *
+   * @example
    * The following example demonstrates how specify imports with the NgModule
    * decorator:
    *
@@ -139,6 +141,7 @@ export interface NgModule {
    * of any component that is part of an Angular module
    * that imports this Angular module.
    *
+   * @example
    * The following example demonstrates how specify exports with the NgModule
    * decorator:
    *

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -42,7 +42,8 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T> {
    *
    * <!-- TODO: Add a link to a chapter on OnPush components -->
    *
-   * ### Example ([live demo](https://stackblitz.com/edit/angular-kx7rrw))
+   * The following example shows marking a component for change detection
+   * ([live demo](https://stackblitz.com/edit/angular-kx7rrw)):
    *
    * ```typescript
    * @Component({
@@ -75,8 +76,6 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T> {
    *
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->
    * <!-- TODO: Add a live demo once ref.detectChanges is merged into master -->
-   *
-   * ### Example
    *
    * The following example defines a component with a large list of readonly data.
    * Imagine the data changes constantly, many times per second. For performance reasons,
@@ -127,11 +126,9 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T> {
    *
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->
    *
-   * ### Example ([live demo](https://stackblitz.com/edit/angular-ymgsxw))
-   *
    * The following example creates a component displaying `live` data. The component will detach
    * its change detector from the main change detector tree when the component's live property
-   * is set to false.
+   * is set to false. ([live demo](https://stackblitz.com/edit/angular-ymgsxw))
    *
    * ```typescript
    * class DataProvider {
@@ -184,8 +181,6 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T> {
    *
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->
    * <!-- TODO: Add a live demo once ref.detectChanges is merged into master -->
-   *
-   * ### Example
    *
    * The following example defines a component with a large list of readonly data.
    * Imagine, the data changes constantly, many times per second. For performance reasons,

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -42,6 +42,7 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T> {
    *
    * <!-- TODO: Add a link to a chapter on OnPush components -->
    *
+   * @example
    * The following example shows marking a component for change detection
    * ([live demo](https://stackblitz.com/edit/angular-kx7rrw)):
    *
@@ -77,6 +78,7 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T> {
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->
    * <!-- TODO: Add a live demo once ref.detectChanges is merged into master -->
    *
+   * @example
    * The following example defines a component with a large list of readonly data.
    * Imagine the data changes constantly, many times per second. For performance reasons,
    * we want to check and update the list every five seconds. We can do that by detaching
@@ -126,6 +128,7 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T> {
    *
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->
    *
+   * @example
    * The following example creates a component displaying `live` data. The component will detach
    * its change detector from the main change detector tree when the component's live property
    * is set to false. ([live demo](https://stackblitz.com/edit/angular-ymgsxw))
@@ -182,7 +185,6 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T> {
    * <!-- TODO: Add a link to a chapter on detach/reattach/local digest -->
    * <!-- TODO: Add a live demo once ref.detectChanges is merged into master -->
    *
-   * The following example defines a component with a large list of readonly data.
    * Imagine, the data changes constantly, many times per second. For performance reasons,
    * we want to check and update the list every five seconds.
    *

--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -24,8 +24,8 @@ import {EventEmitter} from '../event_emitter';
  *   - link to runOutsideAngular/run (throughout this file!)
  *   -->
  *
-   * **Example**:
-   *
+ * The following example demonstrates how to run code inside and outside the Angular zone:
+ *
  * ```
  * import {Component, NgZone} from '@angular/core';
  * import {NgIf} from '@angular/common';

--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -24,8 +24,8 @@ import {EventEmitter} from '../event_emitter';
  *   - link to runOutsideAngular/run (throughout this file!)
  *   -->
  *
- * ### Example
- *
+   * **Example**:
+   *
  * ```
  * import {Component, NgZone} from '@angular/core';
  * import {NgIf} from '@angular/common';

--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -24,6 +24,7 @@ import {EventEmitter} from '../event_emitter';
  *   - link to runOutsideAngular/run (throughout this file!)
  *   -->
  *
+ * @example
  * The following example demonstrates how to run code inside and outside the Angular zone:
  *
  * ```

--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -33,8 +33,6 @@ export function resetFakeAsyncZone(): void {
  *
  * Can be used to wrap inject() calls.
  *
- * ## Example
- *
  * {@example core/testing/ts/fake_async.ts region='basic'}
  *
  * @param fn
@@ -55,8 +53,6 @@ export function fakeAsync(fn: Function): (...args: any[]) => any {
  *
  * The microtasks queue is drained at the very start of this function and after any timer callback
  * has been executed.
- *
- * ## Example
  *
  * {@example core/testing/ts/fake_async.ts region='basic'}
  *

--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -33,7 +33,10 @@ export function resetFakeAsyncZone(): void {
  *
  * Can be used to wrap inject() calls.
  *
- * {@example core/testing/ts/fake_async.ts region='basic'}
+ * @example
+ * This example shows how you can use this helper function.
+ *
+ * <code-example path="core/testing/ts/fake_async.ts" region="basic"></code-example>
  *
  * @param fn
  * @returns The function wrapped to be executed in the fakeAsync zone
@@ -54,7 +57,10 @@ export function fakeAsync(fn: Function): (...args: any[]) => any {
  * The microtasks queue is drained at the very start of this function and after any timer callback
  * has been executed.
  *
- * {@example core/testing/ts/fake_async.ts region='basic'}
+ * @example
+ * This example shows how you can use this helper function.
+ *
+ * <code-example path="core/testing/ts/fake_async.ts" region="basic"></code-example>
  *
  * @experimental
  */

--- a/packages/core/testing/src/fake_async_fallback.ts
+++ b/packages/core/testing/src/fake_async_fallback.ts
@@ -43,8 +43,6 @@ let _inFakeAsyncCall = false;
  *
  * Can be used to wrap inject() calls.
  *
- * ## Example
- *
  * {@example core/testing/ts/fake_async.ts region='basic'}
  *
  * @param fn
@@ -109,8 +107,6 @@ function _getFakeAsyncZoneSpec(): any {
  *
  * The microtasks queue is drained at the very start of this function and after any timer callback
  * has been executed.
- *
- * ## Example
  *
  * {@example core/testing/ts/fake_async.ts region='basic'}
  *

--- a/packages/core/testing/src/fake_async_fallback.ts
+++ b/packages/core/testing/src/fake_async_fallback.ts
@@ -42,8 +42,11 @@ let _inFakeAsyncCall = false;
  * If there are any pending timers at the end of the function, an exception will be thrown.
  *
  * Can be used to wrap inject() calls.
+
+ * @example
+ * This example shows how you can use this helper function.
  *
- * {@example core/testing/ts/fake_async.ts region='basic'}
+ * <code-example path="core/testing/ts/fake_async.ts" region="basic"></code-example>
  *
  * @param fn
  * @returns The function wrapped to be executed in the fakeAsync zone
@@ -108,7 +111,10 @@ function _getFakeAsyncZoneSpec(): any {
  * The microtasks queue is drained at the very start of this function and after any timer callback
  * has been executed.
  *
- * {@example core/testing/ts/fake_async.ts region='basic'}
+ * @example
+ * This example shows how you can use this helper function.
+ *
+ * <code-example path="core/testing/ts/fake_async.ts" region="basic"></code-example>
  *
  * @experimental
  */


### PR DESCRIPTION
This fixes all the "dgeni" errors for the `@angular/core` API docs.