### PR TITLE
docs(aio): Update lazy loading docs for Angular v6

### DIFF
--- a/aio/content/examples/lazy-loading-ngmodules/src/app/app-routing.module.ts
+++ b/aio/content/examples/lazy-loading-ngmodules/src/app/app-routing.module.ts
@@ -8,11 +8,11 @@ import { Routes, RouterModule } from '@angular/router';
 const routes: Routes = [
   {
     path: 'customers',
-    loadChildren: 'app/customers/customers.module#CustomersModule'
+    loadChildren: './customers/customers.module#CustomersModule'
   },
   {
     path: 'orders',
-    loadChildren: 'app/orders/orders.module#OrdersModule'
+    loadChildren: './orders/orders.module#OrdersModule'
   },
   {
     path: '',

--- a/aio/content/guide/lazy-loading-ngmodules.md
+++ b/aio/content/guide/lazy-loading-ngmodules.md
@@ -143,7 +143,7 @@ In `AppRoutingModule`, update the `routes` array with the following:
 </code-example>
 
 
-The import statements stay the same. The first two paths are the routes to the `CustomersModule` and the `OrdersModule` respectively. Notice that the lazy loading syntax uses `loadChildren` followed by a string that is the path to the module, a hash mark or `#`, and the module’s class name.
+The import statements stay the same. The first two paths are the routes to the `CustomersModule` and the `OrdersModule` respectively. Notice that the lazy loading syntax uses `loadChildren` followed by a string that is the relative path to the module, a hash mark or `#`, and the module’s class name.
 
 ### Inside the feature module
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Following the current lazy loading docs results in a compilation error, because loadChildren takes a relative path under Angular V6.

Issue Number: N/A


## What is the new behavior?
Compilation succeeds.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

