### PR TITLE
 refactor(ivy): replace pNextOrParent with TNode props

### DIFF
--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -62,7 +62,6 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   private _bindingCode: o.Statement[] = [];
   private _postfixCode: o.Statement[] = [];
   private _temporary = temporaryAllocator(this._prefixCode, TEMPORARY_NAME);
-  private _projectionDefinitionIndex = -1;
   private _valueConverter: ValueConverter;
   private _unsupported = unsupported;
   private _bindingScope: BindingScope;
@@ -121,8 +120,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
     // Output a `ProjectionDef` instruction when some `<ng-content>` are present
     if (hasNgContent) {
-      this._projectionDefinitionIndex = this.allocateDataSlot();
-      const parameters: o.Expression[] = [o.literal(this._projectionDefinitionIndex)];
+      const parameters: o.Expression[] = [];
 
       // Only selectors with a non-default value are generated
       if (ngContentSelectors.length > 1) {
@@ -217,10 +215,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   visitContent(ngContent: t.Content) {
     const slot = this.allocateDataSlot();
     const selectorIndex = ngContent.selectorIndex;
-    const parameters: o.Expression[] = [
-      o.literal(slot),
-      o.literal(this._projectionDefinitionIndex),
-    ];
+    const parameters: o.Expression[] = [o.literal(slot)];
 
     const attributeAsList: string[] = [];
 

--- a/packages/compiler/test/render3/r3_compiler_compliance_spec.ts
+++ b/packages/compiler/test/render3/r3_compiler_compliance_spec.ts
@@ -871,9 +871,9 @@ describe('compiler compliance', () => {
           factory: function SimpleComponent_Factory() { return new SimpleComponent(); },
           template: function SimpleComponent_Template(rf: IDENT, ctx: IDENT) {
             if (rf & 1) {
-              $r3$.ɵpD(0);
-              $r3$.ɵE(1, 'div');
-              $r3$.ɵP(2, 0);
+              $r3$.ɵpD();
+              $r3$.ɵE(0, 'div');
+              $r3$.ɵP(1);
               $r3$.ɵe();
             }
           }
@@ -891,12 +891,12 @@ describe('compiler compliance', () => {
           factory: function ComplexComponent_Factory() { return new ComplexComponent(); },
           template: function ComplexComponent_Template(rf: IDENT, ctx: IDENT) {
             if (rf & 1) {
-              $r3$.ɵpD(0, $c1$, $c2$);
-              $r3$.ɵE(1, 'div', $c3$);
-              $r3$.ɵP(2, 0, 1);
+              $r3$.ɵpD($c1$, $c2$);
+              $r3$.ɵE(0, 'div', $c3$);
+              $r3$.ɵP(1, 1);
               $r3$.ɵe();
-              $r3$.ɵE(3, 'div', $c4$);
-              $r3$.ɵP(4, 0, 2);
+              $r3$.ɵE(2, 'div', $c4$);
+              $r3$.ɵP(3, 2);
               $r3$.ɵe();
             }
           }
@@ -1022,9 +1022,9 @@ describe('compiler compliance', () => {
             template: function ContentQueryComponent_Template(
                 rf: $RenderFlags$, ctx: $ContentQueryComponent$) {
               if (rf & 1) {
-                $r3$.ɵpD(0);
-                $r3$.ɵE(1, 'div');
-                $r3$.ɵP(2, 0);
+                $r3$.ɵpD();
+                $r3$.ɵE(0, 'div');
+                $r3$.ɵP(1);
                 $r3$.ɵe();
               }
             }

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -9,7 +9,7 @@
 import {assertEqual, assertLessThan} from './assert';
 import {NO_CHANGE, bindingUpdated, createLNode, getPreviousOrParentNode, getRenderer, getViewData, load, resetApplicationState} from './instructions';
 import {RENDER_PARENT} from './interfaces/container';
-import {LContainerNode, LElementNode, LNode, TContainerNode, TNodeType} from './interfaces/node';
+import {LContainerNode, LElementNode, LNode, TContainerNode, TElementNode, TNodeType} from './interfaces/node';
 import {BINDING_INDEX, HEADER_OFFSET, TVIEW} from './interfaces/view';
 import {appendChild, createTextNode, getParentLNode, removeChild} from './node_manipulation';
 import {stringify} from './util';
@@ -243,14 +243,17 @@ function appendI18nNode(node: LNode, parentNode: LNode, previousNode: LNode) {
   // On first pass, re-organize node tree to put this node in the correct position.
   const firstTemplatePass = node.view[TVIEW].firstTemplatePass;
   if (firstTemplatePass) {
-    node.tNode.next = null;
     if (previousNode === parentNode && node.tNode !== parentNode.tNode.child) {
       node.tNode.next = parentNode.tNode.child;
       parentNode.tNode.child = node.tNode;
     } else if (previousNode !== parentNode && node.tNode !== previousNode.tNode.next) {
       node.tNode.next = previousNode.tNode.next;
       previousNode.tNode.next = node.tNode;
+    } else {
+      node.tNode.next = null;
     }
+
+    if (parentNode.view === node.view) node.tNode.parent = parentNode.tNode as TElementNode;
   }
 
   // Template containers also have a comment node for the `ViewContainerRef` that should be moved

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1963,12 +1963,9 @@ export function projectionDef(
     // execute selector matching logic if and only if:
     // - there are selectors defined
     // - a node has a tag name / attributes that can be matched
-    if (selectors) {
-      const matchedIdx = matchingSelectorIndex(componentChild.tNode, selectors, textSelectors !);
-      distributedNodes[matchedIdx].push(componentChild);
-    } else {
-      distributedNodes[0].push(componentChild);
-    }
+    const bucketIndex =
+        selectors ? matchingSelectorIndex(componentChild.tNode, selectors, textSelectors !) : 0;
+    distributedNodes[bucketIndex].push(componentChild);
 
     componentChild = getNextLNode(componentChild);
   }
@@ -2031,8 +2028,10 @@ export function projection(
 
   const currentParent = getParentLNode(node);
   const canInsert = canInsertNativeNode(currentParent, viewData);
+  let grandparent: LContainerNode;
   const renderParent = currentParent.tNode.type === TNodeType.View ?
-      (getParentLNode(currentParent) as LContainerNode).data[RENDER_PARENT] ! :
+      (grandparent = getParentLNode(currentParent) as LContainerNode) &&
+          grandparent.data[RENDER_PARENT] ! :
       currentParent as LElementNode;
 
   for (let i = 0; i < nodesForSelector.length; i++) {

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1188,7 +1188,7 @@ export function createTNode(
     dynamicContainerNode: null,
     detached: null,
     stylingTemplate: null,
-    pData: null,
+    projection: null,
     pTargetIndex: -1,
     pListIndex: -1
   };
@@ -1956,9 +1956,9 @@ export function projectionDef(
   // to save them to traverse from a projected node to parent projection node.
   store(index, []);
 
-  if (!componentNode.tNode.pData) {
+  if (!componentNode.tNode.projection) {
     const noOfNodeBuckets = selectors ? selectors.length + 1 : 1;
-    const pData: (TNode | null)[] = componentNode.tNode.pData =
+    const pData: (TNode | null)[] = componentNode.tNode.projection =
         new Array(noOfNodeBuckets).fill(null);
     const tails: (TNode | null)[] = pData.slice();
 
@@ -2014,14 +2014,15 @@ export function projection(
       parent as LElementNode;
 
   if (canInsertNativeNode(parent, viewData)) {
-    let nodeToProject = componentNode.tNode.pData ![selectorIndex];
+    let nodeToProject = componentNode.tNode.projection ![selectorIndex];
     let projectedView = componentNode.view;
 
     while (nodeToProject) {
       if (nodeToProject.type === TNodeType.Projection) {
         // This node is re-projected, so we must go up the tree to get its projected nodes.
         const currentComponentHost = findComponentHost(projectedView);
-        const firstProjectedNode = currentComponentHost.tNode.pData ![nodeToProject.pListIndex];
+        const firstProjectedNode =
+            currentComponentHost.tNode.projection ![nodeToProject.pListIndex];
 
         if (firstProjectedNode) {
           nodeToProject = firstProjectedNode;

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1960,22 +1960,22 @@ export function projectionDef(
     const noOfNodeBuckets = selectors ? selectors.length + 1 : 1;
     const pData: (TNode | null)[] = componentNode.tNode.pData =
         new Array(noOfNodeBuckets).fill(null);
-    const tails: (TNode | null)[] = new Array(noOfNodeBuckets).fill(null);
+    const tails: (TNode | null)[] = pData.slice();
 
-    let componentChild = getChildLNode(componentNode);
+    let componentChild = componentNode.tNode.child;
 
     while (componentChild !== null) {
-      const bucketIndex = componentChild.tNode.pTargetIndex =
-          selectors ? matchingSelectorIndex(componentChild.tNode, selectors, textSelectors !) : 0;
-      const nextNode = getNextLNode(componentChild);
+      const bucketIndex = componentChild.pTargetIndex =
+          selectors ? matchingSelectorIndex(componentChild, selectors, textSelectors !) : 0;
+      const nextNode = componentChild.next;
 
       if (tails[bucketIndex]) {
-        tails[bucketIndex] !.next = componentChild.tNode;
+        tails[bucketIndex] !.next = componentChild;
       } else {
-        pData[bucketIndex] = componentChild.tNode;
-        componentChild.tNode.next = null;
+        pData[bucketIndex] = componentChild;
+        componentChild.next = null;
       }
-      tails[bucketIndex] = componentChild.tNode;
+      tails[bucketIndex] = componentChild;
 
       componentChild = nextNode;
     }

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1986,7 +1986,7 @@ export function projectionDef(
  *
  * This is deliberately created outside of projection() to avoid allocating
  * a new array each time the function is called. Instead the array will be
- * re-used by each invocation.
+ * re-used by each invocation. This works because the function is not reentrant.
  */
 const projectionNodeStack: LProjectionNode[] = [];
 

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -337,112 +337,50 @@ export interface TNode {
 
   stylingTemplate: StylingContext|null;
   /**
-   * List of projected TNodes for a given component host.
+   * List of projected TNodes for a given component host element OR index into the said nodes.
    *
-   * If this is the host TNode for a component with content projection, all projection data
-   * for that component *usage* is saved here as an array. Specifically, the head TNode of each
-   * projection list is stored here according to selector index. Otherwise, this is null.
+   * For easier discussion assume this example:
+   * `<parent>`'s view definition:
+   * ```
+   * <child id="c1">content1</child>
+   * <child id="c2"><span>content2</span></child>
+   * ```
+   * `<child>`'s view definition:
+   * ```
+   * <ng-content id="cont1"></ng-content>
+   * ```
    *
-   * e.g. If there are two projection targets inside the component, there will be two projection
-   * lists represented in the array (saving only the head TNode of the list). i.e. [TNode, TNode]
+   * If `Array.isArray(projection)` then `TNode` is a host element:
+   * - `projection` stores the content nodes which are to be projected.
+   *    - The nodes represent categories defined by the selector: For example:
+   *      `<ng-content/><ng-content select="abc"/>` would represent the heads for `<ng-content/>`
+   *      and `<ng-content select="abc"/>` respectively.
+   *    - The nodes we store in `projection` are heads only, we used `.next` to get their
+   *      siblings.
+   *    - The nodes `.next` is sorted/rewritten as part of the projection setup.
+   *    - `projection` size is equal to the number of projections `<ng-content>`. The size of
+   *      `c1` will be `1` because `<child>` has only one `<ng-content>`.
+   * - we store `projection` with the host (`c1`, `c2`) rather than the `<ng-content>` (`cont1`)
+   *   because the same component (`<child>`) can be used in multiple locations (`c1`, `c2`) and as
+   *   a result have different set of nodes to project.
+   * - without `projection` it would be difficult to efficiently traverse nodes to be projected.
    *
-   * This data cannot be stored in projection target TNodes (e.g. <ng-content> TNodes) because the
-   * projected nodes will change every time the component is used (and TProjectionNodes will be
-   * shared between all instances of the component). Component host nodes will change for every
-   * usage of the component, so we can safely store the projection data on component hosts.
-   *
-   * Example:
-   *
-   * app template:
-   * <comp>                <!-- comp usage #1 -->
-   *    <div>ABC</div>         <!-- projected node -->
-   * </comp>
-   * <comp>                 <!-- comp usage #2 -->
-   *     <div>DEF</div>        <!-- projected node -->
-   * </comp>
-   *
-   * comp template:
-   * <ng-content></ng-content>   <!-- projection target node -->
-   *
-   * In the case above, projection data would be stored on each component host node. In other words,
-   * the TNode for the first <comp> would have a pData array with the TNode for <div>ABC</div> and
-   * the TNode for the second <comp> would have its own pData array with the TNode for
-   * <div>DEF</div>.
-   *
-   *  If we didn't have this, we wouldn't be able to jump from a projection target node (ng-content)
-   *  up to the nodes it should be projecting in order to append or detach them.
+   * If `typeof projection == 'number'` then `TNode` is a `<ng-content>` element:
+   * - `projection` is an index of the host's `projection`Nodes.
+   *   - This would return the first head node to project:
+   *     `getHost(currentTNode).projection[currentTNode.projection]`.
+   * - When projecting nodes the parent node retrieved may be a `<ng-content>` node, in which case
+   *   the process is recursive in nature (not implementation).
    */
-  pData: (TNode|null)[]|null;
+  projection: (TNode|null)[]|null;
 
   /**
-   * For projected nodes, this is the index that the parent projection target LNode is stored in the
-   * projection def (projected node -> ng-content). For nodes that aren't projected, this will be
-   * -1.
-   *
-   * If we didn't have this index, it wouldn't be possible to detach embedded views that contain
-   * <ng-content> tags. In those cases, we traverse the node tree to detach the native element
-   * for each node. When an <ng-content> tag is reached, we have to traverse up to the parent view
-   * to detach the nodes projected into that target. Once we're done, we have to traverse back
-   * down to the original <ng-content> tag, so we can detach its "next" in the node tree.
-   * To do this, each projected node knows its 'pTargetIndex', or the index of its parent
-   * projection target in the projection def. Using this, we can jump back to the correct projection
-   * node and continue traversing the tree.
-   *
-   * Example:
-   *
-   * <comp>
-   *     <div>ABC</div>              <!-- projected node -->
-   * </comp>
-   *
-   * comp template:
-   *  % if (showing) {
-   *     <ng-content></ng-content>     <!-- projection target -->
-   *     <div>DEF</div>
-   *  % }
-   *
-   *  When `showing` is false, we walk the node tree to remove that embedded view. The first node in
-   * the view is a projection target (the ng-content tag), so to remove the view properly, we need
-   * to remove any nodes projected into it (i.e. the <div>ABC</div> in the parent view). Once we're
-   * done removing the <div>ABC</div>, we need a way to jump from that projected node to the
-   * original projection target (the ng-content tag), so we can remove its "next", the
-   * <div>DEF</div>.
+   * Will be replaced by stack.
    */
   pTargetIndex: number;
 
   /**
-   * For projection target nodes, the index of their list of projected nodes in the component's
-   * pData. For other types of nodes, this will be -1.
-   *
-   * If we didn't have pListIndex, we wouldn't be able to traverse from a projection target node
-   * (ng-content) to its list of projected nodes so we can append or detach them. This is necessary
-   * when appending re-projected nodes.
-   *
-   * Example:
-   *
-   * app template:
-   * <child>
-   *    <span>span</span>               <!-- projected node -->
-   *    <div>ABC</div>                  <!-- projected node -->
-   * </child>
-   *
-   * child template:
-   * <ng-content select="span"></ng-content>
-   * <grand-child>
-   *    <ng-content></ng-content>       <!-- re-projected target node -->
-   * </grand-child>
-   *
-   * grand-child template:
-   * <ng-content></ng-content>           <!-- projection target node -->
-   *
-   * In the above case, when evaluating the grand-child template, we would try to find the
-   * right nodes to project to the grand-child's projection target node. We would start by
-   * looking at the child of the grand-child component host, which also happens to be an
-   * <ng-content> tag. This means that we've hit a "re-projected target node". We need a way
-   * to get from this re-projected target up to the actual nodes we're re-projecting (e.g.
-   * <div>ABC</div>). We can't just look at the child of the <child> component host because
-   * there are multiple projection targets inside child. However, we've already collected
-   * pData for the child component, so we just need to know the index of the correct projection
-   * list inside pData - `pListIndex`.
+   * To be merged with `projection`
    */
   pListIndex: number;
 }
@@ -473,7 +411,7 @@ export interface TTextNode extends TNode {
    */
   parent: TElementNode|null;
   tViews: null;
-  pData: null;
+  projection: null;
 }
 
 /** Static data for an LContainerNode */
@@ -495,7 +433,7 @@ export interface TContainerNode extends TNode {
    */
   parent: TElementNode|null;
   tViews: TView|TView[]|null;
-  pData: null;
+  projection: null;
 }
 
 /** Static data for an LViewNode  */
@@ -505,7 +443,7 @@ export interface TViewNode extends TNode {
   child: TElementNode|TTextNode|TContainerNode|TProjectionNode|null;
   parent: TContainerNode|null;
   tViews: null;
-  pData: null;
+  projection: null;
 }
 
 /** Static data for an LProjectionNode  */

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -35,11 +35,14 @@ export const enum TNodeFlags {
   /** The number of directives on this node is encoded on the least significant bits */
   DirectiveCountMask = 0b00000000000000000000111111111111,
 
-  /** Then this bit is set when the node is a component */
-  isComponent = 0b1000000000000,
+  /** This bit is set if the node is a component */
+  isComponent = 0b00000000000000000001000000000000,
+
+  /** This bit is set if the node has been projected */
+  isProjected = 0b00000000000000000010000000000000,
 
   /** The index of the first directive on this node is encoded on the most significant bits  */
-  DirectiveStartingIndexShift = 13,
+  DirectiveStartingIndexShift = 14,
 }
 
 /**
@@ -373,11 +376,6 @@ export interface TNode {
    *   the process is recursive in nature (not implementation).
    */
   projection: (TNode|null)[]|number|null;
-
-  /**
-   * Will be replaced by stack.
-   */
-  pTargetIndex: number;
 }
 
 /** Static data for an LElementNode  */

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -347,9 +347,9 @@ export interface TNode {
    * lists represented in the array (saving only the head TNode of the list). i.e. [TNode, TNode]
    *
    * This data cannot be stored in projection target TNodes (e.g. <ng-content> TNodes) because the
-   * projected nodes will change every time the component is used (and TProjectionNodes will be shared
-   * between all instances of the component). Component host nodes will change for every usage of
-   * the component, so we can safely store the projection data on component hosts.
+   * projected nodes will change every time the component is used (and TProjectionNodes will be
+   * shared between all instances of the component). Component host nodes will change for every
+   * usage of the component, so we can safely store the projection data on component hosts.
    *
    * Example:
    *
@@ -366,7 +366,8 @@ export interface TNode {
    *
    * In the case above, projection data would be stored on each component host node. In other words,
    * the TNode for the first <comp> would have a pData array with the TNode for <div>ABC</div> and
-   * the TNode for the second <comp> would have its own pData array with the TNode for <div>DEF</div>.
+   * the TNode for the second <comp> would have its own pData array with the TNode for
+   * <div>DEF</div>.
    *
    *  If we didn't have this, we wouldn't be able to jump from a projection target node (ng-content)
    *  up to the nodes it should be projecting in order to append or detach them.
@@ -375,7 +376,8 @@ export interface TNode {
 
   /**
    * For projected nodes, this is the index that the parent projection target LNode is stored in the
-   * projection def (projected node -> ng-content). For nodes that aren't projected, this will be -1.
+   * projection def (projected node -> ng-content). For nodes that aren't projected, this will be
+   * -1.
    *
    * If we didn't have this index, it wouldn't be possible to detach embedded views that contain
    * <ng-content> tags. In those cases, we traverse the node tree to detach the native element
@@ -398,17 +400,18 @@ export interface TNode {
    *     <div>DEF</div>
    *  % }
    *
-   *  When `showing` is false, we walk the node tree to remove that embedded view. The first node in the
-   *  view is a projection target (the ng-content tag), so to remove the view properly, we need to remove
-   *  any nodes projected into it (i.e. the <div>ABC</div> in the parent view). Once we're done removing
-   *  the <div>ABC</div>, we need a way to jump from that projected node to the original projection target
-   *  (the ng-content tag), so we can remove its "next", the <div>DEF</div>.
+   *  When `showing` is false, we walk the node tree to remove that embedded view. The first node in
+   * the view is a projection target (the ng-content tag), so to remove the view properly, we need
+   * to remove any nodes projected into it (i.e. the <div>ABC</div> in the parent view). Once we're
+   * done removing the <div>ABC</div>, we need a way to jump from that projected node to the
+   * original projection target (the ng-content tag), so we can remove its "next", the
+   * <div>DEF</div>.
    */
   pTargetIndex: number;
 
   /**
-   * For projection target nodes, the index of their list of projected nodes in the component's pData.
-   * For other types of nodes, this will be -1.
+   * For projection target nodes, the index of their list of projected nodes in the component's
+   * pData. For other types of nodes, this will be -1.
    *
    * If we didn't have pListIndex, we wouldn't be able to traverse from a projection target node
    * (ng-content) to its list of projected nodes so we can append or detach them. This is necessary

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -372,17 +372,12 @@ export interface TNode {
    * - When projecting nodes the parent node retrieved may be a `<ng-content>` node, in which case
    *   the process is recursive in nature (not implementation).
    */
-  projection: (TNode|null)[]|null;
+  projection: (TNode|null)[]|number|null;
 
   /**
    * Will be replaced by stack.
    */
   pTargetIndex: number;
-
-  /**
-   * To be merged with `projection`
-   */
-  pListIndex: number;
 }
 
 /** Static data for an LElementNode  */
@@ -397,6 +392,13 @@ export interface TElementNode extends TNode {
    */
   parent: TElementNode|null;
   tViews: null;
+
+  /**
+   * If this is a component TNode with projection, this will be an array of projected
+   * TNodes (see TNode.projection for more info). If it's a regular element node or a
+   * component without projection, it will be null.
+   */
+  projection: (TNode|null)[]|null;
 }
 
 /** Static data for an LTextNode  */
@@ -457,6 +459,9 @@ export interface TProjectionNode extends TNode {
    */
   parent: TElementNode|null;
   tViews: null;
+
+  /** Index of the projection node. (See TNode.projection for more info.) */
+  projection: number;
 }
 
 /**

--- a/packages/core/src/render3/interfaces/projection.ts
+++ b/packages/core/src/render3/interfaces/projection.ts
@@ -1,3 +1,4 @@
+
 /**
  * @license
  * Copyright Google Inc. All Rights Reserved.
@@ -6,15 +7,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {LContainerNode, LElementNode, LTextNode} from './node';
-
-/**
- * Linked list of projected nodes (using the pNextOrParent property).
- */
-export interface LProjection {
-  head: LElementNode|LTextNode|LContainerNode|null;
-  tail: LElementNode|LTextNode|LContainerNode|null;
-}
 
 /**
  * Expresses a single CSS Selector.

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -37,8 +37,7 @@ export function getChildLNode(node: LNode): LNode|null {
   return null;
 }
 
-/** Given a projected node and the component it's projected into, returns the root projection node.
- */
+/** Given a projected node and the comp it's projected into, returns the projection node. */
 export function getProjectionNode(
     projectedNode: TNode, componentLNode: LElementNode): LProjectionNode {
   return componentLNode.data ![HEADER_OFFSET][projectedNode.pTargetIndex];

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -70,7 +70,7 @@ const enum WalkLNodeTreeAction {
  *
  * This is deliberately created outside of walkLNodeTree to avoid allocating
  * a new array each time the function is called. Instead the array will be
- * re-used by each invocation.
+ * re-used by each invocation. This works because the function is not reentrant.
  */
 const projectionNodeStack: LProjectionNode[] = [];
 

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -118,7 +118,8 @@ function walkLNodeTree(
       }
     } else if (nodeType === TNodeType.Projection) {
       const componentHost = findComponentHost(node.view);
-      const head = componentHost.tNode.projection ![node.tNode.pListIndex];
+      const head =
+          (componentHost.tNode.projection as(TNode | null)[])[node.tNode.projection as number];
 
       nextNode = head ? (componentHost.data as LViewData)[PARENT] ![head.index] : null;
     } else {

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -117,7 +117,7 @@ function walkLNodeTree(
       }
     } else if (node.tNode.type === TNodeType.Projection) {
       const componentHost = findComponentHost(node.view);
-      const head = componentHost.tNode.pData ![node.tNode.pListIndex];
+      const head = componentHost.tNode.projection ![node.tNode.pListIndex];
 
       nextNode = head ? (componentHost.data as LViewData)[PARENT] ![head.index] : null;
     } else {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -489,9 +489,6 @@
     "name": "getPreviousOrParentNode"
   },
   {
-    "name": "getProjectionNode"
-  },
-  {
     "name": "getRenderFlags"
   },
   {
@@ -607,6 +604,9 @@
   },
   {
     "name": "notImplemented"
+  },
+  {
+    "name": "projectionNodeStack"
   },
   {
     "name": "queueComponentIndexForCheck"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -423,6 +423,9 @@
     "name": "findAttrIndexInNode"
   },
   {
+    "name": "findComponentHost"
+  },
+  {
     "name": "findDirectiveMatches"
   },
   {
@@ -451,9 +454,6 @@
   },
   {
     "name": "getNextLNode"
-  },
-  {
-    "name": "getNextLNodeWithProjection"
   },
   {
     "name": "getOrCreateContainerRef"
@@ -487,6 +487,9 @@
   },
   {
     "name": "getPreviousOrParentNode"
+  },
+  {
+    "name": "getProjectionNode"
   },
   {
     "name": "getRenderFlags"

--- a/packages/core/test/render3/compiler_canonical/content_projection_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/content_projection_spec.ts
@@ -27,9 +27,9 @@ describe('content projection', () => {
         factory: () => new SimpleComponent(),
         template: function(rf: $RenderFlags$, ctx: $SimpleComponent$) {
           if (rf & 1) {
-            $r3$.ɵpD(0);
-            $r3$.ɵEe(1, 'div');
-            $r3$.ɵP(2, 0);
+            $r3$.ɵpD();
+            $r3$.ɵEe(0, 'div');
+            $r3$.ɵP(1);
           }
         }
       });
@@ -56,11 +56,11 @@ describe('content projection', () => {
         factory: () => new ComplexComponent(),
         template: function(rf: $RenderFlags$, ctx: $ComplexComponent$) {
           if (rf & 1) {
-            $r3$.ɵpD(0, $pD_0P$, $pD_0R$);
-            $r3$.ɵEe(1, 'div', ['id', 'first']);
-            $r3$.ɵP(2, 0, 1);
-            $r3$.ɵEe(3, 'div', ['id', 'second']);
-            $r3$.ɵP(4, 0, 2);
+            $r3$.ɵpD($pD_0P$, $pD_0R$);
+            $r3$.ɵEe(0, 'div', ['id', 'first']);
+            $r3$.ɵP(1, 1);
+            $r3$.ɵEe(2, 'div', ['id', 'second']);
+            $r3$.ɵP(3, 2);
           }
         }
       });

--- a/packages/core/test/render3/compiler_canonical/query_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/query_spec.ts
@@ -124,9 +124,9 @@ describe('queries', () => {
         template: function ContentQueryComponent_Template(
             rf: $number$, ctx: $ContentQueryComponent$) {
           if (rf & 1) {
-            $r3$.ɵpD(0);
-            $r3$.ɵE(1, 'div');
-            $r3$.ɵP(2, 0);
+            $r3$.ɵpD();
+            $r3$.ɵE(0, 'div');
+            $r3$.ɵP(1);
             $r3$.ɵe();
           }
         }

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -475,8 +475,8 @@ describe('content projection', () => {
     /**
      * <div>
      *  % if (!skipContent) {
-   *      <ng-content></ng-content>
-   *      text
+     *      <ng-content></ng-content>
+     *      text
      *  % }
      * </div>
      */

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -25,9 +25,9 @@ describe('content projection', () => {
      */
     const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'div');
-        { projection(2, 0); }
+        projectionDef();
+        elementStart(0, 'div');
+        { projection(1); }
         elementEnd();
       }
     });
@@ -51,8 +51,8 @@ describe('content projection', () => {
     /** <ng-content></ng-content> */
     const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        projection(1, 0);
+        projectionDef();
+        projection(0);
       }
     });
 
@@ -73,8 +73,8 @@ describe('content projection', () => {
     /** <ng-content></ng-content> */
     const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        projection(1, 0);
+        projectionDef();
+        projection(0);
       }
     });
 
@@ -107,9 +107,9 @@ describe('content projection', () => {
     /** <div><ng-content></ng-content></div> */
     const GrandChild = createComponent('grand-child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'div');
-        { projection(2, 0); }
+        projectionDef();
+        elementStart(0, 'div');
+        { projection(1); }
         elementEnd();
       }
     });
@@ -117,9 +117,9 @@ describe('content projection', () => {
     /** <grand-child><ng-content></ng-content></grand-child> */
     const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'grand-child');
-        { projection(2, 0); }
+        projectionDef();
+        elementStart(0, 'grand-child');
+        { projection(1); }
         elementEnd();
       }
     }, [GrandChild]);
@@ -148,9 +148,9 @@ describe('content projection', () => {
     /** <div><ng-content></ng-content></div> */
     const Child = createComponent('child', (rf: RenderFlags, ctx: any) => {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'div');
-        { projection(2, 0); }
+        projectionDef();
+        elementStart(0, 'div');
+        { projection(1); }
         elementEnd();
       }
     });
@@ -186,9 +186,9 @@ describe('content projection', () => {
     /** <div><ng-content></ng-content></div> */
     const Child = createComponent('child', (rf: RenderFlags, ctx: any) => {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'div');
-        { projection(2, 0); }
+        projectionDef();
+        elementStart(0, 'div');
+        { projection(1); }
         elementEnd();
       }
     });
@@ -196,9 +196,9 @@ describe('content projection', () => {
     /** <p><ng-content></ng-content></p> */
     const ProjectedComp = createComponent('projected-comp', (rf: RenderFlags, ctx: any) => {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'p');
-        projection(2, 0);
+        projectionDef();
+        elementStart(0, 'p');
+        projection(1);
         elementEnd();
       }
     });
@@ -239,9 +239,9 @@ describe('content projection', () => {
     /** <div> <ng-content></ng-content></div> */
     const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'div');
-        { projection(2, 0); }
+        projectionDef();
+        elementStart(0, 'div');
+        { projection(1); }
         elementEnd();
       }
     });
@@ -296,8 +296,8 @@ describe('content projection', () => {
     /** <ng-content></ng-content> */
     const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        projection(1, 0);
+        projectionDef();
+        projection(0);
       }
     });
 
@@ -345,9 +345,9 @@ describe('content projection', () => {
     /** <div><ng-content></ng-content></div> */
     const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'div');
-        { projection(2, 0); }
+        projectionDef();
+        elementStart(0, 'div');
+        { projection(1); }
         elementEnd();
       }
     });
@@ -417,19 +417,19 @@ describe('content projection', () => {
      */
     const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'div');
-        { container(2); }
+        projectionDef();
+        elementStart(0, 'div');
+        { container(1); }
         elementEnd();
       }
       if (rf & RenderFlags.Update) {
-        containerRefreshStart(2);
+        containerRefreshStart(1);
         {
           if (!ctx.skipContent) {
             let rf0 = embeddedViewStart(0);
             if (rf0 & RenderFlags.Create) {
               elementStart(0, 'span');
-              projection(1, 0);
+              projection(1);
               elementEnd();
             }
             embeddedViewEnd();
@@ -482,18 +482,18 @@ describe('content projection', () => {
      */
     const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'div');
-        { container(2); }
+        projectionDef();
+        elementStart(0, 'div');
+        { container(1); }
         elementEnd();
       }
       if (rf & RenderFlags.Update) {
-        containerRefreshStart(2);
+        containerRefreshStart(1);
         {
           if (!ctx.skipContent) {
             let rf0 = embeddedViewStart(0);
             if (rf0 & RenderFlags.Create) {
-              projection(0, 0);
+              projection(0);
               text(1, 'text');
             }
             embeddedViewEnd();
@@ -535,18 +535,18 @@ describe('content projection', () => {
         */
        const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
          if (rf & RenderFlags.Create) {
-           projectionDef(0);
-           elementStart(1, 'div');
-           { container(2); }
+           projectionDef();
+           elementStart(0, 'div');
+           { container(1); }
            elementEnd();
          }
          if (rf & RenderFlags.Update) {
-           containerRefreshStart(2);
+           containerRefreshStart(1);
            {
              if (!ctx.skipContent) {
                let rf0 = embeddedViewStart(0);
                if (rf0 & RenderFlags.Create) {
-                 projection(0, 0);
+                 projection(0);
                }
                embeddedViewEnd();
              }
@@ -589,22 +589,22 @@ describe('content projection', () => {
      */
     const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'div');
+        projectionDef();
+        elementStart(0, 'div');
         {
-          text(2, 'Before (inside)-');
-          container(3);
-          text(4, '-After (inside)');
+          text(1, 'Before (inside)-');
+          container(2);
+          text(3, '-After (inside)');
         }
         elementEnd();
       }
       if (rf & RenderFlags.Update) {
-        containerRefreshStart(3);
+        containerRefreshStart(2);
         {
           if (!ctx.skipContent) {
             let rf0 = embeddedViewStart(0);
             if (rf0 & RenderFlags.Create) {
-              projection(0, 0);
+              projection(0);
             }
             embeddedViewEnd();
           }
@@ -669,18 +669,18 @@ describe('content projection', () => {
      */
     const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'div');
-        { container(2); }
+        projectionDef();
+        elementStart(0, 'div');
+        { container(1); }
         elementEnd();
       }
       if (rf & RenderFlags.Update) {
-        containerRefreshStart(2);
+        containerRefreshStart(1);
         {
           if (!ctx.skipContent) {
             let rf0 = embeddedViewStart(0);
             if (rf0 & RenderFlags.Create) {
-              projection(0, 0);
+              projection(0);
             }
             embeddedViewEnd();
           }
@@ -700,22 +700,22 @@ describe('content projection', () => {
      */
     const Parent = createComponent('parent', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'child');
+        projectionDef();
+        elementStart(0, 'child');
         {
-          text(2, 'Before text');
-          container(3);
-          text(4, '-After text');
+          text(1, 'Before text');
+          container(2);
+          text(3, '-After text');
         }
         elementEnd();
       }
       if (rf & RenderFlags.Update) {
-        containerRefreshStart(3);
+        containerRefreshStart(2);
         {
           if (!ctx.skipContent) {
             let rf0 = embeddedViewStart(0);
             if (rf0 & RenderFlags.Create) {
-              projection(0, 0);
+              projection(0);
             }
             embeddedViewEnd();
           }
@@ -763,19 +763,19 @@ describe('content projection', () => {
         */
        const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
          if (rf & RenderFlags.Create) {
-           projectionDef(0);
-           elementStart(1, 'div');
-           { container(2); }
+           projectionDef();
+           elementStart(0, 'div');
+           { container(1); }
            elementEnd();
          }
          if (rf & RenderFlags.Update) {
-           containerRefreshStart(2);
+           containerRefreshStart(1);
            {
              if (!ctx.skipContent) {
                let rf0 = embeddedViewStart(0);
                if (rf0 & RenderFlags.Create) {
                  text(0, 'before-');
-                 projection(1, 0);
+                 projection(1);
                  text(2, '-after');
                }
                embeddedViewEnd();
@@ -833,19 +833,19 @@ describe('content projection', () => {
      */
     const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        text(1, 'Before-');
-        container(2, IfTemplate, '', [AttributeMarker.SelectOnly, 'ngIf']);
-        text(3, '-After');
+        projectionDef();
+        text(0, 'Before-');
+        container(1, IfTemplate, '', [AttributeMarker.SelectOnly, 'ngIf']);
+        text(2, '-After');
       }
       if (rf & RenderFlags.Update) {
-        elementProperty(2, 'ngIf', bind(ctx.showing));
+        elementProperty(1, 'ngIf', bind(ctx.showing));
       }
 
       function IfTemplate(rf1: RenderFlags, ctx1: any) {
         if (rf1 & RenderFlags.Create) {
-          projectionDef(0);
-          projection(1, 0);
+          projectionDef();
+          projection(0);
         }
       }
     }, [NgIf]);
@@ -918,19 +918,19 @@ describe('content projection', () => {
      */
     const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        text(1, 'Before-');
-        container(2, IfTemplate, '', [AttributeMarker.SelectOnly, 'ngIf']);
-        text(3, '-After');
+        projectionDef();
+        text(0, 'Before-');
+        container(1, IfTemplate, '', [AttributeMarker.SelectOnly, 'ngIf']);
+        text(2, '-After');
       }
       if (rf & RenderFlags.Update) {
-        elementProperty(2, 'ngIf', bind(ctx.showing));
+        elementProperty(1, 'ngIf', bind(ctx.showing));
       }
 
       function IfTemplate(rf1: RenderFlags, ctx1: any) {
         if (rf1 & RenderFlags.Create) {
-          projectionDef(0);
-          projection(1, 0);
+          projectionDef();
+          projection(0);
         }
       }
     }, [NgIf]);
@@ -979,12 +979,12 @@ describe('content projection', () => {
      */
     const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'div');
-        { projection(2, 0); }
+        projectionDef();
+        elementStart(0, 'div');
+        { projection(1); }
         elementEnd();
-        elementStart(3, 'span');
-        { projection(4, 0); }
+        elementStart(2, 'span');
+        { projection(3); }
         elementEnd();
       }
     });
@@ -1025,19 +1025,19 @@ describe('content projection', () => {
      */
     const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        projection(1, 0);
-        elementStart(2, 'div');
-        { container(3); }
+        projectionDef();
+        projection(0);
+        elementStart(1, 'div');
+        { container(2); }
         elementEnd();
       }
       if (rf & RenderFlags.Update) {
-        containerRefreshStart(3);
+        containerRefreshStart(2);
         {
           if (ctx.show) {
             let rf0 = embeddedViewStart(0);
             if (rf0 & RenderFlags.Create) {
-              projection(0, 0);
+              projection(0);
             }
             embeddedViewEnd();
           }
@@ -1071,10 +1071,10 @@ describe('content projection', () => {
   it('should project with multiple instances of a component with projection', () => {
     const ProjectionComp = createComponent('projection-comp', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        text(1, 'Before');
-        projection(2, 0);
-        text(3, 'After');
+        projectionDef();
+        text(0, 'Before');
+        projection(1);
+        text(2, 'After');
       }
     });
 
@@ -1129,10 +1129,10 @@ describe('content projection', () => {
      */
     const ProjectionComp = createComponent('projection-comp', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        text(1, 'Before');
-        projection(2, 0);
-        text(3, 'After');
+        projectionDef();
+        text(0, 'Before');
+        projection(1);
+        text(2, 'After');
       }
     });
 
@@ -1149,25 +1149,25 @@ describe('content projection', () => {
      */
     const ProjectionParent = createComponent('parent-comp', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'projection-comp');
+        projectionDef();
+        elementStart(0, 'projection-comp');
         {
-          elementStart(2, 'div');
-          { text(3, 'A'); }
+          elementStart(1, 'div');
+          { text(2, 'A'); }
           elementEnd();
-          projection(4, 0);
-          elementStart(5, 'p');
-          { text(6, '123'); }
+          projection(3, 0);
+          elementStart(4, 'p');
+          { text(5, '123'); }
           elementEnd();
         }
         elementEnd();
-        elementStart(7, 'projection-comp');
+        elementStart(6, 'projection-comp');
         {
-          elementStart(8, 'div');
-          { text(9, 'B'); }
+          elementStart(7, 'div');
+          { text(8, 'B'); }
           elementEnd();
-          elementStart(10, 'p');
-          { text(11, '456'); }
+          elementStart(9, 'p');
+          { text(10, '456'); }
           elementEnd();
         }
         elementEnd();
@@ -1215,13 +1215,13 @@ describe('content projection', () => {
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
           projectionDef(
-              0, [[['span', 'title', 'toFirst']], [['span', 'title', 'toSecond']]],
+              [[['span', 'title', 'toFirst']], [['span', 'title', 'toSecond']]],
               ['span[title=toFirst]', 'span[title=toSecond]']);
-          elementStart(1, 'div', ['id', 'first']);
-          { projection(2, 0, 1); }
+          elementStart(0, 'div', ['id', 'first']);
+          { projection(1, 1); }
           elementEnd();
-          elementStart(3, 'div', ['id', 'second']);
-          { projection(4, 0, 2); }
+          elementStart(2, 'div', ['id', 'second']);
+          { projection(3, 2); }
           elementEnd();
         }
       });
@@ -1260,8 +1260,8 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          projectionDef(0, [[['', 'title', '']]], ['[title]']);
-          { projection(1, 0, 1); }
+          projectionDef([[['', 'title', '']]], ['[title]']);
+          { projection(0, 1); }
         }
       });
 
@@ -1298,17 +1298,16 @@ describe('content projection', () => {
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
           projectionDef(
-              0,
               [
                 [['span', SelectorFlags.CLASS, 'toFirst']],
                 [['span', SelectorFlags.CLASS, 'toSecond']]
               ],
               ['span.toFirst', 'span.toSecond']);
-          elementStart(1, 'div', ['id', 'first']);
-          { projection(2, 0, 1); }
+          elementStart(0, 'div', ['id', 'first']);
+          { projection(1, 1); }
           elementEnd();
-          elementStart(3, 'div', ['id', 'second']);
-          { projection(4, 0, 2); }
+          elementStart(2, 'div', ['id', 'second']);
+          { projection(3, 2); }
           elementEnd();
         }
       });
@@ -1348,17 +1347,16 @@ describe('content projection', () => {
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
           projectionDef(
-              0,
               [
                 [['span', SelectorFlags.CLASS, 'toFirst']],
                 [['span', SelectorFlags.CLASS, 'toSecond']]
               ],
               ['span.toFirst', 'span.toSecond']);
-          elementStart(1, 'div', ['id', 'first']);
-          { projection(2, 0, 1); }
+          elementStart(0, 'div', ['id', 'first']);
+          { projection(1, 1); }
           elementEnd();
-          elementStart(3, 'div', ['id', 'second']);
-          { projection(4, 0, 2); }
+          elementStart(2, 'div', ['id', 'second']);
+          { projection(3, 2); }
           elementEnd();
         }
       });
@@ -1398,13 +1396,12 @@ describe('content projection', () => {
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
           projectionDef(
-              0, [[['span']], [['span', SelectorFlags.CLASS, 'toSecond']]],
-              ['span', 'span.toSecond']);
-          elementStart(1, 'div', ['id', 'first']);
-          { projection(2, 0, 1); }
+              [[['span']], [['span', SelectorFlags.CLASS, 'toSecond']]], ['span', 'span.toSecond']);
+          elementStart(0, 'div', ['id', 'first']);
+          { projection(1, 1); }
           elementEnd();
-          elementStart(3, 'div', ['id', 'second']);
-          { projection(4, 0, 2); }
+          elementStart(2, 'div', ['id', 'second']);
+          { projection(3, 2); }
           elementEnd();
         }
       });
@@ -1443,12 +1440,12 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          projectionDef(0, [[['span', SelectorFlags.CLASS, 'toFirst']]], ['span.toFirst']);
-          elementStart(1, 'div', ['id', 'first']);
-          { projection(2, 0, 1); }
+          projectionDef([[['span', SelectorFlags.CLASS, 'toFirst']]], ['span.toFirst']);
+          elementStart(0, 'div', ['id', 'first']);
+          { projection(1, 1); }
           elementEnd();
-          elementStart(3, 'div', ['id', 'second']);
-          { projection(4, 0); }
+          elementStart(2, 'div', ['id', 'second']);
+          { projection(3); }
           elementEnd();
         }
       });
@@ -1488,12 +1485,12 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          projectionDef(0, [[['span', SelectorFlags.CLASS, 'toSecond']]], ['span.toSecond']);
-          elementStart(1, 'div', ['id', 'first']);
-          { projection(2, 0); }
+          projectionDef([[['span', SelectorFlags.CLASS, 'toSecond']]], ['span.toSecond']);
+          elementStart(0, 'div', ['id', 'first']);
+          { projection(1); }
           elementEnd();
-          elementStart(3, 'div', ['id', 'second']);
-          { projection(4, 0, 1); }
+          elementStart(2, 'div', ['id', 'second']);
+          { projection(3, 1); }
           elementEnd();
         }
       });
@@ -1540,11 +1537,11 @@ describe('content projection', () => {
        */
       const GrandChild = createComponent('grand-child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          projectionDef(0, [[['span']]], ['span']);
-          projection(1, 0, 1);
-          elementStart(2, 'hr');
+          projectionDef([[['span']]], ['span']);
+          projection(0, 1);
+          elementStart(1, 'hr');
           elementEnd();
-          projection(3, 0, 0);
+          projection(2);
         }
       });
 
@@ -1556,12 +1553,12 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          projectionDef(0);
-          elementStart(1, 'grand-child');
+          projectionDef();
+          elementStart(0, 'grand-child');
           {
-            projection(2, 0);
-            elementStart(3, 'span');
-            { text(4, 'in child template'); }
+            projection(1);
+            elementStart(2, 'span');
+            { text(3, 'in child template'); }
             elementEnd();
           }
           elementEnd();
@@ -1603,12 +1600,12 @@ describe('content projection', () => {
       const Card = createComponent('card', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
           projectionDef(
-              0, [[['', 'card-title', '']], [['', 'card-content', '']]],
+              [[['', 'card-title', '']], [['', 'card-content', '']]],
               ['[card-title]', '[card-content]']);
-          projection(1, 0, 1);
-          elementStart(2, 'hr');
+          projection(0, 1);
+          elementStart(1, 'hr');
           elementEnd();
-          projection(3, 0, 2);
+          projection(2, 2);
         }
       });
 
@@ -1620,13 +1617,13 @@ describe('content projection', () => {
        */
       const CardWithTitle = createComponent('card-with-title', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          projectionDef(0);
-          elementStart(1, 'card');
+          projectionDef();
+          elementStart(0, 'card');
           {
-            elementStart(2, 'h1', ['card-title', '']);
-            { text(3, 'Title'); }
+            elementStart(1, 'h1', ['card-title', '']);
+            { text(2, 'Title'); }
             elementEnd();
-            projection(4, 0, 0, ['card-content', '']);
+            projection(3, 0, ['card-content', '']);
           }
           elementEnd();
         }
@@ -1662,12 +1659,12 @@ describe('content projection', () => {
       const Card = createComponent('card', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
           projectionDef(
-              0, [[['', 'card-title', '']], [['', 'card-content', '']]],
+              [[['', 'card-title', '']], [['', 'card-content', '']]],
               ['[card-title]', '[card-content]']);
-          projection(1, 0, 1);
-          elementStart(2, 'hr');
+          projection(0, 1);
+          elementStart(1, 'hr');
           elementEnd();
-          projection(3, 0, 2);
+          projection(2, 2);
         }
       });
 
@@ -1679,13 +1676,13 @@ describe('content projection', () => {
        */
       const CardWithTitle = createComponent('card-with-title', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          projectionDef(0);
-          elementStart(1, 'card');
+          projectionDef();
+          elementStart(0, 'card');
           {
-            elementStart(2, 'h1', ['ngProjectAs', '[card-title]']);
-            { text(3, 'Title'); }
+            elementStart(1, 'h1', ['ngProjectAs', '[card-title]']);
+            { text(2, 'Title'); }
             elementEnd();
-            projection(4, 0, 0, ['ngProjectAs', '[card-content]']);
+            projection(3, 0, ['ngProjectAs', '[card-content]']);
           }
           elementEnd();
         }
@@ -1717,8 +1714,8 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          projectionDef(0, [[['div']]], ['div']);
-          projection(1, 0, 1);
+          projectionDef([[['div']]], ['div']);
+          projection(0, 1);
         }
       });
 
@@ -1756,9 +1753,9 @@ describe('content projection', () => {
        */
       const Child = createComponent('child', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          projectionDef(0, [[['div']]], ['div']);
-          elementStart(1, 'span');
-          { projection(2, 0, 1); }
+          projectionDef([[['div']]], ['div']);
+          elementStart(0, 'span');
+          { projection(1, 1); }
           elementEnd();
         }
       });

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -947,8 +947,8 @@ describe('di', () => {
         factory: () => comp = new MyComp(injectChangeDetectorRef()),
         template: function(rf: RenderFlags, ctx: MyComp) {
           if (rf & RenderFlags.Create) {
-            projectionDef(0);
-            projection(1, 0);
+            projectionDef();
+            projection(0);
           }
         }
       });

--- a/packages/core/test/render3/i18n_spec.ts
+++ b/packages/core/test/render3/i18n_spec.ts
@@ -971,9 +971,9 @@ describe('Runtime i18n', () => {
           factory: () => new Child(),
           template: (rf: RenderFlags, cmp: Child) => {
             if (rf & RenderFlags.Create) {
-              projectionDef(0);
-              elementStart(1, 'p');
-              { projection(2, 0); }
+              projectionDef();
+              elementStart(0, 'p');
+              { projection(1); }
               elementEnd();
             }
           }
@@ -1063,9 +1063,9 @@ describe('Runtime i18n', () => {
           factory: () => new Child(),
           template: (rf: RenderFlags, cmp: Child) => {
             if (rf & RenderFlags.Create) {
-              projectionDef(0);
-              elementStart(1, 'p');
-              { projection(2, 0); }
+              projectionDef();
+              elementStart(0, 'p');
+              { projection(1); }
               elementEnd();
             }
           }
@@ -1145,9 +1145,9 @@ describe('Runtime i18n', () => {
           factory: () => new GrandChild(),
           template: (rf: RenderFlags, cmp: Child) => {
             if (rf & RenderFlags.Create) {
-              projectionDef(0);
-              elementStart(1, 'div');
-              { projection(2, 0); }
+              projectionDef();
+              elementStart(0, 'div');
+              { projection(1); }
               elementEnd();
             }
           }
@@ -1164,9 +1164,9 @@ describe('Runtime i18n', () => {
           factory: () => new Child(),
           template: (rf: RenderFlags, cmp: Child) => {
             if (rf & RenderFlags.Create) {
-              projectionDef(0);
-              elementStart(1, 'grand-child');
-              { projection(2, 0); }
+              projectionDef();
+              elementStart(0, 'grand-child');
+              { projection(1); }
               elementEnd();
             }
           }
@@ -1224,8 +1224,8 @@ describe('Runtime i18n', () => {
           factory: () => new Child(),
           template: (rf: RenderFlags, cmp: Child) => {
             if (rf & RenderFlags.Create) {
-              projectionDef(0, [[['span']]], ['span']);
-              projection(1, 0, 1);
+              projectionDef([[['span']]], ['span']);
+              projection(0, 1);
             }
           }
         });

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -502,19 +502,19 @@ describe('render3 integration test', () => {
         template: function ChildComponentTemplate(
             rf: RenderFlags, ctx: {beforeTree: Tree, afterTree: Tree}) {
           if (rf & RenderFlags.Create) {
-            projectionDef(0);
-            container(1);
-            projection(2, 0);
-            container(3);
+            projectionDef();
+            container(0);
+            projection(1);
+            container(2);
           }
-          containerRefreshStart(1);
+          containerRefreshStart(0);
           {
             const rf0 = embeddedViewStart(0);
             { showTree(rf0, {tree: ctx.beforeTree}); }
             embeddedViewEnd();
           }
           containerRefreshEnd();
-          containerRefreshStart(3);
+          containerRefreshStart(2);
           {
             const rf0 = embeddedViewStart(0);
             { showTree(rf0, {tree: ctx.afterTree}); }

--- a/packages/core/test/render3/lifecycle_spec.ts
+++ b/packages/core/test/render3/lifecycle_spec.ts
@@ -33,9 +33,9 @@ describe('lifecycles', () => {
 
     let Comp = createOnInitComponent('comp', (rf: RenderFlags, ctx: any) => {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'div');
-        { projection(2, 0); }
+        projectionDef();
+        elementStart(0, 'div');
+        { projection(1); }
         elementEnd();
       }
     });
@@ -500,27 +500,27 @@ describe('lifecycles', () => {
 
     let Comp = createAfterContentInitComp('comp', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        projection(1, 0);
+        projectionDef();
+        projection(0);
       }
     });
 
     let Parent = createAfterContentInitComp('parent', function(rf: RenderFlags, ctx: any) {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'comp');
-        { projection(2, 0); }
+        projectionDef();
+        elementStart(0, 'comp');
+        { projection(1); }
         elementEnd();
       }
       if (rf & RenderFlags.Update) {
-        elementProperty(1, 'val', bind(ctx.val));
+        elementProperty(0, 'val', bind(ctx.val));
       }
     }, [Comp]);
 
     let ProjectedComp = createAfterContentInitComp('projected', (rf: RenderFlags, ctx: any) => {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        projection(1, 0);
+        projectionDef();
+        projection(0);
       }
     });
 
@@ -893,9 +893,9 @@ describe('lifecycles', () => {
 
     let Comp = createAfterViewInitComponent('comp', (rf: RenderFlags, ctx: any) => {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'div');
-        { projection(2, 0); }
+        projectionDef();
+        elementStart(0, 'div');
+        { projection(1); }
         elementEnd();
       }
     });
@@ -1356,8 +1356,8 @@ describe('lifecycles', () => {
 
     let Comp = createOnDestroyComponent('comp', (rf: RenderFlags, ctx: any) => {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        projection(1, 0);
+        projectionDef();
+        projection(0);
       }
     });
     let Parent = createOnDestroyComponent('parent', getParentTemplate('comp'), [Comp]);
@@ -1893,9 +1893,9 @@ describe('lifecycles', () => {
 
     const Comp = createOnChangesComponent('comp', (rf: RenderFlags, ctx: any) => {
       if (rf & RenderFlags.Create) {
-        projectionDef(0);
-        elementStart(1, 'div');
-        { projection(2, 0); }
+        projectionDef();
+        elementStart(0, 'div');
+        { projection(1); }
         elementEnd();
       }
     });
@@ -2444,13 +2444,13 @@ describe('lifecycles', () => {
       /** <ng-content></ng-content><view [val]="val"></view> */
       const Parent = createAllHooksComponent('parent', (rf: RenderFlags, ctx: any) => {
         if (rf & RenderFlags.Create) {
-          projectionDef(0);
-          projection(1, 0);
-          elementStart(2, 'view');
+          projectionDef();
+          projection(0);
+          elementStart(1, 'view');
           elementEnd();
         }
         if (rf & RenderFlags.Update) {
-          elementProperty(2, 'val', bind(ctx.val));
+          elementProperty(1, 'val', bind(ctx.val));
         }
       }, [View]);
 

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -10,29 +10,16 @@ import {AttributeMarker, TAttributes, TNode, TNodeType} from '../../src/render3/
 
 import {CssSelector, CssSelectorList, NG_PROJECT_AS_ATTR_NAME, SelectorFlags,} from '../../src/render3/interfaces/projection';
 import {getProjectAsAttrValue, isNodeMatchingSelectorList, isNodeMatchingSelector} from '../../src/render3/node_selector_matcher';
+import {createTNode} from '@angular/core/src/render3/instructions';
 
 function testLStaticData(tagName: string, attrs: TAttributes | null): TNode {
-  return {
-    type: TNodeType.Element,
-    index: 0,
-    flags: 0, tagName, attrs,
-    localNames: null,
-    initialInputs: undefined,
-    inputs: undefined,
-    outputs: undefined,
-    tViews: null,
-    next: null,
-    child: null,
-    parent: null,
-    dynamicContainerNode: null,
-    detached: null,
-    stylingTemplate: null
-  };
+  return createTNode(TNodeType.Element, 0, tagName, attrs, null, null);
 }
 
 describe('css selector matching', () => {
   function isMatching(tagName: string, attrs: TAttributes | null, selector: CssSelector): boolean {
-    return isNodeMatchingSelector(testLStaticData(tagName, attrs), selector);
+    return isNodeMatchingSelector(
+        createTNode(TNodeType.Element, 0, tagName, attrs, null, null), selector);
   }
 
   describe('isNodeMatchingSimpleSelector', () => {

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -671,9 +671,9 @@ describe('ViewContainerRef', () => {
           factory: () => new Child(),
           template: (rf: RenderFlags, cmp: Child) => {
             if (rf & RenderFlags.Create) {
-              projectionDef(0);
-              elementStart(1, 'div');
-              { projection(2, 0); }
+              projectionDef();
+              elementStart(0, 'div');
+              { projection(1); }
               elementEnd();
             }
           }
@@ -742,17 +742,17 @@ describe('ViewContainerRef', () => {
           factory: () => new ChildWithView(),
           template: (rf: RenderFlags, cmp: ChildWithView) => {
             if (rf & RenderFlags.Create) {
-              projectionDef(0);
-              text(1, 'Before (inside)-');
-              container(2);
-              text(3, 'After (inside)');
+              projectionDef();
+              text(0, 'Before (inside)-');
+              container(1);
+              text(2, 'After (inside)');
             }
             if (rf & RenderFlags.Update) {
-              containerRefreshStart(2);
+              containerRefreshStart(1);
               if (cmp.show) {
                 let rf0 = embeddedViewStart(0);
                 if (rf0 & RenderFlags.Create) {
-                  projection(0, 0);
+                  projection(0);
                 }
                 embeddedViewEnd();
               }
@@ -827,12 +827,12 @@ describe('ViewContainerRef', () => {
           factory: () => new ChildWithSelector(),
           template: (rf: RenderFlags, cmp: ChildWithSelector) => {
             if (rf & RenderFlags.Create) {
-              projectionDef(0, [[['header']]], ['header']);
-              elementStart(1, 'first');
-              { projection(2, 0, 1); }
+              projectionDef([[['header']]], ['header']);
+              elementStart(0, 'first');
+              { projection(1, 1); }
               elementEnd();
-              elementStart(3, 'second');
-              { projection(4, 0); }
+              elementStart(2, 'second');
+              { projection(3); }
               elementEnd();
             }
           },


### PR DESCRIPTION
This PR reworks content projection to remove `LNode.pNextOrParent`. Instead, we re-assign `TNode.next` for projected nodes during `projectionDef` sorting and use a stack to keep track of the latest projection nodes when walking the node tree. This is part of a larger effort to reduce our memory footprint and eventually remove `LNode`.

Takeaways:
- The `projectionDef()` instruction no longer requires the allocation of a data slot. The instruction can be invoked directly because the data that used to be stored there is now stored on `TNode`. 
- Similarly, the `projection` instruction no longer requires an arg for the projection def index because this info can be retrieved using `TNode` props.
- Since we are storing projection data on the component host `TNode`, we only need to sort projected nodes on the first template pass. Later passes can re-use existing data.