### PR TITLE
fix(common): format fractional seconds

### DIFF
--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -193,20 +193,9 @@ function padNumber(
   return neg + strNum;
 }
 
-/**
- * Trim a fractional part to `digits` number of digits.
- * Right pads with "0" to fit the requested number of digits if needed.
- *
- * @param num The fractional part value
- * @param digits The width of the output
- */
-function trimRPadFractional(num: number, digits: number): string {
-  let strNum = String(num);
-  // Add padding at the end
-  while (strNum.length < digits) {
-    strNum = strNum + 0;
-  }
-  return strNum.substr(0, digits);
+function formatFractionalSeconds(milliseconds: number, digits: number): string {
+  const strMs = padNumber(milliseconds, 3);
+  return strMs.substr(0, digits);
 }
 
 /**
@@ -226,7 +215,7 @@ function dateGetter(
         part = 12;
       }
     } else if (name === DateType.FractionalSeconds) {
-      return trimRPadFractional(part, size);
+      return formatFractionalSeconds(part, size);
     }
 
     const localeMinus = getLocaleNumberSymbol(locale, NumberSymbol.MinusSign);

--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -319,6 +319,10 @@ describe('Format date', () => {
       expect(formatDate(3000, 'm:ss.S', 'en')).toEqual('0:03.0');
       expect(formatDate(3000, 'm:ss.SS', 'en')).toEqual('0:03.00');
       expect(formatDate(3000, 'm:ss.SSS', 'en')).toEqual('0:03.000');
+      expect(formatDate(3001, 'm:ss', 'en')).toEqual('0:03');
+      expect(formatDate(3001, 'm:ss.S', 'en')).toEqual('0:03.0');
+      expect(formatDate(3001, 'm:ss.SS', 'en')).toEqual('0:03.00');
+      expect(formatDate(3001, 'm:ss.SSS', 'en')).toEqual('0:03.001');
     });
   });
 });


### PR DESCRIPTION
fix a bug introduced in #24831

`formatDate(3001, 'm:ss.SSS', 'en')` was incorrectly returning `3.100`