### PR TITLE
feat(forms): add updateOn option to FormBuilder

### DIFF
--- a/packages/examples/forms/ts/formBuilder/form_builder_example.ts
+++ b/packages/examples/forms/ts/formBuilder/form_builder_example.ts
@@ -22,7 +22,7 @@ import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
       <input formControlName="email" placeholder="Email">
       <button>Submit</button>
     </form>
-    
+
     <p>Value: {{ form.value | json }}</p>
     <p>Validation status: {{ form.status }}</p>
   `
@@ -31,13 +31,15 @@ export class FormBuilderComp {
   form: FormGroup;
 
   constructor(@Inject(FormBuilder) fb: FormBuilder) {
-    this.form = fb.group({
-      name: fb.group({
-        first: ['Nancy', Validators.minLength(2)],
-        last: 'Drew',
-      }),
-      email: '',
-    });
+    this.form = fb.group(
+        {
+          name: fb.group({
+            first: ['Nancy', Validators.minLength(2)],
+            last: 'Drew',
+          }),
+          email: '',
+        },
+        {updateOn: 'change'});
   }
 }
 // #enddocregion

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -9,7 +9,7 @@
 import {Injectable} from '@angular/core';
 
 import {AsyncValidatorFn, ValidatorFn} from './directives/validators';
-import {AbstractControl, FormArray, FormControl, FormGroup} from './model';
+import {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormGroup, FormHooks} from './model';
 
 /**
  * @description
@@ -36,24 +36,42 @@ export class FormBuilder {
    * * `asyncValidator`: A single async validator or array of async validator functions
    *
    */
-  group(controlsConfig: {[key: string]: any}, extra: {[key: string]: any}|null = null): FormGroup {
+  group(controlsConfig: {[key: string]: any}, legacyOrOpts: {[key: string]: any}|null = null):
+      FormGroup {
     const controls = this._reduceControls(controlsConfig);
-    const validator: ValidatorFn = extra != null ? extra['validator'] : null;
-    const asyncValidator: AsyncValidatorFn = extra != null ? extra['asyncValidator'] : null;
-    return new FormGroup(controls, validator, asyncValidator);
+
+    let validators: ValidatorFn|ValidatorFn[]|null = null;
+    let asyncValidators: AsyncValidatorFn|AsyncValidatorFn[]|null = null;
+    let updateOn: FormHooks|undefined = undefined;
+
+    if (legacyOrOpts != null &&
+        (legacyOrOpts.asyncValidator !== undefined || legacyOrOpts.validator !== undefined)) {
+      // `legacyOrOpts` are legacy form group options
+      validators = legacyOrOpts.validator != null ? legacyOrOpts.validator : null;
+      asyncValidators = legacyOrOpts.asyncValidator != null ? legacyOrOpts.asyncValidator : null;
+    } else if (legacyOrOpts != null) {
+      // `legacyOrOpts` are `AbstractControlOptions`
+      validators = legacyOrOpts.validators != null ? legacyOrOpts.validators : null;
+      asyncValidators = legacyOrOpts.asyncValidators != null ? legacyOrOpts.asyncValidators : null;
+      updateOn = legacyOrOpts.updateOn != null ? legacyOrOpts.updateOn : undefined;
+    }
+
+    return new FormGroup(controls, {asyncValidators, updateOn, validators});
   }
 
   /**
    * @description
-   * Construct a new `FormControl` instance.
+   * Construct a new `FormControl` with the given state, validators and options.
    *
-   * @param formState Initializes the control with an initial value,
-   * or an object that defines the initial value and disabled state.
+   * @param formState Initializes the control with an initial state value, or
+   * with an object that contains both a value and a disabled status.
    *
-   * @param validator A synchronous validator function, or an array of synchronous validator
+   * @param validatorOrOpts A synchronous validator function, or an array of
+   * such functions, or an `AbstractControlOptions` object that contains
+   * validation functions and a validation trigger.
+   *
+   * @param asyncValidator A single async validator or array of async validator
    * functions.
-   *
-   * @param asyncValidator A single async validator or array of async validator functions
    *
    * @usageNotes
    *
@@ -64,31 +82,33 @@ export class FormBuilder {
    * <code-example path="forms/ts/formBuilder/form_builder_example.ts"
    *   linenums="false" region="disabled-control">
    * </code-example>
-   *
    */
   control(
-      formState: any, validator?: ValidatorFn|ValidatorFn[]|null,
+      formState: any, validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null,
       asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): FormControl {
-    return new FormControl(formState, validator, asyncValidator);
+    return new FormControl(formState, validatorOrOpts, asyncValidator);
   }
 
   /**
-   * @description
-   * Construct a new `FormArray` instance.
+   * Constructs a new `FormArray` from the given array of configurations,
+   * validators and options.
    *
-   * @param controlsConfig An array of child controls. The key for each child control is its index
-   * in the array.
+   * @param controlsConfig An array of child controls or control configs. Each
+   * child control is given an index when it is registered.
    *
-   * @param validator A synchronous validator function, or an array of synchronous validator
+   * @param validatorOrOpts A synchronous validator function, or an array of
+   * such functions, or an `AbstractControlOptions` object that contains
+   * validation functions and a validation trigger.
+   *
+   * @param asyncValidator A single async validator or array of async validator
    * functions.
-   *
-   * @param asyncValidator A single async validator or array of async validator functions
    */
   array(
-      controlsConfig: any[], validator?: ValidatorFn|ValidatorFn[]|null,
+      controlsConfig: any[],
+      validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null,
       asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): FormArray {
     const controls = controlsConfig.map(c => this._createControl(c));
-    return new FormArray(controls, validator, asyncValidator);
+    return new FormArray(controls, validatorOrOpts, asyncValidator);
   }
 
   /** @internal */

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -206,11 +206,11 @@ export declare class FormArrayName extends ControlContainer implements OnInit, O
 }
 
 export declare class FormBuilder {
-    array(controlsConfig: any[], validator?: ValidatorFn | ValidatorFn[] | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormArray;
-    control(formState: any, validator?: ValidatorFn | ValidatorFn[] | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormControl;
+    array(controlsConfig: any[], validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormArray;
+    control(formState: any, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormControl;
     group(controlsConfig: {
         [key: string]: any;
-    }, extra?: {
+    }, legacyOrOpts?: {
         [key: string]: any;
     } | null): FormGroup;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #19163


## What is the new behavior?
Support `updateOn` option in `FormBuilder` methods `array`, `control` and `group`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Special care has been taken to keep backwards compatibility with the `extra` object containing optional `validator` and `asyncValidator` properties in the `FormBuilder#group` method so as not to create breaking changes.

Unit tests have been massaged from the form control spec.