### PR TITLE
fix(bazel): Allow ng_module to depend on targets w no deps

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -263,7 +263,7 @@ def _collect_summaries_aspect_impl(target, ctx):
   srcs = ctx.rule.attr.srcs if hasattr(ctx.rule.attr, "srcs") else []
 
   # "re-export" rules should expose all the files of their deps
-  if not srcs:
+  if not srcs and hasattr(ctx.rule.attr, "deps"):
     for dep in ctx.rule.attr.deps:
       if (hasattr(dep, "angular")):
         results = depset(dep.angular.summaries, transitive = [results])


### PR DESCRIPTION
Check if deps attribute exists to compute transitionnal dependencies of an ng_module.
(This allows us to depend on targets that don't have a deps attribute)

synced from http://cl/199909726