### PR TITLE
build(bazel): entry point file couldn't be resolved [ts-api-guardian]

### DIFF
--- a/tools/ts-api-guardian/lib/serializer.ts
+++ b/tools/ts-api-guardian/lib/serializer.ts
@@ -42,7 +42,9 @@ export function publicApi(fileName: string, options: SerializationOptions = {}):
 export function publicApiInternal(
     host: ts.CompilerHost, fileName: string, tsOptions: ts.CompilerOptions,
     options: SerializationOptions = {}): string {
-  const entrypoint = path.normalize(fileName);
+  // Since the entry point will be compared with the source files from the TypeScript program,
+  // the path needs to be normalized with forward slashes in order to work within Windows.
+  const entrypoint = path.normalize(fileName).replace(/\\/g, '/');
 
   if (!entrypoint.match(/\.d\.ts$/)) {
     throw new Error(`Source file "${fileName}" is not a declaration file`);


### PR DESCRIPTION
* When using `ts-api-guardian` on Windows, the input file can't be found due to wrong normalized path delimiters.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

cc. @alexeagle. Wasn't sure how to indicate that this affects ts-api-guardian, so I've added it as a suffix.