### PR TITLE
Update xhr.ts with updated error message for JSONP

### DIFF
--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -75,7 +75,7 @@ export class HttpXhrBackend implements HttpBackend {
     // Quick check to give a better error message when a user attempts to use
     // HttpClient.jsonp() without installing the JsonpClientModule
     if (req.method === 'JSONP') {
-      throw new Error(`Attempted to construct Jsonp request without JsonpClientModule installed.`);
+      throw new Error(`Attempted to construct Jsonp request without HttpClientJsonpModule installed.`);
     }
 
     // Everything happens on Observable subscription.


### PR DESCRIPTION
Update the error message with the new Module that should be imported.
JsonpClientModule instead of HttpClientJsonpModule.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[x] Other: Error message
```

## What is the current behavior?

Message displayed if using the incorrect module: 

```
Error: Attempted to construct Jsonp request without JsonpClientModule installed.
    at HttpXhrBackend.webpackJsonp.../../../common/@angular/common/http.es5.js.HttpXhrBackend.handle (http.es5.js:1617)
    at MergeMapSubscriber.project (coveauth.umd.js:1040)
    at MergeMapSubscriber.webpackJsonp.../../../../rxjs/operators/mergeMap.js.MergeMapSubscriber._tryNext (mergeMap.js:122)
    at MergeMapSubscriber.webpackJsonp.../../../../rxjs/operators/mergeMap.js.MergeMapSubscriber._next (mergeMap.js:112)
    at MergeMapSubscriber.webpackJsonp.../../../../rxjs/Subscriber.js.Subscriber.next (Subscriber.js:93)
    at MapSubscriber.webpackJsonp.../../../../rxjs/operators/map.js.MapSubscriber._next (map.js:85)
    at MapSubscriber.webpackJsonp.../../../../rxjs/Subscriber.js.Subscriber.next (Subscriber.js:93)
    at CatchSubscriber.webpackJsonp.../../../../rxjs/Subscriber.js.Subscriber._next (Subscriber.js:129)
    at CatchSubscriber.webpackJsonp.../../../../rxjs/Subscriber.js.Subscriber.next (Subscriber.js:93)
    at MapSubscriber.webpackJsonp.../../../../rxjs/operators/map.js.MapSubscriber._next (map.js:85)
```


## What is the new behavior?

The message displays as:

```
Error: Attempted to construct Jsonp request without HttpClientJsonpModule installed.
    at HttpXhrBackend.webpackJsonp.../../../common/@angular/common/http.es5.js.HttpXhrBackend.handle (http.es5.js:1617)
    at MergeMapSubscriber.project (coveauth.umd.js:1040)
    at MergeMapSubscriber.webpackJsonp.../../../../rxjs/operators/mergeMap.js.MergeMapSubscriber._tryNext (mergeMap.js:122)
    at MergeMapSubscriber.webpackJsonp.../../../../rxjs/operators/mergeMap.js.MergeMapSubscriber._next (mergeMap.js:112)
    at MergeMapSubscriber.webpackJsonp.../../../../rxjs/Subscriber.js.Subscriber.next (Subscriber.js:93)
    at MapSubscriber.webpackJsonp.../../../../rxjs/operators/map.js.MapSubscriber._next (map.js:85)
    at MapSubscriber.webpackJsonp.../../../../rxjs/Subscriber.js.Subscriber.next (Subscriber.js:93)
    at CatchSubscriber.webpackJsonp.../../../../rxjs/Subscriber.js.Subscriber._next (Subscriber.js:129)
    at CatchSubscriber.webpackJsonp.../../../../rxjs/Subscriber.js.Subscriber.next (Subscriber.js:93)
    at MapSubscriber.webpackJsonp.../../../../rxjs/operators/map.js.MapSubscriber._next (map.js:85)
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
