### PR TITLE
refactor(ivy): move LView.template and component templates to TView

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -139,7 +139,7 @@ export function renderComponent<T>(
   };
   const rootView: LView = createLView(
       rendererFactory.createRenderer(hostNode, componentDef.rendererType),
-      createTView(-1, null, null), null, rootContext,
+      createTView(-1, null, null, null), rootContext,
       componentDef.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways);
   rootView.injector = opts.injector || null;
 
@@ -160,7 +160,7 @@ export function renderComponent<T>(
 
     executeInitAndContentHooks();
     setHostBindings(ROOT_DIRECTIVE_INDICES);
-    detectChangesInternal(elementNode.data as LView, elementNode, componentDef, component);
+    detectChangesInternal(elementNode.data as LView, elementNode, component);
   } finally {
     leaveView(oldView);
     if (rendererFactory.end) rendererFactory.end();

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -704,12 +704,12 @@ export function getOrCreateTemplateRef<T>(di: LInjector): viewEngine_TemplateRef
     const hostTNode = hostNode.tNode;
     const hostTView = hostNode.view.tView;
     if (!hostTNode.tViews) {
-      hostTNode.tViews = createTView(-1, hostTView.directiveRegistry, hostTView.pipeRegistry);
+      hostTNode.tViews = createTView(
+          -1, hostNode.data.template !, hostTView.directiveRegistry, hostTView.pipeRegistry);
     }
     ngDevMode && assertNotNull(hostTNode.tViews, 'TView must be allocated');
     di.templateRef = new TemplateRef<any>(
-        getOrCreateElementRef(di), hostTNode.tViews as TView, hostNode.data.template !,
-        getRenderer(), hostNode.data.queries);
+        getOrCreateElementRef(di), hostTNode.tViews as TView, getRenderer(), hostNode.data.queries);
   }
   return di.templateRef;
 }
@@ -718,15 +718,14 @@ class TemplateRef<T> implements viewEngine_TemplateRef<T> {
   readonly elementRef: viewEngine_ElementRef;
 
   constructor(
-      elementRef: viewEngine_ElementRef, private _tView: TView,
-      private _template: ComponentTemplate<T>, private _renderer: Renderer3,
+      elementRef: viewEngine_ElementRef, private _tView: TView, private _renderer: Renderer3,
       private _queries: LQueries|null) {
     this.elementRef = elementRef;
   }
 
   createEmbeddedView(context: T): viewEngine_EmbeddedViewRef<T> {
-    const viewNode = renderEmbeddedTemplate(
-        null, this._tView, this._template, context, this._renderer, this._queries);
-    return new EmbeddedViewRef(viewNode, this._template, context);
+    const viewNode =
+        renderEmbeddedTemplate(null, this._tView, context, this._renderer, this._queries);
+    return new EmbeddedViewRef(viewNode, this._tView.template !as ComponentTemplate<T>, context);
   }
 }

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -127,11 +127,6 @@ export interface LView {
   tView: TView;
 
   /**
-   * For dynamically inserted views, the template function to refresh the view.
-   */
-  template: ComponentTemplate<{}>|null;
-
-  /**
    * - For embedded views, the context with which to render the template.
    * - For root view of the root component the context contains change detection data.
    * - `null` otherwise.
@@ -211,6 +206,12 @@ export interface TView {
    * If this is -1, then this is a component view or a dynamically created view.
    */
   readonly id: number;
+
+  /**
+   * The template function used to refresh the view of dynamically created views
+   * and components. Will be null for inline views.
+   */
+  template: ComponentTemplate<{}>|null;
 
   /**
    * Pointer to the `TNode` that represents the root of the view.

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -1404,7 +1404,7 @@ describe('di', () => {
   describe('getOrCreateNodeInjector', () => {
     it('should handle initial undefined state', () => {
       const contentView =
-          createLView(null !, createTView(-1, null, null), null, null, LViewFlags.CheckAlways);
+          createLView(null !, createTView(-1, null, null, null), null, LViewFlags.CheckAlways);
       const oldView = enterView(contentView, null !);
       try {
         const parent = createLNode(0, TNodeType.Element, null, null, null, null);


### PR DESCRIPTION
This PR ports `LView.template` to `TView`, as part of a larger refactor to slim down `LView` and reduce memory pressure.

I also moved component templates into `TView.template`. They were previously only stored on `def.template`, which made it difficult in a few places to get ahold of it (e.g. `detectChanges`). 