### PR TITLE
feat(core): expose a Compiler API for accessing module ids from NgModule types

### DIFF
--- a/packages/core/src/linker/compiler.ts
+++ b/packages/core/src/linker/compiler.ts
@@ -78,6 +78,11 @@ export class Compiler {
    * Clears the cache for the given component/ngModule.
    */
   clearCacheFor(type: Type<any>) {}
+
+  /**
+   * Returns the id for a given NgModule, if one is defined and known to the compiler.
+   */
+  getModuleId(moduleType: Type<any>): string|undefined { return undefined; }
 }
 
 /**

--- a/packages/platform-browser-dynamic/src/compiler_factory.ts
+++ b/packages/platform-browser-dynamic/src/compiler_factory.ts
@@ -78,6 +78,10 @@ export class CompilerImpl implements Compiler {
   }
   clearCache(): void { this._delegate.clearCache(); }
   clearCacheFor(type: Type<any>) { this._delegate.clearCacheFor(type); }
+  getModuleId(moduleType: Type<any>): string|undefined {
+    const meta = this._metadataResolver.getNgModuleMetadata(moduleType);
+    return meta && meta.id || undefined;
+  }
 }
 
 /**

--- a/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
+++ b/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ResourceLoader} from '@angular/compiler';
-import {Component} from '@angular/core';
+import {Compiler, Component, NgModule} from '@angular/core';
 import {TestBed, async, fakeAsync, inject, tick} from '@angular/core/testing';
 
 import {ResourceLoaderImpl} from '../src/resource_loader/resource_loader_impl';
@@ -73,6 +73,22 @@ class BadTemplateUrl {
              tick();
              expect(value).toEqual('async value');
            })));
+      });
+    });
+
+    describe('Compiler', () => {
+      it('should return NgModule id when asked', () => {
+        @NgModule({
+          id: 'test-module',
+        })
+        class TestModule {
+        }
+
+        TestBed.configureTestingModule({
+          imports: [TestModule],
+        });
+        const compiler = TestBed.get(Compiler) as Compiler;
+        expect(compiler.getModuleId(TestModule)).toBe('test-module');
       });
     });
 

--- a/packages/platform-browser-dynamic/testing/src/compiler_factory.ts
+++ b/packages/platform-browser-dynamic/testing/src/compiler_factory.ts
@@ -99,4 +99,8 @@ export class TestingCompilerImpl implements TestingCompiler {
   clearCacheFor(type: Type<any>) { this._compiler.clearCacheFor(type); }
 
   getComponentFromError(error: Error) { return (error as any)[ERROR_COMPONENT_TYPE] || null; }
+
+  getModuleId(moduleType: Type<any>): string|undefined {
+    return this._moduleResolver.resolve(moduleType, true).id;
+  }
 }

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -86,6 +86,7 @@ export declare class Compiler {
     compileModuleAndAllComponentsSync<T>(moduleType: Type<T>): ModuleWithComponentFactories<T>;
     compileModuleAsync<T>(moduleType: Type<T>): Promise<NgModuleFactory<T>>;
     compileModuleSync<T>(moduleType: Type<T>): NgModuleFactory<T>;
+    getModuleId(moduleType: Type<any>): string | undefined;
 }
 
 /** @experimental */


### PR DESCRIPTION
This will allow RouterTestingModule to better support lazy loading of modules
when using summaries, since it can detect whether a module is already loaded
if it can access the id.