### PR TITLE
fix(ivy): support queries for views inserted in lifecycle hooks

### DIFF
--- a/packages/core/src/render3/STATUS.md
+++ b/packages/core/src/render3/STATUS.md
@@ -192,7 +192,7 @@ The goal is for the `@Component` (and friends) to be the compiler of template. S
 | `@ContentChildren`              |  ✅     |  ✅      |  ❌       |
 | `@ContentChild`                 |  ✅     |  ✅      |  ✅       |
 | `@ViewChildren`                 |  ✅     |  ✅      |  ❌       |
-| `@ViewChild`                    |  ✅     |  ✅      |  ✅       |
+| `@ViewChild`                    |  ✅     |  ✅      |  ❌       |
 
 
 

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -15,7 +15,7 @@ import {Sanitizer} from '../sanitization/security';
 import {assertComponentType, assertDefined} from './assert';
 import {queueInitHooks, queueLifecycleHooks} from './hooks';
 import {CLEAN_PROMISE, ROOT_DIRECTIVE_INDICES, _getComponentHostLElementNode, baseDirectiveCreate, createLViewData, createTView, detectChangesInternal, enterView, executeInitAndContentHooks, getRootView, hostElement, initChangeDetectorIfExisting, leaveView, locateHostElement, setHostBindings,} from './instructions';
-import {ComponentDef, ComponentDefInternal, ComponentType} from './interfaces/definition';
+import {ComponentDef, ComponentDefInternal, ComponentType, RenderFlags} from './interfaces/definition';
 import {LElementNode} from './interfaces/node';
 import {RElement, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
 import {LViewData, LViewFlags, RootContext, INJECTOR, CONTEXT, TVIEW} from './interfaces/view';
@@ -107,7 +107,7 @@ export function renderComponent<T>(
 
   const rootView: LViewData = createLViewData(
       rendererFactory.createRenderer(hostNode, componentDef.rendererType),
-      createTView(-1, null, null, null), rootContext,
+      createTView(-1, null, null, null, null), rootContext,
       componentDef.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways);
   rootView[INJECTOR] = opts.injector || null;
 

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -15,7 +15,7 @@ import {Sanitizer} from '../sanitization/security';
 import {assertComponentType, assertDefined} from './assert';
 import {queueInitHooks, queueLifecycleHooks} from './hooks';
 import {CLEAN_PROMISE, ROOT_DIRECTIVE_INDICES, _getComponentHostLElementNode, baseDirectiveCreate, createLViewData, createTView, detectChangesInternal, enterView, executeInitAndContentHooks, getRootView, hostElement, initChangeDetectorIfExisting, leaveView, locateHostElement, setHostBindings,} from './instructions';
-import {ComponentDef, ComponentDefInternal, ComponentType, RenderFlags} from './interfaces/definition';
+import {ComponentDef, ComponentDefInternal, ComponentType} from './interfaces/definition';
 import {LElementNode} from './interfaces/node';
 import {RElement, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
 import {LViewData, LViewFlags, RootContext, INJECTOR, CONTEXT, TVIEW} from './interfaces/view';

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -96,7 +96,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
     // Create the root view. Uses empty TView and ContentTemplate.
     const rootView: LViewData = createLViewData(
         rendererFactory.createRenderer(hostNode, this.componentDef.rendererType),
-        createTView(-1, null, null, null), null,
+        createTView(-1, null, null, null, null), null,
         this.componentDef.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways);
     rootView[INJECTOR] = ngModule && ngModule.injector || null;
 

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -16,7 +16,7 @@ import {Type} from '../type';
 import {resolveRendererType2} from '../view/util';
 
 import {diPublic} from './di';
-import {ComponentDefFeature, ComponentDefInternal, ComponentTemplate, ComponentType, DirectiveDefFeature, DirectiveDefInternal, DirectiveDefListOrFactory, DirectiveType, DirectiveTypesOrFactory, PipeDef, PipeType, PipeTypesOrFactory, RenderFlags} from './interfaces/definition';
+import {ComponentDefFeature, ComponentDefInternal, ComponentQuery, ComponentTemplate, ComponentType, DirectiveDefFeature, DirectiveDefInternal, DirectiveDefListOrFactory, DirectiveType, DirectiveTypesOrFactory, PipeDef, PipeType, PipeTypesOrFactory} from './interfaces/definition';
 import {CssSelectorList, SelectorFlags} from './interfaces/projection';
 
 
@@ -126,13 +126,14 @@ export function defineComponent<T>(componentDefinition: {
   template: ComponentTemplate<T>;
 
   /**
-   * Additional set of instructions specific to query processing. This could be seen as an
-   * "additional" template function.
+   * Additional set of instructions specific to view query processing. This could be seen as a
+   * set of instruction to be inserted into the template function.
+   *
    * Query-related instructions need to be pulled out to a specific function as a timing of
    * execution is different as compared to all other instructions (after change detection hooks but
    * before view hooks).
    */
-  queryInstructions?: ComponentTemplate<T>| null;
+  viewQuery?: ComponentQuery<T>| null;
 
   /**
    * A list of optional features to apply.
@@ -202,7 +203,7 @@ export function defineComponent<T>(componentDefinition: {
         () => (typeof pipeTypes === 'function' ? pipeTypes() : pipeTypes).map(extractPipeDef) :
         null,
     selectors: componentDefinition.selectors,
-    queryInstructions: componentDefinition.queryInstructions || null,
+    viewQuery: componentDefinition.viewQuery || null,
   };
   const feature = componentDefinition.features;
   feature && feature.forEach((fn) => fn(def));

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -19,6 +19,11 @@ export type ComponentTemplate<T> = {
 };
 
 /**
+ * Definition of what a query function should look like.
+ */
+export type ComponentQuery<T> = ComponentTemplate<T>;
+
+/**
  * Flags passed into template functions to determine which blocks (i.e. creation, update)
  * should be executed.
  *
@@ -153,22 +158,16 @@ export type ComponentDefInternal<T> = ComponentDef<T, string>;
 export interface ComponentDef<T, Selector extends string> extends DirectiveDef<T, Selector> {
   /**
    * The View template of the component.
-   *
-   * NOTE: only used with component directives.
    */
   readonly template: ComponentTemplate<T>;
 
   /**
    * Query-related instructions for a component.
-   *
-   * NOTE: only used with component directives.
    */
-  queryInstructions: ComponentTemplate<T>|null;
+  readonly viewQuery: ComponentQuery<T>|null;
 
   /**
    * Renderer type data of the component.
-   *
-   * NOTE: only used with component directives.
    */
   readonly rendererType: RendererType2|null;
 

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -159,6 +159,13 @@ export interface ComponentDef<T, Selector extends string> extends DirectiveDef<T
   readonly template: ComponentTemplate<T>;
 
   /**
+   * Query-related instructions for a component.
+   *
+   * NOTE: only used with component directives.
+   */
+  queryInstructions: ComponentTemplate<T>|null;
+
+  /**
    * Renderer type data of the component.
    *
    * NOTE: only used with component directives.

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -201,6 +201,11 @@ export interface TView {
   template: ComponentTemplate<{}>|null;
 
   /**
+   * A function containing query-related instructions.
+   */
+  queryInstructions: ComponentTemplate<{}>|null;
+
+  /**
    * Pointer to the `TNode` that represents the root of the view.
    *
    * If this is a `TNode` for an `LViewNode`, this is an embedded view of a container.

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -10,7 +10,7 @@ import {Injector} from '../../di/injector';
 import {Sanitizer} from '../../sanitization/security';
 
 import {LContainer} from './container';
-import {ComponentTemplate, DirectiveDefInternal, DirectiveDefList, PipeDef, PipeDefList} from './definition';
+import {ComponentQuery, ComponentTemplate, DirectiveDefInternal, DirectiveDefList, PipeDef, PipeDefList} from './definition';
 import {LElementNode, LViewNode, TNode} from './node';
 import {LQueries} from './query';
 import {Renderer3} from './renderer';
@@ -203,7 +203,7 @@ export interface TView {
   /**
    * A function containing query-related instructions.
    */
-  queryInstructions: ComponentTemplate<{}>|null;
+  viewQuery: ComponentQuery<{}>|null;
 
   /**
    * Pointer to the `TNode` that represents the root of the view.

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -189,6 +189,12 @@
     "name": "locateHostElement"
   },
   {
+    "name": "queryCreateInstructions"
+  },
+  {
+    "name": "queryUpdateInstructions"
+  },
+  {
     "name": "refreshChildComponents"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -120,6 +120,9 @@
     "name": "createTextNode"
   },
   {
+    "name": "createViewQuery"
+  },
+  {
     "name": "defineComponent"
   },
   {
@@ -189,12 +192,6 @@
     "name": "locateHostElement"
   },
   {
-    "name": "queryCreateInstructions"
-  },
-  {
-    "name": "queryUpdateInstructions"
-  },
-  {
     "name": "refreshChildComponents"
   },
   {
@@ -226,6 +223,9 @@
   },
   {
     "name": "text"
+  },
+  {
+    "name": "updateViewQuery"
   },
   {
     "name": "viewAttached"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -441,6 +441,12 @@
     "name": "namespaceHTML"
   },
   {
+    "name": "queryCreateInstructions"
+  },
+  {
+    "name": "queryUpdateInstructions"
+  },
+  {
     "name": "queueComponentIndexForCheck"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -267,6 +267,9 @@
     "name": "createTextNode"
   },
   {
+    "name": "createViewQuery"
+  },
+  {
     "name": "defineComponent"
   },
   {
@@ -441,12 +444,6 @@
     "name": "namespaceHTML"
   },
   {
-    "name": "queryCreateInstructions"
-  },
-  {
-    "name": "queryUpdateInstructions"
-  },
-  {
     "name": "queueComponentIndexForCheck"
   },
   {
@@ -553,6 +550,9 @@
   },
   {
     "name": "tickRootContext"
+  },
+  {
+    "name": "updateViewQuery"
   },
   {
     "name": "viewAttached"

--- a/packages/core/test/render3/common_integration_spec.ts
+++ b/packages/core/test/render3/common_integration_spec.ts
@@ -8,11 +8,12 @@
 
 import {NgForOfContext} from '@angular/common';
 
-import {defineComponent} from '../../src/render3/index';
-import {bind, container, elementEnd, elementProperty, elementStart, interpolation1, interpolation3, listener, text, textBinding, tick} from '../../src/render3/instructions';
+import {getOrCreateNodeInjectorForNode, getOrCreateTemplateRef} from '../../src/render3/di';
+import {AttributeMarker, defineComponent} from '../../src/render3/index';
+import {bind, container, elementEnd, elementProperty, elementStart, interpolation1, interpolation3, listener, load, text, textBinding} from '../../src/render3/instructions';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 
-import {NgForOf, NgIf} from './common_with_def';
+import {NgForOf, NgIf, NgTemplateOutlet} from './common_with_def';
 import {ComponentFixture} from './render_util';
 
 describe('@angular/common integration', () => {
@@ -258,6 +259,52 @@ describe('@angular/common integration', () => {
       fixture.component.valueTwo = '$$two$$';
       fixture.update();
       expect(fixture.html).toEqual('<div>$$one$$</div><div>$$two$$</div>');
+    });
+
+  });
+
+  describe('NgTemplateOutlet', () => {
+
+    it('should create and remove embedded views', () => {
+
+      class MyApp {
+        showing = false;
+        static ngComponentDef = defineComponent({
+          type: MyApp,
+          factory: () => new MyApp(),
+          selectors: [['my-app']],
+          /**
+           * <ng-template #tpl>from tpl</ng-template>
+           * <ng-template [ngTemplateOutlet]="showing ? tpl : null"></ng-template>
+           */
+          template: (rf: RenderFlags, myApp: MyApp) => {
+            if (rf & RenderFlags.Create) {
+              container(0, (rf1: RenderFlags) => {
+                if (rf1 & RenderFlags.Create) {
+                  text(0, 'from tpl');
+                }
+              }, undefined, undefined, ['tpl', '']);
+              container(2, undefined, null, [AttributeMarker.SelectOnly, 'ngTemplateOutlet']);
+            }
+            if (rf & RenderFlags.Update) {
+              const tplRef = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(0)));
+              elementProperty(2, 'ngTemplateOutlet', bind(myApp.showing ? tplRef : null));
+            }
+          },
+          directives: () => [NgTemplateOutlet]
+        });
+      }
+
+      const fixture = new ComponentFixture(MyApp);
+      expect(fixture.html).toEqual('');
+
+      fixture.component.showing = true;
+      fixture.update();
+      expect(fixture.html).toEqual('from tpl');
+
+      fixture.component.showing = false;
+      fixture.update();
+      expect(fixture.html).toEqual('');
     });
 
   });

