### PR TITLE
feat(core): add support for ShadowDOM v1

### DIFF
--- a/packages/compiler/src/core.ts
+++ b/packages/compiler/src/core.ts
@@ -75,7 +75,8 @@ export interface Component extends Directive {
 export enum ViewEncapsulation {
   Emulated = 0,
   Native = 1,
-  None = 2
+  None = 2,
+  ShadowDom = 3
 }
 
 export enum ChangeDetectionStrategy {

--- a/packages/core/src/metadata/view.ts
+++ b/packages/core/src/metadata/view.ts
@@ -23,6 +23,7 @@ export enum ViewEncapsulation {
    */
   Emulated = 0,
   /**
+   * @deprecated use {ViewEncapsulation.ShadowDom}
    * Use the native encapsulation mechanism of the renderer.
    *
    * For the DOM this means using [Shadow DOM](https://w3c.github.io/webcomponents/spec/shadow/) and
@@ -32,5 +33,13 @@ export enum ViewEncapsulation {
   /**
    * Don't provide any template or style encapsulation.
    */
-  None = 2
+  None = 2,
+
+  /**
+   * Use Shadow DOM to encapsulate styles.
+   *
+   * For the DOM this means using [Shadow DOM](https://w3c.github.io/webcomponents/spec/shadow/) and
+   * creating a ShadowRoot for Component's Host Element.
+   */
+  ShadowDom = 3
 }

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -256,7 +256,11 @@ class ShadowDomRenderer extends DefaultDomRenderer2 {
       eventManager: EventManager, private sharedStylesHost: DomSharedStylesHost,
       private hostEl: any, private component: RendererType2) {
     super(eventManager);
-    this.shadowRoot = (hostEl as any).createShadowRoot();
+    if (component.encapsulation === ViewEncapsulation.ShadowDom) {
+      this.shadowRoot = (hostEl as any).attachShadow({mode: 'open'});
+    } else {
+      this.shadowRoot = (hostEl as any).createShadowRoot();
+    }
     this.sharedStylesHost.addHost(this.shadowRoot);
     const styles = flattenStyles(component.id, component.styles, []);
     for (let i = 0; i < styles.length; i++) {

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -20,7 +20,8 @@ import {NAMESPACE_URIS} from '../../src/dom/dom_renderer';
     beforeEach(() => {
       TestBed.configureTestingModule({
         declarations: [
-          TestCmp, SomeApp, CmpEncapsulationEmulated, CmpEncapsulationNative, CmpEncapsulationNone
+          TestCmp, SomeApp, CmpEncapsulationEmulated, CmpEncapsulationNative, CmpEncapsulationNone,
+          CmpEncapsulationNative
         ]
       });
       renderer = TestBed.createComponent(TestCmp).componentInstance.renderer;
@@ -133,6 +134,15 @@ class CmpEncapsulationEmulated {
   encapsulation: ViewEncapsulation.None
 })
 class CmpEncapsulationNone {
+}
+
+@Component({
+  selector: 'cmp-shadow',
+  template: `<div class="shadow"></div><cmp-emulated></cmp-emulated><cmp-none></cmp-none>`,
+  styles: [`.native { color: red; }`],
+  encapsulation: ViewEncapsulation.ShadowDom
+})
+class CmpEncapsulationShadow {
 }
 
 @Component({

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -938,6 +938,7 @@ export declare enum ViewEncapsulation {
     Emulated = 0,
     Native = 1,
     None = 2,
+    ShadowDom = 3,
 }
 
 export declare abstract class ViewRef extends ChangeDetectorRef {


### PR DESCRIPTION
Partially resolves #23636 - it adds a new ViewEncapsulation option which uses the modern Shadow DOM API - `.attachShadow({ mode: 'open' })`

This should allow Angular Elements to be used in combination with `<slot>` elements for basic native content projection. 

`ViewEncapsulation.Shadow` is added as a new API, rather than changing the behavior of the `ViewEncapsulation.Native` option, which could lead to unexpected results for developers currently using the v0 API. 

This should (eventually?) deprecate the `ViewEncapsulation.Native` option.