### PR TITLE
fix(core): stop reusing provider definitions across NgModuleRef insta…

### DIFF
--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -8,10 +8,13 @@
 
 import {ANALYZE_FOR_ENTRY_COMPONENTS, CUSTOM_ELEMENTS_SCHEMA, Compiler, Component, ComponentFactoryResolver, Directive, HostBinding, Inject, Injectable, InjectionToken, Injector, Input, NgModule, NgModuleRef, Optional, Pipe, Provider, Self, Type, forwardRef, getModuleFactory} from '@angular/core';
 import {Console} from '@angular/core/src/console';
+import {InjectableDef, defineInjectable} from '@angular/core/src/di/defs';
+import {NgModuleData} from '@angular/core/src/view/types';
+import {tokenKey} from '@angular/core/src/view/util';
 import {ComponentFixture, TestBed, inject} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-import {InternalNgModuleRef} from '../../src/linker/ng_module_factory';
+import {InternalNgModuleRef, NgModuleFactory} from '../../src/linker/ng_module_factory';
 import {clearModulesForTest} from '../../src/linker/ng_module_factory_loader';
 import {stringify} from '../../src/util';
 
@@ -125,9 +128,13 @@ function declareTests({useJit}: {useJit: boolean}) {
       injector = _injector;
     }));
 
+    function createModuleFactory<T>(moduleType: Type<T>): NgModuleFactory<T> {
+      return compiler.compileModuleSync(moduleType);
+    }
+
     function createModule<T>(
         moduleType: Type<T>, parentInjector?: Injector | null): NgModuleRef<T> {
-      return compiler.compileModuleSync(moduleType).create(parentInjector || null);
+      return createModuleFactory(moduleType).create(parentInjector || null);
     }
 
     function createComp<T>(compType: Type<T>, moduleType: Type<any>): ComponentFixture<T> {
@@ -1296,6 +1303,37 @@ function declareTests({useJit}: {useJit: boolean}) {
           expect(() => createModule(SomeModule).injector)
               .toThrowError(
                   `Invalid provider for the NgModule 'ImportedModule1' - only instances of Provider and Type are allowed, got: [?broken?]`);
+        });
+      });
+
+      describe('tree shakable providers', () => {
+        it('definition should not persist across NgModuleRef instances', () => {
+          @NgModule()
+          class SomeModule {
+          }
+
+          class Bar {
+            static ngInjectableDef: InjectableDef<Bar> = defineInjectable({
+              factory: () => new Bar(),
+              providedIn: SomeModule,
+            });
+          }
+
+          const factory = createModuleFactory(SomeModule);
+          const ngModuleRef1 = factory.create(null);
+
+          // Inject a tree shakeable provider token.
+          ngModuleRef1.injector.get(Bar);
+
+          // Tree Shakeable provider definition should get added to the NgModule data.
+          const providerDef1 = (ngModuleRef1 as NgModuleData)._def.providersByKey[tokenKey(Bar)];
+          expect(providerDef1).not.toBeUndefined();
+
+          // Instantiate the same module. The tree shakeable provider
+          // definition should not already be present.
+          const ngModuleRef2 = factory.create(null);
+          const providerDef2 = (ngModuleRef2 as NgModuleData)._def.providersByKey[tokenKey(Bar)];
+          expect(providerDef2).toBeUndefined();
         });
       });
     });


### PR DESCRIPTION
…nces

Fixes #25018.

Instantiating a NgModuleRef from NgModuleFactory reuses the NgModuleDefinition if it is already present. However the NgModuleDefinition has a providers array which modified when tree shakable providers are instantiated. This corrupts the provider definitions the next time the same factory is used to create a new NgModuleRef - Two provider definitions can end up with the same index and the injector could potentially return a completely wrong object for a provider token.

This scenario is more likely on the server where the same NgModuleFactory is reused across requests.

The fix clones the cached NgModuleDefinition so that any tree shakable providers added later do not affect the cached copy.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Cherry picked from from master.