### PR TITLE
refactor(ivy): rename `PipeDef.n` to `PipeDef.factory`

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -431,7 +431,7 @@ export function definePipe<T>(pipeDef: {
 }): never {
   return (<PipeDef<T>>{
     name: pipeDef.name,
-    n: pipeDef.factory,
+    factory: pipeDef.factory,
     pure: pipeDef.pure !== false,
     onDestroy: pipeDef.type.prototype.ngOnDestroy || null
   }) as never;

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -204,12 +204,9 @@ export interface PipeDef<T> {
   name: string;
 
   /**
-   * factory function used to create a new directive instance.
-   *
-   * NOTE: this property is short (1 char) because it is used in
-   * component templates which is sensitive to size.
+   * Factory function used to create a new pipe instance.
    */
-  n: () => T;
+  factory: () => T;
 
   /**
    * Whether or not the pipe is pure.

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -33,7 +33,7 @@ export function pipe(index: number, pipeName: string): any {
     pipeDef = tView.data[index] as PipeDef<any>;
   }
 
-  const pipeInstance = pipeDef.n();
+  const pipeInstance = pipeDef.factory();
   store(index, pipeInstance);
   return pipeInstance;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

A vague property name for a pipe's factory function was used.

## What is the new behavior?

A descriptive property name is used, equal to `DirectiveDef`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

The original reason for this property to be short no longer holds true, as pipes always need to be defined using `definePipe`.