### PR TITLE
fix(platform-browser): workaround wrong import path generated by ngc …

### DIFF
--- a/packages/platform-browser/src/browser/meta.ts
+++ b/packages/platform-browser/src/browser/meta.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable} from '@angular/core';
+import {Inject, Injectable, inject} from '@angular/core';
 
 import {DomAdapter, getDOM} from '../dom/dom_adapter';
 import {DOCUMENT} from '../dom/dom_tokens';
+
 
 
 /**
@@ -30,11 +31,18 @@ export type MetaDefinition = {
 };
 
 /**
+ * Factory to create Meta service.
+ */
+export function createMeta() {
+  return new Meta(inject(DOCUMENT));
+}
+
+/**
  * A service that can be used to get and add meta tags.
  *
  * @experimental
  */
-@Injectable({providedIn: 'root'})
+@Injectable({providedIn: 'root', useFactory: createMeta, deps: []})
 export class Meta {
   private _dom: DomAdapter;
   constructor(@Inject(DOCUMENT) private _doc: any) { this._dom = getDOM(); }

--- a/packages/platform-browser/src/browser/title.ts
+++ b/packages/platform-browser/src/browser/title.ts
@@ -6,11 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable} from '@angular/core';
+import {Inject, Injectable, inject} from '@angular/core';
 
 import {getDOM} from '../dom/dom_adapter';
 import {DOCUMENT} from '../dom/dom_tokens';
 
+/**
+ * Factory to create Title service.
+ */
+export function createTitle() {
+  return new Title(inject(DOCUMENT));
+}
 
 /**
  * A service that can be used to get and set the title of a current HTML document.
@@ -22,7 +28,7 @@ import {DOCUMENT} from '../dom/dom_tokens';
  *
  * @experimental
  */
-@Injectable({providedIn: 'root'})
+@Injectable({providedIn: 'root', useFactory: createTitle, deps: []})
 export class Title {
   constructor(@Inject(DOCUMENT) private _doc: any) {}
   /**


### PR DESCRIPTION
…for DOCUMENT

Fixes Travis breakage while building platform-browser rollup bundle.
