### PR TITLE
refactor(ivy): remove dynamicParent from LNode

### DIFF
--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -301,7 +301,6 @@ export function i18nApply(startIndex: number, instructions: I18nInstruction[]): 
         // But since this text doesn't have an index in `LViewData`, we need to create an
         // `LElementNode` with the index -1 so that it isn't saved in `LViewData`
         const textLNode = createLNode(-1, TNodeType.Element, textRNode, null, null);
-        textLNode.dynamicParent = localParentNode as LElementNode | LContainerNode;
         localPreviousNode = appendI18nNode(textLNode, localParentNode, localPreviousNode);
         break;
       case I18nInstructions.CloseNode:

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -17,7 +17,7 @@ import {ACTIVE_INDEX, LContainer, RENDER_PARENT, VIEWS} from './interfaces/conta
 import {LInjector} from './interfaces/injector';
 import {CssSelectorList, LProjection, NG_PROJECT_AS_ATTR_NAME} from './interfaces/projection';
 import {LQueries} from './interfaces/query';
-import {BINDING_INDEX, CLEANUP, CONTEXT, CurrentMatchesList, DIRECTIVES, FLAGS, HEADER_OFFSET, HOST_NODE, INJECTOR, LViewData, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, RootContext, SANITIZER, TAIL, TData, TVIEW, TView} from './interfaces/view';
+import {BINDING_INDEX, CLEANUP, CONTAINER_INDEX, CONTEXT, CurrentMatchesList, DIRECTIVES, FLAGS, HEADER_OFFSET, HOST_NODE, INJECTOR, LViewData, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, RootContext, SANITIZER, TAIL, TData, TVIEW, TView} from './interfaces/view';
 
 import {AttributeMarker, TAttributes, LContainerNode, LElementNode, LNode, TNodeType, TNodeFlags, LProjectionNode, LTextNode, LViewNode, TNode, TContainerNode, InitialInputData, InitialInputs, PropertyAliases, PropertyAliasValue, TElementNode,} from './interfaces/node';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
@@ -303,7 +303,8 @@ export function createLViewData<T>(
     viewData && viewData[INJECTOR],                                              // injector
     renderer,                                                                    // renderer
     sanitizer || null,                                                           // sanitizer
-    null                                                                         // tail
+    null,                                                                        // tail
+    -1                                                                           // containerIndex
   ];
 }
 
@@ -325,7 +326,6 @@ export function createLNodeObject(
     tNode: null !,
     pNextOrParent: null,
     dynamicLContainerNode: null,
-    dynamicParent: null,
     pChild: null,
   };
 }
@@ -1783,14 +1783,10 @@ export function embeddedViewStart(viewBlockId: number): RenderFlags {
     enterView(
         newView, viewNode = createLNode(viewBlockId, TNodeType.View, null, null, null, newView));
   }
-  const containerNode = getParentLNode(viewNode) as LContainerNode;
-  if (containerNode) {
-    ngDevMode && assertNodeType(viewNode, TNodeType.View);
-    ngDevMode && assertNodeType(containerNode, TNodeType.Container);
-    const lContainer = containerNode.data;
+  if (container) {
     if (creationMode) {
       // it is a new view, insert it into collection of views for a given container
-      insertView(containerNode, viewNode, lContainer[ACTIVE_INDEX] !);
+      insertView(container, viewNode, lContainer[ACTIVE_INDEX] !);
     }
     lContainer[ACTIVE_INDEX] !++;
   }

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -118,12 +118,6 @@ export interface LNode {
    */
   // TODO(kara): Remove when removing LNodes
   dynamicLContainerNode: LContainerNode|null;
-
-  /**
-   * A pointer to a parent LNode created dynamically and virtually by directives requesting
-   * ViewContainerRef. Applicable only to LContainerNode and LViewNode.
-   */
-  dynamicParent: LElementNode|LContainerNode|LViewNode|null;
 }
 
 
@@ -142,7 +136,6 @@ export interface LTextNode extends LNode {
   native: RText;
   readonly data: null;
   dynamicLContainerNode: null;
-  dynamicParent: null;
 }
 
 /** Abstract node which contains root nodes of a view. */

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -11,12 +11,12 @@ import {Sanitizer} from '../../sanitization/security';
 
 import {LContainer} from './container';
 import {ComponentQuery, ComponentTemplate, DirectiveDefInternal, DirectiveDefList, PipeDef, PipeDefList} from './definition';
-import {LElementNode, LViewNode, TNode} from './node';
+import {LContainerNode, LElementNode, LViewNode, TNode} from './node';
 import {LQueries} from './query';
 import {Renderer3} from './renderer';
 
 /** Size of LViewData's header. Necessary to adjust for it when setting slots.  */
-export const HEADER_OFFSET = 14;
+export const HEADER_OFFSET = 15;
 
 // Below are constants for LViewData indices to help us look up LViewData members
 // without having to remember the specific indices.
@@ -35,6 +35,7 @@ export const INJECTOR = 10;
 export const RENDERER = 11;
 export const SANITIZER = 12;
 export const TAIL = 13;
+export const CONTAINER_INDEX = 14;
 
 /**
  * `LViewData` stores all of the information needed to process the instructions as
@@ -122,7 +123,7 @@ export interface LViewData extends Array<any> {
    * - For embedded views, the context with which to render the template.
    * - For root view of the root component the context contains change detection data.
    * - `null` otherwise.
-  */
+   */
   [CONTEXT]: {}|RootContext|null;
 
   /** An optional Module Injector to be used as fall back after Element Injectors are consulted. */
@@ -142,6 +143,16 @@ export interface LViewData extends Array<any> {
    */
   // TODO: replace with global
   [TAIL]: LViewData|LContainer|null;
+
+  /**
+   * The index of the parent container's host node. Applicable only to embedded views that
+   * have been inserted dynamically. Will be -1 for component views and inline views.
+   *
+   * This is necessary to jump from dynamically created embedded views to their parent
+   * containers because their parent cannot be stored on the TViewNode (views may be inserted
+   * in multiple containers, so the parent cannot be shared between view instances).
+   */
+  [CONTAINER_INDEX]: number;
 }
 
 /** Flags associated with an LView (saved in LViewData[FLAGS]) */

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -9,6 +9,9 @@
     "name": "CLEAN_PROMISE"
   },
   {
+    "name": "CONTAINER_INDEX"
+  },
+  {
     "name": "CONTEXT"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -18,6 +18,9 @@
     "name": "CLEAN_PROMISE"
   },
   {
+    "name": "CONTAINER_INDEX"
+  },
+  {
     "name": "CONTEXT"
   },
   {


### PR DESCRIPTION
This PR removes `dynamicParent` from `LNode` and replaces it with `LViewData[CONTAINER_INDEX]`.  This is part of a larger refactor to eventually remove `LNodes`.
