### PR TITLE
feat(ivy): separate attributes for directive matching purposes

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -22,7 +22,7 @@ import {assertGreaterThan, assertLessThan, assertNotNull} from './assert';
 import {addToViewTree, assertPreviousIsParent, createLContainer, createLNodeObject, createTNode, createTView, getDirectiveInstance, getPreviousOrParentNode, getRenderer, isComponent, renderEmbeddedTemplate, resolveDirective} from './instructions';
 import {ComponentTemplate, DirectiveDef, DirectiveDefList, PipeDefList} from './interfaces/definition';
 import {LInjector} from './interfaces/injector';
-import {LContainerNode, LElementNode, LNode, LViewNode, TNodeFlags, TNodeType} from './interfaces/node';
+import {AttributeMarker, LContainerNode, LElementNode, LNode, LViewNode, TNodeFlags, TNodeType} from './interfaces/node';
 import {QueryReadType} from './interfaces/query';
 import {Renderer3} from './interfaces/renderer';
 import {LView, TView} from './interfaces/view';
@@ -251,7 +251,7 @@ export function injectChangeDetectorRef(): viewEngine_ChangeDetectorRef {
  *
  * @experimental
  */
-export function injectAttribute(attrName: string): string|undefined {
+export function injectAttribute(attrNameToInject: string): string|undefined {
   ngDevMode && assertPreviousIsParent();
   const lElement = getPreviousOrParentNode() as LElementNode;
   ngDevMode && assertNodeType(lElement, TNodeType.Element);
@@ -260,8 +260,10 @@ export function injectAttribute(attrName: string): string|undefined {
   const attrs = tElement.attrs;
   if (attrs) {
     for (let i = 0; i < attrs.length; i = i + 2) {
-      if (attrs[i] == attrName) {
-        return attrs[i + 1];
+      const attrName = attrs[i];
+      if (attrName === AttributeMarker.SELECT_ONLY) break;
+      if (attrName == attrNameToInject) {
+        return attrs[i + 1] as string;
       }
     }
   }

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -74,6 +74,10 @@ export {
 } from './instructions';
 
 export {
+    AttributeMarker
+} from './interfaces/node';
+
+export {
   pipe as Pp,
   pipeBind1 as pb1,
   pipeBind2 as pb2,

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -159,6 +159,29 @@ export interface LProjectionNode extends LNode {
 }
 
 /**
+ * A set of marker values to be used in the attributes arrays. Those markers indicate that some
+ * items are not regular attributes and the processing should be adapted accordingly.
+ */
+export const enum AttributeMarker {
+  NS = 0,  // namespace. Has to be repeated.
+
+  /**
+   * This marker indicates that the following attribute names were extracted from bindings (ex.:
+   * [foo]="exp") and / or event handlers (ex. (bar)="doSth()").
+   * Taking the above bindings and outputs as an example an attributes array could look as follows:
+   * ['class', 'fade in', AttributeMarker.SELECT_ONLY, 'foo', 'bar']
+   */
+  SELECT_ONLY = 1
+}
+
+/**
+ * A combination of:
+ * - attribute names and values
+ * - special markers acting as flags to alter attributes processing.
+ */
+export type TAttributes = (string | AttributeMarker)[];
+
+/**
  * LNode binding data (flyweight) for a particular node that is shared between all templates
  * of a specific type.
  *
@@ -198,18 +221,20 @@ export interface TNode {
   tagName: string|null;
 
   /**
-   * Static attributes associated with an element. We need to store
-   * static attributes to support content projection with selectors.
-   * Attributes are stored statically because reading them from the DOM
-   * would be way too slow for content projection and queries.
+   * Attributes associated with an element. We need to store attributes to support various use-cases
+   * (attribute injection, content projection with selectors, directives matching).
+   * Attributes are stored statically because reading them from the DOM would be way too slow for
+   * content projection and queries.
    *
-   * Since attrs will always be calculated first, they will never need
-   * to be marked undefined by other instructions.
+   * Since attrs will always be calculated first, they will never need to be marked undefined by
+   * other instructions.
    *
-   * The name of the attribute and its value alternate in the array.
+   * For regular attributes a name of an attribute and its value alternate in the array.
    * e.g. ['role', 'checkbox']
+   * This array can contain flags that will indicate "special attributes" (attributes with
+   * namespaces, attributes extracted from bindings and outputs).
    */
-  attrs: string[]|null;
+  attrs: TAttributes|null;
 
   /**
    * A set of local names under which a given element is exported in a template and

--- a/packages/core/test/render3/directive_spec.ts
+++ b/packages/core/test/render3/directive_spec.ts
@@ -6,10 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {defineDirective} from '../../src/render3/index';
-import {bind, elementEnd, elementProperty, elementStart, loadDirective} from '../../src/render3/instructions';
-import {RenderFlags} from '../../src/render3/interfaces/definition';
-import {renderToHtml} from './render_util';
+import {EventEmitter} from '@angular/core';
+
+import {AttributeMarker, defineDirective} from '../../src/render3/index';
+import {bind, elementEnd, elementProperty, elementStart, listener, loadDirective} from '../../src/render3/instructions';
+
+import {TemplateFixture} from './render_util';
 
 describe('directive', () => {
 
@@ -31,17 +33,151 @@ describe('directive', () => {
         });
       }
 
-      function Template(rf: RenderFlags, ctx: any) {
-        if (rf & RenderFlags.Create) {
-          elementStart(0, 'span', ['dir', '']);
-          elementEnd();
+      function Template() {
+        elementStart(0, 'span', [AttributeMarker.SELECT_ONLY, 'dir']);
+        elementEnd();
+      }
+
+      const fixture = new TemplateFixture(Template, () => {}, [Directive]);
+      expect(fixture.html).toEqual('<span class="foo"></span>');
+
+      directiveInstance !.klass = 'bar';
+      fixture.update();
+      expect(fixture.html).toEqual('<span class="bar"></span>');
+    });
+
+  });
+
+  describe('selectors', () => {
+
+    it('should match directives with attribute selectors on bindings', () => {
+      let directiveInstance: Directive;
+
+      class Directive {
+        static ngDirectiveDef = defineDirective({
+          type: Directive,
+          selectors: [['', 'test', '']],
+          factory: () => directiveInstance = new Directive,
+          inputs: {test: 'test', other: 'other'}
+        });
+
+        testValue: boolean;
+        other: boolean;
+
+        /**
+         * A setter to assert that a binding is not invoked with stringified attribute value
+         */
+        set test(value: any) {
+          // if a binding is processed correctly we should only be invoked with a false Boolean
+          // and never with the "false" string literal
+          this.testValue = value;
+          if (value !== false) {
+            fail('Should only be called with a false Boolean value, got a non-falsy value');
+          }
         }
       }
 
-      const defs = [Directive];
-      expect(renderToHtml(Template, {}, defs)).toEqual('<span class="foo" dir=""></span>');
-      directiveInstance !.klass = 'bar';
-      expect(renderToHtml(Template, {}, defs)).toEqual('<span class="bar" dir=""></span>');
+      /**
+       * <span [test]="false" [other]="true"></span>
+       */
+      function createTemplate() {
+        // using 2 bindings to show example shape of attributes array
+        elementStart(0, 'span', ['class', 'fade', AttributeMarker.SELECT_ONLY, 'test', 'other']);
+        elementEnd();
+      }
+
+      function updateTemplate() { elementProperty(0, 'test', bind(false)); }
+
+      const fixture = new TemplateFixture(createTemplate, updateTemplate, [Directive]);
+
+      // the "test" attribute should not be reflected in the DOM as it is here only for directive
+      // matching purposes
+      expect(fixture.html).toEqual('<span class="fade"></span>');
+      expect(directiveInstance !.testValue).toBe(false);
+    });
+
+    it('should not accidentally set inputs from attributes extracted from bindings / outputs',
+       () => {
+         let directiveInstance: Directive;
+
+         class Directive {
+           static ngDirectiveDef = defineDirective({
+             type: Directive,
+             selectors: [['', 'test', '']],
+             factory: () => directiveInstance = new Directive,
+             inputs: {test: 'test', prop1: 'prop1', prop2: 'prop2'}
+           });
+
+           prop1: boolean;
+           prop2: boolean;
+           testValue: boolean;
+
+
+           /**
+            * A setter to assert that a binding is not invoked with stringified attribute value
+            */
+           set test(value: any) {
+             // if a binding is processed correctly we should only be invoked with a false Boolean
+             // and never with the "false" string literal
+             this.testValue = value;
+             if (value !== false) {
+               fail('Should only be called with a false Boolean value, got a non-falsy value');
+             }
+           }
+         }
+
+         /**
+          * <span [prop1]="true" [test]="false" [prop2]="true"></span>
+          */
+         function createTemplate() {
+           // putting name (test) in the "usual" value position
+           elementStart(
+               0, 'span', ['class', 'fade', AttributeMarker.SELECT_ONLY, 'prop1', 'test', 'prop2']);
+           elementEnd();
+         }
+
+         function updateTemplate() {
+           elementProperty(0, 'prop1', bind(true));
+           elementProperty(0, 'test', bind(false));
+           elementProperty(0, 'prop2', bind(true));
+         }
+
+         const fixture = new TemplateFixture(createTemplate, updateTemplate, [Directive]);
+
+         // the "test" attribute should not be reflected in the DOM as it is here only for directive
+         // matching purposes
+         expect(fixture.html).toEqual('<span class="fade"></span>');
+         expect(directiveInstance !.testValue).toBe(false);
+       });
+
+    it('should match directives with attribute selectors on outputs', () => {
+      let directiveInstance: Directive;
+
+      class Directive {
+        static ngDirectiveDef = defineDirective({
+          type: Directive,
+          selectors: [['', 'out', '']],
+          factory: () => directiveInstance = new Directive,
+          outputs: {out: 'out'}
+        });
+
+        out = new EventEmitter();
+      }
+
+      /**
+       * <span (out)="someVar = true"></span>
+       */
+      function createTemplate() {
+        elementStart(0, 'span', [AttributeMarker.SELECT_ONLY, 'out']);
+        { listener('out', () => {}); }
+        elementEnd();
+      }
+
+      const fixture = new TemplateFixture(createTemplate, () => {}, [Directive]);
+
+      // "out" should not be part of reflected attributes
+      expect(fixture.html).toEqual('<span></span>');
+      expect(directiveInstance !).not.toBeUndefined();
     });
 
   });

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {TNode, TNodeType} from '../../src/render3/interfaces/node';
+import {AttributeMarker, TAttributes, TNode, TNodeType} from '../../src/render3/interfaces/node';
 
 import {CssSelector, CssSelectorList, NG_PROJECT_AS_ATTR_NAME, SelectorFlags,} from '../../src/render3/interfaces/projection';
 import {getProjectAsAttrValue, isNodeMatchingSelectorList, isNodeMatchingSelector} from '../../src/render3/node_selector_matcher';
 
-function testLStaticData(tagName: string, attrs: string[] | null): TNode {
+function testLStaticData(tagName: string, attrs: TAttributes | null): TNode {
   return {
     type: TNodeType.Element,
     index: 0,
@@ -29,7 +29,7 @@ function testLStaticData(tagName: string, attrs: string[] | null): TNode {
 }
 
 describe('css selector matching', () => {
-  function isMatching(tagName: string, attrs: string[] | null, selector: CssSelector): boolean {
+  function isMatching(tagName: string, attrs: TAttributes | null, selector: CssSelector): boolean {
     return isNodeMatchingSelector(testLStaticData(tagName, attrs), selector);
   }
 
@@ -177,6 +177,28 @@ describe('css selector matching', () => {
           '', 'class', 'foo'
         ])).toBeTruthy(`Selector '[class="foo"]' should match <span class="foo">`);
       });
+
+      it('should take optional binding attribute names into account', () => {
+        expect(isMatching('span', [AttributeMarker.SELECT_ONLY, 'directive'], [
+          '', 'directive', ''
+        ])).toBeTruthy(`Selector '[directive]' should match <span [directive]="exp">`);
+      });
+
+      it('should not match optional binding attribute names if attribute selector has value',
+         () => {
+           expect(isMatching('span', [AttributeMarker.SELECT_ONLY, 'directive'], [
+             '', 'directive', 'value'
+           ])).toBeFalsy(`Selector '[directive=value]' should not match <span [directive]="exp">`);
+         });
+
+      it('should not match optional binding attribute names if attribute selector has value and next name equals to value',
+         () => {
+           expect(isMatching(
+                      'span', [AttributeMarker.SELECT_ONLY, 'directive', 'value'],
+                      ['', 'directive', 'value']))
+               .toBeFalsy(
+                   `Selector '[directive=value]' should not match <span [directive]="exp" [value]="otherExp">`);
+         });
     });
 
     describe('class matching', () => {


### PR DESCRIPTION
In ngIvy directives matching (determining which directives are active based
on a CSS seletor) happens at runtime. This means that runtime needs to have
enough context to match directives. This PR takes care of cases where a directive's
selector should match bindings (ex. [foo]="exp") and event handlers (ex. (out)="do()").
In the mentioned cases we need to have binding / output "attributes" for directive's
CSS selector matching purposes. At the same time those are not regular attributes and
as such should not  be reflected in the DOM.

In the proposed PR binding / output "attributes" are _not_ stored on TNode and only
used for directives matching on the first render of a given template.

Closes #23706
