### PR TITLE
feat(forms): add AbstractControl.setEnabled

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -424,6 +424,14 @@ export abstract class AbstractControl {
     }
   }
 
+  setEnabled(enabled: boolean, opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+    if (enabled) {
+      this.enable(opts);
+    } else {
+      this.disable(opts);
+    }
+  }
+
   setParent(parent: FormGroup|FormArray): void { this._parent = parent; }
 
   /**

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -877,7 +877,7 @@ import {FormArray} from '@angular/forms/src/model';
       });
     });
 
-    describe('disable() & enable()', () => {
+    describe('disable(), enable() & setEnabled()', () => {
 
       it('should mark the control as disabled', () => {
         const c = new FormControl(null);
@@ -891,6 +891,14 @@ import {FormArray} from '@angular/forms/src/model';
         c.enable();
         expect(c.disabled).toBe(false);
         expect(c.valid).toBe(true);
+
+        c.setEnabled(false);
+        expect(c.disabled).toBe(true);
+        expect(c.valid).toBe(false);
+
+        c.setEnabled(true);
+        expect(c.disabled).toBe(false);
+        expect(c.valid).toBe(true);
       });
 
       it('should set the control status as disabled', () => {
@@ -901,6 +909,12 @@ import {FormArray} from '@angular/forms/src/model';
         expect(c.status).toEqual('DISABLED');
 
         c.enable();
+        expect(c.status).toEqual('VALID');
+
+        c.setEnabled(false);
+        expect(c.status).toEqual('DISABLED');
+
+        c.setEnabled(true);
         expect(c.status).toEqual('VALID');
       });
 


### PR DESCRIPTION
PR Close #23414

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently `AbstractControl` have two methods to enable/disable: `enable()` and `disable()`.
So If I want to enable/disable according to another field I need to write:
```typescript
this.petForm.get('hasDog')!.valueChanges.subscribe((newVal: boolean) => {
    if (newVal) {
        this.petForm.get('dogName')!.enable();
    } else {
        this.petForm.get('dogName')!.disable();
    }
});
```

Issue Number: #23414


## What is the new behavior?
Add `AbstractControl.setEnabled(enabled: boolean)`, so I can write:
```typescript
this.petForm.get('petType')!.valueChanges.subscribe((newVal: string) => {
    this.petForm.get('dogName')!.setEnabled(newVal === 'Dog');
    this.petForm.get('catName')!.setEnabled(newVal === 'Cat');
});
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
