### PR TITLE
build(docs-infra): ensure stability is computed before the API list

### DIFF
--- a/aio/tools/transforms/angular-api-package/processors/generateApiListDoc.js
+++ b/aio/tools/transforms/angular-api-package/processors/generateApiListDoc.js
@@ -1,7 +1,7 @@
 module.exports = function generateApiListDoc() {
 
   return {
-    $runAfter: ['extra-docs-added'],
+    $runAfter: ['extra-docs-added', 'computeStability'],
     $runBefore: ['rendering-docs'],
     outputFolder: null,
     $validate: {outputFolder: {presence: true}},

--- a/aio/tools/transforms/angular-api-package/processors/generateApiListDoc.spec.js
+++ b/aio/tools/transforms/angular-api-package/processors/generateApiListDoc.spec.js
@@ -13,7 +13,7 @@ describe('generateApiListDoc processor', () => {
 
   it('should run after the correct processor', () => {
     const processor = processorFactory();
-    expect(processor.$runAfter).toEqual(['extra-docs-added']);
+    expect(processor.$runAfter).toEqual(['extra-docs-added', 'computeStability']);
   });
 
   it('should run before the correct processor', () => {


### PR DESCRIPTION
Previously the API list was being generated before the stability had
been computed. This meant that the API list page showed no API docs
when filtering by `stable` stability status.

Closes #24329

