### PR TITLE
test(ivy): run render3 tests with test.sh

### DIFF
--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -77,7 +77,7 @@ module.exports = function(config) {
       'dist/all/@angular/compiler/test/aot/**',
       'dist/all/@angular/compiler/test/render3/**',
       'dist/all/@angular/core/test/bundling/**',
-      'dist/all/@angular/core/test/render3/**',
+      'dist/all/@angular/core/test/render3/ivy/**',
       'dist/all/@angular/elements/schematics/**',
       'dist/all/@angular/examples/**/e2e_test/*',
       'dist/all/@angular/language-service/**',


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Test related changes
```

## What is the current behavior?
Render3 tests have been excluded from karma (test.sh) because there's a test that only works with bazel

## What is the new behavior?
I changed the exclusion to only exclude the bazel-only tests, so that people on windows (me) can still run render3 tests with karma until bazel works on Windows

## Does this PR introduce a breaking change?
```
[x] No
```