### PR TITLE
router(feature): allow configuration of when URL gets updated in navigation flow

### DIFF
--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -405,6 +405,18 @@ export interface ExtraOptions {
    * */
   malformedUriErrorHandler?:
       (error: URIError, urlSerializer: UrlSerializer, url: string) => UrlTree;
+
+  /**
+   * Defines when the router updates the browser URL. The default behavior is to update after
+   * successful navigation. However, some applications may prefer a mode where the URL gets
+   * updated at the beginning of navigation. The most common use case would be updating the
+   * URL early so if navigation fails, you can show an error message with the URL that failed.
+   * Available options are:
+   *
+   * - `'deferred'`, the default, updates the browser URL after navigation has finished.
+   * - `'eager'`, updates browser URL at the beginning of navigation.
+   */
+  urlUpdateStrategy?: 'deferred'|'eager';
 }
 
 export function setupRouter(
@@ -447,6 +459,10 @@ export function setupRouter(
 
   if (opts.paramsInheritanceStrategy) {
     router.paramsInheritanceStrategy = opts.paramsInheritanceStrategy;
+  }
+
+  if (opts.urlUpdateStrategy) {
+    router.urlUpdateStrategy = opts.urlUpdateStrategy;
   }
 
   return router;

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -121,6 +121,7 @@ export interface ExtraOptions {
     preloadingStrategy?: any;
     scrollOffset?: [number, number] | (() => [number, number]);
     scrollPositionRestoration?: 'disabled' | 'enabled' | 'top';
+    urlUpdateStrategy?: 'deferred' | 'eager';
     useHash?: boolean;
 }
 
@@ -323,6 +324,7 @@ export declare class Router {
     readonly routerState: RouterState;
     readonly url: string;
     urlHandlingStrategy: UrlHandlingStrategy;
+    urlUpdateStrategy: 'deferred' | 'eager';
     constructor(rootComponentType: Type<any> | null, urlSerializer: UrlSerializer, rootContexts: ChildrenOutletContexts, location: Location, injector: Injector, loader: NgModuleFactoryLoader, compiler: Compiler, config: Routes);
     createUrlTree(commands: any[], navigationExtras?: NavigationExtras): UrlTree;
     dispose(): void;


### PR DESCRIPTION
Fixes #24616

In the AngularJS routers (ui-router and ng-route), the URL would be updated before navigation happened. In the Angular Router, this was changed under the assumption that application developers would want to stay on the most recently successfully navigated to route.

However, this might not always be the case. For example, when a user lands on a page they don't have permissions for, we might want the application to show the target URL with a message saying the user doesn't have permissions. This way, if the user were to copy the URL or perform a refresh at this point, they would remain on the same page.

The point of this feature is to allow the developer to choose when the URL gets updated. Error handling has not changed with this PR, meaning the URL will get reset back to the last previously successful URL. There may need to be another change allowing configuration of error handling.