### PR TITLE
Ivy resource loader

### DIFF
--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -18,6 +18,7 @@ export {APP_ROOT as ɵAPP_ROOT} from './di/scope';
 export {ivyEnabled as ɵivyEnabled} from './ivy_switch';
 export {ComponentFactory as ɵComponentFactory} from './linker/component_factory';
 export {CodegenComponentFactoryResolver as ɵCodegenComponentFactoryResolver} from './linker/component_factory_resolver';
+export {resolveComponentResources as ɵresolveComponentResources} from './metadata/resource_loading';
 export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/reflection_capabilities';
 export {GetterFn as ɵGetterFn, MethodFn as ɵMethodFn, SetterFn as ɵSetterFn} from './reflection/types';
 export {DirectRenderer as ɵDirectRenderer, RenderDebugInfo as ɵRenderDebugInfo} from './render/api';

--- a/packages/core/src/ivy_switch_on.ts
+++ b/packages/core/src/ivy_switch_on.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {compileComponentDecorator, compileDirective} from './render3/jit/directive';
+import {compileComponent, compileDirective} from './render3/jit/directive';
 import {compileInjectable} from './render3/jit/injectable';
 import {compileNgModule} from './render3/jit/module';
 
 export const ivyEnabled = true;
-export const R3_COMPILE_COMPONENT = compileComponentDecorator;
+export const R3_COMPILE_COMPONENT = compileComponent;
 export const R3_COMPILE_DIRECTIVE = compileDirective;
 export const R3_COMPILE_INJECTABLE = compileInjectable;
 export const R3_COMPILE_NGMODULE = compileNgModule;

--- a/packages/core/src/metadata/resource_loading.ts
+++ b/packages/core/src/metadata/resource_loading.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from './directives';
+
+
+/**
+ * Used to resolve resource URLs on `@Component` when used with JIT compilation.
+ *
+ * Example:
+ * ```
+ * @Component({
+ *   selector: 'my-comp',
+ *   templateUrl: 'my-comp.html', // This requires asynchronous resolution
+ * })
+ * class MyComponnent{
+ * }
+ *
+ * // Calling `renderComponent` will fail because `MyComponent`'s `@Compenent.templateUrl`
+ * // needs to be resolved because `renderComponent` is synchronous process.
+ * // renderComponent(MyComponent);
+ *
+ * // Calling `resolveComponentResources` will resolve `@Compenent.templateUrl` into
+ * // `@Compenent.template`, which would allow `renderComponent` to proceed in synchronous manner.
+ * // Use browser's `fetch` function as the default resource resolution strategy.
+ * resolveComponentResources(fetch).then(() => {
+ *   // After resolution all URLs have been converted into strings.
+ *   renderComponent(MyComponent);
+ * });
+ *
+ * ```
+ *
+ * NOTE: In AOT the resolution happens during compilation, and so there should be no need
+ * to call this method outside JIT mode.
+ *
+ * @param resourceResolver a function which is responsible to returning a `Promise` of the resolved
+ * URL. Browser's `fetch` method is a good default implementation.
+ */
+export function resolveComponentResources(
+    resourceResolver: (url: string) => (Promise<string|{text(): Promise<string>}>)): Promise<null> {
+  // Store all promises which are fetching the resources.
+  const urlFetches: Promise<string>[] = [];
+
+  // Cache so that we don't fetch the same resource more than once.
+  const urlMap = new Map<string, Promise<string>>();
+  function cachedResourceResolve(url: string): Promise<string> {
+    let promise = urlMap.get(url);
+    if (!promise) {
+      const resp = resourceResolver(url);
+      urlMap.set(url, promise = resp.then(unwrapResponse));
+      urlFetches.push(promise);
+    }
+    return promise;
+  }
+
+  componentResourceResolutionQueue.forEach((component: Component) => {
+    if (component.templateUrl) {
+      cachedResourceResolve(component.templateUrl).then((template) => {
+        component.template = template;
+        component.templateUrl = undefined;
+      });
+    }
+    const styleUrls = component.styleUrls;
+    const styles = component.styles || (component.styles = []);
+    const styleOffset = component.styles.length;
+    styleUrls && styleUrls.forEach((styleUrl, index) => {
+      styles.push('');  // pre-allocate array.
+      cachedResourceResolve(styleUrl).then((style) => {
+        styles[styleOffset + index] = style;
+        styleUrls.splice(styleUrls.indexOf(styleUrl), 1);
+        if (styleUrls.length == 0) {
+          component.styleUrls = undefined;
+        }
+      });
+    });
+  });
+  componentResourceResolutionQueue.clear();
+  return Promise.all(urlFetches).then(() => null);
+}
+
+const componentResourceResolutionQueue: Set<Component> = new Set();
+
+export function maybeQueueResolutionOfComponentResources(metadata: Component) {
+  if (componentNeedsResolution(metadata)) {
+    componentResourceResolutionQueue.add(metadata);
+  }
+}
+
+export function componentNeedsResolution(component: Component) {
+  return component.templateUrl || component.styleUrls && component.styleUrls.length;
+}
+export function clearResolutionOfComponentResourcesQueue() {
+  componentResourceResolutionQueue.clear();
+}
+
+function unwrapResponse(response: string | {text(): Promise<string>}): string|Promise<string> {
+  return typeof response == 'string' ? response : response.text();
+}

