### PR TITLE
fix(ivy): pipes are pure by default

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -50,7 +50,7 @@ export class PipeDecoratorHandler implements DecoratorHandler<R3PipeMetadata> {
     }
     this.scopeRegistry.registerPipe(clazz, pipeName);
 
-    let pure = false;
+    let pure = true;
     if (pipe.has('pure')) {
       const pureValue = staticallyResolve(pipe.get('pure') !, this.checker);
       if (typeof pureValue !== 'boolean') {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -270,6 +270,31 @@ describe('ngtsc behavioral tests', () => {
     expect(dtsContents).toContain('static ngPipeDef: i0.ɵPipeDef<TestPipe, \'test-pipe\'>;');
   });
 
+  it('should compile pure Pipes without errors', () => {
+    writeConfig();
+    write('test.ts', `
+        import {Pipe} from '@angular/core';
+
+        @Pipe({
+          name: 'test-pipe',
+        })
+        export class TestPipe {}
+    `);
+
+    const exitCode = main(['-p', basePath], errorSpy);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(exitCode).toBe(0);
+
+    const jsContents = getContents('test.js');
+    const dtsContents = getContents('test.d.ts');
+
+    expect(jsContents)
+        .toContain(
+            'TestPipe.ngPipeDef = i0.ɵdefinePipe({ name: "test-pipe", type: TestPipe, ' +
+            'factory: function TestPipe_Factory() { return new TestPipe(); }, pure: true })');
+    expect(dtsContents).toContain('static ngPipeDef: i0.ɵPipeDef<TestPipe, \'test-pipe\'>;');
+  });
+
   it('should compile Pipes with dependencies', () => {
     writeConfig();
     write('test.ts', `


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

PR #24703 added compilation for `@Pipes` in JiT and AoT. Pipes are considered pure by default in jiT but currently not in AoT

See https://github.com/angular/angular/pull/24703#discussion_r199970297


## What is the new behavior?

Makes pipes pure by default in AoT too.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```