### PR TITLE
fix(core): Add generics support for `OnChanges`

### DIFF
--- a/aio/content/examples/lifecycle-hooks/src/app/counter.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/counter.component.ts
@@ -18,11 +18,11 @@ import { LoggerService }  from './logger.service';
   `,
   styles: ['.counter {background: LightYellow; padding: 8px; margin-top: 8px}']
 })
-export class MyCounterComponent implements OnChanges {
+export class MyCounterComponent implements OnChanges<MyCounterComponent> {
   @Input() counter: number;
   changeLog: string[] = [];
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(changes: SimpleChanges<this>) {
 
     // Empty the changeLog whenever counter goes to zero
     // hint: this is a way to respond programmatically to external value changes.
@@ -31,7 +31,7 @@ export class MyCounterComponent implements OnChanges {
     }
 
     // A change to `counter` is the only change we care about
-    let chng = changes['counter'];
+    let chng = changes.counter;
     let cur = chng.currentValue;
     let prev = JSON.stringify(chng.previousValue); // first time is {}; after is integer
     this.changeLog.push(`counter: currentValue = ${cur}, previousValue = ${prev}`);

--- a/packages/core/src/change_detection/change_detection_util.ts
+++ b/packages/core/src/change_detection/change_detection_util.ts
@@ -66,8 +66,9 @@ export class WrappedValue {
  * Represents a basic change from a previous to a new value.
  *
  */
-export class SimpleChange {
-  constructor(public previousValue: any, public currentValue: any, public firstChange: boolean) {}
+export class SimpleChange<TValue = any> {
+  constructor(
+      public previousValue: TValue, public currentValue: TValue, public firstChange: boolean) {}
 
   /**
    * Check whether the new value is the first value assigned.
@@ -78,12 +79,12 @@ export class SimpleChange {
 export function isListLikeIterable(obj: any): boolean {
   if (!isJsObject(obj)) return false;
   return Array.isArray(obj) ||
-      (!(obj instanceof Map) &&      // JS Map are iterables but return entries as [k, v]
-       getSymbolIterator() in obj);  // JS Iterable have a Symbol.iterator prop
+    (!(obj instanceof Map) &&      // JS Map are iterables but return entries as [k, v]
+      getSymbolIterator() in obj);  // JS Iterable have a Symbol.iterator prop
 }
 
 export function areIterablesEqual(
-    a: any, b: any, comparator: (a: any, b: any) => boolean): boolean {
+  a: any, b: any, comparator: (a: any, b: any) => boolean): boolean {
   const iterator1 = a[getSymbolIterator()]();
   const iterator2 = b[getSymbolIterator()]();
 

--- a/packages/core/src/metadata/lifecycle_hooks.ts
+++ b/packages/core/src/metadata/lifecycle_hooks.ts
@@ -14,7 +14,9 @@ import {SimpleChange} from '../change_detection/change_detection_util';
  * values are instances of {@link SimpleChange}. See {@link OnChanges}
  *
  */
-export interface SimpleChanges { [propName: string]: SimpleChange; }
+export type SimpleChanges<TComponent extends object = any> = {
+  [P in keyof TComponent]?: SimpleChange<TComponent[P]>;
+};
 
 /**
  * @usageNotes
@@ -31,7 +33,9 @@ export interface SimpleChanges { [propName: string]: SimpleChange; }
  *
  *
  */
-export interface OnChanges { ngOnChanges(changes: SimpleChanges): void; }
+export interface OnChanges<TComponent extends object = any> {
+  ngOnChanges(changes: SimpleChanges<TComponent>): void;
+}
 
 /**
  * @usageNotes


### PR DESCRIPTION
`OnChanges` interface supports generics (optional) to get better types in `ngOnChanges()`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [24073](https://github.com/angular/angular/issues/24073)


## What is the new behavior?
Generics support (optional) in `OnChanges` from `@angular/core`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```