### PR TITLE
WIP: docs(tutorial): fix url inconsistency in tutorial chapters

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -72,44 +72,40 @@
       "tooltip": "The Tour of Heroes tutorial takes you through the steps of creating an Angular application in TypeScript.",
       "children": [
         {
-          "url": "tutorial",
-          "title": "1. Introduction",
-          "tooltip": "Part 1: Introduction to the Tour of Heroes tutorial"
-        },
-        {
           "url": "tutorial/toh-pt0",
-          "title": "2. The Application Shell",
-          "tooltip": "Part 2: Creating the application shell"
+          "title": "Introduction",
+          "tooltip": "Introduction to the Tour of Heroes tutorial"
         },
+  
         {
           "url": "tutorial/toh-pt1",
-          "title": "3. The Hero Editor",
-          "tooltip": "Part 3: Build a simple hero editor"
+          "title": "1. The Hero Editor",
+          "tooltip": "Part 1: Build a simple hero editor"
         },
         {
           "url": "tutorial/toh-pt2",
-          "title": "4. Displaying a List",
-          "tooltip": "Part 4: Build a master/detail page with a list of heroes."
+          "title": "2. Displaying a List",
+          "tooltip": "Part 2: Build a master/detail page with a list of heroes."
         },
         {
           "url": "tutorial/toh-pt3",
-          "title": "5. Master/Detail Components",
-          "tooltip": "Part 5: Refactor the master/detail view into separate components."
+          "title": "3. Master/Detail Components",
+          "tooltip": "Part 3: Refactor the master/detail view into separate components."
         },
         {
           "url": "tutorial/toh-pt4",
-          "title": "6. Services",
-          "tooltip": "Part 6: Create a reusable service to manage hero data."
+          "title": "4. Services",
+          "tooltip": "Part 4: Create a reusable service to manage hero data."
         },
         {
           "url": "tutorial/toh-pt5",
-          "title": "7. Routing",
-          "tooltip": "Part 7: Add the Angular router and navigate among the views."
+          "title": "5. Routing",
+          "tooltip": "Part 5: Add the Angular router and navigate among the views."
         },
         {
           "url": "tutorial/toh-pt6",
-          "title": "8. HTTP",
-          "tooltip": "Part 8: Use HTTP to retrieve and save hero data."
+          "title": "6. HTTP",
+          "tooltip": "Part 6: Use HTTP to retrieve and save hero data."
         }
       ]
     },

--- a/aio/content/tutorial/toh-pt0.md
+++ b/aio/content/tutorial/toh-pt0.md
@@ -1,4 +1,76 @@
-# The Application Shell
+<h1 class="no-toc">Tutorial: Tour of Heroes</h1>
+
+The _Tour of Heroes_ tutorial covers the fundamentals of Angular.  
+In this tutorial you will build an app that helps a staffing agency manage its stable of heroes.
+
+This basic app has many of the features you'd expect to find in a data-driven application.
+It acquires and displays a list of heroes, edits a selected hero's detail, and navigates among different views of heroic data.
+
+By the end of the tutorial you will be able to do the following:
+
+* Use built-in Angular directives to show and hide elements and display lists of hero data.
+* Create Angular components to display hero details and show an array of heroes.
+* Use one-way data binding for read-only data.
+* Add editable fields to update a model with two-way data binding.
+* Bind component methods to user events, like keystrokes and clicks.
+* Enable users to select a hero from a master list and edit that hero in the details view. 
+* Format data with pipes.
+* Create a shared service to assemble the heroes.
+* Use routing to navigate among different views and their components.
+
+You'll learn enough Angular to get started and gain confidence that
+Angular can do whatever you need it to do. 
+
+After completing all tutorial steps, the final app will look like this <live-example name="toh-pt6"></live-example>.
+
+
+## What you'll build
+
+Here's a visual idea of where this tutorial leads, beginning with the "Dashboard"
+view and the most heroic heroes:
+
+<figure>
+  <img src='generated/images/guide/toh/heroes-dashboard-1.png' alt="Output of heroes dashboard">
+</figure>
+
+You can click the two links above the dashboard ("Dashboard" and "Heroes")
+to navigate between this Dashboard view and a Heroes view.
+
+If you click the dashboard hero "Magneta," the router opens a "Hero Details" view
+where you can change the hero's name.
+
+<figure>
+  <img src='generated/images/guide/toh/hero-details-1.png' alt="Details of hero in app">
+</figure>
+
+Clicking the "Back" button returns you to the Dashboard.
+Links at the top take you to either of the main views.
+If you click "Heroes," the app displays the "Heroes" master list view.
+
+
+<figure>
+  <img src='generated/images/guide/toh/heroes-list-2.png' alt="Output of heroes list app">
+</figure>
+
+When you click a different hero name, the read-only mini detail beneath the list reflects the new choice.
+
+You can click the "View Details" button to drill into the
+editable details of the selected hero.
+
+The following diagram captures all of the navigation options.
+
+<figure>
+  <img src='generated/images/guide/toh/nav-diagram.png' alt="View navigations">
+</figure>
+
+Here's the app in action:
+
+<figure>
+  <img src='generated/images/guide/toh/toh-anim.gif' alt="Tour of Heroes in Action">
+</figure>
+
+
+Now, let us create a basic application structure using the Angular CLI.
 
 ## Install the Angular CLI
 

--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -82,6 +82,9 @@
       {"type": 301, "source": "/api/upgrade/:package/index/:api-*", "destination": "/api/upgrade/:package/:api"},
       {"type": 301, "source": "/api/upgrade/:package/:api-*", "destination": "/api/upgrade/:package/:api"},
 
+      // URL to tutorial introduction page (index.md) now points to toh-pt0
+      {"type": 301, "source": "/tutorial", "destination": "/tutorial/toh-pt0"},
+
       // URLs that use the old scheme before we moved the docs to the angular/angular repo
       {"type": 301, "source": "/docs/*/latest", "destination": "/docs"},
       {"type": 301, "source": "/docs/*/latest/api/", "destination": "/api"},


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
URL to tutorial chapters do not match the chapter sequencing.
Issue Number: N/A
#17645

## What is the new behavior?
tutorial chapter numbers and URL pointing to them are matching.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
