### PR TITLE
Support testing @angular/material with Ivy

### DIFF
--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -85,5 +85,5 @@ export {jitExpression} from './render3/r3_jit';
 export {R3DependencyMetadata, R3FactoryMetadata, R3ResolvedDependencyType} from './render3/r3_factory';
 export {compileNgModule, R3NgModuleMetadata} from './render3/r3_module_compiler';
 export {makeBindingParser, parseTemplate} from './render3/view/template';
-export {compileComponentFromMetadata, compileDirectiveFromMetadata} from './render3/view/compiler';
+export {compileComponentFromMetadata, compileDirectiveFromMetadata, parseHostBindings} from './render3/view/compiler';
 // This file only reexports content of the `src` folder. Keep it that way.

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -84,10 +84,6 @@ export class Identifiers {
   static projection: o.ExternalReference = {name: 'ɵP', moduleName: CORE};
   static projectionDef: o.ExternalReference = {name: 'ɵpD', moduleName: CORE};
 
-  static refreshComponent: o.ExternalReference = {name: 'ɵr', moduleName: CORE};
-
-  static directiveLifeCycle: o.ExternalReference = {name: 'ɵl', moduleName: CORE};
-
   static inject: o.ExternalReference = {name: 'inject', moduleName: CORE};
 
   static injectAttribute: o.ExternalReference = {name: 'ɵinjectAttribute', moduleName: CORE};

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -445,3 +445,34 @@ function typeMapToExpressionMap(
       ([key, type]): [string, o.Expression] => [key, outputCtx.importExpr(type)]);
   return new Map(entries);
 }
+
+
+// group 0: "[prop] or (event) or @trigger"
+// group 1: "prop" from "[prop]"
+// group 2: "event" from "(event)"
+// group 3: "@trigger" from "@trigger"
+const HOST_REG_EXP = /^(?:(?:\[([^\]]+)\])|(?:\(([^\)]+)\)))|(\@[-\w]+)$/;
+
+export function parseHostBindings(host: {[key: string]: string}): {
+  attributes: {[key: string]: string},
+  listeners: {[key: string]: string},
+  properties: {[key: string]: string},
+} {
+  const attributes: {[key: string]: string} = {};
+  const listeners: {[key: string]: string} = {};
+  const properties: {[key: string]: string} = {};
+
+  Object.keys(host).forEach(key => {
+    const value = host[key];
+    const matches = key.match(HOST_REG_EXP);
+    if (matches === null) {
+      attributes[key] = value;
+    } else if (matches[1] != null) {
+      properties[matches[1]] = value;
+    } else if (matches[2] != null) {
+      listeners[matches[2]] = value;
+    }
+  });
+
+  return {attributes, listeners, properties};
+}

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -446,33 +446,44 @@ function typeMapToExpressionMap(
   return new Map(entries);
 }
 
-
-// group 0: "[prop] or (event) or @trigger"
-// group 1: "prop" from "[prop]"
-// group 2: "event" from "(event)"
-// group 3: "@trigger" from "@trigger"
 const HOST_REG_EXP = /^(?:(?:\[([^\]]+)\])|(?:\(([^\)]+)\)))|(\@[-\w]+)$/;
