### PR TITLE
fix(core): Injector correctly honors the @Self flag

### DIFF
--- a/packages/core/src/view/ng_module.ts
+++ b/packages/core/src/view/ng_module.ts
@@ -118,6 +118,8 @@ export function resolveNgModuleDep(
       return (
           data._providers[index] =
               _createProviderInstance(data, data._def.providersByKey[depDef.tokenKey]));
+    } else if (depDef.flags & DepFlags.Self) {
+      return notFoundValue;
     }
     return data._parent.get(depDef.token, notFoundValue);
   } finally {

--- a/packages/core/test/view/ng_module_spec.ts
+++ b/packages/core/test/view/ng_module_spec.ts
@@ -80,11 +80,14 @@ class FromChildWithOptionalDep {
 }
 
 class FromChildWithSkipSelfDep {
-  constructor(public depFromParent: ChildDep|null, public depFromChild: Bar|null) {}
+  constructor(
+      public skipSelfChildDep: ChildDep|null, public selfChildDep: ChildDep|null,
+      public optionalSelfBar: Bar|null) {}
   static ngInjectableDef: InjectableDef<FromChildWithSkipSelfDep> = defineInjectable({
     factory: () => new FromChildWithSkipSelfDep(
                  inject(ChildDep, InjectFlags.SkipSelf|InjectFlags.Optional),
-                 inject(Bar, InjectFlags.Self|InjectFlags.Optional)),
+                 inject(ChildDep, InjectFlags.Self),
+                 inject(Bar, InjectFlags.Self|InjectFlags.Optional), ),
     providedIn: MyChildModule,
   });
 }
@@ -162,8 +165,9 @@ describe('NgModuleRef_ injector', () => {
   it('injects skip-self and self deps across injectors properly', () => {
     const instance = childRef.injector.get(FromChildWithSkipSelfDep);
     expect(instance instanceof FromChildWithSkipSelfDep).toBeTruthy();
-    expect(instance.depFromParent).toBeNull();
-    expect(instance.depFromChild instanceof Bar).toBeTruthy();
+    expect(instance.skipSelfChildDep).toBeNull();
+    expect(instance.selfChildDep instanceof ChildDep).toBeTruthy();
+    expect(instance.optionalSelfBar).toBeNull();
   });
 
   it('does not inject something not scoped to the module',


### PR DESCRIPTION
Injector was incorrectly returning instance from parent injector even
when `@Self` was specified.
