### PR TITLE
build(docs-infra): include parameter short description in API docs

### DIFF
--- a/aio/tools/transforms/templates/api/lib/paramList.html
+++ b/aio/tools/transforms/templates/api/lib/paramList.html
@@ -21,8 +21,7 @@
       {% if showType %}<td class="param-type"><code>{$ parameter.type $}</code></td>{% endif %}
       <td class="param-description">
       {% marked %}
-      {% if parameter.description | trim %}{$ parameter.description $}
-
+      {% if (parameter.shortDescription | trim) or (parameter.description | trim) %}{$ parameter.shortDescription + '\n\n' + parameter.description $}
       {% elseif not showType and parameter.type %}<p>Type: <code>{$ parameter.type $}</code>.</p>
       {% endif %}
 


### PR DESCRIPTION
Previously we were not rendering the short description of parameters.

As an example consider the `animations/trigger()` function...

**Before:**

<img width="1074" alt="screen shot 2018-06-15 at 13 37 28" src="https://user-images.githubusercontent.com/15655/41468274-4e5e375c-70a1-11e8-8e47-1a24a2c2527e.png">


**After:**

<img width="1053" alt="screen shot 2018-06-15 at 13 37 36" src="https://user-images.githubusercontent.com/15655/41468280-52dd209a-70a1-11e8-9718-d74e8c5f0e3b.png">
