### PR TITLE
build(aio): display types of API const docs correctly

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -112,7 +112,7 @@
     "cross-spawn": "^5.1.0",
     "css-selector-parser": "^1.3.0",
     "dgeni": "^0.4.7",
-    "dgeni-packages": "^0.26.0",
+    "dgeni-packages": "^0.26.1",
     "entities": "^1.1.1",
     "eslint": "^3.19.0",
     "eslint-plugin-jasmine": "^2.2.0",

--- a/aio/tools/transforms/templates/api/var.template.html
+++ b/aio/tools/transforms/templates/api/var.template.html
@@ -2,7 +2,7 @@
 
 {% block overview %}
   <code-example language="ts" hideCopy="true" class="no-box api-heading">
-  const {$ doc.name $}: {$ doc.symbolTypeName or 'any' $};
+  const {$ doc.name $}: {$ (doc.type | escape) or 'any' $};
   </code-example>
 {% endblock %}
 

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -3086,9 +3086,9 @@ devtools-timeline-model@1.1.6:
     chrome-devtools-frontend "1.0.401423"
     resolve "1.1.7"
 
-dgeni-packages@^0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.26.0.tgz#4311a0631f8459703001a5e65e390a29321a0562"
+dgeni-packages@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.26.1.tgz#34b5ed880be2f91862095b15085c50cc84507aa8"
   dependencies:
     canonical-path "0.0.2"
     catharsis "^0.8.1"


### PR DESCRIPTION
Previously these docs always displayed `any` as the type
of the const export. Now the type is computed correctly from
the declared type or initializer of the constant.
