### PR TITLE
refactor(ivy): move type from LNode to TNode

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -187,7 +187,7 @@ export function LifecycleHooksFeature(component: any, def: ComponentDef<any>): v
 
   // Root component is always created at dir index 0
   queueInitHooks(0, def.onInit, def.doCheck, elementNode.view.tView);
-  queueLifecycleHooks(elementNode.tNode !.flags, elementNode.view);
+  queueLifecycleHooks(elementNode.tNode.flags, elementNode.view);
 }
 
 /**

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -19,7 +19,7 @@ import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, ViewRef as viewEngine_Vie
 import {Type} from '../type';
 
 import {assertGreaterThan, assertLessThan, assertNotNull} from './assert';
-import {addToViewTree, assertPreviousIsParent, createLContainer, createLNodeObject, createTView, getDirectiveInstance, getPreviousOrParentNode, getRenderer, isComponent, renderEmbeddedTemplate, resolveDirective} from './instructions';
+import {addToViewTree, assertPreviousIsParent, createLContainer, createLNodeObject, createTNode, createTView, getDirectiveInstance, getPreviousOrParentNode, getRenderer, isComponent, renderEmbeddedTemplate, resolveDirective} from './instructions';
 import {ComponentTemplate, DirectiveDef, DirectiveDefList, PipeDefList} from './interfaces/definition';
 import {LInjector} from './interfaces/injector';
 import {LContainerNode, LElementNode, LNode, LNodeType, LViewNode, TNodeFlags} from './interfaces/node';
@@ -254,7 +254,7 @@ export function injectAttribute(attrName: string): string|undefined {
   ngDevMode && assertPreviousIsParent();
   const lElement = getPreviousOrParentNode() as LElementNode;
   ngDevMode && assertNodeType(lElement, LNodeType.Element);
-  const tElement = lElement.tNode !;
+  const tElement = lElement.tNode;
   ngDevMode && assertNotNull(tElement, 'expecting tNode');
   const attrs = tElement.attrs;
   if (attrs) {
@@ -278,7 +278,7 @@ export function getOrCreateChangeDetectorRef(
   if (di.changeDetectorRef) return di.changeDetectorRef;
 
   const currentNode = di.node;
-  if (isComponent(currentNode.tNode !)) {
+  if (isComponent(currentNode.tNode)) {
     return di.changeDetectorRef = createViewRef(currentNode.data as LView, context);
   } else if (currentNode.type === LNodeType.Element) {
     return di.changeDetectorRef = getOrCreateHostChangeDetector(currentNode.view.node);
@@ -298,7 +298,7 @@ function getOrCreateHostChangeDetector(currentNode: LViewNode | LElementNode):
       createViewRef(
           hostNode.data as LView,
           hostNode.view
-              .directives ![hostNode.tNode !.flags >> TNodeFlags.DirectiveStartingIndexShift]);
+              .directives ![hostNode.tNode.flags >> TNodeFlags.DirectiveStartingIndexShift]);
 }
 
 /**
@@ -361,7 +361,7 @@ export function getOrCreateInjectable<T>(
       // At this point, we have an injector which *may* contain the token, so we step through the
       // directives associated with the injector's corresponding node to get the directive instance.
       const node = injector.node;
-      const nodeFlags = node.tNode !.flags;
+      const nodeFlags = node.tNode.flags;
       const count = nodeFlags & TNodeFlags.DirectiveCountMask;
 
       if (count !== 0) {
@@ -572,8 +572,12 @@ export function getOrCreateContainerRef(di: LInjector): viewEngine_ViewContainer
     const lContainerNode: LContainerNode = createLNodeObject(
         LNodeType.Container, vcRefHost.view, vcRefHost.parent !, undefined, lContainer, null);
 
-    // TODO(kara): Separate into own TNode when moving parent/child properties
-    lContainerNode.tNode = vcRefHost.tNode;
+    const hostTNode = vcRefHost.tNode;
+    if (!hostTNode.dynamicContainerNode) {
+      hostTNode.dynamicContainerNode = createTNode(hostTNode.index, null, null, null);
+    }
+
+    lContainerNode.tNode = hostTNode.dynamicContainerNode;
     vcRefHost.dynamicLContainerNode = lContainerNode;
 
     addToViewTree(vcRefHost.view, lContainer);
@@ -699,7 +703,7 @@ export function getOrCreateTemplateRef<T>(di: LInjector): viewEngine_TemplateRef
   if (!di.templateRef) {
     ngDevMode && assertNodeType(di.node, LNodeType.Container);
     const hostNode = di.node as LContainerNode;
-    const hostTNode = hostNode.tNode !;
+    const hostTNode = hostNode.tNode;
     const hostTView = hostNode.view.tView;
     if (!hostTNode.tViews) {
       hostTNode.tViews = createTView(hostTView.directiveRegistry, hostTView.pipeRegistry);

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -22,7 +22,7 @@ import {assertGreaterThan, assertLessThan, assertNotNull} from './assert';
 import {addToViewTree, assertPreviousIsParent, createLContainer, createLNodeObject, createTNode, createTView, getDirectiveInstance, getPreviousOrParentNode, getRenderer, isComponent, renderEmbeddedTemplate, resolveDirective} from './instructions';
 import {ComponentTemplate, DirectiveDef, DirectiveDefList, PipeDefList} from './interfaces/definition';
 import {LInjector} from './interfaces/injector';
-import {LContainerNode, LElementNode, LNode, TNodeType, LViewNode, TNodeFlags} from './interfaces/node';
+import {LContainerNode, LElementNode, LNode, LViewNode, TNodeFlags, TNodeType} from './interfaces/node';
 import {QueryReadType} from './interfaces/query';
 import {Renderer3} from './interfaces/renderer';
 import {LView, TView} from './interfaces/view';

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -22,7 +22,7 @@ import {assertGreaterThan, assertLessThan, assertNotNull} from './assert';
 import {addToViewTree, assertPreviousIsParent, createLContainer, createLNodeObject, createTNode, createTView, getDirectiveInstance, getPreviousOrParentNode, getRenderer, isComponent, renderEmbeddedTemplate, resolveDirective} from './instructions';
 import {ComponentTemplate, DirectiveDef, DirectiveDefList, PipeDefList} from './interfaces/definition';
 import {LInjector} from './interfaces/injector';
-import {LContainerNode, LElementNode, LNode, LNodeType, LViewNode, TNodeFlags} from './interfaces/node';
+import {LContainerNode, LElementNode, LNode, TNodeType, LViewNode, TNodeFlags} from './interfaces/node';
 import {QueryReadType} from './interfaces/query';
 import {Renderer3} from './interfaces/renderer';
 import {LView, TView} from './interfaces/view';
@@ -253,7 +253,7 @@ export function injectChangeDetectorRef(): viewEngine_ChangeDetectorRef {
 export function injectAttribute(attrName: string): string|undefined {
   ngDevMode && assertPreviousIsParent();
   const lElement = getPreviousOrParentNode() as LElementNode;
-  ngDevMode && assertNodeType(lElement, LNodeType.Element);
+  ngDevMode && assertNodeType(lElement, TNodeType.Element);
   const tElement = lElement.tNode;
   ngDevMode && assertNotNull(tElement, 'expecting tNode');
   const attrs = tElement.attrs;
@@ -280,7 +280,7 @@ export function getOrCreateChangeDetectorRef(
   const currentNode = di.node;
   if (isComponent(currentNode.tNode)) {
     return di.changeDetectorRef = createViewRef(currentNode.data as LView, context);
-  } else if (currentNode.type === LNodeType.Element) {
+  } else if (currentNode.tNode.type === TNodeType.Element) {
     return di.changeDetectorRef = getOrCreateHostChangeDetector(currentNode.view.node);
   }
   return null !;
@@ -307,7 +307,7 @@ function getOrCreateHostChangeDetector(currentNode: LViewNode | LElementNode):
  * returns itself.
  */
 function getClosestComponentAncestor(node: LViewNode | LElementNode): LElementNode {
-  while (node.type === LNodeType.View) {
+  while (node.tNode.type === TNodeType.View) {
     node = node.view.node;
   }
   return node as LElementNode;
@@ -523,7 +523,7 @@ export class ReadFromInjectorFn<T> {
  */
 export function getOrCreateElementRef(di: LInjector): viewEngine_ElementRef {
   return di.elementRef || (di.elementRef = new ElementRef(
-                               di.node.type === LNodeType.Container ? null : di.node.native));
+                               di.node.tNode.type === TNodeType.Container ? null : di.node.native));
 }
 
 export const QUERY_READ_TEMPLATE_REF = <QueryReadType<viewEngine_TemplateRef<any>>>(
@@ -540,12 +540,12 @@ export const QUERY_READ_ELEMENT_REF =
 
 export const QUERY_READ_FROM_NODE =
     (new ReadFromInjectorFn<any>((injector: LInjector, node: LNode, directiveIdx: number) => {
-      ngDevMode && assertNodeOfPossibleTypes(node, LNodeType.Container, LNodeType.Element);
+      ngDevMode && assertNodeOfPossibleTypes(node, TNodeType.Container, TNodeType.Element);
       if (directiveIdx > -1) {
         return node.view.directives ![directiveIdx];
-      } else if (node.type === LNodeType.Element) {
+      } else if (node.tNode.type === TNodeType.Element) {
         return getOrCreateElementRef(injector);
-      } else if (node.type === LNodeType.Container) {
+      } else if (node.tNode.type === TNodeType.Container) {
         return getOrCreateTemplateRef(injector);
       }
       throw new Error('fail');
@@ -567,14 +567,15 @@ export function getOrCreateContainerRef(di: LInjector): viewEngine_ViewContainer
   if (!di.viewContainerRef) {
     const vcRefHost = di.node;
 
-    ngDevMode && assertNodeOfPossibleTypes(vcRefHost, LNodeType.Container, LNodeType.Element);
+    ngDevMode && assertNodeOfPossibleTypes(vcRefHost, TNodeType.Container, TNodeType.Element);
     const lContainer = createLContainer(vcRefHost.parent !, vcRefHost.view);
     const lContainerNode: LContainerNode = createLNodeObject(
-        LNodeType.Container, vcRefHost.view, vcRefHost.parent !, undefined, lContainer, null);
+        TNodeType.Container, vcRefHost.view, vcRefHost.parent !, undefined, lContainer, null);
 
     const hostTNode = vcRefHost.tNode;
     if (!hostTNode.dynamicContainerNode) {
-      hostTNode.dynamicContainerNode = createTNode(hostTNode.index, null, null, null);
+      hostTNode.dynamicContainerNode =
+          createTNode(TNodeType.Container, hostTNode.index, null, null, null);
     }
 
     lContainerNode.tNode = hostTNode.dynamicContainerNode;
@@ -650,7 +651,7 @@ class ViewContainerRef implements viewEngine_ViewContainerRef {
       // Look for the parent node and increment its dynamic view count.
       if (this._lContainerNode.parent !== null && this._lContainerNode.parent.data !== null) {
         ngDevMode && assertNodeOfPossibleTypes(
-                         this._lContainerNode.parent, LNodeType.View, LNodeType.Element);
+                         this._lContainerNode.parent, TNodeType.View, TNodeType.Element);
         this._lContainerNode.parent.data.dynamicViewCount++;
       }
     }
@@ -701,7 +702,7 @@ class ViewContainerRef implements viewEngine_ViewContainerRef {
  */
 export function getOrCreateTemplateRef<T>(di: LInjector): viewEngine_TemplateRef<T> {
   if (!di.templateRef) {
-    ngDevMode && assertNodeType(di.node, LNodeType.Container);
+    ngDevMode && assertNodeType(di.node, TNodeType.Container);
     const hostNode = di.node as LContainerNode;
     const hostTNode = hostNode.tNode;
     const hostTView = hostNode.view.tView;

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -337,9 +337,9 @@ export function createLView<T>(
  * (same properties assigned in the same order).
  */
 export function createLNodeObject(
-  type: TNodeType, currentView: LView, parent: LNode, native: RText | RElement | null | undefined,
-  state: any,
-  queries: LQueries | null): LElementNode&LTextNode&LViewNode&LContainerNode&LProjectionNode {
+    type: TNodeType, currentView: LView, parent: LNode, native: RText | RElement | null | undefined,
+    state: any,
+    queries: LQueries | null): LElementNode&LTextNode&LViewNode&LContainerNode&LProjectionNode {
   return {
     native: native as any,
     view: currentView,
@@ -367,20 +367,20 @@ export function createLNodeObject(
  * @param data Any data that should be saved on the LNode
  */
 export function createLNode(
-  index: number | null, type: TNodeType.Element, native: RElement | RText | null,
-  name: string | null, attrs: string[] | null, lView?: LView | null): LElementNode;
+    index: number | null, type: TNodeType.Element, native: RElement | RText | null,
+    name: string | null, attrs: string[] | null, lView?: LView | null): LElementNode;
 export function createLNode(
-  index: number | null, type: TNodeType.View, native: null, name: null, attrs: null,
-  lView: LView): LViewNode;
+    index: number | null, type: TNodeType.View, native: null, name: null, attrs: null,
+    lView: LView): LViewNode;
 export function createLNode(
-  index: number, type: TNodeType.Container, native: undefined, name: string | null,
-  attrs: string[] | null, lContainer: LContainer): LContainerNode;
+    index: number, type: TNodeType.Container, native: undefined, name: string | null,
+    attrs: string[] | null, lContainer: LContainer): LContainerNode;
 export function createLNode(
-  index: number, type: TNodeType.Projection, native: null, name: null, attrs: string[] | null,
-  lProjection: LProjection): LProjectionNode;
+    index: number, type: TNodeType.Projection, native: null, name: null, attrs: string[] | null,
+    lProjection: LProjection): LProjectionNode;
 export function createLNode(
-  index: number | null, type: TNodeType, native: RText | RElement | null | undefined,
-  name: string | null, attrs: string[] | null, state?: null | LView | LContainer |
+    index: number | null, type: TNodeType, native: RText | RElement | null | undefined,
+    name: string | null, attrs: string[] | null, state?: null | LView | LContainer |
         LProjection): LElementNode&LTextNode&LViewNode&LContainerNode&LProjectionNode {
   const parent = isParent ? previousOrParentNode :
                             previousOrParentNode && previousOrParentNode.parent as LNode;
@@ -1048,8 +1048,8 @@ export function elementProperty<T>(
  * @returns the TNode object
  */
 export function createTNode(
-  type: TNodeType, index: number | null, tagName: string | null, attrs: string[] | null,
-  tViews: TView[] | null): TNode {
+    type: TNodeType, index: number | null, tagName: string | null, attrs: string[] | null,
+    tViews: TView[] | null): TNode {
   ngDevMode && ngDevMode.tNode++;
   return {
     type: type,

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -15,7 +15,7 @@ import {CssSelectorList, LProjection, NG_PROJECT_AS_ATTR_NAME} from './interface
 import {LQueries} from './interfaces/query';
 import {CurrentMatchesList, LView, LViewFlags, LifecycleStage, RootContext, TData, TView} from './interfaces/view';
 
-import {LContainerNode, LElementNode, LNode, LNodeType, TNodeFlags, LProjectionNode, LTextNode, LViewNode, TNode, TContainerNode, InitialInputData, InitialInputs, PropertyAliases, PropertyAliasValue,} from './interfaces/node';
+import {LContainerNode, LElementNode, LNode, TNodeType, TNodeFlags, LProjectionNode, LTextNode, LViewNode, TNode, TContainerNode, InitialInputData, InitialInputs, PropertyAliases, PropertyAliasValue,} from './interfaces/node';
 import {assertNodeType} from './node_assert';
 import {appendChild, insertView, appendProjectedNode, removeView, canInsertNativeNode, createTextNode, getNextLNode} from './node_manipulation';
 import {isNodeMatchingSelectorList, matchingSelectorIndex} from './node_selector_matcher';
@@ -337,11 +337,10 @@ export function createLView<T>(
  * (same properties assigned in the same order).
  */
 export function createLNodeObject(
-    type: LNodeType, currentView: LView, parent: LNode, native: RText | RElement | null | undefined,
-    state: any,
-    queries: LQueries | null): LElementNode&LTextNode&LViewNode&LContainerNode&LProjectionNode {
+  type: TNodeType, currentView: LView, parent: LNode, native: RText | RElement | null | undefined,
+  state: any,
+  queries: LQueries | null): LElementNode&LTextNode&LViewNode&LContainerNode&LProjectionNode {
   return {
-    type: type,
     native: native as any,
     view: currentView,
     parent: parent as any,
@@ -368,20 +367,20 @@ export function createLNodeObject(
  * @param data Any data that should be saved on the LNode
  */
 export function createLNode(
-    index: number | null, type: LNodeType.Element, native: RElement | RText | null,
-    name: string | null, attrs: string[] | null, lView?: LView | null): LElementNode;
+  index: number | null, type: TNodeType.Element, native: RElement | RText | null,
+  name: string | null, attrs: string[] | null, lView?: LView | null): LElementNode;
 export function createLNode(
-    index: number | null, type: LNodeType.View, native: null, name: null, attrs: null,
-    lView: LView): LViewNode;
+  index: number | null, type: TNodeType.View, native: null, name: null, attrs: null,
+  lView: LView): LViewNode;
 export function createLNode(
-    index: number, type: LNodeType.Container, native: undefined, name: string | null,
-    attrs: string[] | null, lContainer: LContainer): LContainerNode;
+  index: number, type: TNodeType.Container, native: undefined, name: string | null,
+  attrs: string[] | null, lContainer: LContainer): LContainerNode;
 export function createLNode(
-    index: number, type: LNodeType.Projection, native: null, name: null, attrs: string[] | null,
-    lProjection: LProjection): LProjectionNode;
+  index: number, type: TNodeType.Projection, native: null, name: null, attrs: string[] | null,
+  lProjection: LProjection): LProjectionNode;
 export function createLNode(
-    index: number | null, type: LNodeType, native: RText | RElement | null | undefined,
-    name: string | null, attrs: string[] | null, state?: null | LView | LContainer |
+  index: number | null, type: TNodeType, native: RText | RElement | null | undefined,
+  name: string | null, attrs: string[] | null, state?: null | LView | LContainer |
         LProjection): LElementNode&LTextNode&LViewNode&LContainerNode&LProjectionNode {
   const parent = isParent ? previousOrParentNode :
                             previousOrParentNode && previousOrParentNode.parent as LNode;
@@ -392,10 +391,10 @@ export function createLNode(
   const node =
       createLNodeObject(type, currentView, parent, native, isState ? state as any : null, queries);
 
-  if (index === null || type === LNodeType.View) {
+  if (index === null || type === TNodeType.View) {
     // View nodes are not stored in data because they can be added / removed at runtime (which
     // would cause indices to change). Their TNodes are instead stored in TView.node.
-    node.tNode = (state as LView).tView.node || createTNode(index, null, null, null);
+    node.tNode = (state as LView).tView.node || createTNode(type, index, null, null, null);
   } else {
     // This is an element or container or projection node
     ngDevMode && assertDataNext(index);
@@ -403,7 +402,7 @@ export function createLNode(
 
     // Every node adds a value to the static data array to avoid a sparse array
     if (index >= tData.length) {
-      const tNode = tData[index] = createTNode(index, name, attrs, null);
+      const tNode = tData[index] = createTNode(type, index, name, attrs, null);
       if (!isParent && previousOrParentNode) {
         const previousTNode = previousOrParentNode.tNode;
         previousTNode.next = tNode;
@@ -416,7 +415,7 @@ export function createLNode(
     if (isParent) {
       currentQueries = null;
       if (previousOrParentNode.view === currentView ||
-          previousOrParentNode.type === LNodeType.View) {
+          previousOrParentNode.tNode.type === TNodeType.View) {
         // We are in the same view, which means we are adding content node to the parent View.
         ngDevMode && assertNull(
                          previousOrParentNode.child,
@@ -429,7 +428,7 @@ export function createLNode(
   }
 
   // View nodes and host elements need to set their host node (components set host nodes later)
-  if ((type & LNodeType.ViewOrElement) === LNodeType.ViewOrElement && isState) {
+  if ((type & TNodeType.ViewOrElement) === TNodeType.ViewOrElement && isState) {
     // Bit of a hack to bust through the readonly because there is a circular dep between
     // LView and LNode.
     ngDevMode && assertNull((state as LView).node, 'LView.node should not have been initialized');
@@ -475,7 +474,7 @@ export function renderTemplate<T>(
     rendererFactory = providedRendererFactory;
     const tView = getOrCreateTView(template, directives || null, pipes || null);
     host = createLNode(
-        null, LNodeType.Element, hostNode, null, null,
+        null, TNodeType.Element, hostNode, null, null,
         createLView(
             -1, providedRendererFactory.createRenderer(null, null), tView, null, {},
             LViewFlags.CheckAlways, sanitizer));
@@ -512,7 +511,7 @@ export function renderEmbeddedTemplate<T>(
       const lView = createLView(
           -1, renderer, tView, template, context, LViewFlags.CheckAlways, getCurrentSanitizer());
 
-      viewNode = createLNode(null, LNodeType.View, null, null, null, lView);
+      viewNode = createLNode(null, TNodeType.View, null, null, null, lView);
       rf = RenderFlags.Create;
     }
     oldView = enterView(viewNode.data, viewNode);
@@ -600,7 +599,7 @@ export function elementStart(
   ngDevMode && assertDataInRange(index - 1);
 
   const node: LElementNode =
-      createLNode(index, LNodeType.Element, native !, name, attrs || null, null);
+      createLNode(index, TNodeType.Element, native !, name, attrs || null, null);
 
   if (attrs) setUpAttributes(native, attrs);
   appendChild(node.parent !, native, currentView);
@@ -884,7 +883,7 @@ export function hostElement(
     sanitizer?: Sanitizer | null): LElementNode {
   resetApplicationState();
   const node = createLNode(
-      0, LNodeType.Element, rNode, null, null,
+      0, TNodeType.Element, rNode, null, null,
       createLView(
           -1, renderer, getOrCreateTView(def.template, def.directiveDefs, def.pipeDefs), null, null,
           def.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways, sanitizer));
@@ -963,7 +962,7 @@ export function elementEnd() {
     ngDevMode && assertHasParent();
     previousOrParentNode = previousOrParentNode.parent !;
   }
-  ngDevMode && assertNodeType(previousOrParentNode, LNodeType.Element);
+  ngDevMode && assertNodeType(previousOrParentNode, TNodeType.Element);
   const queries = previousOrParentNode.queries;
   queries && queries.addNode(previousOrParentNode);
   queueLifecycleHooks(previousOrParentNode.tNode.flags, currentView);
@@ -1041,6 +1040,7 @@ export function elementProperty<T>(
 /**
  * Constructs a TNode object from the arguments.
  *
+ * @param type The type of the node
  * @param index The index of the TNode in TView.data
  * @param tagName The tag name of the node
  * @param attrs The attributes defined on this node
@@ -1048,10 +1048,11 @@ export function elementProperty<T>(
  * @returns the TNode object
  */
 export function createTNode(
-    index: number | null, tagName: string | null, attrs: string[] | null,
-    tViews: TView[] | null): TNode {
+  type: TNodeType, index: number | null, tagName: string | null, attrs: string[] | null,
+  tViews: TView[] | null): TNode {
   ngDevMode && ngDevMode.tNode++;
   return {
+    type: type,
     index: index,
     flags: 0,
     tagName: tagName,
@@ -1257,7 +1258,7 @@ export function text(index: number, value?: any): void {
           currentView.bindingStartIndex, -1, 'text nodes should be created before bindings');
   ngDevMode && ngDevMode.rendererCreateTextNode++;
   const textNode = createTextNode(value, renderer);
-  const node = createLNode(index, LNodeType.Element, textNode, null, null);
+  const node = createLNode(index, TNodeType.Element, textNode, null, null);
 
   // Text nodes are self closing.
   isParent = false;
@@ -1386,7 +1387,7 @@ export function baseDirectiveCreate<T>(
     if (diPublic) diPublic(directiveDef !);
   }
 
-  if (directiveDef !.attributes != null && previousOrParentNode.type == LNodeType.Element) {
+  if (directiveDef !.attributes != null && previousOrParentNode.tNode.type == TNodeType.Element) {
     setUpAttributes(
         (previousOrParentNode as LElementNode).native, directiveDef !.attributes as string[]);
   }
@@ -1495,7 +1496,7 @@ export function container(
   const lContainer = createLContainer(currentParent, currentView, template);
 
   const node = createLNode(
-      index, LNodeType.Container, undefined, tagName || null, attrs || null, lContainer);
+      index, TNodeType.Container, undefined, tagName || null, attrs || null, lContainer);
 
   if (firstTemplatePass && template == null) node.tNode.tViews = [];
 
@@ -1505,7 +1506,7 @@ export function container(
   createDirectivesAndLocals(index, tagName || null, attrs, localRefs, template == null);
 
   isParent = false;
-  ngDevMode && assertNodeType(previousOrParentNode, LNodeType.Container);
+  ngDevMode && assertNodeType(previousOrParentNode, TNodeType.Container);
   const queries = node.queries;
   if (queries) {
     // check if a given container node matches
@@ -1523,7 +1524,7 @@ export function container(
 export function containerRefreshStart(index: number): void {
   ngDevMode && assertDataInRange(index);
   previousOrParentNode = data[index] as LNode;
-  ngDevMode && assertNodeType(previousOrParentNode, LNodeType.Container);
+  ngDevMode && assertNodeType(previousOrParentNode, TNodeType.Container);
   isParent = true;
   (previousOrParentNode as LContainerNode).data.nextIndex = 0;
   ngDevMode && assertSame(
@@ -1546,14 +1547,14 @@ export function containerRefreshEnd(): void {
   if (isParent) {
     isParent = false;
   } else {
-    ngDevMode && assertNodeType(previousOrParentNode, LNodeType.View);
+    ngDevMode && assertNodeType(previousOrParentNode, TNodeType.View);
     ngDevMode && assertHasParent();
     previousOrParentNode = previousOrParentNode.parent !;
   }
-  ngDevMode && assertNodeType(previousOrParentNode, LNodeType.Container);
+  ngDevMode && assertNodeType(previousOrParentNode, TNodeType.Container);
   const container = previousOrParentNode as LContainerNode;
   container.native = undefined;
-  ngDevMode && assertNodeType(container, LNodeType.Container);
+  ngDevMode && assertNodeType(container, TNodeType.Container);
   const nextIndex = container.data.nextIndex;
 
   // remove extra views at the end of the container
@@ -1616,13 +1617,13 @@ function scanForView(
 export function embeddedViewStart(viewBlockId: number): RenderFlags {
   const container =
       (isParent ? previousOrParentNode : previousOrParentNode.parent !) as LContainerNode;
-  ngDevMode && assertNodeType(container, LNodeType.Container);
+  ngDevMode && assertNodeType(container, TNodeType.Container);
   const lContainer = container.data;
   let viewNode: LViewNode|null = scanForView(container, lContainer.nextIndex, viewBlockId);
 
   if (viewNode) {
     previousOrParentNode = viewNode;
-    ngDevMode && assertNodeType(previousOrParentNode, LNodeType.View);
+    ngDevMode && assertNodeType(previousOrParentNode, TNodeType.View);
     isParent = true;
     enterView(viewNode.data, viewNode);
   } else {
@@ -1635,7 +1636,7 @@ export function embeddedViewStart(viewBlockId: number): RenderFlags {
     }
 
     enterView(
-        newView, viewNode = createLNode(viewBlockId, LNodeType.View, null, null, null, newView));
+        newView, viewNode = createLNode(viewBlockId, TNodeType.View, null, null, null, newView));
   }
   return getRenderFlags(viewNode.data);
 }
@@ -1652,7 +1653,7 @@ export function embeddedViewStart(viewBlockId: number): RenderFlags {
  * @returns TView
  */
 function getOrCreateEmbeddedTView(viewIndex: number, parent: LContainerNode): TView {
-  ngDevMode && assertNodeType(parent, LNodeType.Container);
+  ngDevMode && assertNodeType(parent, TNodeType.Container);
   const containerTViews = (parent !.tNode as TContainerNode).tViews as TView[];
   ngDevMode && assertNotNull(containerTViews, 'TView expected');
   ngDevMode && assertEqual(Array.isArray(containerTViews), true, 'TViews should be in an array');
@@ -1670,8 +1671,8 @@ export function embeddedViewEnd(): void {
   const viewNode = previousOrParentNode = currentView.node as LViewNode;
   const containerNode = previousOrParentNode.parent as LContainerNode;
   if (containerNode) {
-    ngDevMode && assertNodeType(viewNode, LNodeType.View);
-    ngDevMode && assertNodeType(containerNode, LNodeType.Container);
+    ngDevMode && assertNodeType(viewNode, TNodeType.View);
+    ngDevMode && assertNodeType(containerNode, TNodeType.Container);
     const lContainer = containerNode.data;
 
     if (creationMode) {
@@ -1686,7 +1687,7 @@ export function embeddedViewEnd(): void {
   }
   leaveView(currentView !.parent !);
   ngDevMode && assertEqual(isParent, false, 'isParent');
-  ngDevMode && assertNodeType(previousOrParentNode, LNodeType.View);
+  ngDevMode && assertNodeType(previousOrParentNode, TNodeType.View);
 }
 
 /**
@@ -1700,7 +1701,7 @@ function setRenderParentInProjectedNodes(
   if (renderParent != null) {
     let node: LNode|null = viewNode.child;
     while (node) {
-      if (node.type === LNodeType.Projection) {
+      if (node.tNode.type === TNodeType.Projection) {
         let nodeToProject: LNode|null = (node as LProjectionNode).data.head;
         const lastNodeToProject = (node as LProjectionNode).data.tail;
         while (nodeToProject) {
@@ -1726,7 +1727,7 @@ function setRenderParentInProjectedNodes(
 export function componentRefresh<T>(directiveIndex: number, elementIndex: number): void {
   ngDevMode && assertDataInRange(elementIndex);
   const element = data ![elementIndex] as LElementNode;
-  ngDevMode && assertNodeType(element, LNodeType.Element);
+  ngDevMode && assertNodeType(element, TNodeType.Element);
   ngDevMode && assertNotNull(element.data, `Component's host node should have an LView attached.`);
   const hostView = element.data !;
 
@@ -1836,7 +1837,7 @@ function appendToProjectionNode(
 export function projection(
     nodeIndex: number, localIndex: number, selectorIndex: number = 0, attrs?: string[]): void {
   const node = createLNode(
-      nodeIndex, LNodeType.Projection, null, null, attrs || null, {head: null, tail: null});
+      nodeIndex, TNodeType.Projection, null, null, attrs || null, {head: null, tail: null});
 
   // `<ng-content>` has no content
   isParent = false;
@@ -1850,7 +1851,7 @@ export function projection(
   // build the linked list of projected nodes:
   for (let i = 0; i < nodesForSelector.length; i++) {
     const nodeToProject = nodesForSelector[i];
-    if (nodeToProject.type === LNodeType.Projection) {
+    if (nodeToProject.tNode.type === TNodeType.Projection) {
       // Reprojecting a projection -> append the list of previously projected nodes
       const previouslyProjected = (nodeToProject as LProjectionNode).data;
       appendToProjectionNode(node, previouslyProjected.head, previouslyProjected.tail);
@@ -1863,7 +1864,7 @@ export function projection(
   }
 
   if (canInsertNativeNode(currentParent, currentView)) {
-    ngDevMode && assertNodeType(currentParent, LNodeType.Element);
+    ngDevMode && assertNodeType(currentParent, TNodeType.Element);
     // process each node in the list of projected nodes:
     let nodeToProject: LNode|null = node.data.head;
     const lastNodeToProject = node.data.tail;
@@ -1884,13 +1885,13 @@ export function projection(
  */
 function findComponentHost(lView: LView): LElementNode {
   let viewRootLNode = lView.node;
-  while (viewRootLNode.type === LNodeType.View) {
+  while (viewRootLNode.tNode.type === TNodeType.View) {
     ngDevMode && assertNotNull(lView.parent, 'lView.parent');
     lView = lView.parent !;
     viewRootLNode = lView.node;
   }
 
-  ngDevMode && assertNodeType(viewRootLNode, LNodeType.Element);
+  ngDevMode && assertNodeType(viewRootLNode, TNodeType.Element);
   ngDevMode && assertNotNull(viewRootLNode.data, 'node.data');
 
   return viewRootLNode as LElementNode;

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -118,11 +118,12 @@ export interface LNode {
    * Pointer to the corresponding TNode object, which stores static
    * data about this node.
    */
-  tNode: TNode|null;
+  tNode: TNode;
 
   /**
    * A pointer to a LContainerNode created by directives requesting ViewContainerRef
    */
+  // TODO(kara): Remove when removing LNodes
   dynamicLContainerNode: LContainerNode|null;
 }
 
@@ -210,8 +211,10 @@ export interface TNode {
    *
    * This is necessary to get from any TNode to its corresponding LNode when
    * traversing the node tree.
+   *
+   * If null, this is a view node created from a dynamically created view.
    */
-  index: number;
+  index: number|null;
 
   /**
    * This number stores two values using its bits:
@@ -306,6 +309,11 @@ export interface TNode {
    * to insert them or remove them from the DOM.
    */
   next: TNode|null;
+
+  /**
+   * A pointer to a LContainerNode created by directives requesting ViewContainerRef
+   */
+  dynamicContainerNode: TNode|null;
 }
 
 /** Static data for an LElementNode  */

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -16,10 +16,10 @@ import {LView, TData, TView} from './view';
 
 
 /**
- * LNodeType corresponds to the LNode.type property. It contains information
+ * TNodeType corresponds to the TNode.type property. It contains information
  * on how to map a particular set of bits in LNode.flags to the node type.
  */
-export const enum LNodeType {
+export const enum TNodeType {
   Container = 0b00,
   Projection = 0b01,
   View = 0b10,
@@ -58,9 +58,6 @@ export const enum TNodeFlags {
  * instructions.
  */
 export interface LNode {
-  /** The type of the node (see LNodeFlags) */
-  type: LNodeType;
-
   /**
    * The associated DOM node. Storing this allows us to:
    *  - append children to their element parents in the DOM (e.g. `parent.native.appendChild(...)`)
@@ -121,7 +118,7 @@ export interface LNode {
   tNode: TNode;
 
   /**
-   * A pointer to a LContainerNode created by directives requesting ViewContainerRef
+   * A pointer to an LContainerNode created by directives requesting ViewContainerRef
    */
   // TODO(kara): Remove when removing LNodes
   dynamicLContainerNode: LContainerNode|null;
@@ -206,6 +203,9 @@ export interface LProjectionNode extends LNode {
  * see: https://en.wikipedia.org/wiki/Flyweight_pattern for more on the Flyweight pattern
  */
 export interface TNode {
+  /** The type of the TNode. See TNodeType. */
+  type: TNodeType;
+
   /**
    * Index of the TNode in TView.data and corresponding LNode in LView.data.
    *
@@ -311,7 +311,7 @@ export interface TNode {
   next: TNode|null;
 
   /**
-   * A pointer to a LContainerNode created by directives requesting ViewContainerRef
+   * A pointer to a TContainerNode created by directives requesting ViewContainerRef
    */
   dynamicContainerNode: TNode|null;
 }

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -46,6 +46,7 @@ export interface LView {
    *
    * If `LElementNode`, this is the LView of a component.
    */
+  // TODO(kara): Remove when we have parent/child on TNodes
   readonly node: LViewNode|LElementNode;
 
   /**
@@ -241,6 +242,17 @@ export interface LViewOrLContainer {
  * Stored on the template function as ngPrivateData.
  */
 export interface TView {
+  /**
+   * Pointer to the `TNode` that represents the root of the view.
+   *
+   * If this is a `TNode` for an `LViewNode`, this is an embedded view of a container.
+   * We need this pointer to be able to efficiently find this node when inserting the view
+   * into an anchor.
+   *
+   * If this is a `TNode` for an `LElementNode`, this is the TView of a component.
+   */
+  node: TNode;
+
   /** Whether or not this template has been processed. */
   firstTemplatePass: boolean;
 

--- a/packages/core/src/render3/node_assert.ts
+++ b/packages/core/src/render3/node_assert.ts
@@ -7,23 +7,23 @@
  */
 
 import {assertEqual, assertNotNull} from './assert';
-import {LNode, LNodeType} from './interfaces/node';
+import {LNode, TNodeType} from './interfaces/node';
 
-export function assertNodeType(node: LNode, type: LNodeType) {
+export function assertNodeType(node: LNode, type: TNodeType) {
   assertNotNull(node, 'should be called with a node');
-  assertEqual(node.type, type, `should be a ${typeName(type)}`);
+  assertEqual(node.tNode.type, type, `should be a ${typeName(type)}`);
 }
 
-export function assertNodeOfPossibleTypes(node: LNode, ...types: LNodeType[]) {
+export function assertNodeOfPossibleTypes(node: LNode, ...types: TNodeType[]) {
   assertNotNull(node, 'should be called with a node');
-  const found = types.some(type => node.type === type);
+  const found = types.some(type => node.tNode.type === type);
   assertEqual(found, true, `Should be one of ${types.map(typeName).join(', ')}`);
 }
 
-function typeName(type: LNodeType): string {
-  if (type == LNodeType.Projection) return 'Projection';
-  if (type == LNodeType.Container) return 'Container';
-  if (type == LNodeType.View) return 'View';
-  if (type == LNodeType.Element) return 'Element';
+function typeName(type: TNodeType): string {
+  if (type == TNodeType.Projection) return 'Projection';
+  if (type == TNodeType.Container) return 'Container';
+  if (type == TNodeType.View) return 'View';
+  if (type == TNodeType.Element) return 'Element';
   return '<unknown>';
 }

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -72,7 +72,7 @@ export function getNextLNode(node: LNode): LNode|null {
     const lView = node.data as LView;
     return lView.next ? (lView.next as LView).node : null;
   }
-  return node.tNode !.next ? node.view.data[node.tNode !.next !.index] : null;
+  return node.tNode.next ? node.view.data[node.tNode.next !.index as number] : null;
 }
 
 /**

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -9,7 +9,7 @@
 import {assertNotNull} from './assert';
 import {callHooks} from './hooks';
 import {LContainer, unusedValueExportToPlacateAjd as unused1} from './interfaces/container';
-import {LContainerNode, LElementNode, LNode, TNodeType, LProjectionNode, LTextNode, LViewNode, unusedValueExportToPlacateAjd as unused2} from './interfaces/node';
+import {LContainerNode, LElementNode, LNode, LProjectionNode, LTextNode, LViewNode, TNodeType, unusedValueExportToPlacateAjd as unused2} from './interfaces/node';
 import {unusedValueExportToPlacateAjd as unused3} from './interfaces/projection';
 import {ProceduralRenderer3, RElement, RNode, RText, Renderer3, isProceduralRenderer, unusedValueExportToPlacateAjd as unused4} from './interfaces/renderer';
 import {HookData, LView, LViewOrLContainer, TView, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -9,7 +9,7 @@
 import {assertNotNull} from './assert';
 import {callHooks} from './hooks';
 import {LContainer, unusedValueExportToPlacateAjd as unused1} from './interfaces/container';
-import {LContainerNode, LElementNode, LNode, LNodeType, LProjectionNode, LTextNode, LViewNode, unusedValueExportToPlacateAjd as unused2} from './interfaces/node';
+import {LContainerNode, LElementNode, LNode, TNodeType, LProjectionNode, LTextNode, LViewNode, unusedValueExportToPlacateAjd as unused2} from './interfaces/node';
 import {unusedValueExportToPlacateAjd as unused3} from './interfaces/projection';
 import {ProceduralRenderer3, RElement, RNode, RText, Renderer3, isProceduralRenderer, unusedValueExportToPlacateAjd as unused4} from './interfaces/renderer';
 import {HookData, LView, LViewOrLContainer, TView, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
@@ -35,7 +35,7 @@ function findNextRNodeSibling(node: LNode | null, stopNode: LNode | null): RElem
   while (currentNode && currentNode !== stopNode) {
     let pNextOrParent = currentNode.pNextOrParent;
     if (pNextOrParent) {
-      while (pNextOrParent.type !== LNodeType.Projection) {
+      while (pNextOrParent.tNode.type !== TNodeType.Projection) {
         const nativeNode = findFirstRNode(pNextOrParent);
         if (nativeNode) {
           return nativeNode;
@@ -55,8 +55,8 @@ function findNextRNodeSibling(node: LNode | null, stopNode: LNode | null): RElem
       const parentNode = currentNode.parent;
       currentNode = null;
       if (parentNode) {
-        const parentType = parentNode.type;
-        if (parentType === LNodeType.Container || parentType === LNodeType.View) {
+        const parentType = parentNode.tNode.type;
+        if (parentType === TNodeType.Container || parentType === TNodeType.View) {
           currentNode = parentNode;
         }
       }
@@ -68,7 +68,7 @@ function findNextRNodeSibling(node: LNode | null, stopNode: LNode | null): RElem
 /** Retrieves the sibling node for the given node. */
 export function getNextLNode(node: LNode): LNode|null {
   // View nodes don't have TNodes, so their next must be retrieved through their LView.
-  if (node.type === LNodeType.View) {
+  if (node.tNode.type === TNodeType.View) {
     const lView = node.data as LView;
     return lView.next ? (lView.next as LView).node : null;
   }
@@ -87,7 +87,7 @@ function getNextLNodeWithProjection(node: LNode): LNode|null {
 
   if (pNextOrParent) {
     // The node is projected
-    const isLastProjectedNode = pNextOrParent.type === LNodeType.Projection;
+    const isLastProjectedNode = pNextOrParent.tNode.type === TNodeType.Projection;
     // returns pNextOrParent if we are not at the end of the list, null otherwise
     return isLastProjectedNode ? null : pNextOrParent;
   }
@@ -132,16 +132,16 @@ function findFirstRNode(rootNode: LNode): RElement|RText|null {
   let node: LNode|null = rootNode;
   while (node) {
     let nextNode: LNode|null = null;
-    if (node.type === LNodeType.Element) {
+    if (node.tNode.type === TNodeType.Element) {
       // A LElementNode has a matching RNode in LElementNode.native
       return (node as LElementNode).native;
-    } else if (node.type === LNodeType.Container) {
+    } else if (node.tNode.type === TNodeType.Container) {
       const lContainerNode: LContainerNode = (node as LContainerNode);
       const childContainerData: LContainer = lContainerNode.dynamicLContainerNode ?
           lContainerNode.dynamicLContainerNode.data :
           lContainerNode.data;
       nextNode = childContainerData.views.length ? childContainerData.views[0].child : null;
-    } else if (node.type === LNodeType.Projection) {
+    } else if (node.tNode.type === TNodeType.Projection) {
       // For Projection look at the first projected node
       nextNode = (node as LProjectionNode).data.head;
     } else {
@@ -179,8 +179,8 @@ export function addRemoveViewFromContainer(
 export function addRemoveViewFromContainer(
     container: LContainerNode, rootNode: LViewNode, insertMode: boolean,
     beforeNode?: RNode | null): void {
-  ngDevMode && assertNodeType(container, LNodeType.Container);
-  ngDevMode && assertNodeType(rootNode, LNodeType.View);
+  ngDevMode && assertNodeType(container, TNodeType.Container);
+  ngDevMode && assertNodeType(rootNode, TNodeType.View);
   const parentNode = container.data.renderParent;
   const parent = parentNode ? parentNode.native : null;
   let node: LNode|null = rootNode.child;
@@ -188,7 +188,7 @@ export function addRemoveViewFromContainer(
     while (node) {
       let nextNode: LNode|null = null;
       const renderer = container.view.renderer;
-      if (node.type === LNodeType.Element) {
+      if (node.tNode.type === TNodeType.Element) {
         if (insertMode) {
           isProceduralRenderer(renderer) ?
               renderer.insertBefore(parent, node.native !, beforeNode as RNode | null) :
@@ -198,13 +198,13 @@ export function addRemoveViewFromContainer(
                                            parent.removeChild(node.native !);
         }
         nextNode = getNextLNode(node);
-      } else if (node.type === LNodeType.Container) {
+      } else if (node.tNode.type === TNodeType.Container) {
         // if we get to a container, it must be a root node of a view because we are only
         // propagating down into child views / containers and not child elements
         const childContainerData: LContainer = (node as LContainerNode).data;
         childContainerData.renderParent = parentNode;
         nextNode = childContainerData.views.length ? childContainerData.views[0].child : null;
-      } else if (node.type === LNodeType.Projection) {
+      } else if (node.tNode.type === TNodeType.Projection) {
         nextNode = (node as LProjectionNode).data.head;
       } else {
         nextNode = (node as LViewNode).child;
@@ -357,7 +357,7 @@ export function removeView(container: LContainerNode, removeIndex: number): LVie
  */
 export function getParentState(state: LViewOrLContainer, rootView: LView): LViewOrLContainer|null {
   let node;
-  if ((node = (state as LView) !.node) && node.type === LNodeType.View) {
+  if ((node = (state as LView) !.node) && node.tNode.type === TNodeType.View) {
     // if it's an embedded view, the state needs to go up to the container, in case the
     // container has a next
     return node.parent !.data as any;
@@ -429,7 +429,7 @@ function executePipeOnDestroys(view: LView): void {
  * @return boolean Whether the child element should be inserted.
  */
 export function canInsertNativeNode(parent: LNode, currentView: LView): boolean {
-  const parentIsElement = parent.type === LNodeType.Element;
+  const parentIsElement = parent.tNode.type === TNodeType.Element;
 
   return parentIsElement &&
       (parent.view !== currentView || parent.data === null /* Regular Element. */);
@@ -486,7 +486,7 @@ export function insertChild(node: LNode, currentView: LView): void {
 export function appendProjectedNode(
     node: LElementNode | LTextNode | LContainerNode, currentParent: LElementNode,
     currentView: LView): void {
-  if (node.type !== LNodeType.Container) {
+  if (node.tNode.type !== TNodeType.Container) {
     appendChild(currentParent, (node as LElementNode | LTextNode).native, currentView);
   } else {
     // The node we are adding is a Container and we are adding it to Element which

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -195,7 +195,7 @@ function getIdxOfMatchingSelector(tNode: TNode, selector: string): number|null {
  */
 function getIdxOfMatchingDirective(node: LNode, type: Type<any>): number|null {
   const defs = node.view.tView.directives !;
-  const flags = node.tNode !.flags;
+  const flags = node.tNode.flags;
   const count = flags & TNodeFlags.DirectiveCountMask;
   const start = flags >> TNodeFlags.DirectiveStartingIndexShift;
   const end = start + count;
@@ -241,8 +241,7 @@ function add(query: LQuery<any>| null, node: LNode) {
     } else {
       const selector = predicate.selector !;
       for (let i = 0; i < selector.length; i++) {
-        ngDevMode && assertNotNull(node.tNode, 'node.tNode');
-        const directiveIdx = getIdxOfMatchingSelector(node.tNode !, selector[i]);
+        const directiveIdx = getIdxOfMatchingSelector(node.tNode, selector[i]);
         if (directiveIdx !== null) {
           // a node is matching a predicate - determine what to read
           // note that queries using name selector must specify read strategy

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -14,7 +14,7 @@ import {bloomAdd, bloomFindPossibleInjector, getOrCreateNodeInjector, injectAttr
 import {NgOnChangesFeature, PublicFeature, defineDirective, directiveInject, injectChangeDetectorRef, injectElementRef, injectTemplateRef, injectViewContainerRef} from '../../src/render3/index';
 import {bind, container, containerRefreshEnd, containerRefreshStart, createLNode, createLView, createTView, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, enterView, interpolation2, leaveView, load, projection, projectionDef, text, textBinding} from '../../src/render3/instructions';
 import {LInjector} from '../../src/render3/interfaces/injector';
-import {LNodeType} from '../../src/render3/interfaces/node';
+import {TNodeType} from '../../src/render3/interfaces/node';
 import {LViewFlags} from '../../src/render3/interfaces/view';
 import {ViewRef} from '../../src/render3/view_ref';
 
@@ -1367,7 +1367,7 @@ describe('di', () => {
           createLView(-1, null !, createTView(null, null), null, null, LViewFlags.CheckAlways);
       const oldView = enterView(contentView, null !);
       try {
-        const parent = createLNode(0, LNodeType.Element, null, null, null, null);
+        const parent = createLNode(0, TNodeType.Element, null, null, null, null);
 
         // Simulate the situation where the previous parent is not initialized.
         // This happens on first bootstrap because we don't init existing values

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -48,7 +48,7 @@ describe('instructions', () => {
       expect(t.html).toEqual('<div title="javascript:true"></div>');
       expect(ngDevMode).toHaveProperties({
         firstTemplatePass: 1,
-        tNode: 1,
+        tNode: 2,  // 1 for div, 1 for host element
         tView: 1,
         rendererCreateElement: 1,
         rendererSetAttribute: 2
@@ -69,7 +69,7 @@ describe('instructions', () => {
       expect(t.html).toEqual('<div title="javascript:false"></div>');
       expect(ngDevMode).toHaveProperties({
         firstTemplatePass: 1,
-        tNode: 1,
+        tNode: 2,  // 1 for div, 1 for host element
         tView: 1,
         rendererCreateElement: 1,
       });
@@ -83,7 +83,7 @@ describe('instructions', () => {
       expect((t.hostNode.native as HTMLElement).querySelector('div') !.hidden).toEqual(false);
       expect(ngDevMode).toHaveProperties({
         firstTemplatePass: 1,
-        tNode: 1,
+        tNode: 2,  // 1 for div, 1 for host element
         tView: 1,
         rendererCreateElement: 1,
         rendererSetProperty: 1

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -32,7 +32,7 @@ describe('render3 integration test', () => {
       }
       expect(ngDevMode).toHaveProperties({
         firstTemplatePass: 1,
-        tNode: 2,
+        tNode: 3,  // 1 for div, 1 for text, 1 for host element
         tView: 1,
         rendererCreateElement: 1,
       });

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -19,7 +19,8 @@ function testLStaticData(tagName: string, attrs: string[] | null): TNode {
     inputs: undefined,
     outputs: undefined,
     tViews: null,
-    next: null
+    next: null,
+    dynamicContainerNode: null
   };
 }
 

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {TNodeType, TNode} from '../../src/render3/interfaces/node';
+import {TNode, TNodeType} from '../../src/render3/interfaces/node';
 
 import {CssSelector, CssSelectorList, NG_PROJECT_AS_ATTR_NAME, SelectorFlags,} from '../../src/render3/interfaces/projection';
 import {getProjectAsAttrValue, isNodeMatchingSelectorList, isNodeMatchingSelector} from '../../src/render3/node_selector_matcher';

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -6,12 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {TNode} from '../../src/render3/interfaces/node';
+import {TNodeType, TNode} from '../../src/render3/interfaces/node';
+
 import {CssSelector, CssSelectorList, NG_PROJECT_AS_ATTR_NAME, SelectorFlags,} from '../../src/render3/interfaces/projection';
 import {getProjectAsAttrValue, isNodeMatchingSelectorList, isNodeMatchingSelector} from '../../src/render3/node_selector_matcher';
 
 function testLStaticData(tagName: string, attrs: string[] | null): TNode {
   return {
+    type: TNodeType.Element,
     index: 0,
     flags: 0, tagName, attrs,
     localNames: null,


### PR DESCRIPTION
Review only last 2 commits, waiting on https://github.com/angular/angular/pull/23869.

This PR has two primary changes:

- Creates `TNodes` for any remaining `LNode` types that don't have them (i.e. view nodes, host elements, and dynamically created containers). This is a necessary step so we can eventually move all node tree traversal markers to `TNode` (so all nodes are accessible via `TNode`). It also allows us to move `type` to `TNode`. 

- Moves `type` property from `LNode` to `TNode`. This improves memory pressure and gives us the necessary extra info to move other properties over.

TODO:

- parent, child, and most things
