### PR TITLE
feat(core): better error message when providedIn target being undefined

### DIFF
--- a/packages/core/src/di/injectable.ts
+++ b/packages/core/src/di/injectable.ts
@@ -19,6 +19,8 @@ import {ClassSansProvider, ConstructorProvider, ConstructorSansProvider, Existin
 const GET_PROPERTY_NAME = {} as any;
 const USE_VALUE = getClosureSafeProperty<ValueProvider>(
     {provide: String, useValue: GET_PROPERTY_NAME}, GET_PROPERTY_NAME);
+const PROVIDED_IN =
+    getClosureSafeProperty<Injectable>({providedIn: GET_PROPERTY_NAME}, GET_PROPERTY_NAME);
 
 /**
  * Injectable providers used in `@Injectable` decorator.
@@ -105,11 +107,17 @@ export function convertInjectableProviderToFactory(
 function preR3InjectableCompile(
     injectableType: InjectableType<any>,
     options: {providedIn?: Type<any>| 'root' | null} & InjectableProvider): void {
-  if (options && options.providedIn !== undefined && injectableType.ngInjectableDef === undefined) {
-    injectableType.ngInjectableDef = defineInjectable({
-      providedIn: options.providedIn,
-      factory: convertInjectableProviderToFactory(injectableType, options),
-    });
+  if (options && PROVIDED_IN in options) {
+    if (options.providedIn === undefined) {
+      console && console.warn &&
+          console.warn(
+              `Encountered undefined providedIn target in type '${injectableType.name}'! Usually this means you have a circular dependencies.`);
+    } else if (injectableType.ngInjectableDef === undefined) {
+      injectableType.ngInjectableDef = defineInjectable({
+        providedIn: options.providedIn,
+        factory: convertInjectableProviderToFactory(injectableType, options),
+      });
+    }
   }
 }
 

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -7,8 +7,13 @@
  */
 
 import {Type} from '../type';
+import {getClosureSafeProperty} from '../util/property';
 
 import {InjectableDef, defineInjectable} from './defs';
+
+const GET_PROPERTY_NAME = {} as any;
+const PROVIDED_IN = getClosureSafeProperty<{providedIn?: Type<any>| 'root' | null}>(
+    {providedIn: GET_PROPERTY_NAME}, GET_PROPERTY_NAME);
 
 /**
  * Creates a token that can be used in a DI Provider.
@@ -57,6 +62,11 @@ export class InjectionToken<T> {
     factory: () => T
   }) {
     if (options !== undefined) {
+      if (PROVIDED_IN in options && options.providedIn === undefined) {
+        console && console.warn &&
+            console.warn(
+                `Encountered undefined providedIn target in InjectionToken '${_desc}'! Usually this means you have a circular dependencies.`);
+      }
       this.ngInjectableDef = defineInjectable({
         providedIn: options.providedIn || 'root',
         factory: options.factory,

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -714,6 +714,9 @@
     "name": "GET_PROPERTY_NAME$1"
   },
   {
+    "name": "GET_PROPERTY_NAME$2"
+  },
+  {
     "name": "GOOG_GET_MSG"
   },
   {
@@ -1132,6 +1135,12 @@
   },
   {
     "name": "PROP_METADATA"
+  },
+  {
+    "name": "PROVIDED_IN"
+  },
+  {
+    "name": "PROVIDED_IN$1"
   },
   {
     "name": "ParseError"

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -12,6 +12,9 @@
     "name": "GET_PROPERTY_NAME"
   },
   {
+    "name": "GET_PROPERTY_NAME$1"
+  },
+  {
     "name": "INJECTOR"
   },
   {
@@ -34,6 +37,9 @@
   },
   {
     "name": "PARAMETERS"
+  },
+  {
+    "name": "PROVIDED_IN"
   },
   {
     "name": "R3Injector"
@@ -82,6 +88,9 @@
   },
   {
     "name": "forwardRef"
+  },
+  {
+    "name": "getClosureSafeProperty"
   },
   {
     "name": "getClosureSafeProperty$1"


### PR DESCRIPTION
closes #24082

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/24082

Default providers fails silently with `{ providedIn: undefined }`.

This is most likely caused by circular dependency (also possibly non-hoisting variable, misspelled name, etc.)

## What is the new behavior?

Producing an error message when `providedIn` exists but got `undefined` value.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
