### PR TITLE
feat(ivy): support templateUrl for ngtsc

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/index.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/index.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+export {ResourceLoader} from './src/api';
 export {ComponentDecoratorHandler} from './src/component';
 export {DirectiveDecoratorHandler} from './src/directive';
 export {InjectableDecoratorHandler} from './src/injectable';

--- a/packages/compiler-cli/src/ngtsc/annotations/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/api.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export interface ResourceLoader {
+  preload?(url: string): Promise<void>|undefined;
+  load(url: string): string;
+}

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -12,17 +12,28 @@ import * as ts from 'typescript';
 
 import * as api from '../transformers/api';
 
-import {ComponentDecoratorHandler, DirectiveDecoratorHandler, InjectableDecoratorHandler, NgModuleDecoratorHandler, PipeDecoratorHandler, SelectorScopeRegistry} from './annotations';
+import {ComponentDecoratorHandler, DirectiveDecoratorHandler, InjectableDecoratorHandler, NgModuleDecoratorHandler, PipeDecoratorHandler, ResourceLoader, SelectorScopeRegistry} from './annotations';
 import {CompilerHost} from './compiler_host';
 import {TypeScriptReflectionHost} from './metadata';
+import {ApiResourceLoader, FileResourceLoader} from './resource_loader';
 import {IvyCompilation, ivyTransformFactory} from './transform';
 
 export class NgtscProgram implements api.Program {
   private tsProgram: ts.Program;
+  private resourceLoader: ResourceLoader;
+  private compilation: IvyCompilation|undefined = undefined;
+
+  private _coreImportsFrom: ts.SourceFile|null|undefined = undefined;
+  private _reflector: TypeScriptReflectionHost|undefined = undefined;
+  private _isCore: boolean|undefined = undefined;
 
   constructor(
       rootNames: ReadonlyArray<string>, private options: api.CompilerOptions,
       private host: api.CompilerHost, oldProgram?: api.Program) {
+    this.resourceLoader = host.readResource !== undefined ?
+        new ApiResourceLoader(host.readResource.bind(host)) :
+        new FileResourceLoader();
+
     this.tsProgram =
         ts.createProgram(rootNames, options, host, oldProgram && oldProgram.getTsProgram());
   }
@@ -62,7 +73,16 @@ export class NgtscProgram implements api.Program {
     return [];
   }
 
-  loadNgStructureAsync(): Promise<void> { return Promise.resolve(); }
+  async loadNgStructureAsync(): Promise<void> {
+    if (this.compilation === undefined) {
+      this.compilation = this.makeCompilation();
+
+      await this.tsProgram.getSourceFiles()
+          .filter(file => !file.fileName.endsWith('.d.ts'))
+          .map(file => this.compilation !.analyzeAsync(file))
+          .filter((result): result is Promise<void> => result !== undefined);
+    }
+  }
 
   listLazyRoutes(entryRoute?: string|undefined): api.LazyRoute[] {
     throw new Error('Method not implemented.');
@@ -88,30 +108,13 @@ export class NgtscProgram implements api.Program {
     mergeEmitResultsCallback?: api.TsMergeEmitResultsCallback
   }): ts.EmitResult {
     const emitCallback = opts && opts.emitCallback || defaultEmitCallback;
-    const mergeEmitResultsCallback = opts && opts.mergeEmitResultsCallback || mergeEmitResults;
 
-    const checker = this.tsProgram.getTypeChecker();
-    const isCore = isAngularCorePackage(this.tsProgram);
-    const reflector = new TypeScriptReflectionHost(checker);
-    const scopeRegistry = new SelectorScopeRegistry(checker, reflector);
-
-    // Set up the IvyCompilation, which manages state for the Ivy transformer.
-    const handlers = [
-      new ComponentDecoratorHandler(checker, reflector, scopeRegistry, isCore),
-      new DirectiveDecoratorHandler(checker, reflector, scopeRegistry, isCore),
-      new InjectableDecoratorHandler(reflector, isCore),
-      new NgModuleDecoratorHandler(checker, reflector, scopeRegistry, isCore),
-      new PipeDecoratorHandler(reflector, isCore),
-    ];
-
-    const coreImportsFrom = isCore && getR3SymbolsFile(this.tsProgram) || null;
-
-    const compilation = new IvyCompilation(handlers, checker, reflector, coreImportsFrom);
-
-    // Analyze every source file in the program.
-    this.tsProgram.getSourceFiles()
-        .filter(file => !file.fileName.endsWith('.d.ts'))
-        .forEach(file => compilation.analyze(file));
+    if (this.compilation === undefined) {
+      this.compilation = this.makeCompilation();
+      this.tsProgram.getSourceFiles()
+          .filter(file => !file.fileName.endsWith('.d.ts'))
+          .forEach(file => this.compilation !.analyzeSync(file));
+    }
 
     // Since there is no .d.ts transformation API, .d.ts files are transformed during write.
     const writeFile: ts.WriteFileCallback =
@@ -120,7 +123,8 @@ export class NgtscProgram implements api.Program {
          sourceFiles: ReadonlyArray<ts.SourceFile>) => {
           if (fileName.endsWith('.d.ts')) {
             data = sourceFiles.reduce(
-                (data, sf) => compilation.transformedDtsFor(sf.fileName, data, fileName), data);
+                (data, sf) => this.compilation !.transformedDtsFor(sf.fileName, data, fileName),
+                data);
           }
           this.host.writeFile(fileName, data, writeByteOrderMark, onError, sourceFiles);
         };
@@ -133,10 +137,48 @@ export class NgtscProgram implements api.Program {
       options: this.options,
       emitOnlyDtsFiles: false, writeFile,
       customTransformers: {
-        before: [ivyTransformFactory(compilation, reflector, coreImportsFrom)],
+        before: [ivyTransformFactory(this.compilation !, this.reflector, this.coreImportsFrom)],
       },
     });
     return emitResult;
