### PR TITLE
fix(core): make DefaultIterableDiffer keep the order of duplicates

### DIFF
--- a/packages/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/packages/core/src/change_detection/differs/default_iterable_differ.ts
@@ -281,23 +281,24 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
       this._remove(record);
     }
 
-    // Attempt to see if we have seen the item before.
-    record = this._linkedRecords === null ? null : this._linkedRecords.get(itemTrackBy, index);
+    // See if we have evicted the item, which used to be at some anterior position of _itHead list.
+    record = this._unlinkedRecords === null ? null : this._unlinkedRecords.get(itemTrackBy, null);
     if (record !== null) {
-      // We have seen this before, we need to move it forward in the collection.
-      // But first we need to check if identity changed, so we can update in view if necessary
+      // It is an item which we have evicted earlier: reinsert it back into the list.
+      // But first we need to check if identity changed, so we can update in view if necessary.
       if (!Object.is(record.item, item)) this._addIdentityChange(record, item);
 
-      this._moveAfter(record, previousRecord, index);
+      this._reinsertAfter(record, previousRecord, index);
     } else {
-      // Never seen it, check evicted list.
-      record = this._unlinkedRecords === null ? null : this._unlinkedRecords.get(itemTrackBy, null);
+      // Attempt to see if the item is at some posterior position of _itHead list.
+      record = this._linkedRecords === null ? null : this._linkedRecords.get(itemTrackBy, index);
       if (record !== null) {
-        // It is an item which we have evicted earlier: reinsert it back into the list.
-        // But first we need to check if identity changed, so we can update in view if necessary
+        // We have the item in _itHead at/after `index` position. We need to move it forward in the
+        // collection.
+        // But first we need to check if identity changed, so we can update in view if necessary.
         if (!Object.is(record.item, item)) this._addIdentityChange(record, item);
 
-        this._reinsertAfter(record, previousRecord, index);
+        this._moveAfter(record, previousRecord, index);
       } else {
         // It is a new item: add it.
         record =

--- a/packages/core/test/change_detection/differs/default_iterable_differ_spec.ts
+++ b/packages/core/test/change_detection/differs/default_iterable_differ_spec.ts
@@ -561,6 +561,65 @@ class ComplexItem {
         }));
       });
 
+      it('should keep the order of duplicates', () => {
+        const l1 = [
+          new ComplexItem('a', 'blue'),
+          new ComplexItem('b', 'yellow'),
+          new ComplexItem('c', 'orange'),
+          new ComplexItem('a', 'red'),
+        ];
+        differ.check(l1);
+
+        const l2 = [
+          new ComplexItem('b', 'yellow'),
+          new ComplexItem('a', 'blue'),
+          new ComplexItem('c', 'orange'),
+          new ComplexItem('a', 'red'),
+        ];
+        differ.check(l2);
+
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+          collection: [
+            '{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]', '{id: c, color: orange}',
+            '{id: a, color: red}'
+          ],
+          identityChanges: [
+            '{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]', '{id: c, color: orange}',
+            '{id: a, color: red}'
+          ],
+          previous: [
+            '{id: a, color: blue}[0->1]', '{id: b, color: yellow}[1->0]', '{id: c, color: orange}',
+            '{id: a, color: red}'
+          ],
+          moves: ['{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]'],
+        }));
+      });
+
+      it('should not have identity changed', () => {
+        const l1 = [
+          new ComplexItem('a', 'blue'),
+          new ComplexItem('b', 'yellow'),
+          new ComplexItem('c', 'orange'),
+          new ComplexItem('a', 'red'),
+        ];
+        differ.check(l1);
+
+        const l2 = [l1[1], l1[0], l1[2], l1[3]];
+        differ.check(l2);
+
+        expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
+          collection: [
+            '{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]', '{id: c, color: orange}',
+            '{id: a, color: red}'
+          ],
+          previous: [
+            '{id: a, color: blue}[0->1]', '{id: b, color: yellow}[1->0]', '{id: c, color: orange}',
+            '{id: a, color: red}'
+          ],
+          moves: ['{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]'],
+        }));
+      });
+
       it('should track removals normally', () => {
         const l = buildItemList(['a', 'b', 'c']);
         differ.check(l);


### PR DESCRIPTION
Previously, in _mismatch, DefaultIterableDiffer first check _linkedRecords for itemTrackBy, then check _unlinkedRecords.
This cause DefaultIterableDiffer match itemTrackBy with the "later" duplicate in the old collection, rather than the "preceding" one.
Now we check _unlinkedRecords first, so that DefaultIterableDiffer can give more simple and reasonable info after diffing:
a1 b c a2 => b a1 c a2 (a1 and a2 have same trackById)
See the new test case in default_iterable_differ_spec.ts and #23815.

Fix #23815

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #23815


## What is the new behavior?
DefaultIterableDiffer can give more simple and reasonable info after diffing `a1 b c a2 => b a1 c a2 (a1 and a2 have same trackById)`. See #23815 .

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
