### PR TITLE
fix(elements): initialization should run in ngZone (#24181)

### DIFF
--- a/packages/elements/public_api.ts
+++ b/packages/elements/public_api.ts
@@ -11,6 +11,7 @@
  * @description
  * Entry point for all public APIs of the `elements` package.
  */
+export {ComponentNgElementZoneStrategyFactory} from './src/component-factory-strategy-zone';
 export {NgElement, NgElementConfig, NgElementConstructor, WithProperties, createCustomElement} from './src/create-custom-element';
 export {NgElementStrategy, NgElementStrategyEvent, NgElementStrategyFactory} from './src/element-strategy';
 export {VERSION} from './src/version';

--- a/packages/elements/src/component-factory-strategy-zone.ts
+++ b/packages/elements/src/component-factory-strategy-zone.ts
@@ -22,7 +22,7 @@ export class ComponentNgElementZoneStrategyFactory extends ComponentNgElementStr
 }
 
 /**
- * extends ComponentNgElementStrategy to insure callbacks run in the Angular zone
+ * extends ComponentNgElementStrategy to ensure callbacks run in the Angular zone
  *
  * @experimental
  */
@@ -35,20 +35,20 @@ export class ComponentNgElementZoneStrategy extends ComponentNgElementStrategy {
   }
 
   connect(element: HTMLElement) {
-    this.insureAngularZone(() => { super.connect(element); });
+    this.runInZone(() => { super.connect(element); });
   }
 
-  disconnect() { this.insureAngularZone(super.disconnect); }
+  disconnect() {
+    this.runInZone(() => { super.disconnect(); });
+  }
 
   getInputValue(propName: string) {
-    return this.insureAngularZone(() => { return super.getInputValue(propName); });
+    return this.runInZone(() => { return super.getInputValue(propName); });
   }
 
   setInputValue(propName: string, value: string) {
-    this.insureAngularZone(() => { super.setInputValue(propName, value); });
+    this.runInZone(() => { super.setInputValue(propName, value); });
   }
 
-  private insureAngularZone(fn: () => any) {
-    return NgZone.isInAngularZone() ? fn() : this.ngZone.run(fn);
-  }
+  private runInZone(fn: () => any) { return NgZone.isInAngularZone() ? fn() : this.ngZone.run(fn); }
 }

--- a/packages/elements/src/component-factory-strategy-zone.ts
+++ b/packages/elements/src/component-factory-strategy-zone.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentFactory, ComponentRef, Injector, NgZone} from '@angular/core';
+
+import {ComponentNgElementStrategy, ComponentNgElementStrategyFactory} from './component-factory-strategy';
+
+/**
+ * Factory that creates new ComponentNgElementZoneStrategy instance.
+ *
+ * @experimental
+ */
+export class ComponentNgElementZoneStrategyFactory extends ComponentNgElementStrategyFactory {
+  create(injector: Injector) {
+    return new ComponentNgElementZoneStrategy(this.componentFactory, injector);
+  }
+}
+
+/**
+ * extends ComponentNgElementStrategy to insure callbacks run in the Angular zone
+ *
+ * @experimental
+ */
+export class ComponentNgElementZoneStrategy extends ComponentNgElementStrategy {
+  private ngZone: NgZone;
+
+  constructor(protected componentFactory: ComponentFactory<any>, protected injector: Injector) {
+    super(componentFactory, injector);
+    this.ngZone = this.injector.get<NgZone>(NgZone);
+  }
+
+  connect(element: HTMLElement) {
+    this.insureAngularZone(() => { super.connect(element); });
+  }
+
+  disconnect() { this.insureAngularZone(super.disconnect); }
+
+  getInputValue(propName: string) {
+    return this.insureAngularZone(() => { return super.getInputValue(propName); });
+  }
+
+  setInputValue(propName: string, value: string) {
+    this.insureAngularZone(() => { super.setInputValue(propName, value); });
+  }
+
+  private insureAngularZone(fn: () => any) {
+    return NgZone.isInAngularZone() ? fn() : this.ngZone.run(fn);
+  }
+}

--- a/packages/elements/src/component-factory-strategy-zone.ts
+++ b/packages/elements/src/component-factory-strategy-zone.ts
@@ -5,10 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
+///<reference path="../../../node_modules/zone.js/dist/zone.js.d.ts" />
 import {ComponentFactory, ComponentRef, Injector, NgZone} from '@angular/core';
