### PR TITLE
refactor(ivy): rename, limit usage of global vars

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -232,15 +232,16 @@ export function leaveView(newView: LViewData, creationOnly?: boolean): void {
 
 /**
  * Refreshes the view, executing the following steps in that order:
- * triggers init hooks, refreshes dynamic children, triggers content hooks, sets host bindings,
+ * triggers init hooks, refreshes dynamic embedded views, triggers content hooks, sets host
+ * bindings,
  * refreshes child components.
  * Note: view hooks are triggered later when leaving the view.
- * */
+ */
 function refreshView() {
   if (!checkNoChangesMode) {
     executeInitHooks(viewData, tView, creationMode);
   }
-  refreshDynamicChildren();
+  refreshDynamicEmbeddedViews(viewData);
   if (!checkNoChangesMode) {
     executeHooks(directives !, tView.contentHooks, tView.contentCheckHooks, creationMode);
   }
@@ -1677,8 +1678,12 @@ export function containerRefreshEnd(): void {
   }
 }
 
-function refreshDynamicChildren() {
-  for (let current = getLViewChild(viewData); current !== null; current = current[NEXT]) {
+/**
+ * Goes over dynamic embedded views (ones created through ViewContainerRef APIs) and refreshes them
+ * by executing an associated template function.
+ */
+function refreshDynamicEmbeddedViews(lViewData: LViewData) {
+  for (let current = getLViewChild(lViewData); current !== null; current = current[NEXT]) {
     // Note: current can be an LViewData or an LContainer instance, but here we are only interested
     // in LContainer. We can tell it's an LContainer because its length is less than the LViewData
     // header.

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -195,7 +195,7 @@
     "name": "refreshChildComponents"
   },
   {
-    "name": "refreshDynamicChildren"
+    "name": "refreshDynamicEmbeddedViews"
   },
   {
     "name": "refreshView"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -468,7 +468,7 @@
     "name": "refreshChildComponents"
   },
   {
-    "name": "refreshDynamicChildren"
+    "name": "refreshDynamicEmbeddedViews"
   },
   {
     "name": "refreshView"


### PR DESCRIPTION
Minor refactoring that (IMO) improves code:
* the `refreshDynamicChildren` name wasn't clear as it wasn't obvious what children we are talking about;
* we can pass argument explicitly instead of relaying on global vars (this allows us to move this function out of instructions file if needs be) 