### PR TITLE
fix(core): merge extend functionality to create in differs

### DIFF
--- a/packages/common/test/pipes/keyvalue_pipe_spec.ts
+++ b/packages/common/test/pipes/keyvalue_pipe_spec.ts
@@ -7,111 +7,118 @@
  */
 
 import {KeyValuePipe} from '@angular/common';
-import {EventEmitter, KeyValueDiffers, WrappedValue, ɵdefaultKeyValueDiffers as defaultKeyValueDiffers} from '@angular/core';
-import {AsyncTestCompleter, beforeEach, describe, expect, inject, it} from '@angular/core/testing/src/testing_internal';
-import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
-import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
+import {KeyValueDiffers} from '@angular/core';
+import {describe, expect, inject, it} from '@angular/core/testing/src/testing_internal';
 
 import {defaultComparator} from '../../src/pipes/keyvalue_pipe';
-import {SpyChangeDetectorRef} from '../spies';
 
 describe('KeyValuePipe', () => {
-  it('should return null when given null', () => {
-    const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-    expect(pipe.transform(null)).toEqual(null);
-  });
-  it('should return null when given undefined', () => {
-    const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-    expect(pipe.transform(undefined as any)).toEqual(null);
-  });
-  it('should return null for an unsupported type', () => {
-    const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-    const fn = () => {};
-    expect(pipe.transform(fn as any)).toEqual(null);
-  });
+  it('should return null when given null', inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+       const pipe = new KeyValuePipe(differs);
+       expect(pipe.transform(null)).toEqual(null);
+     }));
+  it('should return null when given undefined',
+     inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+       const pipe = new KeyValuePipe(differs);
+       expect(pipe.transform(undefined as any)).toEqual(null);
+     }));
+  it('should return null for an unsupported type',
+     inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+       const pipe = new KeyValuePipe(differs);
+       const fn = () => {};
+       expect(pipe.transform(fn as any)).toEqual(null);
+     }));
   describe('object dictionary', () => {
-    it('should transform a basic dictionary', () => {
-      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-      expect(pipe.transform({1: 2})).toEqual([{key: '1', value: 2}]);
-    });
-    it('should order by alpha', () => {
-      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-      expect(pipe.transform({'b': 1, 'a': 1})).toEqual([
-        {key: 'a', value: 1}, {key: 'b', value: 1}
-      ]);
-    });
-    it('should order by numerical', () => {
-      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-      expect(pipe.transform({2: 1, 1: 1})).toEqual([{key: '1', value: 1}, {key: '2', value: 1}]);
-    });
-    it('should order by numerical and alpha', () => {
-      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-      const input = {2: 1, 1: 1, 'b': 1, 0: 1, 3: 1, 'a': 1};
-      expect(pipe.transform(input)).toEqual([
-        {key: '0', value: 1}, {key: '1', value: 1}, {key: '2', value: 1}, {key: '3', value: 1},
-        {key: 'a', value: 1}, {key: 'b', value: 1}
-      ]);
-    });
-    it('should return the same ref if nothing changes', () => {
-      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-      const transform1 = pipe.transform({1: 2});
-      const transform2 = pipe.transform({1: 2});
-      expect(transform1 === transform2).toEqual(true);
-    });
-    it('should return a new ref if something changes', () => {
-      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-      const transform1 = pipe.transform({1: 2});
-      const transform2 = pipe.transform({1: 3});
-      expect(transform1 !== transform2).toEqual(true);
-    });
+    it('should transform a basic dictionary',
+       inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+         const pipe = new KeyValuePipe(differs);
+         expect(pipe.transform({1: 2})).toEqual([{key: '1', value: 2}]);
+       }));
+    it('should order by alpha', inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+         const pipe = new KeyValuePipe(differs);
+         expect(pipe.transform({'b': 1, 'a': 1})).toEqual([
+           {key: 'a', value: 1}, {key: 'b', value: 1}
+         ]);
+       }));
+    it('should order by numerical', inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+         const pipe = new KeyValuePipe(differs);
+         expect(pipe.transform({2: 1, 1: 1})).toEqual([{key: '1', value: 1}, {key: '2', value: 1}]);
+       }));
+    it('should order by numerical and alpha',
+       inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+         const pipe = new KeyValuePipe(differs);
+         const input = {2: 1, 1: 1, 'b': 1, 0: 1, 3: 1, 'a': 1};
+         expect(pipe.transform(input)).toEqual([
+           {key: '0', value: 1}, {key: '1', value: 1}, {key: '2', value: 1}, {key: '3', value: 1},
+           {key: 'a', value: 1}, {key: 'b', value: 1}
+         ]);
+       }));
+    it('should return the same ref if nothing changes',
+       inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+         const pipe = new KeyValuePipe(differs);
+         const transform1 = pipe.transform({1: 2});
+         const transform2 = pipe.transform({1: 2});
+         expect(transform1 === transform2).toEqual(true);
+       }));
+    it('should return a new ref if something changes',
+       inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+         const pipe = new KeyValuePipe(differs);
+         const transform1 = pipe.transform({1: 2});
+         const transform2 = pipe.transform({1: 3});
+         expect(transform1 !== transform2).toEqual(true);
+       }));
   });
 
   describe('Map', () => {
-    it('should transform a basic Map', () => {
-      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-      expect(pipe.transform(new Map([[1, 2]]))).toEqual([{key: 1, value: 2}]);
-    });
-    it('should order by alpha', () => {
-      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-      expect(pipe.transform(new Map([['b', 1], ['a', 1]]))).toEqual([
-        {key: 'a', value: 1}, {key: 'b', value: 1}
-      ]);
-    });
-    it('should order by numerical', () => {
-      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-      expect(pipe.transform(new Map([[2, 1], [1, 1]]))).toEqual([
-        {key: 1, value: 1}, {key: 2, value: 1}
-      ]);
-    });
-    it('should order by numerical and alpha', () => {
-      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-      const input = [[2, 1], [1, 1], ['b', 1], [0, 1], [3, 1], ['a', 1]];
-      expect(pipe.transform(new Map(input as any))).toEqual([
-        {key: 0, value: 1}, {key: 1, value: 1}, {key: 2, value: 1}, {key: 3, value: 1},
-        {key: 'a', value: 1}, {key: 'b', value: 1}
-      ]);
-    });
-    it('should order by complex types with compareFn', () => {
-      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-      const input = new Map([[{id: 1}, 1], [{id: 0}, 1]]);
-      expect(pipe.transform<{id: number}, number>(input, (a, b) => a.key.id > b.key.id ? 1 : -1))
-          .toEqual([
-            {key: {id: 0}, value: 1},
-            {key: {id: 1}, value: 1},
-          ]);
-    });
-    it('should return the same ref if nothing changes', () => {
-      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-      const transform1 = pipe.transform(new Map([[1, 2]]));
-      const transform2 = pipe.transform(new Map([[1, 2]]));
-      expect(transform1 === transform2).toEqual(true);
-    });
-    it('should return a new ref if something changes', () => {
-      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
-      const transform1 = pipe.transform(new Map([[1, 2]]));
-      const transform2 = pipe.transform(new Map([[1, 3]]));
-      expect(transform1 !== transform2).toEqual(true);
-    });
+    it('should transform a basic Map', inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+         const pipe = new KeyValuePipe(differs);
+         expect(pipe.transform(new Map([[1, 2]]))).toEqual([{key: 1, value: 2}]);
+       }));
+    it('should order by alpha', inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+         const pipe = new KeyValuePipe(differs);
+         expect(pipe.transform(new Map([['b', 1], ['a', 1]]))).toEqual([
+           {key: 'a', value: 1}, {key: 'b', value: 1}
+         ]);
+       }));
+    it('should order by numerical', inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+         const pipe = new KeyValuePipe(differs);
+         expect(pipe.transform(new Map([[2, 1], [1, 1]]))).toEqual([
+           {key: 1, value: 1}, {key: 2, value: 1}
+         ]);
+       }));
+    it('should order by numerical and alpha',
+       inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+         const pipe = new KeyValuePipe(differs);
+         const input = [[2, 1], [1, 1], ['b', 1], [0, 1], [3, 1], ['a', 1]];
+         expect(pipe.transform(new Map(input as any))).toEqual([
+           {key: 0, value: 1}, {key: 1, value: 1}, {key: 2, value: 1}, {key: 3, value: 1},
+           {key: 'a', value: 1}, {key: 'b', value: 1}
+         ]);
+       }));
+    it('should order by complex types with compareFn',
+       inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+         const pipe = new KeyValuePipe(differs);
+         const input = new Map([[{id: 1}, 1], [{id: 0}, 1]]);
+         expect(pipe.transform<{id: number}, number>(input, (a, b) => a.key.id > b.key.id ? 1 : -1))
+             .toEqual([
+               {key: {id: 0}, value: 1},
+               {key: {id: 1}, value: 1},
+             ]);
+       }));
+    it('should return the same ref if nothing changes',
+       inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+         const pipe = new KeyValuePipe(differs);
+         const transform1 = pipe.transform(new Map([[1, 2]]));
+         const transform2 = pipe.transform(new Map([[1, 2]]));
+         expect(transform1 === transform2).toEqual(true);
+       }));
+    it('should return a new ref if something changes',
+       inject([KeyValueDiffers], (differs: KeyValueDiffers) => {
+         const pipe = new KeyValuePipe(differs);
+         const transform1 = pipe.transform(new Map([[1, 2]]));
+         const transform2 = pipe.transform(new Map([[1, 3]]));
+         expect(transform1 !== transform2).toEqual(true);
+       }));
   });
 });
 