--- a/packages/core/test/metadata/resource_loading_spec.ts
+++ b/packages/core/test/metadata/resource_loading_spec.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {jasmineAwait} from '@angular/core/testing';
+
+import {Component} from '../../src/core';
+import {clearResolutionOfComponentResourcesQueue, resolveComponentResources} from '../../src/metadata/resource_loading';
+import {ComponentType} from '../../src/render3/interfaces/definition';
+import {compileComponent} from '../../src/render3/jit/directive';
+
+describe('resource_loading', () => {
+  describe('error handling', () => {
+    afterEach(clearResolutionOfComponentResourcesQueue);
+    it('should throw an error when compiling component that has unresolved templateUrl', () => {
+      const MyComponent: ComponentType<any> = (class MyComponent{}) as any;
+      compileComponent(MyComponent, {templateUrl: 'someUrl'});
+      expect(() => MyComponent.ngComponentDef).toThrowError(`
+Component 'MyComponent' is not resolved:
+ - templateUrl: someUrl
+Did you run and wait for 'resolveComponentResources()'?`.trim());
+    });
+
+    it('should throw an error when compiling component that has unresolved styleUrls', () => {
+      const MyComponent: ComponentType<any> = (class MyComponent{}) as any;
+      compileComponent(MyComponent, {styleUrls: ['someUrl1', 'someUrl2']});
+      expect(() => MyComponent.ngComponentDef).toThrowError(`
+Component 'MyComponent' is not resolved:
+ - styleUrls: ["someUrl1","someUrl2"]
+Did you run and wait for 'resolveComponentResources()'?`.trim());
+    });
+
+    it('should throw an error when compiling component that has unresolved templateUrl and styleUrls',
+       () => {
+         const MyComponent: ComponentType<any> = (class MyComponent{}) as any;
+         compileComponent(
+             MyComponent, {templateUrl: 'someUrl', styleUrls: ['someUrl1', 'someUrl2']});
+         expect(() => MyComponent.ngComponentDef).toThrowError(`
+Component 'MyComponent' is not resolved:
+ - templateUrl: someUrl
+ - styleUrls: ["someUrl1","someUrl2"]
+Did you run and wait for 'resolveComponentResources()'?`.trim());
+       });
+  });
+
+  describe('resolution', () => {
+    const URLS: {[url: string]: Promise<string>} = {
+      'test://content': Promise.resolve('content'),
+      'test://style1': Promise.resolve('style1'),
+      'test://style2': Promise.resolve('style2'),
+    };
+    let resourceFetchCount: number;
+    function testResolver(url: string): Promise<string> {
+      resourceFetchCount++;
+      return URLS[url] || Promise.reject('NOT_FOUND: ' + url);
+    }
+    beforeEach(() => resourceFetchCount = 0);
+
+    it('should resolve template', jasmineAwait(async() => {
+         const MyComponent: ComponentType<any> = (class MyComponent{}) as any;
+         const metadata: Component = {templateUrl: 'test://content'};
+         compileComponent(MyComponent, metadata);
+         await resolveComponentResources(testResolver);
+         expect(MyComponent.ngComponentDef).toBeDefined();
+         expect(metadata.templateUrl).toBe(undefined);
+         expect(metadata.template).toBe('content');
+         expect(resourceFetchCount).toBe(1);
+       }));
+
+    it('should resolve styleUrls', jasmineAwait(async() => {
+         const MyComponent: ComponentType<any> = (class MyComponent{}) as any;
+         const metadata: Component = {template: '', styleUrls: ['test://style1', 'test://style2']};
+         compileComponent(MyComponent, metadata);
+         await resolveComponentResources(testResolver);
+         expect(MyComponent.ngComponentDef).toBeDefined();
+         expect(metadata.styleUrls).toBe(undefined);
+         expect(metadata.styles).toEqual(['style1', 'style2']);
+         expect(resourceFetchCount).toBe(2);
+       }));
+
+    it('should cache multiple resolution to same URL', jasmineAwait(async() => {
+         const MyComponent: ComponentType<any> = (class MyComponent{}) as any;
+         const metadata: Component = {template: '', styleUrls: ['test://style1', 'test://style1']};
+         compileComponent(MyComponent, metadata);
+         await resolveComponentResources(testResolver);
+         expect(MyComponent.ngComponentDef).toBeDefined();
+         expect(metadata.styleUrls).toBe(undefined);
+         expect(metadata.styles).toEqual(['style1', 'style1']);
+         expect(resourceFetchCount).toBe(1);
+       }));
+
+    it('should keep order even if the resolution is out of order', jasmineAwait(async() => {
+         const MyComponent: ComponentType<any> = (class MyComponent{}) as any;
+         const metadata: Component = {
+           template: '',
+           styles: ['existing'],
+           styleUrls: ['test://style1', 'test://style2']
+         };
+         compileComponent(MyComponent, metadata);
+         const resolvers: any[] = [];
+         const resolved = resolveComponentResources(
+             (url) => new Promise((resolve, response) => resolvers.push(url, resolve)));
+         // Out of order resolution
+         expect(resolvers[0]).toEqual('test://style1');
+         expect(resolvers[2]).toEqual('test://style2');
+         resolvers[3]('second');
+         resolvers[1]('first');
+         await resolved;
+         expect(metadata.styleUrls).toBe(undefined);
+         expect(metadata.styles).toEqual(['existing', 'first', 'second']);
+       }));
+
+  });
+
+  describe('fetch', () => {
+    function fetch(url: string): Promise<Response> {
+      return Promise.resolve({
+        text() { return 'response for ' + url; }
+      } as any as Response);
+    }
+
+    it('should work with fetch', jasmineAwait(async() => {
+         const MyComponent: ComponentType<any> = (class MyComponent{}) as any;
+         const metadata: Component = {templateUrl: 'test://content'};
+         compileComponent(MyComponent, metadata);
+         await resolveComponentResources(fetch);
+         expect(MyComponent.ngComponentDef).toBeDefined();
+         expect(metadata.templateUrl).toBe(undefined);
+         expect(metadata.template).toBe('response for test://content');
+       }));
+  });
+});