--- a/packages/core/test/render3/common_with_def.ts
+++ b/packages/core/test/render3/common_with_def.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgForOf as NgForOfDef, NgIf as NgIfDef} from '@angular/common';
-import {InjectFlags, IterableDiffers} from '@angular/core';
+import {NgForOf as NgForOfDef, NgIf as NgIfDef, NgTemplateOutlet as NgTemplateOutletDef} from '@angular/common';
+import {IterableDiffers} from '@angular/core';
 
-import {defaultIterableDiffers} from '../../src/change_detection/change_detection';
 import {DirectiveType, NgOnChangesFeature, defineDirective, directiveInject, injectTemplateRef, injectViewContainerRef} from '../../src/render3/index';
 
 export const NgForOf: DirectiveType<NgForOfDef<any>> = NgForOfDef as any;
 export const NgIf: DirectiveType<NgIfDef> = NgIfDef as any;
+export const NgTemplateOutlet: DirectiveType<NgTemplateOutletDef> = NgTemplateOutletDef as any;
 
 NgForOf.ngDirectiveDef = defineDirective({
   type: NgForOfDef,
@@ -32,4 +32,14 @@ NgForOf.ngDirectiveDef = defineDirective({
   selectors: [['', 'ngIf', '']],
   factory: () => new NgIfDef(injectViewContainerRef(), injectTemplateRef()),
   inputs: {ngIf: 'ngIf', ngIfThen: 'ngIfThen', ngIfElse: 'ngIfElse'}
+});
+
+(NgTemplateOutlet as any).ngDirectiveDef = defineDirective({
+  type: NgTemplateOutletDef,
+  selectors: [['', 'ngTemplateOutlet', '']],
+  factory: () => new NgTemplateOutletDef(injectViewContainerRef()),
+  features: [NgOnChangesFeature(
+      {ngTemplateOutlet: 'ngTemplateOutlet', ngTemplateOutletContext: 'ngTemplateOutletContext'})],
+  inputs:
+      {ngTemplateOutlet: 'ngTemplateOutlet', ngTemplateOutletContext: 'ngTemplateOutletContext'}
 });

--- a/packages/core/test/render3/compiler_canonical/query_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/query_spec.ts
@@ -54,13 +54,18 @@ describe('queries', () => {
         factory: function ViewQueryComponent_Factory() { return new ViewQueryComponent(); },
         template: function ViewQueryComponent_Template(
             rf: $RenderFlags$, ctx: $ViewQueryComponent$) {
-          let $tmp$: any;
+          if (rf & 1) {
+            $r3$.ɵEe(2, 'div', $e1_attrs$);
+          }
+        },
+        queryInstructions: function ViewQueryComponent_Query_Instructions(
+            rf: $RenderFlags$, ctx: $ViewQueryComponent$) {
           if (rf & 1) {
             $r3$.ɵQ(0, SomeDirective, false);
             $r3$.ɵQ(1, SomeDirective, false);
-            $r3$.ɵEe(2, 'div', $e1_attrs$);
           }
           if (rf & 2) {
+            let $tmp$: any;
             $r3$.ɵqR($tmp$ = $r3$.ɵld<QueryList<any>>(0)) && (ctx.someDir = $tmp$.first);
             $r3$.ɵqR($tmp$ = $r3$.ɵld<QueryList<any>>(1)) &&
                 (ctx.someDirList = $tmp$ as QueryList<any>);

--- a/packages/core/test/render3/compiler_canonical/query_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/query_spec.ts
@@ -58,8 +58,7 @@ describe('queries', () => {
             $r3$.ɵEe(2, 'div', $e1_attrs$);
           }
         },
-        queryInstructions: function ViewQueryComponent_Query_Instructions(
-            rf: $RenderFlags$, ctx: $ViewQueryComponent$) {
+        viewQuery: function ViewQueryComponent_Query(rf: $RenderFlags$, ctx: $ViewQueryComponent$) {
           if (rf & 1) {
             $r3$.ɵQ(0, SomeDirective, false);
             $r3$.ɵQ(1, SomeDirective, false);

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -1403,8 +1403,8 @@ describe('di', () => {
 
   describe('getOrCreateNodeInjector', () => {
     it('should handle initial undefined state', () => {
-      const contentView =
-          createLViewData(null !, createTView(-1, null, null, null), null, LViewFlags.CheckAlways);
+      const contentView = createLViewData(
+          null !, createTView(-1, null, null, null, null), null, LViewFlags.CheckAlways);
       const oldView = enterView(contentView, null !);
       try {
         const parent = createLNode(0, TNodeType.Element, null, null, null, null);

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -955,7 +955,7 @@ describe('query', () => {
                 elementProperty(1, 'ngForOf', bind(ctx.value));
               }
             },
-            queryInstructions: function(rf: RenderFlags, ctx: Cmpt) {
+            viewQuery: function(rf: RenderFlags, ctx: Cmpt) {
               let tmp: any;
               if (rf & RenderFlags.Create) {
                 query(0, ['foo'], true, QUERY_READ_FROM_NODE);
@@ -1135,7 +1135,7 @@ describe('query', () => {
                  }
 
                },
-               queryInstructions: (rf: RenderFlags, cmpt: Cmpt) => {
+               viewQuery: (rf: RenderFlags, cmpt: Cmpt) => {
                  let tmp: any;
                  if (rf & RenderFlags.Create) {
                    query(0, ['foo'], true, QUERY_READ_FROM_NODE);
@@ -1201,7 +1201,7 @@ describe('query', () => {
               }
             },
             directives: () => [NgTemplateOutlet],
-            queryInstructions: (rf: RenderFlags, myApp: MyApp) => {
+            viewQuery: (rf: RenderFlags, myApp: MyApp) => {
               let tmp: any;
               if (rf & RenderFlags.Create) {
                 query(0, ['foo'], true, QUERY_READ_FROM_NODE);

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -16,7 +16,7 @@ import {bind, container, containerRefreshEnd, containerRefreshStart, element, el
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {query, queryRefresh} from '../../src/render3/query';
 
-import {NgForOf, NgIf} from './common_with_def';
+import {NgForOf, NgIf, NgTemplateOutlet} from './common_with_def';
 import {ComponentFixture, TemplateFixture, createComponent, createDirective, renderComponent} from './render_util';
 
 
@@ -54,640 +54,794 @@ describe('query', () => {
 
     let child1 = null;
     let child2 = null;
-    const Cmp = createComponent('cmp', function(rf: RenderFlags, ctx: any) {
-      /**
-       * <child>
-       *   <child>
-       *   </child>
-       * </child>
-       * class Cmp {
-       *   @ViewChildren(Child) query0;
-       *   @ViewChildren(Child, {descend: true}) query1;
-       * }
-       */
-      let tmp: any;
-      if (rf & RenderFlags.Create) {
-        query(0, Child, false);
-        query(1, Child, true);
-        elementStart(2, 'child');
-        {
-          child1 = loadDirective(0);
-          elementStart(3, 'child');
-          { child2 = loadDirective(1); }
-          elementEnd();
-        }
-        elementEnd();
-      }
-      if (rf & RenderFlags.Update) {
-        queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query0 = tmp as QueryList<any>);
-        queryRefresh(tmp = load<QueryList<any>>(1)) && (ctx.query1 = tmp as QueryList<any>);
-      }
-    }, [Child]);
+    const Cmp = createComponent(
+        'cmp',
+        function(rf: RenderFlags, ctx: any) {
+          /**
+           * <child>
+           *   <child>
+           *   </child>
+           * </child>
+           * class Cmp {
+           *   @ViewChildren(Child) query0;
+           *   @ViewChildren(Child, {descend: true}) query1;
+           * }
+           */
+          if (rf & RenderFlags.Create) {
+            elementStart(2, 'child');
+            { element(3, 'child'); }
+            elementEnd();
+          }
+          if (rf & RenderFlags.Update) {
+            child1 = loadDirective(0);
+            child2 = loadDirective(1);
+          }
+        },
+        [Child], [],
+        function(rf: RenderFlags, ctx: any) {
+          if (rf & RenderFlags.Create) {
+            query(0, Child, false);
+            query(1, Child, true);
+          }
+          if (rf & RenderFlags.Update) {
+            let tmp: any;
+            queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query0 = tmp as QueryList<any>);
+            queryRefresh(tmp = load<QueryList<any>>(1)) && (ctx.query1 = tmp as QueryList<any>);
+          }
+        });
 
     const parent = renderComponent(Cmp);
     expect((parent.query0 as QueryList<any>).toArray()).toEqual([child1]);
     expect((parent.query1 as QueryList<any>).toArray()).toEqual([child1, child2]);
   });
 
-  describe('types predicate', () => {
+  describe('predicate', () => {
+    describe('types', () => {
 
-    it('should query using type predicate and read a specified token', () => {
-      const Child = createDirective('child');
-      let elToQuery;
-      /**
-       * <div child></div>
-       * class Cmpt {
-       *  @ViewChildren(Child, {read: ElementRef}) query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, Child, false, QUERY_READ_ELEMENT_REF);
-          elToQuery = elementStart(1, 'div', ['child', '']);
-          elementEnd();
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
-      }, [Child]);
+      it('should query using type predicate and read a specified token', () => {
+        const Child = createDirective('child');
+        let elToQuery;
+        /**
+         * <div child></div>
+         * class Cmpt {
+         *  @ViewChildren(Child, {read: ElementRef}) query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                elToQuery = elementStart(1, 'div', ['child', '']);
+                elementEnd();
+              }
+            },
+            [Child], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, Child, false, QUERY_READ_ELEMENT_REF);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
 
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(1);
-      expect(isElementRef(qList.first)).toBeTruthy();
-      expect(qList.first.nativeElement).toEqual(elToQuery);
-    });
-
-
-    it('should query using type predicate and read another directive type', () => {
-      const Child = createDirective('child');
-      const OtherChild = createDirective('otherChild');
-      let otherChildInstance;
-      /**
-       * <div child otherChild></div>
-       * class Cmpt {
-       *  @ViewChildren(Child, {read: OtherChild}) query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, Child, false, OtherChild);
-          elementStart(1, 'div', ['child', '', 'otherChild', '']);
-          { otherChildInstance = loadDirective(1); }
-          elementEnd();
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
-      }, [Child, OtherChild]);
-
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(1);
-      expect(qList.first).toBe(otherChildInstance);
-    });
-
-    it('should not add results to query if a requested token cant be read', () => {
-      const Child = createDirective('child');
-      const OtherChild = createDirective('otherChild');
-      /**
-       * <div child></div>
-       * class Cmpt {
-       *  @ViewChildren(Child, {read: OtherChild}) query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, Child, false, OtherChild);
-          elementStart(1, 'div', ['child', '']);
-          elementEnd();
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
-      }, [Child, OtherChild]);
-
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(0);
-    });
-  });
-
-  describe('local names predicate', () => {
-
-    it('should query for a single element and read ElementRef by default', () => {
-
-      let elToQuery;
-      /**
-       * <div #foo></div>
-       * <div></div>
-       * class Cmpt {
-       *  @ViewChildren('foo') query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo'], false, QUERY_READ_FROM_NODE);
-          elToQuery = elementStart(1, 'div', null, ['foo', '']);
-          elementEnd();
-          elementStart(3, 'div');
-          elementEnd();
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(1);
+        expect(isElementRef(qList.first)).toBeTruthy();
+        expect(qList.first.nativeElement).toBe(elToQuery);
       });
 
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(1);
-      expect(qList.first.nativeElement).toEqual(elToQuery);
-    });
+      it('should query using type predicate and read another directive type', () => {
+        const Child = createDirective('child');
+        const OtherChild = createDirective('otherChild');
+        let otherChildInstance;
+        /**
+         * <div child otherChild></div>
+         * class Cmpt {
+         *  @ViewChildren(Child, {read: OtherChild}) query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                elementStart(1, 'div', ['child', '', 'otherChild', '']);
+                { otherChildInstance = loadDirective(1); }
+                elementEnd();
+              }
+            },
+            [Child, OtherChild], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, Child, false, OtherChild);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
 
-    it('should query multiple locals on the same element', () => {
-      let elToQuery;
-
-      /**
-       * <div #foo #bar></div>
-       * <div></div>
-       * class Cmpt {
-       *  @ViewChildren('foo') fooQuery;
-       *  @ViewChildren('bar') barQuery;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo'], false, QUERY_READ_FROM_NODE);
-          query(1, ['bar'], false, QUERY_READ_FROM_NODE);
-          elToQuery = elementStart(2, 'div', null, ['foo', '', 'bar', '']);
-          elementEnd();
-          elementStart(5, 'div');
-          elementEnd();
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.fooQuery = tmp as QueryList<any>);
-          queryRefresh(tmp = load<QueryList<any>>(1)) && (ctx.barQuery = tmp as QueryList<any>);
-        }
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(1);
+        expect(qList.first).toBe(otherChildInstance);
       });
 
-      const cmptInstance = renderComponent(Cmpt);
+      it('should not add results to query if a requested token cant be read', () => {
+        const Child = createDirective('child');
+        const OtherChild = createDirective('otherChild');
+        /**
+         * <div child></div>
+         * class Cmpt {
+         *  @ViewChildren(Child, {read: OtherChild}) query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                elementStart(1, 'div', ['child', '']);
+                elementEnd();
+              }
+            },
+            [Child, OtherChild], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, Child, false, OtherChild);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
 
-      const fooList = (cmptInstance.fooQuery as QueryList<any>);
-      expect(fooList.length).toBe(1);
-      expect(fooList.first.nativeElement).toEqual(elToQuery);
-
-      const barList = (cmptInstance.barQuery as QueryList<any>);
-      expect(barList.length).toBe(1);
-      expect(barList.first.nativeElement).toEqual(elToQuery);
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(0);
+      });
     });
 
-    it('should query for multiple elements and read ElementRef by default', () => {
+    describe('local names', () => {
 
-      let el1ToQuery;
-      let el2ToQuery;
-      /**
-       * <div #foo></div>
-       * <div></div>
-       * <div #bar></div>
-       * class Cmpt {
-       *  @ViewChildren('foo,bar') query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo', 'bar'], undefined, QUERY_READ_FROM_NODE);
-          el1ToQuery = elementStart(1, 'div', null, ['foo', '']);
-          elementEnd();
-          elementStart(3, 'div');
-          elementEnd();
-          el2ToQuery = elementStart(4, 'div', null, ['bar', '']);
-          elementEnd();
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
+      it('should query for a single element and read ElementRef by default', () => {
+
+        let elToQuery;
+        /**
+         * <div #foo></div>
+         * <div></div>
+         * class Cmpt {
+         *  @ViewChildren('foo') query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                elToQuery = elementStart(1, 'div', null, ['foo', '']);
+                elementEnd();
+                elementStart(3, 'div');
+                elementEnd();
+              }
+            },
+            [], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], false, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(1);
+        expect(qList.first.nativeElement).toEqual(elToQuery);
       });
 
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(2);
-      expect(qList.first.nativeElement).toEqual(el1ToQuery);
-      expect(qList.last.nativeElement).toEqual(el2ToQuery);
-    });
+      it('should query multiple locals on the same element', () => {
+        let elToQuery;
 
-    it('should read ElementRef from an element when explicitly asked for', () => {
+        /**
+         * <div #foo #bar></div>
+         * <div></div>
+         * class Cmpt {
+         *  @ViewChildren('foo') fooQuery;
+         *  @ViewChildren('bar') barQuery;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                elToQuery = elementStart(2, 'div', null, ['foo', '', 'bar', '']);
+                elementEnd();
+                elementStart(5, 'div');
+                elementEnd();
+              }
+            },
+            [], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], false, QUERY_READ_FROM_NODE);
+                query(1, ['bar'], false, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) &&
+                    (ctx.fooQuery = tmp as QueryList<any>);
+                queryRefresh(tmp = load<QueryList<any>>(1)) &&
+                    (ctx.barQuery = tmp as QueryList<any>);
+              }
+            });
 
-      let elToQuery;
-      /**
-       * <div #foo></div>
-       * <div></div>
-       * class Cmpt {
-       *  @ViewChildren('foo', {read: ElementRef}) query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo'], false, QUERY_READ_ELEMENT_REF);
-          elToQuery = elementStart(1, 'div', null, ['foo', '']);
-          elementEnd();
-          elementStart(3, 'div');
-          elementEnd();
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
+        const cmptInstance = renderComponent(Cmpt);
+
+        const fooList = (cmptInstance.fooQuery as QueryList<any>);
+        expect(fooList.length).toBe(1);
+        expect(fooList.first.nativeElement).toEqual(elToQuery);
+
+        const barList = (cmptInstance.barQuery as QueryList<any>);
+        expect(barList.length).toBe(1);
+        expect(barList.first.nativeElement).toEqual(elToQuery);
       });
 
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(1);
-      expect(isElementRef(qList.first)).toBeTruthy();
-      expect(qList.first.nativeElement).toEqual(elToQuery);
-    });
+      it('should query for multiple elements and read ElementRef by default', () => {
 
-    it('should read ViewContainerRef from element nodes when explicitly asked for', () => {
-      /**
-       * <div #foo></div>
-       * class Cmpt {
-       *  @ViewChildren('foo', {read: ViewContainerRef}) query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo'], false, QUERY_READ_CONTAINER_REF);
-          elementStart(1, 'div', null, ['foo', '']);
-          elementEnd();
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
+        let el1ToQuery;
+        let el2ToQuery;
+        /**
+         * <div #foo></div>
+         * <div></div>
+         * <div #bar></div>
+         * class Cmpt {
+         *  @ViewChildren('foo,bar') query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                el1ToQuery = elementStart(1, 'div', null, ['foo', '']);
+                elementEnd();
+                elementStart(3, 'div');
+                elementEnd();
+                el2ToQuery = elementStart(4, 'div', null, ['bar', '']);
+                elementEnd();
+              }
+            },
+            [], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo', 'bar'], undefined, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(2);
+        expect(qList.first.nativeElement).toEqual(el1ToQuery);
+        expect(qList.last.nativeElement).toEqual(el2ToQuery);
       });
 
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(1);
-      expect(isViewContainerRef(qList.first)).toBeTruthy();
-    });
+      it('should read ElementRef from an element when explicitly asked for', () => {
 
-    it('should read ViewContainerRef from container nodes when explicitly asked for', () => {
-      /**
-       * <ng-template #foo></ng-template>
-       * class Cmpt {
-       *  @ViewChildren('foo', {read: ViewContainerRef}) query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo'], false, QUERY_READ_CONTAINER_REF);
-          container(1, undefined, undefined, undefined, ['foo', '']);
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
+        let elToQuery;
+        /**
+         * <div #foo></div>
+         * <div></div>
+         * class Cmpt {
+         *  @ViewChildren('foo', {read: ElementRef}) query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                elToQuery = elementStart(1, 'div', null, ['foo', '']);
+                elementEnd();
+                element(3, 'div');
+              }
+            },
+            [], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], false, QUERY_READ_ELEMENT_REF);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(1);
+        expect(isElementRef(qList.first)).toBeTruthy();
+        expect(qList.first.nativeElement).toEqual(elToQuery);
       });
 
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(1);
-      expect(isViewContainerRef(qList.first)).toBeTruthy();
-    });
+      it('should read ViewContainerRef from element nodes when explicitly asked for', () => {
+        /**
+         * <div #foo></div>
+         * class Cmpt {
+         *  @ViewChildren('foo', {read: ViewContainerRef}) query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                element(1, 'div', null, ['foo', '']);
+              }
+            },
+            [], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], false, QUERY_READ_CONTAINER_REF);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
 
-    it('should read ElementRef with a native element pointing to comment DOM node from containers',
-       () => {
-         /**
-          * <ng-template #foo></ng-template>
-          * class Cmpt {
-          *  @ViewChildren('foo', {read: ElementRef}) query;
-          * }
-          */
-         const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-           let tmp: any;
-           if (rf & RenderFlags.Create) {
-             query(0, ['foo'], false, QUERY_READ_ELEMENT_REF);
-             container(1, undefined, undefined, undefined, ['foo', '']);
-           }
-           if (rf & RenderFlags.Update) {
-             queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-           }
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(1);
+        expect(isViewContainerRef(qList.first)).toBeTruthy();
+      });
+
+      it('should read ViewContainerRef from container nodes when explicitly asked for', () => {
+        /**
+         * <ng-template #foo></ng-template>
+         * class Cmpt {
+         *  @ViewChildren('foo', {read: ViewContainerRef}) query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                container(1, undefined, undefined, undefined, ['foo', '']);
+              }
+            },
+            [], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], false, QUERY_READ_CONTAINER_REF);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(1);
+        expect(isViewContainerRef(qList.first)).toBeTruthy();
+      });
+
+      it('should read ElementRef with a native element pointing to comment DOM node from containers',
+         () => {
+           /**
+            * <ng-template #foo></ng-template>
+            * class Cmpt {
+            *  @ViewChildren('foo', {read: ElementRef}) query;
+            * }
+            */
+           const Cmpt = createComponent(
+               'cmpt',
+               function(rf: RenderFlags, ctx: any) {
+                 if (rf & RenderFlags.Create) {
+                   container(1, undefined, undefined, undefined, ['foo', '']);
+                 }
+               },
+               [], [],
+               function(rf: RenderFlags, ctx: any) {
+
+                 if (rf & RenderFlags.Create) {
+                   query(0, ['foo'], false, QUERY_READ_ELEMENT_REF);
+                 }
+                 if (rf & RenderFlags.Update) {
+                   let tmp: any;
+                   queryRefresh(tmp = load<QueryList<any>>(0)) &&
+                       (ctx.query = tmp as QueryList<any>);
+                 }
+               });
+
+           const cmptInstance = renderComponent(Cmpt);
+           const qList = (cmptInstance.query as QueryList<any>);
+           expect(qList.length).toBe(1);
+           expect(isElementRef(qList.first)).toBeTruthy();
+           expect(qList.first.nativeElement.nodeType).toBe(8);  // Node.COMMENT_NODE = 8
          });
 
-         const cmptInstance = renderComponent(Cmpt);
-         const qList = (cmptInstance.query as QueryList<any>);
-         expect(qList.length).toBe(1);
-         expect(isElementRef(qList.first)).toBeTruthy();
-         expect(qList.first.nativeElement.nodeType).toBe(8);  // Node.COMMENT_NODE = 8
-       });
+      it('should read TemplateRef from container nodes by default', () => {
+        // http://plnkr.co/edit/BVpORly8wped9I3xUYsX?p=preview
+        /**
+         * <ng-template #foo></ng-template>
+         * class Cmpt {
+         *  @ViewChildren('foo') query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                container(1, undefined, undefined, undefined, ['foo', '']);
+              }
+            },
+            [], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], undefined, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
 
-    it('should read TemplateRef from container nodes by default', () => {
-      // http://plnkr.co/edit/BVpORly8wped9I3xUYsX?p=preview
-      /**
-       * <ng-template #foo></ng-template>
-       * class Cmpt {
-       *  @ViewChildren('foo') query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo'], undefined, QUERY_READ_FROM_NODE);
-          container(1, undefined, undefined, undefined, ['foo', '']);
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(1);
+        expect(isTemplateRef(qList.first)).toBeTruthy();
       });
 
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(1);
-      expect(isTemplateRef(qList.first)).toBeTruthy();
-    });
 
+      it('should read TemplateRef from container nodes when explicitly asked for', () => {
+        /**
+         * <ng-template #foo></ng-template>
+         * class Cmpt {
+         *  @ViewChildren('foo', {read: TemplateRef}) query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                container(1, undefined, undefined, undefined, ['foo', '']);
+              }
+            },
+            [], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], false, QUERY_READ_TEMPLATE_REF);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
 
-    it('should read TemplateRef from container nodes when explicitly asked for', () => {
-      /**
-       * <ng-template #foo></ng-template>
-       * class Cmpt {
-       *  @ViewChildren('foo', {read: TemplateRef}) query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo'], false, QUERY_READ_TEMPLATE_REF);
-          container(1, undefined, undefined, undefined, ['foo', '']);
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(1);
+        expect(isTemplateRef(qList.first)).toBeTruthy();
       });
 
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(1);
-      expect(isTemplateRef(qList.first)).toBeTruthy();
+      it('should read component instance if element queried for is a component host', () => {
+        const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {});
+
+        let childInstance;
+        /**
+         * <child #foo></child>
+         * class Cmpt {
+         *  @ViewChildren('foo') query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                element(1, 'child', null, ['foo', '']);
+              }
+              if (rf & RenderFlags.Update) {
+                childInstance = loadDirective(0);
+              }
+            },
+            [Child], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], true, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(1);
+        expect(qList.first).toBe(childInstance);
+      });
+
+      it('should read component instance with explicit exportAs', () => {
+        let childInstance: Child;
+
+        class Child {
+          static ngComponentDef = defineComponent({
+            type: Child,
+            selectors: [['child']],
+            factory: () => childInstance = new Child(),
+            template: (rf: RenderFlags, ctx: Child) => {},
+            exportAs: 'child'
+          });
+        }
+
+        /**
+         * <child #foo="child"></child>
+         * class Cmpt {
+         *  @ViewChildren('foo') query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                element(1, 'child', null, ['foo', 'child']);
+              }
+            },
+            [Child], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], true, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(1);
+        expect(qList.first).toBe(childInstance !);
+      });
+
+      it('should read directive instance if element queried for has an exported directive with a matching name',
+         () => {
+           const Child = createDirective('child', {exportAs: 'child'});
+
+           let childInstance;
+           /**
+            * <div #foo="child" child></div>
+            * class Cmpt {
+            *  @ViewChildren('foo') query;
+            * }
+            */
+           const Cmpt = createComponent(
+               'cmpt',
+               function(rf: RenderFlags, ctx: any) {
+                 if (rf & RenderFlags.Create) {
+                   element(1, 'div', ['child', ''], ['foo', 'child']);
+                 }
+                 if (rf & RenderFlags.Update) {
+                   childInstance = loadDirective(0);
+                 }
+               },
+               [Child], [],
+               function(rf: RenderFlags, ctx: any) {
+                 if (rf & RenderFlags.Create) {
+                   query(0, ['foo'], true, QUERY_READ_FROM_NODE);
+                 }
+                 if (rf & RenderFlags.Update) {
+                   let tmp: any;
+                   queryRefresh(tmp = load<QueryList<any>>(0)) &&
+                       (ctx.query = tmp as QueryList<any>);
+                 }
+               });
+
+           const cmptInstance = renderComponent(Cmpt);
+           const qList = (cmptInstance.query as QueryList<any>);
+           expect(qList.length).toBe(1);
+           expect(qList.first).toBe(childInstance);
+         });
+
+      it('should read all matching directive instances from a given element', () => {
+        const Child1 = createDirective('child1', {exportAs: 'child1'});
+        const Child2 = createDirective('child2', {exportAs: 'child2'});
+
+        let child1Instance, child2Instance;
+        /**
+         * <div #foo="child1" child1 #bar="child2" child2></div>
+         * class Cmpt {
+         *  @ViewChildren('foo, bar') query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                element(1, 'div', ['child1', '', 'child2', ''], ['foo', 'child1', 'bar', 'child2']);
+              }
+              if (rf & RenderFlags.Update) {
+                child1Instance = loadDirective(0);
+                child2Instance = loadDirective(1);
+              }
+            },
+            [Child1, Child2], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo', 'bar'], true, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(2);
+        expect(qList.first).toBe(child1Instance);
+        expect(qList.last).toBe(child2Instance);
+      });
+
+      it('should read multiple locals exporting the same directive from a given element', () => {
+        const Child = createDirective('child', {exportAs: 'child'});
+        let childInstance;
+
+        /**
+         * <div child #foo="child" #bar="child"></div>
+         * class Cmpt {
+         *  @ViewChildren('foo') fooQuery;
+         *  @ViewChildren('bar') barQuery;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                element(2, 'div', ['child', ''], ['foo', 'child', 'bar', 'child']);
+              }
+              if (rf & RenderFlags.Update) {
+                childInstance = loadDirective(0);
+              }
+            },
+            [Child], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], true, QUERY_READ_FROM_NODE);
+                query(1, ['bar'], true, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) &&
+                    (ctx.fooQuery = tmp as QueryList<any>);
+                queryRefresh(tmp = load<QueryList<any>>(1)) &&
+                    (ctx.barQuery = tmp as QueryList<any>);
+              }
+            });
+
+        const cmptInstance = renderComponent(Cmpt);
+
+        const fooList = cmptInstance.fooQuery as QueryList<any>;
+        expect(fooList.length).toBe(1);
+        expect(fooList.first).toBe(childInstance);
+
+        const barList = cmptInstance.barQuery as QueryList<any>;
+        expect(barList.length).toBe(1);
+        expect(barList.first).toBe(childInstance);
+      });
+
+      it('should match on exported directive name and read a requested token', () => {
+        const Child = createDirective('child', {exportAs: 'child'});
+
+        let div;
+        /**
+         * <div #foo="child" child></div>
+         * class Cmpt {
+         *  @ViewChildren('foo', {read: ElementRef}) query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                div = elementStart(1, 'div', ['child', ''], ['foo', 'child']);
+                elementEnd();
+              }
+            },
+            [Child], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], undefined, QUERY_READ_ELEMENT_REF);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(1);
+        expect(qList.first.nativeElement).toBe(div);
+      });
+
+      it('should support reading a mix of ElementRef and directive instances', () => {
+        const Child = createDirective('child', {exportAs: 'child'});
+
+        let childInstance, div;
+        /**
+         * <div #foo #bar="child" child></div>
+         * class Cmpt {
+         *  @ViewChildren('foo, bar') query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                div = elementStart(1, 'div', ['child', ''], ['foo', '', 'bar', 'child']);
+                elementEnd();
+              }
+              if (rf & RenderFlags.Update) {
+                childInstance = loadDirective(0);
+              }
+            },
+            [Child], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo', 'bar'], undefined, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(2);
+        expect(qList.first.nativeElement).toBe(div);
+        expect(qList.last).toBe(childInstance);
+      });
+
+      it('should not add results to query if a requested token cant be read', () => {
+        const Child = createDirective('child');
+
+        /**
+         * <div #foo></div>
+         * class Cmpt {
+         *  @ViewChildren('foo', {read: Child}) query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                element(1, 'div', ['foo', '']);
+              }
+            },
+            [Child], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], false, Child);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(0);
+      });
+
     });
-
-    it('should read component instance if element queried for is a component host', () => {
-      const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {});
-
-      let childInstance;
-      /**
-       * <child #foo></child>
-       * class Cmpt {
-       *  @ViewChildren('foo') query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo'], true, QUERY_READ_FROM_NODE);
-          elementStart(1, 'child', null, ['foo', '']);
-          { childInstance = loadDirective(0); }
-          elementEnd();
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
-      }, [Child]);
-
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(1);
-      expect(qList.first).toBe(childInstance);
-    });
-
-    it('should read component instance with explicit exportAs', () => {
-      let childInstance: Child;
-
-      class Child {
-        static ngComponentDef = defineComponent({
-          type: Child,
-          selectors: [['child']],
-          factory: () => childInstance = new Child(),
-          template: (rf: RenderFlags, ctx: Child) => {},
-          exportAs: 'child'
-        });
-      }
-
-      /**
-       * <child #foo="child"></child>
-       * class Cmpt {
-       *  @ViewChildren('foo') query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo'], true, QUERY_READ_FROM_NODE);
-          elementStart(1, 'child', null, ['foo', 'child']);
-          elementEnd();
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
-      }, [Child]);
-
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(1);
-      expect(qList.first).toBe(childInstance !);
-    });
-
-    it('should read directive instance if element queried for has an exported directive with a matching name',
-       () => {
-         const Child = createDirective('child', {exportAs: 'child'});
-
-         let childInstance;
-         /**
-          * <div #foo="child" child></div>
-          * class Cmpt {
-          *  @ViewChildren('foo') query;
-          * }
-          */
-         const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-           let tmp: any;
-           if (rf & RenderFlags.Create) {
-             query(0, ['foo'], true, QUERY_READ_FROM_NODE);
-             elementStart(1, 'div', ['child', ''], ['foo', 'child']);
-             childInstance = loadDirective(0);
-             elementEnd();
-           }
-           if (rf & RenderFlags.Update) {
-             queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-           }
-         }, [Child]);
-
-         const cmptInstance = renderComponent(Cmpt);
-         const qList = (cmptInstance.query as QueryList<any>);
-         expect(qList.length).toBe(1);
-         expect(qList.first).toBe(childInstance);
-       });
-
-    it('should read all matching directive instances from a given element', () => {
-      const Child1 = createDirective('child1', {exportAs: 'child1'});
-      const Child2 = createDirective('child2', {exportAs: 'child2'});
-
-      let child1Instance, child2Instance;
-      /**
-       * <div #foo="child1" child1 #bar="child2" child2></div>
-       * class Cmpt {
-       *  @ViewChildren('foo, bar') query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo', 'bar'], true, QUERY_READ_FROM_NODE);
-          elementStart(1, 'div', ['child1', '', 'child2', ''], ['foo', 'child1', 'bar', 'child2']);
-          {
-            child1Instance = loadDirective(0);
-            child2Instance = loadDirective(1);
-          }
-          elementEnd();
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
-      }, [Child1, Child2]);
-
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(2);
-      expect(qList.first).toBe(child1Instance);
-      expect(qList.last).toBe(child2Instance);
-    });
-
-    it('should read multiple locals exporting the same directive from a given element', () => {
-      const Child = createDirective('child', {exportAs: 'child'});
-      let childInstance;
-
-      /**
-       * <div child #foo="child" #bar="child"></div>
-       * class Cmpt {
-       *  @ViewChildren('foo') fooQuery;
-       *  @ViewChildren('bar') barQuery;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo'], true, QUERY_READ_FROM_NODE);
-          query(1, ['bar'], true, QUERY_READ_FROM_NODE);
-          elementStart(2, 'div', ['child', ''], ['foo', 'child', 'bar', 'child']);
-          { childInstance = loadDirective(0); }
-          elementEnd();
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.fooQuery = tmp as QueryList<any>);
-          queryRefresh(tmp = load<QueryList<any>>(1)) && (ctx.barQuery = tmp as QueryList<any>);
-        }
-      }, [Child]);
-
-      const cmptInstance = renderComponent(Cmpt);
-
-      const fooList = cmptInstance.fooQuery as QueryList<any>;
-      expect(fooList.length).toBe(1);
-      expect(fooList.first).toBe(childInstance);
-
-      const barList = cmptInstance.barQuery as QueryList<any>;
-      expect(barList.length).toBe(1);
-      expect(barList.first).toBe(childInstance);
-    });
-
-    it('should match on exported directive name and read a requested token', () => {
-      const Child = createDirective('child', {exportAs: 'child'});
-
-      let div;
-      /**
-       * <div #foo="child" child></div>
-       * class Cmpt {
-       *  @ViewChildren('foo', {read: ElementRef}) query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo'], undefined, QUERY_READ_ELEMENT_REF);
-          div = elementStart(1, 'div', ['child', ''], ['foo', 'child']);
-          elementEnd();
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
-      }, [Child]);
-
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(1);
-      expect(qList.first.nativeElement).toBe(div);
-    });
-
-    it('should support reading a mix of ElementRef and directive instances', () => {
-      const Child = createDirective('child', {exportAs: 'child'});
-
-      let childInstance, div;
-      /**
-       * <div #foo #bar="child" child></div>
-       * class Cmpt {
-       *  @ViewChildren('foo, bar') query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo', 'bar'], undefined, QUERY_READ_FROM_NODE);
-          div = elementStart(1, 'div', ['child', ''], ['foo', '', 'bar', 'child']);
-          { childInstance = loadDirective(0); }
-          elementEnd();
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
-      }, [Child]);
-
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(2);
-      expect(qList.first.nativeElement).toBe(div);
-      expect(qList.last).toBe(childInstance);
-    });
-
-    it('should not add results to query if a requested token cant be read', () => {
-      const Child = createDirective('child');
-
-      /**
-       * <div #foo></div>
-       * class Cmpt {
-       *  @ViewChildren('foo', {read: Child}) query;
-       * }
-       */
-      const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo'], false, Child);
-          elementStart(1, 'div', ['foo', '']);
-          elementEnd();
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-        }
-      }, [Child]);
-
-      const cmptInstance = renderComponent(Cmpt);
-      const qList = (cmptInstance.query as QueryList<any>);
-      expect(qList.length).toBe(0);
-    });
-
   });
 
   describe('view boundaries', () => {
@@ -729,22 +883,31 @@ describe('query', () => {
          *  @ViewChildren('foo') query;
          * }
          */
-        const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-          let tmp: any;
-          if (rf & RenderFlags.Create) {
-            query(0, ['foo'], true, QUERY_READ_FROM_NODE);
-            container(1, (rf1: RenderFlags, ctx1: any) => {
-              if (rf1 & RenderFlags.Create) {
-                elementStart(0, 'div', null, ['foo', '']);
-                elementEnd();
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                container(1, (rf1: RenderFlags, ctx1: any) => {
+                  if (rf1 & RenderFlags.Create) {
+                    elementStart(0, 'div', null, ['foo', '']);
+                    elementEnd();
+                  }
+                }, null, ['ngIf', '']);
               }
-            }, null, ['ngIf', '']);
-          }
-          if (rf & RenderFlags.Update) {
-            elementProperty(1, 'ngIf', bind(ctx.value));
-            queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-          }
-        }, [NgIf]);
+              if (rf & RenderFlags.Update) {
+                elementProperty(1, 'ngIf', bind(ctx.value));
+              }
+            },
+            [NgIf], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], true, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
 
         const fixture = new ComponentFixture(Cmpt);
         const qList = fixture.component.query;
@@ -769,25 +932,41 @@ describe('query', () => {
          *  @ViewChildren('foo') query;
          * }
          */
-        const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-          let tmp: any;
-          if (rf & RenderFlags.Create) {
-            query(0, ['foo'], true, QUERY_READ_FROM_NODE);
-            container(1, (rf1: RenderFlags, row: NgForOfContext<string>) => {
-              if (rf1 & RenderFlags.Create) {
-                elementStart(0, 'div', null, ['foo', '']);
-                elementEnd();
+        class Cmpt {
+          value: string[];
+          query: any;
+          static ngComponentDef = defineComponent({
+            type: Cmpt,
+            factory: () => new Cmpt(),
+            selectors: [['my-app']],
+            template: function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                container(1, (rf1: RenderFlags, row: NgForOfContext<string>) => {
+                  if (rf1 & RenderFlags.Create) {
+                    elementStart(0, 'div', null, ['foo', '']);
+                    elementEnd();
+                  }
+                  if (rf1 & RenderFlags.Update) {
+                    elementProperty(0, 'id', bind(row.$implicit));
+                  }
+                }, null, ['ngForOf', '']);
               }
-              if (rf1 & RenderFlags.Update) {
-                elementProperty(0, 'id', bind(row.$implicit));
+              if (rf & RenderFlags.Update) {
+                elementProperty(1, 'ngForOf', bind(ctx.value));
               }
-            }, null, ['ngForOf', '']);
-          }
-          if (rf & RenderFlags.Update) {
-            elementProperty(1, 'ngForOf', bind(ctx.value));
-            queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-          }
-        }, [NgForOf]);
+            },
+            queryInstructions: function(rf: RenderFlags, ctx: Cmpt) {
+              let tmp: any;
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], true, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            },
+            directives: () => [NgForOf]
+          });
+        }
 
         const fixture = new ComponentFixture(Cmpt);
         const qList = fixture.component.query;
@@ -795,14 +974,10 @@ describe('query', () => {
 
         fixture.component.value = ['a', 'b', 'c'];
         fixture.update();
-        fixture
-            .update();  // invoking CD twice due to https://github.com/angular/angular/issues/23707
         expect(qList.length).toBe(3);
 
         fixture.component.value.splice(1, 1);  // remove "b"
         fixture.update();
-        fixture
-            .update();  // invoking CD twice due to https://github.com/angular/angular/issues/23707
         expect(qList.length).toBe(2);
 
         // make sure that a proper element was removed from query results
@@ -831,44 +1006,53 @@ describe('query', () => {
             *
             * <ng-template viewInserter #vi="vi"></ng-template>
             */
-           const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-             let tmp: any;
-             if (rf & RenderFlags.Create) {
-               query(0, ['foo'], true, QUERY_READ_FROM_NODE);
-
-               container(1, (rf: RenderFlags, ctx: {idx: number}) => {
+           const Cmpt = createComponent(
+               'cmpt',
+               function(rf: RenderFlags, ctx: any) {
                  if (rf & RenderFlags.Create) {
-                   elementStart(0, 'div', null, ['foo', '']);
+                   container(1, (rf: RenderFlags, ctx: {idx: number}) => {
+                     if (rf & RenderFlags.Create) {
+                       elementStart(0, 'div', null, ['foo', '']);
+                       elementEnd();
+                     }
+                     if (rf & RenderFlags.Update) {
+                       elementProperty(0, 'id', bind('foo1_' + ctx.idx));
+                     }
+                   }, null, []);
+
+                   elementStart(2, 'div', ['id', 'middle'], ['foo', '']);
                    elementEnd();
+
+                   container(4, (rf: RenderFlags, ctx: {idx: number}) => {
+                     if (rf & RenderFlags.Create) {
+                       elementStart(0, 'div', null, ['foo', '']);
+                       elementEnd();
+                     }
+                     if (rf & RenderFlags.Update) {
+                       elementProperty(0, 'id', bind('foo2_' + ctx.idx));
+                     }
+                   }, null, []);
+
+                   container(5, undefined, null, [AttributeMarker.SelectOnly, 'vc']);
+                 }
+
+                 if (rf & RenderFlags.Update) {
+                   tpl1 = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(1)));
+                   tpl2 = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(4)));
+                 }
+
+               },
+               [ViewContainerManipulatorDirective], [],
+               function(rf: RenderFlags, ctx: any) {
+                 if (rf & RenderFlags.Create) {
+                   query(0, ['foo'], true, QUERY_READ_FROM_NODE);
                  }
                  if (rf & RenderFlags.Update) {
-                   elementProperty(0, 'id', bind('foo1_' + ctx.idx));
+                   let tmp: any;
+                   queryRefresh(tmp = load<QueryList<any>>(0)) &&
+                       (ctx.query = tmp as QueryList<any>);
                  }
-               }, null, []);
-
-               elementStart(2, 'div', ['id', 'middle'], ['foo', '']);
-               elementEnd();
-
-               container(4, (rf: RenderFlags, ctx: {idx: number}) => {
-                 if (rf & RenderFlags.Create) {
-                   elementStart(0, 'div', null, ['foo', '']);
-                   elementEnd();
-                 }
-                 if (rf & RenderFlags.Update) {
-                   elementProperty(0, 'id', bind('foo2_' + ctx.idx));
-                 }
-               }, null, []);
-
-               container(5, undefined, null, [AttributeMarker.SelectOnly, 'vc']);
-             }
-
-             if (rf & RenderFlags.Update) {
-               tpl1 = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(1)));
-               tpl2 = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(4)));
-               queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-             }
-
-           }, [ViewContainerManipulatorDirective]);
+               });
 
            const fixture = new ComponentFixture(Cmpt);
            const qList = fixture.component.query;
@@ -923,32 +1107,47 @@ describe('query', () => {
             * <ng-template viewInserter #vi1="vi"></ng-template>
             * <ng-template viewInserter #vi2="vi"></ng-template>
             */
-           const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-             let tmp: any;
-             if (rf & RenderFlags.Create) {
-               query(0, ['foo'], true, QUERY_READ_FROM_NODE);
-
-               container(1, (rf: RenderFlags, ctx: {idx: number, container_idx: number}) => {
+           class Cmpt {
+             query: any;
+             static ngComponentDef = defineComponent({
+               type: Cmpt,
+               factory: () => new Cmpt(),
+               selectors: [['my-app']],
+               template: function(rf: RenderFlags, ctx: any) {
+                 let tmp: any;
                  if (rf & RenderFlags.Create) {
-                   elementStart(0, 'div', null, ['foo', '']);
-                   elementEnd();
+                   container(1, (rf: RenderFlags, ctx: {idx: number, container_idx: number}) => {
+                     if (rf & RenderFlags.Create) {
+                       elementStart(0, 'div', null, ['foo', '']);
+                       elementEnd();
+                     }
+                     if (rf & RenderFlags.Update) {
+                       elementProperty(0, 'id', bind('foo_' + ctx.container_idx + '_' + ctx.idx));
+                     }
+                   }, null, []);
+
+                   container(2, undefined, null, [AttributeMarker.SelectOnly, 'vc']);
+                   container(3, undefined, null, [AttributeMarker.SelectOnly, 'vc']);
+                 }
+
+                 if (rf & RenderFlags.Update) {
+                   tpl = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(1)));
+                 }
+
+               },
+               queryInstructions: (rf: RenderFlags, cmpt: Cmpt) => {
+                 let tmp: any;
+                 if (rf & RenderFlags.Create) {
+                   query(0, ['foo'], true, QUERY_READ_FROM_NODE);
                  }
                  if (rf & RenderFlags.Update) {
-                   elementProperty(0, 'id', bind('foo_' + ctx.container_idx + '_' + ctx.idx));
+                   queryRefresh(tmp = load<QueryList<any>>(0)) &&
+                       (cmpt.query = tmp as QueryList<any>);
                  }
-               }, null, []);
-
-               container(2, undefined, null, [AttributeMarker.SelectOnly, 'vc']);
-               container(3, undefined, null, [AttributeMarker.SelectOnly, 'vc']);
-             }
-
-             if (rf & RenderFlags.Update) {
-               tpl = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(1)));
-               queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-             }
-
-           }, [ViewContainerManipulatorDirective]);
-
+               },
+               directives: () => [ViewContainerManipulatorDirective],
+             });
+           }
            const fixture = new ComponentFixture(Cmpt);
            const qList = fixture.component.query;
 
@@ -972,6 +1171,64 @@ describe('query', () => {
            fixture.update();
            expect(qList.length).toBe(0);
          });
+
+      // https://stackblitz.com/edit/angular-wpd6gv?file=src%2Fapp%2Fapp.component.ts
+      it('should report results from views inserted in a lifecycle hook', () => {
+
+        class MyApp {
+          show = false;
+          query: any;
+          static ngComponentDef = defineComponent({
+            type: MyApp,
+            factory: () => new MyApp(),
+            selectors: [['my-app']],
+            /**
+             * <ng-template #tpl><span #foo id="from_tpl">from tpl</span></ng-template>
+             * <ng-template [ngTemplateOutlet]="show ? tpl : null"></ng-template>
+             */
+            template: (rf: RenderFlags, myApp: MyApp) => {
+              if (rf & RenderFlags.Create) {
+                container(1, (rf1: RenderFlags) => {
+                  if (rf1 & RenderFlags.Create) {
+                    element(0, 'span', ['id', 'from_tpl'], ['foo', '']);
+                  }
+                }, undefined, undefined, ['tpl', '']);
+                container(3, undefined, null, [AttributeMarker.SelectOnly, 'ngTemplateOutlet']);
+              }
+              if (rf & RenderFlags.Update) {
+                const tplRef = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(1)));
+                elementProperty(3, 'ngTemplateOutlet', bind(myApp.show ? tplRef : null));
+              }
+            },
+            directives: () => [NgTemplateOutlet],
+            queryInstructions: (rf: RenderFlags, myApp: MyApp) => {
+              let tmp: any;
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], true, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                queryRefresh(tmp = load<QueryList<any>>(0)) &&
+                    (myApp.query = tmp as QueryList<any>);
+              }
+            }
+          });
+        }
+
+        const fixture = new ComponentFixture(MyApp);
+        const qList = fixture.component.query;
+
+        expect(qList.length).toBe(0);
+
+        fixture.component.show = true;
+        fixture.update();
+        expect(qList.length).toBe(1);
+        expect(qList.first.nativeElement.id).toBe('from_tpl');
+
+        fixture.component.show = false;
+        fixture.update();
+        expect(qList.length).toBe(0);
+      });
+
     });
 
     describe('JS blocks', () => {
@@ -986,30 +1243,39 @@ describe('query', () => {
          *  @ViewChildren('foo') query;
          * }
          */
-        const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-          let tmp: any;
-          if (rf & RenderFlags.Create) {
-            query(0, ['foo'], true, QUERY_READ_FROM_NODE);
-            container(1);
-          }
-          if (rf & RenderFlags.Update) {
-            containerRefreshStart(1);
-            {
-              if (ctx.exp) {
-                let rf1 = embeddedViewStart(1);
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                container(1);
+              }
+              if (rf & RenderFlags.Update) {
+                containerRefreshStart(1);
                 {
-                  if (rf1 & RenderFlags.Create) {
-                    firstEl = elementStart(0, 'div', null, ['foo', '']);
-                    elementEnd();
+                  if (ctx.exp) {
+                    let rf1 = embeddedViewStart(1);
+                    {
+                      if (rf1 & RenderFlags.Create) {
+                        firstEl = elementStart(0, 'div', null, ['foo', '']);
+                        elementEnd();
+                      }
+                    }
+                    embeddedViewEnd();
                   }
                 }
-                embeddedViewEnd();
+                containerRefreshEnd();
               }
-            }
-            containerRefreshEnd();
-            queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-          }
-        });
+            },
+            [], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], true, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
 
         const cmptInstance = renderComponent(Cmpt);
         const qList = (cmptInstance.query as any);
@@ -1038,34 +1304,44 @@ describe('query', () => {
             *  @ViewChildren('foo') query;
             * }
             */
-           const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-             let tmp: any;
-             if (rf & RenderFlags.Create) {
-               query(0, ['foo'], true, QUERY_READ_FROM_NODE);
-               firstEl = elementStart(1, 'span', null, ['foo', '']);
-               elementEnd();
-               container(3);
-               lastEl = elementStart(4, 'span', null, ['foo', '']);
-               elementEnd();
-             }
-             if (rf & RenderFlags.Update) {
-               containerRefreshStart(3);
-               {
-                 if (ctx.exp) {
-                   let rf1 = embeddedViewStart(1);
+           const Cmpt = createComponent(
+               'cmpt',
+               function(rf: RenderFlags, ctx: any) {
+                 if (rf & RenderFlags.Create) {
+                   firstEl = elementStart(1, 'span', null, ['foo', '']);
+                   elementEnd();
+                   container(3);
+                   lastEl = elementStart(4, 'span', null, ['foo', '']);
+                   elementEnd();
+                 }
+                 if (rf & RenderFlags.Update) {
+                   containerRefreshStart(3);
                    {
-                     if (rf1 & RenderFlags.Create) {
-                       viewEl = elementStart(0, 'div', null, ['foo', '']);
-                       elementEnd();
+                     if (ctx.exp) {
+                       let rf1 = embeddedViewStart(1);
+                       {
+                         if (rf1 & RenderFlags.Create) {
+                           viewEl = elementStart(0, 'div', null, ['foo', '']);
+                           elementEnd();
+                         }
+                       }
+                       embeddedViewEnd();
                      }
                    }
-                   embeddedViewEnd();
+                   containerRefreshEnd();
                  }
-               }
-               containerRefreshEnd();
-               queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-             }
-           });
+               },
+               [], [],
+               function(rf: RenderFlags, ctx: any) {
+                 if (rf & RenderFlags.Create) {
+                   query(0, ['foo'], true, QUERY_READ_FROM_NODE);
+                 }
+                 if (rf & RenderFlags.Update) {
+                   let tmp: any;
+                   queryRefresh(tmp = load<QueryList<any>>(0)) &&
+                       (ctx.query = tmp as QueryList<any>);
+                 }
+               });
 
            const cmptInstance = renderComponent(Cmpt);
            const qList = (cmptInstance.query as any);
@@ -1099,40 +1375,49 @@ describe('query', () => {
          *  @ViewChildren('foo') query;
          * }
          */
-        const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-          let tmp: any;
-          if (rf & RenderFlags.Create) {
-            query(0, ['foo'], true, QUERY_READ_FROM_NODE);
-            container(1);
-          }
-          if (rf & RenderFlags.Update) {
-            containerRefreshStart(1);
-            {
-              if (ctx.exp1) {
-                let rf0 = embeddedViewStart(0);
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                container(1);
+              }
+              if (rf & RenderFlags.Update) {
+                containerRefreshStart(1);
                 {
-                  if (rf0 & RenderFlags.Create) {
-                    firstEl = elementStart(0, 'div', null, ['foo', '']);
-                    elementEnd();
+                  if (ctx.exp1) {
+                    let rf0 = embeddedViewStart(0);
+                    {
+                      if (rf0 & RenderFlags.Create) {
+                        firstEl = elementStart(0, 'div', null, ['foo', '']);
+                        elementEnd();
+                      }
+                    }
+                    embeddedViewEnd();
+                  }
+                  if (ctx.exp2) {
+                    let rf1 = embeddedViewStart(1);
+                    {
+                      if (rf1 & RenderFlags.Create) {
+                        lastEl = elementStart(0, 'span', null, ['foo', '']);
+                        elementEnd();
+                      }
+                    }
+                    embeddedViewEnd();
                   }
                 }
-                embeddedViewEnd();
+                containerRefreshEnd();
               }
-              if (ctx.exp2) {
-                let rf1 = embeddedViewStart(1);
-                {
-                  if (rf1 & RenderFlags.Create) {
-                    lastEl = elementStart(0, 'span', null, ['foo', '']);
-                    elementEnd();
-                  }
-                }
-                embeddedViewEnd();
+            },
+            [], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], true, QUERY_READ_FROM_NODE);
               }
-            }
-            containerRefreshEnd();
-            queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-          }
-        });
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
 
         const cmptInstance = renderComponent(Cmpt);
         const qList = (cmptInstance.query as any);
