### PR TITLE
Enable manual ts_web_test_suite tests that require static_files

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -44,6 +44,7 @@ filegroup(
         "//:node_modules/zone.js/dist/zone.js",
         "//:node_modules/zone.js/dist/zone-testing.js",
         "//:node_modules/zone.js/dist/task-tracking.js",
+        "//:test-events.js",
     ],
 )
 

--- a/packages/platform-browser-dynamic/test/BUILD.bazel
+++ b/packages/platform-browser-dynamic/test/BUILD.bazel
@@ -31,7 +31,7 @@ ts_web_test_suite(
     name = "test_web",
     static_files = [
         "//packages/platform-browser/test:static_assets/test.html",
-        "//packages/platform-browser/test:browser/static_assets/200.html"
+        "//packages/platform-browser/test:browser/static_assets/200.html",
     ],
     deps = [
         ":test_lib",

--- a/packages/platform-browser-dynamic/test/BUILD.bazel
+++ b/packages/platform-browser-dynamic/test/BUILD.bazel
@@ -29,8 +29,10 @@ jasmine_node_test(
 
 ts_web_test_suite(
     name = "test_web",
-    # disable since tests are running but not yet passing
-    tags = ["manual"],
+    static_files = [
+        "//packages/platform-browser/test:static_assets/test.html",
+        "//packages/platform-browser/test:browser/static_assets/200.html"
+    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/platform-browser-dynamic/test/resource_loader/resource_loader_impl_spec.ts
+++ b/packages/platform-browser-dynamic/test/resource_loader/resource_loader_impl_spec.ts
@@ -19,7 +19,7 @@ import {ResourceLoaderImpl} from '../../src/resource_loader/resource_loader_impl
     // will be relative to here, so url200 should look like
     // static_assets/200.html.
     // We currently have no way of detecting this.
-    const url200 = '/base/packages/platform-browser/test/browser/static_assets/200.html';
+    const url200 = '/base/angular/packages/platform-browser/test/browser/static_assets/200.html';
     const url404 = '/bad/path/404.html';
 
     beforeEach(() => { resourceLoader = new ResourceLoaderImpl(); });

--- a/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
+++ b/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
@@ -48,7 +48,8 @@ class BadTemplateUrl {
 
       it('should run async tests with ResourceLoaders', async(() => {
            const resourceLoader = new ResourceLoaderImpl();
-           resourceLoader.get('/base/angular/packages/platform-browser/test/static_assets/test.html')
+           resourceLoader
+               .get('/base/angular/packages/platform-browser/test/static_assets/test.html')
                .then(() => { actuallyDone = true; });
          }),
          10000);  // Long timeout here because this test makes an actual ResourceLoader.

--- a/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
+++ b/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
@@ -26,7 +26,7 @@ class FancyService {
 
 @Component({
   selector: 'external-template-comp',
-  templateUrl: '/base/packages/platform-browser/test/static_assets/test.html'
+  templateUrl: '/base/angular/packages/platform-browser/test/static_assets/test.html'
 })
 class ExternalTemplateComp {
 }
@@ -48,7 +48,7 @@ class BadTemplateUrl {
 
       it('should run async tests with ResourceLoaders', async(() => {
            const resourceLoader = new ResourceLoaderImpl();
-           resourceLoader.get('/base/packages/platform-browser/test/static_assets/test.html')
+           resourceLoader.get('/base/angular/packages/platform-browser/test/static_assets/test.html')
                .then(() => { actuallyDone = true; });
          }),
          10000);  // Long timeout here because this test makes an actual ResourceLoader.

--- a/packages/platform-browser/test/BUILD.bazel
+++ b/packages/platform-browser/test/BUILD.bazel
@@ -1,6 +1,11 @@
 load("//tools:defaults.bzl", "ts_library", "ts_web_test_suite")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
+exports_files([
+  "browser/static_assets/200.html",
+  "static_assets/test.html",
+])
+
 ts_library(
     name = "test_lib",
     testonly = 1,
@@ -35,8 +40,9 @@ jasmine_node_test(
 
 ts_web_test_suite(
     name = "test_web",
-    # disable since tests are running but not yet passing
-    tags = ["manual"],
+    static_files = [
+        ":static_assets/test.html"
+    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/platform-browser/test/BUILD.bazel
+++ b/packages/platform-browser/test/BUILD.bazel
@@ -2,8 +2,8 @@ load("//tools:defaults.bzl", "ts_library", "ts_web_test_suite")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 exports_files([
-  "browser/static_assets/200.html",
-  "static_assets/test.html",
+    "browser/static_assets/200.html",
+    "static_assets/test.html",
 ])
 
 ts_library(
@@ -41,7 +41,7 @@ jasmine_node_test(
 ts_web_test_suite(
     name = "test_web",
     static_files = [
-        ":static_assets/test.html"
+        ":static_assets/test.html",
     ],
     deps = [
         ":test_lib",

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -104,7 +104,7 @@ class SomeLibModule {
 }
 
 @Component(
-    {selector: 'comp', templateUrl: '/base/packages/platform-browser/test/static_assets/test.html'})
+    {selector: 'comp', templateUrl: '/base/angular/packages/platform-browser/test/static_assets/test.html'})
 class CompWithUrlTemplate {
 }
 

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -103,8 +103,10 @@ class CompUsingModuleDirectiveAndPipe {
 class SomeLibModule {
 }
 
-@Component(
-    {selector: 'comp', templateUrl: '/base/angular/packages/platform-browser/test/static_assets/test.html'})
+@Component({
+  selector: 'comp',
+  templateUrl: '/base/angular/packages/platform-browser/test/static_assets/test.html'
+})
 class CompWithUrlTemplate {
 }
 


### PR DESCRIPTION
Enables manual tests:

```
//packages/platform-browser-dynamic/test:test_web
//packages/platform-browser/test:test_web
```

Paths updated to `base/angular` for Bazel which may cause breakage when these tests are run outside of Bazel.

`//packages/platform-browser/test:test_web` also has another zone.js related failure that shows up now:

```
[1A[2KHeadlessChrome 66.0.3356 (Mac OS X 10.13.4) EventManager should run blackListedEvents handler outside of ngZone FAILED
	Expected 'ProxyZone' to be '<root>'.
	    at eval (http://concatjs../../packages/platform-browser/test/dom/events/event_manager_spec.ts:315:32 <- angular/packages/platform-browser/test/dom/events/event_manager_spec.js:288:62)
	    at UserContext.eval (http://concatjs../../packages/core/testing/src/testing_internal.ts:136:21 <- angular/packages/core/testing/src/testing_internal.js:152:30)
	    at ZoneDelegate.invoke (http://concatjsangular/node_modules/zone.js/dist/zone.js:388:26)
	    at ProxyZoneSpec.onInvoke (http://concatjsangular/node_modules/zone.js/dist/zone-testing.js:288:39)
```