### PR TITLE
perf(ivy): avoid creating bound function in pipeBind3

### DIFF
--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -102,7 +102,7 @@ export function pipeBind2(index: number, v1: any, v2: any): any {
  */
 export function pipeBind3(index: number, v1: any, v2: any, v3: any): any {
   const pipeInstance = load<PipeTransform>(index);
-  return isPure(index) ? pureFunction3(pipeInstance.transform.bind(pipeInstance), v1, v2, v3) :
+  return isPure(index) ? pureFunction3(pipeInstance.transform, v1, v2, v3, pipeInstance) :
                          pipeInstance.transform(v1, v2, v3);
 }
 

--- a/packages/core/src/render3/pure_function.ts
+++ b/packages/core/src/render3/pure_function.ts
@@ -15,6 +15,7 @@ import {bindingUpdated, bindingUpdated2, bindingUpdated4, checkAndUpdateBinding,
  * value. If it has been saved, returns the saved value.
  *
  * @param pureFn Function that returns a value
+ * @param thisArg Optional calling context of pureFn
  * @returns value
  */
 export function pureFunction0<T>(pureFn: () => T, thisArg?: any): T {
@@ -28,6 +29,7 @@ export function pureFunction0<T>(pureFn: () => T, thisArg?: any): T {
  *
  * @param pureFn Function that returns an updated value
  * @param exp Updated expression value
+ * @param thisArg Optional calling context of pureFn
  * @returns Updated value
  */
 export function pureFunction1(pureFn: (v: any) => any, exp: any, thisArg?: any): any {
@@ -43,6 +45,7 @@ export function pureFunction1(pureFn: (v: any) => any, exp: any, thisArg?: any):
  * @param pureFn
  * @param exp1
  * @param exp2
+ * @param thisArg Optional calling context of pureFn
  * @returns Updated value
  */
 export function pureFunction2(
@@ -60,6 +63,7 @@ export function pureFunction2(
  * @param exp1
  * @param exp2
  * @param exp3
+ * @param thisArg Optional calling context of pureFn
  * @returns Updated value
  */
 export function pureFunction3(
@@ -81,6 +85,7 @@ export function pureFunction3(
  * @param exp2
  * @param exp3
  * @param exp4
+ * @param thisArg Optional calling context of pureFn
  * @returns Updated value
  */
 export function pureFunction4(
@@ -102,6 +107,7 @@ export function pureFunction4(
  * @param exp3
  * @param exp4
  * @param exp5
+ * @param thisArg Optional calling context of pureFn
  * @returns Updated value
  */
 export function pureFunction5(
@@ -126,6 +132,7 @@ export function pureFunction5(
  * @param exp4
  * @param exp5
  * @param exp6
+ * @param thisArg Optional calling context of pureFn
  * @returns Updated value
  */
 export function pureFunction6(
@@ -151,6 +158,7 @@ export function pureFunction6(
  * @param exp5
  * @param exp6
  * @param exp7
+ * @param thisArg Optional calling context of pureFn
  * @returns Updated value
  */
 export function pureFunction7(
@@ -178,6 +186,7 @@ export function pureFunction7(
  * @param exp6
  * @param exp7
  * @param exp8
+ * @param thisArg Optional calling context of pureFn
  * @returns Updated value
  */
 export function pureFunction8(
@@ -200,7 +209,8 @@ export function pureFunction8(
  *
  * @param pureFn A pure function that takes binding values and builds an object or array
  * containing those values.
- * @param exp An array of binding values
+ * @param exps An array of binding values
+ * @param thisArg Optional calling context of pureFn
  * @returns Updated value
  */
 export function pureFunctionV(pureFn: (...v: any[]) => any, exps: any[], thisArg?: any): any {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[x] Other... Please describe:
Performance improvement
```

## What is the current behavior?

Unlike all other `pipeBind#` functions, `pipeBind3` was creating a new bound function with each update, even when the pipe's input did not change.

## What is the new behavior?

Reusing `pureFunction3`'s ability to specify the calling context of the pureFn invocation, such that creating a bound function is not necessary.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