@@ -1163,47 +1448,56 @@ describe('query', () => {
          *  @ViewChildren('foo') query;
          * }
          */
-        const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-          let tmp: any;
-          if (rf & RenderFlags.Create) {
-            query(0, ['foo'], true, QUERY_READ_FROM_NODE);
-            container(1);
-          }
-          if (rf & RenderFlags.Update) {
-            containerRefreshStart(1);
-            {
-              if (ctx.exp1) {
-                let rf0 = embeddedViewStart(0);
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                container(1);
+              }
+              if (rf & RenderFlags.Update) {
+                containerRefreshStart(1);
                 {
-                  if (rf0 & RenderFlags.Create) {
-                    firstEl = elementStart(0, 'div', null, ['foo', '']);
-                    elementEnd();
-                    container(2);
-                  }
-                  if (rf0 & RenderFlags.Update) {
-                    containerRefreshStart(2);
+                  if (ctx.exp1) {
+                    let rf0 = embeddedViewStart(0);
                     {
-                      if (ctx.exp2) {
-                        let rf2 = embeddedViewStart(0);
+                      if (rf0 & RenderFlags.Create) {
+                        firstEl = elementStart(0, 'div', null, ['foo', '']);
+                        elementEnd();
+                        container(2);
+                      }
+                      if (rf0 & RenderFlags.Update) {
+                        containerRefreshStart(2);
                         {
-                          if (rf2) {
-                            lastEl = elementStart(0, 'span', null, ['foo', '']);
-                            elementEnd();
+                          if (ctx.exp2) {
+                            let rf2 = embeddedViewStart(0);
+                            {
+                              if (rf2) {
+                                lastEl = elementStart(0, 'span', null, ['foo', '']);
+                                elementEnd();
+                              }
+                            }
+                            embeddedViewEnd();
                           }
                         }
-                        embeddedViewEnd();
+                        containerRefreshEnd();
                       }
                     }
-                    containerRefreshEnd();
+                    embeddedViewEnd();
                   }
                 }
-                embeddedViewEnd();
+                containerRefreshEnd();
               }
-            }
-            containerRefreshEnd();
-            queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
-          }
-        });
+            },
+            [], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], true, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
 
         const cmptInstance = renderComponent(Cmpt);
         const qList = (cmptInstance.query as any);
