### PR TITLE
fix(platform-server): provide Domino DOM types globally

### DIFF
--- a/packages/platform-server/src/domino_adapter.ts
+++ b/packages/platform-server/src/domino_adapter.ts
@@ -13,6 +13,12 @@ function _notImplemented(methodName: string) {
   return new Error('This method is not implemented in DominoAdapter: ' + methodName);
 }
 
+function setDomTypes() {
+  // Make all Domino types available as types in the global env.
+  Object.assign(global, domino.impl);
+  (global as any)['KeyboardEvent'] = domino.impl.Event;
+}
+
 /**
  * Parses a document string to a Document object.
  */
@@ -33,7 +39,10 @@ export function serializeDocument(doc: Document): string {
  * DOM Adapter for the server platform based on https://github.com/fgnass/domino.
  */
 export class DominoAdapter extends BrowserDomAdapter {
-  static makeCurrent() { setRootDomAdapter(new DominoAdapter()); }
+  static makeCurrent() {
+    setDomTypes();
+    setRootDomAdapter(new DominoAdapter());
+  }
 
   private static defaultDoc: Document;
 


### PR DESCRIPTION
Fixes #23280, #23133.

This fix lets code access DOM types like Node, HTMLElement in the code. These are invariant across requests and the corresponding classes from Domino can be safely provided during platform initialization.

This is needed for the current sanitizer to work properly on platform-server. Also allows HTML types in injection - Ex. `@inject(DOCUMENT) doc: Document`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Using Sanitizer in platform-server throws an exception about `Node` being undefined

Issue Number: #23280

## What is the new behavior?
Can use Sanitizer on platform-server.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
