### PR TITLE
fix(elements): should not detectChanges in tick, and should run detectChanges in ngZone

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -498,6 +498,11 @@ export class ApplicationRef {
   }
 
   /**
+   * Returns a boolean to tell whether ApplicationRef is running tick.
+   */
+  isTicking() { return this._runningTick; }
+
+  /**
    * Invoke this method to explicitly process change detection and its side-effects.
    *
    * In development mode, `tick()` also performs a second change detection cycle to ensure that no

--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -143,7 +143,10 @@ export class NgZone {
     forkInnerZoneWithAngularBehavior(self);
   }
 
-  static isInAngularZone(): boolean { return Zone.current.get('isAngularZone') === true; }
+  static isInAngularZone(): boolean {
+    // if in noop zone, Zone is undefined
+    return typeof Zone !== 'undefined' ? Zone.current.get('isAngularZone') === true : true;
+  }
 
   static assertInAngularZone(): void {
     if (!NgZone.isInAngularZone()) {

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -46,6 +46,7 @@ export declare class ApplicationRef {
     attachView(viewRef: ViewRef): void;
     bootstrap<C>(componentOrFactory: ComponentFactory<C> | Type<C>, rootSelectorOrNode?: string | any): ComponentRef<C>;
     detachView(viewRef: ViewRef): void;
+    isTicking(): boolean;
     tick(): void;
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 
#23813 

Should not trigger `detectChanges` in `elements` again if already inside `applicationRef.tick`.
https://github.com/angular/angular/compare/master...JiaLiPassion:element-scheduler?expand=1#diff-c0d4cfddef0e50ed399624e91049d934R217

Add a new API ` isTicking()` in `ApplicationRef`.

#23841

Should run `detectChanges` in `ngZone` to make sure `event handlers` are added inside `ngZone`.


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Add a new API ` isTicking()` in `ApplicationRef`. Also updated the `Public API Golden file`.

@mhevery , @robwormald , please review , thank you!