@@ -1221,44 +1515,59 @@ describe('query', () => {
         expect(qList.last.nativeElement).toBe(lastEl);
       });
 
+      /**
+       * What is tested here can't be achieved in the Renderer2 as all view queries are deep by
+       * default and can't be marked as shallow by a user.
+       */
       it('should support combination of deep and shallow queries', () => {
         /**
-         * <ng-template [ngIf]="exp">
+         * % if (exp) { ">
          *    <div #foo></div>
-         * </ng-template>
+         * % }
          * <span #foo></span>
          * class Cmpt {
-         *  @ViewChildren('foo') query;
+         *  @ViewChildren('foo') deep;
+         *  @ViewChildren('foo') shallow;
          * }
          */
-        const Cmpt = createComponent('cmpt', function(rf: RenderFlags, ctx: any) {
-          let tmp: any;
-          if (rf & RenderFlags.Create) {
-            query(0, ['foo'], true, QUERY_READ_FROM_NODE);
-            query(1, ['foo'], false, QUERY_READ_FROM_NODE);
-            container(2);
-            elementStart(3, 'span', null, ['foo', '']);
-            elementEnd();
-          }
-          if (rf & RenderFlags.Update) {
-            containerRefreshStart(2);
-            {
-              if (ctx.exp) {
-                let rf0 = embeddedViewStart(0);
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                container(2);
+                elementStart(3, 'span', null, ['foo', '']);
+                elementEnd();
+              }
+              if (rf & RenderFlags.Update) {
+                containerRefreshStart(2);
                 {
-                  if (rf0 & RenderFlags.Create) {
-                    elementStart(0, 'div', null, ['foo', '']);
-                    elementEnd();
+                  if (ctx.exp) {
+                    let rf0 = embeddedViewStart(0);
+                    {
+                      if (rf0 & RenderFlags.Create) {
+                        elementStart(0, 'div', null, ['foo', '']);
+                        elementEnd();
+                      }
+                    }
+                    embeddedViewEnd();
                   }
                 }
-                embeddedViewEnd();
+                containerRefreshEnd();
               }
-            }
-            containerRefreshEnd();
-            queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.deep = tmp as QueryList<any>);
-            queryRefresh(tmp = load<QueryList<any>>(1)) && (ctx.shallow = tmp as QueryList<any>);
-          }
-        });
+            },
+            [], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], true, QUERY_READ_FROM_NODE);
+                query(1, ['foo'], false, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.deep = tmp as QueryList<any>);
+                queryRefresh(tmp = load<QueryList<any>>(1)) &&
+                    (ctx.shallow = tmp as QueryList<any>);
+              }
+            });
 
         const cmptInstance = renderComponent(Cmpt);
         const deep = (cmptInstance.deep as any);
