### PR TITLE
fix(service-worker): fix `SwPush.unsubscribe()`

### DIFF
--- a/packages/service-worker/src/push.ts
+++ b/packages/service-worker/src/push.ts
@@ -13,7 +13,6 @@ import {map, switchMap, take} from 'rxjs/operators';
 import {ERR_SW_NOT_SUPPORTED, NgswCommChannel} from './low_level';
 
 
-
 /**
  * Subscribe and listen to push notifications from the Service Worker.
  *
@@ -55,7 +54,7 @@ export class SwPush {
       return Promise.reject(new Error(ERR_SW_NOT_SUPPORTED));
     }
     const pushOptions: PushSubscriptionOptionsInit = {userVisibleOnly: true};
-    let key = atob(options.serverPublicKey.replace(/_/g, '/').replace(/-/g, '+'));
+    let key = this.decodeBase64(options.serverPublicKey.replace(/_/g, '/').replace(/-/g, '+'));
     let applicationServerKey = new Uint8Array(new ArrayBuffer(key.length));
     for (let i = 0; i < key.length; i++) {
       applicationServerKey[i] = key.charCodeAt(i);
@@ -90,4 +89,6 @@ export class SwPush {
     }));
     return unsubscribe.pipe(take(1)).toPromise();
   }
+
+  private decodeBase64(input: string): string { return atob(input); }
 }

--- a/packages/service-worker/test/integration_spec.ts
+++ b/packages/service-worker/test/integration_spec.ts
@@ -90,7 +90,7 @@ const serverUpdate =
       mock.messages.subscribe(msg => { scope.handleMessage(msg, 'default'); });
 
       mock.setupSw();
-      reg = await mock.mockRegistration;
+      reg = mock.mockRegistration !;
 
       await Promise.all(scope.handleFetch(new MockRequest('/only.txt'), 'default'));
       await driver.initialized;

--- a/packages/service-worker/testing/mock.ts
+++ b/packages/service-worker/testing/mock.ts
@@ -56,4 +56,25 @@ export class MockServiceWorker {
   postMessage(value: Object) { this.mock.messages.next(value); }
 }
 
-export class MockServiceWorkerRegistration {}
+export class MockServiceWorkerRegistration {
+  pushManager: PushManager = new MockPushManager() as any;
+}
+
+export class MockPushManager {
+  private subscription: PushSubscription|null = null;
+
+  getSubscription(): Promise<PushSubscription|null> {
+    return Promise.resolve(this.subscription);
+  }
+
+  subscribe(options?: PushSubscriptionOptionsInit): Promise<PushSubscription> {
+    this.subscription = new MockPushSubscription() as any;
+    return Promise.resolve(this.subscription !);
+  }
+}
+
+export class MockPushSubscription {
+  unsubscribe(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+}

--- a/packages/service-worker/testing/mock.ts
+++ b/packages/service-worker/testing/mock.ts
@@ -11,9 +11,8 @@ import {Subject} from 'rxjs';
 export class MockServiceWorkerContainer {
   private onControllerChange: Function[] = [];
   private onMessage: Function[] = [];
-  private registration: MockServiceWorkerRegistration|null = null;
+  mockRegistration: MockServiceWorkerRegistration|null = null;
   controller: MockServiceWorker|null = null;
-
   messages = new Subject();
 
   addEventListener(event: 'controllerchange'|'message', handler: Function) {
@@ -34,16 +33,14 @@ export class MockServiceWorkerContainer {
 
   async register(url: string): Promise<void> { return; }
 
-  async getRegistration(): Promise<ServiceWorkerRegistration> { return this.registration as any; }
-
-  setupSw(url: string = '/ngsw-worker.js'): void {
-    this.registration = new MockServiceWorkerRegistration();
-    this.controller = new MockServiceWorker(this, url);
-    this.onControllerChange.forEach(onChange => onChange(this.controller));
+  async getRegistration(): Promise<ServiceWorkerRegistration> {
+    return this.mockRegistration as any;
   }
 
-  get mockRegistration(): Promise<MockServiceWorkerRegistration> {
-    return Promise.resolve(this.registration !);
+  setupSw(url: string = '/ngsw-worker.js'): void {
+    this.mockRegistration = new MockServiceWorkerRegistration();
+    this.controller = new MockServiceWorker(this, url);
+    this.onControllerChange.forEach(onChange => onChange(this.controller));
   }
 
   sendMessage(value: Object): void {

--- a/packages/service-worker/testing/mock.ts
+++ b/packages/service-worker/testing/mock.ts
@@ -8,6 +8,20 @@
 
 import {Subject} from 'rxjs';
 
+export const patchDecodeBase64 = (proto: {decodeBase64: typeof atob}) => {
+  let unpatch: () => void = () => undefined;
+
+  if ((typeof atob === 'undefined') && (typeof Buffer === 'function')) {
+    const oldDecodeBase64 = proto.decodeBase64;
+    const newDecodeBase64 = (input: string) => Buffer.from(input, 'base64').toString('binary');
+
+    proto.decodeBase64 = newDecodeBase64;
+    unpatch = () => { proto.decodeBase64 = oldDecodeBase64; };
+  }
+
+  return unpatch;
+};
+
 export class MockServiceWorkerContainer {
   private onControllerChange: Function[] = [];
   private onMessage: Function[] = [];
@@ -63,9 +77,7 @@ export class MockServiceWorkerRegistration {
 export class MockPushManager {
   private subscription: PushSubscription|null = null;
 
-  getSubscription(): Promise<PushSubscription|null> {
-    return Promise.resolve(this.subscription);
-  }
+  getSubscription(): Promise<PushSubscription|null> { return Promise.resolve(this.subscription); }
 
   subscribe(options?: PushSubscriptionOptionsInit): Promise<PushSubscription> {
     this.subscription = new MockPushSubscription() as any;
@@ -74,7 +86,5 @@ export class MockPushManager {
 }
 
 export class MockPushSubscription {
-  unsubscribe(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
+  unsubscribe(): Promise<boolean> { return Promise.resolve(true); }
 }


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] Bugfix
[x] Refactoring (no functional changes, no api changes)
```

## What is the current behavior?
`SwPush.unsubscribe()` returns a rejection after successfully unsubscribing from push notifications. This happens because it uses `this.subscription.switchMap(fn)` and also emits `null` on `this.subscription` from within `fn`.

Issue Number: #24095


## What is the new behavior?
`SwPush.unsubscribe()` works correctly (i.e. does not return a rejection even when successfully unsubscribing).


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
Fixes #24095.