### PR TITLE
fix(compiler-cli): metadata resolution error when generating flat mod…

### DIFF
--- a/packages/compiler-cli/src/metadata/bundler.ts
+++ b/packages/compiler-cli/src/metadata/bundler.ts
@@ -235,7 +235,8 @@ export class MetadataBundler {
     const rootExport = getRootExport(symbol);
     const declaration = getSymbolDeclaration(symbol);
     const isPrivate = !this.exported.has(rootExport);
-    const canonicalSymbol = isPrivate ? declaration : rootExport;
+    let canonicalSymbol = isPrivate ? declaration : rootExport;
+    canonicalSymbol = canonicalSymbol.declaration ? canonicalSymbol : getRootExport(declaration);
     symbol.isPrivate = isPrivate;
     symbol.declaration = declaration;
     symbol.canonicalSymbol = canonicalSymbol;
@@ -600,8 +601,8 @@ export class CompilerHostAdapter implements MetadataBundlerHost {
   constructor(private host: ts.CompilerHost, private cache: MetadataCache|null) {}
 
   getMetadataFor(fileName: string): ModuleMetadata|undefined {
-    if (!this.host.fileExists(fileName + '.ts')) return undefined;
-    const sourceFile = this.host.getSourceFile(fileName + '.ts', ts.ScriptTarget.Latest);
+    if (!this.host.fileExists(`${fileName}.ts`)) return undefined;
+    const sourceFile = this.host.getSourceFile(`${fileName}.ts`, ts.ScriptTarget.Latest);
     // If there is a metadata cache, use it to get the metadata for this source file. Otherwise,
     // fall back on the locally created MetadataCollector.
     if (!sourceFile) {

--- a/packages/compiler-cli/test/metadata/bundler_spec.ts
+++ b/packages/compiler-cli/test/metadata/bundler_spec.ts
@@ -193,6 +193,44 @@ describe('metadata bundler', () => {
     expect(result.metadata.origins !['E']).toBeUndefined();
   });
 
+  it('should be able to bundle a library with referenced re-exported symbols', () => {
+    const host = new MockStringBundlerHost('/', {
+      'public-api.ts': `
+        export * from './src/module';
+      `,
+      'src': {
+        'components': {
+          'hello.component.ts': `
+            import { Component } from '@angular/core';
+
+            @Component({
+              template: ''
+            })
+            export class HelloComponent { }
+          `,
+          'index.ts': `
+            export * from './hello.component';
+          `,
+        },
+        'module.ts': `
+          import { NgModule } from '@angular/core';
+          import { HelloComponent } from './components'
+
+          @NgModule({
+            declarations: [
+              HelloComponent
+            ]
+          })
+          export class AppModule {}
+        `
+      }
+    });
+
+    const bundler = new MetadataBundler('/public-api', 'index.js', host);
+    const result = bundler.getMetadataBundle();
+    expect(result.metadata.__symbolic).toEqual('module');
+  });
+
   it('should be able to de-duplicate symbols of re-exported modules', () => {
     const host = new MockStringBundlerHost('/', {
       'public-api.ts': `


### PR DESCRIPTION
…ule with reference in re-export

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Error: Cannot read property 'module' of undefined


Issue Number: #20931


## What is the new behavior?
that re-exported symbols are resolved when using barrel files

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The test written should fail before this change, however it doesn't. I am thinking that it's due to mocking of the host.

Maybe an Integration test is better? Any help with that please?