### PR TITLE
fix(ivy): compile interpolated bindings without bind instruction

### DIFF
--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -33,7 +33,7 @@ export class Identifiers {
 
   static text: o.ExternalReference = {name: 'ɵT', moduleName: CORE};
 
-  static textCreateBound: o.ExternalReference = {name: 'ɵt', moduleName: CORE};
+  static textBinding: o.ExternalReference = {name: 'ɵt', moduleName: CORE};
 
   static bind: o.ExternalReference = {name: 'ɵb', moduleName: CORE};
 

--- a/packages/compiler/test/render3/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler/test/render3/r3_view_compiler_binding_spec.ts
@@ -37,7 +37,6 @@ describe('compiler compliance: bindings', () => {
       };
 
       const template = `
-      // ...
       template:function MyComponent_Template(rf: IDENT, $ctx$: IDENT){
         if (rf & 1) {
           $i0$.ɵE(0, 'div');
@@ -74,7 +73,6 @@ describe('compiler compliance: bindings', () => {
       };
 
       const template = `
-      // ...
       template:function MyComponent_Template(rf: IDENT, $ctx$: IDENT){
         if (rf & 1) {
           $i0$.ɵE(0, 'a');
@@ -108,7 +106,6 @@ describe('compiler compliance: bindings', () => {
       };
 
       const template = `
-      // ...
       template:function MyComponent_Template(rf: IDENT, $ctx$: IDENT){
         if (rf & 1) {
           $i0$.ɵE(0, 'a');

--- a/packages/compiler/test/render3/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler/test/render3/r3_view_compiler_binding_spec.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {MockDirectory, setup} from '../aot/test_util';
+import {compile, expectEmit} from './mock_compile';
+
+describe('compiler compliance: bindings', () => {
+  const angularFiles = setup({
+    compileAngular: true,
+    compileAnimations: false,
+    compileCommon: false,
+  });
+
+  describe('text bindings', () => {
+    it('should generate interpolation instruction', () => {
+      const files: MockDirectory = {
+        app: {
+          'example.ts': `
+          import {Component, NgModule} from '@angular/core';
+          @Component({
+            selector: 'my-component',
+            template: \`
+              <div>Hello {{ name }}</div>\`
+          })
+          export class MyComponent {
+            name = 'World';
+          }
+          @NgModule({declarations: [MyComponent]})
+          export class MyModule {}
+          `
+        }
+      };
+
+      const template = `
+      // ...
+      template:function MyComponent_Template(rf: IDENT, $ctx$: IDENT){
+        if (rf & 1) {
+          $i0$.ɵE(0, 'div');
+          $i0$.ɵT(1);
+          $i0$.ɵe();
+        }
+        if (rf & 2) {
+          $i0$.ɵt(1, $i0$.ɵi1('Hello ', $ctx$.name, ''));
+        }
+      }`;
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect interpolated text binding');
+    });
+  });
+
+  describe('property bindings', () => {
+    it('should generate bind instruction', () => {
+      const files: MockDirectory = {
+        app: {
+          'example.ts': `
+          import {Component, NgModule} from '@angular/core';
+
+          @Component({
+            selector: 'my-app',
+            template: '<a [title]="title"></a>'
+          })
+          export class MyComponent {
+            title = 'Hello World';
+          }
+
+          @NgModule({declarations: [MyComponent]})
+          export class MyModule {}`
+        }
+      };
+
+      const template = `
+      // ...
+      template:function MyComponent_Template(rf: IDENT, $ctx$: IDENT){
+        if (rf & 1) {
+          $i0$.ɵE(0, 'a');
+          $i0$.ɵe();
+        }
+        if (rf & 2) {
+          $i0$.ɵp(0, 'title', $i0$.ɵb($ctx$.title));
+        }
+      }`;
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect property binding');
+    });
+
+    it('should generate interpolation instruction for {{...}} bindings', () => {
+      const files: MockDirectory = {
+        app: {
+          'example.ts': `
+          import {Component, NgModule} from '@angular/core';
+          @Component({
+            selector: 'my-component',
+            template: \`
+              <a title="Hello {{name}}"></a>\`
+          })
+          export class MyComponent {
+            name = 'World';
+          }
+          @NgModule({declarations: [MyComponent]})
+          export class MyModule {}
+          `
+        }
+      };
+
+      const template = `
+      // ...
+      template:function MyComponent_Template(rf: IDENT, $ctx$: IDENT){
+        if (rf & 1) {
+          $i0$.ɵE(0, 'a');
+          $i0$.ɵe();
+        }
+        if (rf & 2) {
+          $i0$.ɵp(0, 'title', $i0$.ɵi1('Hello ', $ctx$.name, ''));
+        }
+      }`;
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect interpolated property binding');
+    });
+  });
+
+});


### PR DESCRIPTION
This fixes the case where the compiler would generate a bind(interpolation#())
instruction.

## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

In #23881 it was discovered that the compiler may generate an `interpolation#` instruction within the `bind` instruction. This sequence of instructions will fail a runtime assertion once #23881 is merged, given that by then a potential `NO_CHANGE` value from `interpolation#` is no longer accepted by `bind`.

## What is the new behavior?

The compiler correctly identifies the interpolated binding and does not generate the `bind` instruction in that case.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

For the scope of this bugfix I have not included testcases for bindings in the form of `<a title={{ title }}></a>`, given that this would currently generate `interpolation0('', ctx.title, '')` which is again not necessarily the output we want the compiler to generate, as we can optimize to `bind`.