### PR TITLE
fix(platform-server): don't reflect innerHTML property to attibute

### DIFF
--- a/packages/platform-server/src/server_renderer.ts
+++ b/packages/platform-server/src/server_renderer.ts
@@ -154,9 +154,11 @@ class DefaultServerRenderer2 implements Renderer2 {
     checkNoSyntheticProp(name, 'property');
     getDOM().setProperty(el, name, value);
     // Mirror property values for known HTML element properties in the attributes.
+    // Skip `innerhtml` which is conservatively marked as an attribute for security
+    // purposes but is not actually an attribute.
     const tagName = (el.tagName as string).toLowerCase();
     if (value != null && (typeof value === 'number' || typeof value == 'string') &&
-        this.schema.hasElement(tagName, EMPTY_ARRAY) &&
+        name.toLowerCase() !== 'innerhtml' && this.schema.hasElement(tagName, EMPTY_ARRAY) &&
         this.schema.hasProperty(tagName, name, EMPTY_ARRAY) &&
         this._isSafeToReflectProperty(tagName, name)) {
       this.setAttribute(el, name, value.toString());

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -587,7 +587,7 @@ class EscapedTransferStoreModule {
            renderModule(HTMLTypesModule, {document: doc}).then(output => {
              expect(output).toBe(
                  '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
-                 '<div innerhtml="<b>foo</b> bar"><b>foo</b> bar</div></app></body></html>');
+                 '<div><b>foo</b> bar</div></app></body></html>');
              called = true;
            });
          }));


### PR DESCRIPTION
Fixes #19278.

innerHTML is conservatively marked as an attribute for security purpose so that it's sanitized when set. However this same mapping is used by the server renderer to decide whether the `innerHTML` property needs to be reflected to the `innerhtml` attribute. The fix is to just skip the property to attribute reflection for `innerHTML`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
When innerHTML property is set on an element it is wrongly reflected to an "innerhtml" attribute in addition to actually setting the innerHTML.
```
<div [innerHTML]="'content'"></div>
```
in template produces
```
<div innerhtml="content">content</div>
```

Issue Number: #19278


## What is the new behavior?
```
<div [innerHTML]="'content'"></div>
```
in template produces
```
<div>content</div>
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
