### PR TITLE
refactor(ivy): remove need for LContainer.template

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -572,7 +572,7 @@ export function getOrCreateContainerRef(di: LInjector): viewEngine_ViewContainer
 
     ngDevMode && assertNodeOfPossibleTypes(vcRefHost, TNodeType.Container, TNodeType.Element);
     const hostParent = getParentLNode(vcRefHost) !;
-    const lContainer = createLContainer(hostParent, vcRefHost.view, undefined, true);
+    const lContainer = createLContainer(hostParent, vcRefHost.view, true);
     const lContainerNode: LContainerNode = createLNodeObject(
         TNodeType.Container, vcRefHost.view, hostParent, undefined, lContainer, null);
 
@@ -702,11 +702,6 @@ export function getOrCreateTemplateRef<T>(di: LInjector): viewEngine_TemplateRef
     ngDevMode && assertNodeType(di.node, TNodeType.Container);
     const hostNode = di.node as LContainerNode;
     const hostTNode = hostNode.tNode;
-    const hostTView = hostNode.view.tView;
-    if (!hostTNode.tViews) {
-      hostTNode.tViews = createTView(
-          -1, hostNode.data.template !, hostTView.directiveRegistry, hostTView.pipeRegistry);
-    }
     ngDevMode && assertDefined(hostTNode.tViews, 'TView must be allocated');
     di.templateRef = new TemplateRef<any>(
         getOrCreateElementRef(di), hostTNode.tViews as TView, getRenderer(), hostNode.data.queries);

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1494,7 +1494,7 @@ function generateInitialInputs(
  * @returns LContainer
  */
 export function createLContainer(
-    parentLNode: LNode, currentView: LView, template?: ComponentTemplate<any>,
+    parentLNode: LNode, currentView: LView,
     isForViewContainerRef?: boolean): LContainer {
   ngDevMode && assertDefined(parentLNode, 'containers should have a parent');
   return <LContainer>{
@@ -1503,7 +1503,6 @@ export function createLContainer(
     // If the direct parent of the container is a view, its views will need to be added
     // through insertView() when its parent view is being inserted:
     renderParent: canInsertNativeNode(parentLNode, currentView) ? parentLNode : null,
-    template: template == null ? null : template,
     next: null,
     parent: currentView,
     queries: null
@@ -1529,12 +1528,16 @@ export function container(
           currentView.bindingIndex, -1, 'container nodes should be created before any bindings');
 
   const currentParent = isParent ? previousOrParentNode : getParentLNode(previousOrParentNode) !;
-  const lContainer = createLContainer(currentParent, currentView, template);
+  const lContainer = createLContainer(currentParent, currentView);
 
   const node = createLNode(
       index, TNodeType.Container, undefined, tagName || null, attrs || null, lContainer);
 
-  if (firstTemplatePass && template == null) node.tNode.tViews = [];
+  if (firstTemplatePass) {
+    const tView = currentView.tView;
+    node.tNode.tViews =
+        template ? createTView(-1, template, tView.directiveRegistry, tView.pipeRegistry) : [];
+  }
 
   // Containers are added to the current view tree instead of their embedded views
   // because views can be removed and re-inserted.

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentTemplate} from './definition';
 import {LContainerNode, LElementNode, LViewNode} from './node';
 import {LQueries} from './query';
 import {LView, TView} from './view';
@@ -66,11 +65,6 @@ export interface LContainer {
    *   `LViewNode`s into.
    */
   renderParent: LElementNode|null;
-
-  /**
-   * The template extracted from the location of the Container.
-   */
-  readonly template: ComponentTemplate<any>|null;
 
   /**
    * Queries active for this container - all the views inserted to / removed from


### PR DESCRIPTION
Small PR to remove `template` from `LContainer`. It's no longer necessary and we want to slim down items stored in every instance to reduce memory pressure.