### PR TITLE
feat(ivy): implement ViewContainerRef.remove

### DIFF
--- a/packages/core/src/render3/STATUS.md
+++ b/packages/core/src/render3/STATUS.md
@@ -271,8 +271,8 @@ The goal is for the `@Component` (and friends) to be the compiler of template. S
 | `insertBefore()`                    |  ✅     |
 | `removeChild()`                     |  ✅     |
 | `selectRootElement()`               |  ✅     |
-| `parentNode()`                      |  ❌     |
-| `nextSibling()`                     |  ❌     |
+| `parentNode()`                      |  n/a    |
+| `nextSibling()`                     |  n/a    |
 | `setAttribute()`                    |  ✅     |
 | `removeAttribute()`                 |  ✅     |
 | `addClass()`                        |  ✅     |

--- a/packages/core/src/render3/STATUS.md
+++ b/packages/core/src/render3/STATUS.md
@@ -238,22 +238,25 @@ The goal is for the `@Component` (and friends) to be the compiler of template. S
 ### `______Ref`s
 | Method                 | View Container Ref | Template Ref | Embeded View Ref | View Ref | Element Ref | Change Detection Ref |
 | ---------------------- | ------------------ | ------------ | ---------------- | -------- | ----------- | -------------------- |
-| `clear()`              |  ❌                | n/a          | n/a              | n/a      | n/a         | n/a                  |
-| `get()`                |  ❌                | n/a          | n/a              | n/a      | n/a         | n/a                  |
+| `clear()`              |  ✅                | n/a          | n/a              | n/a      | n/a         | n/a                  |
+| `get()`                |  ✅                | n/a          | n/a              | n/a      | n/a         | n/a                  |
 | `createEmbededView()`  |  ✅                | ✅           | n/a              | n/a      | n/a         | n/a                  |
-| `createComponent()`    |  ✅                | n/a          | n/a              | n/a      | n/a         | n/a                  |
+| `createComponent()`    |  ❌                | n/a          | n/a              | n/a      | n/a         | n/a                  |
 | `insert()`             |  ✅                | n/a          | n/a              | n/a      | n/a         | n/a                  |
