### PR TITLE
fix(common): use canonical signature in HttpRequest constructor

### DIFF
--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -363,9 +363,9 @@ export class HttpClient {
       }
 
       // Construct the request.
-      req = new HttpRequest(first, url !, (options.body !== undefined ? options.body : null), {
-        headers,
-        params,
+      req = new HttpRequest(url !, {
+        method: first,
+        body: options.body !== undefined ? options.body : null, headers, params,
         reportProgress: options.reportProgress,
         // By default, JSON is assumed to be returned for all calls.
         responseType: options.responseType || 'json',

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -61,6 +61,14 @@ const TEST_STRING = `I'm a body!`;
         const req = new HttpRequest('GET', TEST_URL);
         expect(req.responseType).toBe('json');
       });
+      it('accepts canonical parameters', () => {
+        const headers = new HttpHeaders();
+        const req = new HttpRequest(TEST_URL, {method: 'DELETE', body: TEST_STRING, headers});
+        expect(req.method).toBe('DELETE');
+        expect(req.url).toBe(TEST_URL);
+        expect(req.body).toBe(TEST_STRING);
+        expect(req.headers instanceof HttpHeaders).toBeTruthy();
+      });
     });
     describe('clone() copies the request', () => {
       const headers = new HttpHeaders({

--- a/tools/public_api_guard/common/http.d.ts
+++ b/tools/public_api_guard/common/http.d.ts
@@ -1591,21 +1591,30 @@ export declare class HttpRequest<T> {
     readonly url: string;
     readonly urlWithParams: string;
     readonly withCredentials: boolean;
-    constructor(method: 'DELETE' | 'GET' | 'HEAD' | 'JSONP' | 'OPTIONS', url: string, init?: {
+    /** @deprecated */ constructor(method: 'DELETE' | 'GET' | 'HEAD' | 'JSONP' | 'OPTIONS', url: string, init?: {
         headers?: HttpHeaders;
         reportProgress?: boolean;
         params?: HttpParams;
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
         withCredentials?: boolean;
     });
-    constructor(method: 'POST' | 'PUT' | 'PATCH', url: string, body: T | null, init?: {
+    /** @deprecated */ constructor(method: 'POST' | 'PUT' | 'PATCH', url: string, body: T | null, init?: {
         headers?: HttpHeaders;
         reportProgress?: boolean;
         params?: HttpParams;
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
         withCredentials?: boolean;
     });
-    constructor(method: string, url: string, body: T | null, init?: {
+    /** @deprecated */ constructor(method: string, url: string, body: T | null, init?: {
+        headers?: HttpHeaders;
+        reportProgress?: boolean;
+        params?: HttpParams;
+        responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
+        withCredentials?: boolean;
+    });
+    constructor(url: string, init: {
+        method: string;
+        body?: T | null;
         headers?: HttpHeaders;
         reportProgress?: boolean;
         params?: HttpParams;


### PR DESCRIPTION
ref #19438

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #19438

Note this PR doesn't completely fix <sub>%disable keyword%</sub> #19438, but would ease it a lot (from `workaround: none` to `workaround: obvious`).

The `HttpClient.delete()` API still needs to be fixed, but haven't found a non-breaking way. The `body` parameter is indistinguishable with `init` options, which also could be a valid body shape.

## What is the new behavior?

Change the `HttpRequest` constructor to a canonical API which has unified signature for any method (following [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request) standard), to support DELETE method with a request body in manual constructed `HttpRequest`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

No breaking in this one, but if the deprecated APIs are going to be removed, will be breaking at that time.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
