### PR TITLE
fix(forms): Don't override form group's dirty state when disabling controls

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -462,6 +462,10 @@ export abstract class AbstractControl {
    * When false, no events are emitted.
    */
   disable(opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+    // If parent has been marked artificially dirty we don't want to re-calculate the
+    // parent's dirtiness based on the children.
+    const skipPristineCheck = this._parentMarkedDirty(opts.onlySelf);
+
     (this as{status: string}).status = DISABLED;
     (this as{errors: ValidationErrors | null}).errors = null;
     this._forEachChild(
@@ -473,7 +477,7 @@ export abstract class AbstractControl {
       (this.statusChanges as EventEmitter<string>).emit(this.status);
     }
 
-    this._updateAncestors(opts);
+    this._updateAncestors({...opts, skipPristineCheck});
     this._onDisabledChange.forEach((changeFn) => changeFn(true));
   }
 
@@ -494,19 +498,26 @@ export abstract class AbstractControl {
    * When false, no events are emitted.
    */
   enable(opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+    // If parent has been marked artificially dirty we don't want to re-calculate the
+    // parent's dirtiness based on the children.
+    const skipPristineCheck = this._parentMarkedDirty(opts.onlySelf);
+
     (this as{status: string}).status = VALID;
     this._forEachChild(
         (control: AbstractControl) => { control.enable({...opts, onlySelf: true}); });
     this.updateValueAndValidity({onlySelf: true, emitEvent: opts.emitEvent});
 
-    this._updateAncestors(opts);
+    this._updateAncestors({...opts, skipPristineCheck});
     this._onDisabledChange.forEach((changeFn) => changeFn(false));
   }
 
-  private _updateAncestors(opts: {onlySelf?: boolean, emitEvent?: boolean}) {
+  private _updateAncestors(
+      opts: {onlySelf?: boolean, emitEvent?: boolean, skipPristineCheck?: boolean}) {
     if (this._parent && !opts.onlySelf) {
       this._parent.updateValueAndValidity(opts);
-      this._parent._updatePristine();
+      if (!opts.skipPristineCheck) {
+        this._parent._updatePristine();
+      }
       this._parent._updateTouched();
     }
   }
@@ -816,6 +827,16 @@ export abstract class AbstractControl {
     if (isOptionsObj(opts) && (opts as AbstractControlOptions).updateOn != null) {
       this._updateOn = (opts as AbstractControlOptions).updateOn !;
     }
+  }
+
+  /**
+   * Check to see if parent has been marked artificially dirty.
+   *
+   * @internal
+   */
+  _parentMarkedDirty(onlySelf?: boolean): boolean {
+    const parentDirty = this._parent && this._parent.dirty;
+    return !onlySelf && parentDirty && !this._parent._anyControlsDirty();
   }
 }
 

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -834,7 +834,7 @@ export abstract class AbstractControl {
    *
    * @internal
    */
-  _parentMarkedDirty(onlySelf?: boolean): boolean {
+  private _parentMarkedDirty(onlySelf?: boolean): boolean {
     const parentDirty = this._parent && this._parent.dirty;
     return !onlySelf && parentDirty && !this._parent._anyControlsDirty();
   }

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -991,6 +991,37 @@ import {FormArray} from '@angular/forms/src/model';
         expect(a.value).toEqual(['one']);
       });
 
+      it('should ignore disabled array controls when determining dirtiness', () => {
+        const c = new FormControl('one');
+        const c2 = new FormControl('two');
+        const a = new FormArray([c, c2]);
+        c.markAsDirty();
+        expect(a.dirty).toBe(true);
+
+        c.disable();
+        expect(c.dirty).toBe(true);
+        expect(a.dirty).toBe(false);
+
+        c.enable();
+        expect(a.dirty).toBe(true);
+      });
+
+      it('should not make a dirty array not dirty when disabling controls', () => {
+        const c = new FormControl('one');
+        const c2 = new FormControl('two');
+        const a = new FormArray([c, c2]);
+
+        a.markAsDirty();
+        expect(a.dirty).toBe(true);
+        expect(c.dirty).toBe(false);
+
+        c.disable();
+        expect(a.dirty).toBe(true);
+
+        c.enable();
+        expect(a.dirty).toBe(true);
+      });
+
       it('should ignore disabled controls in validation', () => {
         const c = new FormControl(null, Validators.required);
         const c2 = new FormControl(null);
@@ -1040,6 +1071,22 @@ import {FormArray} from '@angular/forms/src/model';
         c.disable();
         expect(c.dirty).toBe(true);
         expect(g.dirty).toBe(false);
+
+        c.enable();
+        expect(g.dirty).toBe(true);
+      });
+
+      it('should not make a dirty group not dirty when disabling controls', () => {
+        const c = new FormControl('one');
+        const c2 = new FormControl('two');
+        const g = new FormGroup({one: c, two: c2});
+
+        g.markAsDirty();
+        expect(g.dirty).toBe(true);
+        expect(c.dirty).toBe(false);
+
+        c.disable();
+        expect(g.dirty).toBe(true);
 
         c.enable();
         expect(g.dirty).toBe(true);


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

```
form = this.fb.group({ a: ['a'], b: ['b'] });
form.markAsDirty();
console.log(form.dirty); // true

form.controls['a'].disable();
console.log(form.dirty); // false
```

I can manually change `dirty` state of a `FormGroup` but when I disable a single control it changes `dirty` state of its parent.

Demo: https://stackblitz.com/edit/angular-8bab4v?file=src%2Fapp%2Fapp.component.ts

Issue Number: #23309

## What is the new behavior?

When calling `disable()` on `AbstractControl` it now checks whether its parent is `dirty` and if its `dirty` state corresponds to the current state of its children. If not it means I had to change it myself with `markAsDirty` so I won't override parent's `dirty` state.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

This could be a BC but it's probably very unlikely that anybody was relying on this behavior since its counter-intuitive.
