### PR TITLE
fix(docs-infra): fix table header layout in API pages

### DIFF
--- a/aio/src/styles/2-modules/_api-pages.scss
+++ b/aio/src/styles/2-modules/_api-pages.scss
@@ -31,13 +31,10 @@
   }
 
   .method-table, .option-table, .list-table {
-    th {
-      display: flex;
+    .with-github-links {
       align-items: center;
-
-      h3 {
-        flex: 1;
-      }
+      display: flex;
+      justify-content: space-between;
 
       .github-links {
         a {

--- a/aio/tools/transforms/templates/api/decorator.template.html
+++ b/aio/tools/transforms/templates/api/decorator.template.html
@@ -13,8 +13,10 @@
   <a id="{$ option.anchor $}"></a>
   <table class="is-full-width option-table">
     <thead><tr><th>
-      <h3>{$ option.name $}</h3>
-      {$ github.githubLinks(option, versionInfo) $}
+      <div class="with-github-links">
+        <h3>{$ option.name $}</h3>
+        {$ github.githubLinks(option, versionInfo) $}
+      </div>
     </th></tr></thead>
     <tbody>
       <tr>

--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -74,13 +74,15 @@
 <a id="{$ method.anchor $}"></a>
 <table class="is-full-width method-table {$ cssClass $}">
   {% if method.name !== 'constructor' %}<thead><tr><th>
-    <h3>
-      {% if method.isCallMember %}<i>call signature</i>
-      {% elseif method.isNewMember %}<i>construct signature</i>
-      {% else %}{$ method.name $}()
-      {% endif %}
-    </h3>
-    {$ github.githubLinks(method, versionInfo) $}
+    <div class="with-github-links">
+      <h3>
+        {% if method.isCallMember %}<i>call signature</i>
+        {% elseif method.isNewMember %}<i>construct signature</i>
+        {% else %}{$ method.name $}()
+        {% endif %}
+      </h3>
+      {$ github.githubLinks(method, versionInfo) $}
+    </div>
   </th></tr></thead>{% endif %}
   <tbody>
     {% if method.shortDescription %}<tr>


### PR DESCRIPTION
Previously, `th` elements in API pages tables were given `display: flex` to align `.github-links`. This looks fine when there is only one `th` per row (e.g. method tables), but breaks the layout when there are 2+ `th` per row (e.g. property tables).

**Before:**
![api-tables-before](https://user-images.githubusercontent.com/8604205/42808280-9f9b23fe-89bb-11e8-9990-0ed804173765.png)

**After:**
![api-tables-after](https://user-images.githubusercontent.com/8604205/42808286-a71b9fdc-89bb-11e8-879a-e95b63088a34.png)

##
Fixes #24902.
Fixes #24920.