### PR TITLE
fix(ivy): correctly handle queries with embedded views

### DIFF
--- a/packages/core/src/render3/interfaces/query.ts
+++ b/packages/core/src/render3/interfaces/query.ts
@@ -49,7 +49,7 @@ export interface LQueries {
    * Notify `LQueries` that an `LView` has been removed from `LContainer`. As a result all
    * the matching nodes from this view should be removed from container's queries.
    */
-  removeView(removeIndex: number): void;
+  removeView(): void;
 
   /**
    * Add additional `QueryList` to track.

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -393,7 +393,7 @@ export function detachView(container: LContainerNode, removeIndex: number): LVie
   // Notify query that view has been removed
   const removedLview = viewNode.data;
   if (removedLview[QUERIES]) {
-    removedLview[QUERIES] !.removeView(removeIndex);
+    removedLview[QUERIES] !.removeView();
   }
   // Unsets the attached flag
   viewNode.data[FLAGS] &= ~LViewFlags.Attached;

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -176,13 +176,16 @@ export class LQueries_ implements LQueries {
     add(this.deep, node);
   }
 
-  removeView(index: number): void {
+  removeView(): void {
     let query = this.deep;
     while (query) {
       ngDevMode &&
           assertDefined(
               query.containerValues, 'View queries need to have a pointer to container values.');
-      const removed = query.containerValues !.splice(index, 1);
+
+      const containerValues = query.containerValues !;
+      const viewValuesIdx = containerValues.indexOf(query.values);
+      const removed = containerValues.splice(viewValuesIdx, 1);
 
       // mark a query as dirty only when removed view had matching modes
       ngDevMode && assertEqual(removed.length, 1, 'removed.length');


### PR DESCRIPTION
This PR takes care of all the remaining cases where embedded view definition
and insertion points are different.
