### PR TITLE
fix(forms): recognize errors independent of their values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ modules/.settings
 .bazelrc
 .vscode
 modules/.vscode
+**/nbproject/
 
 # Don't check in secret files
 *secret.js

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -549,7 +549,7 @@ export abstract class AbstractControl {
    * If no path is given, it checks for the error on the present control.
    */
   getError(errorCode: string, path?: string[]): any {
-    const control = path ? this.get(path) : this;
+    const control = this._resolvePath(path);
     return control && control.errors ? control.errors[errorCode] : null;
   }
 
@@ -559,7 +559,19 @@ export abstract class AbstractControl {
    *
    * If no path is given, it checks for the error on the present control.
    */
-  hasError(errorCode: string, path?: string[]): boolean { return !!this.getError(errorCode, path); }
+  hasError(errorCode: string, path?: string[]): boolean {
+    const control = this._resolvePath(path);
+    return control && control.errors ? (control.errors as Object).hasOwnProperty(errorCode) : false;
+  }
+
+  /**
+   * Returns the control for the given path.
+   *
+   * If no path is given, it returns the present control.
+   *
+   * @internal
+   */
+  _resolvePath(path?: string[]): AbstractControl|null { return path ? this.get(path) : this; }
 
   /**
    * Retrieves the top-level ancestor of this control.

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -877,6 +877,51 @@ import {FormArray} from '@angular/forms/src/model';
       });
     });
 
+    describe('hasError', () => {
+      let c: FormControl;
+
+      beforeEach(() => { c = new FormControl(null); });
+
+      it('should return false if errors is undefined on present control',
+         () => { expect(c.hasError('nonExisting')).toBeFalsy(); });
+      it('should return false if errors is undefined for given path', () => {
+        const g = new FormGroup({'one': c});
+
+        expect(g.hasError('nonExisting', ['one'])).toBeFalsy();
+      });
+      it('should return false if control for the given path does not exist', () => {
+        const g = new FormGroup({'one': c});
+
+        c.setErrors({anErrorCode: true});
+
+        expect(g.hasError('anErrorCode', ['two'])).toBeFalsy();
+      });
+      it('should return false if error code is undefined on present control', () => {
+        c.setErrors({anErrorCode: true});
+
+        expect(c.hasError('unknownErrorCode')).toBeFalsy();
+      });
+      it('should return false if error code is undefined for given path', () => {
+        const g = new FormGroup({'one': c});
+
+        c.setErrors({anErrorCode: true});
+
+        expect(g.hasError('unknownErrorCode', ['one'])).toBeFalsy();
+      });
+      it('should return true if error code exists on present control', () => {
+        c.setErrors({anErrorCode: undefined});
+
+        expect(c.hasError('anErrorCode')).toBeTruthy();
+      });
+      it('should return true if error code exists for given path', () => {
+        const g = new FormGroup({'one': c});
+
+        c.setErrors({anErrorCode: undefined});
+
+        expect(g.hasError('anErrorCode', ['one'])).toBeTruthy();
+      });
+    });
+
     describe('disable() & enable()', () => {
 
       it('should mark the control as disabled', () => {


### PR DESCRIPTION
Recognize the error, even if the error contains a falsy value. The
existence of the error code is already enough to have an error.
This change allows to use enums as value for the error codes. It's also
possible to determine e.g. if an error is critical or not.
Add missing tests for hasError() method.

Closes #24276
BREAKING CHANGE: errors that contained falsy values were not recognized
and now they are present

To migrate the code follow the example below:

Before:

const c = new FormControl(null);
c.setErrors({anError: true}); // hasError('anError') -> true
// unset the error
c.setErrors({anError: false}); // hasError('anError') -> false

After:

const c = new FormControl(null);
c.setErrors({anError: true}); // hasError('anError') -> true
c.setErrors({anError: false}); // hasError('anError') -> true
c.setErrors({anError: undefined}); // hasError('anError') -> true
c.setErrors({anError: null}); // hasError('anError') -> true
// unset the error. The key 'anError' has to be removed.
c.setErrors({otherError: true}); // hasError('anError') -> false

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

```ts
const c = new FormControl(null);
c.setErrors({anError: true}); // hasError('anError') -> true
c.setErrors({anError: 1}); // hasError('anError') -> true
// unset the error
c.setErrors({anError: false}); // hasError('anError') -> false
c.setErrors({anError: 0}); // hasError('anError') -> false
```

Issue Number: #24276


## What is the new behavior?

```ts
const c = new FormControl(null);
c.setErrors({anError: true}); // hasError('anError') -> true
c.setErrors({anError: false}); // hasError('anError') -> true
c.setErrors({anError: undefined}); // hasError('anError') -> true
c.setErrors({anError: null}); // hasError('anError') -> true
c.setErrors({anError: 0}); // hasError('anError') -> true
// unset the error. The key 'anError' has to be removed.
c.setErrors({otherError: true}); // hasError('anError') -> false
```

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

BREAKING CHANGE: errors that contained falsy values were not recognized
and now they are present

To migrate the code follow the example below:

Before:

```ts
const c = new FormControl(null);
c.setErrors({anError: true}); // hasError('anError') -> true
// unset the error
c.setErrors({anError: false}); // hasError('anError') -> false
```

After:

```ts
const c = new FormControl(null);
c.setErrors({anError: true}); // hasError('anError') -> true
c.setErrors({anError: false}); // hasError('anError') -> true
c.setErrors({anError: undefined}); // hasError('anError') -> true
c.setErrors({anError: null}); // hasError('anError') -> true
c.setErrors({anError: 0}); // hasError('anError') -> true
// unset the error. The key 'anError' has to be removed.
c.setErrors({otherError: true}); // hasError('anError') -> false
```

## Other information