-import {} from 'zone.js';
-
 import {ComponentNgElementStrategy, ComponentNgElementStrategyFactory} from './component-factory-strategy';
 
 /**
@@ -29,12 +27,12 @@ export class ComponentNgElementZoneStrategyFactory extends ComponentNgElementStr
  */
 export class ComponentNgElementZoneStrategy extends ComponentNgElementStrategy {
   private readonly ngZone: NgZone;
-  private elementZone !: Zone;
+  private readonly elementZone: Zone;
 
   constructor(componentFactory: ComponentFactory<any>, injector: Injector) {
     super(componentFactory, injector);
     this.ngZone = this.injector.get<NgZone>(NgZone);
-    this.ngZone.run(() => { this.elementZone = Zone.current; });
+    this.elementZone = this.ngZone.run(() => { return Zone.current; });
   }
 
   connect(element: HTMLElement) {

--- a/packages/elements/src/component-factory-strategy-zone.ts
+++ b/packages/elements/src/component-factory-strategy-zone.ts
@@ -29,7 +29,7 @@ export class ComponentNgElementZoneStrategyFactory extends ComponentNgElementStr
 export class ComponentNgElementZoneStrategy extends ComponentNgElementStrategy {
   private readonly ngZone: NgZone;
 
-  constructor(componentFactory: ComponentFactory<any>, protected readonly injector: Injector) {
+  constructor(componentFactory: ComponentFactory<any>, injector: Injector) {
     super(componentFactory, injector);
     this.ngZone = this.injector.get<NgZone>(NgZone);
   }

--- a/packages/elements/src/component-factory-strategy-zone.ts
+++ b/packages/elements/src/component-factory-strategy-zone.ts
@@ -29,7 +29,7 @@ export class ComponentNgElementZoneStrategyFactory extends ComponentNgElementStr
  */
 export class ComponentNgElementZoneStrategy extends ComponentNgElementStrategy {
   private readonly ngZone: NgZone;
-  private elementZone: Zone;
+  private elementZone !: Zone;
 
   constructor(componentFactory: ComponentFactory<any>, injector: Injector) {
     super(componentFactory, injector);

--- a/packages/elements/src/component-factory-strategy-zone.ts
+++ b/packages/elements/src/component-factory-strategy-zone.ts
@@ -27,9 +27,9 @@ export class ComponentNgElementZoneStrategyFactory extends ComponentNgElementStr
  * @experimental
  */
 export class ComponentNgElementZoneStrategy extends ComponentNgElementStrategy {
-  private ngZone: NgZone;
+  private readonly ngZone: NgZone;
 
-  constructor(protected componentFactory: ComponentFactory<any>, protected injector: Injector) {
+  constructor(componentFactory: ComponentFactory<any>, protected readonly injector: Injector) {
     super(componentFactory, injector);
     this.ngZone = this.injector.get<NgZone>(NgZone);
   }

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, EventEmitter, Injector, NgZone, OnChanges, SimpleChange, SimpleChanges, Type} from '@angular/core';
+import {ApplicationRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, EventEmitter, Injector, OnChanges, SimpleChange, SimpleChanges, Type} from '@angular/core';
 import {Observable, merge} from 'rxjs';
 import {map} from 'rxjs/operators';
 
@@ -67,13 +67,7 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
   /** Set of inputs that were not initially set when the component was created. */
   private readonly uninitializedInputs = new Set<string>();
 
-  private ngZone: NgZone;
-  private applicationRef: ApplicationRef;
-
-  constructor(private componentFactory: ComponentFactory<any>, private injector: Injector) {
-    this.ngZone = this.injector.get<NgZone>(NgZone);
-    this.applicationRef = this.injector.get<ApplicationRef>(ApplicationRef);
-  }
+  constructor(protected componentFactory: ComponentFactory<any>, protected injector: Injector) {}
 
   /**
    * Initializes a new component if one has not yet been created and cancels any scheduled
@@ -88,8 +82,7 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
     }
 
     if (!this.componentRef) {
-      let initializeComponentFn = () => { this.initializeComponent(element); };
-      NgZone.isInAngularZone() ? initializeComponentFn() : this.ngZone.run(initializeComponentFn);
+      this.initializeComponent(element);
     }
   }
 

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, EventEmitter, Injector, OnChanges, SimpleChange, SimpleChanges, Type} from '@angular/core';
+import {ApplicationRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, EventEmitter, Injector, NgZone, OnChanges, SimpleChange, SimpleChanges, Type} from '@angular/core';
 import {Observable, merge} from 'rxjs';
 import {map} from 'rxjs/operators';
 
@@ -67,7 +67,13 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
   /** Set of inputs that were not initially set when the component was created. */
   private readonly uninitializedInputs = new Set<string>();
 
-  constructor(private componentFactory: ComponentFactory<any>, private injector: Injector) {}
+  private ngZone: NgZone;
+  private applicationRef: ApplicationRef;
+
+  constructor(private componentFactory: ComponentFactory<any>, private injector: Injector) {
+    this.ngZone = this.injector.get<NgZone>(NgZone);
+    this.applicationRef = this.injector.get<ApplicationRef>(ApplicationRef);
+  }
 
   /**
    * Initializes a new component if one has not yet been created and cancels any scheduled
@@ -82,7 +88,8 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
     }
 
     if (!this.componentRef) {
-      this.initializeComponent(element);
+      let initializeComponentFn = () => { this.initializeComponent(element); };
+      NgZone.isInAngularZone() ? initializeComponentFn() : this.ngZone.run(initializeComponentFn);
     }
   }
 

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, EventEmitter, Injector, OnChanges, SimpleChange, SimpleChanges, Type} from '@angular/core';
+import {ApplicationRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, EventEmitter, Injector, NgZone, OnChanges, SimpleChange, SimpleChanges, Type} from '@angular/core';
 import {Observable, merge} from 'rxjs';
 import {map} from 'rxjs/operators';
 
@@ -67,7 +67,13 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
   /** Set of inputs that were not initially set when the component was created. */
   private readonly uninitializedInputs = new Set<string>();
 
-  constructor(private componentFactory: ComponentFactory<any>, private injector: Injector) {}
+  private ngZone: NgZone;
+  private applicationRef: ApplicationRef;
+
+  constructor(private componentFactory: ComponentFactory<any>, private injector: Injector) {
+    this.ngZone = this.injector.get<NgZone>(NgZone);
+    this.applicationRef = this.injector.get<ApplicationRef>(ApplicationRef);
+  }
 
   /**
    * Initializes a new component if one has not yet been created and cancels any scheduled
@@ -82,7 +88,9 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
     }
 
     if (!this.componentRef) {
-      this.initializeComponent(element);
+      let initializeComponentFn = () => { this.initializeComponent(element); };
+      NgZone.isInAngularZone() ? initializeComponentFn() :
+                                      this.ngZone.run(initializeComponentFn);
     }
   }
 

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -89,12 +89,7 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
 
     if (!this.componentRef) {
       let initializeComponentFn = () => { this.initializeComponent(element); };
-<<<<<<< HEAD
       NgZone.isInAngularZone() ? initializeComponentFn() : this.ngZone.run(initializeComponentFn);
-=======
-      NgZone.isInAngularZone() ? initializeComponentFn() :
-                                      this.ngZone.run(initializeComponentFn);
->>>>>>> 5b5dfdd4add9276950e9ce9b76760382ea57a57e
     }
   }
 

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -67,7 +67,9 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
   /** Set of inputs that were not initially set when the component was created. */
   private readonly uninitializedInputs = new Set<string>();
 
-  constructor(protected componentFactory: ComponentFactory<any>, protected injector: Injector) {}
+  constructor(
+      protected readonly componentFactory: ComponentFactory<any>,
+      protected readonly injector: Injector) {}
 
   /**
    * Initializes a new component if one has not yet been created and cancels any scheduled

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentFactory, ComponentRef, Injector, NgModuleRef, NgZone, SimpleChange, SimpleChanges, Type} from '@angular/core';
+import {ComponentFactory, ComponentRef, Injector, NgModuleRef, SimpleChange, SimpleChanges, Type} from '@angular/core';
 import {fakeAsync, tick} from '@angular/core/testing';
 import {Subject} from 'rxjs';
 
@@ -20,27 +20,12 @@ describe('ComponentFactoryNgElementStrategy', () => {
   let injector: any;
   let componentRef: any;
   let applicationRef: any;
-  let factoryResolver: any;
-  let ngZone: any;
 
   beforeEach(() => {
     factory = new FakeComponentFactory();
     componentRef = factory.componentRef;
 
     applicationRef = jasmine.createSpyObj('applicationRef', ['attachView']);
-    ngZone = jasmine.createSpyObj('ngZone', ['run']);
-    ngZone.run.and.callFake((fn: any) => { return fn(); });
-    injector = jasmine.createSpyObj('injector', ['get']);
-    injector.get.and.callFake(function(identify: any) {
-      const name = identify && identify.name;
-      if (name === 'ApplicationRef') {
-        return applicationRef;
-      } else if (name === 'NgZone') {
-        return ngZone;
-      } else if (name === 'ComponentFactoryResolver') {
-        return factoryResolver;
-      }
-    });
 
     strategy = new ComponentNgElementStrategy(factory, injector);
   });
@@ -55,34 +40,6 @@ describe('ComponentFactoryNgElementStrategy', () => {
     expect(strategyFactory.create(injector)).toBeTruthy();
   });
 
-  describe('connected', () => {
-
-    it('should not run initializeComponentFn in ngZone if is already inAngularZone',
-       fakeAsync(() => {
-         const spy = spyOn(NgZone, 'isInAngularZone');
-         spy.and.callFake(function() { return true; });
-         ngZone.run.calls.reset();
-
-         strategy.connect(document.createElement('div'));
-
-         expect(ngZone.run).not.toHaveBeenCalled();
-         ngZone.run.and.callFake(() => {});
-         tick(16);  // scheduler waits 16ms if RAF is unavailable
-         expect(ngZone.run).not.toHaveBeenCalled();
-       }));
-
-    it('should run initializeComponentFn in ngZone if is not already inAngularZone',
-       fakeAsync(() => {
-         const spy = spyOn(NgZone, 'isInAngularZone');
-         spy.and.callFake(function() { return false; });
-         ngZone.run.calls.reset();
-
-         strategy.connect(document.createElement('div'));
-
-         expect(ngZone.run).toHaveBeenCalled();
-       }));
-
-  });
   describe('after connected', () => {
     beforeEach(() => {
       // Set up an initial value to make sure it is passed to the component

--- a/packages/elements/test/component-factory-strategy_zone_spec.ts
+++ b/packages/elements/test/component-factory-strategy_zone_spec.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ComponentFactory, Injector, NgZone} from '@angular/core';
+import {fakeAsync, tick} from '@angular/core/testing';
+
+import {ComponentNgElementStrategy} from '../src/component-factory-strategy';
+import {ComponentNgElementZoneStrategy, ComponentNgElementZoneStrategyFactory} from '../src/component-factory-strategy-zone';
+import {FakeComponent, FakeComponentFactory} from './component-factory-strategy_spec';
+
+describe('ComponentNgElementZoneStrategyFactory', () => {
+  let factory: FakeComponentFactory;
+  let strategy: ComponentNgElementZoneStrategy;
+
+  let injector: any;
+  let componentRef: any;
+  let applicationRef: any;
+  let factoryResolver: any;
+  let ngZone: any;
+
+  beforeEach(() => {
+    factory = new FakeComponentFactory();
+    componentRef = factory.componentRef;
+
+    applicationRef = jasmine.createSpyObj('applicationRef', ['attachView']);
+
+    ngZone = jasmine.createSpyObj('ngZone', ['run']);
+    ngZone.run.and.callFake((fn: any) => { return fn(); });
+
+    injector = jasmine.createSpyObj('injector', ['get']);
+    injector.get.and.callFake(function(identify: any) {
+      const name = identify && identify.name;
+      if (name === 'ApplicationRef') {
+        return applicationRef;
+      } else if (name === 'NgZone') {
+        return ngZone;
+      } else if (name === 'ComponentFactoryResolver') {
+        return factoryResolver;
+      }
+    });
+    strategy = new ComponentNgElementZoneStrategy(factory, injector);
+  });
+
+  it('should create a new strategy from the factory', () => {
+    factoryResolver = jasmine.createSpyObj('factoryResolver', ['resolveComponentFactory']);
+    factoryResolver.resolveComponentFactory.and.returnValue(factory);
+
+    const strategyFactory = new ComponentNgElementZoneStrategyFactory(FakeComponent, injector);
+    expect(strategyFactory.create(injector)).toBeTruthy();
+  });
+
+  it('should connect already in NgZone', () => {
+    const parent = spyOn(ComponentNgElementStrategy.prototype, 'connect');
+    const isInAngularZone =
+        spyOn(NgZone, 'isInAngularZone').and.callFake(function() { return true; });
+    ngZone.run.calls.reset();
+    strategy.connect(document.createElement('div'));
+    expect(parent).toHaveBeenCalled();
+    expect(ngZone.run).not.toHaveBeenCalled();
+  });
+
+  it('should connect not already in NgZone', () => {
+    const parent = spyOn(ComponentNgElementStrategy.prototype, 'connect');
+    const isInAngularZone =
+        spyOn(NgZone, 'isInAngularZone').and.callFake(function() { return false; });
+    ngZone.run.calls.reset();
+    strategy.connect(document.createElement('div'));
+    expect(parent).toHaveBeenCalled();
+    expect(ngZone.run).toHaveBeenCalled();
+  });
+
+  describe('after connected not in NgZone', () => {
+    beforeEach(() => {
+      const isInAngularZone =
+          spyOn(NgZone, 'isInAngularZone').and.callFake(function() { return false; });
+      strategy.connect(document.createElement('div'));
+      ngZone.run.calls.reset();
+    });
+
+    it('should disconnect', () => {
+      const parent = spyOn(ComponentNgElementStrategy.prototype, 'disconnect');
+      strategy.disconnect();
+      expect(parent).toHaveBeenCalled();
+      expect(ngZone.run).toHaveBeenCalled();
+    });
+
+    it('should setInputValue', () => {
+      const parent = spyOn(ComponentNgElementStrategy.prototype, 'setInputValue');
+      strategy.setInputValue('fooFoo', 'fooFoo-1');
+      expect(parent).toHaveBeenCalled();
+      expect(ngZone.run).toHaveBeenCalled();
+    });
+
+    it('should getInputValue', () => {
+      strategy.setInputValue('fooFoo', 'fooFoo-1');
+      ngZone.run.calls.reset();
+      const value = strategy.getInputValue('fooFoo');
+      expect(ngZone.run).toHaveBeenCalled();
+      expect(value).toEqual('fooFoo-1');
+    });
+  });
+
+});

--- a/packages/elements/test/component-factory-strategy_zone_spec.ts
+++ b/packages/elements/test/component-factory-strategy_zone_spec.ts
@@ -56,7 +56,7 @@ describe('ComponentNgElementZoneStrategyFactory', () => {
 
   it('should connect already in NgZone', () => {
     const parent = spyOn(ComponentNgElementStrategy.prototype, 'connect');
-    strategy['elementZone'] = Zone.current;
+    (strategy as any)['elementZone'] = Zone.current;
     ngZone.run.calls.reset();
     strategy.connect(document.createElement('div'));
     expect(parent).toHaveBeenCalled();
@@ -65,7 +65,7 @@ describe('ComponentNgElementZoneStrategyFactory', () => {
 
   it('should connect not already in NgZone', () => {
     const parent = spyOn(ComponentNgElementStrategy.prototype, 'connect');
-    strategy['elementZone'] = Zone.current.parent;
+    (strategy as any)['elementZone'] = Zone.current.parent;
     ngZone.run.calls.reset();
     strategy.connect(document.createElement('div'));
     expect(parent).toHaveBeenCalled();
@@ -74,7 +74,7 @@ describe('ComponentNgElementZoneStrategyFactory', () => {
 
   describe('after connected not in NgZone', () => {
     beforeEach(() => {
-      strategy['elementZone'] = Zone.current.parent;
+      (strategy as any)['elementZone'] = Zone.current.parent;
       strategy.connect(document.createElement('div'));
       ngZone.run.calls.reset();
     });

--- a/packages/elements/test/component-factory-strategy_zone_spec.ts
+++ b/packages/elements/test/component-factory-strategy_zone_spec.ts
@@ -56,8 +56,7 @@ describe('ComponentNgElementZoneStrategyFactory', () => {
 
   it('should connect already in NgZone', () => {
     const parent = spyOn(ComponentNgElementStrategy.prototype, 'connect');
-    const isInAngularZone =
-        spyOn(NgZone, 'isInAngularZone').and.callFake(function() { return true; });
+    strategy['elementZone'] = Zone.current;
     ngZone.run.calls.reset();
     strategy.connect(document.createElement('div'));
     expect(parent).toHaveBeenCalled();
@@ -66,8 +65,7 @@ describe('ComponentNgElementZoneStrategyFactory', () => {
 
   it('should connect not already in NgZone', () => {
     const parent = spyOn(ComponentNgElementStrategy.prototype, 'connect');
-    const isInAngularZone =
-        spyOn(NgZone, 'isInAngularZone').and.callFake(function() { return false; });
+    strategy['elementZone'] = Zone.current.parent;
     ngZone.run.calls.reset();
     strategy.connect(document.createElement('div'));
     expect(parent).toHaveBeenCalled();
@@ -76,8 +74,7 @@ describe('ComponentNgElementZoneStrategyFactory', () => {
 
   describe('after connected not in NgZone', () => {
     beforeEach(() => {
-      const isInAngularZone =
-          spyOn(NgZone, 'isInAngularZone').and.callFake(function() { return false; });
+      strategy['elementZone'] = Zone.current.parent;
       strategy.connect(document.createElement('div'));
       ngZone.run.calls.reset();
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #24181 
When an angular element is created outside the angular zone, such as in setTimeout(), automatic change detection no longer works


## What is the new behavior?
during connect(), initializeComponent is always called in the angular zone

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
@JiaLiPassion this is based/extends on your PR 23885, please review