### PR TITLE
refactor(ivy): simplify bind instruction to reuse bindingUpdated logic

### DIFF
--- a/packages/compiler/test/render3/r3_view_compiler_spec.ts
+++ b/packages/compiler/test/render3/r3_view_compiler_spec.ts
@@ -120,5 +120,43 @@ describe('r3_view_compiler', () => {
       const result = compile(files, angularFiles);
       expectEmit(result.source, bV_call, 'Incorrect bV call');
     });
+
+    it('should generate interpolated bindings', () => {
+      const files: MockDirectory = {
+        app: {
+          'example.ts': `
+          import {Component, NgModule} from '@angular/core';
+
+          @Component({
+            selector: 'my-component',
+            template: \`
+              <a title="Hello {{name}}"></a>\`
+          })
+          export class MyComponent {
+            name = 'World';
+          }
+
+          @NgModule({declarations: [MyComponent]})
+          export class MyModule {}
+          `
+        }
+      };
+
+      const template = `
+      // ...
+      template:function MyComponent_Template(rf: IDENT, $ctx$: IDENT){
+        if (rf & 1) {
+          $i0$.ɵE(0, 'a');
+          $i0$.ɵe();
+        }
+        if (rf & 2) {
+          $i0$.ɵp(0, 'title', $i0$.ɵb($i0$.ɵi1('Hello ', $ctx$.name, '')));
+        }
+      }`;
+
+      const result = compile(files, angularFiles);
+
+      expectEmit(result.source, template, 'Incorrect interpolated binding');
+    });
   });
 });

--- a/packages/compiler/test/render3/r3_view_compiler_spec.ts
+++ b/packages/compiler/test/render3/r3_view_compiler_spec.ts
@@ -120,43 +120,5 @@ describe('r3_view_compiler', () => {
       const result = compile(files, angularFiles);
       expectEmit(result.source, bV_call, 'Incorrect bV call');
     });
