### PR TITLE
fix(animations): do not truncate decimals for delay

### DIFF
--- a/packages/animations/browser/src/util.ts
+++ b/packages/animations/browser/src/util.ts
@@ -64,7 +64,7 @@ function parseTimeExpression(
 
     const delayMatch = matches[3];
     if (delayMatch != null) {
-      delay = _convertTimeValueToMS(Math.floor(parseFloat(delayMatch)), matches[4]);
+      delay = _convertTimeValueToMS(parseFloat(delayMatch), matches[4]);
     }
 
     const easingVal = matches[5];


### PR DESCRIPTION
Do not truncate decimals for animation delay if specified in seconds

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
When timing has next format: `100ms 0.5s ...` applying `Math.floor` to `0.5` gives us `0` delay. But should be `500`

Issue Number: #24291 #23040

## What is the new behavior?
`100ms 0.5s` parsed as:

- `100ms duration`

- `500ms delay`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
