### PR TITLE
fix(elements): add polyfill to specified project

### DIFF
--- a/packages/elements/schematics/ng-add/index.ts
+++ b/packages/elements/schematics/ng-add/index.ts
@@ -59,7 +59,7 @@ function addScript(options: Schema) {
       const angularJsonFile = host.read('angular.json');
       if (angularJsonFile) {
         const json = JSON.parse(angularJsonFile.toString('utf-8'));
-        const project = Object.keys(json['projects'])[0] || options.project;
+        const project = options.project || Object.keys(json['projects'])[0];
         const scripts = json['projects'][project]['architect']['build']['options']['scripts'];
         scripts.push({input: script});
         host.overwrite('angular.json', JSON.stringify(json, null, 2));

--- a/packages/elements/schematics/ng-add/index_spec.ts
+++ b/packages/elements/schematics/ng-add/index_spec.ts
@@ -40,11 +40,24 @@ describe('Elements Schematics', () => {
     skipTests: false,
   };
 
+  // tslint:disable-next-line:no-any
+  const secondAppOptions: any = {
+    name: 'foo',
+    inlineStyle: false,
+    inlineTemplate: false,
+    routing: false,
+    style: 'css',
+    skipTests: false,
+  };
+
   beforeEach((done) => {
     schematicRunner.runExternalSchematicAsync('@schematics/angular', 'workspace', workspaceOptions)
         .pipe(concatMap(
             (tree) => schematicRunner.runExternalSchematicAsync(
-                '@schematics/angular', 'application', appOptions, tree)))
+                '@schematics/angular', 'application', appOptions, tree)),
+            (tree) => schematicRunner.runExternalSchematicAsync(
+                '@schematics/angular', 'application', secondAppOptions, tree))
+        )
         .subscribe((tree: UnitTestTree) => appTree = tree, done.fail, done);
   });
 
