### PR TITLE
docs(releases): remove location of angular labs projects

### DIFF
--- a/aio/content/guide/releases.md
+++ b/aio/content/guide/releases.md
@@ -130,5 +130,3 @@ Any changes to the public API surface will be done using the versioning, support
 Angular Labs is an initiative to cultivate new features and iterate on them quickly. Angular Labs provides a safe place for exploration and experimentation by the Angular team. 
 
 Angular Labs projects are are not ready for production use, and no commitment is made to bring them to production. The policies and practices that are described in this document do not apply to Angular Labs projects. 
-
-Angular Labs projects typically are in separate branches in the Angular repo, clearly separated from the main Angular codebase. 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Removed paragraph that said Angular labs projects are typically in separate branches. While elements and two others were in separate branches, that is not a reliable convention. Some labs projects are in separate repos or other locations. 

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ X] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://angular.io/guide/releases#angular-labs

Says this: 
"Angular Labs projects typically are in separate branches in the Angular repo, clearly separated from the main Angular codebase."


Issue Number: N/A


## What is the new behavior?
https://angular.io/guide/releases#angular-labs

No longer contains that paragraph. Simple removal. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[X ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
