### PR TITLE
test(bazel): fix flakey bazel integration e2e test

### DIFF
--- a/integration/bazel/test/e2e/app.spec.ts
+++ b/integration/bazel/test/e2e/app.spec.ts
@@ -1,5 +1,7 @@
 import {browser, by, element, ExpectedConditions} from 'protractor';
 
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
+
 describe('angular example application', () => {
   it('should display: Hello World!', (done) => {
     browser.get('');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Bazel integration e2e test is flaky

## What is the new behavior?
Increase the jasmine DEFAULT_TIMEOUT_INTERVAL from 5s to 120s

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
