### PR TITLE
refactor(ivy): use comment nodes to mark view containers

### DIFF
--- a/packages/core/src/render3/STATUS.md
+++ b/packages/core/src/render3/STATUS.md
@@ -266,7 +266,7 @@ The goal is for the `@Component` (and friends) to be the compiler of template. S
 | `data()`                            |  n/a    |
 | `destroy()`                         |  ✅     |
 | `createElement()`                   |  ✅     |
-| `createComment()`                   |  n/a    |
+| `createComment()`                   |  ✅    |
 | `createText()`                      |  ✅     |
 | `destroyNode()`                     |  ✅     |
 | `appendChild()`                     |  ✅     |

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -10,7 +10,7 @@ import {LContainer} from './container';
 import {LInjector} from './injector';
 import {LProjection} from './projection';
 import {LQueries} from './query';
-import {RElement, RText} from './renderer';
+import {RComment, RElement, RText} from './renderer';
 import {LViewData, TView} from './view';
 
 
@@ -63,7 +63,7 @@ export interface LNode {
    *  - append children to their element parents in the DOM (e.g. `parent.native.appendChild(...)`)
    *  - retrieve the sibling elements of text nodes whose creation / insertion has been delayed
    */
-  readonly native: RElement|RText|null|undefined;
+  readonly native: RComment|RElement|RText|null;
 
   /**
    * If regular LElementNode, then `data` will be null.
@@ -141,13 +141,13 @@ export interface LViewNode extends LNode {
 /** Abstract node container which contains other views. */
 export interface LContainerNode extends LNode {
   /*
-   * Caches the reference of the first native node following this container in the same native
-   * parent.
-   * This is reset to undefined in containerRefreshEnd.
-   * When it is undefined, it means the value has not been computed yet.
-   * Otherwise, it contains the result of findBeforeNode(container, null).
+   * This comment node is appended to the container's parent element to mark where
+   * in the DOM the container's child views should be added.
+   *
+   * If the container is a root node of a view, this comment will not be appended
+   * until the parent view is processed.
    */
-  native: RElement|RText|null|undefined;
+  native: RComment;
   readonly data: LContainer;
 }
 

--- a/packages/core/src/render3/interfaces/renderer.ts
+++ b/packages/core/src/render3/interfaces/renderer.ts
@@ -35,6 +35,7 @@ export type Renderer3 = ObjectOrientedRenderer3 | ProceduralRenderer3;
  * (reducing payload size).
  * */
 export interface ObjectOrientedRenderer3 {
+  createComment(data: string): RComment;
   createElement(tagName: string): RElement;
   createElementNS(namespace: string, tagName: string): RElement;
   createTextNode(data: string): RText;
@@ -57,6 +58,7 @@ export function isProceduralRenderer(renderer: ProceduralRenderer3 | ObjectOrien
  */
 export interface ProceduralRenderer3 {
   destroy(): void;
+  createComment(value: string): RComment;
   createElement(name: string, namespace?: string|null): RElement;
   createText(value: string): RText;
   /**
@@ -143,6 +145,8 @@ export interface RDomTokenList {
 }
 
 export interface RText extends RNode { textContent: string|null; }
+
+export interface RComment extends RNode {}
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency
 // failure based on types.

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -114,20 +114,18 @@ const enum WalkLNodeTreeAction {
 /**
  * Walks a tree of LNodes, applying a transformation on the LElement nodes, either only on the first
  * one found, or on all of them.
- * NOTE: for performance reasons, the possible actions are inlined within the function instead of
- * being passed as an argument.
  *
  * @param startingNode the node from which the walk is started.
  * @param rootNode the root node considered.
- * @param action Identifies the action to be performed on the LElement nodes.
- * @param renderer Optional the current renderer, required for action modes 1, 2 and 3.
- * @param renderParentNode Optionnal the render parent node to be set in all LContainerNodes found,
- * required for action modes 1 and 2.
- * @param beforeNode Optionnal the node before which elements should be added, required for action
- * modes 1.
+ * @param action identifies the action to be performed on the LElement nodes.
+ * @param renderer the current renderer.
+ * @param renderParentNode Optional the render parent node to be set in all LContainerNodes found,
+ * required for action modes Insert and Destroy.
+ * @param beforeNode Optional the node before which elements should be added, required for action
+ * Insert.
  */
 function walkLNodeTree(
-    startingNode: LNode | null, rootNode: LNode, action: WalkLNodeTreeAction, renderer?: Renderer3,
+    startingNode: LNode | null, rootNode: LNode, action: WalkLNodeTreeAction, renderer: Renderer3,
     renderParentNode?: LElementNode | null, beforeNode?: RNode | null) {
   let node: LNode|null = startingNode;
   let beforeNodeStack: (RNode | null | undefined)[] = [beforeNode];
@@ -136,14 +134,14 @@ function walkLNodeTree(
     const parent = renderParentNode ? renderParentNode.native : null;
     if (node.tNode.type === TNodeType.Element) {
       // Execute the action
-      executeNodeAction(action, renderer !, parent, node.native !, beforeNode);
+      executeNodeAction(action, renderer, parent, node.native !, beforeNode);
       if (node.dynamicLContainerNode) {
         executeNodeAction(
-            action, renderer !, parent, node.dynamicLContainerNode.native !, beforeNode);
+            action, renderer, parent, node.dynamicLContainerNode.native !, beforeNode);
       }
       nextNode = getNextLNode(node);
     } else if (node.tNode.type === TNodeType.Container) {
-      executeNodeAction(action, renderer !, parent, node.native !, beforeNode);
+      executeNodeAction(action, renderer, parent, node.native !, beforeNode);
       const lContainerNode: LContainerNode = (node as LContainerNode);
       const childContainerData: LContainer = lContainerNode.dynamicLContainerNode ?
           lContainerNode.dynamicLContainerNode.data :
@@ -176,6 +174,10 @@ function walkLNodeTree(
   }
 }
 
+/**
+ * NOTE: for performance reasons, the possible actions are inlined within the function instead of
+ * being passed as an argument.
+ */
 function executeNodeAction(
     action: WalkLNodeTreeAction, renderer: Renderer3, parent: RElement | null,
     node: RComment | RElement | RText, beforeNode?: RNode | null) {

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -10,59 +10,12 @@ import {callHooks} from './hooks';
 import {LContainer, RENDER_PARENT, VIEWS, unusedValueExportToPlacateAjd as unused1} from './interfaces/container';
 import {LContainerNode, LElementNode, LNode, LProjectionNode, LTextNode, LViewNode, TNodeType, unusedValueExportToPlacateAjd as unused2} from './interfaces/node';
 import {unusedValueExportToPlacateAjd as unused3} from './interfaces/projection';
-import {ProceduralRenderer3, RElement, RNode, RText, Renderer3, isProceduralRenderer, unusedValueExportToPlacateAjd as unused4} from './interfaces/renderer';
+import {ProceduralRenderer3, RComment, RElement, RNode, RText, Renderer3, isProceduralRenderer, unusedValueExportToPlacateAjd as unused4} from './interfaces/renderer';
 import {CLEANUP, DIRECTIVES, FLAGS, HEADER_OFFSET, HOST_NODE, HookData, LViewData, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, TVIEW, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
 import {assertNodeType} from './node_assert';
 import {stringify} from './util';
 
 const unusedValueToPlacateAjd = unused1 + unused2 + unused3 + unused4 + unused5;
-
-/**
- * Returns the first RNode following the given LNode in the same parent DOM element.
- *
- * This is needed in order to insert the given node with insertBefore.
- *
- * @param node The node whose following DOM node must be found.
- * @param stopNode A parent node at which the lookup in the tree should be stopped, or null if the
- * lookup should not be stopped until the result is found.
- * @returns RNode before which the provided node should be inserted or null if the lookup was
- * stopped
- * or if there is no native node after the given logical node in the same native parent.
- */
-function findNextRNodeSibling(node: LNode | null, stopNode: LNode | null): RElement|RText|null {
-  let currentNode = node;
-  while (currentNode && currentNode !== stopNode) {
-    let pNextOrParent = currentNode.pNextOrParent;
-    if (pNextOrParent) {
-      while (pNextOrParent.tNode.type !== TNodeType.Projection) {
-        const nativeNode = findFirstRNode(pNextOrParent);
-        if (nativeNode) {
-          return nativeNode;
-        }
-        pNextOrParent = pNextOrParent.pNextOrParent !;
-      }
-      currentNode = pNextOrParent;
-    } else {
-      let currentSibling = getNextLNode(currentNode);
-      while (currentSibling) {
-        const nativeNode = findFirstRNode(currentSibling);
-        if (nativeNode) {
-          return nativeNode;
-        }
-        currentSibling = getNextLNode(currentSibling);
-      }
-      const parentNode = getParentLNode(currentNode);
-      currentNode = null;
-      if (parentNode) {
-        const parentType = parentNode.tNode.type;
-        if (parentType === TNodeType.Container || parentType === TNodeType.View) {
-          currentNode = parentNode;
-        }
-      }
-    }
-  }
-  return null;
-}
 
 /** Retrieves the sibling node for the given node. */
 export function getNextLNode(node: LNode): LNode|null {
@@ -84,8 +37,8 @@ export function getChildLNode(node: LNode): LNode|null {
 }
 
 /** Retrieves the parent LNode of a given node. */
-export function getParentLNode(node: LElementNode | LTextNode | LProjectionNode): LElementNode|
-    LViewNode;
+export function getParentLNode(node: LContainerNode | LElementNode | LTextNode | LProjectionNode):
+    LElementNode|LViewNode;
 export function getParentLNode(node: LViewNode): LContainerNode|null;
 export function getParentLNode(node: LNode): LElementNode|LContainerNode|LViewNode|null;
 export function getParentLNode(node: LNode): LElementNode|LContainerNode|LViewNode|null {
@@ -126,7 +79,9 @@ function getNextLNodeWithProjection(node: LNode): LNode|null {
  * @param rootNode The root node at which the lookup should stop.
  * @return LNode|null The following node in the LNode tree.
  */
-function getNextOrParentSiblingNode(initialNode: LNode, rootNode: LNode): LNode|null {
+function getNextOrParentSiblingNode(
+    initialNode: LNode, rootNode: LNode, beforeNodeStack: (RNode | null | undefined)[]): LNode|
+    null {
   let node: LNode|null = initialNode;
   let nextNode = getNextLNodeWithProjection(node);
   while (node && !nextNode) {
@@ -136,33 +91,24 @@ function getNextOrParentSiblingNode(initialNode: LNode, rootNode: LNode): LNode|
     if (node === rootNode) {
       return null;
     }
+    // When the walker exits a container, the beforeNode has to be restored to the previous value.
+    if (node && !node.pNextOrParent && node.tNode.type === TNodeType.Container) {
+      beforeNodeStack.pop();
+    }
     nextNode = node && getNextLNodeWithProjection(node);
   }
   return nextNode;
 }
 
-/**
- * Returns the first RNode inside the given LNode.
- *
- * @param node The node whose first DOM node must be found
- * @returns RNode The first RNode of the given LNode or null if there is none.
- */
-function findFirstRNode(rootNode: LNode): RElement|RText|null {
-  return walkLNodeTree(rootNode, rootNode, WalkLNodeTreeAction.Find) || null;
-}
-
 const enum WalkLNodeTreeAction {
-  /** returns the first available native node */
-  Find = 0,
-
   /** node insert in the native environment */
-  Insert = 1,
+  Insert = 0,
 
   /** node detach from the native environment */
-  Detach = 2,
+  Detach = 1,
 
   /** node destruction using the renderer's API */
-  Destroy = 3,
+  Destroy = 2,
 }
 
 /**
@@ -184,29 +130,20 @@ function walkLNodeTree(
     startingNode: LNode | null, rootNode: LNode, action: WalkLNodeTreeAction, renderer?: Renderer3,
     renderParentNode?: LElementNode | null, beforeNode?: RNode | null) {
   let node: LNode|null = startingNode;
+  let beforeNodeStack: (RNode | null | undefined)[] = [beforeNode];
   while (node) {
     let nextNode: LNode|null = null;
+    const parent = renderParentNode ? renderParentNode.native : null;
     if (node.tNode.type === TNodeType.Element) {
       // Execute the action
-      if (action === WalkLNodeTreeAction.Find) {
-        return node.native;
-      } else if (action === WalkLNodeTreeAction.Insert) {
-        const parent = renderParentNode !.native;
-        isProceduralRenderer(renderer !) ?
-            (renderer as ProceduralRenderer3)
-                .insertBefore(parent !, node.native !, beforeNode as RNode | null) :
-            parent !.insertBefore(node.native !, beforeNode as RNode | null, true);
-      } else if (action === WalkLNodeTreeAction.Detach) {
-        const parent = renderParentNode !.native;
-        isProceduralRenderer(renderer !) ?
-            (renderer as ProceduralRenderer3).removeChild(parent as RElement, node.native !) :
-            parent !.removeChild(node.native !);
-      } else if (action === WalkLNodeTreeAction.Destroy) {
-        ngDevMode && ngDevMode.rendererDestroyNode++;
-        (renderer as ProceduralRenderer3).destroyNode !(node.native !);
+      executeNodeAction(action, renderer !, parent, node.native !, beforeNode);
+      if (node.dynamicLContainerNode) {
+        executeNodeAction(
+            action, renderer !, parent, node.dynamicLContainerNode.native !, beforeNode);
       }
       nextNode = getNextLNode(node);
     } else if (node.tNode.type === TNodeType.Container) {
+      executeNodeAction(action, renderer !, parent, node.native !, beforeNode);
       const lContainerNode: LContainerNode = (node as LContainerNode);
       const childContainerData: LContainer = lContainerNode.dynamicLContainerNode ?
           lContainerNode.dynamicLContainerNode.data :
@@ -214,6 +151,12 @@ function walkLNodeTree(
       if (renderParentNode) {
         childContainerData[RENDER_PARENT] = renderParentNode;
       }
+      // When the walker enters a container, then the beforeNode has to become the local native
+      // comment node.
+      beforeNodeStack.push(beforeNode);
+      beforeNode = lContainerNode.dynamicLContainerNode ?
+          lContainerNode.dynamicLContainerNode.native :
+          lContainerNode.native;
       nextNode =
           childContainerData[VIEWS].length ? getChildLNode(childContainerData[VIEWS][0]) : null;
     } else if (node.tNode.type === TNodeType.Projection) {
@@ -224,7 +167,29 @@ function walkLNodeTree(
       nextNode = getChildLNode(node as LViewNode);
     }
 
-    node = nextNode === null ? getNextOrParentSiblingNode(node, rootNode) : nextNode;
+    if (nextNode == null) {
+      node = getNextOrParentSiblingNode(node, rootNode, beforeNodeStack);
+      beforeNode = beforeNodeStack[beforeNodeStack.length - 1];
+    } else {
+      node = nextNode;
+    }
+  }
+}
+
+function executeNodeAction(
+    action: WalkLNodeTreeAction, renderer: Renderer3, parent: RElement | null,
+    node: RComment | RElement | RText, beforeNode?: RNode | null) {
+  if (action === WalkLNodeTreeAction.Insert) {
+    isProceduralRenderer(renderer !) ?
+        (renderer as ProceduralRenderer3).insertBefore(parent !, node, beforeNode as RNode | null) :
+        parent !.insertBefore(node, beforeNode as RNode | null, true);
+  } else if (action === WalkLNodeTreeAction.Detach) {
+    isProceduralRenderer(renderer !) ?
+        (renderer as ProceduralRenderer3).removeChild(parent !, node) :
+        parent !.removeChild(node);
+  } else if (action === WalkLNodeTreeAction.Destroy) {
+    ngDevMode && ngDevMode.rendererDestroyNode++;
+    (renderer as ProceduralRenderer3).destroyNode !(node);
   }
 }
 
@@ -354,15 +319,9 @@ export function insertView(
   // and we should wait until that parent processes its nodes (otherwise, we will insert this view's
   // nodes twice - once now and once when its parent inserts its views).
   if (container.data[RENDER_PARENT] !== null) {
-    let beforeNode = findNextRNodeSibling(viewNode, container);
-
-    if (!beforeNode) {
-      let containerNextNativeNode = container.native;
-      if (containerNextNativeNode === undefined) {
-        containerNextNativeNode = container.native = findNextRNodeSibling(container, null);
-      }
-      beforeNode = containerNextNativeNode;
-    }
+    // Find the node to insert in front of
+    const beforeNode =
+        index + 1 < views.length ? (getChildLNode(views[index + 1]) !).native : container.native;
     addRemoveViewFromContainer(container, viewNode, true, beforeNode);
   }
 
@@ -581,9 +540,8 @@ export function appendChild(parent: LNode, child: RNode | null, currentView: LVi
 export function appendProjectedNode(
     node: LElementNode | LTextNode | LContainerNode, currentParent: LElementNode,
     currentView: LViewData): void {
-  if (node.tNode.type !== TNodeType.Container) {
-    appendChild(currentParent, (node as LElementNode | LTextNode).native, currentView);
-  } else {
+  appendChild(currentParent, node.native, currentView);
+  if (node.tNode.type === TNodeType.Container) {
     // The node we are adding is a Container and we are adding it to Element which
     // is not a component (no more re-projection).
     // Alternatively a container is projected at the root of a component's template
@@ -598,5 +556,6 @@ export function appendProjectedNode(
   }
   if (node.dynamicLContainerNode) {
     node.dynamicLContainerNode.data[RENDER_PARENT] = currentParent;
+    appendChild(currentParent, node.dynamicLContainerNode.native, currentView);
   }
 }

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -399,6 +399,9 @@
     "name": "executeInitHooks"
   },
   {
+    "name": "executeNodeAction"
+  },
+  {
     "name": "executeOnDestroys"
   },
   {
@@ -418,12 +421,6 @@
   },
   {
     "name": "findDirectiveMatches"
-  },
-  {
-    "name": "findFirstRNode"
-  },
-  {
-    "name": "findNextRNodeSibling"
   },
   {
     "name": "firstTemplatePass"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -453,9 +453,6 @@
     "name": "getNextLNodeWithProjection"
   },
   {
-    "name": "getNextOrParentSiblingNode"
-  },
-  {
     "name": "getOrCreateContainerRef"
   },
   {

--- a/packages/core/test/render3/control_flow_spec.ts
+++ b/packages/core/test/render3/control_flow_spec.ts
@@ -9,7 +9,7 @@
 import {defineComponent} from '../../src/render3/definition';
 import {bind, container, containerRefreshEnd, containerRefreshStart, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, text, textBinding} from '../../src/render3/instructions';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
-import {ComponentFixture, createComponent, renderToHtml} from './render_util';
+import {ComponentFixture, TemplateFixture, createComponent, renderToHtml} from './render_util';
 
 describe('JS control flow', () => {
   it('should work with if block', () => {
@@ -135,9 +135,6 @@ describe('JS control flow', () => {
   });
 
   it('should work with nested adjacent if blocks', () => {
-    // Note: this test fails without the beforeNodeStack in node_manipulation.ts,
-    // comment nodes are wrongly inserted in the DOM tree, causing the final output
-    // to be 'WorldHello' instead of 'HelloWorld'
     const ctx: {condition: boolean,
                 condition2: boolean,
                 condition3: boolean} = {condition: true, condition2: false, condition3: true};
@@ -152,60 +149,59 @@ describe('JS control flow', () => {
      *   % }
      * % }
      */
-    function Template(rf: RenderFlags, ctx: any) {
-      if (rf & RenderFlags.Create) {
-        { container(0); }
-      }
-      if (rf & RenderFlags.Update) {
-        containerRefreshStart(0);
-        {
-          if (ctx.condition) {
-            let rf1 = embeddedViewStart(1);
-            {
-              if (rf1 & RenderFlags.Create) {
-                { container(0); }
-                { container(1); }
-              }
-              if (rf1 & RenderFlags.Update) {
-                containerRefreshStart(0);
-                {
-                  if (ctx.condition2) {
-                    let rf2 = embeddedViewStart(2);
-                    {
-                      if (rf2 & RenderFlags.Create) {
-                        text(0, 'Hello');
-                      }
-                    }
-                    embeddedViewEnd();
-                  }
-                }
-                containerRefreshEnd();
-                containerRefreshStart(1);
-                {
-                  if (ctx.condition3) {
-                    let rf2 = embeddedViewStart(2);
-                    {
-                      if (rf2 & RenderFlags.Create) {
-                        text(0, 'World');
-                      }
-                    }
-                    embeddedViewEnd();
-                  }
-                }
-                containerRefreshEnd();
-              }
+    function createTemplate() { container(0); }
+
+    function updateTemplate() {
+      containerRefreshStart(0);
+      {
+        if (ctx.condition) {
+          let rf1 = embeddedViewStart(1);
+          {
+            if (rf1 & RenderFlags.Create) {
+              { container(0); }
+              { container(1); }
             }
-            embeddedViewEnd();
+            if (rf1 & RenderFlags.Update) {
+              containerRefreshStart(0);
+              {
+                if (ctx.condition2) {
+                  let rf2 = embeddedViewStart(2);
+                  {
+                    if (rf2 & RenderFlags.Create) {
+                      text(0, 'Hello');
+                    }
+                  }
+                  embeddedViewEnd();
+                }
+              }
+              containerRefreshEnd();
+              containerRefreshStart(1);
+              {
+                if (ctx.condition3) {
+                  let rf2 = embeddedViewStart(2);
+                  {
+                    if (rf2 & RenderFlags.Create) {
+                      text(0, 'World');
+                    }
+                  }
+                  embeddedViewEnd();
+                }
+              }
+              containerRefreshEnd();
+            }
           }
+          embeddedViewEnd();
         }
-        containerRefreshEnd();
       }
+      containerRefreshEnd();
     }
 
-    expect(renderToHtml(Template, ctx)).toEqual('World');
+    const fixture = new TemplateFixture(createTemplate, updateTemplate);
+    expect(fixture.html).toEqual('World');
 
     ctx.condition2 = true;
-    expect(renderToHtml(Template, ctx)).toEqual('HelloWorld');
+    fixture.update();
+    expect(fixture.html).toEqual('HelloWorld');
   });
 
   it('should work with adjacent if blocks managing views in the same container', () => {

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -361,7 +361,7 @@ describe('query', () => {
       expect(isViewContainerRef(qList.first)).toBeTruthy();
     });
 
-    it('should no longer read ElementRef with a native element pointing to comment DOM node from containers',
+    it('should read ElementRef with a native element pointing to comment DOM node from containers',
        () => {
          /**
           * <ng-template #foo></ng-template>
@@ -383,7 +383,8 @@ describe('query', () => {
          const cmptInstance = renderComponent(Cmpt);
          const qList = (cmptInstance.query as QueryList<any>);
          expect(qList.length).toBe(1);
-         expect(qList.first.nativeElement).toBe(null);
+         expect(isElementRef(qList.first)).toBeTruthy();
+         expect(qList.first.nativeElement.nodeType).toBe(8);  // Node.COMMENT_NODE = 8
        });
 
     it('should read TemplateRef from container nodes by default', () => {

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -32,11 +32,7 @@ export abstract class BaseFixture {
   /**
    * Current state of rendered HTML.
    */
-  get html(): string {
-    return (this.hostElement as any as Element)
-        .innerHTML.replace(/ style=""/g, '')
-        .replace(/ class=""/g, '');
-  }
+  get html(): string { return toHtml(this.hostElement as any as Element); }
 }
 
 function noop() {}
@@ -223,9 +219,10 @@ export function toHtml<T>(componentOrElement: T | RElement): string {
   } else {
     return stringifyElement(componentOrElement)
         .replace(/^<div host="">/, '')
+        .replace(/^<div fixture="mark">/, '')
         .replace(/<\/div>$/, '')
         .replace(' style=""', '')
-        .replace(/<!--[\w]*-->/g, '');
+        .replace(/<!--container-->/g, '');
   }
 }
 

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -595,7 +595,7 @@ describe('ViewContainerRef', () => {
         expect(fixture.html).toEqual('<p vcref=""></p>ABC');
 
         // The DOM is manually modified here to ensure that the text node is actually moved
-        fixture.hostElement.childNodes[1].nodeValue = '**A**';
+        fixture.hostElement.childNodes[2].nodeValue = '**A**';
         expect(fixture.html).toEqual('<p vcref=""></p>**A**BC');
 
         let viewRef = directiveInstance !.vcref.get(0);


### PR DESCRIPTION
This PR brings back comment nodes for containers, in order to simplify the code and to ease the implementation of i18n.
Once the code base is more mature, we might consider removing them again.

The main issue with these nodes could be performance. So I've run the existing benchmarks with and without them (only a few runs on my local machine).
On the large table one which creates 202 containers, there is no measurable difference (i.e. too small to be visible in Benchpress).
On deep tree one which creates 8190 containers, there is definitely an impact at creation time only. The penalty is around 5ms (~10%) of script time.