### PR TITLE
refactor(common): fix a merge error

### DIFF
--- a/packages/examples/common/pipes/ts/e2e_test/pipe_spec.ts
+++ b/packages/examples/common/pipes/ts/e2e_test/pipe_spec.ts
@@ -58,17 +58,6 @@ describe('pipe', () => {
     });
   });
 
-  describe('keyvalue', () => {
-    it('should work properly', () => {
-      browser.get(URL);
-      waitForElement('keyvalue-pipe');
-      expect(element.all(by.css('keyvalue-pipe div')).get(0).getText()).toEqual('1:bar');
-      expect(element.all(by.css('keyvalue-pipe div')).get(1).getText()).toEqual('2:foo');
-      expect(element.all(by.css('keyvalue-pipe div')).get(2).getText()).toEqual('1:bar');
-      expect(element.all(by.css('keyvalue-pipe div')).get(3).getText()).toEqual('2:foo');
-    });
-  });
-
   describe('number', () => {
     it('should work properly', () => {
       browser.get(URL);


### PR DESCRIPTION
A `keyvalue-pipe` was inadvertently pulled in  When merging #25028 (commit
6eca36756). This pipe is NOT in the patch branch and the test fails.

This commit remove the faulty spec.
