### PR TITLE
Remove usage of deprecated WORKSPACE http rule

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,6 @@
 workspace(name = "angular")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 #
 # Download Bazel toolchain dependencies as needed by build actions
 #


### PR DESCRIPTION
Per https://groups.google.com/d/msg/bazel-discuss/dO2MHQLwJF0/2OXHjMAaAAAJ the
native rules for `http_archive` are to be replaced with their skylark
implementations. This commit updates the WORKSPACE to use the skylark
definitions.

Tested using `bazel build //... --incompatible_remove_native_http_archive --incompatible_remove_native_git_repository` which previously failed with:

```
$ bazel build //... --incompatible_remove_native_http_archive --incompatible_remove_native_git_repository
Starting local Bazel server and connecting to it...
................
ERROR: error loading package '': Encountered error while reading extension file 'defs.bzl': no such package '@build_bazel_rules_nodejs//': The native http_archive rule is deprecated. load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") for a drop-in replacement.
Use --incompatible_remove_native_http_archive=false to temporarily continue using the native rule.
ERROR: error loading package '': Encountered error while reading extension file 'defs.bzl': no such package '@build_bazel_rules_nodejs//': The native http_archive rule is deprecated. load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") for a drop-in replacement.
Use --incompatible_remove_native_http_archive=false to temporarily continue using the native rule.
INFO: Elapsed time: 0.390s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
```

and now no longer emits that error.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently angular uses the builtin workspace rules for its http archives.


## What is the new behavior?
Use the skylark versions currently shipped with bazel.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

