### PR TITLE
fix(animations): @internal must use JSDoc tags.

### DIFF
--- a/packages/animations/browser/src/render/css_keyframes/css_keyframes_player.ts
+++ b/packages/animations/browser/src/render/css_keyframes/css_keyframes_player.ts
@@ -124,7 +124,7 @@ export class CssKeyframesPlayer implements AnimationPlayer {
         DEFAULT_FILL_MODE, () => this.finish());
   }
 
-  /* @internal */
+  /** @internal */
   triggerCallback(phaseName: string): void {
     const methods = phaseName == 'start' ? this._onStartFns : this._onDoneFns;
     methods.forEach(fn => fn());

--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -1514,7 +1514,7 @@ export class TransitionAnimationPlayer implements AnimationPlayer {
 
   getPosition(): number { return this.queued ? 0 : this._player.getPosition(); }
 
-  /* @internal */
+  /** @internal */
   triggerCallback(phaseName: string): void {
     const p = this._player as any;
     if (p.triggerCallback) {

--- a/packages/animations/browser/src/render/web_animations/web_animations_player.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_player.ts
@@ -155,7 +155,7 @@ export class WebAnimationsPlayer implements AnimationPlayer {
     this.currentSnapshot = styles;
   }
 
-  /* @internal */
+  /** @internal */
   triggerCallback(phaseName: string): void {
     const methods = phaseName == 'start' ? this._onStartFns : this._onDoneFns;
     methods.forEach(fn => fn());

--- a/packages/animations/src/players/animation_group_player.ts
+++ b/packages/animations/src/players/animation_group_player.ts
@@ -140,7 +140,7 @@ export class AnimationGroupPlayer implements AnimationPlayer {
     });
   }
 
-  /* @internal */
+  /** @internal */
   triggerCallback(phaseName: string): void {
     const methods = phaseName == 'start' ? this._onStartFns : this._onDoneFns;
     methods.forEach(fn => fn());

--- a/packages/animations/src/players/animation_player.ts
+++ b/packages/animations/src/players/animation_player.ts
@@ -31,9 +31,9 @@ export interface AnimationPlayer {
   parentPlayer: AnimationPlayer|null;
   readonly totalTime: number;
   beforeDestroy?: () => any;
-  /* @internal */
+  /** @internal */
   triggerCallback?: (phaseName: string) => void;
-  /* @internal */
+  /** @internal */
   disabled?: boolean;
 }
 
@@ -70,7 +70,7 @@ export class NoopAnimationPlayer implements AnimationPlayer {
     this._started = true;
   }
 
-  /* @internal */
+  /** @internal */
   triggerMicrotask() { scheduleMicroTask(() => this._onFinish()); }
 
   private _onStart() {
@@ -96,7 +96,7 @@ export class NoopAnimationPlayer implements AnimationPlayer {
   setPosition(p: number): void {}
   getPosition(): number { return 0; }
 
-  /* @internal */
+  /** @internal */
   triggerCallback(phaseName: string): void {
     const methods = phaseName == 'start' ? this._onStartFns : this._onDoneFns;
     methods.forEach(fn => fn());

--- a/packages/platform-browser/animations/src/animation_renderer.ts
+++ b/packages/platform-browser/animations/src/animation_renderer.ts
@@ -74,7 +74,7 @@ export class AnimationRendererFactory implements RendererFactory2 {
     this.promise.then(() => { this._microtaskId++; });
   }
 
-  /* @internal */
+  /** @internal */
   scheduleListenerCallback(count: number, fn: (e: any) => any, data: any) {
     if (count >= 0 && count < this._microtaskId) {
       this._zone.run(() => fn(data));


### PR DESCRIPTION
This change fixes up several comments that accidentally used the JSDoc
tag `@internal` in regular block comments (`/*` instead of `/**`).

This prevents a problem with Closure Compiler that balks at `@` tags
occuring in regular block comments, because it assumes they were
intended to be tags for the compiler.

When occuring in `/**` JSDoc, tsickle escapes the tags, so they do not
cause problems.
