### PR TITLE
fix(router): make sure deactivation does not fail when router outlet cannot be found

### DIFF
--- a/packages/router/src/pre_activation.ts
+++ b/packages/router/src/pre_activation.ts
@@ -124,8 +124,10 @@ export class PreActivation {
       }
 
       if (shouldRunGuardsAndResolvers) {
-        const outlet = context !.outlet !;
-        this.canDeactivateChecks.push(new CanDeactivate(outlet.component, curr));
+        const outlet = context ? context.outlet : null;
+        if (outlet && outlet.component) {
+          this.canDeactivateChecks.push(new CanDeactivate(outlet.component, curr));
+        }
       }
     } else {
       if (curr) {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1856,6 +1856,28 @@ describe('Integration', () => {
                })));
           });
 
+      describe('should activate a child wildcard route router outlet has yet to be mounted', () => {
+        it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+             const fixture = createRoot(router, RootCmp);
+
+             router.resetConfig([{
+               path: 'teams',
+               component: BlankCmp,
+               children: [{path: ':team-id', children: [{path: '**', component: BlankCmp}]}]
+             }]);
+
+             router.navigateByUrl('/teams/22/members');
+             advance(fixture);
+
+             expect(location.path()).toEqual('/teams/22/members');
+
+             router.navigateByUrl('/teams/22/manage');
+             advance(fixture);
+
+             expect(location.path()).toEqual('/teams/22/manage');
+           })));
+      });
+
       describe('should activate a route when CanActivate returns true', () => {
         beforeEach(() => {
           TestBed.configureTestingModule({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
If no router-outlet is present (usually because of the router-outlet being inserted conditionally, ie with a ngIf for instance) and deactivation checks are set on the route, the routing will fail with an error:

```
ERROR Error: Uncaught (in promise): TypeError: Cannot read property 'component' of null
TypeError: Cannot read property 'component' of null
[..]
```

Issue Number: 18253


## What is the new behavior?

It checks whether there is an outlet. If not: Simply skip the deactivation checks (which are related to a component) instead of hard fail.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information

This is heavily inspired from https://github.com/angular/angular/pull/19374, whose maintainer (@blaubaer) is currently inactive.