### PR TITLE
fix(router): lazy routing tries loading destroyed module

### DIFF
--- a/aio/src/app/custom-elements/elements-loader.spec.ts
+++ b/aio/src/app/custom-elements/elements-loader.spec.ts
@@ -260,6 +260,7 @@ class FakeModuleRef extends NgModuleRef<WithCustomElementComponent> {
   injector = jasmine.createSpyObj('injector', ['get']);
   componentFactoryResolver = new FakeComponentFactoryResolver(this.modulePath);
   instance: WithCustomElementComponent = new FakeCustomElementModule();
+  destroyed: boolean;
 
   constructor(private modulePath) {
     super();

--- a/modules/benchmarks/src/tree/ng2_next/tree.ts
+++ b/modules/benchmarks/src/tree/ng2_next/tree.ts
@@ -126,6 +126,7 @@ export class AppModule implements Injector, NgModuleRef<any> {
   get injector() { return this; }
   get componentFactoryResolver(): ComponentFactoryResolver { return null; }
   get instance() { return this; }
+  get destroyed() { return false; }
   destroy() {}
   onDestroy(callback: () => void) {}
 }

--- a/packages/core/src/linker/ng_module_factory.ts
+++ b/packages/core/src/linker/ng_module_factory.ts
@@ -43,6 +43,11 @@ export abstract class NgModuleRef<T> {
   abstract destroy(): void;
 
   /**
+   * Returns whether the module has been destroyed.
+   */
+  abstract get destroyed(): boolean;
+
+  /**
    * Allows to register a callback that will be called when the module is destroyed.
    */
   abstract onDestroy(callback: () => void): void;

--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -36,6 +36,7 @@ export class NgModuleRef<T> extends viewEngine_NgModuleRef<T> implements Interna
   injector: Injector = this;
   instance: T;
   destroyCbs: (() => void)[]|null = [];
+  get destroyed(): boolean { return this.destroyCbs === null; }
 
   constructor(ngModuleType: Type<T>, public _parent: Injector|null) {
     super();

--- a/packages/core/src/view/refs.ts
+++ b/packages/core/src/view/refs.ts
@@ -522,5 +522,7 @@ class NgModuleRef_ implements NgModuleData, InternalNgModuleRef<any> {
     this._destroyListeners.forEach((listener) => listener());
   }
 
+  get destroyed() { return this._destroyed; }
+
   onDestroy(callback: () => void): void { this._destroyListeners.push(callback); }
 }

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -293,7 +293,8 @@ class ApplyRedirects {
 
     if (route.loadChildren) {
       // lazy children belong to the loaded module
-      if (route._loadedConfig !== undefined) {
+      // & re-initialize the (lazy loaded) module if destroyed
+      if (route._loadedConfig !== undefined && !route._loadedConfig.module.destroyed) {
         return of (route._loadedConfig);
       }
 

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -570,6 +570,7 @@ export declare abstract class NgModuleFactoryLoader {
 
 export declare abstract class NgModuleRef<T> {
     abstract readonly componentFactoryResolver: ComponentFactoryResolver;
+    abstract readonly destroyed: boolean;
     abstract readonly injector: Injector;
     abstract readonly instance: T;
     abstract destroy(): void;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The router can lazy load modules. It doesn't check whether that module has been destroyed or not.


Issue Number: #24962


## What is the new behavior?
If it has been destroyed, it will create a new instance of it.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```



## Other information
I'm a complete noob to angular and I need this change :kissing_heart: 