### PR TITLE
fix(aio): polyfill for custom elements

### DIFF
--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -31,6 +31,9 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="translucent">
 
+  <!-- Imports custom elements polyfill for iOS 9.3.5 Safari -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/custom-elements/1.1.2/custom-elements.min.js"></script>
+
   <script>
     // Dynamically, pre-emptively, add `noindex`, which will be removed when the doc is ready and valid
     tag = document.createElement('meta'); tag.name = 'robots'; tag.content = 'noindex';
@@ -50,7 +53,7 @@
   </script>
   <!-- End Google Analytics -->
 
-  <script>
+  <!-- <script>
     // Report fatal errors to Google Analytics
     window.onerror = function() {
       ga('send', 'exception', {exDescription: formatError.apply(null, arguments), exFatal: true});
@@ -80,7 +83,7 @@
         return (msg + '\n' + stack).substr(0, 150);
       }
     };
-  </script>
+  </script> -->
 
   <script nomodule src="generated/ie-polyfills.min.js"></script>
 

--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -53,7 +53,7 @@
   </script>
   <!-- End Google Analytics -->
 
-  <!-- <script>
+  <script>
     // Report fatal errors to Google Analytics
     window.onerror = function() {
       ga('send', 'exception', {exDescription: formatError.apply(null, arguments), exFatal: true});
@@ -83,7 +83,7 @@
         return (msg + '\n' + stack).substr(0, 150);
       }
     };
-  </script> -->
+  </script>
 
   <script nomodule src="generated/ie-polyfills.min.js"></script>
 


### PR DESCRIPTION
The intention of this commit is to fix the Safari/Chrome issue on iOS 9.3.5 by adding a polyfill for custom elements

This commit fixes issue #24392

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ X ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ X ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #24392

Trying to load Angular.io on an iDevice with iOS 9.3.5 results in a blank page. Console errors indicate custom-elements-related issues with **TypeError: Attempted to assign to readonly property**.


## What is the new behavior?

With the polyfill, he website now loads on Safari and Chrome on iDevices with iOS 9.3.5.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ X ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
My newbie self doesn't know if this is the best way to import a polyfill. Please, enlighten me.