### PR TITLE
docs:Add StongBrew to the trainer list

### DIFF
--- a/aio/content/guide/component-styles.md
+++ b/aio/content/guide/component-styles.md
@@ -216,10 +216,9 @@ You can also write `<link>` tags into the component's HTML template.
 
 <div class="alert is-critical">
 
-The link tag's `href` URL must be relative to the
-_**application root**_, not relative to the component file.
-
 When building with the CLI, be sure to include the linked style file among the assets to be copied to the server as described in the [CLI documentation](https://github.com/angular/angular-cli/wiki/stories-asset-configuration).
+
+Once included, the CLI will include the stylesheet, whether the link tag's href URL is relative to the application root or the component file.
 
 </div>
 

--- a/aio/content/marketing/resources.json
+++ b/aio/content/marketing/resources.json
@@ -698,6 +698,13 @@
             "title": "Thoughtram",
             "url": "http://thoughtram.io/"
           },
+          "strbrw": {
+            "desc": "Angular and RxJS trainings, Code Reviews and consultancy. We help software engineers all over the world to create better web-applications...",
+            "logo": "",
+            "rev": true,
+            "title": "StrongBrew",
+            "url": "https://strongbrew.io/"
+          },
           "jsru": {
             "desc": "Complete Angular online course. Constantly updating. Real-time webinars with immediate feedback from the teacher.",
             "logo": "https://learn.javascript.ru/img/sitetoolbar__logo_ru.svg",


### PR DESCRIPTION
We would love to add the StrongBrew website/blog to the resources list since we are specialized in Angular and RxJS workshops.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is no link to the StrongBrew website
Issue Number: N/A


## What is the new behavior?
There is a link to the StrongBrew website

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
