### PR TITLE
docs: fix typo in dependency injection guide

### DIFF
--- a/aio/content/guide/dependency-injection.md
+++ b/aio/content/guide/dependency-injection.md
@@ -692,7 +692,7 @@ If the factory function needs access to other DI tokens, it can use the inject f
 const TOKEN = 
   new InjectionToken('tree-shakeable token', 
     { providedIn: 'root', factory: () => 
-        new AppConfig(inject(Parameter1), inject(Paremeter2)), });
+        new AppConfig(inject(Parameter1), inject(Parameter2)), });
 </code-example>
 
 {@a optional}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The second "parameter" is spelled incorrectly:
`new AppConfig(inject(Parameter1), inject(Paremeter2)), });`

## What is the new behavior?

The spelling is fixed:
`new AppConfig(inject(Parameter1), inject(Parameter2)), });`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
