### PR TITLE
feat(ivy): implement the getters of ViewContainerRef

### DIFF
--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -41,6 +41,7 @@ export abstract class ViewContainerRef {
 
   abstract get injector(): Injector;
 
+  /** @deprecated No replacement */
   abstract get parentInjector(): Injector;
 
   /**

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -329,7 +329,7 @@ export function createLViewData<T>(
     null,                                                                        // directives
     null,                                                                        // cleanupInstances
     context,                                                                     // context
-    viewData && viewData[INJECTOR],                                              // injector
+    viewData && viewData[INJECTOR] || null,                                      // injector
     renderer,                                                                    // renderer
     sanitizer || null,                                                           // sanitizer
     null,                                                                        // tail

--- a/packages/core/src/view/refs.ts
+++ b/packages/core/src/view/refs.ts
@@ -138,6 +138,7 @@ class ViewContainerRef_ implements ViewContainerData {
 
   get injector(): Injector { return new Injector_(this._view, this._elDef); }
 
+  /** @deprecated No replacement */
   get parentInjector(): Injector {
     let view = this._view;
     let elDef = this._elDef.parent;

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -27,6 +27,9 @@
     "name": "ChangeDetectionStrategy"
   },
   {
+    "name": "ChangeDetectorRef"
+  },
+  {
     "name": "DIRECTIVES"
   },
   {
@@ -40,6 +43,9 @@
   },
   {
     "name": "EMPTY_RENDERER_TYPE_ID"
+  },
+  {
+    "name": "ElementRef"
   },
   {
     "name": "ElementRef$1"
@@ -96,6 +102,12 @@
     "name": "NgModuleRef"
   },
   {
+    "name": "NodeInjector"
+  },
+  {
+    "name": "NullInjector"
+  },
+  {
     "name": "Optional"
   },
   {
@@ -138,6 +150,9 @@
     "name": "TemplateRef"
   },
   {
+    "name": "TemplateRef$1"
+  },
+  {
     "name": "Todo"
   },
   {
@@ -151,6 +166,9 @@
   },
   {
     "name": "ViewContainerRef"
+  },
+  {
+    "name": "ViewContainerRef$1"
   },
   {
     "name": "ViewEncapsulation$1"
@@ -169,6 +187,9 @@
   },
   {
     "name": "_ROOT_DIRECTIVE_INDICES"
+  },
+  {
+    "name": "_THROW_IF_NOT_FOUND"
   },
   {
     "name": "__read"
@@ -471,6 +492,9 @@
     "name": "getCleanup"
   },
   {
+    "name": "getClosestComponentAncestor"
+  },
+  {
     "name": "getCurrentSanitizer"
   },
   {
@@ -492,10 +516,16 @@
     "name": "getNextLNode"
   },
   {
+    "name": "getOrCreateChangeDetectorRef"
+  },
+  {
     "name": "getOrCreateContainerRef"
   },
   {
     "name": "getOrCreateElementRef"
+  },
+  {
+    "name": "getOrCreateHostChangeDetector"
   },
   {
     "name": "getOrCreateInjectable"
@@ -592,6 +622,9 @@
   },
   {
     "name": "invertObject"
+  },
+  {
+    "name": "isComponent"
   },
   {
     "name": "isContextDirty"

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ComponentFactoryResolver, Directive, EmbeddedViewRef, NgModuleRef, Pipe, PipeTransform, RendererFactory2, TemplateRef, ViewContainerRef, createInjector, defineInjector, ɵAPP_ROOT as APP_ROOT, ɵNgModuleDef as NgModuleDef} from '../../src/core';
+import {Component, ComponentFactoryResolver, ElementRef, EmbeddedViewRef, NgModuleRef, Pipe, PipeTransform, RendererFactory2, TemplateRef, ViewContainerRef, createInjector, defineInjector, ɵAPP_ROOT as APP_ROOT, ɵNgModuleDef as NgModuleDef} from '../../src/core';
 import {getOrCreateNodeInjectorForNode, getOrCreateTemplateRef} from '../../src/render3/di';
 import {NgOnChangesFeature, defineComponent, defineDirective, definePipe, injectComponentFactoryResolver, injectTemplateRef, injectViewContainerRef} from '../../src/render3/index';
 import {bind, container, containerRefreshEnd, containerRefreshStart, element, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, interpolation1, load, loadDirective, projection, projectionDef, reserveSlots, text, textBinding} from '../../src/render3/instructions';
@@ -821,6 +821,66 @@ describe('ViewContainerRef', () => {
         expect(fixture.html)
             .toEqual(
                 '<p vcref=""></p><embedded-cmp-with-ngcontent>12<hr>34</embedded-cmp-with-ngcontent>');
+      });
+    });
+
+    describe('getters', () => {
+      it('should work on elements', () => {
+        function createTemplate() {
+          elementStart(0, 'header', ['vcref', '']);
+          elementEnd();
+          elementStart(1, 'footer');
+          elementEnd();
+        }
+
+        new TemplateFixture(createTemplate, undefined, [DirectiveWithVCRef]);
+
+        expect(directiveInstance !.vcref.element.nativeElement.tagName.toLowerCase())
+            .toEqual('header');
+        expect(
+            directiveInstance !.vcref.injector.get(ElementRef).nativeElement.tagName.toLowerCase())
+            .toEqual('header');
+        expect(() => directiveInstance !.vcref.parentInjector.get(ElementRef)).toThrow();
+      });
+
+      it('should work on components', () => {
+        const HeaderComponent =
+            createComponent('header-cmp', function(rf: RenderFlags, ctx: any) {});
+
+        function createTemplate() {
+          elementStart(0, 'header-cmp', ['vcref', '']);
+          elementEnd();
+          elementStart(1, 'footer');
+          elementEnd();
+        }
+
+        new TemplateFixture(createTemplate, undefined, [HeaderComponent, DirectiveWithVCRef]);
+
+        expect(directiveInstance !.vcref.element.nativeElement.tagName.toLowerCase())
+            .toEqual('header-cmp');
+        expect(
+            directiveInstance !.vcref.injector.get(ElementRef).nativeElement.tagName.toLowerCase())
+            .toEqual('header-cmp');
+        expect(() => directiveInstance !.vcref.parentInjector.get(ElementRef)).toThrow();
+      });
+
+      it('should work on containers', () => {
+        function createTemplate() {
+          container(0, embeddedTemplate, undefined, ['vcref', '']);
+          elementStart(1, 'footer');
+          elementEnd();
+        }
+
+        function updateTemplate() {
+          containerRefreshStart(0);
+          containerRefreshEnd();
+        }
+
+        new TemplateFixture(createTemplate, updateTemplate, [DirectiveWithVCRef]);
+        expect(directiveInstance !.vcref.element.nativeElement.textContent).toEqual('container');
+        expect(directiveInstance !.vcref.injector.get(ElementRef).nativeElement.textContent)
+            .toEqual('container');
+        expect(() => directiveInstance !.vcref.parentInjector.get(ElementRef)).toThrow();
       });
     });
   });

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -922,7 +922,7 @@ export declare abstract class ViewContainerRef {
     abstract readonly element: ElementRef;
     abstract readonly injector: Injector;
     abstract readonly length: number;
-    abstract readonly parentInjector: Injector;
+    /** @deprecated */ abstract readonly parentInjector: Injector;
     abstract clear(): void;
     abstract createComponent<C>(componentFactory: ComponentFactory<C>, index?: number, injector?: Injector, projectableNodes?: any[][], ngModule?: NgModuleRef<any>): ComponentRef<C>;
     abstract createEmbeddedView<C>(templateRef: TemplateRef<C>, context?: C, index?: number): EmbeddedViewRef<C>;


### PR DESCRIPTION
This PR implements the getters of ViewContainerRef: element and injector.
As per @mhevery comment, parentInjector is deprecated.