### PR TITLE
fix(core): stop reusing provider definitions across NgModuleRef insta…

### DIFF
--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -2415,6 +2415,9 @@
     "name": "checkStable"
   },
   {
+    "name": "cloneNgModuleDefinition"
+  },
+  {
     "name": "collectReferences"
   },
   {


### PR DESCRIPTION
…nces

Fixes #25018.

Instantiating a NgModuleRef from NgModuleFactory reuses the NgModuleDefinition if it is already present. However the NgModuleDefinition has a providers array which is modified when tree shakable providers are instantiated. This corrupts the provider definitions the next time the same factory is used to create a new NgModuleRef - Two provider definitions can end up with the same index and the injector could potentially return a completely wrong object for a provider token.

This scenario is more likely on the server where the same NgModuleFactory is reused across requests.

The fix is to clone the cached NgModuleDefinition so that any tree shakable providers added to it later do not affect the cached copy.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Using Tree shakable providers on the server ends up returning completely wrong provider for a given token because there is a global definitions cache that is shared across requests and the cached value are mutated.

## What is the new behavior?
Tree shakable providers on the server no longer cause the wrong injector behavior.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
