### PR TITLE
fix(comiler): correct realPath to realpath

### DIFF
--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -591,7 +591,7 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
   getNewLine = () => this.context.getNewLine();
   // Make sure we do not `host.realpath()` from TS as we do not want to resolve symlinks.
   // https://github.com/Microsoft/TypeScript/issues/9552
-  realPath = (p: string) => p;
+  realpath = (p: string) => p;
   writeFile = this.context.writeFile.bind(this.context);
 }
 


### PR DESCRIPTION
The optional property on `ts.CompilerHost` is called `realpath` (lower case), not `realPath` (lower camel case).

It is not clear to me what the impact of this is, but the author's intent was clearly to override `realpath`.

This was not caught by the compiler as `realpath` is optional, so these were just different properties.