### PR TITLE
docs: fix docregion in highlight.directive.2.ts  Fixes #23503

### DIFF
--- a/aio/content/examples/attribute-directives/src/app/highlight.directive.2.ts
+++ b/aio/content/examples/attribute-directives/src/app/highlight.directive.2.ts
@@ -40,5 +40,7 @@ export class HighlightDirective {
   // #docregion color-2
   @Input() appHighlight: string;
   // #enddocregion color-2
-}
 
+// #docregion
+}
+// #enddocregion


### PR DESCRIPTION
Fixes #23503.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is a small typo in ‘src/app/highlight.directive.ts’ embedded code snippet on ['https://angular.io/guide/attribute-directives#respond-to-user-initiated-events'](https://angular.io/guide/attribute-directives#respond-to-user-initiated-events)
Issue Number: 23503


## What is the new behavior?
'}' is added as expected at the last line in ‘src/app/highlight.directive.ts’ embedded code snippet on ['https://angular.io/guide/attribute-directives#respond-to-user-initiated-events'](https://angular.io/guide/attribute-directives#respond-to-user-initiated-events)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
