### PR TITLE
feat(ivy): port the static resolver to use the ReflectionHost

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -43,7 +43,8 @@ export class ComponentDecoratorHandler implements DecoratorHandler<R3ComponentMe
     const component = reflectObjectLiteral(meta);
 
     if (this.resourceLoader.preload !== undefined && component.has('templateUrl')) {
-      const templateUrl = staticallyResolve(component.get('templateUrl') !, this.checker);
+      const templateUrl =
+          staticallyResolve(component.get('templateUrl') !, this.reflector, this.checker);
       if (typeof templateUrl !== 'string') {
         throw new Error(`templateUrl should be a string`);
       }
@@ -73,7 +74,8 @@ export class ComponentDecoratorHandler implements DecoratorHandler<R3ComponentMe
 
     let templateStr: string|null = null;
     if (component.has('templateUrl')) {
-      const templateUrl = staticallyResolve(component.get('templateUrl') !, this.checker);
+      const templateUrl =
+          staticallyResolve(component.get('templateUrl') !, this.reflector, this.checker);
       if (typeof templateUrl !== 'string') {
         throw new Error(`templateUrl should be a string`);
       }
@@ -81,7 +83,7 @@ export class ComponentDecoratorHandler implements DecoratorHandler<R3ComponentMe
       templateStr = this.resourceLoader.load(url);
     } else if (component.has('template')) {
       const templateExpr = component.get('template') !;
-      const resolvedTemplate = staticallyResolve(templateExpr, this.checker);
+      const resolvedTemplate = staticallyResolve(templateExpr, this.reflector, this.checker);
       if (typeof resolvedTemplate !== 'string') {
         throw new Error(`Template must statically resolve to a string: ${node.name!.text}`);
       }
@@ -92,7 +94,8 @@ export class ComponentDecoratorHandler implements DecoratorHandler<R3ComponentMe
 
     let preserveWhitespaces: boolean = false;
     if (component.has('preserveWhitespaces')) {
-      const value = staticallyResolve(component.get('preserveWhitespaces') !, this.checker);
+      const value =
+          staticallyResolve(component.get('preserveWhitespaces') !, this.reflector, this.checker);
       if (typeof value !== 'boolean') {
         throw new Error(`preserveWhitespaces must resolve to a boolean if present`);
       }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -54,17 +54,20 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
     // Extract the module declarations, imports, and exports.
     let declarations: Reference[] = [];
     if (ngModule.has('declarations')) {
-      const declarationMeta = staticallyResolve(ngModule.get('declarations') !, this.checker);
+      const declarationMeta =
+          staticallyResolve(ngModule.get('declarations') !, this.reflector, this.checker);
       declarations = resolveTypeList(declarationMeta, 'declarations');
     }
     let imports: Reference[] = [];
     if (ngModule.has('imports')) {
-      const importsMeta = staticallyResolve(ngModule.get('imports') !, this.checker);
+      const importsMeta =
+          staticallyResolve(ngModule.get('imports') !, this.reflector, this.checker);
       imports = resolveTypeList(importsMeta, 'imports');
     }
     let exports: Reference[] = [];
     if (ngModule.has('exports')) {
-      const exportsMeta = staticallyResolve(ngModule.get('exports') !, this.checker);
+      const exportsMeta =
+          staticallyResolve(ngModule.get('exports') !, this.reflector, this.checker);
       exports = resolveTypeList(exportsMeta, 'exports');
     }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -44,7 +44,7 @@ export class PipeDecoratorHandler implements DecoratorHandler<R3PipeMetadata> {
     if (!pipe.has('name')) {
       throw new Error(`@Pipe decorator is missing name field`);
     }
-    const pipeName = staticallyResolve(pipe.get('name') !, this.checker);
+    const pipeName = staticallyResolve(pipe.get('name') !, this.reflector, this.checker);
     if (typeof pipeName !== 'string') {
       throw new Error(`@Pipe.name must be a string`);
     }
@@ -52,7 +52,7 @@ export class PipeDecoratorHandler implements DecoratorHandler<R3PipeMetadata> {
 
     let pure = true;
     if (pipe.has('pure')) {
-      const pureValue = staticallyResolve(pipe.get('pure') !, this.checker);
+      const pureValue = staticallyResolve(pipe.get('pure') !, this.reflector, this.checker);
       if (typeof pureValue !== 'boolean') {
         throw new Error(`@Pipe.pure must be a boolean`);
       }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/reflector.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/reflector.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {ClassMember, ClassMemberKind, Decorator, Import, Parameter, ReflectionHost} from '../../host';
+import {ClassMember, ClassMemberKind, Declaration, Decorator, Import, Parameter, ReflectionHost} from '../../host';
 
 /**
  * reflector.ts implements static reflection of declarations using the TypeScript `ts.TypeChecker`.
@@ -104,7 +104,91 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     return {from, name};
   }
 
-  isClass(node: ts.Node): node is ts.Declaration { return ts.isClassDeclaration(node); }
+  getExportsOfModule(node: ts.Node): Map<string, Declaration>|null {
+    // In TypeScript code, modules are only ts.SourceFiles. Throw if the node isn't a module.
+    if (!ts.isSourceFile(node)) {
+      throw new Error(`getDeclarationsOfModule() called on non-SourceFile in TS code`);
+    }
+    const map = new Map<string, Declaration>();
+
+    // Reflect the module to a Symbol, and use getExportsOfModule() to get a list of exported
+    // Symbols.
+    const symbol = this.checker.getSymbolAtLocation(node);
+    if (symbol === undefined) {
+      return null;
+    }
+    this.checker.getExportsOfModule(symbol).forEach(exportSymbol => {
+      // Map each exported Symbol to a Declaration and add it to the map.
+      const decl = this._getDeclarationOfSymbol(exportSymbol);
+      if (decl !== null) {
+        map.set(exportSymbol.name, decl);
+      }
+    });
+    return map;
+  }
+
+  isClass(node: ts.Declaration): node is ts.ClassDeclaration {
+    // In TypeScript code, classes are ts.ClassDeclarations.
+    return ts.isClassDeclaration(node);
+  }
+
+  getDeclarationOfIdentifier(id: ts.Identifier): Declaration|null {
+    // Resolve the identifier to a Symbol, and return the declaration of that.
+    let symbol: ts.Symbol|undefined = this.checker.getSymbolAtLocation(id);
+    if (symbol === undefined) {
+      return null;
+    }
+    return this._getDeclarationOfSymbol(symbol);
+  }
+
+  /**
+   * Resolve a `ts.Symbol` to its declaration, keeping track of the `viaModule` along the way.
+   */
+  protected _getDeclarationOfSymbol(symbol: ts.Symbol): Declaration|null {
+    let viaModule: string|null = null;
+    // Look through the Symbol's immediate declarations, and see if any of them are import-type
+    // statements.
+    if (symbol.declarations !== undefined && symbol.declarations.length > 0) {
+      for (let i = 0; i < symbol.declarations.length; i++) {
+        const decl = symbol.declarations[i];
+        if (ts.isImportSpecifier(decl) && decl.parent !== undefined &&
+            decl.parent.parent !== undefined && decl.parent.parent.parent !== undefined) {
+          // Find the ImportDeclaration that imported this Symbol.
+          const importDecl = decl.parent.parent.parent;
+          // The moduleSpecifier should always be a string.
+          if (ts.isStringLiteral(importDecl.moduleSpecifier)) {
+            // Check if the moduleSpecifier is absolute. If it is, this symbol comes from an
+            // external module, and the import path becomes the viaModule.
+            const moduleSpecifier = importDecl.moduleSpecifier.text;
+            if (!moduleSpecifier.startsWith('.')) {
+              viaModule = moduleSpecifier;
+            }
+          }
+        }
+      }
+    }
+
+    // Now, resolve the Symbol to its declaration by following any and all aliases.
+    while (symbol.flags & ts.SymbolFlags.Alias) {
+      symbol = this.checker.getAliasedSymbol(symbol);
+    }
+
+    // Look at the resolved Symbol's declarations and pick one of them to return. Value declarations
+    // are given precedence over type declarations.
+    if (symbol.valueDeclaration !== undefined) {
+      return {
+        node: symbol.valueDeclaration,
+        viaModule,
+      };
+    } else if (symbol.declarations !== undefined && symbol.declarations.length > 0) {
+      return {
+        node: symbol.declarations[0],
+        viaModule,
+      };
+    } else {
+      return null;
+    }
+  }
 
   private _reflectDecorator(node: ts.Decorator): Decorator|null {
     // Attempt to resolve the decorator expression into a reference to a concrete Identifier. The
@@ -135,13 +219,13 @@ export class TypeScriptReflectionHost implements ReflectionHost {
 
   private _reflectMember(node: ts.ClassElement): ClassMember|null {
     let kind: ClassMemberKind|null = null;
-    let initializer: ts.Expression|null = null;
+    let value: ts.Expression|null = null;
     let name: string|null = null;
     let nameNode: ts.Identifier|null = null;
 
     if (ts.isPropertyDeclaration(node)) {
       kind = ClassMemberKind.Property;
-      initializer = node.initializer || null;
+      value = node.initializer || null;
     } else if (ts.isGetAccessorDeclaration(node)) {
       kind = ClassMemberKind.Getter;
     } else if (ts.isSetAccessorDeclaration(node)) {
@@ -169,8 +253,8 @@ export class TypeScriptReflectionHost implements ReflectionHost {
 
     return {
       node,
-      kind,
-      type: node.type || null, name, nameNode, decorators, initializer, isStatic,
+      declaration: node, kind,
+      type: node.type || null, name, nameNode, decorators, value, isStatic,
     };
   }
 }

--- a/packages/compiler-cli/src/ngtsc/metadata/test/resolver_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/test/resolver_spec.ts
@@ -9,6 +9,7 @@
 import {ExternalExpr} from '@angular/compiler';
 import * as ts from 'typescript';
 
+import {TypeScriptReflectionHost} from '..';
 import {getDeclaration, makeProgram} from '../../testing/in_memory_typescript';
 import {Reference, ResolvedValue, staticallyResolve} from '../src/resolver';
 
@@ -30,7 +31,8 @@ function makeExpression(
 
 function evaluate<T extends ResolvedValue>(code: string, expr: string): T {
   const {expression, checker} = makeExpression(code, expr);
-  return staticallyResolve(expression, checker) as T;
+  const host = new TypeScriptReflectionHost(checker);
+  return staticallyResolve(expression, host, checker) as T;
 }
 
 describe('ngtsc metadata', () => {
@@ -52,8 +54,9 @@ describe('ngtsc metadata', () => {
       }
     ]);
     const decl = getDeclaration(program, 'entry.ts', 'X', ts.isVariableDeclaration);
+    const host = new TypeScriptReflectionHost(program.getTypeChecker());
 
-    const value = staticallyResolve(decl.initializer !, program.getTypeChecker());
+    const value = staticallyResolve(decl.initializer !, host, program.getTypeChecker());
     expect(value).toEqual('test');
   });
 
@@ -132,9 +135,10 @@ describe('ngtsc metadata', () => {
       },
     ]);
     const checker = program.getTypeChecker();
+    const host = new TypeScriptReflectionHost(checker);
     const result = getDeclaration(program, 'entry.ts', 'target$', ts.isVariableDeclaration);
     const expr = result.initializer !;
-    const resolved = staticallyResolve(expr, checker);
+    const resolved = staticallyResolve(expr, host, checker);
     if (!(resolved instanceof Reference)) {
       return fail('Expected expression to resolve to a reference');
     }
@@ -160,9 +164,10 @@ describe('ngtsc metadata', () => {
       },
     ]);
     const checker = program.getTypeChecker();
+    const host = new TypeScriptReflectionHost(checker);
     const result = getDeclaration(program, 'entry.ts', 'target$', ts.isVariableDeclaration);
     const expr = result.initializer !;
-    const resolved = staticallyResolve(expr, checker);
+    const resolved = staticallyResolve(expr, host, checker);
     if (!(resolved instanceof Reference)) {
       return fail('Expected expression to resolve to a reference');
     }
@@ -188,9 +193,10 @@ describe('ngtsc metadata', () => {
       },
     ]);
     const checker = program.getTypeChecker();
+    const host = new TypeScriptReflectionHost(checker);
     const result = getDeclaration(program, 'entry.ts', 'target$', ts.isVariableDeclaration);
     const expr = result.initializer !;
-    expect(staticallyResolve(expr, checker)).toEqual('test');
+    expect(staticallyResolve(expr, host, checker)).toEqual('test');
   });
 
   it('reads values from named exports', () => {
@@ -205,9 +211,10 @@ describe('ngtsc metadata', () => {
       },
     ]);
     const checker = program.getTypeChecker();
+    const host = new TypeScriptReflectionHost(checker);
     const result = getDeclaration(program, 'entry.ts', 'target$', ts.isVariableDeclaration);
     const expr = result.initializer !;
-    expect(staticallyResolve(expr, checker)).toEqual('test');
+    expect(staticallyResolve(expr, host, checker)).toEqual('test');
   });
 
   it('chain of re-exports works', () => {
@@ -222,9 +229,10 @@ describe('ngtsc metadata', () => {
       },
     ]);
     const checker = program.getTypeChecker();
+    const host = new TypeScriptReflectionHost(checker);
     const result = getDeclaration(program, 'entry.ts', 'target$', ts.isVariableDeclaration);
     const expr = result.initializer !;
-    expect(staticallyResolve(expr, checker)).toEqual('test');
+    expect(staticallyResolve(expr, host, checker)).toEqual('test');
   });
 
   it('map spread works', () => {


### PR DESCRIPTION
Previously, the static resolver did its own interpretation of statements
in the TypeScript AST, which only functioned on TypeScript code. ES5
code in particular would not work with the resolver as it had hard-coded
assumptions about AST structure.

This commit changes the resolver to use a ReflectionHost instead, which
abstracts away understanding of the structural side of the AST. It adds 3
new methods to the ReflectionHost in support of this functionality:

* getDeclarationOfIdentifier
* getExportsOfModule
* isClass