### PR TITLE
fix(ivy): invoke lifecycle hooks of directives placed on ng-template

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1746,10 +1746,8 @@ export function container(
 
   isParent = false;
   ngDevMode && assertNodeType(previousOrParentNode, TNodeType.Container);
-  if (queries) {
-    // check if a given container node matches
-    queries.addNode(node);
-  }
+  queries && queries.addNode(node);  // check if a given container node matches
+  queueLifecycleHooks(node.tNode.flags, tView);
 }
 
 /**


### PR DESCRIPTION
Small fix for an issue discovered while poking around `<ng-container>` design / implementation. 

My current thinking is that we will, most probably, introduce a new instruction for `<ng-template>` and keep `container(...)` for JS blocks only. But today we use `container(...)` for  `<ng-template>` so this PR fixes an existing issue and adds the test so we won't miss this use-case in the future.