### PR TITLE
 fix(service-worker): avoid network requests when looking up hashed resources in cache

### DIFF
--- a/packages/service-worker/worker/src/app-version.ts
+++ b/packages/service-worker/worker/src/app-version.ts
@@ -198,8 +198,6 @@ export class AppVersion implements UpdateSource {
    * Check this version for a given resource with a particular hash.
    */
   async lookupResourceWithHash(url: string, hash: string): Promise<Response|null> {
-    const req = this.adapter.newRequest(url);
-
     // Verify that this version has the requested resource cached. If not,
     // there's no point in trying.
     if (!this.hashTable.has(url)) {
@@ -208,16 +206,12 @@ export class AppVersion implements UpdateSource {
 
     // Next, check whether the resource has the correct hash. If not, any cached
     // response isn't usable.
-    if (this.hashTable.get(url) ! !== hash) {
+    if (this.hashTable.get(url) !== hash) {
       return null;
     }
 
-    // TODO: no-op context and appropriate contract. Currently this is a violation
-    // of the typings and could cause issues if handleFetch() has side effects. A
-    // better strategy to deal with side effects is needed.
-    // TODO: this could result in network fetches if the response is lazy. Refactor
-    // to avoid them.
-    return this.handleFetch(req, null !);
+    const cacheState = await this.lookupResourceWithoutHash(url);
+    return cacheState && cacheState.response;
   }
 
   /**


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] Bugfix
[x] Refactoring (no functional changes, no api changes)
```

## What is the current behavior?
Calling `lookupResourceWithHash()` might make a network request if a lazy asset-group of a previous version matches the URL. This is unintended, because `lookupResourceWithHash()` is supposed to retrieve resources from cache.
This also affected lazy asset-groups, which ended up prefetching all of their matched resources.


## What is the new behavior?
Calling `lookupResourceWithHash()` does not make a network request and only retrieves resources from the cache.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
