### PR TITLE
docs(router): fix `dgeni` errors

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -42,7 +42,7 @@ import {UrlSegment, UrlSegmentGroup} from './url_tree';
  * - `loadChildren` is a reference to lazy loaded child routes. See `LoadChildren` for more
  *   info.
  *
- * ### Simple Configuration
+ * **Simple Configuration**
  *
  * ```
  * [{
@@ -58,7 +58,7 @@ import {UrlSegment, UrlSegmentGroup} from './url_tree';
  * When navigating to `/team/11/user/bob`, the router will create the team component with the user
  * component in it.
  *
- * ### Multiple Outlets
+ * **Multiple Outlets**
  *
  * ```
  * [{
@@ -74,7 +74,7 @@ import {UrlSegment, UrlSegmentGroup} from './url_tree';
  * When navigating to `/team/11(aux:chat/jim)`, the router will create the team component next to
  * the chat component. The chat component will be placed into the aux outlet.
  *
- * ### Wild Cards
+ * **Wild Cards**
  *
  * ```
  * [{
@@ -85,7 +85,7 @@ import {UrlSegment, UrlSegmentGroup} from './url_tree';
  *
  * Regardless of where you navigate to, the router will instantiate the sink component.
  *
- * ### Redirects
+ * **Redirects**
  *
  * ```
  * [{
@@ -108,7 +108,7 @@ import {UrlSegment, UrlSegmentGroup} from './url_tree';
  * If the `redirectTo` value starts with a '/', then it is an absolute redirect. E.g., if in the
  * example above we change the `redirectTo` to `/user/:name`, the result url will be '/user/jim'.
  *
- * ### Empty Path
+ * **Empty Path**
  *
  * Empty-path route configurations can be used to instantiate components that do not 'consume'
  * any url segments. Let's look at the following configuration:
@@ -152,7 +152,7 @@ import {UrlSegment, UrlSegmentGroup} from './url_tree';
  * An empty path route inherits its parent's params and data. This is because it cannot have its
  * own params, and, as a result, it often uses its parent's params and data as its own.
  *
- * ### Matching Strategy
+ * **Matching Strategy**
  *
  * By default the router will look at what is left in the url, and check if it starts with
  * the specified path (e.g., `/team/11/user` starts with `team/:id`).
@@ -190,7 +190,7 @@ import {UrlSegment, UrlSegmentGroup} from './url_tree';
  * }]
  * ```
  *
- * ### Componentless Routes
+ * **Componentless Routes**
  *
  * It is useful at times to have the ability to share parameters between sibling components.
  *
@@ -233,7 +233,7 @@ import {UrlSegment, UrlSegmentGroup} from './url_tree';
  * With this configuration in place, navigating to '/parent/10' will create the main child and aux
  * components.
  *
- * ### Lazy Loading
+ * **Lazy Loading**
  *
  * Lazy loading speeds up our application load time by splitting it into multiple bundles, and
  * loading them on demand. The router is designed to make lazy loading simple and easy. Instead of

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -327,7 +327,7 @@ export class Router {
   get url(): string { return this.serializeUrl(this.currentUrlTree); }
 
   /** @internal */
-  triggerEvent(e: Event): void { (this.events as Subject<Event>).next(e); }
+  triggerEvent(event: Event): void { (this.events as Subject<Event>).next(event); }
 
   /**
    * Resets the configuration used for navigation and generating links.

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -44,16 +44,16 @@ export interface NavigationExtras {
    *
    * ```
    * [{
-  *   path: 'parent',
-  *   component: ParentComponent,
-  *   children: [{
-  *     path: 'list',
-  *     component: ListComponent
-  *   },{
-  *     path: 'child',
-  *     component: ChildComponent
-  *   }]
-  * }]
+   *   path: 'parent',
+   *   component: ParentComponent,
+   *   children: [{
+   *     path: 'list',
+   *     component: ListComponent
+   *   },{
+   *     path: 'child',
+   *     component: ChildComponent
+   *   }]
+   * }]
    * ```
    *
    * Navigate to list route from child route:
@@ -332,7 +332,7 @@ export class Router {
   /**
    * Resets the configuration used for navigation and generating links.
    *
-   * ### Usage
+   * **Usage**
    *
    * ```
    * router.resetConfig([
@@ -367,7 +367,7 @@ export class Router {
    * When given an activate route, applies the given commands starting from the route.
    * When not given a route, applies the given command starting from the root.
    *
-   * ### Usage
+   * **Usage**
    *
    * ```
    * // create /team/33/user/11
@@ -439,7 +439,7 @@ export class Router {
    * - resolves to 'false' when navigation fails,
    * - is rejected when an error happens.
    *
-   * ### Usage
+   * **Usage**
    *
    * ```
    * router.navigateByUrl("/team/33/user/11");
@@ -468,7 +468,7 @@ export class Router {
    * - resolves to 'false' when navigation fails,
    * - is rejected when an error happens.
    *
-   * ### Usage
+   * **Usage**
    *
    * ```
    * router.navigate(['team', 33, 'user', 11], {relativeTo: route});

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -203,7 +203,7 @@ export function provideForRootGuard(router: Router): any {
  *
  * Registers routes.
  *
- * ### Example
+ * **Example**
  *
  * ```
  * @NgModule({

--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -26,7 +26,7 @@ import {Tree, TreeNode} from './utils/tree';
  * RouterState is a tree of activated routes. Every node in this tree knows about the "consumed" URL
  * segments, the extracted parameters, and the resolved data.
  *
- * ### Example
+ * **Example**
  *
  * ```
  * @Component({templateUrl:'template.html'})
@@ -332,7 +332,7 @@ export class ActivatedRouteSnapshot {
  * This is a tree of activated route snapshots. Every node in this tree knows about
  * the "consumed" URL segments, the extracted parameters, and the resolved data.
  *
- * ### Example
+ * **Example**
  *
  * ```
  * @Component({templateUrl:'template.html'})

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -82,7 +82,7 @@ function containsSegmentGroupHelper(
  * serialized tree.
  * UrlTree is a data structure that provides a lot of affordances in dealing with URLs
  *
- * ### Example
+ * **Example**
  *
  * ```
  * @Component({templateUrl:'template.html'})
@@ -170,7 +170,7 @@ export class UrlSegmentGroup {
  * A UrlSegment is a part of a URL between the two slashes. It contains a path and the matrix
  * parameters associated with the segment.
  *
- * ## Example
+ * **Example**
  *
  * ```
  * @Component({templateUrl:'template.html'})

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -139,7 +139,7 @@ export function setupTestingRouter(
  * It provides spy implementations of `Location`, `LocationStrategy`, and {@link
  * NgModuleFactoryLoader}.
  *
- * ### Example
+ * **Example**
  *
  * ```
  * beforeEach(() => {


### PR DESCRIPTION
This PR fixes all `dgeni` errors in the `@angular/router` package.