### PR TITLE
build(bazel): Undo temporary dependency on unleased TS bazel rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,9 +20,9 @@ http_archive(
 
 http_archive(
     name = "build_bazel_rules_typescript",
-    url = "https://github.com/rkirov/rules_typescript/archive/v0.16.0.zip",
-    strip_prefix = "rules_typescript-0.16.0",
-    sha256 = "f5aedd3a792e5af19cd0c0f0318cb692e2989e816e896e794152d07808fccacd",
+    url = "https://github.com/bazelbuild/rules_typescript/archive/0.15.1.zip",
+    strip_prefix = "rules_typescript-0.15.1",
+    sha256 = "3792cc20ef13bb1d1d8b1760894c3320f02a87843e3a04fed7e8e454a75328b6",
 )
 
 http_archive(


### PR DESCRIPTION
Point to a proper new release version 0.15.1.

