### PR TITLE
fix(forms): don't restrict SelectControlValueAccessor and SelectMultipleControlValueAccessor to only direct <option>'s parents

### DIFF
--- a/packages/forms/src/directives/select_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_control_value_accessor.ts
@@ -210,7 +210,7 @@ export class NgSelectOption implements OnDestroy {
 
   constructor(
       private _element: ElementRef, private _renderer: Renderer2,
-      @Optional() @Host() private _select: SelectControlValueAccessor) {
+      @Optional() private _select: SelectControlValueAccessor) {
     if (this._select) this.id = this._select._registerOption();
   }
 

--- a/packages/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -234,7 +234,7 @@ export class ɵNgSelectMultipleOption implements OnDestroy {
 
   constructor(
       private _element: ElementRef, private _renderer: Renderer2,
-      @Optional() @Host() private _select: SelectMultipleControlValueAccessor) {
+      @Optional() private _select: SelectMultipleControlValueAccessor) {
     if (this._select) {
       this.id = this._select._registerOption(this);
     }

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -240,7 +240,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
         it('should update selected DOM element when options added via a nested component', () => {
           if (isNode) return;
-          const fixture = initTest(FormControlSelectWithInnerComponent, FormControlSelectOptionsInnerComponent);
+          const fixture =
+              initTest(FormControlSelectWithInnerComponent, FormControlSelectOptionsInnerComponent);
           fixture.detectChanges();
 
           const select = fixture.debugElement.query(By.css('select'));
@@ -458,6 +459,19 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              expect(sfOption.nativeElement.selected).toBe(true);
            }));
 
+        it('should update selected DOM element when options added via a nested component', () => {
+          if (isNode) return;
+          const fixture = initTest(
+              FormControlSelectMultipleWithInnerComponent, FormControlSelectOptionsInnerComponent);
+          fixture.detectChanges();
+
+          const select = fixture.debugElement.query(By.css('select'));
+          const options = fixture.debugElement.queryAll(By.css('option'));
+
+          expect(options[0].nativeElement.selected).toBe(false);
+          expect(options[1].nativeElement.selected).toBe(true);
+          expect(options[2].nativeElement.selected).toBe(true);
+        });
       });
 
       describe('in template-driven forms', () => {
@@ -1245,6 +1259,17 @@ class FormControlSelectMultipleWithCompareFn {
       (o1: any, o2: any) => boolean = (o1: any, o2: any) => o1 && o2? o1.id === o2.id: o1 === o2
   cities = [{id: 1, name: 'SF'}, {id: 2, name: 'NY'}];
   form = new FormGroup({city: new FormControl([{id: 1, name: 'SF'}])});
+}
+
+@Component({
+  selector: 'form-control-select-multiple-with-inner-component',
+  template: `
+    <div [formGroup]="form">
+      <select multiple formControlName="number" [formControlSelectOptionsInnerComponent]></select>
+    </div>`
+})
+class FormControlSelectMultipleWithInnerComponent {
+  form = new FormGroup({number: new FormControl([2, 3])});
 }
 
 

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -11,7 +11,6 @@ import {ComponentFixture, TestBed, async, fakeAsync, tick} from '@angular/core/t
 import {AbstractControl, ControlValueAccessor, FormControl, FormGroup, FormsModule, NG_VALIDATORS, NG_VALUE_ACCESSOR, NgControl, NgForm, NgModel, ReactiveFormsModule, Validators} from '@angular/forms';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
-
 {
   describe('value accessors', () => {
 
@@ -239,6 +238,16 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           expect(nyOption.nativeElement.selected).toBe(true);
         });
 
+        it('should update selected DOM element when options added via a nested component', () => {
+          if (isNode) return;
+          const fixture = initTest(FormControlSelectWithInnerComponent, FormControlSelectOptionsInnerComponent);
+          fixture.detectChanges();
+
+          const select = fixture.debugElement.query(By.css('select'));
+
+          expect(select.nativeElement.selectedIndex).toEqual(1);
+          expect(select.nativeElement.value).toEqual('2');
+        });
       });
 
       describe('in template-driven forms', () => {
@@ -1170,6 +1179,28 @@ class FormControlSelectWithCompareFn {
       (o1: any, o2: any) => boolean = (o1: any, o2: any) => o1 && o2? o1.id === o2.id: o1 === o2
   cities = [{id: 1, name: 'SF'}, {id: 2, name: 'NY'}];
   form = new FormGroup({city: new FormControl({id: 1, name: 'SF'})});
+}
+
+@Component({
+  selector: '[formControlSelectOptionsInnerComponent]',
+  template: `
+    <option [value]="1">#1</option>
+    <option [value]="2">#2</option>
+    <option [value]="3">#3</option>`
+})
+class FormControlSelectOptionsInnerComponent {
+  @Input() formControlSelectOptionsInnerComponent: any;
+}
+
+@Component({
+  selector: 'form-control-select-with-inner-component',
+  template: `
+    <div [formGroup]="form">
+      <select formControlName="number" [formControlSelectOptionsInnerComponent]></select>
+    </div>`
+})
+class FormControlSelectWithInnerComponent {
+  form = new FormGroup({number: new FormControl(2)});
 }
 
 @Component({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #24085

This is a simplified example that demonstrates the problem:
https://stackblitz.com/edit/angular-q2fxcw?file=src%2Fapp%2Fapp.component.ts

The `NgSelectOption` class needs its parent `SelectControlValueAccessor` to be injected in the constructor. Since it's marked with `@Host()` it will look only to the host element of the current component which is `AppNumbersComponent` that doesn't provide any `SelectControlValueAccessor`.

https://github.com/angular/angular/blob/9dd647b0879544015dec14fc8f8d5ee1cc16066d/packages/forms/src/directives/select_control_value_accessor.ts#L173-L177

This caused `NgSelectOption` to never be assigned to any `SelectControlValueAccessor` and therefore they never updated their parent `<select>` (I'm not sure if this had some other consequences that aren't covered by tests):

https://github.com/angular/angular/blob/9dd647b0879544015dec14fc8f8d5ee1cc16066d/packages/forms/src/directives/select_control_value_accessor.ts#L188-L191

Interestingly this worked when updating form control value after the `<option>`'s were added because of this:

https://github.com/angular/angular/blob/9dd647b0879544015dec14fc8f8d5ee1cc16066d/packages/forms/src/directives/select_control_value_accessor.ts#L127

That same problem was with multi-selects (`NgSelectMultipleOption`).

## What is the new behavior?

I only removed `@Host()` decorators and added tests (these tests would fail with `@Host()`). Now `NgSelectOption`s correctly update their parent `<select>` right in their constructor because they aren't looking only to the host component.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

This shouldn't be a breaking change because I think it's very unlikely anybody was relying to the previous behaviour.
