### PR TITLE
fix(ivy): fix performance counter for textBinding instruction

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1254,14 +1254,15 @@ export function text(index: number, value?: any): void {
  * @param value Stringified value to write.
  */
 export function textBinding<T>(index: number, value: T | NO_CHANGE): void {
-  ngDevMode && assertDataInRange(index);
-  let existingNode = data[index] as LTextNode;
-  ngDevMode && assertNotNull(existingNode, 'LNode should exist');
-  ngDevMode && assertNotNull(existingNode.native, 'native element should exist');
-  ngDevMode && ngDevMode.rendererSetText++;
-  value !== NO_CHANGE &&
-      (isProceduralRenderer(renderer) ? renderer.setValue(existingNode.native, stringify(value)) :
-                                        existingNode.native.textContent = stringify(value));
+  if (value !== NO_CHANGE) {
+    ngDevMode && assertDataInRange(index);
+    const existingNode = data[index] as LTextNode;
+    ngDevMode && assertNotNull(existingNode, 'LNode should exist');
+    ngDevMode && assertNotNull(existingNode.native, 'native element should exist');
+    ngDevMode && ngDevMode.rendererSetText++;
+    isProceduralRenderer(renderer) ? renderer.setValue(existingNode.native, stringify(value)) :
+                                     existingNode.native.textContent = stringify(value);
+  }
 }
 
 //////////////////////////

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -68,6 +68,12 @@ describe('render3 integration test', () => {
 
       expect(renderToHtml(Template, 'benoit')).toEqual('benoit');
       expect(renderToHtml(Template, undefined)).toEqual('');
+      expect(ngDevMode).toHaveProperties({
+        firstTemplatePass: 0,
+        tNode: 0,
+        tView: 1,
+        rendererSetText: 2,
+      });
     });
 
     it('should render "null" as "" when used with `bind()`', () => {
@@ -82,6 +88,12 @@ describe('render3 integration test', () => {
 
       expect(renderToHtml(Template, 'benoit')).toEqual('benoit');
       expect(renderToHtml(Template, null)).toEqual('');
+      expect(ngDevMode).toHaveProperties({
+        firstTemplatePass: 0,
+        tNode: 0,
+        tView: 1,
+        rendererSetText: 2,
+      });
     });
 
     it('should support creation-time values in text nodes', () => {
@@ -95,6 +107,12 @@ describe('render3 integration test', () => {
       }
       expect(renderToHtml(Template, 'once')).toEqual('once');
       expect(renderToHtml(Template, 'twice')).toEqual('once');
+      expect(ngDevMode).toHaveProperties({
+        firstTemplatePass: 0,
+        tNode: 0,
+        tView: 1,
+        rendererSetText: 1,
+      });
     });
 
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Performance counter `rendererSetText` for the `textBinding` instruction was incremented even for `NO_CHANGE` values.

## What is the new behavior?
Performance counter `rendererSetText` is incremented only when rendered text is actually updated. Furthermore the node is not retrieved from the data array for `NO_CHANGE` values.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
