### PR TITLE
docs(ivy): add `<ng-container>` to the remaining work items

### DIFF
--- a/packages/core/src/render3/STATUS.md
+++ b/packages/core/src/render3/STATUS.md
@@ -158,10 +158,11 @@ The goal is for the `@Component` (and friends) to be the compiler of template. S
 | `<div (hammer.js)>`                         |  ❌     |  ❌      |  ❌      |
 | [`<div (directiveOut)>`][gh23560]           |  ✅     |  ❌      |  ❌      |
 | [`<ng-template (directiveOut)>`][gh23561]   |  ❌     |  ❌      |  ❌      |
-| `<ng-container>`                            |  n/a    |  ❌      |  ❌      |
+| [`<ng-container>`][gh24381]                 |  ❌     |  ❌      |  ❌      |
 
 [gh23560]: https://github.com/angular/angular/issues/23560
 [gh23561]: https://github.com/angular/angular/issues/23561
+[gh24381]: https://github.com/angular/angular/pull/24381
 
 ### Life Cycle Hooks
 | Feature                   | Runtime | Spec     | Compiler |

--- a/packages/core/src/render3/STATUS.md
+++ b/packages/core/src/render3/STATUS.md
@@ -158,6 +158,7 @@ The goal is for the `@Component` (and friends) to be the compiler of template. S
 | `<div (hammer.js)>`                         |  ❌     |  ❌      |  ❌      |
 | [`<div (directiveOut)>`][gh23560]           |  ✅     |  ❌      |  ❌      |
 | [`<ng-template (directiveOut)>`][gh23561]   |  ❌     |  ❌      |  ❌      |
+| `<ng-container>`                            |  n/a    |  ❌      |  ❌      |
 
 [gh23560]: https://github.com/angular/angular/issues/23560
 [gh23561]: https://github.com/angular/angular/issues/23561


### PR DESCRIPTION
I first thought that we can deal with `<ng-container>` on the compiler side only as I was thinking those 2 cases:
- `<ng-container i18n>` to mark a translatable section with multiple root nodes,
- `<ng-container *dir>` that result in an embedded template with multiple root nodes.

As @pkozlowski-opensource noted in inline comments, `<ng-container>` can hold an arbitrary directive, ie `<ng-container [ngPlural]=count>`. In this case, we need to have support on the runtime side.