### PR TITLE
build: disable IE web worker tests

### DIFF
--- a/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
+++ b/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
@@ -81,6 +81,10 @@ let lastCreatedRenderer: Renderer2;
     }
 
     it('should update text nodes', () => {
+      // IE (v11 to be exact) has been problematic lately with saucelabs for this specific test
+      // TODO (matsko): revisit this once things become more stable in the saucelabs world
+      if (isOldIE()) return;
+
       const fixture =
           TestBed.overrideTemplate(MyComp2, '<div>{{ctxProp}}</div>').createComponent(MyComp2);
       const renderEl = getRenderElement(fixture.nativeElement);
@@ -93,6 +97,10 @@ let lastCreatedRenderer: Renderer2;
 
     it('should update any element property/attributes/class/style(s) independent of the compilation on the root element and other elements',
        () => {
+         // IE (v11 to be exact) has been problematic lately with saucelabs for this specific test
+         // TODO (matsko): revisit this once things become more stable in the saucelabs world
+         if (isOldIE()) return;
+
          const fixture =
              TestBed.overrideTemplate(MyComp2, '<input [title]="y" style="position:absolute">')
                  .createComponent(MyComp2);
@@ -127,6 +135,10 @@ let lastCreatedRenderer: Renderer2;
        });
 
     it('should update any template comment property/attributes', () => {
+      // IE (v11 to be exact) has been problematic lately with saucelabs for this specific test
+      // TODO (matsko): revisit this once things become more stable in the saucelabs world
+      if (isOldIE()) return;
+
       const fixture =
           TestBed.overrideTemplate(MyComp2, '<ng-container *ngIf="ctxBoolProp"></ng-container>')
               .createComponent(MyComp2);
@@ -137,6 +149,10 @@ let lastCreatedRenderer: Renderer2;
     });
 
     it('should add and remove fragments', () => {
+      // IE (v11 to be exact) has been problematic lately with saucelabs for this specific test
+      // TODO (matsko): revisit this once things become more stable in the saucelabs world
+      if (isOldIE()) return;
+
       const fixture =
           TestBed
               .overrideTemplate(MyComp2, '<ng-container *ngIf="ctxBoolProp">hello</ng-container>')
@@ -156,6 +172,10 @@ let lastCreatedRenderer: Renderer2;
 
     if (getDOM().supportsDOMEvents()) {
       it('should listen to events', () => {
+        // IE (v11 to be exact) has been problematic lately with saucelabs for this specific test
+        // TODO (matsko): revisit this once things become more stable in the saucelabs world
+        if (isOldIE()) return;
+
         const fixture = TestBed.overrideTemplate(MyComp2, '<input (change)="ctxNumProp = 1">')
                             .createComponent(MyComp2);
 
@@ -213,4 +233,9 @@ class RenderFactory extends WebWorkerRendererFactory2 {
     lastCreatedRenderer = super.createRenderer(element, type);
     return lastCreatedRenderer;
   }
+}
+
+function isOldIE() {
+  // note that this only applies to older IEs (not edge)
+  return (window as any).document['documentMode'] ? true : false;
 }


### PR DESCRIPTION
Travis (saucelabs) has been super flaky when running IE
web worker tests lately. This patch temporarily disables
these tests on IE (not edge) until things get more stable.