### PR TITLE
build(docs-infra): log warning rather than error if content errors are not fatal

### DIFF
--- a/aio/tools/transforms/angular-base-package/processors/checkContentRules.js
+++ b/aio/tools/transforms/angular-base-package/processors/checkContentRules.js
@@ -34,6 +34,7 @@ module.exports = function checkContentRules(log, createDocMessage) {
     $runAfter: ['tags-extracted'],
     $runBefore: ['processing-docs'],
     $process(docs) {
+      const logMessage = this.failOnContentErrors ? log.error.bind(log) : log.warn.bind(log);
       const errors = [];
       docs.forEach(doc => {
         const docErrors = [];
@@ -55,10 +56,10 @@ module.exports = function checkContentRules(log, createDocMessage) {
       });
 
       if (errors.length) {
-        log.error('Content contains errors');
+        logMessage('Content contains errors');
         errors.forEach(docError => {
           const errors = docError.errors.join('\n        ');
-          log.error(createDocMessage(errors + '\n        ', docError.doc));
+          logMessage(createDocMessage(errors + '\n        ', docError.doc));
         });
         if (this.failOnContentErrors) {
           throw new Error('Stopping due to content errors.');

--- a/aio/tools/transforms/angular-base-package/processors/checkContentRules.spec.js
+++ b/aio/tools/transforms/angular-base-package/processors/checkContentRules.spec.js
@@ -67,10 +67,11 @@ describe('checkContentRules processor', function() {
     expect(descriptionSpy3).toHaveBeenCalledWith(docs[0], 'description', 'test doc 1');
   });
 
-  it('should log errors if the rule returns error messages', () => {
+  it('should log warnings if the rule returns error messages and `failOnContentErrors` is false', () => {
     const nameSpy1 = jasmine.createSpy('name 1').and.returnValue('name error message');
     const descriptionSpy1 = jasmine.createSpy('description 1').and.returnValue('description error message');
 
+    processor.failOnContentErrors = false;
     processor.docTypeRules = {
       'test1': {
         name: [nameSpy1],
@@ -85,24 +86,37 @@ describe('checkContentRules processor', function() {
 
     processor.$process(docs);
 
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith('Content contains errors');
+    expect(logger.warn).toHaveBeenCalledWith(`name error message
+        description error message
+         - doc "test-1" (test1) `);
+  });
+
+  it('should log errors and then throw if `failOnContentErrors` is true and errors are found', () => {
+    const nameSpy1 = jasmine.createSpy('name 1').and.returnValue('name error message');
+    const descriptionSpy1 = jasmine.createSpy('description 1').and.returnValue('description error message');
+
+    processor.failOnContentErrors = true;
+    processor.docTypeRules = {
+      'test1': {
+        name: [nameSpy1],
+        description: [descriptionSpy1]
+      }
+    };
+
+    const docs = [
+      { docType: 'test1', description: 'test doc 1', name: 'test-1' },
+      { docType: 'test2', description: 'test doc 2', name: 'test-2' }
+    ];
+
+    expect(() => processor.$process(docs)).toThrowError('Stopping due to content errors.');
+
     expect(logger.error).toHaveBeenCalledTimes(2);
     expect(logger.error).toHaveBeenCalledWith('Content contains errors');
     expect(logger.error).toHaveBeenCalledWith(`name error message
         description error message
          - doc "test-1" (test1) `);
-  });
-
-  it('should throw an error if `failOnContentErrors` is true and errors are found', () => {
-    const errorRule = jasmine.createSpy('error rule').and.returnValue('some error');
-    processor.docTypeRules = {
-      'test': { description: [errorRule] }
-    };
-    processor.failOnContentErrors = true;
-
-    const docs = [
-      { docType: 'test', description: 'test doc' },
-    ];
-    expect(() => processor.$process(docs)).toThrowError('Stopping due to content errors.');
   });
 
 });


### PR DESCRIPTION
This should make the many current documentation messages less confusing - since at the moment they are not actually errors.