### PR TITLE
Correct typo of ContentChildred to ContentChildren in STATUS.md

### DIFF
--- a/packages/core/src/render3/STATUS.md
+++ b/packages/core/src/render3/STATUS.md
@@ -186,7 +186,7 @@ The goal is for the `@Component` (and friends) to be the compiler of template. S
 | `@Query(read)`                  |  ✅     |  ✅      |  n/a      |
 | `@Query(selector)`              |  ✅     |  ✅      |  n/a      |
 | `@Query(Type)`                  |  ✅     |  ✅      |  n/a      |
-| `@ContentChildred`              |  ✅     |  ✅      |  ❌       |
+| `@ContentChildren`              |  ✅     |  ✅      |  ❌       |
 | `@ContentChild`                 |  ✅     |  ✅      |  ✅       |
 | `@ViewChildren`                 |  ✅     |  ✅      |  ❌       |
 | `@ViewChild`                    |  ✅     |  ✅      |  ✅       |


### PR DESCRIPTION
Doing a search of the entire repository for `ContentChildred` found **only** the reference in this `STATUS.md` file, so very confident it should really be `ContentChildren`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~Tests for the changes have been added (for bug fixes / features)~ N/A
- [ ] ~Docs have been added / updated (for bug fixes / features)~ N/A


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
 
N/A

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