-| `move()`               |  ❌                | n/a          | n/a              | n/a      | n/a         | n/a                  |
-| `indexOf()`            |  ❌                | n/a          | n/a              | n/a      | n/a         | n/a                  |
-| `destroy()`            | n/a                | n/a          |  ❌              | ❌       | n/a         | n/a                  |
-| `destroyed`            | n/a                | n/a          |  ❌              | ❌       | n/a         | n/a                  |
-| `onDestroy()`          | n/a                | n/a          |  ❌              | ❌       | n/a         | n/a                  |
-| `markForCheck()`       | n/a                | n/a          |  ❌              | n/a      | n/a         | ✅                   |
-| `detach()`             |  ❌                | n/a          |  ❌              | n/a      | n/a         | ✅                   |
-| `detachChanges()`      | n/a                | n/a          |  ❌              | n/a      | n/a         | ✅                   |
-| `checkNoChanges()`     | n/a                | n/a          |  ❌              | n/a      | n/a         | ✅                   |
-| `reattach()`           | n/a                | n/a          |  ❌              | n/a      | n/a         | ✅                   |
-| `nativeElement()`      | n/a                | n/a          | n/a              | n/a      |  ✅         | n/a                  |
+| `move()`               |  ✅                | n/a          | n/a              | n/a      | n/a         | n/a                  |
+| `indexOf()`            |  ✅                | n/a          | n/a              | n/a      | n/a         | n/a                  |
+| `length()`             |  ✅                | n/a          | n/a              | n/a      | n/a         | n/a                  |
+| `remove()`             |  ✅                | n/a          | n/a              | n/a      | n/a         | n/a                  |
+| `destroy()`            | n/a                | n/a          |  ✅              | ✅       | n/a         | n/a                  |
+| `destroyed`            | n/a                | n/a          |  ✅              | ✅       | n/a         | n/a                  |
+| `onDestroy()`          | n/a                | n/a          |  ✅              | ✅       | n/a         | n/a                  |
+| `markForCheck()`       | n/a                | n/a          |  ✅              | ✅       | n/a         | ✅                   |
+| `detach()`             |  ✅                | n/a          |  ✅              | ✅       | n/a         | ✅                   |
+| `detachChanges()`      | n/a                | n/a          |  ✅              | ✅       | n/a         | ✅                   |
+| `checkNoChanges()`     | n/a                | n/a          |  ✅              | ✅       | n/a         | ✅                   |
+| `reattach()`           | n/a                | n/a          |  ✅              | ✅       | n/a         | ✅                   |
+| `nativeElement()`      | n/a                | n/a          | n/a              | n/a     |  ✅         | n/a                  |
+| `elementRef`           | n/a                | ✅           | n/a              | n/a      |  n/a        | n/a                  |
 
 ### Renderer2
 | Method                              | Runtime |

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -21,7 +21,7 @@ import {LElementNode, TNodeFlags} from './interfaces/node';
 import {RElement, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
 import {LView, LViewFlags, RootContext} from './interfaces/view';
 import {stringify} from './util';
-import {createViewRef} from './view_ref';
+import {ViewRef} from './view_ref';
 
 
 
@@ -82,7 +82,7 @@ export function createComponentRef<T>(
     componentType: ComponentType<T>, opts: CreateComponentOptions): viewEngine_ComponentRef<T> {
   const component = renderComponent(componentType, opts);
   const hostView = _getComponentHostLElementNode(component).data as LView;
-  const hostViewRef = createViewRef(hostView, component);
+  const hostViewRef = new ViewRef(hostView, component);
   return {
     location: {nativeElement: getHostElement(component)},
     injector: opts.injector || NULL_INJECTOR,

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -27,9 +27,9 @@ import {LQueries, QueryReadType} from './interfaces/query';
 import {Renderer3} from './interfaces/renderer';
 import {LView, TView} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
-import {getParentLNode, insertView, removeView} from './node_manipulation';
+import {detachView, getParentLNode, insertView, removeView} from './node_manipulation';
 import {notImplemented, stringify} from './util';
-import {EmbeddedViewRef, ViewRef, addDestroyable, createViewRef} from './view_ref';
+import {EmbeddedViewRef, ViewRef, createViewRef} from './view_ref';
 
 
 
@@ -638,8 +638,13 @@ class ViewContainerRef implements viewEngine_ViewContainerRef {
   }
 
   insert(viewRef: viewEngine_ViewRef, index?: number): viewEngine_ViewRef {
+    if (viewRef.destroyed) {
+      throw new Error('Cannot insert a destroyed View in a ViewContainer!');
+    }
     const lViewNode = (viewRef as EmbeddedViewRef<any>)._lViewNode;
     const adjustedIdx = this._adjustIndex(index);
+
+    (viewRef as EmbeddedViewRef<any>).attachToViewContainerRef(this);
 
     insertView(this._lContainerNode, lViewNode, adjustedIdx);
     // invalidate cache of next sibling RNode (we do similar operation in the containerRefreshEnd
@@ -661,15 +666,14 @@ class ViewContainerRef implements viewEngine_ViewContainerRef {
   indexOf(viewRef: viewEngine_ViewRef): number { return this._viewRefs.indexOf(viewRef); }
 
   remove(index?: number): void {
-    this.detach(index);
-    // TODO(ml): proper destroy of the ViewRef, i.e. recursively destroy the LviewNode and its
-    // children, delete DOM nodes and QueryList, trigger hooks (onDestroy), destroy the renderer,
-    // detach projected nodes
+    const adjustedIdx = this._adjustIndex(index, -1);
+    removeView(this._lContainerNode, adjustedIdx);
+    this._viewRefs.splice(adjustedIdx, 1)[0] || null;
   }
 
   detach(index?: number): viewEngine_ViewRef|null {
     const adjustedIdx = this._adjustIndex(index, -1);
-    removeView(this._lContainerNode, adjustedIdx);
+    detachView(this._lContainerNode, adjustedIdx);
     return this._viewRefs.splice(adjustedIdx, 1)[0] || null;
   }
 
@@ -723,6 +727,6 @@ class TemplateRef<T> implements viewEngine_TemplateRef<T> {
   createEmbeddedView(context: T): viewEngine_EmbeddedViewRef<T> {
     const viewNode = renderEmbeddedTemplate(
         null, this._tView, this._template, context, this._renderer, this._queries);
-    return addDestroyable(new EmbeddedViewRef(viewNode, this._template, context));
+    return new EmbeddedViewRef(viewNode, this._template, context);
   }
 }

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -29,7 +29,7 @@ import {LView, TView} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
 import {detachView, getParentLNode, insertView, removeView} from './node_manipulation';
 import {notImplemented, stringify} from './util';
-import {EmbeddedViewRef, ViewRef, createViewRef} from './view_ref';
+import {EmbeddedViewRef, ViewRef} from './view_ref';
 
 
 
@@ -282,7 +282,7 @@ export function getOrCreateChangeDetectorRef(
 
   const currentNode = di.node;
   if (isComponent(currentNode.tNode)) {
-    return di.changeDetectorRef = createViewRef(currentNode.data as LView, context);
+    return di.changeDetectorRef = new ViewRef(currentNode.data as LView, context);
   } else if (currentNode.tNode.type === TNodeType.Element) {
     return di.changeDetectorRef = getOrCreateHostChangeDetector(currentNode.view.node);
   }
@@ -298,7 +298,7 @@ function getOrCreateHostChangeDetector(currentNode: LViewNode | LElementNode):
 
   return existingRef ?
       existingRef :
-      createViewRef(
+      new ViewRef(
           hostNode.data as LView,
           hostNode.view
               .directives ![hostNode.tNode.flags >> TNodeFlags.DirectiveStartingIndexShift]);

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -668,7 +668,7 @@ class ViewContainerRef implements viewEngine_ViewContainerRef {
   remove(index?: number): void {
     const adjustedIdx = this._adjustIndex(index, -1);
     removeView(this._lContainerNode, adjustedIdx);
-    this._viewRefs.splice(adjustedIdx, 1)[0] || null;
+    this._viewRefs.splice(adjustedIdx, 1);
   }
 
   detach(index?: number): viewEngine_ViewRef|null {

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -173,6 +173,11 @@ let directives: any[]|null;
  */
 let cleanup: any[]|null;
 
+export function getCleanup(): any[] {
+  // top level variables should not be exported for performance reason (PERF_NOTES.md)
+  return cleanup || (cleanup = currentView.cleanup = []);
+}
+
 /**
  * In this mode, any changes in bindings will throw an ExpressionChangedAfterChecked error.
  *
@@ -913,7 +918,7 @@ export function listener(
 
   // In order to match current behavior, native DOM event listeners must be added for all
   // events (including outputs).
-  const cleanupFns = cleanup || (cleanup = currentView.cleanup = []);
+  const cleanupFns = getCleanup();
   ngDevMode && ngDevMode.rendererAddEventListener++;
   if (isProceduralRenderer(renderer)) {
     const wrappedListener = wrapListenerWithDirtyLogic(currentView, listenerFn);
@@ -947,7 +952,7 @@ function createOutput(outputs: PropertyAliasValue, listener: Function): void {
   for (let i = 0; i < outputs.length; i += 2) {
     ngDevMode && assertDataInRange(outputs[i] as number, directives !);
     const subscription = directives ![outputs[i] as number][outputs[i + 1]].subscribe(listener);
-    cleanup !.push(subscription.unsubscribe, subscription);
+    getCleanup().push(subscription.unsubscribe, subscription);
   }
 }
 

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -81,7 +81,7 @@ let renderer: Renderer3;
 let rendererFactory: RendererFactory3;
 
 export function getRenderer(): Renderer3 {
-  // top level variables should not be exported for performance reason (PERF_NOTES.md)
+  // top level variables should not be exported for performance reasons (PERF_NOTES.md)
   return renderer;
 }
 
@@ -93,7 +93,7 @@ export function getCurrentSanitizer(): Sanitizer|null {
 let previousOrParentNode: LNode;
 
 export function getPreviousOrParentNode(): LNode {
-  // top level variables should not be exported for performance reason (PERF_NOTES.md)
+  // top level variables should not be exported for performance reasons (PERF_NOTES.md)
   return previousOrParentNode;
 }
 
@@ -126,7 +126,7 @@ let currentView: LView = null !;
 let currentQueries: LQueries|null;
 
 export function getCurrentQueries(QueryType: {new (): LQueries}): LQueries {
-  // top level variables should not be exported for performance reason (PERF_NOTES.md)
+  // top level variables should not be exported for performance reasons (PERF_NOTES.md)
   return currentQueries || (currentQueries = new QueryType());
 }
 
@@ -136,7 +136,7 @@ export function getCurrentQueries(QueryType: {new (): LQueries}): LQueries {
 let creationMode: boolean;
 
 export function getCreationMode(): boolean {
-  // top level variables should not be exported for performance reason (PERF_NOTES.md)
+  // top level variables should not be exported for performance reasons (PERF_NOTES.md)
   return creationMode;
 }
 
@@ -174,7 +174,7 @@ let directives: any[]|null;
 let cleanup: any[]|null;
 
 export function getCleanup(): any[] {
-  // top level variables should not be exported for performance reason (PERF_NOTES.md)
+  // top level variables should not be exported for performance reasons (PERF_NOTES.md)
   return cleanup || (cleanup = currentView.cleanup = []);
 }
 

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -164,16 +164,16 @@ export const enum LViewFlags {
    * back into the parent view, `data` will be defined and `creationMode` will be
    * improperly reported as false.
    */
-  CreationMode = 0b00001,
+  CreationMode = 0b000001,
 
   /** Whether this view has default change detection strategy (checks always) or onPush */
-  CheckAlways = 0b00010,
+  CheckAlways = 0b000010,
 
   /** Whether or not this view is currently dirty (needing check) */
-  Dirty = 0b00100,
+  Dirty = 0b000100,
 
   /** Whether or not this view is currently attached to change detection tree. */
-  Attached = 0b01000,
+  Attached = 0b001000,
 
   /**
    *  Whether or not the init hooks have run.
@@ -182,7 +182,10 @@ export const enum LViewFlags {
    * runs OR the first cR() instruction that runs (so inits are run for the top level view before
    * any embedded views).
    */
-  RunInit = 0b10000,
+  RunInit = 0b010000,
+  
+  /** Whether or not this view is destroyed. */
+  Destroyed = 0b100000,
 }
 
 /** Interface necessary to work with view tree traversal */

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -183,7 +183,7 @@ export const enum LViewFlags {
    * any embedded views).
    */
   RunInit = 0b010000,
-  
+
   /** Whether or not this view is destroyed. */
   Destroyed = 0b100000,
 }

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -149,21 +149,21 @@ function getNextOrParentSiblingNode(initialNode: LNode, rootNode: LNode): LNode|
  * @returns RNode The first RNode of the given LNode or null if there is none.
  */
 function findFirstRNode(rootNode: LNode): RElement|RText|null {
-  return walkLNodeTree(rootNode, rootNode, WalkLNodeTreeAction.FIND) || null;
+  return walkLNodeTree(rootNode, rootNode, WalkLNodeTreeAction.Find) || null;
 }
 
 const enum WalkLNodeTreeAction {
   /** returns the first available native node */
-  FIND = 0,
+  Find = 0,
 
   /** node insert in the native environment */
-  INSERT = 1,
+  Insert = 1,
 
   /** node detach from the native environment */
-  DETACH = 2,
+  Detach = 2,
 
   /** node destruction using the renderer's API */
-  DESTROY = 3,
+  Destroy = 3,
 }
 
 /**
@@ -189,20 +189,20 @@ function walkLNodeTree(
     let nextNode: LNode|null = null;
     if (node.tNode.type === TNodeType.Element) {
       // Execute the action
-      if (action === WalkLNodeTreeAction.FIND) {
+      if (action === WalkLNodeTreeAction.Find) {
         return node.native;
-      } else if (action === WalkLNodeTreeAction.INSERT) {
+      } else if (action === WalkLNodeTreeAction.Insert) {
         const parent = renderParentNode !.native;
         isProceduralRenderer(renderer !) ?
             (renderer as ProceduralRenderer3)
                 .insertBefore(parent !, node.native !, beforeNode as RNode | null) :
             parent !.insertBefore(node.native !, beforeNode as RNode | null, true);
-      } else if (action === WalkLNodeTreeAction.DETACH) {
+      } else if (action === WalkLNodeTreeAction.Detach) {
         const parent = renderParentNode !.native;
         isProceduralRenderer(renderer !) ?
             (renderer as ProceduralRenderer3).removeChild(parent as RElement, node.native !) :
             parent !.removeChild(node.native !);
-      } else if (action === WalkLNodeTreeAction.DESTROY) {
+      } else if (action === WalkLNodeTreeAction.Destroy) {
         ngDevMode && ngDevMode.rendererDestroyNode++;
         (renderer as ProceduralRenderer3).destroyNode !(node.native !);
       }
@@ -262,7 +262,7 @@ export function addRemoveViewFromContainer(
     let node: LNode|null = getChildLNode(rootNode);
     const renderer = container.view.renderer;
     walkLNodeTree(
-        node, rootNode, insertMode ? WalkLNodeTreeAction.INSERT : WalkLNodeTreeAction.DETACH,
+        node, rootNode, insertMode ? WalkLNodeTreeAction.Insert : WalkLNodeTreeAction.Detach,
         renderer, parentNode, beforeNode);
   }
 }
@@ -436,7 +436,7 @@ export function getLViewChild(view: LView): LView|LContainer|null {
 export function destroyLView(view: LView) {
   const renderer = view.renderer;
   if (isProceduralRenderer(renderer) && renderer.destroyNode) {
-    walkLNodeTree(view.node, view.node, WalkLNodeTreeAction.DESTROY, renderer);
+    walkLNodeTree(view.node, view.node, WalkLNodeTreeAction.Destroy, renderer);
   }
   destroyViewTree(view);
   // Sets the destroyed flag

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -17,7 +17,7 @@ import {getSymbolIterator} from '../util';
 
 import {assertEqual, assertNotNull} from './assert';
 import {ReadFromInjectorFn, getOrCreateNodeInjectorForNode} from './di';
-import {assertPreviousIsParent, getCurrentQueries, store} from './instructions';
+import {assertPreviousIsParent, getCleanup, getCurrentQueries, store} from './instructions';
 import {DirectiveDef, unusedValueExportToPlacateAjd as unused1} from './interfaces/definition';
 import {LInjector, unusedValueExportToPlacateAjd as unused2} from './interfaces/injector';
 import {LContainerNode, LElementNode, LNode, TNode, TNodeFlags, unusedValueExportToPlacateAjd as unused3} from './interfaces/node';
@@ -416,7 +416,7 @@ export function query<T>(
   const queryList = new QueryList<T>();
   const queries = getCurrentQueries(LQueries_);
   queries.track(queryList, predicate, descend, read);
-
+  getCleanup().push(queryList.destroy, queryList);
   if (memoryIndex != null) {
     store(memoryIndex, queryList);
   }

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -6,19 +6,20 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ViewContainerRef as viewEngine_ViewContainerRef} from '../linker/view_container_ref';
 import {EmbeddedViewRef as viewEngine_EmbeddedViewRef} from '../linker/view_ref';
 
 import {checkNoChanges, detectChanges, markViewDirty} from './instructions';
 import {ComponentTemplate} from './interfaces/definition';
 import {LViewNode} from './interfaces/node';
 import {LView, LViewFlags} from './interfaces/view';
-import {notImplemented} from './util';
+import {destroyLView} from './node_manipulation';
 
 export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T> {
   context: T;
   rootNodes: any[];
 
-  constructor(private _view: LView, context: T|null, ) { this.context = context !; }
+  constructor(protected _view: LView, context: T|null) { this.context = context !; }
 
   /** @internal */
   _setComponentContext(view: LView, context: T) {
@@ -26,9 +27,15 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T> {
     this.context = context;
   }
 
-  destroy(): void { notImplemented(); }
-  destroyed: boolean;
-  onDestroy(callback: Function) { notImplemented(); }
+  get destroyed(): boolean {
+    return (this._view.flags & LViewFlags.Destroyed) === LViewFlags.Destroyed;
+  }
+
+  destroy(): void { destroyLView(this._view); }
+
+  onDestroy(callback: Function) {
+    (this._view.cleanup || (this._view.cleanup = [])).push(callback, null);
+  }
 
   /**
    * Marks a view and all of its ancestors dirty.
@@ -213,11 +220,23 @@ export class EmbeddedViewRef<T> extends ViewRef<T> {
    * @internal
    */
   _lViewNode: LViewNode;
+  private _viewContainerRef: viewEngine_ViewContainerRef|null = null;
 
   constructor(viewNode: LViewNode, template: ComponentTemplate<T>, context: T) {
     super(viewNode.data, context);
     this._lViewNode = viewNode;
   }
+
+  destroy(): void {
+    if (this._viewContainerRef &&
+        (this._view.flags & LViewFlags.Attached) === LViewFlags.Attached) {
+      this._viewContainerRef.detach(this._viewContainerRef.indexOf(this));
+      this._viewContainerRef = null;
+    }
+    super.destroy();
+  }
+
+  attachToViewContainerRef(vcRef: viewEngine_ViewContainerRef) { this._viewContainerRef = vcRef; }
 }
 
 /**
@@ -228,33 +247,5 @@ export class EmbeddedViewRef<T> extends ViewRef<T> {
  */
 export function createViewRef<T>(view: LView | null, context: T): ViewRef<T> {
   // TODO: add detectChanges back in when implementing ChangeDetectorRef.detectChanges
-  return addDestroyable(new ViewRef(view !, context));
-}
-
-/** Interface for destroy logic. Implemented by addDestroyable. */
-export interface DestroyRef<T> {
-  /** Whether or not this object has been destroyed */
-  destroyed: boolean;
-  /** Destroy the instance and call all onDestroy callbacks. */
-  destroy(): void;
-  /** Register callbacks that should be called onDestroy */
-  onDestroy(cb: Function): void;
-}
-
-/**
- * Decorates an object with destroy logic (implementing the DestroyRef interface)
- * and returns the enhanced object.
- *
- * @param obj The object to decorate
- * @returns The object with destroy logic
- */
-export function addDestroyable<T, C>(obj: any): T&DestroyRef<C> {
-  let destroyFn: Function[]|null = null;
-  obj.destroyed = false;
-  obj.destroy = function() {
-    destroyFn && destroyFn.forEach((fn) => fn());
-    this.destroyed = true;
-  };
-  obj.onDestroy = (fn: Function) => (destroyFn || (destroyFn = [])).push(fn);
-  return obj;
+  return new ViewRef(view !, context);
 }

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -238,14 +238,3 @@ export class EmbeddedViewRef<T> extends ViewRef<T> {
 
   attachToViewContainerRef(vcRef: viewEngine_ViewContainerRef) { this._viewContainerRef = vcRef; }
 }
-
-/**
- * Creates a ViewRef bundled with destroy functionality.
- *
- * @param context The context for this view
- * @returns The ViewRef
- */
-export function createViewRef<T>(view: LView | null, context: T): ViewRef<T> {
-  // TODO: add detectChanges back in when implementing ChangeDetectorRef.detectChanges
-  return new ViewRef(view !, context);
-}

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -195,9 +195,6 @@
     "name": "addComponentLogic"
   },
   {
-    "name": "addDestroyable"
-  },
-  {
     "name": "addRemoveViewFromContainer"
   },
   {
@@ -294,7 +291,13 @@
     "name": "defineInjector"
   },
   {
+    "name": "destroyLView"
+  },
+  {
     "name": "destroyViewTree"
+  },
+  {
+    "name": "detachView"
   },
   {
     "name": "detectChanges"
@@ -373,6 +376,9 @@
   },
   {
     "name": "getChildLNode"
+  },
+  {
+    "name": "getCleanup"
   },
   {
     "name": "getCurrentSanitizer"
@@ -649,6 +655,9 @@
   },
   {
     "name": "viewAttached"
+  },
+  {
+    "name": "walkLNodeTree"
   },
   {
     "name": "wrapListenerWithDirtyAndDefault"

--- a/packages/core/test/render3/imported_renderer2.ts
+++ b/packages/core/test/render3/imported_renderer2.ts
@@ -35,7 +35,15 @@ export class SimpleDomEventsPlugin extends EventManagerPlugin {
 export function getRendererFactory2(document: any): RendererFactory2 {
   const fakeNgZone: NgZone = new NoopNgZone();
   const eventManager = new EventManager([new SimpleDomEventsPlugin(document)], fakeNgZone);
-  return new ɵDomRendererFactory2(eventManager, new ɵDomSharedStylesHost(document));
+  const rendererFactory =
+      new ɵDomRendererFactory2(eventManager, new ɵDomSharedStylesHost(document));
+  const origCreateRenderer = rendererFactory.createRenderer;
+  rendererFactory.createRenderer = function() {
+    const renderer = origCreateRenderer.apply(this, arguments);
+    renderer.destroyNode = () => {};
+    return renderer;
+  };
+  return rendererFactory;
 }
 
 export function getAnimationRendererFactory2(document: any): RendererFactory2 {

--- a/packages/core/test/render3/query_list_spec.ts
+++ b/packages/core/test/render3/query_list_spec.ts
@@ -91,4 +91,12 @@ describe('QueryList', () => {
 
   });
 
+  describe('destroy', () => {
+    it('should close all subscriptions', () => {
+      let completed = false;
+      q.changes.subscribe(() => {}, () => {}, () => { completed = true; });
+      q.destroy();
+      expect(completed).toBeTruthy();
+    });
+  });
 });

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -9,6 +9,7 @@
 import {NgForOfContext} from '@angular/common';
 import {TemplateRef, ViewContainerRef} from '@angular/core';
 
+import {EventEmitter} from '../..';
 import {QUERY_READ_CONTAINER_REF, QUERY_READ_ELEMENT_REF, QUERY_READ_FROM_NODE, QUERY_READ_TEMPLATE_REF, getOrCreateNodeInjectorForNode, getOrCreateTemplateRef} from '../../src/render3/di';
 import {AttributeMarker, QueryList, defineComponent, defineDirective, detectChanges, injectViewContainerRef} from '../../src/render3/index';
 import {bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, load, loadDirective} from '../../src/render3/instructions';
@@ -16,7 +17,8 @@ import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {query, queryRefresh} from '../../src/render3/query';
 
 import {NgForOf, NgIf} from './common_with_def';
-import {ComponentFixture, createComponent, createDirective, renderComponent} from './render_util';
+import {ComponentFixture, TemplateFixture, createComponent, createDirective, renderComponent} from './render_util';
+
 
 
 
@@ -1236,5 +1238,59 @@ describe('query', () => {
       expect(changes).toBe(2);
     });
 
+  });
+
+  describe('queryList', () => {
+    it('should be destroyed when the containing view is destroyed', () => {
+      let queryInstance: QueryList<any>;
+
+      const SimpleComponentWithQuery =
+          createComponent('some-component-with-query', function(rf: RenderFlags, ctx: any) {
+            let tmp: any;
+            if (rf & RenderFlags.Create) {
+              query(0, ['foo'], false, QUERY_READ_FROM_NODE);
+              elementStart(1, 'div', null, ['foo', '']);
+              elementEnd();
+            }
+            if (rf & RenderFlags.Update) {
+              queryRefresh(tmp = load<QueryList<any>>(0)) &&
+                  (ctx.query = queryInstance = tmp as QueryList<any>);
+            }
+          });
+
+      function createTemplate() { container(0); }
+
+      function updateTemplate() {
+        containerRefreshStart(0);
+        {
+          if (condition) {
+            let rf1 = embeddedViewStart(1);
+            {
+              if (rf1 & RenderFlags.Create) {
+                elementStart(0, 'some-component-with-query');
+                elementEnd();
+              }
+            }
+            embeddedViewEnd();
+          }
+        }
+        containerRefreshEnd();
+      }
+
+      /**
+       * % if (condition) {
+       *   <some-component-with-query></some-component-with-query>
+       * %}
+       */
+      let condition = true;
+      const t = new TemplateFixture(createTemplate, updateTemplate, [SimpleComponentWithQuery]);
+      expect(t.html).toEqual('<some-component-with-query><div></div></some-component-with-query>');
+      expect((queryInstance !.changes as EventEmitter<any>).closed).toBeFalsy();
+
+      condition = false;
+      t.update();
+      expect(t.html).toEqual('');
+      expect((queryInstance !.changes as EventEmitter<any>).closed).toBeTruthy();
+    });
   });
 });

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -21,7 +21,6 @@ import {ComponentFixture, TemplateFixture, createComponent, createDirective, ren
 
 
 
-
 /**
  * Helper function to check if a given candidate object resembles ElementRef
  * @param candidate

--- a/packages/core/test/render3/renderer_factory_spec.ts
+++ b/packages/core/test/render3/renderer_factory_spec.ts
@@ -209,12 +209,6 @@ describe('animation renderer factory', () => {
 
 describe('Renderer2 destruction hooks', () => {
   const rendererFactory = getRendererFactory2(document);
-  const origCreateRenderer = rendererFactory.createRenderer;
-  rendererFactory.createRenderer = function() {
-    const renderer = origCreateRenderer.apply(this, arguments);
-    renderer.destroyNode = () => {};
-    return renderer;
-  };
 
   it('should call renderer.destroyNode for each node destroyed', () => {
     let condition = true;


### PR DESCRIPTION
This PR implements the `ViewContainerRef.remove` API. Removing here basically means detaching and then destroying.

The changes are mainly about making sure that we have a proper destroy process, independent of the detach process, with the same APIs as in the current view engine. It involves several connected changes:
 - split detach and destroy in node_manipulation.ts (+ refactor to introduce the walkLNodeTree() to avoid duplicating the same code 3 times).
 - add a Destroyed state to LView.
 - implement destroy(), destroyed and onDestroy() in ViewRef and EmbeddedViewRef (+ refactor to remove the DestroyRef interface which didn't seem to be a good fit, @kara please comment).
 - add QueryList.destroy to the cleanup functions of the LView