### PR TITLE
refactor(ivy): remove pChild from LNode

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -335,8 +335,7 @@ export function createLNodeObject(
     queries: queries,
     tNode: null !,
     pNextOrParent: null,
-    dynamicLContainerNode: null,
-    pChild: null,
+    dynamicLContainerNode: null
   };
 }
 
@@ -440,7 +439,7 @@ export function createLNode(
 /**
  * Resets the application state.
  */
-function resetApplicationState() {
+export function resetApplicationState() {
   isParent = false;
   previousOrParentNode = null !;
 }
@@ -1894,16 +1893,7 @@ export function projectionDef(
   }
 
   const componentNode: LElementNode = findComponentHost(viewData);
-  let isProjectingI18nNodes = false;
-  let componentChild: LNode|null;
-  // for i18n translations we use pChild to point to the next child
-  // TODO(kara): Remove when removing LNodes
-  if (componentNode.pChild) {
-    isProjectingI18nNodes = true;
-    componentChild = componentNode.pChild;
-  } else {
-    componentChild = getChildLNode(componentNode);
-  }
+  let componentChild = getChildLNode(componentNode);
 
   while (componentChild !== null) {
     // execute selector matching logic if and only if:
@@ -1916,11 +1906,7 @@ export function projectionDef(
       distributedNodes[0].push(componentChild);
     }
 
-    if (isProjectingI18nNodes) {
-      componentChild = componentChild.pNextOrParent;
-    } else {
-      componentChild = getNextLNode(componentChild);
-    }
+    componentChild = getNextLNode(componentChild);
   }
 
   ngDevMode && assertDataNext(index + HEADER_OFFSET);

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -101,13 +101,6 @@ export interface LNode {
   pNextOrParent: LNode|null;
 
   /**
-   * If this node is part of an i18n block, pointer to the first child after translation
-   * If this node is not part of an i18n block, this field is null.
-   */
-  // TODO(kara): Remove this when removing pNextOrParent
-  pChild: LNode|null;
-
-  /**
    * Pointer to the corresponding TNode object, which stores static
    * data about this node.
    */

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -29,9 +29,6 @@ export function getNextLNode(node: LNode): LNode|null {
 
 /** Retrieves the first child of a given node */
 export function getChildLNode(node: LNode): LNode|null {
-  if (node.pChild) {
-    return node.pChild;
-  }
   if (node.tNode.child) {
     const viewData = node.tNode.type === TNodeType.View ? node.data as LViewData : node.view;
     return viewData[node.tNode.child.index];

--- a/packages/core/test/render3/i18n_spec.ts
+++ b/packages/core/test/render3/i18n_spec.ts
@@ -518,7 +518,7 @@ describe('Runtime i18n', () => {
 
           // Translated to:
           // <ul i18n>
-          //   <li *ngFor="let item of items">valeur: {{item}}</li>
+          //   <li *ngFor="let item of items">valeur: {{item}}!</li>
           // </ul>
           template: (rf: RenderFlags, myApp: MyApp) => {
             if (rf & RenderFlags.Create) {


### PR DESCRIPTION
This PR reworks i18n to use the existing TNode tree instead of `LNode.pChild`. This is part of an ongoing refactor to remove `LNode` and reduce memory pressure.

Notes:
- Previously, static text nodes created by i18n were stored in `pChild` because there wasn't a reserved slot for static i18n text in `LViewData`. This PR pushes the text nodes to the end of `LViewData` upon creation, as the `i18nApply` instruction always occurs before any bindings. This way, the nodes have an index and can be looked up like any other node in the tree.
- The node tree assignments only occur on first template pass, so we can save some time on subsequent runs.