### PR TITLE
refactor(ivy): combine lifecycleStage with LViewFlags

### DIFF
--- a/packages/core/src/render3/hooks.ts
+++ b/packages/core/src/render3/hooks.ts
@@ -9,7 +9,8 @@
 import {assertEqual} from './assert';
 import {DirectiveDef} from './interfaces/definition';
 import {TNodeFlags} from './interfaces/node';
-import {HookData, LView, LifecycleStage, TView} from './interfaces/view';
+import {HookData, LView, LViewFlags, TView} from './interfaces/view';
+
 
 /**
  * If this is the first template pass, any ngOnInit or ngDoCheck hooks will be queued into
@@ -97,9 +98,9 @@ function queueDestroyHooks(def: DirectiveDef<any>, tView: TView, i: number): voi
  * @param currentView The current view
  */
 export function executeInitHooks(currentView: LView, tView: TView, creationMode: boolean): void {
-  if (currentView.lifecycleStage === LifecycleStage.Init) {
+  if (currentView.flags & LViewFlags.RunInit) {
     executeHooks(currentView.directives !, tView.initHooks, tView.checkHooks, creationMode);
-    currentView.lifecycleStage = LifecycleStage.AfterInit;
+    currentView.flags &= ~LViewFlags.RunInit;
   }
 }
 

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -13,7 +13,7 @@ import {LContainer} from './interfaces/container';
 import {LInjector} from './interfaces/injector';
 import {CssSelectorList, LProjection, NG_PROJECT_AS_ATTR_NAME} from './interfaces/projection';
 import {LQueries} from './interfaces/query';
-import {CurrentMatchesList, LView, LViewFlags, LifecycleStage, RootContext, TData, TView} from './interfaces/view';
+import {CurrentMatchesList, LView, LViewFlags, RootContext, TData, TView} from './interfaces/view';
 
 import {AttributeMarker, TAttributes, LContainerNode, LElementNode, LNode, TNodeType, TNodeFlags, LProjectionNode, LTextNode, LViewNode, TNode, TContainerNode, InitialInputData, InitialInputs, PropertyAliases, PropertyAliasValue, TElementNode,} from './interfaces/node';
 import {assertNodeType} from './node_assert';
@@ -244,7 +244,7 @@ export function leaveView(newView: LView, creationOnly?: boolean): void {
     // Views are clean and in update mode after being checked, so these bits are cleared
     currentView.flags &= ~(LViewFlags.CreationMode | LViewFlags.Dirty);
   }
-  currentView.lifecycleStage = LifecycleStage.Init;
+  currentView.flags |= LViewFlags.RunInit;
   currentView.bindingIndex = -1;
   enterView(newView, null);
 }
@@ -307,7 +307,7 @@ export function createLView<T>(
   const newView = {
     parent: currentView,
     id: viewId,  // -1 for component views
-    flags: flags | LViewFlags.CreationMode | LViewFlags.Attached,
+    flags: flags | LViewFlags.CreationMode | LViewFlags.Attached | LViewFlags.RunInit,
     node: null !,  // until we initialize it in createNode.
     data: [],
     directives: null,
@@ -320,7 +320,6 @@ export function createLView<T>(
     bindingIndex: -1,
     template: template,
     context: context,
-    lifecycleStage: LifecycleStage.Init,
     queries: null,
     injector: currentView && currentView.injector,
     sanitizer: sanitizer || null

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -96,23 +96,6 @@ export interface LView {
   cleanup: any[]|null;
 
   /**
-   * This number tracks the next lifecycle hook that needs to be run.
-   *
-   * If lifecycleStage === LifecycleStage.ON_INIT, the init hooks haven't yet been run
-   * and should be executed by the first r() instruction that runs OR the first
-   * cR() instruction that runs (so inits are run for the top level view before any
-   * embedded views).
-   *
-   * If lifecycleStage === LifecycleStage.CONTENT_INIT, the init hooks have been run, but
-   * the content hooks have not yet been run. They should be executed on the first
-   * r() instruction that runs.
-   *
-   * If lifecycleStage === LifecycleStage.VIEW_INIT, both the init hooks and content hooks
-   * have already been run.
-   */
-  lifecycleStage: LifecycleStage;
-
-  /**
    * The last LView or LContainer beneath this LView in the hierarchy.
    *
    * The tail allows us to quickly add a new state to the end of the view list
@@ -196,16 +179,25 @@ export const enum LViewFlags {
    * back into the parent view, `data` will be defined and `creationMode` will be
    * improperly reported as false.
    */
-  CreationMode = 0b0001,
+  CreationMode = 0b00001,
 
   /** Whether this view has default change detection strategy (checks always) or onPush */
-  CheckAlways = 0b0010,
+  CheckAlways = 0b00010,
 
   /** Whether or not this view is currently dirty (needing check) */
-  Dirty = 0b0100,
+  Dirty = 0b00100,
 
   /** Whether or not this view is currently attached to change detection tree. */
-  Attached = 0b1000,
+  Attached = 0b01000,
+
+  /**
+   *  Whether or not the init hooks have run.
+   *
+   * If on, the init hooks haven't yet been run and should be executed by the first component that
+   * runs OR the first cR() instruction that runs (so inits are run for the top level view before
+   * any embedded views).
+   */
+  RunInit = 0b10000,
 }
 
 /** Interface necessary to work with view tree traversal */
@@ -420,17 +412,6 @@ export interface RootContext {
  * Odd indices: Hook function
  */
 export type HookData = (number | (() => void))[];
-
-/** Possible values of LView.lifecycleStage, used to determine which hooks to run.  */
-// TODO: Remove this enum when containerRefresh instructions are removed
-export const enum LifecycleStage {
-
-  /* Init hooks need to be run, if any. */
-  Init = 1,
-
-  /* Content hooks need to be run, if any. Init hooks have already run. */
-  AfterInit = 2,
-}
 
 /**
  * Static data that corresponds to the instance-specific data array on an LView.


### PR DESCRIPTION
This PR removes `LView.lifecycleStage` by combining it with the existing property, `LView.flags`. This is part of a larger refactor to slim down `LView` to reduce memory pressure. 

Takeaways:
 - To check lifecycle stage, check `currentView.flags & LViewFlags.RunInit` instead of `currentView.lifecycleStage === LifecycleStage.Init`.