+
+// Represents the groups in the above regex.
+const enum HostBindingGroup {
+  // group 1: "prop" from "[prop]"
+  Property = 1,
+
+  // group 2: "event" from "(event)"
+  Event = 2,
+
+  // group 3: "@trigger" from "@trigger"
+  Animation = 3,
+}
 
 export function parseHostBindings(host: {[key: string]: string}): {
   attributes: {[key: string]: string},
   listeners: {[key: string]: string},
   properties: {[key: string]: string},
+  animations: {[key: string]: string},
 } {
   const attributes: {[key: string]: string} = {};
   const listeners: {[key: string]: string} = {};
   const properties: {[key: string]: string} = {};
+  const animations: {[key: string]: string} = {};
 
   Object.keys(host).forEach(key => {
     const value = host[key];
     const matches = key.match(HOST_REG_EXP);
     if (matches === null) {
       attributes[key] = value;
-    } else if (matches[1] != null) {
-      properties[matches[1]] = value;
-    } else if (matches[2] != null) {
-      listeners[matches[2]] = value;
+    } else if (matches[HostBindingGroup.Property] != null) {
+      properties[matches[HostBindingGroup.Property]] = value;
+    } else if (matches[HostBindingGroup.Event] != null) {
+      listeners[matches[HostBindingGroup.Event]] = value;
+    } else if (matches[HostBindingGroup.Animation] != null) {
+      animations[matches[HostBindingGroup.Animation]] = value;
     }
   });
 
-  return {attributes, listeners, properties};
+  return {attributes, listeners, properties, animations};
 }

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -221,7 +221,7 @@ export class BindingParser {
 
   private _parseBinding(value: string, isHostBinding: boolean, sourceSpan: ParseSourceSpan):
       ASTWithSource {
-    const sourceInfo = sourceSpan.start.toString();
+    const sourceInfo = (sourceSpan && sourceSpan.start || '(unknown)').toString();
 
     try {
       const ast = isHostBinding ?
@@ -343,7 +343,7 @@ export class BindingParser {
   }
 
   private _parseAction(value: string, sourceSpan: ParseSourceSpan): ASTWithSource {
-    const sourceInfo = sourceSpan.start.toString();
+    const sourceInfo = (sourceSpan && sourceSpan.start || '(unknown').toString();
 
     try {
       const ast = this._exprParser.parseAction(value, sourceInfo, this._interpolationConfig);

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ConstantPool, R3DirectiveMetadata, WrappedNodeExpr, compileComponentFromMetadata as compileR3Component, compileDirectiveFromMetadata as compileR3Directive, jitExpression, makeBindingParser, parseTemplate} from '@angular/compiler';
+import {ConstantPool, R3DirectiveMetadata, WrappedNodeExpr, compileComponentFromMetadata as compileR3Component, compileDirectiveFromMetadata as compileR3Directive, jitExpression, makeBindingParser, parseHostBindings, parseTemplate} from '@angular/compiler';
 
-import {Component, Directive, HostBinding, Input, Output} from '../../metadata/directives';
+import {Component, Directive, HostBinding, HostListener, Input, Output} from '../../metadata/directives';
 import {ReflectionCapabilities} from '../../reflection/reflection_capabilities';
 import {Type} from '../../type';
 
@@ -18,6 +18,10 @@ import {patchComponentDefWithScope} from './module';
 import {getReflect, reflectDependencies} from './util';
 
 let _pendingPromises: Promise<void>[] = [];
+
+type StringMap = {
+  [key: string]: string
+};
 
 /**
  * Compile an Angular component according to its decorator metadata, and patch the resulting
@@ -138,8 +142,10 @@ export function awaitCurrentlyCompilingComponents(): Promise<void> {
 function directiveMetadata(type: Type<any>, metadata: Directive): R3DirectiveMetadata {
   // Reflect inputs and outputs.
   const props = getReflect().propMetadata(type);
-  const inputs: {[key: string]: string} = {};
-  const outputs: {[key: string]: string} = {};
+  const inputs: StringMap = {};
+  const outputs: StringMap = {};
+
+  const host = extractHostBindings(metadata, props);
 
   for (let field in props) {
     props[field].forEach(ann => {
@@ -155,14 +161,7 @@ function directiveMetadata(type: Type<any>, metadata: Directive): R3DirectiveMet
     name: type.name,
     type: new WrappedNodeExpr(type),
     selector: metadata.selector !,
-    deps: reflectDependencies(type),
-    host: {
-      attributes: {},
-      listeners: {},
-      properties: {},
-    },
-    inputs,
-    outputs,
+    deps: reflectDependencies(type), host, inputs, outputs,
     queries: [],
     lifecycle: {
       usesOnChanges: type.prototype.ngOnChanges !== undefined,
@@ -171,10 +170,40 @@ function directiveMetadata(type: Type<any>, metadata: Directive): R3DirectiveMet
   };
 }
 
+function extractHostBindings(metadata: Directive, props: {[key: string]: any[]}): {
+  attributes: StringMap,
+  listeners: StringMap,
+  properties: StringMap,
+} {
+  // First parse the declarations from the metadata.
+  const host = parseHostBindings(metadata.host || {});
+
+  // Next, loop over the properties of the object, looking for @HostBinding and @HostListener.
+  for (let field in props) {
+    props[field].forEach(ann => {
+      if (isHostBinding(ann)) {
+        host.properties[ann.hostPropertyName || field] = field;
+      } else if (isHostListener(ann)) {
+        host.listeners[ann.eventName || field] = `${field}(${(ann.args || []).join(',')})`;
+      }
+    });
+  }
+
+  return host;
+}
+
 function isInput(value: any): value is Input {
   return value.ngMetadataName === 'Input';
 }
 
 function isOutput(value: any): value is Output {
   return value.ngMetadataName === 'Output';
+}
+
+function isHostBinding(value: any): value is HostBinding {
+  return value.ngMetadataName === 'HostBinding';
+}
+
+function isHostListener(value: any): value is HostListener {
+  return value.ngMetadataName === 'HostListener';
 }

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {defineInjectable} from '../../di/defs';
+import {defineInjectable, defineInjector,} from '../../di/defs';
 import {inject} from '../../di/injector';
 import {defineNgModule} from '../../metadata/ng_module';
 import * as r3 from '../index';
@@ -21,7 +21,9 @@ export const angularCoreEnv: {[name: string]: Function} = {
   'ɵdefineComponent': r3.defineComponent,
   'ɵdefineDirective': r3.defineDirective,
   'defineInjectable': defineInjectable,
+  'defineInjector': defineInjector,
   'ɵdefineNgModule': defineNgModule,
+  'ɵdefinePipe': r3.definePipe,
   'ɵdirectiveInject': r3.directiveInject,
   'inject': inject,
   'ɵinjectAttribute': r3.injectAttribute,
@@ -60,18 +62,23 @@ export const angularCoreEnv: {[name: string]: Function} = {
   'ɵi6': r3.i6,
   'ɵi7': r3.i7,
   'ɵi8': r3.i8,
+  'ɵiV': r3.iV,
   'ɵk': r3.k,
   'ɵkn': r3.kn,
   'ɵL': r3.L,
   'ɵld': r3.ld,
+  'ɵP': r3.P,
   'ɵp': r3.p,
   'ɵpb1': r3.pb1,
   'ɵpb2': r3.pb2,
   'ɵpb3': r3.pb3,
   'ɵpb4': r3.pb4,
   'ɵpbV': r3.pbV,
+  'ɵpD': r3.pD,
+  'ɵPp': r3.Pp,
   'ɵQ': r3.Q,
   'ɵqR': r3.qR,
+  'ɵrS': r3.rS,
   'ɵs': r3.s,
   'ɵsn': r3.sn,
   'ɵst': r3.st,

--- a/packages/core/test/render3/BUILD.bazel
+++ b/packages/core/test/render3/BUILD.bazel
@@ -21,6 +21,7 @@ ts_library(
         "//packages/animations/browser",
         "//packages/animations/browser/testing",
         "//packages/common",
+        "//packages/compiler",
         "//packages/core",
         "//packages/core/testing",
         "//packages/platform-browser",

--- a/packages/core/test/render3/compiler_canonical/component_directives_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/component_directives_spec.ts
@@ -530,7 +530,11 @@ describe('components & directives', () => {
               $r3$.ɵT(0);
             }
             if (rf & 2) {
+              // clang-format wants to break this line by changing the second 'ɵ' to an invalid
+              // unicode sequence.
+              // clang-format off
               $r3$.ɵt(0, $r3$.ɵb(ctx.num));
+              // clang-format on
             }
           },
           inputs: {num: 'num'}

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -9,7 +9,7 @@
 import {Injectable} from '@angular/core/src/di/injectable';
 import {inject, setCurrentInjector} from '@angular/core/src/di/injector';
 import {ivyEnabled} from '@angular/core/src/ivy_switch';
-import {Component} from '@angular/core/src/metadata/directives';
+import {Component, HostBinding, HostListener} from '@angular/core/src/metadata/directives';
 import {NgModule, NgModuleDef} from '@angular/core/src/metadata/ng_module';
 import {ComponentDef} from '@angular/core/src/render3/interfaces/definition';
 
@@ -160,6 +160,29 @@ ivyEnabled && describe('render3 jit', () => {
     const moduleDef: NgModuleDef<Module> = (Module as any).ngModuleDef;
     expect(cmpDef.directiveDefs instanceof Function).toBe(true);
     expect((cmpDef.directiveDefs as Function)()).toEqual([cmpDef]);
+  });
+
+  it('should add hostbindings and hostlisteners', () => {
+    @Component({
+      template: 'foo',
+      selector: 'foo',
+      host: {
+        '[class.red]': 'isRed',
+        '(click)': 'onClick()',
+      },
+    })
+    class Cmp {
+      @HostBinding('class.green')
+      green: boolean = false;
+
+      @HostListener('change', ['$event'])
+      onChange(event: any): void {}
+    }
+
+    const cmpDef = (Cmp as any).ngComponentDef as ComponentDef<Cmp>;
+
+    expect(cmpDef.hostBindings).toBeDefined();
+    expect(cmpDef.hostBindings !.length).toBe(2);
   });
 });
 

--- a/packages/core/test/render3/jit_environment_spec.ts
+++ b/packages/core/test/render3/jit_environment_spec.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ExternalReference} from '@angular/compiler';
+import {Identifiers} from '@angular/compiler/src/render3/r3_identifiers';
+
+import {angularCoreEnv} from '../../src/render3/jit/environment';
+
+const INTERFACE_EXCEPTIONS = new Set<string>([
+  'ComponentDef',
+  'DirectiveDef',
+]);
+
+describe('r3 jit environment', () => {
+  // This test keeps render3/jit/environment and r3_identifiers in the compiler in sync, ensuring
+  // that if the compiler writes a reference to a render3 symbol, it will be resolvable at runtime
+  // in JIT mode.
+  it('should support all r3 symbols', () => {
+    Object
+        // Map over the static properties of Identifiers.
+        .keys(Identifiers)
+        .map(key => (Identifiers as any as{[key: string]: string | ExternalReference})[key])
+        // A few such properties are string constants. Ignore them, and focus on ExternalReferences.
+        .filter(isExternalReference)
+        // Some references are to interface types. Only take properties which have runtime values.
+        .filter(sym => !INTERFACE_EXCEPTIONS.has(sym.name))
+        .forEach(sym => {
+          // Assert that angularCoreEnv has a reference to the runtime symbol.
+          expect(angularCoreEnv.hasOwnProperty(sym.name))
+              .toBe(true, `Missing symbol ${sym.name} in render3/jit/environment`);
+        });
+  });
+});
+
+function isExternalReference(sym: ExternalReference | string): sym is ExternalReference&
+    {name: string} {
+  return typeof sym === 'object' && sym.name !== null && sym.moduleName !== null;
+}


### PR DESCRIPTION
This PR bundles two commits needed to help test `@angular/material`:

1) it adds support for host bindings and host listeners to the JIT compiler.

2) it brings the JIT symbol table in sync with the instructions the compiler can reference (and adds a test that ensures it stays that way).