### PR TITLE
docs: update `lowercase` pipe example in "AngularJS to Angular" guide

### DIFF
--- a/aio/content/guide/ajs-quick-reference.md
+++ b/aio/content/guide/ajs-quick-reference.md
@@ -895,7 +895,7 @@ For more information on pipes, see [Pipes](guide/pipes).
       ### lowercase
 
       <code-example hideCopy>
-        &lt;div>{{movie.title | lowercase}}&lt;/div>
+        &lt;td>{{movie.title | lowercase}}&lt;/td>
       </code-example>
 
 


### PR DESCRIPTION
I updated the lowercase example, of the angular migration guide.

Please check the screenshot:
![image](https://user-images.githubusercontent.com/11459192/41659612-716dd11c-74a2-11e8-8790-3b9dd7965533.png)
