### PR TITLE
fix(ivy): support projecting containers into containers

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1825,46 +1825,9 @@ export function embeddedViewEnd(): void {
   refreshView();
   isParent = false;
   previousOrParentNode = viewData[HOST_NODE] as LViewNode;
-  if (creationMode) {
-    const containerNode = getParentLNode(previousOrParentNode) as LContainerNode;
-    if (containerNode) {
-      ngDevMode && assertNodeType(previousOrParentNode, TNodeType.View);
-      ngDevMode && assertNodeType(containerNode, TNodeType.Container);
-      // When projected nodes are going to be inserted, the renderParent of the dynamic container
-      // used by the ViewContainerRef must be set.
-      setRenderParentInProjectedNodes(
-          containerNode.data[RENDER_PARENT], previousOrParentNode as LViewNode);
-    }
-  }
   leaveView(viewData[PARENT] !);
   ngDevMode && assertEqual(isParent, false, 'isParent');
   ngDevMode && assertNodeType(previousOrParentNode, TNodeType.View);
-}
-
-/**
- * For nodes which are projected inside an embedded view, this function sets the renderParent
- * of their dynamic LContainerNode.
- * @param renderParent the renderParent of the LContainer which contains the embedded view.
- * @param viewNode the embedded view.
- */
-function setRenderParentInProjectedNodes(
-    renderParent: LElementNode | null, viewNode: LViewNode): void {
-  if (renderParent != null) {
-    let node: LNode|null = getChildLNode(viewNode);
-    while (node) {
-      if (node.tNode.type === TNodeType.Projection) {
-        let nodeToProject: LNode|null = (node as LProjectionNode).data.head;
-        const lastNodeToProject = (node as LProjectionNode).data.tail;
-        while (nodeToProject) {
-          if (nodeToProject.dynamicLContainerNode) {
-            nodeToProject.dynamicLContainerNode.data[RENDER_PARENT] = renderParent;
-          }
-          nodeToProject = nodeToProject === lastNodeToProject ? null : nodeToProject.pNextOrParent;
-        }
-      }
-      node = getNextLNode(node);
-    }
-  }
 }
 
 /////////////
@@ -1940,7 +1903,7 @@ export function projectionDef(
     // execute selector matching logic if and only if:
     // - there are selectors defined
     // - a node has a tag name / attributes that can be matched
-    if (selectors && componentChild.tNode) {
+    if (selectors) {
       const matchedIdx = matchingSelectorIndex(componentChild.tNode, selectors, textSelectors !);
       distributedNodes[matchedIdx].push(componentChild);
     } else {
@@ -2031,10 +1994,14 @@ export function projection(
     // process each node in the list of projected nodes:
     let nodeToProject: LNode|null = node.data.head;
     const lastNodeToProject = node.data.tail;
+    const renderParent = currentParent.tNode.type === TNodeType.View ?
+        (getParentLNode(currentParent) as LContainerNode).data[RENDER_PARENT] ! :
+        currentParent as LElementNode;
+
     while (nodeToProject) {
       appendProjectedNode(
-          nodeToProject as LTextNode | LElementNode | LContainerNode, currentParent as LElementNode,
-          viewData);
+          nodeToProject as LTextNode | LElementNode | LContainerNode, currentParent, viewData,
+          renderParent);
       nodeToProject = nodeToProject === lastNodeToProject ? null : nodeToProject.pNextOrParent;
     }
   }

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -476,14 +476,14 @@ function executePipeOnDestroys(viewData: LViewData): void {
 
 /**
  * Returns whether a native element can be inserted into the given parent.
- * 
+ *
  * There are two reasons why we may not be able to insert a element immediately.
- * - Projection: When creating a child content element of a component, we have to skip the 
+ * - Projection: When creating a child content element of a component, we have to skip the
  *   insertion because the content of a component will be projected.
  *   `<component><content>delayed due to projection</content></component>`
- * - Parent container is disconnected: This can happen when we are inserting a view into 
- *   parent container, which itself is disconnected. For example the parent container is part 
- *   of a View which has not be inserted or is mare for projection but has not been inserted 
+ * - Parent container is disconnected: This can happen when we are inserting a view into
+ *   parent container, which itself is disconnected. For example the parent container is part
+ *   of a View which has not be inserted or is mare for projection but has not been inserted
  *   into destination.
  *
 
@@ -597,24 +597,24 @@ export function removeChild(parent: LNode, child: RNode | null, currentView: LVi
  * @param currentView Current LView
  */
 export function appendProjectedNode(
-    node: LElementNode | LTextNode | LContainerNode, currentParent: LElementNode,
-    currentView: LViewData): void {
+    node: LElementNode | LTextNode | LContainerNode, currentParent: LElementNode | LViewNode,
+    currentView: LViewData, renderParent: LElementNode): void {
   appendChild(currentParent, node.native, currentView);
   if (node.tNode.type === TNodeType.Container) {
-    // The node we are adding is a Container and we are adding it to Element which
+    // The node we are adding is a container and we are adding it to an element which
     // is not a component (no more re-projection).
     // Alternatively a container is projected at the root of a component's template
     // and can't be re-projected (as not content of any component).
-    // Assignee the final projection location in those cases.
+    // Assign the final projection location in those cases.
     const lContainer = (node as LContainerNode).data;
-    lContainer[RENDER_PARENT] = currentParent;
+    lContainer[RENDER_PARENT] = renderParent;
     const views = lContainer[VIEWS];
     for (let i = 0; i < views.length; i++) {
       addRemoveViewFromContainer(node as LContainerNode, views[i], true, null);
     }
   }
   if (node.dynamicLContainerNode) {
-    node.dynamicLContainerNode.data[RENDER_PARENT] = currentParent;
+    node.dynamicLContainerNode.data[RENDER_PARENT] = renderParent;
     appendChild(currentParent, node.dynamicLContainerNode.native, currentView);
   }
 }


### PR DESCRIPTION
This PR fixes our support for projecting inline containers into containers. Previously, we were assuming that projection nodes were always nested in elements or components, so the render parent of projected inline containers was sometimes being set to view nodes. (Note: projected dynamic containers worked because their render parents were set using a separate process. There is an existing test for this in view_container_ref_spec.ts).