### PR TITLE
refactor(core): use Partial<T> for MetadataOverride

### DIFF
--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -2367,9 +2367,9 @@ The [override metadata object](#metadata-override-object) is a generic defined a
 
 <code-example format="." language="javascript">
   type MetadataOverride<T> = {
-    add?: T;
-    remove?: T;
-    set?: T;
+    add?: Partial<T>;
+    remove?: Partial<T>;
+    set?: Partial<T>;
   };
 </code-example>
 
@@ -2725,9 +2725,9 @@ appropriate to the method, that is, the parameter of an `@NgModule`,
 
 <code-example format="." language="javascript">
   type MetadataOverride<T> = {
-    add?: T;
-    remove?: T;
-    set?: T;
+    add?: Partial<T>;
+    remove?: Partial<T>;
+    set?: Partial<T>;
   };
 </code-example>
 

--- a/packages/core/testing/src/metadata_override.ts
+++ b/packages/core/testing/src/metadata_override.ts
@@ -12,7 +12,7 @@
  * @experimental
  */
 export type MetadataOverride<T> = {
-  add?: T,
-  remove?: T,
-  set?: T
+  add?: Partial<T>,
+  remove?: Partial<T>,
+  set?: Partial<T>
 };

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -376,7 +376,8 @@ class CompWithUrlTemplate {
             TestBed
                 .overrideComponent(
                     SomeComponent, {set: {selector: 'comp', template: `{{'hello' | somePipe}}`}})
-                .overridePipe(SomePipe, {set: {name: 'somePipe'}});
+                .overridePipe(SomePipe, {set: {name: 'somePipe'}})
+                .overridePipe(SomePipe, {add: {pure: false}});
           });
           it('should work', () => {
             const compFixture = TestBed.createComponent(SomeComponent);

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -55,9 +55,9 @@ export declare class InjectSetupWrapper {
 
 /** @experimental */
 export declare type MetadataOverride<T> = {
-    add?: T;
-    remove?: T;
-    set?: T;
+    add?: Partial<T>;
+    remove?: Partial<T>;
+    set?: Partial<T>;
 };
 
 /** @experimental */


### PR DESCRIPTION
Allows to write:

```typescript
const fixture = TestBed
      .overridePipe(DisplayNamePipe, { set: { pure: false } })
      .createComponent(MenuComponent);
```

when you only want to set the `pure` metadata,
instead of currently:

```typescript
const fixture = TestBed
      .overridePipe(DisplayNamePipe, { set: { name: 'displayName', pure: false } })
      .createComponent(MenuComponent);
```

which forces you to redefine the name of the pipe even if it is useless.

Fixes #24102

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #24102

## What is the new behavior?

Allows:

```typescript
const fixture = TestBed
          .overridePipe(DisplayNamePipe, { set: { pure: false } })
          .createComponent(MenuComponent);
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
