### PR TITLE
feat(platform-browser): add HammerJS lazy-loader symbols to public API

### DIFF
--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -14,7 +14,8 @@ export {BrowserTransferStateModule, StateKey, TransferState, makeStateKey} from 
 export {By} from './dom/debug/by';
 export {DOCUMENT} from './dom/dom_tokens';
 export {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
-export {HAMMER_GESTURE_CONFIG, HammerGestureConfig} from './dom/events/hammer_gestures';
+export {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HammerGestureConfig, HammerLoader} from './dom/events/hammer_gestures';
 export {DomSanitizer, SafeHtml, SafeResourceUrl, SafeScript, SafeStyle, SafeUrl, SafeValue} from './security/dom_sanitization_service';
+
 export * from './private_export';
 export {VERSION} from './version';

--- a/tools/public_api_guard/platform-browser/platform-browser.d.ts
+++ b/tools/public_api_guard/platform-browser/platform-browser.d.ts
@@ -46,6 +46,8 @@ export declare class EventManager {
 /** @experimental */
 export declare const HAMMER_GESTURE_CONFIG: InjectionToken<HammerGestureConfig>;
 
+export declare const HAMMER_LOADER: InjectionToken<HammerLoader>;
+
 /** @experimental */
 export declare class HammerGestureConfig {
     events: string[];
@@ -64,6 +66,8 @@ export declare class HammerGestureConfig {
     };
     buildHammer(element: HTMLElement): HammerInstance;
 }
+
+export declare type HammerLoader = (() => Promise<void>) | null;
 
 /** @experimental */
 export declare function makeStateKey<T = void>(key: string): StateKey<T>;


### PR DESCRIPTION
I forgot to expose the API for this publicly in #23906 