### PR TITLE
fix(ivy): move next property to TNode

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -20,7 +20,6 @@ import {Type} from '../type';
 
 import {assertGreaterThan, assertLessThan, assertNotNull} from './assert';
 import {addToViewTree, assertPreviousIsParent, createLContainer, createLNodeObject, createTView, getDirectiveInstance, getPreviousOrParentNode, getRenderer, isComponent, renderEmbeddedTemplate, resolveDirective} from './instructions';
-import {LContainer} from './interfaces/container';
 import {ComponentTemplate, DirectiveDef, DirectiveDefList, PipeDefList} from './interfaces/definition';
 import {LInjector} from './interfaces/injector';
 import {LContainerNode, LElementNode, LNode, LNodeType, LViewNode, TNodeFlags} from './interfaces/node';
@@ -573,6 +572,8 @@ export function getOrCreateContainerRef(di: LInjector): viewEngine_ViewContainer
     const lContainerNode: LContainerNode = createLNodeObject(
         LNodeType.Container, vcRefHost.view, vcRefHost.parent !, undefined, lContainer, null);
 
+    // TODO(kara): Separate into own TNode when moving parent/child properties
+    lContainerNode.tNode = vcRefHost.tNode;
     vcRefHost.dynamicLContainerNode = lContainerNode;
 
     addToViewTree(vcRefHost.view, lContainer);

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -80,12 +80,6 @@ export interface LNode {
   child: LNode|null;
 
   /**
-   * The next sibling node. Necessary so we can propagate through the root nodes of a view
-   * to insert them or remove them from the DOM.
-   */
-  next: LNode|null;
-
-  /**
    * If regular LElementNode, then `data` will be null.
    * If LElementNode with component, then `data` contains LView.
    * If LViewNode, then `data` contains the LView.
@@ -139,7 +133,6 @@ export interface LElementNode extends LNode {
   readonly native: RElement;
 
   child: LContainerNode|LElementNode|LTextNode|LProjectionNode|null;
-  next: LContainerNode|LElementNode|LTextNode|LProjectionNode|null;
 
   /** If Component then data has LView (light DOM) */
   readonly data: LView|null;
@@ -153,7 +146,6 @@ export interface LTextNode extends LNode {
   /** The text node associated with this node. */
   native: RText;
   child: null;
-  next: LContainerNode|LElementNode|LTextNode|LProjectionNode|null;
 
   /** LTextNodes can be inside LElementNodes or inside LViewNodes. */
   readonly parent: LElementNode|LViewNode;
@@ -165,7 +157,6 @@ export interface LTextNode extends LNode {
 export interface LViewNode extends LNode {
   readonly native: null;
   child: LContainerNode|LElementNode|LTextNode|LProjectionNode|null;
-  next: LViewNode|null;
 
   /**  LViewNodes can only be added to LContainerNodes. */
   readonly parent: LContainerNode|null;
@@ -185,7 +176,6 @@ export interface LContainerNode extends LNode {
   native: RElement|RText|null|undefined;
   readonly data: LContainer;
   child: null;
-  next: LContainerNode|LElementNode|LTextNode|LProjectionNode|null;
 
   /** Containers can be added to elements or views. */
   readonly parent: LElementNode|LViewNode|null;
@@ -195,7 +185,6 @@ export interface LContainerNode extends LNode {
 export interface LProjectionNode extends LNode {
   readonly native: null;
   child: null;
-  next: LContainerNode|LElementNode|LTextNode|LProjectionNode|null;
 
   readonly data: LProjection;
 
@@ -216,6 +205,14 @@ export interface LProjectionNode extends LNode {
  * see: https://en.wikipedia.org/wiki/Flyweight_pattern for more on the Flyweight pattern
  */
 export interface TNode {
+  /**
+   * Index of the TNode in TView.data and corresponding LNode in LView.data.
+   *
+   * This is necessary to get from any TNode to its corresponding LNode when
+   * traversing the node tree.
+   */
+  index: number;
+
   /**
    * This number stores two values using its bits:
    *
@@ -303,6 +300,12 @@ export interface TNode {
    * If this TNode corresponds to an LElementNode, tViews will be null .
    */
   tViews: TView|TView[]|null;
+
+  /**
+   * The next sibling node. Necessary so we can propagate through the root nodes of a view
+   * to insert them or remove them from the DOM.
+   */
+  next: TNode|null;
 }
 
 /** Static data for an LElementNode  */

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -390,6 +390,9 @@
     "name": "getDirectiveInstance"
   },
   {
+    "name": "getNextLNode"
+  },
+  {
     "name": "getNextLNodeWithProjection"
   },
   {
@@ -616,9 +619,6 @@
   },
   {
     "name": "setUpAttributes"
-  },
-  {
-    "name": "setViewNext"
   },
   {
     "name": "stringify"

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -1367,7 +1367,7 @@ describe('di', () => {
           createLView(-1, null !, createTView(null, null), null, null, LViewFlags.CheckAlways);
       const oldView = enterView(contentView, null !);
       try {
-        const parent = createLNode(0, LNodeType.Element, null, null);
+        const parent = createLNode(0, LNodeType.Element, null, null, null, null);
 
         // Simulate the situation where the previous parent is not initialized.
         // This happens on first bootstrap because we don't init existing values

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -32,7 +32,7 @@ describe('render3 integration test', () => {
       }
       expect(ngDevMode).toHaveProperties({
         firstTemplatePass: 1,
-        tNode: 1,
+        tNode: 2,
         tView: 1,
         rendererCreateElement: 1,
       });

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -12,14 +12,14 @@ import {getProjectAsAttrValue, isNodeMatchingSelectorList, isNodeMatchingSelecto
 
 function testLStaticData(tagName: string, attrs: string[] | null): TNode {
   return {
-    flags: 0,
-    tagName,
-    attrs,
+    index: 0,
+    flags: 0, tagName, attrs,
     localNames: null,
     initialInputs: undefined,
     inputs: undefined,
     outputs: undefined,
     tViews: null,
+    next: null
   };
 }
 

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -271,7 +271,7 @@ describe('ViewContainerRef', () => {
             * <ng-template directive>A<ng-template>
             * % if (condition) {
             *  B
-            * }
+            * % }
             * |after
             */
            class TestComponent {


### PR DESCRIPTION
This PR moves the `next` property from `LNode` to `TNode`. This is a part of a bigger, ongoing refactor to move navigational markers off of `LNode` (and eventually remove it), which will help reduce memory pressure.

Notes:
- We now navigate to `next` through the `TNode`, then use a new `TNode.index` property to look up the corresponding `LNode` in `data`.
- Text nodes now have `TNodes` so they can be properly accessed through `next`.

Still TODO:
- Most things, like moving `parent`, `child`, etc. 
