### PR TITLE
fix(benchpress): Use performance.mark() instead of console.time()

### DIFF
--- a/packages/benchpress/src/webdriver/chrome_driver_extension.ts
+++ b/packages/benchpress/src/webdriver/chrome_driver_extension.ts
@@ -58,13 +58,13 @@ export class ChromeDriverExtension extends WebDriverExtension {
       // so that the chrome buffer does not fill up.
       await this._driver.logs('performance');
     }
-    return this._driver.executeScript(`console.time('${name}');`);
+    return this._driver.executeScript(`performance.mark('${name}-bpstart');`);
   }
 
   timeEnd(name: string, restartName: string|null = null): Promise<any> {
-    let script = `console.timeEnd('${name}');`;
+    let script = `performance.mark('${name}-bpend');`;
     if (restartName) {
-      script += `console.time('${restartName}');`;
+      script += `performance.mark('${restartName}-bpstart');`;
     }
     return this._driver.executeScript(script);
   }
@@ -108,6 +108,8 @@ export class ChromeDriverExtension extends WebDriverExtension {
     const name = event['name'];
     const args = event['args'];
     if (this._isEvent(categories, name, ['blink.console'])) {
+      return normalizeEvent(event, {'name': name});
+    } else if (this._isEvent(categories, name, ['blink.user_timing'])) {
       return normalizeEvent(event, {'name': name});
     } else if (this._isEvent(
                    categories, name, ['benchmark'],
@@ -201,6 +203,15 @@ function normalizeEvent(chromeEvent: {[key: string]: any}, data: PerfLogEvent): 
   } else if (ph === 'R') {
     // mark events from navigation timing
     ph = 'I';
+    // Chrome 65+ doesn't allow user timing measurements across page loads.
+    // Instead, we use performance marks with special names.
+    if (chromeEvent['name'].match(/-bpstart/)) {
+      data['name'] = chromeEvent['name'].slice(0, -8);
+      ph = 'B';
+    } else if (chromeEvent['name'].match(/-bpend$/)) {
+      data['name'] = chromeEvent['name'].slice(0, -6);
+      ph = 'E';
+    }
   }
   const result: {[key: string]: any} =
       {'pid': chromeEvent['pid'], 'ph': ph, 'cat': 'timeline', 'ts': chromeEvent['ts'] / 1000};

--- a/packages/benchpress/test/webdriver/chrome_driver_extension_spec.ts
+++ b/packages/benchpress/test/webdriver/chrome_driver_extension_spec.ts
@@ -61,16 +61,17 @@ import {TraceEventFactory} from '../trace_event_factory';
          });
        }));
 
-    it('should clear the perf logs and mark the timeline via console.time() on the first call',
+    it('should clear the perf logs and mark the timeline via performance.mark() on the first call',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          createExtension().timeBegin('someName').then(() => {
-           expect(log).toEqual(
-               [['logs', 'performance'], ['executeScript', `console.time('someName');`]]);
+           expect(log).toEqual([
+             ['logs', 'performance'], ['executeScript', `performance.mark('someName-bpstart');`]
+           ]);
            async.done();
          });
        }));
 
-    it('should mark the timeline via console.time() on the second call',
+    it('should mark the timeline via performance.mark() on the second call',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          const ext = createExtension();
          ext.timeBegin('someName')
@@ -79,24 +80,25 @@ import {TraceEventFactory} from '../trace_event_factory';
                ext.timeBegin('someName');
              })
              .then(() => {
-               expect(log).toEqual([['executeScript', `console.time('someName');`]]);
+               expect(log).toEqual([['executeScript', `performance.mark('someName-bpstart');`]]);
                async.done();
              });
        }));
 
-    it('should mark the timeline via console.timeEnd()',
+    it('should mark the timeline via performance.mark()',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          createExtension().timeEnd('someName', null).then((_) => {
-           expect(log).toEqual([['executeScript', `console.timeEnd('someName');`]]);
+           expect(log).toEqual([['executeScript', `performance.mark('someName-bpend');`]]);
            async.done();
          });
        }));
 
-    it('should mark the timeline via console.time() and console.timeEnd()',
+    it('should mark the timeline via performance.mark() with start and end of a test',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          createExtension().timeEnd('name1', 'name2').then((_) => {
-           expect(log).toEqual(
-               [['executeScript', `console.timeEnd('name1');console.time('name2');`]]);
+           expect(log).toEqual([[
+             'executeScript', `performance.mark('name1-bpend');performance.mark('name2-bpstart');`
+           ]]);
            async.done();
          });
        }));


### PR DESCRIPTION
Previously, benchpress would use `console.time()` and
`console.timeEnd()` to measure the start and end of a test in the
performance log. This used to work over navigations - if you called
`console.time(id)` then navigated to a different page, calling
`console.timeEnd(id)` would still insert an event in the performance
log.

As of Chrome 65, this is no longer the case. `console.timeEnd(id)` will
simply not insert an event in the performance log unless
`console.time(id)` was called on the same page. Likewise, using
`performance.measure()` does not work if the starting mark was on a
different page.

This simple workaround uses `performance.mark()` to insert events in the
performance log at the start and end of the test. Benchpress looks for
'-bpstart' and '-bpend' in the name of the performance mark, and
normalizes that to the start and end events expected by PerflogMetric.

This solves the problem of seeing a "Tried too often to get the ending mark" error in benchpress tests that involve a navigation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
