### PR TITLE
chore(core): clean up dupe'd imports in reflector

### DIFF
--- a/packages/core/src/reflection/reflector.ts
+++ b/packages/core/src/reflection/reflector.ts
@@ -10,8 +10,8 @@ import {Type} from '../type';
 import {PlatformReflectionCapabilities} from './platform_reflection_capabilities';
 import {GetterFn, MethodFn, SetterFn} from './types';
 
-export {PlatformReflectionCapabilities} from './platform_reflection_capabilities';
-export {GetterFn, MethodFn, SetterFn} from './types';
+export {PlatformReflectionCapabilities};
+export {GetterFn, MethodFn, SetterFn};
 
 /**
  * Provides access to reflection data about symbols. Used internally by Angular


### PR DESCRIPTION
Closure Compiler in some configurations complains about duplicate imports.
This change replaces the export-with-import with an export of the imported
symbol.