### PR TITLE
fix(elements): prevent closure renaming of platform properties

### DIFF
--- a/packages/elements/src/create-custom-element.ts
+++ b/packages/elements/src/create-custom-element.ts
@@ -131,7 +131,9 @@ export function createCustomElement<P>(
   const attributeToPropertyInputs = getDefaultAttributeToPropertyInputs(inputs);
 
   class NgElementImpl extends NgElement {
-    static readonly observedAttributes = Object.keys(attributeToPropertyInputs);
+    // Work around a bug in closure typed optimizations(b/79557487) where it is not honoring static
+    // field externs. So using quoted access to explicitly prevent renaming.
+    static readonly['observedAttributes'] = Object.keys(attributeToPropertyInputs);
 
     constructor(injector?: Injector) {
       super();


### PR DESCRIPTION
Closure compiler with type based optimizations has a bug where externs for inherited static fields are not being honored. For Angular Elements this meant that 'observedAttributes' static field which is marked as an extern for the base HTMLElement class was getting renamed.

This commit works around the bug by using quoted access of 'observedAttributes' that explicitly prevents the renaming.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Custom Elements breaks when using closure typed optimizations (disambiguate properties) because 'observedAttributes' needed by browsers is renamed. 

## What is the new behavior?
observedAttributes is not renamed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Tested in Google with required closure flags.