### PR TITLE
fix: changed behavior of markAsTouched and markAsDirty

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -348,8 +348,11 @@ export abstract class AbstractControl {
   markAsTouched(opts: {onlySelf?: boolean} = {}): void {
     (this as{touched: boolean}).touched = true;
 
+    this._forEachChild(
+      (control: AbstractControl) => { control.markAsUntouched({onlySelf: true}); });
+
     if (this._parent && !opts.onlySelf) {
-      this._parent.markAsTouched(opts);
+      this._parent._updateTouched(opts);
     }
   }
 
@@ -388,8 +391,10 @@ export abstract class AbstractControl {
   markAsDirty(opts: {onlySelf?: boolean} = {}): void {
     (this as{pristine: boolean}).pristine = false;
 
+    this._forEachChild((control: AbstractControl) => { control.markAsDirty({onlySelf: true}); });
+
     if (this._parent && !opts.onlySelf) {
-      this._parent.markAsDirty(opts);
+      this._parent._updatePristine(opts);
     }
   }
 

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -348,8 +348,7 @@ export abstract class AbstractControl {
   markAsTouched(opts: {onlySelf?: boolean} = {}): void {
     (this as{touched: boolean}).touched = true;
 
-    this._forEachChild(
-        (control: AbstractControl) => { control.markAsTouched({onlySelf: true}); });
+    this._forEachChild((control: AbstractControl) => { control.markAsTouched({onlySelf: true}); });
 
     if (this._parent && !opts.onlySelf) {
       this._parent._updateTouched(opts);

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -349,7 +349,7 @@ export abstract class AbstractControl {
     (this as{touched: boolean}).touched = true;
 
     this._forEachChild(
-      (control: AbstractControl) => { control.markAsUntouched({onlySelf: true}); });
+        (control: AbstractControl) => { control.markAsUntouched({onlySelf: true}); });
 
     if (this._parent && !opts.onlySelf) {
       this._parent._updateTouched(opts);

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -349,7 +349,7 @@ export abstract class AbstractControl {
     (this as{touched: boolean}).touched = true;
 
     this._forEachChild(
-        (control: AbstractControl) => { control.markAsUntouched({onlySelf: true}); });
+        (control: AbstractControl) => { control.markAsTouched({onlySelf: true}); });
 
     if (this._parent && !opts.onlySelf) {
       this._parent._updateTouched(opts);

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -126,6 +126,12 @@ import {of } from 'rxjs';
 
         expect(g.dirty).toEqual(true);
       });
+
+      it('should be true after form is marked as dirty', () => {
+        g.markAsDirty();
+
+        expect(с.dirty).toEqual(true);
+      });
     });
 
 
@@ -143,6 +149,12 @@ import {of } from 'rxjs';
         c.markAsTouched();
 
         expect(g.touched).toEqual(true);
+      });
+
+      it('should be true after group is marked as touched', () => {
+        g.markAsTouched();
+
+        expect(c.touched).toEqual(true);
       });
     });
 

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -130,7 +130,7 @@ import {of } from 'rxjs';
       it('should be true after form is marked as dirty', () => {
         g.markAsDirty();
 
-        expect(с.dirty).toEqual(true);
+        expect(c.dirty).toEqual(true);
       });
     });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When you call `form.markAsTouched()` nested controls are still untouched. It's the same for markAsDirty. 

Issue Number: N/A


## What is the new behavior?
When you mark form as dirty or touched children controls react on this

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
I think it can break smth for people who rely on current behavior, but it seems non-logical in my opinion.

## Other information
P.S. sorry for my English. I just wanted to resolve such issues https://github.com/angular/angular/issues/11774 . Current behavior makes me crazy. I dont want to write recursive function every time.