### PR TITLE
docs: rename the "aio" component to "docs-infra"

### DIFF
--- a/docs/TRIAGE_AND_LABELS.md
+++ b/docs/TRIAGE_AND_LABELS.md
@@ -12,7 +12,7 @@ The owner of the component is then responsible for the secondary / component-lev
 The caretaker should be able to determine which component the issue belongs to.
 The components have a clear piece of source code associated with it within the `/packages/` folder of this repo.
 
-* `comp: aio` - the angular.io application
+* `comp: docs-infra` - the angular.io application
 * `comp: animations`
 * `comp: bazel` - @angular/bazel rules
 * `comp: benchpress`

--- a/tools/validate-commit-message/commit-message.json
+++ b/tools/validate-commit-message/commit-message.json
@@ -21,6 +21,7 @@
     "compiler",
     "compiler-cli",
     "core",
+    "docs-infra",
     "elements",
     "forms",
     "http",


### PR DESCRIPTION
The legacy "aio" is still active for currently pending PRs,
The GH label has been renamed as well