### PR TITLE
fix(ci): disable size checking on PRs

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -2,7 +2,7 @@
 
 #options for the size plugin
 size:
-  disabled: false
+  disabled: true
   maxSizeIncrease: 1000
   circleCiStatusName: "ci/circleci: build-packages-dist"
   status:


### PR DESCRIPTION
This feature does not currently work as intended.
Values are not being saved due to an issue with Firebase, therefore the checks are incorrect