### PR TITLE
docs: typos in directives docs

### DIFF
--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -342,9 +342,12 @@ export interface Directive {
    * View queries are set before the `ngAfterViewInit` callback is called.
    *
    * @usageNotes
+   *
    * ### Example
    *
-   * The followoing example (shows what??)
+   * The following example shows how queries are defined
+   * and when their results are available in lifecycle hooks:
+   *
    * ```
    * @Component({
    *   selector: 'someDir',
@@ -475,7 +478,7 @@ export interface Directive {
 }
 
 /**
- * Type of the Component metadata.
+ * Type of the Directive metadata.
  */
 export const Directive: DirectiveDecorator = makeDecorator(
     'Directive', (dir: Directive = {}) => dir, undefined, undefined,


### PR DESCRIPTION
Fixes some typos introduced by #23902

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

#23902 introduced a few typos

## What is the new behavior?

Fixes the typos

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