@@ -57,10 +70,8 @@ describe('Elements Schematics', () => {
   });
 
   it('should run the ng-add schematic on a second project', () => {
-    appOptions.name = 'foo';
-    schematicRunner.runExternalSchematic('@schematics/angular', 'application', appOptions, appTree);
-    const secondAppOptions: ElementsOptions = {project: 'foo', skipPackageJson: false};
-    const tree = schematicRunner.runSchematic('ng-add', secondAppOptions, appTree);
+    const fooOptions: ElementsOptions = {project: 'foo', skipPackageJson: false};
+    const tree = schematicRunner.runSchematic('ng-add', fooOptions, appTree);
     const configText = tree.readContent('/angular.json');
     const config = JSON.parse(configText);
     const firstAppScripts = config.projects.elements.architect.build.options.scripts;

--- a/packages/elements/schematics/ng-add/index_spec.ts
+++ b/packages/elements/schematics/ng-add/index_spec.ts
@@ -19,7 +19,7 @@ const polyfillPath = 'node_modules/document-register-element/build/document-regi
 describe('Elements Schematics', () => {
   const schematicRunner = new SchematicTestRunner(
       '@angular/elements', path.join(__dirname, '../test-collection.json'), );
-  const defaultOptions: ElementsOptions = {project: 'bar', skipPackageJson: false};
+  const defaultOptions: ElementsOptions = {project: 'elements', skipPackageJson: false};
 
   let appTree: UnitTestTree;
 
@@ -54,5 +54,18 @@ describe('Elements Schematics', () => {
     const config = JSON.parse(configText);
     const scripts = config.projects.elements.architect.build.options.scripts;
     expect(scripts[0].input).toEqual(polyfillPath);
+  });
+  
+  it('should run the ng-add schematic on a second project', () => {
+    appOptions.name = 'foo';
+    schematicRunner.runExternalSchematic('@schematics/angular', 'application', appOptions, appTree);
+    const secondAppOptions: ElementsOptions = { project: 'foo', skipPackageJson: false };
+    const tree = schematicRunner.runSchematic('ng-add', secondAppOptions, appTree);
+    const configText = tree.readContent('/angular.json');
+    const config = JSON.parse(configText);
+    const firstAppScripts = config.projects.elements.architect.build.options.scripts;
+    const secondAppScripts = config.projects.foo.architect.build.options.scripts;
+    expect(firstAppScripts).toEqual([]);
+    expect(secondAppScripts[0].input).toEqual(polyfillPath);
   });
 });

--- a/packages/elements/schematics/ng-add/index_spec.ts
+++ b/packages/elements/schematics/ng-add/index_spec.ts
@@ -50,15 +50,18 @@ describe('Elements Schematics', () => {
     skipTests: false,
   };
 
-  beforeEach((done) => {
-    schematicRunner.runExternalSchematicAsync('@schematics/angular', 'workspace', workspaceOptions)
-        .pipe(concatMap(
-            (tree) => schematicRunner.runExternalSchematicAsync(
-                '@schematics/angular', 'application', appOptions, tree)),
-            (tree) => schematicRunner.runExternalSchematicAsync(
-                '@schematics/angular', 'application', secondAppOptions, tree))
+  beforeEach(done => {
+    schematicRunner
+      .runExternalSchematicAsync('@schematics/angular', 'workspace', workspaceOptions)
+      .pipe(
+        concatMap(tree =>
+          schematicRunner.runExternalSchematicAsync('@schematics/angular', 'application', appOptions, tree)
+        ),
+        concatMap(tree =>
+          schematicRunner.runExternalSchematicAsync('@schematics/angular', 'application', secondAppOptions, tree)
         )
-        .subscribe((tree: UnitTestTree) => appTree = tree, done.fail, done);
+      )
+      .subscribe((tree: UnitTestTree) => (appTree = tree), done.fail, done);
   });
 
   it('should run the ng-add schematic', () => {

--- a/packages/elements/schematics/ng-add/index_spec.ts
+++ b/packages/elements/schematics/ng-add/index_spec.ts
@@ -40,28 +40,12 @@ describe('Elements Schematics', () => {
     skipTests: false,
   };
 
-  // tslint:disable-next-line:no-any
-  const secondAppOptions: any = {
-    name: 'foo',
-    inlineStyle: false,
-    inlineTemplate: false,
-    routing: false,
-    style: 'css',
-    skipTests: false,
-  };
-
-  beforeEach(done => {
-    schematicRunner
-      .runExternalSchematicAsync('@schematics/angular', 'workspace', workspaceOptions)
-      .pipe(
-        concatMap(tree =>
-          schematicRunner.runExternalSchematicAsync('@schematics/angular', 'application', appOptions, tree)
-        ),
-        concatMap(tree =>
-          schematicRunner.runExternalSchematicAsync('@schematics/angular', 'application', secondAppOptions, tree)
-        )
-      )
-      .subscribe((tree: UnitTestTree) => (appTree = tree), done.fail, done);
+  beforeEach((done) => {
+    schematicRunner.runExternalSchematicAsync('@schematics/angular', 'workspace', workspaceOptions)
+        .pipe(concatMap(
+            (tree) => schematicRunner.runExternalSchematicAsync(
+                '@schematics/angular', 'application', appOptions, tree)))
+        .subscribe((tree: UnitTestTree) => appTree = tree, done.fail, done);
   });
 
   it('should run the ng-add schematic', () => {
@@ -70,16 +54,5 @@ describe('Elements Schematics', () => {
     const config = JSON.parse(configText);
     const scripts = config.projects.elements.architect.build.options.scripts;
     expect(scripts[0].input).toEqual(polyfillPath);
-  });
-
-  it('should run the ng-add schematic on a second project', () => {
-    const fooOptions: ElementsOptions = {project: 'foo', skipPackageJson: false};
-    const tree = schematicRunner.runSchematic('ng-add', fooOptions, appTree);
-    const configText = tree.readContent('/angular.json');
-    const config = JSON.parse(configText);
-    const firstAppScripts = config.projects.elements.architect.build.options.scripts;
-    const secondAppScripts = config.projects.foo.architect.build.options.scripts;
-    expect(firstAppScripts).toEqual([]);
-    expect(secondAppScripts[0].input).toEqual(polyfillPath);
   });
 });

--- a/packages/elements/schematics/ng-add/index_spec.ts
+++ b/packages/elements/schematics/ng-add/index_spec.ts
@@ -55,11 +55,11 @@ describe('Elements Schematics', () => {
     const scripts = config.projects.elements.architect.build.options.scripts;
     expect(scripts[0].input).toEqual(polyfillPath);
   });
-  
+
   it('should run the ng-add schematic on a second project', () => {
     appOptions.name = 'foo';
     schematicRunner.runExternalSchematic('@schematics/angular', 'application', appOptions, appTree);
-    const secondAppOptions: ElementsOptions = { project: 'foo', skipPackageJson: false };
+    const secondAppOptions: ElementsOptions = {project: 'foo', skipPackageJson: false};
     const tree = schematicRunner.runSchematic('ng-add', secondAppOptions, appTree);
     const configText = tree.readContent('/angular.json');
     const config = JSON.parse(configText);


### PR DESCRIPTION
The document-register-element polyfill script was added to the first project in angular.json regardless of the name passed in the project flag. options.project is now used instead, if it is specified.

fixes #24813

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #24813 


## What is the new behavior?
The document-register-element polyfill script was added to the first project in angular.json regardless of the name passed in the project flag. options.project is now used instead, if it is specified.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
