### PR TITLE
docs(aio): Improvement in lifecycle hook live example

### DIFF
--- a/aio/content/examples/lifecycle-hooks/src/app/logger.service.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/logger.service.ts
@@ -18,7 +18,7 @@ export class LoggerService {
     }
   }
 
-  clear() { this.logs = []; }
+  clear() { this.logs.length = 0; }
 
   // schedules a view refresh to ensure display catches up
   tick() {  this.tick_then(() => { }); }

--- a/aio/content/examples/lifecycle-hooks/src/app/peek-a-boo-parent.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/peek-a-boo-parent.component.ts
@@ -43,7 +43,6 @@ export class PeekABooParentComponent {
       this.heroName = 'Windstorm';
       this.logger.clear(); // clear log on create
     }
-    this.hookLog = this.logger.logs;
     this.logger.tick();
   }
 


### PR DESCRIPTION
Note: This issue was fixed earlier under #23220 , This is an improvement in the solution.

## PR Type
Docs

<!-- Please check the one that applies to this PR using "x". -->
```
Documentation content changes
```

## What is the current behavior?
**https://angular.io/guide/lifecycle-hooks
Live example for lifecycle hooks in documentation is not working as expected.

Below is the example link
https://stackblitz.com/angular/jlqeyrgaoaq

Clicking the 'Create PeekABooComponent' not logging the lifecycle hooks below it on UI.**

Issue Number: 22279


## What is the new behavior?
After clicking the 'Create PeekABooComponent' the logs should be viewed below it.


## Does this PR introduce a breaking change?
```
No
```