--- a/packages/core/src/application_module.ts
+++ b/packages/core/src/application_module.ts
@@ -9,7 +9,6 @@
 import {APP_INITIALIZER, ApplicationInitStatus} from './application_init';
 import {ApplicationRef} from './application_ref';
 import {APP_ID_RANDOM_PROVIDER} from './application_tokens';
-import {IterableDiffers, KeyValueDiffers, defaultIterableDiffers, defaultKeyValueDiffers} from './change_detection/change_detection';
 import {Console} from './console';
 import {InjectionToken, Injector, StaticProvider} from './di';
 import {Inject, Optional, SkipSelf} from './di/metadata';
@@ -19,14 +18,6 @@ import {ComponentFactoryResolver} from './linker';
 import {Compiler} from './linker/compiler';
 import {NgModule} from './metadata';
 import {NgZone} from './zone';
-
-export function _iterableDiffersFactory() {
-  return defaultIterableDiffers;
-}
-
-export function _keyValueDiffersFactory() {
-  return defaultKeyValueDiffers;
-}
 
 export function _localeFactory(locale?: string): string {
   return locale || 'en-US';
@@ -46,8 +37,6 @@ export const APPLICATION_MODULE_PROVIDERS: StaticProvider[] = [
   },
   {provide: Compiler, useClass: Compiler, deps: []},
   APP_ID_RANDOM_PROVIDER,
-  {provide: IterableDiffers, useFactory: _iterableDiffersFactory, deps: []},
-  {provide: KeyValueDiffers, useFactory: _keyValueDiffersFactory, deps: []},
   {
     provide: LOCALE_ID,
     useFactory: _localeFactory,

--- a/packages/core/src/change_detection/change_detection.ts
+++ b/packages/core/src/change_detection/change_detection.ts
@@ -21,19 +21,3 @@ export {DefaultKeyValueDifferFactory} from './differs/default_keyvalue_differ';
 export {CollectionChangeRecord, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, NgIterable, TrackByFunction} from './differs/iterable_differs';
 export {KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers} from './differs/keyvalue_differs';
 export {PipeTransform} from './pipe_transform';
-
-
-
-/**
- * Structural diffing for `Object`s and `Map`s.
- */
-const keyValDiff: KeyValueDifferFactory[] = [new DefaultKeyValueDifferFactory()];
-
-/**
- * Structural diffing for `Iterable` types such as `Array`s.
- */
-const iterableDiff: IterableDifferFactory[] = [new DefaultIterableDifferFactory()];
-
-export const defaultIterableDiffers = new IterableDiffers(iterableDiff);
-
-export const defaultKeyValueDiffers = new KeyValueDiffers(keyValDiff);

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -132,15 +132,15 @@ export interface IterableDifferFactory {
   create<V>(trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
 }
 
+const defaultIterableDifferFactories = [new DefaultIterableDifferFactory()];
+
 /**
  * A repository of different iterable diffing strategies used by NgFor, NgClass, and others.
  *
  */
 export class IterableDiffers {
-  static ngInjectableDef = defineInjectable({
-    providedIn: 'root',
-    factory: () => new IterableDiffers([new DefaultIterableDifferFactory()])
-  });
+  static ngInjectableDef = defineInjectable(
+      {providedIn: 'root', factory: () => new IterableDiffers(defaultIterableDifferFactories)});
 
   /**
    * @deprecated v4.0.0 - Should be private
@@ -152,6 +152,8 @@ export class IterableDiffers {
     if (parent != null) {
       const copied = parent.factories.slice();
       factories = factories.concat(copied);
+    } else {
+      factories = factories.concat(defaultIterableDifferFactories);
     }
 
     return new IterableDiffers(factories);
@@ -161,6 +163,8 @@ export class IterableDiffers {
    * Takes an array of {@link IterableDifferFactory} and returns a provider used to extend the
    * inherited {@link IterableDiffers} instance with the provided factories and return a new
    * {@link IterableDiffers} instance.
+   *
+   * @deprecated v6.1.0 - Use `IterableDiffers.create()` instead
    *
    * @usageNotes
    * ### Example

--- a/packages/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/packages/core/src/change_detection/differs/keyvalue_differs.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Optional, SkipSelf, StaticProvider} from '../../di';
+import {Optional, SkipSelf, StaticProvider, defineInjectable} from '../../di';
 
+import {DefaultKeyValueDifferFactory} from './default_keyvalue_differ';
 
 /**
  * A differ that tracks changes made to an object over time.
@@ -110,11 +111,16 @@ export interface KeyValueDifferFactory {
   create<K, V>(): KeyValueDiffer<K, V>;
 }
 
+const defaultKeyValueDifferFactories = [new DefaultKeyValueDifferFactory()];
+
 /**
  * A repository of different Map diffing strategies used by NgClass, NgStyle, and others.
  *
  */
 export class KeyValueDiffers {
+  static ngInjectableDef = defineInjectable(
+      {providedIn: 'root', factory: () => new KeyValueDiffers(defaultKeyValueDifferFactories)});
+
   /**
    * @deprecated v4.0.0 - Should be private.
    */
@@ -126,7 +132,10 @@ export class KeyValueDiffers {
     if (parent) {
       const copied = parent.factories.slice();
       factories = factories.concat(copied);
+    } else {
+      factories = factories.concat(defaultKeyValueDifferFactories);
     }
+
     return new KeyValueDiffers(factories);
   }
 
@@ -134,6 +143,8 @@ export class KeyValueDiffers {
    * Takes an array of {@link KeyValueDifferFactory} and returns a provider used to extend the
    * inherited {@link KeyValueDiffers} instance with the provided factories and return a new
    * {@link KeyValueDiffers} instance.
+   *
+   * @deprecated v6.1.0 - Use `KeyValueDiffers.create()` instead
    *
    * @usageNotes
    * ### Example

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -8,7 +8,6 @@
 
 export {ALLOW_MULTIPLE_PLATFORMS as ɵALLOW_MULTIPLE_PLATFORMS} from './application_ref';
 export {APP_ID_RANDOM_PROVIDER as ɵAPP_ID_RANDOM_PROVIDER} from './application_tokens';
-export {defaultIterableDiffers as ɵdefaultIterableDiffers, defaultKeyValueDiffers as ɵdefaultKeyValueDiffers} from './change_detection/change_detection';
 export {devModeEqual as ɵdevModeEqual} from './change_detection/change_detection_util';
 export {isListLikeIterable as ɵisListLikeIterable} from './change_detection/change_detection_util';
 export {ChangeDetectorStatus as ɵChangeDetectorStatus, isDefaultChangeDetectionStrategy as ɵisDefaultChangeDetectionStrategy} from './change_detection/constants';

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -366,6 +366,9 @@
     "name": "currentElementNode"
   },
   {
+    "name": "defaultIterableDifferFactories"
+  },
+  {
     "name": "defineComponent"
   },
   {

--- a/packages/core/test/change_detection/differs/iterable_differs_spec.ts
+++ b/packages/core/test/change_detection/differs/iterable_differs_spec.ts
@@ -45,7 +45,14 @@ import {SpyIterableDifferFactory} from '../../spies';
       const parent = IterableDiffers.create(<any>[factory1]);
       const child = IterableDiffers.create(<any>[factory2], parent);
 
-      expect(child.factories).toEqual([factory2, factory1]);
+      expect(child.factories.length).toBe(3);
+      expect(child.factories.slice(0, 2)).toEqual([factory2, factory1]);
+    });
+
+    it('should contain default differ factories by default', () => {
+      const differs = IterableDiffers.create([]);
+
+      expect(differs.find([])).toBeDefined();
     });
 
     describe('.extend()', () => {

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -450,7 +450,7 @@ export declare class IterableDiffers {
     find(iterable: any): IterableDifferFactory;
     static ngInjectableDef: never;
     static create(factories: IterableDifferFactory[], parent?: IterableDiffers): IterableDiffers;
-    static extend(factories: IterableDifferFactory[]): StaticProvider;
+    /** @deprecated */ static extend(factories: IterableDifferFactory[]): StaticProvider;
 }
 
 export interface KeyValueChangeRecord<K, V> {
@@ -483,8 +483,9 @@ export declare class KeyValueDiffers {
     /** @deprecated */ factories: KeyValueDifferFactory[];
     constructor(factories: KeyValueDifferFactory[]);
     find(kv: any): KeyValueDifferFactory;
+    static ngInjectableDef: never;
     static create<S>(factories: KeyValueDifferFactory[], parent?: KeyValueDiffers): KeyValueDiffers;
-    static extend<S>(factories: KeyValueDifferFactory[]): StaticProvider;
+    /** @deprecated */ static extend<S>(factories: KeyValueDifferFactory[]): StaticProvider;
 }
 
 /** @experimental */


### PR DESCRIPTION
closes #11309, closes #18554

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #11309, #18554

The static method `IterableDiffers.extend()` cannot be used in application injector and isn't AOT compatible.

## What is the new behavior?

Deprecate `IterableDiffers.extend()`, instead make `IterableDiffers.create()` to add `DefaultIterableDifferFactory` in the end.

For extending at application-level, just use `IterableDiffers.create()` method:

```typescript
@NgModule({
  providers: [
    { provide: IterableDiffers, useValue: IterableDiffers.create([customDifferFactory]) }
  ]
})
class AppModule {}
```

For extending at directive-level, provide a factory function:

```typescript
export function extendIterableDiffers(parent: IterableDiffers): IterableDiffers {
  return IterableDiffers.create([customDifferFactory], parent)
}

@Component({
  providers: [
    { provide: IterableDiffers, useFactory: extendIterableDiffers, deps: [[new SkipSelf(), IterableDiffers]] }
  ]
})
class AppComponent {}
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

`DefaultIterableDifferFactory` is added in the end, which will always be overriden by custom `IterableDifferFactory`s.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
