### PR TITLE
docs: describe rounding behaviour of "DecimalPipe" (#24038)

### DIFF
--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -20,10 +20,11 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  * separator, decimal-point character, and other locale-specific
  * configurations.
  * 
- * If no parameters are specified the function rounds off to the nearest value, using this
+ * If no parameters are specified, the function rounds off to the nearest value using this
  * [rounding method](https://en.wikibooks.org/wiki/Arithmetic/Rounding).
- * The behavior differs from that of the JavaScript Math.round() function.
- * For example, in the following case, the pipe rounds down, where the Math.round() function rounds up:
+ * The behavior differs from that of the JavaScript ```Math.round()``` function.
+ * In the following case for example, the pipe rounds down where 
+ * ```Math.round()``` rounds up:
  * 
  * ```html
  * -2.5 | number:'1.0-0'

--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -23,16 +23,14 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  * If no parameters are specified the function rounds off to the nearest value, using this
  * [rounding method](https://en.wikibooks.org/wiki/Arithmetic/Rounding).
  * The behavior differs from that of the JavaScript Math.round() function.
- * 
  * For example, in the following case, the pipe rounds down, where the Math.round() function rounds up:
- *
+ * 
+ * ```html
  * -2.5 | number:'1.0-0'
- *
  * > -3
- *
- * Math.round(-2.5):
- *
+ * Math.round(-2.5)
  * > -2
+ * ```
  * 
  * @see `formatNumber()`
  *

--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -25,9 +25,13 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  * The behavior differs from that of the JavaScript Math.round() function.
  * 
  * For example, in the following case, the pipe rounds down, where the Math.round() function rounds up:
+ *
  * -2.5 | number:'1.0-0'
+ *
  * > -3
+ *
  * Math.round(-2.5):
+ *
  * > -2
  * 
  * @see `formatNumber()`

--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -19,13 +19,25 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  * formatted according to locale rules that determine group sizing and
  * separator, decimal-point character, and other locale-specific
  * configurations.
- *
+ * 
+ * If no parameters are specified the function rounds off to the nearest value, using this
+ * [rounding method](https://en.wikibooks.org/wiki/Arithmetic/Rounding).
+ * The behavior differs from that of the JavaScript Math.round() function.
+ * 
+ * For example, in the following case, the pipe rounds down, where the Math.round() function rounds up:
+ * -2.5 | number:'1.0-0'
+ * > -3
+ * Math.round(-2.5):
+ * > -2
+ * 
  * @see `formatNumber()`
  *
  * @usageNotes
  * The following code shows how the pipe transforms numbers
  * into text strings, according to various format specifications,
  * where the caller's default locale is `en-US`.
+ *
+ * ### Example
  *
  * <code-example path="common/pipes/ts/number_pipe.ts" region='NumberPipe'></code-example>
  *

--- a/packages/examples/common/pipes/ts/number_pipe.ts
+++ b/packages/examples/common/pipes/ts/number_pipe.ts
@@ -38,6 +38,9 @@ registerLocaleData(localeFr);
 
     <!--output '003.14000'-->
     <p>pi (3.5-5): {{pi | number:'3.5-5'}}</p>
+
+    <!--output '-3' / unlike '-2' by Math.round()'-->
+    <p>-2.5 (1.0-0): {{-2.5 | number:'1.0-0'}}</p>
   </div>`
 })
 export class NumberPipeComponent {

--- a/packages/examples/common/pipes/ts/number_pipe.ts
+++ b/packages/examples/common/pipes/ts/number_pipe.ts
@@ -39,7 +39,6 @@ registerLocaleData(localeFr);
     <!--output '003.14000'-->
     <p>pi (3.5-5): {{pi | number:'3.5-5'}}</p>
 
-    <!--output '-3' / unlike '-2' by Math.round()'-->
     <!--output '-3' / unlike '-2' by Math.round()-->
     <p>-2.5 (1.0-0): {{-2.5 | number:'1.0-0'}}</p>
   </div>`

--- a/packages/examples/common/pipes/ts/number_pipe.ts
+++ b/packages/examples/common/pipes/ts/number_pipe.ts
@@ -40,6 +40,7 @@ registerLocaleData(localeFr);
     <p>pi (3.5-5): {{pi | number:'3.5-5'}}</p>
 
     <!--output '-3' / unlike '-2' by Math.round()'-->
+    <!--output '-3' / unlike '-2' by Math.round()-->
     <p>-2.5 (1.0-0): {{-2.5 | number:'1.0-0'}}</p>
   </div>`
 })


### PR DESCRIPTION
Document that DecimalPipe incorrectly rounds negative numbers when the fraction is .5.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #24038 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
