### PR TITLE
fix(platform-browser-dynamic): provide a subclass of `Compiler`

### DIFF
--- a/integration/dynamic-compiler/src/app.component.ts
+++ b/integration/dynamic-compiler/src/app.component.ts
@@ -1,4 +1,5 @@
 import {AfterViewInit, Compiler, Component, ViewChild, ViewContainerRef} from '@angular/core';
+import {DynamicCompiler} from "./dynamic-compiler";
 
 declare var System: any;
 
@@ -12,7 +13,7 @@ declare var System: any;
 export class AppComponent implements AfterViewInit {
   @ViewChild('vc', {read: ViewContainerRef}) container: ViewContainerRef;
 
-  constructor(private compiler: Compiler) {
+  constructor(private compiler: DynamicCompiler) {
   }
 
   ngAfterViewInit() {

--- a/integration/dynamic-compiler/src/app.module.ts
+++ b/integration/dynamic-compiler/src/app.module.ts
@@ -1,8 +1,9 @@
-import {Compiler, COMPILER_OPTIONS, CompilerFactory, NgModule} from '@angular/core';
+import {COMPILER_OPTIONS, CompilerFactory, NgModule} from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import {JitCompilerFactory} from '@angular/platform-browser-dynamic';
 
 import { AppComponent } from './app.component';
+import {DynamicCompiler} from './dynamic-compiler';
 
 export function createCompiler(compilerFactory: CompilerFactory) {
   return compilerFactory.createCompiler();
@@ -15,7 +16,7 @@ export function createCompiler(compilerFactory: CompilerFactory) {
   providers: [
     {provide: COMPILER_OPTIONS, useValue: {}, multi: true},
     {provide: CompilerFactory, useClass: JitCompilerFactory, deps: [COMPILER_OPTIONS]},
-    {provide: Compiler, useFactory: createCompiler, deps: [CompilerFactory]}
+    {provide: DynamicCompiler, useFactory: createCompiler, deps: [CompilerFactory]}
   ]
 })
 export class AppModule {}

--- a/integration/dynamic-compiler/src/dynamic-compiler.ts
+++ b/integration/dynamic-compiler/src/dynamic-compiler.ts
@@ -1,0 +1,4 @@
+import {Compiler, Injectable} from '@angular/core';
+
+@Injectable()
+export class DynamicCompiler extends Compiler {}


### PR DESCRIPTION
Providing the `Compiler` will interfere with the `offlineMode` check in `SystemJsNgModuleLoader.load`. Instead we should provide a subclass of Compiler so that

- the `SystemJsNgModuleLoader` will, as expected, find correct factory on AOT builds
- we can still use JitCompiler on lazy modules

Related issue: https://github.com/angular/angular/issues/20639#issuecomment-347516217

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Given `Compiler` provided in root module and building with `--aot`, the `loadChildren` route declaration will fail to find the correct module path.

The culprit is the interference with `offlineMode` check in `SystemJsNgModuleLoader`. (code is [here](https://github.com/angular/angular/blob/6.1.0-rc.3/packages/core/src/linker/system_js_ng_module_factory_loader.ts#L59)) Since the `offlineMode` is always `false`, the AOT compiled factories are never loaded, and the module loader loads the incorrect path on `--aot` builds.

Issue Number: https://github.com/angular/angular/issues/20639#issuecomment-347516217

## What is the new behavior?
The `loadChildren` works as expected on `--aot` builds in case the user properly provides a subclass of `Compiler`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I am not quite sure if it is a bug fix or a documentation change since the issue can be solved in user land only.

Shall we add `loadChildren` to the `dynamic-compiler` example?