### PR TITLE
test(common): rename keyvalue e2e test

### DIFF
--- a/packages/examples/common/pipes/ts/e2e_test/pipe_spec.ts
+++ b/packages/examples/common/pipes/ts/e2e_test/pipe_spec.ts
@@ -57,7 +57,8 @@ describe('pipe', () => {
       expect(element.all(by.css('titlecase-pipe p')).get(5).getText()).toEqual('Foo-vs-bar');
     });
   });
-  describe('titlecase', () => {
+
+  describe('keyvalue', () => {
     it('should work properly', () => {
       browser.get(URL);
       waitForElement('keyvalue-pipe');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
 
The new `KeyValue` pipe e2e test has the wrong name. 

## What is the new behavior?

This fixes the test name

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
