### PR TITLE
refactor(ivy): remove dynamicViewCount from LContainer

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -570,7 +570,7 @@ export function getOrCreateContainerRef(di: LInjector): viewEngine_ViewContainer
 
     ngDevMode && assertNodeOfPossibleTypes(vcRefHost, TNodeType.Container, TNodeType.Element);
     const hostParent = getParentLNode(vcRefHost) !;
-    const lContainer = createLContainer(hostParent, vcRefHost.view);
+    const lContainer = createLContainer(hostParent, vcRefHost.view, undefined, true);
     const lContainerNode: LContainerNode = createLNodeObject(
         TNodeType.Container, vcRefHost.view, hostParent, undefined, lContainer, null);
 
@@ -642,19 +642,6 @@ class ViewContainerRef implements viewEngine_ViewContainerRef {
 
     this._viewRefs.splice(adjustedIdx, 0, viewRef);
 
-    // If the view is dynamic (has a template), it needs to be counted both at the container
-    // level and at the node above the container.
-    if (lViewNode.data.template !== null) {
-      // Increment the container view count.
-      this._lContainerNode.data.dynamicViewCount++;
-
-      // Look for the parent node and increment its dynamic view count.
-      const containerParent = getParentLNode(this._lContainerNode) as LElementNode;
-      if (containerParent !== null && containerParent.data !== null) {
-        ngDevMode && assertNodeOfPossibleTypes(containerParent, TNodeType.View, TNodeType.Element);
-        containerParent.data.dynamicViewCount++;
-      }
-    }
     return viewRef;
   }
 

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -18,8 +18,11 @@ export interface LContainer {
   /**
    * The next active index in the views array to read or write to. This helps us
    * keep track of where we are in the views array.
+   * In the case the LContainer is created for a ViewContainerRef,
+   * it is set to null to identify this scenario, as indices are "absolute" in that case,
+   * i.e. provided directly by the user of the ViewContainerRef API.
    */
-  nextIndex: number;
+  nextIndex: number|null;
 
   /**
    * This allows us to jump from a container to a sibling container or
@@ -68,12 +71,6 @@ export interface LContainer {
    * The template extracted from the location of the Container.
    */
   readonly template: ComponentTemplate<any>|null;
-
-  /**
-   * A count of dynamic views rendered into this container. If this is non-zero, the `views` array
-   * will be traversed when refreshing dynamic views on this container.
-   */
-  dynamicViewCount: number;
 
   /**
    * Queries active for this container - all the views inserted to / removed from

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -182,14 +182,6 @@ export interface LView {
   context: {}|RootContext|null;
 
   /**
-   * A count of dynamic views that are children of this view (indirectly via containers).
-   *
-   * This is used to decide whether to scan children of this view when refreshing dynamic views
-   * after refreshing the view itself.
-   */
-  dynamicViewCount: number;
-
-  /**
    * Queries active for this view - nodes from a view are reported to those queries
    */
   queries: LQueries|null;

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -126,6 +126,9 @@
     "name": "invertObject"
   },
   {
+    "name": "isLContainer"
+  },
+  {
     "name": "isProceduralRenderer"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -495,6 +495,9 @@
     "name": "isJsObject"
   },
   {
+    "name": "isLContainer"
+  },
+  {
     "name": "isListLikeIterable"
   },
   {


### PR DESCRIPTION
From my understanding, the `dynamicViewCount` property of `LContainer` was introduced during the initial implementation of `ViewContainerRef` to count the number of dynamic views in the container, but it is now used as a flag to know if the `LContainer` belongs to a `ViewContainerRef` or if it was created from an instruction.
In fact, this flag can be simplified and be simply set when the `LContainer` is created.

Following a tricky suggestion from @pkozlowski-opensource , having a dedicated flag is not even needed as the `nextIndex` property is not used when the `LContainer` belongs to a `ViewContainerRef`. **Using -1 as a special value for `nextIndex` is enough to create a flag**