### PR TITLE
refactor(ivy): convert TNode.index to number, general cleanup

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -583,8 +583,7 @@ export function getOrCreateContainerRef(di: LInjector): viewEngine_ViewContainer
 
     const hostTNode = vcRefHost.tNode;
     if (!hostTNode.dynamicContainerNode) {
-      hostTNode.dynamicContainerNode =
-          createTNode(TNodeType.Container, null, null, null, null, null);
+      hostTNode.dynamicContainerNode = createTNode(TNodeType.Container, -1, null, null, null, null);
     }
 
     lContainerNode.tNode = hostTNode.dynamicContainerNode;

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -363,10 +363,10 @@ export function createLNodeObject(
  * @param data Any data that should be saved on the LNode
  */
 export function createLNode(
-    index: number | null, type: TNodeType.Element, native: RElement | RText | null,
-    name: string | null, attrs: TAttributes | null, lView?: LView | null): LElementNode;
+    index: number, type: TNodeType.Element, native: RElement | RText | null, name: string | null,
+    attrs: TAttributes | null, lView?: LView | null): LElementNode;
 export function createLNode(
-    index: number | null, type: TNodeType.View, native: null, name: null, attrs: null,
+    index: number, type: TNodeType.View, native: null, name: null, attrs: null,
     lView: LView): LViewNode;
 export function createLNode(
     index: number, type: TNodeType.Container, native: undefined, name: string | null,
@@ -375,7 +375,7 @@ export function createLNode(
     index: number, type: TNodeType.Projection, native: null, name: null, attrs: TAttributes | null,
     lProjection: LProjection): LProjectionNode;
 export function createLNode(
-    index: number | null, type: TNodeType, native: RText | RElement | null | undefined,
+    index: number, type: TNodeType, native: RText | RElement | null | undefined,
     name: string | null, attrs: TAttributes | null, state?: null | LView | LContainer |
         LProjection): LElementNode&LTextNode&LViewNode&LContainerNode&LProjectionNode {
   const parent = isParent ? previousOrParentNode :
@@ -391,7 +391,7 @@ export function createLNode(
   const node =
       createLNodeObject(type, currentView, parent, native, isState ? state as any : null, queries);
 
-  if (index === null || type === TNodeType.View) {
+  if (index === -1 || type === TNodeType.View) {
     // View nodes are not stored in data because they can be added / removed at runtime (which
     // would cause indices to change). Their TNodes are instead stored in TView.node.
     node.tNode = (state as LView).tView.node || createTNode(type, index, null, null, tParent, null);
@@ -469,7 +469,7 @@ export function renderTemplate<T>(
     rendererFactory = providedRendererFactory;
     const tView = getOrCreateTView(template, directives || null, pipes || null);
     host = createLNode(
-        null, TNodeType.Element, hostNode, null, null,
+        -1, TNodeType.Element, hostNode, null, null,
         createLView(
             -1, providedRendererFactory.createRenderer(null, null), tView, null, {},
             LViewFlags.CheckAlways, sanitizer));
@@ -509,7 +509,7 @@ export function renderEmbeddedTemplate<T>(
         lView.queries = queries.createView();
       }
 
-      viewNode = createLNode(null, TNodeType.View, null, null, null, lView);
+      viewNode = createLNode(-1, TNodeType.View, null, null, null, lView);
       rf = RenderFlags.Create;
     }
     oldView = enterView(viewNode.data, viewNode);
@@ -1045,7 +1045,7 @@ export function elementProperty<T>(
  * @returns the TNode object
  */
 export function createTNode(
-    type: TNodeType, index: number | null, tagName: string | null, attrs: TAttributes | null,
+    type: TNodeType, index: number, tagName: string | null, attrs: TAttributes | null,
     parent: TElementNode | TContainerNode | null, tViews: TView[] | null): TNode {
   ngDevMode && ngDevMode.tNode++;
   return {
@@ -1209,7 +1209,7 @@ export function elementStyleNamed<T>(
  * @param index The index of the element to update in the data array
  * @param value A value indicating if a given style should be added or removed.
  *   The expected shape of `value` is an object where keys are style names and the values
- *   are their corresponding values to set. If value is falsy than the style is remove. An absence
+ *   are their corresponding values to set. If value is falsy, then the style is removed. An absence
  *   of style does not cause that style to be removed. `NO_CHANGE` implies that no update should be
  *   performed.
  */
@@ -1616,7 +1616,7 @@ function scanForView(
       // found a view that should not be at this position - remove
       removeView(containerNode, i);
     } else {
-      // found a view with id grater than the one we are searching for
+      // found a view with id greater than the one we are searching for
       // which means that required view doesn't exist and can't be found at
       // later positions in the views array - stop the search here
       break;
@@ -2166,7 +2166,7 @@ export function bind<T>(value: T): T|NO_CHANGE {
 /**
  * Reserves slots for pure functions (`pureFunctionX` instructions)
  *
- * Binding for pure functions are store after the LNodes in the data array but before the binding.
+ * Bindings for pure functions are stored after the LNodes in the data array but before the binding.
  *
  *  ----------------------------------------------------------------------------
  *  |  LNodes ... | pure function bindings | regular bindings / interpolations |
@@ -2182,7 +2182,7 @@ export function bind<T>(value: T): T|NO_CHANGE {
  */
 export function reserveSlots(numSlots: number) {
   // Init the slots with a unique `NO_CHANGE` value so that the first change is always detected
-  // whether is happens or not during the first change detection pass - pure functions checks
+  // whether it happens or not during the first change detection pass - pure functions checks
   // might be skipped when short-circuited.
   data.length += numSlots;
   data.fill(NO_CHANGE, -numSlots);
@@ -2192,7 +2192,7 @@ export function reserveSlots(numSlots: number) {
 }
 
 /**
- * Sets up the binding index before execute any `pureFunctionX` instructions.
+ * Sets up the binding index before executing any `pureFunctionX` instructions.
  *
  * The index must be restored after the pure function is executed
  *
@@ -2447,9 +2447,9 @@ function assertDataNext(index: number, arr?: any[]) {
 }
 
 /**
- * On the first template pass the reserved slots should be set `NO_CHANGE`.
+ * On the first template pass, the reserved slots should be set `NO_CHANGE`.
  *
- * If not they might not have been actually reserved.
+ * If not, they might not have been actually reserved.
  */
 export function assertReservedSlotInitialized(slotOffset: number, numSlots: number) {
   if (firstTemplatePass) {

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -202,9 +202,9 @@ export interface TNode {
    * This is necessary to get from any TNode to its corresponding LNode when
    * traversing the node tree.
    *
-   * If null, this is a dynamically created container node or embedded view node.
+   * If index is -1, this is a dynamically created container node or embedded view node.
    */
-  index: number|null;
+  index: number;
 
   /**
    * This number stores two values using its bits:
@@ -363,12 +363,12 @@ export interface TTextNode extends TNode {
 /** Static data for an LContainerNode */
 export interface TContainerNode extends TNode {
   /**
-   * If number, index in the data[] array.
+   * Index in the data[] array.
    *
-   * If null, this is a dynamically created container node that isn't stored in
+   * If it's -1, this is a dynamically created container node that isn't stored in
    * data[] (e.g. when you inject ViewContainerRef) .
    */
-  index: number|null;
+  index: number;
   child: null;
 
   /**
@@ -383,8 +383,8 @@ export interface TContainerNode extends TNode {
 
 /** Static data for an LViewNode  */
 export interface TViewNode extends TNode {
-  /** If null, it's a dynamically created view*/
-  index: number|null;
+  /** If -1, it's a dynamically created view. Otherwise, it is the view block ID. */
+  index: number;
   child: TElementNode|TTextNode|TContainerNode|TProjectionNode|null;
   parent: TContainerNode|null;
   tViews: null;

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -72,14 +72,14 @@ export function getNextLNode(node: LNode): LNode|null {
     const lView = node.data as LView;
     return lView.next ? (lView.next as LView).node : null;
   }
-  return node.tNode.next ? node.view.data[node.tNode.next !.index as number] : null;
+  return node.tNode.next ? node.view.data[node.tNode.next !.index] : null;
 }
 
 /** Retrieves the first child of a given node */
 export function getChildLNode(node: LNode): LNode|null {
   if (node.tNode.child) {
     const view = node.tNode.type === TNodeType.View ? node.data as LView : node.view;
-    return view.data[node.tNode.child.index as number];
+    return view.data[node.tNode.child.index];
   }
   return null;
 }
@@ -90,9 +90,9 @@ export function getParentLNode(node: LElementNode | LTextNode | LProjectionNode)
 export function getParentLNode(node: LViewNode): LContainerNode|null;
 export function getParentLNode(node: LNode): LElementNode|LContainerNode|LViewNode|null;
 export function getParentLNode(node: LNode): LElementNode|LContainerNode|LViewNode|null {
-  if (node.tNode.index === null) return null;
+  if (node.tNode.index === -1) return null;
   const parent = node.tNode.parent;
-  return parent ? node.view.data[parent.index as number] : node.view.node;
+  return parent ? node.view.data[parent.index] : node.view.node;
 }
 
 /**
@@ -508,25 +508,6 @@ export function appendChild(parent: LNode, child: RNode | null, currentView: LVi
     return true;
   }
   return false;
-}
-
-/**
- * Inserts the provided node before the correct element in the DOM.
- *
- * The element insertion might be delayed {@link canInsertNativeNode}
- *
- * @param node Node to insert
- * @param currentView Current LView
- */
-export function insertChild(node: LNode, currentView: LView): void {
-  const parent = getParentLNode(node) !;
-  if (canInsertNativeNode(parent, currentView)) {
-    let nativeSibling: RNode|null = findNextRNodeSibling(node, null);
-    const renderer = currentView.renderer;
-    isProceduralRenderer(renderer) ?
-        renderer.insertBefore(parent.native !, node.native !, nativeSibling) :
-        parent.native !.insertBefore(node.native !, nativeSibling, false);
-  }
 }
 
 /**


### PR DESCRIPTION
Quick PR to clean up some minor technical debt:

-  Switched `TNode.index` to use `-1` instead of `null` to better match existing conventions (e.g. childIndex, bindingStartIndex, etc). 
- `insertChild` is no longer used anywhere, so removed it.
- Fixed typos from #24039 
