### PR TITLE
docs: square odds example in rxjs guide

### DIFF
--- a/aio/content/examples/rx-library/src/operators.1.ts
+++ b/aio/content/examples/rx-library/src/operators.1.ts
@@ -8,7 +8,7 @@ const nums = of(1, 2, 3, 4, 5);
 
 // Create a function that accepts an Observable.
 const squareOddVals = pipe(
-  filter(n => n % 2),
+  filter((n: number) => n % 2 !== 0),
   map(n => n * n)
 );
 


### PR DESCRIPTION
The example `squareOdd` for showing squaring odd numbers using RxJS operators is wrong. The current snippet will square even numbers. The same example is shown correctly in the `chaining` section.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
