### PR TITLE
docs: add message property to compose-message component

### DIFF
--- a/aio/content/examples/router/src/app/compose-message.component.ts
+++ b/aio/content/examples/router/src/app/compose-message.component.ts
@@ -15,6 +15,7 @@ export class ComposeMessageComponent {
   @HostBinding('style.position')  position = 'absolute';
 
   details: string;
+  message: string;
   sending = false;
 
   constructor(private router: Router) {}


### PR DESCRIPTION
docs: add message property to compose-message component

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
error occurs while running "ng serve --aot" (ERROR in src/app/compose-message.component.html(10,15): : Property 'message' does not exist on type 'ComposeMessageComponent'.)


Issue Number: N/A


## What is the new behavior?
result: Compiled successfully

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
