### PR TITLE
refactor(ivy): move static parts of LView.cleanup to TView

### DIFF
--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -63,22 +63,14 @@ export interface LView {
 
   /**
    * When a view is destroyed, listeners need to be released and outputs need to be
-   * unsubscribed. This cleanup array stores both listener data (in chunks of 4)
-   * and output data (in chunks of 2) for a particular view. Combining the arrays
-   * saves on memory (70 bytes per array) and on a few bytes of code size (for two
-   * separate for loops).
+   * unsubscribed. This context array stores both listener functions wrapped with
+   * their context and output subscription instances for a particular view.
    *
-   * If it's a listener being stored:
-   * 1st index is: event name to remove
-   * 2nd index is: native element
-   * 3rd index is: listener function
-   * 4th index is: useCapture boolean
-   *
-   * If it's an output subscription:
-   * 1st index is: unsubscribe function
-   * 2nd index is: context for function
+   * These change per LView instance, so they cannot be stored on TView. Instead,
+   * TView.cleanup saves an index to the necessary context in this array.
    */
-  cleanup: any[]|null;
+  // TODO: collapse into data[]
+  cleanupInstances: any[]|null;
 
   /**
    * The last LView or LContainer beneath this LView in the hierarchy.
@@ -366,6 +358,29 @@ export interface TView {
    * are stored in data.
    */
   pipeDestroyHooks: HookData|null;
+
+  /**
+   * When a view is destroyed, listeners need to be released and outputs need to be
+   * unsubscribed. This cleanup array stores both listener data (in chunks of 4)
+   * and output data (in chunks of 2) for a particular view. Combining the arrays
+   * saves on memory (70 bytes per array) and on a few bytes of code size (for two
+   * separate for loops).
+   *
+   * If it's a native DOM listener being stored:
+   * 1st index is: event name to remove
+   * 2nd index is: index of native element in LView.data[]
+   * 3rd index is: index of wrapped listener function in LView.cleanupInstances[]
+   * 4th index is: useCapture boolean
+   *
+   * If it's a renderer2 style listener or ViewRef destroy hook being stored:
+   * 1st index is: index of the cleanup function in LView.cleanupInstances[]
+   * 2nd index is: null
+   *
+   * If it's an output subscription or query list destroy hook:
+   * 1st index is: output unsubscribe function / query list destroy function
+   * 2nd index is: index of function context in LView.cleanupInstances[]
+   */
+  cleanup: any[]|null;
 
   /**
    * A list of directive and element indices for child components that will need to be

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -17,7 +17,7 @@ import {getSymbolIterator} from '../util';
 
 import {assertEqual, assertNotNull} from './assert';
 import {ReadFromInjectorFn, getOrCreateNodeInjectorForNode} from './di';
-import {assertPreviousIsParent, getCleanup, getCurrentQueries, store} from './instructions';
+import {assertPreviousIsParent, getCurrentQueries, store, storeCleanupWithContext} from './instructions';
 import {DirectiveDef, unusedValueExportToPlacateAjd as unused1} from './interfaces/definition';
 import {LInjector, unusedValueExportToPlacateAjd as unused2} from './interfaces/injector';
 import {LContainerNode, LElementNode, LNode, TNode, TNodeFlags, unusedValueExportToPlacateAjd as unused3} from './interfaces/node';
@@ -416,7 +416,7 @@ export function query<T>(
   const queryList = new QueryList<T>();
   const queries = getCurrentQueries(LQueries_);
   queries.track(queryList, predicate, descend, read);
-  getCleanup().push(queryList.destroy, queryList);
+  storeCleanupWithContext(undefined, queryList, queryList.destroy);
   if (memoryIndex != null) {
     store(memoryIndex, queryList);
   }

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -9,7 +9,7 @@
 import {ViewContainerRef as viewEngine_ViewContainerRef} from '../linker/view_container_ref';
 import {EmbeddedViewRef as viewEngine_EmbeddedViewRef} from '../linker/view_ref';
 
-import {checkNoChanges, detectChanges, markViewDirty} from './instructions';
+import {checkNoChanges, detectChanges, markViewDirty, storeCleanupFn} from './instructions';
 import {ComponentTemplate} from './interfaces/definition';
 import {LViewNode} from './interfaces/node';
 import {LView, LViewFlags} from './interfaces/view';
@@ -33,9 +33,7 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T> {
 
   destroy(): void { destroyLView(this._view); }
 
-  onDestroy(callback: Function) {
-    (this._view.cleanup || (this._view.cleanup = [])).push(callback, null);
-  }
+  onDestroy(callback: Function) { storeCleanupFn(this._view, callback); }
 
   /**
    * Marks a view and all of its ancestors dirty.

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -444,6 +444,9 @@
     "name": "getSymbolIterator"
   },
   {
+    "name": "getTViewCleanup"
+  },
+  {
     "name": "getTypeNameForDebugging"
   },
   {
@@ -625,6 +628,12 @@
   },
   {
     "name": "setUpAttributes"
+  },
+  {
+    "name": "storeCleanupFn"
+  },
+  {
+    "name": "storeCleanupWithContext"
   },
   {
     "name": "stringify"

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -103,7 +103,7 @@ export class ComponentFixture<T> extends BaseFixture {
 
   constructor(
       private componentType: ComponentType<T>,
-      opts: {injector?: Injector, sanitizer?: Sanitizer} = {}) {
+      opts: {injector?: Injector, sanitizer?: Sanitizer, rendererFactory?: RendererFactory3} = {}) {
     super();
     this.requestAnimationFrame = function(fn: () => void) {
       requestAnimationFrame.queue.push(fn);
@@ -119,7 +119,8 @@ export class ComponentFixture<T> extends BaseFixture {
       host: this.hostElement,
       scheduler: this.requestAnimationFrame,
       injector: opts.injector,
-      sanitizer: opts.sanitizer
+      sanitizer: opts.sanitizer,
+      rendererFactory: opts.rendererFactory || domRendererFactory3
     });
   }
 


### PR DESCRIPTION
This PR moves the static parts of `LView.cleanup` to `TView.cleanup`, as part of an ongoing refactor to reduce memory pressure.  

Currently, we store 4 items in `LView.cleanup` for each listener and 6 for each output, but with the refactor, we only need to store 1 item per listener (with the other 3 in `TView` + the index of that item so we can look it up) and 2 per output. 

Notes:
- Listener functions and subscription instances can't be stored on `TView` because they change according to the instance. These have to remain on `LView.cleanupInstances`. `TView.cleanup[]` stores the indices of the data it needs from the instance array.