### PR TITLE
feat(common): support custom JSON parser in HttpClient

### DIFF
--- a/goldens/public-api/common/http/http.d.ts
+++ b/goldens/public-api/common/http/http.d.ts
@@ -1725,12 +1725,18 @@ export declare interface HttpUserEvent<T> {
 }
 
 export declare class HttpXhrBackend implements HttpBackend {
-    constructor(xhrFactory: XhrFactory);
+    constructor(xhrFactory: XhrFactory, jsonParser: JsonParser);
     handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
 }
 
 export declare abstract class HttpXsrfTokenExtractor {
     abstract getToken(): string | null;
+}
+
+export declare const JSON_PARSER: InjectionToken<JsonParser>;
+
+export interface JsonParser {
+    parse(text: string, reviver?: (key: any, value: any) => any): any;
 }
 
 export declare class JsonpClientBackend implements HttpBackend {

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -15,5 +15,5 @@ export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule, HttpInter
 export {HttpParameterCodec, HttpParams, HttpParamsOptions, HttpUrlEncodingCodec} from './src/params';
 export {HttpRequest} from './src/request';
 export {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpProgressEvent, HttpResponse, HttpResponseBase, HttpSentEvent, HttpUploadProgressEvent, HttpUserEvent} from './src/response';
-export {HttpXhrBackend, XhrFactory} from './src/xhr';
+export {HttpXhrBackend, JSON_PARSER, JsonParser, XhrFactory} from './src/xhr';
 export {HttpXsrfTokenExtractor} from './src/xsrf';

--- a/packages/common/http/src/module.ts
+++ b/packages/common/http/src/module.ts
@@ -15,7 +15,7 @@ import {HTTP_INTERCEPTORS, HttpInterceptor, HttpInterceptorHandler, NoopIntercep
 import {JsonpCallbackContext, JsonpClientBackend, JsonpInterceptor} from './jsonp';
 import {HttpRequest} from './request';
 import {HttpEvent} from './response';
-import {BrowserXhr, HttpXhrBackend, XhrFactory} from './xhr';
+import {BrowserXhr, HttpXhrBackend, JSON_PARSER, JsonParser, XhrFactory} from './xhr';
 import {HttpXsrfCookieExtractor, HttpXsrfInterceptor, HttpXsrfTokenExtractor, XSRF_COOKIE_NAME, XSRF_HEADER_NAME} from './xsrf';
 
 /**
@@ -131,6 +131,10 @@ export class HttpClientXsrfModule {
   }
 }
 
+export function _JSON(): JsonParser {
+  return JSON;
+}
+
 /**
  * Configures the [dependency injector](guide/glossary#injector) for `HttpClient`
  * with supporting services for XSRF. Automatically imported by `HttpClientModule`.
@@ -161,6 +165,7 @@ export class HttpClientXsrfModule {
     {provide: HttpBackend, useExisting: HttpXhrBackend},
     BrowserXhr,
     {provide: XhrFactory, useExisting: BrowserXhr},
+    {provide: JSON_PARSER, useFactory: _JSON, deps: []},
   ],
 })
 export class HttpClientModule {


### PR DESCRIPTION
closes #21079

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #21079

When user works with an extended JSON format, eg. [JSON5](https://json5.org/), due to it's not compatible with `JSON.parse()`, user have to make it raw text and parse it manually.

But JSON5 format is still conceptually `'json'` rather than `'text'`, it's a fully superset of ES JSON, just being more human friendly.

## What is the new behavior?

Simply with:

```typescript
@NgModule({
  providers: [
    { provider: JsonParser, useValue: JSON5 }
  ]
})
class AppModule {}
```

Or strip a different receiver:

```typescript
class MyJsonParser implements JsonParser {
  parse(text: string, reviver?: (key: any, value: any) => any): any {
    const strippedText = text.trimStart(CUSTOM_XSSI)
    return JSON.parse(strippedText, reviver)
  }
}
```

Or have a different reviver:

```typescript
class MyJsonParser implements JsonParser {
  parse(text: string, reviver?: (key: any, value: any) => any): any {
    const wrappedReviver = wrapReviver(reviver)
    return JSON.parse(text, wrappedReviver)
  }
}
```

Then server could provide JSON5 response directly and no error would be raised.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
