### PR TITLE
add cygwin support to build.sh and scripts/windows/create-symlinks.sh, so cygwin users can build angular on 32-bit machines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@
 ## IMPORTANT
 # If you change the `docker_image` version, also change the `cache_key` suffix and the version of
 # `com_github_bazelbuild_buildtools` in the `/WORKSPACE` file.
-var_1: &docker_image angular/ngcontainer:0.3.1
-var_2: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.3.1
+var_1: &docker_image angular/ngcontainer:0.3.2
+var_2: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.3.2
 
 # Define common ENV vars
 var_3: &define_env_vars
@@ -187,6 +187,10 @@ jobs:
   # See comments inside the integration/run_tests.sh script.
   integration_test:
     <<: *job_defaults
+    # Note: we run Bazel in one of the integration tests, and it can consume >2G
+    # of memory. Together with the system under test, this can exhaust the RAM
+    # on a 4G worker so we use a larger machine here too.
+    resource_class: xlarge
     steps:
       - *define_env_vars
       - checkout:

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,15 @@ BUILD_EXAMPLES=true
 COMPILE_SOURCE=true
 TYPECHECK_ALL=true
 BUILD_TOOLS=true
-export NODE_PATH=${NODE_PATH:-}:${currentDir}/dist/tools
+
+#if on cygwin build a windows style path for node, since the node
+#will be the windows build
+if [ $OSTYPE = cygwin ]; then
+  export NODE_PATH=${NODE_PATH:-}\;$(cygpath -w ${currentDir}/dist/tools)
+  echo "$NODE_PATH"
+else
+  export NODE_PATH=${NODE_PATH:-}:${currentDir}/dist/tools
+fi
 
 for ARG in "$@"; do
   case "$ARG" in
@@ -243,7 +251,11 @@ compilePackage() {
   else
     echo "======      [${3}]: COMPILING: ${NGC} -p ${1}/tsconfig-build.json"
     local package_name=$(basename "${2}")
-    $NGC -p ${1}/tsconfig-build.json
+    if [ $OSTYPE = cygwin ]; then
+      $NGC -p $(cygpath -w ${1}/tsconfig-build.json)
+    else
+      $NGC -p ${1}/tsconfig-build.json
+    fi 
     if [[ "${package_name}" != "locales" ]]; then
       echo "======           Create ${1}/../${package_name}.d.ts re-export file for tsickle"
       echo "$(cat ${LICENSE_BANNER}) ${N} export * from './${package_name}/${package_name}'" > ${2}/../${package_name}.d.ts
@@ -278,7 +290,12 @@ compilePackageES5() {
   else
     echo "======      [${3}]: COMPILING: ${NGC} -p ${1}/tsconfig-build.json --target es5 -d false --outDir ${2} --importHelpers true --sourceMap"
     local package_name=$(basename "${2}")
-    $NGC -p ${1}/tsconfig-build.json --target es5 -d false --outDir ${2} --importHelpers true --sourceMap
+    if [ $OSTYPE = cygwin ]; then
+      $NGC -p $(cygpath -w ${1}/tsconfig-build.json) --target es5 -d false --outDir $(cygpath -w ${2} ) --importHelpers true --sourceMap
+    else
+      $NGC -p ${1}/tsconfig-build.json --target es5 -d false --outDir ${2} --importHelpers true --sourceMap
+
+    fi
   fi
 
   for DIR in ${1}/* ; do
@@ -345,7 +362,14 @@ echo "====== BUILDING: Version ${VERSION}"
 N="
 "
 TSC=`pwd`/node_modules/.bin/tsc
-NGC="node --max-old-space-size=3000 `pwd`/dist/tools/@angular/compiler-cli/src/main"
+
+#if on cygwin build a windows style path for node, since the node
+#will be the windows build
+if [ $OSTYPE = cygwin ]; then
+  NGC="node --max-old-space-size=3000 $(cygpath -w $(pwd)/dist/tools/@angular/compiler-cli/src/main)"
+else
+  NGC="node --max-old-space-size=3000 `pwd`/dist/tools/@angular/compiler-cli/src/main"
+fi
 UGLIFY=`pwd`/node_modules/.bin/uglifyjs
 TSCONFIG=./tools/tsconfig.json
 ROLLUP=`pwd`/node_modules/.bin/rollup

--- a/scripts/windows/create-symlinks.sh
+++ b/scripts/windows/create-symlinks.sh
@@ -4,7 +4,18 @@ cd `dirname $0`
 
 CORE_SRC_ANIMATION_DIR=./../../packages/core/src/animation
 UPGRADE_STATIC_DIR=./../../packages/upgrade/static
+
 mv ${CORE_SRC_ANIMATION_DIR}/dsl.ts ${CORE_SRC_ANIMATION_DIR}/dsl.ts.old
 mv ${UPGRADE_STATIC_DIR}/src ${UPGRADE_STATIC_DIR}/src.old
-cmd <<< "mklink \"..\\..\\packages\\core\\src\\animation\\dsl.ts\" \"..\\..\\..\\animations\\src\\animation_metadata.ts\""
-cmd <<< "mklink /d \"..\\..\\packages\\upgrade\\static\\src\" \"..\\src\""
+
+#make sure that the target locations exist
+mkdir -p $CORE_SRC_ANIMATION_DIR
+mkdir -p $UPGRADE_STATIC_DIR
+
+pushd .
+cd $CORE_SRC_ANIMATION_DIR
+cmd <<< "mklink dsl.ts \"..\\..\\..\\animations\\src\\animation_metadata.ts\""
+
+popd
+cd $UPGRADE_STATIC_DIR
+cmd <<< "mklink /d \"src\" \"..\\src\""

--- a/tools/ngcontainer/Dockerfile
+++ b/tools/ngcontainer/Dockerfile
@@ -19,7 +19,7 @@ RUN JAVA_DEBIAN_VERSION="8u131-b11-1~bpo8+1" \
 ###
 # Bazel install
 # See https://bazel.build/versions/master/docs/install-ubuntu.html#using-bazel-custom-apt-repository-recommended
-RUN BAZEL_VERSION="0.14.0" \
+RUN BAZEL_VERSION="0.14.1" \
  && wget -q -O - https://bazel.build/bazel-release.pub.gpg | apt-key add - \
  && echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/bazel.list \
  && apt-get update \

--- a/tools/ngcontainer/README.md
+++ b/tools/ngcontainer/README.md
@@ -6,7 +6,7 @@ This docker container provides everything needed to build and test Angular appli
 - npm 5.5.1
 - yarn 1.3.2
 - Java 8 (for Closure Compiler and Bazel)
-- Bazel build tool v0.14.0 - http://bazel.build
+- Bazel build tool v0.14.1 - http://bazel.build
 - Google Chrome 63.0.3239.84
 - Mozilla Firefox 47.0.1
 - xvfb (virtual framebuffer) for headless testing


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

I wrote no tests as I did not see a testing framework for the build system scripts.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The build fails to work on windows/cygwin when following the [DEVELOPER.md](https://github.com/angular/angular/blob/master/docs/DEVELOPER.md). Note that this set up involves the windows version of node because cygwin does not package node.

## What is the new behavior?

The build with build.sh now finishes on windows/cygwin without errors. Note that to make the build succeed on a clean build, I had to run `bower install`. This step is undocumented as far as I can tell. This pull request does not modify documentation as I was unsure if this was my fault, or if the documentation actually needs updating. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
In my tests, I only get a log report saying that ` build.sh build package: core ` and not for any of the other packages. I don't know if this is normal behavior or not because I never built angular successfully before 