@@ -1316,15 +1625,21 @@ describe('query', () => {
     it('should be destroyed when the containing view is destroyed', () => {
       let queryInstance: QueryList<any>;
 
-      const SimpleComponentWithQuery =
-          createComponent('some-component-with-query', function(rf: RenderFlags, ctx: any) {
-            let tmp: any;
+      const SimpleComponentWithQuery = createComponent(
+          'some-component-with-query',
+          function(rf: RenderFlags, ctx: any) {
             if (rf & RenderFlags.Create) {
-              query(0, ['foo'], false, QUERY_READ_FROM_NODE);
               elementStart(1, 'div', null, ['foo', '']);
               elementEnd();
             }
+          },
+          [], [],
+          function(rf: RenderFlags, ctx: any) {
+            if (rf & RenderFlags.Create) {
+              query(0, ['foo'], false, QUERY_READ_FROM_NODE);
+            }
             if (rf & RenderFlags.Update) {
+              let tmp: any;
               queryRefresh(tmp = load<QueryList<any>>(0)) &&
                   (ctx.query = queryInstance = tmp as QueryList<any>);
             }
@@ -1404,19 +1719,26 @@ describe('query', () => {
        *  @ViewChildren('foo, bar') foos;
        * }
        */
-      const AppComponent = createComponent('app-component', function(rf: RenderFlags, ctx: any) {
-        let tmp: any;
-        if (rf & RenderFlags.Create) {
-          query(0, ['foo', 'bar'], true, QUERY_READ_FROM_NODE);
-          elementStart(1, 'with-content');
-          { element(2, 'div', null, ['foo', '']); }
-          elementEnd();
-          element(4, 'div', ['id', 'after'], ['bar', '']);
-        }
-        if (rf & RenderFlags.Update) {
-          queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.foos = tmp as QueryList<any>);
-        }
-      }, [WithContentComponent]);
+      const AppComponent = createComponent(
+          'app-component',
+          function(rf: RenderFlags, ctx: any) {
+            if (rf & RenderFlags.Create) {
+              elementStart(1, 'with-content');
+              { element(2, 'div', null, ['foo', '']); }
+              elementEnd();
+              element(4, 'div', ['id', 'after'], ['bar', '']);
+            }
+          },
+          [WithContentComponent], [],
+          function(rf: RenderFlags, ctx: any) {
+            if (rf & RenderFlags.Create) {
+              query(0, ['foo', 'bar'], true, QUERY_READ_FROM_NODE);
+            }
+            if (rf & RenderFlags.Update) {
+              let tmp: any;
+              queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.foos = tmp as QueryList<any>);
+            }
+          });
 
       const fixture = new ComponentFixture(AppComponent);
       const viewQList = fixture.component.foos;

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -228,7 +228,8 @@ export function toHtml<T>(componentOrElement: T | RElement): string {
 
 export function createComponent(
     name: string, template: ComponentTemplate<any>, directives: DirectiveTypesOrFactory = [],
-    pipes: PipeTypesOrFactory = []): ComponentType<any> {
+    pipes: PipeTypesOrFactory = [],
+    queryInstructions: ComponentTemplate<any>| null = null): ComponentType<any> {
   return class Component {
     value: any;
     static ngComponentDef = defineComponent({
@@ -236,6 +237,7 @@ export function createComponent(
       selectors: [[name]],
       factory: () => new Component,
       template: template,
+      queryInstructions: queryInstructions,
       features: [PublicFeature],
       directives: directives,
       pipes: pipes

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -229,7 +229,7 @@ export function toHtml<T>(componentOrElement: T | RElement): string {
 export function createComponent(
     name: string, template: ComponentTemplate<any>, directives: DirectiveTypesOrFactory = [],
     pipes: PipeTypesOrFactory = [],
-    queryInstructions: ComponentTemplate<any>| null = null): ComponentType<any> {
+    viewQuery: ComponentTemplate<any>| null = null): ComponentType<any> {
   return class Component {
     value: any;
     static ngComponentDef = defineComponent({
@@ -237,7 +237,7 @@ export function createComponent(
       selectors: [[name]],
       factory: () => new Component,
       template: template,
-      queryInstructions: queryInstructions,
+      viewQuery: viewQuery,
       features: [PublicFeature],
       directives: directives,
       pipes: pipes


### PR DESCRIPTION
This PR changes how we generate code for view queries. 

Previously query-related instructions (create, refresh) were part of component's template function. Unfortunately this meant that queries are refreshed too early (before change detection hooks are run) and potentially were missing views inserted by directives - more details in #23707

With this PR query-related instructions are generated in a dedicated `queryInstructions` function (similar to a template function). The `queryInstructions` function has the same structure as the main template function but is executed at different time.