### PR TITLE
fix(core): refine Injector.get declaration to infer correct return type

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -230,7 +230,7 @@ export class PlatformRef {
       const ngZoneInjector = Injector.create(
           {providers: providers, parent: this.injector, name: moduleFactory.moduleType.name});
       const moduleRef = <InternalNgModuleRef<M>>moduleFactory.create(ngZoneInjector);
-      const exceptionHandler: ErrorHandler = moduleRef.injector.get(ErrorHandler, null);
+      const exceptionHandler = moduleRef.injector.get(ErrorHandler, null);
       if (!exceptionHandler) {
         throw new Error('No ErrorHandler. Is platform module (BrowserModule) included?');
       }

--- a/packages/core/src/di.ts
+++ b/packages/core/src/di.ts
@@ -16,7 +16,7 @@ export * from './di/metadata';
 export {InjectableType, InjectorType, defineInjectable, defineInjector} from './di/defs';
 export {forwardRef, resolveForwardRef, ForwardRefFn} from './di/forward_ref';
 export {Injectable, InjectableDecorator, InjectableProvider} from './di/injectable';
-export {inject, InjectFlags, INJECTOR, Injector} from './di/injector';
+export {inject, InjectFlags, INJECTOR, Injector, ThrowIfNotFound} from './di/injector';
 export {ReflectiveInjector} from './di/reflective_injector';
 export {StaticProvider, ValueProvider, ExistingProvider, FactoryProvider, Provider, TypeProvider, ClassProvider} from './di/provider';
 export {createInjector} from './di/r3_injector';

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -16,11 +16,13 @@ import {Inject, Optional, Self, SkipSelf} from './metadata';
 import {ConstructorProvider, ExistingProvider, FactoryProvider, StaticClassProvider, StaticProvider, ValueProvider} from './provider';
 
 export const SOURCE = '__source';
-export class ThrowIfNotFound {
-  private constructor() {}
-  static INSTANCE = new ThrowIfNotFound();
+export abstract class ThrowIfNotFound {
+  protected constructor() {}
 }
-const _THROW_IF_NOT_FOUND = ThrowIfNotFound.INSTANCE;
+class _ThrowIfNotFound extends ThrowIfNotFound {
+  constructor() { super(); }
+}
+const _THROW_IF_NOT_FOUND: ThrowIfNotFound = new _ThrowIfNotFound();
 export const THROW_IF_NOT_FOUND = _THROW_IF_NOT_FOUND;
 
 /**

--- a/packages/core/test/di/injector_spec.ts
+++ b/packages/core/test/di/injector_spec.ts
@@ -22,6 +22,11 @@ import {describe, expect, it} from '@angular/core/testing/src/testing_internal';
           .toThrowError('NullInjectorError: No provider for someToken!');
     });
 
+    it('should throw if undefined is given', () => {
+      expect(() => Injector.NULL.get('someToken', undefined))
+          .toThrowError('NullInjectorError: No provider for someToken!');
+    });
+
     it('should return the default value',
        () => { expect(Injector.NULL.get('someToken', 'notFound')).toEqual('notFound'); });
   });

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -400,8 +400,7 @@ export declare abstract class Injector {
     }): Injector;
 }
 
-export declare class ThrowIfNotFound {
-    static INSTANCE: ThrowIfNotFound;
+export declare abstract class ThrowIfNotFound {
 }
 
 /** @experimental */

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -385,15 +385,12 @@ export declare class InjectionToken<T> {
     toString(): string;
 }
 
-export declare class ThrowIfNotFound {
-}
-
 export declare abstract class Injector {
     abstract get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: ThrowIfNotFound | undefined, flags?: InjectFlags): T;
     abstract get<T, U>(token: Type<T> | InjectionToken<T>, notFoundValue: U | ThrowIfNotFound | undefined, flags?: InjectFlags): T | U;
     /** @deprecated */ abstract get(token: any, notFoundValue?: any): any;
     static NULL: Injector;
-    static THROW_IF_NOT_FOUND: Object;
+    static THROW_IF_NOT_FOUND: ThrowIfNotFound;
     static ngInjectableDef: never;
     /** @deprecated */ static create(providers: StaticProvider[], parent?: Injector): Injector;
     static create(options: {
@@ -401,6 +398,10 @@ export declare abstract class Injector {
         parent?: Injector;
         name?: string;
     }): Injector;
+}
+
+export declare class ThrowIfNotFound {
+    static INSTANCE: ThrowIfNotFound;
 }
 
 /** @experimental */

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -385,8 +385,12 @@ export declare class InjectionToken<T> {
     toString(): string;
 }
 
+export declare class ThrowIfNotFound {
+}
+
 export declare abstract class Injector {
-    abstract get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
+    abstract get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: ThrowIfNotFound | undefined, flags?: InjectFlags): T;
+    abstract get<T, U>(token: Type<T> | InjectionToken<T>, notFoundValue: U | ThrowIfNotFound | undefined, flags?: InjectFlags): T | U;
     /** @deprecated */ abstract get(token: any, notFoundValue?: any): any;
     static NULL: Injector;
     static THROW_IF_NOT_FOUND: Object;


### PR DESCRIPTION
These changes address an overload resolution issue whereby Injector.get
calls would resolve to the deprecated overload, disabling all type
checks with an 'any' return type.

BREAKING CHANGE:
Any code now succeeding type checks will fail if the return type was not
used carefully.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Given `x` of type `Type<T>|InjectionToken<T>` and `y` of type `U` (excluding `THROW_IF_NOT_NULL` and `undefined`):
- `injector.get(x, undefined)` is `any`
- `injector.get(x, THROW_IF_NOT_NULL)` is `any`
- `injector.get(x, y)` is `any`
- `injector.get(x, someCondition ? y : THROW_IF_NOT_NULL)` is `any`

## What is the new behavior?
- `injector.get(x, undefined)` is `T`
- `injector.get(x, THROW_IF_NOT_NULL)` is `T`
- `injector.get(x, y)` is `T|U`.
- `injector.get(x, someCondition ? y : THROW_IF_NOT_NULL)` is `T|U`

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Applications may need to be corrected for revealed type errors. Applications explicitly specifying the generic argument to the method should remove the generic argument in favor of type inference.


## Other information