--- a/packages/core/test/testability/jasmine_await_spec.ts
+++ b/packages/core/test/testability/jasmine_await_spec.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {jasmineAwait} from '../../testing';
+
+
+describe('await', () => {
+  let pass: boolean;
+  beforeEach(() => pass = false);
+  afterEach(() => expect(pass).toBe(true));
+
+  it('should convert passes', jasmineAwait(async() => { pass = await Promise.resolve(true); }));
+
+  it('should convert failures', (done) => {
+    const error = new Error();
+    const fakeDone: DoneFn = function() { fail('passed, but should have failed'); } as any;
+    fakeDone.fail = function(value: any) {
+      expect(value).toBe(error);
+      done();
+    };
+    jasmineAwait(async() => {
+      pass = await Promise.resolve(true);
+      throw error;
+    })(fakeDone);
+  });
+});

--- a/packages/core/testing/src/jasmine_await.ts
+++ b/packages/core/testing/src/jasmine_await.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Converts an `async` function, with `await`, into a function which is compatible with Jasmine test
+ * framework.
+ *
+ * For asynchronous function blocks, Jasmine expects `it` (and friends) to take a function which
+ * takes a `done` callback. (Jasmine does not understand functions which return `Promise`.) The
+ * `jasmineAwait()` wrapper converts the test function returning `Promise` into a function which
+ * Jasmine understands.
+ *
+ *
+ * Example:
+ * ```
+ * it('...', jasmineAwait(async() => {
+ *   doSomething();
+ *   await asyncFn();
+ *   doSomethingAfter();
+ * }));
+ * ```
+ *
+ */
+export function jasmineAwait(fn: () => Promise<any>):
+    (done: {(): void; fail: (message?: Error | string) => void;}) => void {
+  return function(done: {(): void; fail: (message?: Error | string) => void;}) {
+    fn().then(done, done.fail);
+  };
+}

--- a/packages/core/testing/src/testing.ts
+++ b/packages/core/testing/src/testing.ts
@@ -13,6 +13,7 @@
  */
 
 export * from './async';
+export * from './jasmine_await';
 export * from './component_fixture';
 export * from './fake_async';
 export * from './test_bed';

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -53,6 +53,11 @@ export declare class InjectSetupWrapper {
     inject(tokens: any[], fn: Function): () => any;
 }
 
+export declare function jasmineAwait(fn: () => Promise<any>): (done: {
+    (): void;
+    fail: (message?: Error | string) => void;
+}) => void;
+
 /** @experimental */
 export declare type MetadataOverride<T> = {
     add?: Partial<T>;


### PR DESCRIPTION
feat(ivy): Support resource resolution in JIT mode.

Used to resolve resource URLs on `@Component` when used with JIT compilation.

```
@Component({
  selector: 'my-comp',
  templateUrl: 'my-comp.html', // This requires asynchronous resolution
})
class MyComponnent{
}

// Calling `renderComponent` will fail because `MyComponent`'s `@Compenent.templateUrl`
// needs to be resolved because `renderComponent` is synchronous process.
// renderComponent(MyComponent);

// Calling `resolveComponentResources` will resolve `@Compenent.templateUrl` into
// `@Compenent.template`, which would allow `renderComponent` to proceed in synchronous manner.
// Use browser's `fetch` function as the default resource resolution strategy.
resolveComponentResources(fetch).then(() => {
  // After resolution all URLs have been converted into strings.
  renderComponent(MyComponent);
});

```