### PR TITLE
fix(platform-server): avoid dependency cycle when using http interceptor

### DIFF
--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -11,7 +11,7 @@ export {HttpClient} from './src/client';
 export {HttpHeaders} from './src/headers';
 export {HTTP_INTERCEPTORS, HttpInterceptor} from './src/interceptor';
 export {JsonpClientBackend, JsonpInterceptor} from './src/jsonp';
-export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule, interceptingHandler as ɵinterceptingHandler} from './src/module';
+export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule, HttpInterceptingHandler as ɵHttpInterceptingHandler} from './src/module';
 export {HttpParameterCodec, HttpParams, HttpUrlEncodingCodec} from './src/params';
 export {HttpRequest} from './src/request';
 export {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpProgressEvent, HttpResponse, HttpResponseBase, HttpSentEvent, HttpUserEvent} from './src/response';

--- a/packages/common/http/src/module.ts
+++ b/packages/common/http/src/module.ts
@@ -43,23 +43,6 @@ export class HttpInterceptingHandler implements HttpHandler {
 }
 
 /**
- * Constructs an `HttpHandler` that applies a bunch of `HttpInterceptor`s
- * to a request before passing it to the given `HttpBackend`.
- *
- * Meant to be used as a factory function within `HttpClientModule`.
- *
- *
- */
-export function interceptingHandler(
-    backend: HttpBackend, interceptors: HttpInterceptor[] | null = []): HttpHandler {
-  if (!interceptors) {
-    return backend;
-  }
-  return interceptors.reduceRight(
-      (next, interceptor) => new HttpInterceptorHandler(next, interceptor), backend);
-}
-
-/**
  * Factory function that determines where to store JSONP callbacks.
  *
  * Ordinarily JSONP callbacks are stored on the `window` object, but this may not exist

--- a/packages/platform-server/src/http.ts
+++ b/packages/platform-server/src/http.ts
@@ -8,10 +8,10 @@
 
 const xhr2: any = require('xhr2');
 
-import {Injectable, Optional, Provider} from '@angular/core';
+import {Injectable, Injector, Optional, Provider, InjectFlags} from '@angular/core';
 import {BrowserXhr, Connection, ConnectionBackend, Http, ReadyState, Request, RequestOptions, Response, XHRBackend, XSRFStrategy} from '@angular/http';
 
-import {HttpEvent, HttpRequest, HttpHandler, HttpInterceptor, HTTP_INTERCEPTORS, HttpBackend, XhrFactory, ɵinterceptingHandler as interceptingHandler} from '@angular/common/http';
+import {HttpEvent, HttpRequest, HttpHandler, HttpInterceptor, HTTP_INTERCEPTORS, HttpBackend, XhrFactory, ɵHttpInterceptingHandler as HttpInterceptingHandler} from '@angular/common/http';
 
 import {Observable, Observer, Subscription} from 'rxjs';
 
@@ -156,9 +156,8 @@ export function httpFactory(xhrBackend: XHRBackend, options: RequestOptions) {
   return new Http(macroBackend, options);
 }
 
-export function zoneWrappedInterceptingHandler(
-    backend: HttpBackend, interceptors: HttpInterceptor[] | null) {
-  const realBackend: HttpBackend = interceptingHandler(backend, interceptors);
+export function zoneWrappedInterceptingHandler(backend: HttpBackend, injector: Injector) {
+  const realBackend: HttpBackend = new HttpInterceptingHandler(backend, injector);
   return new ZoneClientBackend(realBackend);
 }
 
@@ -168,6 +167,6 @@ export const SERVER_HTTP_PROVIDERS: Provider[] = [
   {provide: XhrFactory, useClass: ServerXhr}, {
     provide: HttpHandler,
     useFactory: zoneWrappedInterceptingHandler,
-    deps: [HttpBackend, [new Optional(), HTTP_INTERCEPTORS]]
+    deps: [HttpBackend, Injector]
   }
 ];


### PR DESCRIPTION
Fixes #23023.

When a HTTP Interceptor injects HttpClient it causes a DI cycle. This fix is to use Injector to lazily inject HTTP_INTERCEPTORS while setting up the HttpHandler on the server so as to break the cycle.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Using an HttpInterceptor that in turn depends upon HttpClient on the server causes a DI cycle exception.

Issue Number: #23023

## What is the new behavior?
No DI errors.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
