### PR TITLE
docs(http): fix `dgeni` errors

### DIFF
--- a/packages/http/src/backends/xhr_backend.ts
+++ b/packages/http/src/backends/xhr_backend.ts
@@ -208,7 +208,7 @@ export class CookieXSRFStrategy implements XSRFStrategy {
  * overridden if a different backend implementation should be used,
  * such as in a node backend.
  *
- * ### Example
+ * **Example**
  *
  * ```
  * import {Http, MyNodeBackend, HTTP_PROVIDERS, BaseRequestOptions} from '@angular/http';

--- a/packages/http/src/base_response_options.ts
+++ b/packages/http/src/base_response_options.ts
@@ -26,7 +26,7 @@ import {ResponseOptionsArgs} from './interfaces';
  * This class may be used in tests to build {@link Response Responses} for
  * mock responses (see {@link MockBackend}).
  *
- * ### Example ([live demo](http://plnkr.co/edit/P9Jkk8e8cz6NVzbcxEsD?p=preview))
+ * **Example** ([live demo](http://plnkr.co/edit/P9Jkk8e8cz6NVzbcxEsD?p=preview))
  *
  * ```typescript
  * import {ResponseOptions, Response} from '@angular/http';
@@ -84,7 +84,7 @@ export class ResponseOptions {
    * This may be useful when sharing a base `ResponseOptions` object inside tests,
    * where certain properties may change from test to test.
    *
-   * ### Example ([live demo](http://plnkr.co/edit/1lXquqFfgduTFBWjNoRE?p=preview))
+   * **Example** ([live demo](http://plnkr.co/edit/1lXquqFfgduTFBWjNoRE?p=preview))
    *
    * ```typescript
    * import {ResponseOptions, Response} from '@angular/http';
@@ -123,7 +123,7 @@ export class ResponseOptions {
  * when configuring an {@link Injector}, in order to override the default options
  * used by {@link Http} to create {@link Response Responses}.
  *
- * ### Example ([live demo](http://plnkr.co/edit/qv8DLT?p=preview))
+ * **Example** ([live demo](http://plnkr.co/edit/qv8DLT?p=preview))
  *
  * ```typescript
  * import {provide} from '@angular/core';
@@ -142,7 +142,7 @@ export class ResponseOptions {
  * The options could also be extended when manually creating a {@link Response}
  * object.
  *
- * ### Example ([live demo](http://plnkr.co/edit/VngosOWiaExEtbstDoix?p=preview))
+ * **Example** ([live demo](http://plnkr.co/edit/VngosOWiaExEtbstDoix?p=preview))
  *
  * ```
  * import {BaseResponseOptions, Response} from '@angular/http';

--- a/packages/http/src/http.ts
+++ b/packages/http/src/http.ts
@@ -47,7 +47,7 @@ function mergeOptions(
  * `request` returns an `Observable` which will emit a single {@link Response} when a
  * response is received.
  *
- * ### Example
+ * **Example**
  *
  * ```typescript
  * import {Http, HTTP_PROVIDERS} from '@angular/http';
@@ -71,7 +71,7 @@ function mergeOptions(
  * ```
  *
  *
- * ### Example
+ * **Example**
  *
  * ```
  * http.get('people.json').subscribe((res:Response) => this.people = res.json());
@@ -81,7 +81,7 @@ function mergeOptions(
  * {@link XHRBackend} in this case), which could be mocked with dependency injection by replacing
  * the {@link XHRBackend} provider, as in the following example:
  *
- * ### Example
+ * **Example**
  *
  * ```typescript
  * import {BaseRequestOptions, Http} from '@angular/http';

--- a/packages/http/src/static_response.ts
+++ b/packages/http/src/static_response.ts
@@ -21,7 +21,7 @@ import {Headers} from './headers';
  * usually instantiated by end-users, it is the primary object interacted with when it comes time to
  * add data to a view.
  *
- * ### Example
+ * **Example**
  *
  * ```
  * http.request('my-friends.txt').subscribe(response => this.friends = response.text());

--- a/packages/http/testing/src/mock_backend.ts
+++ b/packages/http/testing/src/mock_backend.ts
@@ -48,7 +48,7 @@ export class MockConnection implements Connection {
    * Sends a mock response to the connection. This response is the value that is emitted to the
    * {@link EventEmitter} returned by {@link Http}.
    *
-   * ### Example
+   * **Example**
    *
    * ```
    * var connection;
@@ -87,7 +87,7 @@ export class MockConnection implements Connection {
    * returned
    * from {@link Http}.
    *
-   * ### Example
+   * **Example**
    *
    * ```
    * var connection;
@@ -110,7 +110,7 @@ export class MockConnection implements Connection {
  * This class can be injected in tests, and should be used to override providers
  * to other backends, such as {@link XHRBackend}.
  *
- * ### Example
+ * **Example**
  *
  * ```
  * import {Injectable, Injector} from '@angular/core';
@@ -198,7 +198,7 @@ export class MockBackend implements ConnectionBackend {
    * of {@link MockConnection} instances that have been created by this backend. Can be subscribed
    * to in order to respond to connections.
    *
-   * ### Example
+   * **Example**
    *
    * ```
    * import {Injector} from '@angular/core';


### PR DESCRIPTION
This PR fixes all `dgeni` errors in the `@angular/http` package.