### PR TITLE
refactor(ivy): move bindingStartIndex to TView

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -211,10 +211,6 @@ export function enterView(newView: LView, host: LElementNode | LViewNode | null)
   cleanup = newView && newView.cleanup;
   renderer = newView && newView.renderer;
 
-  if (newView && newView.bindingIndex < 0) {
-    newView.bindingIndex = newView.bindingStartIndex;
-  }
-
   if (host != null) {
     previousOrParentNode = host;
     isParent = true;
@@ -316,7 +312,6 @@ export function createLView<T>(
     renderer: renderer,
     tail: null,
     next: null,
-    bindingStartIndex: -1,
     bindingIndex: -1,
     template: template,
     context: context,
@@ -590,8 +585,7 @@ export function elementStart(
     index: number, name: string, attrs?: TAttributes | null,
     localRefs?: string[] | null): RElement {
   ngDevMode &&
-      assertEqual(
-          currentView.bindingStartIndex, -1, 'elements should be created before any bindings');
+      assertEqual(currentView.bindingIndex, -1, 'elements should be created before any bindings');
 
   ngDevMode && ngDevMode.rendererCreateElement++;
   const native: RElement = renderer.createElement(name);
@@ -801,7 +795,8 @@ export function createTView(
   return {
     node: null !,
     data: [],
-    childIndex: -1,  // Children set in addToViewTree(), if any
+    childIndex: -1,         // Children set in addToViewTree(), if any
+    bindingStartIndex: -1,  // Set in initBindings()
     directives: null,
     firstTemplatePass: true,
     initHooks: null,
@@ -1253,8 +1248,7 @@ export function elementStyle<T>(
  */
 export function text(index: number, value?: any): void {
   ngDevMode &&
-      assertEqual(
-          currentView.bindingStartIndex, -1, 'text nodes should be created before bindings');
+      assertEqual(currentView.bindingIndex, -1, 'text nodes should be created before bindings');
   ngDevMode && ngDevMode.rendererCreateTextNode++;
   const textNode = createTextNode(value, renderer);
   const node = createLNode(index, TNodeType.Element, textNode, null, null);
@@ -1356,8 +1350,7 @@ function addComponentLogic<T>(index: number, instance: T, def: ComponentDef<T>):
 export function baseDirectiveCreate<T>(
     index: number, directive: T, directiveDef: DirectiveDef<T>| ComponentDef<T>): T {
   ngDevMode &&
-      assertEqual(
-          currentView.bindingStartIndex, -1, 'directives should be created before any bindings');
+      assertEqual(currentView.bindingIndex, -1, 'directives should be created before any bindings');
   ngDevMode && assertPreviousIsParent();
 
   Object.defineProperty(
@@ -1499,9 +1492,9 @@ export function createLContainer(
 export function container(
     index: number, template?: ComponentTemplate<any>, tagName?: string | null, attrs?: TAttributes,
     localRefs?: string[] | null): void {
-  ngDevMode && assertEqual(
-                   currentView.bindingStartIndex, -1,
-                   'container nodes should be created before any bindings');
+  ngDevMode &&
+      assertEqual(
+          currentView.bindingIndex, -1, 'container nodes should be created before any bindings');
 
   const currentParent = isParent ? previousOrParentNode : getParentLNode(previousOrParentNode) !;
   const lContainer = createLContainer(currentParent, currentView, template);
@@ -2146,12 +2139,12 @@ export const NO_CHANGE = {} as NO_CHANGE;
  */
 function initBindings() {
   ngDevMode && assertEqual(
-                   currentView.bindingStartIndex, -1,
-                   'Binding start index should only be set once, when null');
-  ngDevMode && assertEqual(
                    currentView.bindingIndex, -1,
                    'Binding index should not yet be set ' + currentView.bindingIndex);
-  currentView.bindingIndex = currentView.bindingStartIndex = data.length;
+  if (currentView.tView.bindingStartIndex === -1) {
+    currentView.tView.bindingStartIndex = data.length;
+  }
+  currentView.bindingIndex = currentView.tView.bindingStartIndex;
 }
 
 /**
@@ -2172,10 +2165,10 @@ export function bind<T>(value: T): T|NO_CHANGE {
  *  |  LNodes ... | pure function bindings | regular bindings / interpolations |
  *  ----------------------------------------------------------------------------
  *                                         ^
- *                                         LView.bindingStartIndex
+ *                                         TView.bindingStartIndex
  *
- * Pure function instructions are given an offset from LView.bindingStartIndex.
- * Subtracting the offset from LView.bindingStartIndex gives the first index where the bindings
+ * Pure function instructions are given an offset from TView.bindingStartIndex.
+ * Subtracting the offset from TView.bindingStartIndex gives the first index where the bindings
  * are stored.
  *
  * NOTE: reserveSlots instructions are only ever allowed at the very end of the creation block
@@ -2200,7 +2193,7 @@ export function reserveSlots(numSlots: number) {
  */
 export function moveBindingIndexToReservedSlot(offset: number): number {
   const currentSlot = currentView.bindingIndex;
-  currentView.bindingIndex = currentView.bindingStartIndex - offset;
+  currentView.bindingIndex = currentView.tView.bindingStartIndex - offset;
   return currentSlot;
 }
 
@@ -2384,18 +2377,18 @@ export function consumeBinding(): any {
 /** Updates binding if changed, then returns whether it was updated. */
 export function bindingUpdated(value: any): boolean {
   ngDevMode && assertNotEqual(value, NO_CHANGE, 'Incoming value should never be NO_CHANGE.');
+  if (currentView.bindingIndex === -1) initBindings();
 
-  if (currentView.bindingStartIndex < 0) {
-    initBindings();
+  if (currentView.bindingIndex >= data.length) {
+    data[currentView.bindingIndex++] = value;
   } else if (isDifferent(data[currentView.bindingIndex], value)) {
     throwErrorIfNoChangesMode(
         creationMode, checkNoChangesMode, data[currentView.bindingIndex], value);
+    data[currentView.bindingIndex++] = value;
   } else {
     currentView.bindingIndex++;
     return false;
   }
-
-  data[currentView.bindingIndex++] = value;
   return true;
 }
 
@@ -2453,7 +2446,7 @@ function assertDataNext(index: number, arr?: any[]) {
  */
 export function assertReservedSlotInitialized(slotOffset: number, numSlots: number) {
   if (firstTemplatePass) {
-    const startIndex = currentView.bindingStartIndex - slotOffset;
+    const startIndex = currentView.tView.bindingStartIndex - slotOffset;
     for (let i = 0; i < numSlots; i++) {
       assertEqual(
           data[startIndex + i], NO_CHANGE,

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -60,14 +60,6 @@ export interface LView {
   readonly renderer: Renderer3;
 
   /**
-   * The binding start index is the index at which the nodes array
-   * starts to store bindings only. Saving this value ensures that we
-   * will begin reading bindings at the correct point in the array when
-   * we are in update mode.
-   */
-  bindingStartIndex: number;
-
-  /**
    * The binding index we should access next.
    *
    * This is stored so that bindings can continue where they left off
@@ -239,6 +231,14 @@ export interface TView {
 
   /** Static data equivalent of LView.data[]. Contains TNodes. */
   data: TData;
+
+  /**
+   * The binding start index is the index at which the data array
+   * starts to store bindings only. Saving this value ensures that we
+   * will begin reading bindings at the correct point in the array when
+   * we are in update mode.
+   */
+  bindingStartIndex: number;
 
   /**
    * Index of the host node of the first LView or LContainer beneath this LView in


### PR DESCRIPTION
This PR moves `bindingStartIndex` from `LView` to `TView`, as part of a larger refactor to slim down `LView` to reduce memory pressure.

It also resolves a small issue I noticed where we were reading past the length of the array when checking bindings on the first change detection run (which we try not to do because it degrades performance). 

Takeaways: use `currentView.tView.bindingStartIndex` instead of `currentView.bindingStartIndex`.