### PR TITLE
build: fix broken circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@
 ## IMPORTANT
 # If you change the `docker_image` version, also change the `cache_key` suffix and the version of
 # `com_github_bazelbuild_buildtools` in the `/WORKSPACE` file.
-var_1: &docker_image angular/ngcontainer:0.3.1
-var_2: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.3.1
+var_1: &docker_image angular/ngcontainer:0.3.2
+var_2: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.3.2
 
 # Define common ENV vars
 var_3: &define_env_vars
@@ -149,6 +149,10 @@ jobs:
   # See comments inside the integration/run_tests.sh script.
   integration_test:
     <<: *job_defaults
+    # Note: we run Bazel in one of the integration tests, and it can consume >2G
+    # of memory. Together with the system under test, this can exhaust the RAM
+    # on a 4G worker so we use a larger machine here too.
+    resource_class: xlarge
     steps:
       - *define_env_vars
       - checkout:

--- a/tools/ngcontainer/Dockerfile
+++ b/tools/ngcontainer/Dockerfile
@@ -19,7 +19,7 @@ RUN JAVA_DEBIAN_VERSION="8u131-b11-1~bpo8+1" \
 ###
 # Bazel install
 # See https://bazel.build/versions/master/docs/install-ubuntu.html#using-bazel-custom-apt-repository-recommended
-RUN BAZEL_VERSION="0.14.0" \
+RUN BAZEL_VERSION="0.14.1" \
  && wget -q -O - https://bazel.build/bazel-release.pub.gpg | apt-key add - \
  && echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/bazel.list \
  && apt-get update \

--- a/tools/ngcontainer/README.md
+++ b/tools/ngcontainer/README.md
@@ -6,7 +6,7 @@ This docker container provides everything needed to build and test Angular appli
 - npm 5.5.1
 - yarn 1.3.2
 - Java 8 (for Closure Compiler and Bazel)
-- Bazel build tool v0.14.0 - http://bazel.build
+- Bazel build tool v0.14.1 - http://bazel.build
 - Google Chrome 63.0.3239.84
 - Mozilla Firefox 47.0.1
 - xvfb (virtual framebuffer) for headless testing


### PR DESCRIPTION
Bazel 0.14 allocates memory differently and runs out of RAM on a 4G circleci worker
so use an xlarge machine for the integration_test job.
Cherry-pick of #24512 onto patch branch.