+  }
+
+  private makeCompilation(): IvyCompilation {
+    const checker = this.tsProgram.getTypeChecker();
+    const scopeRegistry = new SelectorScopeRegistry(checker, this.reflector);
+
+    // Set up the IvyCompilation, which manages state for the Ivy transformer.
+    const handlers = [
+      new ComponentDecoratorHandler(
+          checker, this.reflector, scopeRegistry, this.isCore, this.resourceLoader),
+      new DirectiveDecoratorHandler(checker, this.reflector, scopeRegistry, this.isCore),
+      new InjectableDecoratorHandler(this.reflector, this.isCore),
+      new NgModuleDecoratorHandler(checker, this.reflector, scopeRegistry, this.isCore),
+      new PipeDecoratorHandler(this.reflector, this.isCore),
+    ];
+
+    return new IvyCompilation(handlers, checker, this.reflector, this.coreImportsFrom);
+  }
+
+  private get reflector(): TypeScriptReflectionHost {
+    if (this._reflector === undefined) {
+      this._reflector = new TypeScriptReflectionHost(this.tsProgram.getTypeChecker());
+    }
+    return this._reflector;
+  }
+
+  private get coreImportsFrom(): ts.SourceFile|null {
+    if (this._coreImportsFrom === undefined) {
+      this._coreImportsFrom = this.isCore && getR3SymbolsFile(this.tsProgram) || null;
+    }
+    return this._coreImportsFrom;
+  }
+
+  private get isCore(): boolean {
+    if (this._isCore === undefined) {
+      this._isCore = isAngularCorePackage(this.tsProgram);
+    }
+    return this._isCore;
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -15,7 +15,7 @@ import * as api from '../transformers/api';
 import {ComponentDecoratorHandler, DirectiveDecoratorHandler, InjectableDecoratorHandler, NgModuleDecoratorHandler, PipeDecoratorHandler, ResourceLoader, SelectorScopeRegistry} from './annotations';
 import {CompilerHost} from './compiler_host';
 import {TypeScriptReflectionHost} from './metadata';
-import {ApiResourceLoader, FileResourceLoader} from './resource_loader';
+import {FileResourceLoader, HostResourceLoader} from './resource_loader';
 import {IvyCompilation, ivyTransformFactory} from './transform';
 
 export class NgtscProgram implements api.Program {
@@ -31,7 +31,7 @@ export class NgtscProgram implements api.Program {
       rootNames: ReadonlyArray<string>, private options: api.CompilerOptions,
       private host: api.CompilerHost, oldProgram?: api.Program) {
     this.resourceLoader = host.readResource !== undefined ?
-        new ApiResourceLoader(host.readResource.bind(host)) :
+        new HostResourceLoader(host.readResource.bind(host)) :
         new FileResourceLoader();
 
     this.tsProgram =

--- a/packages/compiler-cli/src/ngtsc/resource_loader.ts
+++ b/packages/compiler-cli/src/ngtsc/resource_loader.ts
@@ -10,7 +10,10 @@ import * as fs from 'fs';
 
 import {ResourceLoader} from './annotations';
 
-export class ApiResourceLoader implements ResourceLoader {
+/**
+ * `ResourceLoader` which delegates to a `CompilerHost` resource loading method.
+ */
+export class HostResourceLoader implements ResourceLoader {
   private cache = new Map<string, string>();
   private fetching = new Set<string>();
 
@@ -41,13 +44,16 @@ export class ApiResourceLoader implements ResourceLoader {
 
     const result = this.host(url);
     if (typeof result !== 'string') {
-      throw new Error(`ApiResourceLoader: host(${url}) returned a Promise`);
+      throw new Error(`HostResourceLoader: host(${url}) returned a Promise`);
     }
     this.cache.set(url, result);
     return result;
   }
 }
 
+/**
+ * `ResourceLoader` which directly uses the filesystem to resolve resources synchronously.
+ */
 export class FileResourceLoader implements ResourceLoader {
   load(url: string): string { return fs.readFileSync(url, 'utf8'); }
 }

--- a/packages/compiler-cli/src/ngtsc/resource_loader.ts
+++ b/packages/compiler-cli/src/ngtsc/resource_loader.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as fs from 'fs';
+
+import {ResourceLoader} from './annotations';
+
+export class ApiResourceLoader implements ResourceLoader {
+  private cache = new Map<string, string>();
+  private fetching = new Set<string>();
+
+  constructor(private host: (url: string) => string | Promise<string>) {}
+
+  preload(url: string): Promise<void>|undefined {
+    if (this.cache.has(url) || this.fetching.has(url)) {
+      return undefined;
+    }
+
+    const result = this.host(url);
+    if (typeof result === 'string') {
+      this.cache.set(url, result);
+      return undefined;
+    } else {
+      this.fetching.add(url);
+      return result.then(str => {
+        this.fetching.delete(url);
+        this.cache.set(url, str);
+      });
+    }
+  }
+
+  load(url: string): string {
+    if (this.cache.has(url)) {
+      return this.cache.get(url) !;
+    }
+
+    const result = this.host(url);
+    if (typeof result !== 'string') {
+      throw new Error(`ApiResourceLoader: host(${url}) returned a Promise`);
+    }
+    this.cache.set(url, result);
+    return result;
+  }
+}
+
+export class FileResourceLoader implements ResourceLoader {
+  load(url: string): string { return fs.readFileSync(url, 'utf8'); }
+}

--- a/packages/compiler-cli/src/ngtsc/transform/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/api.ts
@@ -26,6 +26,15 @@ export interface DecoratorHandler<A> {
    */
   detect(decorator: Decorator[]): Decorator|undefined;
 
+
+  /**
+   * Asynchronously perform pre-analysis on the decorator/class combination.
+   *
+   * `preAnalyze` is optional and is not guaranteed to be called through all compilation flows. It
+   * will only be called if asynchronicity is supported in the CompilerHost.
+   */
+  preanalyze?(node: ts.Declaration, decorator: Decorator): Promise<void>|undefined;
+
   /**
    * Perform analysis on the decorator/class combination, producing instructions for compilation
    * if successful, or an array of diagnostic messages if the analysis fails or the decorator

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -147,6 +147,27 @@ describe('ngtsc behavioral tests', () => {
     expect(dtsContents).toContain('static ngComponentDef: i0.ComponentDef<TestCmp, \'test-cmp\'>');
   });
 
+  it('should compile Components without errors', () => {
+    writeConfig();
+    write('test.ts', `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test-cmp',
+          templateUrl: './dir/test.html',
+        })
+        export class TestCmp {}
+    `);
+    write('dir/test.html', '<p>Hello World</p>');
+
+    const exitCode = main(['-p', basePath], errorSpy);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(exitCode).toBe(0);
+
+    const jsContents = getContents('test.js');
+    expect(jsContents).toContain('Hello World');
+  });
+
   it('should compile NgModules without errors', () => {
     writeConfig();
     write('test.ts', `


### PR DESCRIPTION
This commit adds support for templateUrl in component templates within
ngtsc. The compilation pipeline is split into sync and async versions,
where asynchronous compilation invokes a special preanalyze() phase of
analysis. The preanalyze() phase can optionally return a Promise which
will delay compilation until it resolves.

A ResourceLoader interface is used to resolve templateUrls to template
strings and can return results either synchronously or asynchronously.
During sync compilation it is an error if the ResourceLoader returns a
Promise.

Two ResourceLoader implementations are provided. One uses 'fs' to read
resources directly from disk and is chosen if the CompilerHost doesn't
provide a readResource method. The other wraps the readResource method
from CompilerHost if it's provided.
