### PR TITLE
docs(aio): changed 'onVoted' output property to 'voted' to be in line with the styleguide

### DIFF
--- a/aio/content/examples/component-interaction/src/app/voter.component.ts
+++ b/aio/content/examples/component-interaction/src/app/voter.component.ts
@@ -5,18 +5,18 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
   selector: 'app-voter',
   template: `
     <h4>{{name}}</h4>
-    <button (click)="vote(true)"  [disabled]="voted">Agree</button>
-    <button (click)="vote(false)" [disabled]="voted">Disagree</button>
+    <button (click)="vote(true)"  [disabled]="didVote">Agree</button>
+    <button (click)="vote(false)" [disabled]="didVote">Disagree</button>
   `
 })
 export class VoterComponent {
   @Input()  name: string;
-  @Output() onVoted = new EventEmitter<boolean>();
-  voted = false;
+  @Output() voted = new EventEmitter<boolean>();
+  didVote = false;
 
   vote(agreed: boolean) {
-    this.onVoted.emit(agreed);
-    this.voted = true;
+    this.voted.emit(agreed);
+    this.didVote = true;
   }
 }
 // #enddocregion

--- a/aio/content/examples/component-interaction/src/app/votetaker.component.ts
+++ b/aio/content/examples/component-interaction/src/app/votetaker.component.ts
@@ -8,7 +8,7 @@ import { Component }      from '@angular/core';
     <h3>Agree: {{agreed}}, Disagree: {{disagreed}}</h3>
     <app-voter *ngFor="let voter of voters"
       [name]="voter"
-      (onVoted)="onVoted($event)">
+      (voted)="onVoted($event)">
     </app-voter>
   `
 })


### PR DESCRIPTION
docs(component-interaction): changed 'onVoted' output property to 'voted' to be in line with the styleguide (https://angular.io/guide/styleguide#dont-prefix-output-properties)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently the [Component Interaction](https://angular.io/guide/component-interaction#parent-listens-for-child-event) contains an output property whose name does not match [convention established in the styleguide](https://angular.io/guide/styleguide#dont-prefix-output-properties).

Issue Number: #23831 


## What is the new behavior?
The output property in the example is now named in accordance with the styleguide:

```
@Output() voted = new EventEmitter<boolean>();
...
<app-voter *ngFor="let voter of voters"
      [name]="voter"
      (voted)="onVoted($event)">
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
