### PR TITLE
fix(core): mark NgModule as not the root if APP_ROOT is set to false

### DIFF
--- a/packages/core/src/view/ng_module.ts
+++ b/packages/core/src/view/ng_module.ts
@@ -43,7 +43,7 @@ export function moduleDef(providers: NgModuleProviderDef[]): NgModuleDefinition 
   let isRoot: boolean = false;
   for (let i = 0; i < providers.length; i++) {
     const provider = providers[i];
-    if (provider.token === APP_ROOT) {
+    if (provider.token === APP_ROOT && provider.value === true) {
       isRoot = true;
     }
     if (provider.flags & NodeFlags.TypeNgModule) {

--- a/packages/core/test/view/ng_module_spec.ts
+++ b/packages/core/test/view/ng_module_spec.ts
@@ -14,6 +14,7 @@ import {NgModuleDefinition, NgModuleProviderDef, NodeFlags} from '@angular/core/
 import {moduleDef, moduleProvideDef, resolveNgModuleDep} from '@angular/core/src/view/ng_module';
 import {createNgModuleRef} from '@angular/core/src/view/refs';
 import {tokenKey} from '@angular/core/src/view/util';
+import {APP_ROOT} from '../../src/di/scope';
 
 class Foo {}
 
@@ -228,5 +229,30 @@ describe('NgModuleRef_ injector', () => {
     expect(Service.destroyed).toBe(0);
     ref.destroy();
     expect(Service.destroyed).toBe(1);
+  });
+
+  describe('moduleDef', () => {
+    function createProvider(token: any, value: any) {
+      return {
+        index: 0,
+        flags: NodeFlags.TypeValueProvider | NodeFlags.LazyProvider,
+        deps: [], token, value
+      };
+    }
+
+    it('sets isRoot to `true` when APP_ROOT is `true`', () => {
+      const def = moduleDef([createProvider(APP_ROOT, true)]);
+      expect(def.isRoot).toBe(true);
+    });
+
+    it('sets isRoot to `false` when APP_ROOT is absent', () => {
+      const def = moduleDef([]);
+      expect(def.isRoot).toBe(false);
+    });
+
+    it('sets isRoot to `false` when APP_ROOT is `false`', () => {
+      const def = moduleDef([createProvider(APP_ROOT, false)]);
+      expect(def.isRoot).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Tree shakable providers use the APP_ROOT token to determine where to attach themselves. APP_ROOT gets set on NgModule with BrowserModule irrespective of whether it is actually the root(Ex. in case of SSR app where the shell app is first bootstrapped without BrowserModule being the root module).

This change allows a NgModule with BrowserModule to explicitly mark itself as not the root by setting APP_ROOT token to false. This allows tree shakable providers to be attached to the right root module.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
NgModule with BrowserModule is always set as the root module. For a SSR app that is progressively bootstrapped the root module doesn't define the BrowserModule while the module with BrowserModule is loaded later.

However tree shakable injectors always attach themselves to the NgModule with BrowserModule and not it's parent.

## What is the new behavior?
This change allows a NgModule that imports BrowserModule to explicitly mark itself as not the root.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
