### PR TITLE
build: update to newer circleCI bazel remote cache proxy

### DIFF
--- a/.circleci/setup_cache.sh
+++ b/.circleci/setup_cache.sh
@@ -5,7 +5,7 @@
 
 set -u -e
 
-readonly DOWNLOAD_URL="https://5-116431813-gh.circle-artifacts.com/0/pkg/bazel-remote-proxy-$(uname -s)_$(uname -m)"
+readonly DOWNLOAD_URL="https://6-116431813-gh.circle-artifacts.com/0/pkg/bazel-remote-proxy-$(uname -s)_$(uname -m)"
 
 curl --fail -o ~/bazel-remote-proxy "$DOWNLOAD_URL"
 chmod +x ~/bazel-remote-proxy


### PR DESCRIPTION
it fixes the error we currently get on CI
