### PR TITLE
refactor(ivy): replace LView.child with TView.childIndex lookup

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -590,7 +590,7 @@ export function getOrCreateContainerRef(di: LInjector): viewEngine_ViewContainer
     lContainerNode.tNode = hostTNode.dynamicContainerNode;
     vcRefHost.dynamicLContainerNode = lContainerNode;
 
-    addToViewTree(vcRefHost.view, lContainer);
+    addToViewTree(vcRefHost.view, hostTNode.index as number, lContainer);
 
     di.viewContainerRef = new ViewContainerRef(lContainerNode);
   }

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -113,17 +113,6 @@ export interface LView {
   lifecycleStage: LifecycleStage;
 
   /**
-   * The first LView or LContainer beneath this LView in the hierarchy.
-   *
-   * Necessary to store this so views can traverse through their nested views
-   * to remove listeners and call onDestroy callbacks.
-   *
-   * For embedded views, we store the LContainer rather than the first ViewState
-   * to avoid managing splicing when views are added/removed.
-   */
-  child: LView|LContainer|null;
-
-  /**
    * The last LView or LContainer beneath this LView in the hierarchy.
    *
    * The tail allows us to quickly add a new state to the end of the view list
@@ -222,8 +211,8 @@ export const enum LViewFlags {
 /** Interface necessary to work with view tree traversal */
 export interface LViewOrLContainer {
   next: LView|LContainer|null;
-  child?: LView|LContainer|null;
   views?: LViewNode[];
+  tView?: TView;
   parent: LView|null;
 }
 
@@ -250,6 +239,18 @@ export interface TView {
 
   /** Static data equivalent of LView.data[]. Contains TNodes. */
   data: TData;
+
+  /**
+   * Index of the host node of the first LView or LContainer beneath this LView in
+   * the hierarchy.
+   *
+   * Necessary to store this so views can traverse through their nested views
+   * to remove listeners and call onDestroy callbacks.
+   *
+   * For embedded views, we store the index of an LContainer's host rather than the first
+   * LView to avoid managing splicing when views are added/removed.
+   */
+  childIndex: number;
 
   /**
    * Selector matches for a node are temporarily cached on the TView so the

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -261,19 +261,19 @@ export function addRemoveViewFromContainer(
  *  @param rootView The view to destroy
  */
 export function destroyViewTree(rootView: LView): void {
-  // A view to cleanup doesn't have children so we should not try to descend down the view tree.
-  if (!rootView.child) {
+  // If the view has no children, we can clean it up and return early.
+  if (rootView.tView.childIndex === -1) {
     return cleanUpView(rootView);
   }
-  let viewOrContainer: LViewOrLContainer|null = rootView.child;
+  let viewOrContainer: LViewOrLContainer|null = getLViewChild(rootView);
 
   while (viewOrContainer) {
     let next: LViewOrLContainer|null = null;
 
     if (viewOrContainer.views && viewOrContainer.views.length) {
       next = viewOrContainer.views[0].data;
-    } else if (viewOrContainer.child) {
-      next = viewOrContainer.child;
+    } else if (viewOrContainer.tView && viewOrContainer.tView.childIndex > -1) {
+      next = getLViewChild(viewOrContainer as LView);
     } else if (viewOrContainer.next) {
       // Only move to the side and clean if operating below rootView -
       // otherwise we would start cleaning up sibling views of the rootView.
@@ -381,6 +381,15 @@ export function removeView(container: LContainerNode, removeIndex: number): LVie
   }
 
   return viewNode;
+}
+
+/** Gets the child of the given LView */
+export function getLViewChild(view: LView): LView|LContainer|null {
+  if (view.tView.childIndex === -1) return null;
+
+  const hostNode: LElementNode|LContainerNode = view.data[view.tView.childIndex];
+
+  return hostNode.data ? hostNode.data : (hostNode.dynamicLContainerNode as LContainerNode).data;
 }
 
 /**

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -108,6 +108,9 @@
     "name": "getDirectiveInstance"
   },
   {
+    "name": "getLViewChild"
+  },
+  {
     "name": "getOrCreateTView"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -390,6 +390,9 @@
     "name": "getDirectiveInstance"
   },
   {
+    "name": "getLViewChild"
+  },
+  {
     "name": "getNextLNode"
   },
   {


### PR DESCRIPTION
This PR removes `LView.child` and replaces it with `getLViewChild()`, a function that looks up the proper view or container instance using the index of its host node in `data[]` (which is now stored in `TView.childIndex`). This approach saves some runtime memory because there should only be one `TView` per component definition (as opposed to one `LView` per component instance). It's a small part of an ongoing refactor to reduce memory pressure (eventually by removing `LNode` and most of `LView`).

From now on, we should use `getLViewChild()` instead of `LView.child` to grab child views.

Still TODO:
- Other `LView` tree markers: next, parent, tail, etc.
- Finish up `LNode` removal (waiting on i18n)