### PR TITLE
feat(ivy): support renderer.destroy and renderer.destroyNode hooks

### DIFF
--- a/packages/core/src/render3/STATUS.md
+++ b/packages/core/src/render3/STATUS.md
@@ -228,10 +228,10 @@ The goal is for the `@Component` (and friends) to be the compiler of template. S
 ### View Encapsulation
 | Feature                             | Runtime | Spec     | Compiler |
 | ----------------------------------- | ------- | -------- | -------- |
-| Render3.None                        |  ✅     |  ✅       |  ✅      |
-| Render2.None                        |  ✅     |  ✅       |  ✅      |
-| Render2.Emulated                    |  ❌     |  ❌       |  ❌      |
-| Render2.Native                      |  ❌     |  ❌       |  ❌      |
+| Renderer3.None                        |  ✅     |  ✅       |  ✅      |
+| Renderer2.None                        |  ✅     |  ✅       |  ✅      |
+| Renderer2.Emulated                    |  ❌     |  ❌       |  ❌      |
+| Renderer2.Native                      |  ❌     |  ❌       |  ❌      |
 
 
 
@@ -254,3 +254,28 @@ The goal is for the `@Component` (and friends) to be the compiler of template. S
 | `checkNoChanges()`     | n/a                | n/a          |  ❌              | n/a      | n/a         | ✅                   |
 | `reattach()`           | n/a                | n/a          |  ❌              | n/a      | n/a         | ✅                   |
 | `nativeElement()`      | n/a                | n/a          | n/a              | n/a      |  ✅         | n/a                  |
+
+### Renderer2
+| Method                              | Runtime |
+| ----------------------------------- | ------- |
+| `data()`                            |  n/a    |
+| `destroy()`                         |  ✅     |
+| `createElement()`                   |  ✅     |
+| `createComment()`                   |  n/a    |
+| `createText()`                      |  ✅     |
+| `destroyNode()`                     |  ✅     |
+| `appendChild()`                     |  ✅     |
+| `insertBefore()`                    |  ✅     |
+| `removeChild()`                     |  ✅     |
+| `selectRootElement()`               |  ✅     |
+| `parentNode()`                      |  ❌     |
+| `nextSibling()`                     |  ❌     |
+| `setAttribute()`                    |  ✅     |
+| `removeAttribute()`                 |  ✅     |
+| `addClass()`                        |  ✅     |
+| `removeClass()`                     |  ✅     |
+| `setStyle()`                        |  ✅     |
+| `removeStyle()`                     |  ✅     |
+| `setProperty()`                     |  ✅     |
+| `setValue()`                        |  ✅     |
+| `listen()`                          |  ✅     |

--- a/packages/core/src/render3/ng_dev_mode.ts
+++ b/packages/core/src/render3/ng_dev_mode.ts
@@ -25,6 +25,8 @@ declare global {
     rendererRemoveClass: number;
     rendererSetStyle: number;
     rendererRemoveStyle: number;
+    rendererDestroy: number;
+    rendererDestroyNode: number;
   }
 }
 
@@ -50,6 +52,8 @@ export const ngDevModeResetPerfCounters: () => void =
            rendererRemoveClass: 0,
            rendererSetStyle: 0,
            rendererRemoveStyle: 0,
+           rendererDestroy: 0,
+           rendererDestroyNode: 0,
          };
        }
        ngDevModeResetPerfCounters();

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -53,6 +53,7 @@ export class TemplateFixture extends BaseFixture {
   private _directiveDefs: DirectiveDefList|null;
   private _pipeDefs: PipeDefList|null;
   private _sanitizer: Sanitizer|null;
+  private _rendererFactory: RendererFactory3;
 
   /**
    *
@@ -64,11 +65,12 @@ export class TemplateFixture extends BaseFixture {
   constructor(
       private createBlock: () => void, private updateBlock: () => void = noop,
       directives?: DirectiveTypesOrFactory|null, pipes?: PipeTypesOrFactory|null,
-      sanitizer?: Sanitizer) {
+      sanitizer?: Sanitizer|null, rendererFactory?: RendererFactory3) {
     super();
     this._directiveDefs = toDefs(directives, extractDirectiveDef);
     this._pipeDefs = toDefs(pipes, extractPipeDef);
     this._sanitizer = sanitizer || null;
+    this._rendererFactory = rendererFactory || domRendererFactory3;
     this.hostNode = renderTemplate(this.hostElement, (rf: RenderFlags, ctx: any) => {
       if (rf & RenderFlags.Create) {
         this.createBlock();
@@ -76,7 +78,7 @@ export class TemplateFixture extends BaseFixture {
       if (rf & RenderFlags.Update) {
         this.updateBlock();
       }
-    }, null !, domRendererFactory3, null, this._directiveDefs, this._pipeDefs, sanitizer);
+    }, null !, this._rendererFactory, null, this._directiveDefs, this._pipeDefs, sanitizer);
   }
 
   /**
@@ -86,7 +88,7 @@ export class TemplateFixture extends BaseFixture {
    */
   update(updateBlock?: () => void): void {
     renderTemplate(
-        this.hostNode.native, updateBlock || this.updateBlock, null !, domRendererFactory3,
+        this.hostNode.native, updateBlock || this.updateBlock, null !, this._rendererFactory,
         this.hostNode, this._directiveDefs, this._pipeDefs, this._sanitizer);
   }
 }


### PR DESCRIPTION
While investigating how to properly destroy embedded views that were created through `ViewContainerRef` APIs, I found out that ivy currently doesn't support these 2 hooks which exist today in `Renderer2`.
This PR implements them.