### PR TITLE
fix(router): empty resolvers cancel navigation

### DIFF
--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -2956,13 +2956,15 @@ Update the `CrisisDetailComponent` to get the crisis from the  `ActivatedRoute.d
 
 <code-example path="router/src/app/crisis-center/crisis-detail/crisis-detail.component.ts" header="src/app/crisis-center/crisis-detail/crisis-detail.component.ts (ngOnInit v2)" region="ngOnInit"></code-example>
 
-Note the following two important points:
+Note the following three important points:
 
 1. The router's `Resolve` interface is optional.
 The `CrisisDetailResolverService` doesn't inherit from a base class.
 The router looks for that method and calls it if found.
 
 1. The router calls the resolver in any case where the the user could navigate away so you don't have to code for each use case.
+
+1. Returning an empty `Observable` in at least one resolver will cancel navigation.
 
 The relevant Crisis Center code for this milestone follows.
 

--- a/packages/router/test/operators/resolve_data.spec.ts
+++ b/packages/router/test/operators/resolve_data.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injector} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {EMPTY, of} from 'rxjs';
+import {TestScheduler} from 'rxjs/testing';
+
+import {resolveData} from '../../src/operators/resolve_data';
+
+describe('resolveData operator', () => {
+  let testScheduler: TestScheduler;
+  let injector: Injector;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: 'resolveTwo', useValue: (a: any, b: any) => of(2)},
+        {provide: 'resolveFour', useValue: (a: any, b: any) => 4},
+        {provide: 'resolveEmpty', useValue: (a: any, b: any) => EMPTY},
+      ]
+    });
+  });
+  beforeEach(() => {
+    testScheduler = new TestScheduler(assertDeepEquals);
+  });
+  beforeEach(() => {
+    injector = TestBed.inject<Injector>(Injector);
+  });
+
+  it('should re-emit updated value from source after all resolvers emit and complete', () => {
+    testScheduler.run(({hot, cold, expectObservable}) => {
+      const transition: any = createTransition({e1: 'resolveTwo'}, {e2: 'resolveFour'});
+      const source = cold('-(t|)', {t: deepClone(transition)});
+      const expected = '-(t|)';
+      const outputTransition = deepClone(transition);
+      outputTransition.guards.canActivateChecks[0].route._resolvedData = {e1: 2};
+      outputTransition.guards.canActivateChecks[1].route._resolvedData = {e2: 4};
+
+      expectObservable(source.pipe(resolveData('emptyOnly', injector))).toBe(expected, {
+        t: outputTransition
+      });
+    });
+  });
+
+  it('should re-emit value from source when there are no resolvers', () => {
+    testScheduler.run(({hot, cold, expectObservable}) => {
+      const transition: any = createTransition({});
+      const source = cold('-(t|)', {t: deepClone(transition)});
+      const expected = '-(t|)';
+      const outputTransition = deepClone(transition);
+      outputTransition.guards.canActivateChecks[0].route._resolvedData = {};
+
+      expectObservable(source.pipe(resolveData('emptyOnly', injector))).toBe(expected, {
+        t: outputTransition
+      });
+    });
+  });
+
+  it('should not emit when there\'s one resolver that doesn\'t emit', () => {
+    testScheduler.run(({hot, cold, expectObservable}) => {
+      const transition: any = createTransition({e2: 'resolveEmpty'});
+      const source = cold('-(t|)', {t: deepClone(transition)});
+      const expected = '-|';
+      expectObservable(source.pipe(resolveData('emptyOnly', injector))).toBe(expected);
+    });
+  });
+
+  it('should not emit if at least one resolver doesn\'t emit', () => {
+    testScheduler.run(({hot, cold, expectObservable}) => {
+      const transition: any = createTransition({e1: 'resolveTwo'}, {e2: 'resolveEmpty'});
+      const source = cold('-(t|)', {t: deepClone(transition)});
+      const expected = '-|';
+      expectObservable(source.pipe(resolveData('emptyOnly', injector))).toBe(expected);
+    });
+  });
+});
+
+function assertDeepEquals(a: any, b: any) {
+  return expect(a).toEqual(b);
+}
+
+function createTransition(...resolvers: {[key: string]: string}[]) {
+  return {
+    targetSnapshot: {},
+    guards: {
+      canActivateChecks:
+          resolvers.map(resolver => ({
+                          route: {_resolve: resolver, pathFromRoot: [{url: '/'}], data: {}},
+                        })),
+    },
+  };
+}
+
+function deepClone(obj: any) {
+  return JSON.parse(JSON.stringify(obj));
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When a route has at least two resolvers (Observables) and both of them `complete` without any `next` item the `last()` operator throws an exception.

Issue Number: #24195

## What is the new behavior?

When there's at least one empty resolver then navigation is canceled.

I think there are two ways this could work. When at least one resolver is empty or when all resolvers are empty. The original issue #24195 mentions the first option and it probably makes more sense because if I'm fine with one of the resolvers producing an empty response I can handle it in the resolver with eg. `defaultIfEmpty` operator.

## Does this PR introduce a breaking change?
```
[X] Yes
[] No
```

~This shouldn't be a breaking change because it's very unlikely that anybody was relying on the previous behavior.~

## Other information

I actually made this more simple because I used only `forkJoin` and `map` operators with single `pipe()` call.

I didn't want to update docs until I have approval from somebody competent that these changes make sense.