### PR TITLE
docs: more info on currency digits

### DIFF
--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -166,6 +166,9 @@ export class CurrencyPipe implements PipeTransform {
    * Default is `0`.
    *   - `maxFractionDigits`: The maximum number of digits after the decimal point.
    * Default is `3`.
+   * If not provided, the number will be formatted with the proper amount of digits,
+   * depending on what the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) specifies.
+   * For example, the Canadian dollar has 2 digits, whereas the Chilean peso has none.
    * @param locale A locale code for the locale format rules to use.
    * When not supplied, uses the value of `LOCALE_ID`, which is `en-US` by default.
    * See [Setting your app locale](guide/i18n#setting-up-the-locale-of-your-app).

--- a/packages/examples/common/pipes/ts/currency_pipe.ts
+++ b/packages/examples/common/pipes/ts/currency_pipe.ts
@@ -18,7 +18,7 @@ registerLocaleData(localeFr);
 @Component({
   selector: 'currency-pipe',
   template: `<div>
-    <!--output '$0.259'-->
+    <!--output '$0.26'-->
     <p>A: {{a | currency}}</p>
 
     <!--output 'CA$0.26'-->
@@ -35,6 +35,9 @@ registerLocaleData(localeFr);
 
     <!--output '0 001,35 CA$'-->
     <p>B: {{b | currency:'CAD':'symbol':'4.2-2':'fr'}}</p>
+
+    <!--output 'CLP1' because CLP has no cents-->
+    <p>B: {{b | currency:'CLP'}}</p>
   </div>`
 })
 export class CurrencyPipeComponent {


### PR DESCRIPTION
Adds an example of using the `currency` pipe with a currency that has no cents like CLP,
which will format the amount with no digits if `digitsInfo` is not provided:

    <!-- outputs CA$14.00 -->
    {{ 14 | currency:'CAD' }}
    <!-- outputs CLP14 -->
    {{ 14 | currency:'CLP' }}

Amends the docs, adds an example and fix an error with a current example.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

See https://github.com/angular/angular/pull/24141#issuecomment-400040009

## What is the new behavior?

Adds a small example of using the currency pipe with no `digitsInfo` and with a currency that has no cents to illustrate that the formatting done by the pipe by default follows the ISO 4217 specification.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
