### PR TITLE
fix(core): add support for ES2015 constructor delegation

### DIFF
--- a/packages/core/src/reflection/reflection_capabilities.ts
+++ b/packages/core/src/reflection/reflection_capabilities.ts
@@ -17,7 +17,8 @@ import {GetterFn, MethodFn, SetterFn} from './types';
 /**
  * Attention: These regex has to hold even if the code is minified!
  */
-const ES5_DELEGATE_CTOR = /^function\s+\S+\(\)\s*{[\s\S]+\.\s*apply\s*\(\s*this\s*,\s*arguments\s*\)/;
+const ES5_DELEGATE_CTOR =
+    /^function\s+\S+\(\)\s*{[\s\S]+\.\s*apply\s*\(\s*this\s*,\s*arguments\s*\)/;
 const ES6_INHERITED_CLASS = /^class\s+[A-Za-z\d$_]*\s*extends\s+[A-Za-z\d$_]+\s*{/;
 const ES6_CTOR = /\bconstructor\s*\(/;
 const ES6_DELEGATE_CTOR = /\bconstructor\s*\(\)\s*{[\s\S]*super\s*\(\s*\.{3}\s*arguments\s*\)/;

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -537,9 +537,6 @@
     "name": "DEFINITION_CACHE"
   },
   {
-    "name": "DELEGATE_CTOR"
-  },
-  {
     "name": "DOCUMENT"
   },
   {
@@ -649,6 +646,18 @@
   },
   {
     "name": "ERROR_SYNTAX_ERROR"
+  },
+  {
+    "name": "ES5_DELEGATE_CTOR"
+  },
+  {
+    "name": "ES6_CTOR"
+  },
+  {
+    "name": "ES6_DELEGATE_CTOR"
+  },
+  {
+    "name": "ES6_INHERITED_CLASS"
   },
   {
     "name": "EVENT_NAMES"
@@ -814,12 +823,6 @@
   },
   {
     "name": "INFERRED_TYPE"
-  },
-  {
-    "name": "INHERITED_CLASS"
-  },
-  {
-    "name": "INHERITED_CLASS_WITH_CTOR"
   },
   {
     "name": "INJECTOR"
@@ -3262,6 +3265,9 @@
   },
   {
     "name": "isDefined"
+  },
+  {
+    "name": "isDelegateCtor"
   },
   {
     "name": "isDevMode"

--- a/packages/core/test/reflection/reflector_spec.ts
+++ b/packages/core/test/reflection/reflector_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {Reflector} from '@angular/core/src/reflection/reflection';
-import {isDelegateCtor, ReflectionCapabilities} from '@angular/core/src/reflection/reflection_capabilities';
+import {ReflectionCapabilities, isDelegateCtor} from '@angular/core/src/reflection/reflection_capabilities';
 import {global} from '@angular/core/src/util';
 import {makeDecorator, makeParamDecorator, makePropDecorator} from '@angular/core/src/util/decorators';
 


### PR DESCRIPTION
The change adds better support for native ES2015 targets. The previous
behavior didn't detect parameter delegation of constructor-less classes
containing at least one inline property initialization before
compilation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The following TypeScript code would incorrectly discard `Parent`'s ctorParameters when compiled targeting ES2015, causing a runtime error when instantiated. See issue [Dependency injection does not work with es2015 target](https://github.com/angular/material2/issues/8284) in angular/material2.
```
class Parent {
  constructor(protected dep: Dep) { }
}
class Child extends Parent {
  x = 10;
}
```

## What is the new behavior?

The above case should now be handled properly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```