### PR TITLE
refactor(ivy): move id to TView

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -138,8 +138,8 @@ export function renderComponent<T>(
     clean: CLEAN_PROMISE,
   };
   const rootView: LView = createLView(
-      -1, rendererFactory.createRenderer(hostNode, componentDef.rendererType),
-      createTView(null, null), null, rootContext,
+      rendererFactory.createRenderer(hostNode, componentDef.rendererType),
+      createTView(-1, null, null), null, rootContext,
       componentDef.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways);
   rootView.injector = opts.injector || null;
 

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -700,7 +700,7 @@ export function getOrCreateTemplateRef<T>(di: LInjector): viewEngine_TemplateRef
     const hostTNode = hostNode.tNode;
     const hostTView = hostNode.view.tView;
     if (!hostTNode.tViews) {
-      hostTNode.tViews = createTView(hostTView.directiveRegistry, hostTView.pipeRegistry);
+      hostTNode.tViews = createTView(-1, hostTView.directiveRegistry, hostTView.pipeRegistry);
     }
     ngDevMode && assertNotNull(hostTNode.tViews, 'TView must be allocated');
     di.templateRef = new TemplateRef<any>(

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -49,13 +49,6 @@ export interface LView {
   // TODO(kara): Remove when we have parent/child on TNodes
   readonly node: LViewNode|LElementNode;
 
-  /**
-   * ID to determine whether this view is the same as the previous view
-   * in this position. If it's not, we know this view needs to be inserted
-   * and the one that exists needs to be removed (e.g. if/else statements)
-   */
-  readonly id: number;
-
   /** Renderer to be used for this view. */
   readonly renderer: Renderer3;
 
@@ -207,6 +200,15 @@ export interface LViewOrLContainer {
  * Stored on the template function as ngPrivateData.
  */
 export interface TView {
+  /**
+   * ID for inline views to determine whether a view is the same as the previous view
+   * in a certain position. If it's not, we know the new view needs to be inserted
+   * and the one that exists needs to be removed (e.g. if/else statements)
+   *
+   * If this is -1, then this is a component view or a dynamically created view.
+   */
+  readonly id: number;
+
   /**
    * Pointer to the `TNode` that represents the root of the view.
    *

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -426,7 +426,7 @@ function cleanUpView(view: LView): void {
   executeOnDestroys(view);
   executePipeOnDestroys(view);
   // For component views only, the local renderer is destroyed as clean up time.
-  if (view.id === -1 && isProceduralRenderer(view.renderer)) {
+  if (view.tView && view.tView.id === -1 && isProceduralRenderer(view.renderer)) {
     ngDevMode && ngDevMode.rendererDestroy++;
     view.renderer.destroy();
   }

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -1404,7 +1404,7 @@ describe('di', () => {
   describe('getOrCreateNodeInjector', () => {
     it('should handle initial undefined state', () => {
       const contentView =
-          createLView(-1, null !, createTView(null, null), null, null, LViewFlags.CheckAlways);
+          createLView(null !, createTView(-1, null, null), null, null, LViewFlags.CheckAlways);
       const oldView = enterView(contentView, null !);
       try {
         const parent = createLNode(0, TNodeType.Element, null, null, null, null);


### PR DESCRIPTION
Small PR to move `LView.id` to `TView.id`, as part of an ongoing effort to slim down `LView` and reduce memory pressure.

Takeaways: use `view.tView.id` instead of `view.id` going forward.