### PR TITLE
test(animations): fix Node.js detection in animation tests

### DIFF
--- a/packages/animations/browser/test/dsl/animation_spec.ts
+++ b/packages/animations/browser/test/dsl/animation_spec.ts
@@ -20,7 +20,7 @@ function createDiv() {
 {
   describe('Animation', () => {
     // these tests are only mean't to be run within the DOM (for now)
-    if (typeof Element == 'undefined') return;
+    if (isNode) return;
 
     let rootElement: any;
     let subElement1: any;

--- a/packages/animations/browser/test/dsl/animation_trigger_spec.ts
+++ b/packages/animations/browser/test/dsl/animation_trigger_spec.ts
@@ -17,7 +17,7 @@ import {makeTrigger} from '../shared';
 {
   describe('AnimationTrigger', () => {
     // these tests are only mean't to be run within the DOM (for now)
-    if (typeof Element == 'undefined') return;
+    if (isNode) return;
 
     let element: any;
     beforeEach(() => {

--- a/packages/animations/browser/test/render/css_keyframes/css_keyframes_driver_spec.ts
+++ b/packages/animations/browser/test/render/css_keyframes/css_keyframes_driver_spec.ts
@@ -16,9 +16,7 @@ import {assertElementExistsInDom, createElement, findKeyframeDefinition, forceRe
 const CSS_KEYFRAME_RULE_TYPE = 7;
 
 describe('CssKeyframesDriver tests', () => {
-  if (typeof Element == 'undefined' || typeof document == 'undefined' ||
-      typeof(window as any)['AnimationEvent'] == 'undefined')
-    return;
+  if (isNode || typeof(window as any)['AnimationEvent'] == 'undefined') return;
 
   describe('building keyframes', () => {
     it('should build CSS keyframe style object containing the keyframe styles', () => {

--- a/packages/animations/browser/test/render/css_keyframes/direct_style_player_spec.ts
+++ b/packages/animations/browser/test/render/css_keyframes/direct_style_player_spec.ts
@@ -14,7 +14,7 @@ import {assertStyle, createElement} from './shared';
 const CSS_KEYFRAME_RULE_TYPE = 7;
 
 describe('DirectStylePlayer tests', () => {
-  if (typeof Element == 'undefined' || typeof document == 'undefined') return;
+  if (isNode) return;
 
   it('should apply the styling to the given element when the animation starts and remove when destroyed',
      () => {

--- a/packages/animations/browser/test/render/css_keyframes/element_animation_style_handler_spec.ts
+++ b/packages/animations/browser/test/render/css_keyframes/element_animation_style_handler_spec.ts
@@ -13,9 +13,7 @@ import {assertStyle, createElement, makeAnimationEvent, supportsAnimationEventCr
 const EMPTY_FN = () => {};
 {
   describe('ElementAnimationStyleHandler', () => {
-    if (typeof Element == 'undefined' || typeof document == 'undefined' ||
-        typeof(window as any)['AnimationEvent'] == 'undefined')
-      return;
+    if (isNode || typeof(window as any)['AnimationEvent'] == 'undefined') return;
 
     it('should add and remove an animation on to an element\'s styling', () => {
       const element = createElement();

--- a/packages/animations/browser/test/render/timeline_animation_engine_spec.ts
+++ b/packages/animations/browser/test/render/timeline_animation_engine_spec.ts
@@ -21,7 +21,7 @@ import {MockAnimationDriver, MockAnimationPlayer} from '../../testing/src/mock_a
   }
 
   // these tests are only mean't to be run within the DOM
-  if (typeof Element == 'undefined') return;
+  if (isNode) return;
 
   describe('TimelineAnimationEngine', () => {
     let element: any;

--- a/packages/animations/browser/test/render/transition_animation_engine_spec.ts
+++ b/packages/animations/browser/test/render/transition_animation_engine_spec.ts
@@ -20,7 +20,7 @@ const DEFAULT_NAMESPACE_ID = 'id';
   const driver = new MockAnimationDriver();
 
   // these tests are only mean't to be run within the DOM
-  if (typeof Element == 'undefined') return;
+  if (isNode) return;
 
   describe('TransitionAnimationEngine', () => {
     let element: any;

--- a/packages/animations/browser/test/render/web_animations/web_animations_driver_spec.ts
+++ b/packages/animations/browser/test/render/web_animations/web_animations_driver_spec.ts
@@ -12,7 +12,7 @@ import {WebAnimationsPlayer} from '../../../src/render/web_animations/web_animat
 
 {
   describe('WebAnimationsDriver', () => {
-    if (typeof Element == 'undefined' || typeof document == 'undefined') return;
+    if (isNode) return;
 
     describe('when web-animations are not supported natively', () => {
       it('should return an instance of a CssKeyframePlayer if scrubbing is not requested', () => {

--- a/packages/core/test/animation/animation_integration_spec.ts
+++ b/packages/core/test/animation/animation_integration_spec.ts
@@ -20,7 +20,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
 (function() {
   // these tests are only mean't to be run within the DOM (for now)
-  if (typeof Element == 'undefined') return;
+  if (isNode) return;
 
   describe('animation tests', function() {
     function getLog(): MockAnimationPlayer[] {

--- a/packages/core/test/animation/animation_query_integration_spec.ts
+++ b/packages/core/test/animation/animation_query_integration_spec.ts
@@ -21,7 +21,7 @@ import {fakeAsync, flushMicrotasks} from '../../testing/src/fake_async';
 
 (function() {
   // these tests are only mean't to be run within the DOM (for now)
-  if (typeof Element == 'undefined') return;
+  if (isNode) return;
 
   describe('animation query tests', function() {
     function getLog(): MockAnimationPlayer[] {

--- a/packages/core/test/animation/animation_router_integration_spec.ts
+++ b/packages/core/test/animation/animation_router_integration_spec.ts
@@ -16,7 +16,7 @@ import {RouterTestingModule} from '@angular/router/testing';
 
 (function() {
   // these tests are only mean't to be run within the DOM (for now)
-  if (typeof Element == 'undefined') return;
+  if (isNode) return;
 
   describe('Animation Router Tests', function() {
     function getLog(): MockAnimationPlayer[] {

--- a/packages/core/test/animation/animations_with_css_keyframes_animations_integration_spec.ts
+++ b/packages/core/test/animation/animations_with_css_keyframes_animations_integration_spec.ts
@@ -17,7 +17,7 @@ import {TestBed} from '../../testing';
 (function() {
   // these tests are only mean't to be run within the DOM (for now)
   // Buggy in Chromium 39, see https://github.com/angular/angular/issues/15793
-  if (typeof Element == 'undefined') return;
+  if (isNode) return;
 
   describe('animation integration tests using css keyframe animations', function() {
 

--- a/packages/core/test/animation/animations_with_web_animations_integration_spec.ts
+++ b/packages/core/test/animation/animations_with_web_animations_integration_spec.ts
@@ -18,7 +18,7 @@ import {TestBed} from '../../testing';
 (function() {
   // these tests are only mean't to be run within the DOM (for now)
   // Buggy in Chromium 39, see https://github.com/angular/angular/issues/15793
-  if (typeof Element == 'undefined' || !ɵsupportsWebAnimations()) return;
+  if (isNode || !ɵsupportsWebAnimations()) return;
 
   describe('animation integration tests using web animations', function() {
 

--- a/packages/platform-browser/test/animation/animation_renderer_spec.ts
+++ b/packages/platform-browser/test/animation/animation_renderer_spec.ts
@@ -117,7 +117,7 @@ import {el} from '../../testing/src/browser_util';
 
     describe('flushing animations', () => {
       // these tests are only mean't to be run within the DOM
-      if (typeof Element == 'undefined') return;
+      if (isNode) return;
 
       it('should flush and fire callbacks when the zone becomes stable', (async) => {
         @Component({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Animations tests rely on (typeof Element === 'undefined') to detect node. This is not a reliable way as we are starting to provide Element on the server through the Domino types.

## What is the new behavior?
Use the existing `isNode` flag available in Jasmine tests for animation tests.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```