-
-    it('should generate interpolated bindings', () => {
-      const files: MockDirectory = {
-        app: {
-          'example.ts': `
-          import {Component, NgModule} from '@angular/core';
-
-          @Component({
-            selector: 'my-component',
-            template: \`
-              <a title="Hello {{name}}"></a>\`
-          })
-          export class MyComponent {
-            name = 'World';
-          }
-
-          @NgModule({declarations: [MyComponent]})
-          export class MyModule {}
-          `
-        }
-      };
-
-      const template = `
-      // ...
-      template:function MyComponent_Template(rf: IDENT, $ctx$: IDENT){
-        if (rf & 1) {
-          $i0$.ɵE(0, 'a');
-          $i0$.ɵe();
-        }
-        if (rf & 2) {
-          $i0$.ɵp(0, 'title', $i0$.ɵb($i0$.ɵi1('Hello ', $ctx$.name, '')));
-        }
-      }`;
-
-      const result = compile(files, angularFiles);
-
-      expectEmit(result.source, template, 'Incorrect interpolated binding');
-    });
   });
 });

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1266,7 +1266,7 @@ export function text(index: number, value?: any): void {
 
 /**
  * Create text node with binding
- * Bindings should be handled externally with the proper bind(1-8) method
+ * Bindings should be handled externally with the proper interpolation(1-8) method
  *
  * @param index Index of the node in the data array.
  * @param value Stringified value to write.
@@ -2151,8 +2151,8 @@ function initBindings() {
  *
  * @param value Value to diff
  */
-export function bind<T>(value: T | NO_CHANGE): T|NO_CHANGE {
-  return value !== NO_CHANGE && bindingUpdated(value) ? value : NO_CHANGE;
+export function bind<T>(value: T): T|NO_CHANGE {
+  return bindingUpdated(value) ? value : NO_CHANGE;
 }
 
 /**

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -2152,20 +2152,7 @@ function initBindings() {
  * @param value Value to diff
  */
 export function bind<T>(value: T | NO_CHANGE): T|NO_CHANGE {
-  if (currentView.bindingStartIndex < 0) {
-    initBindings();
-    return data[currentView.bindingIndex++] = value;
-  }
-
-  const changed: boolean =
-      value !== NO_CHANGE && isDifferent(data[currentView.bindingIndex], value);
-  if (changed) {
-    throwErrorIfNoChangesMode(
-        creationMode, checkNoChangesMode, data[currentView.bindingIndex], value);
-    data[currentView.bindingIndex] = value;
-  }
-  currentView.bindingIndex++;
-  return changed ? value : NO_CHANGE;
+  return value !== NO_CHANGE && bindingUpdated(value) ? value : NO_CHANGE;
 }
 
 /**

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -35,6 +35,62 @@ describe('instructions', () => {
     elementEnd();
   }
 
+  describe('bind', () => {
+    it('should update bindings when value changes', () => {
+      const t = new TemplateFixture(createAnchor);
+
+      t.update(() => elementProperty(0, 'title', bind('Hello')));
+      expect(t.html).toEqual('<a title="Hello"></a>');
+
+      t.update(() => elementProperty(0, 'title', bind('World')));
+      expect(t.html).toEqual('<a title="World"></a>');
+      expect(ngDevMode).toHaveProperties({
+        firstTemplatePass: 1,
+        tNode: 1,
+        tView: 1,
+        rendererCreateElement: 1,
+        rendererSetProperty: 2
+      });
+    });
+
+    it('should not update bindings when value does not change', () => {
+      const idempotentUpdate = () => elementProperty(0, 'title', bind('Hello'));
+      const t = new TemplateFixture(createAnchor, idempotentUpdate);
+
+      t.update();
+      expect(t.html).toEqual('<a title="Hello"></a>');
+
+      t.update();
+      expect(t.html).toEqual('<a title="Hello"></a>');
+      expect(ngDevMode).toHaveProperties({
+        firstTemplatePass: 1,
+        tNode: 1,
+        tView: 1,
+        rendererCreateElement: 1,
+        rendererSetProperty: 1
+      });
+    });
+
+    it('should handle NO_CHANGE value from interpolation bindings', () => {
+      const idempotentUpdate = () =>
+          elementProperty(0, 'title', bind(interpolation1('Hello ', 'world', '')));
+      const t = new TemplateFixture(createAnchor, idempotentUpdate);
+
+      t.update();
+      expect(t.html).toEqual('<a title="Hello world"></a>');
+
+      t.update();
+      expect(t.html).toEqual('<a title="Hello world"></a>');
+      expect(ngDevMode).toHaveProperties({
+        firstTemplatePass: 1,
+        tNode: 1,
+        tView: 1,
+        rendererCreateElement: 1,
+        rendererSetProperty: 1
+      });
+    });
+  });
+
   describe('elementAttribute', () => {
     it('should use sanitizer function', () => {
       const t = new TemplateFixture(createDiv);

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -46,7 +46,7 @@ describe('instructions', () => {
       expect(t.html).toEqual('<a title="World"></a>');
       expect(ngDevMode).toHaveProperties({
         firstTemplatePass: 1,
-        tNode: 1,
+        tNode: 2,  // 1 for hostElement + 1 for the template under test
         tView: 1,
         rendererCreateElement: 1,
         rendererSetProperty: 2
@@ -64,7 +64,7 @@ describe('instructions', () => {
       expect(t.html).toEqual('<a title="Hello"></a>');
       expect(ngDevMode).toHaveProperties({
         firstTemplatePass: 1,
-        tNode: 1,
+        tNode: 2,  // 1 for hostElement + 1 for the template under test
         tView: 1,
         rendererCreateElement: 1,
         rendererSetProperty: 1

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -70,25 +70,6 @@ describe('instructions', () => {
         rendererSetProperty: 1
       });
     });
-
-    it('should handle NO_CHANGE value from interpolation bindings', () => {
-      const idempotentUpdate = () =>
-          elementProperty(0, 'title', bind(interpolation1('Hello ', 'world', '')));
-      const t = new TemplateFixture(createAnchor, idempotentUpdate);
-
-      t.update();
-      expect(t.html).toEqual('<a title="Hello world"></a>');
-
-      t.update();
-      expect(t.html).toEqual('<a title="Hello world"></a>');
-      expect(ngDevMode).toHaveProperties({
-        firstTemplatePass: 1,
-        tNode: 1,
-        tView: 1,
-        rendererCreateElement: 1,
-        rendererSetProperty: 1
-      });
-    });
   });
 
   describe('elementAttribute', () => {

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -58,9 +58,9 @@ export class TemplateFixture extends BaseFixture {
   /**
    *
    * @param createBlock Instructions which go into the creation block:
-   *          `if (creationMode) { __here__ }`.
-   * @param updateBlock Optional instructions which go after the creation block:
-   *          `if (creationMode) { ... } __here__`.
+   *          `if (rf & RenderFlags.Create) { __here__ }`.
+   * @param updateBlock Optional instructions which go into the update block:
+   *          `if (rf & RenderFlags.Update) { __here__ }`.
    */
   constructor(
       private createBlock: () => void, private updateBlock: () => void = noop,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

The pipe instruction in Ivy duplicated the logic for updating a value binding.

## What is the new behavior?

The pipe instruction now reuses common logic to update a binding.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I was looking into where a `NO_CHANGE` input value would actually come from, given that no testcases seemed to cover that situation. After looking into the compiler it became apparent that it may generate a "double binding" in the form of `bind(interpolate#(value))`, which in runtime would cause the `NO_CHANGE` to be passed into `bind`.

For now I decided to add a compiler testcase that shows that the current behavior actually generates a double binding, and a runtime testcase that verifies that this situation is handled correctly. We may choose to identify this case in the compiler and not emit the `bind` instruction in the first place, given that it takes an extra data slot for tracking the binding value and also duplicates the difference checking of the binding.