### PR TITLE
refactor(ivy): move parent from LNode to TNode

### DIFF
--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -111,6 +111,9 @@
     "name": "getOrCreateTView"
   },
   {
+    "name": "getParentLNode"
+  },
+  {
     "name": "getRenderFlags"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -423,6 +423,9 @@
     "name": "getOrCreateTemplateRef"
   },
   {
+    "name": "getParentLNode"
+  },
+  {
     "name": "getParentState"
   },
   {

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -1372,7 +1372,7 @@ describe('di', () => {
         // Simulate the situation where the previous parent is not initialized.
         // This happens on first bootstrap because we don't init existing values
         // so that we have smaller HelloWorld.
-        (parent as{parent: any}).parent = undefined;
+        (parent.tNode as{parent: any}).parent = undefined;
 
         const injector = getOrCreateNodeInjector();
         expect(injector).not.toBe(null);

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -23,6 +23,7 @@ function testLStaticData(tagName: string, attrs: string[] | null): TNode {
     tViews: null,
     next: null,
     child: null,
+    parent: null,
     dynamicContainerNode: null
   };
 }


### PR DESCRIPTION
This PR moves `LNode.parent` to `TNode` as part of an ongoing refactor to reduce memory pressure (eventually removing `LNode` entirely).

Notes:
- From now on, use `getParentLNode()` to retrieve parent nodes instead of `LNode.parent`.

- `TNode.parent` is not exactly equivalent to `LNode.parent` because `TNode.parent` can only store nodes in the same view.  It's important that we don't try to cross component boundaries when storing the parent because the parent will change (e.g. index, attrs) depending on where the component is being used. If the parent would be in a different view, we use `LView.node` to retrieve it because that will be instance-specific.


TODO:
- `pNextOrParent` -> `TNode`
- LView tree refactor