### PR TITLE
fix(compiler): Fix look up of entryComponents in AOT Summaries generated by references from router configuration.

### DIFF
--- a/packages/compiler/src/jit/compiler.ts
+++ b/packages/compiler/src/jit/compiler.ts
@@ -196,7 +196,7 @@ export class JitCompiler {
         }
       });
       localModuleMeta.entryComponents.forEach((entryComponentType) => {
-        if (!this.hasAotSummary(entryComponentType.componentType.reference)) {
+        if (!this.hasAotSummary(entryComponentType.componentType)) {
           const moduleMeta = moduleByJitDirective.get(entryComponentType.componentType) !;
           templates.add(
               this._createCompiledHostTemplate(entryComponentType.componentType, moduleMeta));

--- a/packages/router/test/BUILD.bazel
+++ b/packages/router/test/BUILD.bazel
@@ -1,14 +1,10 @@
 load("//tools:defaults.bzl", "ts_library", "ts_web_test_suite")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ng_module")
-
 
 ts_library(
     name = "test_lib",
     testonly = 1,
-    srcs = glob(
-        ["**/*.ts"]
-    ),
+    srcs = glob(["**/*.ts"]),
     deps = [
         "//packages/common",
         "//packages/common/testing",

--- a/packages/router/test/aot_ngsummary_test/BUILD.bazel
+++ b/packages/router/test/aot_ngsummary_test/BUILD.bazel
@@ -2,7 +2,6 @@ load("//tools:defaults.bzl", "ts_library", "ts_web_test_suite")
 load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "ng_module")
 
-
 ng_module(
     name = "aot_routing_module",
     srcs = ["aot_router_module.ts"],

--- a/packages/router/test/aot_ngsummary_test/BUILD.bazel
+++ b/packages/router/test/aot_ngsummary_test/BUILD.bazel
@@ -3,24 +3,26 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "ng_module")
 
 
-ts_library(
-    name = "test_lib",
-    testonly = 1,
-    srcs = glob(
-        ["**/*.ts"]
-    ),
+ng_module(
+    name = "aot_routing_module",
+    srcs = ["aot_router_module.ts"],
     deps = [
-        "//packages/common",
-        "//packages/common/testing",
+        "//packages/core",
+        "//packages/router",
+        "@rxjs",
+    ],
+)
+
+ts_library(
+    name = "aot_test_lib",
+    testonly = 1,
+    srcs = ["aot_router_bootstrap.spec.ts"],
+    deps = [
+        ":aot_routing_module",
         "//packages/core",
         "//packages/core/testing",
-        "//packages/platform-browser",
-        "//packages/platform-browser-dynamic",
-        "//packages/platform-browser/testing",
         "//packages/router",
         "//packages/router/testing",
-        "@rxjs",
-        "@rxjs//operators",
     ],
 )
 
@@ -28,14 +30,7 @@ jasmine_node_test(
     name = "test",
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
     deps = [
-        ":test_lib",
+        ":aot_test_lib",
         "//tools/testing:node",
-    ],
-)
-
-ts_web_test_suite(
-    name = "test_web",
-    deps = [
-        ":test_lib",
     ],
 )

--- a/packages/router/test/aot_ngsummary_test/aot_router_bootstrap.spec.ts
+++ b/packages/router/test/aot_ngsummary_test/aot_router_bootstrap.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {TestBed} from '@angular/core/testing';
+
+import {RouterTestingModule} from '../../testing';
+
+import {AotRouterModule, ROUTES} from './aot_router_module';
+import {AotRouterModuleNgSummary} from './aot_router_module.ngsummary';
+
+describe('The Aot Routing Component', () => {
+  it('should be able to compile the components while using aotSummaries', () => {
+    TestBed
+        .configureTestingModule({
+          imports: [
+            AotRouterModule,
+            RouterTestingModule.withRoutes(ROUTES),
+          ],
+          aotSummaries: () => [AotRouterModuleNgSummary],
+        })
+        .compileComponents();
+  });
+});

--- a/packages/router/test/aot_ngsummary_test/aot_router_module.ts
+++ b/packages/router/test/aot_ngsummary_test/aot_router_module.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, NgModule} from '@angular/core';
+import {RouterModule, Routes} from '../../';
+
+@Component({
+  selector: 'aot-router',
+  template: '<router-outlet></router-outlet>',
+})
+export class AotRouterCmp {
+}
+
+@Component({
+  selector: 'aot-router-child',
+  template: 'arc',
+})
+export class AotRouterChildCmp {
+}
+
+export const ROUTES: Routes = [
+  {path: '', component: AotRouterChildCmp},
+];
+
+@NgModule({
+  declarations: [
+    AotRouterCmp,
+    AotRouterChildCmp,
+  ],
+  exports: [
+    AotRouterCmp,
+    AotRouterChildCmp,
+  ],
+  imports: [
+    RouterModule.forRoot(ROUTES),
+  ],
+})
+export class AotRouterModule {
+}

--- a/packages/tsconfig-metadata.json
+++ b/packages/tsconfig-metadata.json
@@ -12,6 +12,7 @@
     "compiler/test",
     "compiler-cli/integrationtest",
     "platform-server/integrationtest",
+    "router/test/aot_ngsummary_test",
     "common/locales",
     "examples",
     "**/*_spec.ts",

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -34,7 +34,7 @@
     "compiler-cli/integrationtest",
     "elements/schematics",
     "examples/**/e2e_test/*",
-    "platform-server/integrationtest"
+    "platform-server/integrationtest",
+    "router/test/aot_ngsummary_test",
   ]
-
 }


### PR DESCRIPTION
Previously, when you attempted to bootstrap a component that had a router-outlet using ngsummaries, it would complain that the component was not provided by any module even if it was. This commit fixes a mistake (AFAICT) which caused the lookup of the component in the AOT summaries to fail.

I believe this change is safe. I've run the Angular tests and affected tests within Google and there were no breakages caused by this change.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
When you attempt to bootstrap a component that includes a routerconfig using AOT Summaries, the test fails complaining that the Component that you referenced in the router config was not included in any modules even though it is.

"Error: Component AotRouterChildCmp is not part of any NgModule or the module has not been imported into your module."

Issue Number: N/A


## What is the new behavior?
You are able to bootstrap the component successfully.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The formatting changes were generated by clang formatter.