### PR TITLE
fix(router): allow using query params without '='

### DIFF
--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -43,7 +43,13 @@ function tree(
   let qp: any = {};
   if (queryParams) {
     forEach(queryParams, (value: any, name: any) => {
-      qp[name] = Array.isArray(value) ? value.map((v: any) => `${v}`) : `${value}`;
+      if (Array.isArray(value)) {
+        qp[name] = value.map((v: any) => `${v}`);
+      } else if (value === null) {
+        qp[name] = null;
+      } else {
+        qp[name] = `${value}`;
+      }
     });
   }
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1045,7 +1045,7 @@ export class Router {
   private removeEmptyProps(params: Params): Params {
     return Object.keys(params).reduce((result: Params, key: string) => {
       const value: any = params[key];
-      if (value !== null && value !== undefined) {
+      if (value !== undefined) {
         result[key] = value;
       }
       return result;

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1031,16 +1031,16 @@ describe('Integration', () => {
        expect(fixture.nativeElement).toHaveText('query: 2 fragment: fragment2');
      })));
 
-  it('should ignore null and undefined query params',
+  it('should ignore undefined and include null and empty string query params',
      fakeAsync(inject([Router], (router: Router) => {
        const fixture = createRoot(router, RootCmp);
 
        router.resetConfig([{path: 'query', component: EmptyQueryParamsCmp}]);
 
-       router.navigate(['query'], {queryParams: {name: 1, age: null, page: undefined}});
+       router.navigate(['query'], {queryParams: {name: 1, age: null, page: undefined, search: ''}});
        advance(fixture);
        const cmp = fixture.debugElement.children[1].componentInstance;
-       expect(cmp.recordedParams).toEqual([{name: '1'}]);
+       expect(cmp.recordedParams).toEqual([{name: '1', age: null, search: ''}]);
      })));
 
   it('should throw an error when one of the commands is null/undefined',
@@ -1881,7 +1881,7 @@ describe('Integration', () => {
          @Component({
            selector: 'someRoot',
            template:
-               `<router-outlet></router-outlet><a routerLink="/home" [queryParams]="{removeMe: null, q: 456}" queryParamsHandling="merge">Link</a>`
+               `<router-outlet></router-outlet><a routerLink="/home" [queryParams]="{removeMe: undefined, q: 456}" queryParamsHandling="merge">Link</a>`
          })
          class RootCmpWithLink {
          }

--- a/packages/router/test/url_serializer.spec.ts
+++ b/packages/router/test/url_serializer.spec.ts
@@ -142,7 +142,7 @@ describe('url serializer', () => {
 
   it('should parse key only query params', () => {
     const tree = url.parse('/one?a');
-    expect(tree.queryParams).toEqual({a: ''});
+    expect(tree.queryParams).toEqual({a: null});
   });
 
   it('should parse a value-empty query param', () => {
@@ -155,8 +155,13 @@ describe('url serializer', () => {
     expect(tree.queryParams).toEqual({a: '', b: ''});
   });
 
-  it('should serializer query params', () => {
+  it('should serialize query params', () => {
     const tree = url.parse('/one?a');
+    expect(url.serialize(tree)).toEqual('/one?a');
+  });
+
+  it('should serialize empty query params', () => {
+    const tree = url.parse('/one?a=');
     expect(url.serialize(tree)).toEqual('/one?a=');
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other: Error message
```
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There's no way we can create query params such as `foo&bar`. The only closest solution is `foo=&bar=` where their values are parsed as empty strings.

Parameters with `undefined` or `null` value are ignored

Issue Number: #23714

## What is the new behavior?

New behavior is as follows:

- `undefined` - `[queryParams]="{foo: undefined, bar: 1}"` - param is ignored => `bar=1`
- `null` - `[queryParams]="{foo: null, bar: 1}"` - param is added without "=" char => `foo&bar=1`
- `''` - `[queryParams]="{foo: '', bar: 1}"` - param is added with "=" char => `foo=&bar=1`

This is mostly because I updated `serializeQueryParams` and `parseQueryParam` methods.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
