### PR TITLE
fix(ivy): determine value of SimpleChange.firstChange per property

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -272,7 +272,13 @@ export function NgOnChangesFeature(inputPropertyNames?: {[key: string]: string})
                 this, PRIVATE_PREFIX, {value: simpleChanges = {}, writable: true});
           }
           const isFirstChange = !this.hasOwnProperty(privateMinKey);
-          simpleChanges[propertyName] = new SimpleChange(this[privateMinKey], value, isFirstChange);
+          const currentChange: SimpleChange|undefined = simpleChanges[propertyName];
+          if (currentChange) {
+            currentChange.currentValue = value;
+          } else {
+            simpleChanges[propertyName] =
+                new SimpleChange(this[privateMinKey], value, isFirstChange);
+          }
           if (isFirstChange) {
             // Create a place where the actual value will be stored and make it non-enumerable
             Object.defineProperty(this, privateMinKey, {value, writable: true});

--- a/packages/core/test/render3/define_spec.ts
+++ b/packages/core/test/render3/define_spec.ts
@@ -45,7 +45,7 @@ describe('define', () => {
         expect(myDir.valB).toEqual('works');
         myDir.log.length = 0;
         (MyDirective.ngDirectiveDef as DirectiveDef<MyDirective>).doCheck !.call(myDir);
-        const changeA = new SimpleChange('initValue', 'first', false);
+        const changeA = new SimpleChange(undefined, 'first', true);
         const changeB = new SimpleChange(undefined, 'second', true);
         expect(myDir.log).toEqual(['ngOnChanges', 'valA', changeA, 'valB', changeB, 'ngDoCheck']);
       });
@@ -75,7 +75,7 @@ describe('define', () => {
         myDir.valA = 'first';
         myDir.valB = 'second';
         (MyDirective.ngDirectiveDef as DirectiveDef<MyDirective>).doCheck !.call(myDir);
-        const changeA1 = new SimpleChange('initValue', 'first', false);
+        const changeA1 = new SimpleChange(undefined, 'first', true);
         const changeB1 = new SimpleChange(undefined, 'second', true);
         expect(myDir.log).toEqual(['valA', changeA1, 'valB', changeB1]);
 

--- a/packages/core/test/render3/define_spec.ts
+++ b/packages/core/test/render3/define_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {DoCheck, OnChanges, SimpleChanges} from '../../src/core';
+import {DoCheck, OnChanges, SimpleChange, SimpleChanges} from '../../src/core';
 import {DirectiveDef, NgOnChangesFeature, defineDirective} from '../../src/render3/index';
 
 describe('define', () => {
@@ -14,7 +14,7 @@ describe('define', () => {
     describe('NgOnChangesFeature', () => {
       it('should patch class', () => {
         class MyDirective implements OnChanges, DoCheck {
-          public log: string[] = [];
+          public log: Array<string|SimpleChange> = [];
           public valA: string = 'initValue';
           public set valB(value: string) { this.log.push(value); }
 
@@ -23,8 +23,8 @@ describe('define', () => {
           ngDoCheck(): void { this.log.push('ngDoCheck'); }
           ngOnChanges(changes: SimpleChanges): void {
             this.log.push('ngOnChanges');
-            this.log.push('valA', changes['valA'].previousValue, changes['valA'].currentValue);
-            this.log.push('valB', changes['valB'].previousValue, changes['valB'].currentValue);
+            this.log.push('valA', changes['valA']);
+            this.log.push('valB', changes['valB']);
           }
 
           static ngDirectiveDef = defineDirective({
@@ -45,9 +45,74 @@ describe('define', () => {
         expect(myDir.valB).toEqual('works');
         myDir.log.length = 0;
         (MyDirective.ngDirectiveDef as DirectiveDef<MyDirective>).doCheck !.call(myDir);
-        expect(myDir.log).toEqual([
-          'ngOnChanges', 'valA', 'initValue', 'first', 'valB', undefined, 'second', 'ngDoCheck'
-        ]);
+        const changeA = new SimpleChange('initValue', 'first', false);
+        const changeB = new SimpleChange(undefined, 'second', true);
+        expect(myDir.log).toEqual(['ngOnChanges', 'valA', changeA, 'valB', changeB, 'ngDoCheck']);
+      });
+
+      it('correctly computes firstChange', () => {
+        class MyDirective implements OnChanges {
+          public log: Array<string|SimpleChange> = [];
+          public valA: string = 'initValue';
+          public valB: string;
+
+          ngOnChanges(changes: SimpleChanges): void {
+            this.log.push('valA', changes['valA']);
+            this.log.push('valB', changes['valB']);
+          }
+
+          static ngDirectiveDef = defineDirective({
+            type: MyDirective,
+            selectors: [['', 'myDir', '']],
+            factory: () => new MyDirective(),
+            features: [NgOnChangesFeature()],
+            inputs: {valA: 'valA', valB: 'valB'}
+          });
+        }
+
+        const myDir =
+            (MyDirective.ngDirectiveDef as DirectiveDef<MyDirective>).factory() as MyDirective;
+        myDir.valA = 'first';
+        myDir.valB = 'second';
+        (MyDirective.ngDirectiveDef as DirectiveDef<MyDirective>).doCheck !.call(myDir);
+        const changeA1 = new SimpleChange('initValue', 'first', false);
+        const changeB1 = new SimpleChange(undefined, 'second', true);
+        expect(myDir.log).toEqual(['valA', changeA1, 'valB', changeB1]);
+
+        myDir.log.length = 0;
+        myDir.valA = 'third';
+        (MyDirective.ngDirectiveDef as DirectiveDef<MyDirective>).doCheck !.call(myDir);
+        const changeA2 = new SimpleChange('first', 'third', false);
+        expect(myDir.log).toEqual(['valA', changeA2, 'valB', undefined]);
+      });
+
+      it('should not create a getter when only a setter is originally defined', () => {
+        class MyDirective implements OnChanges {
+          public log: Array<string|SimpleChange> = [];
+
+          public set onlySetter(value: string) { this.log.push(value); }
+
+          ngOnChanges(changes: SimpleChanges): void {
+            this.log.push('ngOnChanges');
+            this.log.push('onlySetter', changes['onlySetter']);
+          }
+
+          static ngDirectiveDef = defineDirective({
+            type: MyDirective,
+            selectors: [['', 'myDir', '']],
+            factory: () => new MyDirective(),
+            features: [NgOnChangesFeature()],
+            inputs: {onlySetter: 'onlySetter'}
+          });
+        }
+
+        const myDir =
+            (MyDirective.ngDirectiveDef as DirectiveDef<MyDirective>).factory() as MyDirective;
+        myDir.onlySetter = 'someValue';
+        expect(myDir.onlySetter).toBeUndefined();
+        (MyDirective.ngDirectiveDef as DirectiveDef<MyDirective>).doCheck !.call(myDir);
+        const changeSetter = new SimpleChange(undefined, 'someValue', true);
+        expect(myDir.log).toEqual(['someValue', 'ngOnChanges', 'onlySetter', changeSetter]);
       });
     });
   });


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

In Ivy, using `OnChanges` incorrectly determines the `firstChange` flag of a registered change if multiple property changes occur within a single change detection run.

Next, having an initial value causes the `firstChange` always to be false, which is different from Render2 (see [StackBlitz example](https://stackblitz.com/edit/angular-agt18s)).

Somewhat unrelated did I change how property descriptors are assigned. First, no getter will be created if originally only a setter existed. This avoids exposing the "private" data that is now always stored to be able to determine `firstChange` per property. Secondly, the properties for per-instance data are no longer created on the prototype but instead on the instance itself, see the following screenshot for what used to be case:

<img width="658" alt="screen shot 2018-05-18 at 23 29 37" src="https://user-images.githubusercontent.com/123679/40586604-ab1a5ab6-61c4-11e8-957b-ba8606faca69.png">

The instance's `_ngOnChanges_` is enumerable because the property descriptor we used to set on the prototype is not inherited when we assign to the property on the instance, so a new property is created on the instance itself. The prototype's property is therefore never relevant.

## What is the new behavior?

Determination of `firstChange` has been updated to occur per property.

Because of the property descriptor changes, the directive instance now looks as follows.

<img width="765" alt="screen shot 2018-05-18 at 23 30 55" src="https://user-images.githubusercontent.com/123679/40586610-b4aea26c-61c4-11e8-8b69-825b5c808e9a.png">

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

Because of the property descriptor we set on the directive's prototype, any regular properties will no longer be considered as "own property" as their assignment flows through the prototype's `setter` instead, therefore not actually creating the property on the instance itself. Thus, compared to Render2 an instance's own properties will be affected.

Another noticeable change from Render2 is with programmatic property updates, which will now be picked up by `OnChanges` whereas before only input binding changes would be picked up. Moreover, we now hit an edge case where a value is changed programmatically and immediately changed back to its original value.

This PR is split in two commits. The second commit changes the behavior for a property with an initial value to be the same as in Render2.