### PR TITLE
A couple fixes for Ivy JIT

### DIFF
--- a/packages/compiler/src/injectable_compiler_2.ts
+++ b/packages/compiler/src/injectable_compiler_2.ts
@@ -52,7 +52,6 @@ export function compileInjectable(meta: R3InjectableMetadata): InjectableDef {
         fnOrClass,
         useNew,
         injectFn: Identifiers.inject,
-        useOptionalParam: true,
         deps: meta.deps,
       });
     } else if (meta.useClass !== undefined) {
@@ -94,7 +93,6 @@ export function compileInjectable(meta: R3InjectableMetadata): InjectableDef {
       fnOrClass: meta.type,
       useNew: true,
       injectFn: Identifiers.inject,
-      useOptionalParam: true,
       deps: meta.deps,
     });
   }

--- a/packages/compiler/src/render3/r3_pipe_compiler.ts
+++ b/packages/compiler/src/render3/r3_pipe_compiler.ts
@@ -37,7 +37,6 @@ export function compilePipe(
     fnOrClass: outputCtx.importExpr(pipe.type.reference), deps,
     useNew: true,
     injectFn: R3.directiveInject,
-    useOptionalParam: false,
   });
   definitionMapValues.push({key: 'factory', value: templateFactory, quoted: false});
 

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -49,7 +49,6 @@ function baseDirectiveFields(
                       deps: meta.deps,
                       useNew: true,
                       injectFn: R3.directiveInject,
-                      useOptionalParam: false,
                       extraResults: queryDefinitions,
                     }));
 


### PR DESCRIPTION
* Support `inputs` and `outputs` from metadata.
* Remove option to use default value parameter for `inject()` in code generation.