### PR TITLE
fix(ivy): correct position for re-projected containers

### DIFF
--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -9,7 +9,7 @@
 import {assertEqual, assertLessThan} from './assert';
 import {NO_CHANGE, bindingUpdated, createLNode, getPreviousOrParentNode, getRenderer, getViewData, load, resetApplicationState} from './instructions';
 import {RENDER_PARENT} from './interfaces/container';
-import {LContainerNode, LElementNode, LNode, TNodeType} from './interfaces/node';
+import {LContainerNode, LElementNode, LNode, TContainerNode, TNodeType} from './interfaces/node';
 import {BINDING_INDEX, HEADER_OFFSET, TVIEW} from './interfaces/view';
 import {appendChild, createTextNode, getParentLNode, removeChild} from './node_manipulation';
 import {stringify} from './util';
@@ -241,7 +241,8 @@ function appendI18nNode(node: LNode, parentNode: LNode, previousNode: LNode) {
   appendChild(parentNode, node.native || null, viewData);
 
   // On first pass, re-organize node tree to put this node in the correct position.
-  if (node.view[TVIEW].firstTemplatePass) {
+  const firstTemplatePass = node.view[TVIEW].firstTemplatePass;
+  if (firstTemplatePass) {
     node.tNode.next = null;
     if (previousNode === parentNode && node.tNode !== parentNode.tNode.child) {
       node.tNode.next = parentNode.tNode.child;
@@ -257,7 +258,10 @@ function appendI18nNode(node: LNode, parentNode: LNode, previousNode: LNode) {
     // (node.native as RComment).textContent = 'test';
     // console.log(node.native);
     appendChild(parentNode, node.dynamicLContainerNode.native || null, viewData);
-    node.pNextOrParent = node.dynamicLContainerNode;
+    if (firstTemplatePass) {
+      node.tNode.dynamicContainerNode = node.dynamicLContainerNode.tNode;
+      node.dynamicLContainerNode.tNode.parent = node.tNode as TContainerNode;
+    }
     return node.dynamicLContainerNode;
   }
 

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -618,7 +618,7 @@ export function appendProjectedNode(
     lContainer[RENDER_PARENT] = renderParent;
     const views = lContainer[VIEWS];
     for (let i = 0; i < views.length; i++) {
-      addRemoveViewFromContainer(node as LContainerNode, views[i], true, null);
+      addRemoveViewFromContainer(node as LContainerNode, views[i], true, node.native);
     }
   }
   if (node.dynamicLContainerNode) {


### PR DESCRIPTION
This PR fixes a bug where nodes in re-projected containers were being inserted without a beforeNode (and thus always appended to the end of their renderParent). This meant that any nodes that should have been after the containers were actually before them in the order.

Note:
- Also simplified the projection instruction to only iterate through the projection list once. Previously, we were iterating through the projectionDef bucket and building the projection linked list, then iterating through the linked list to append nodes. Instead, we can append nodes as we build the projection linked list.