### PR TITLE
fix(router): always stringify matrix parameters

### DIFF
--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -296,7 +296,7 @@ function createNewSegmentGroup(
     // if we start with an object literal, we need to reuse the path part from the segment
     if (i === 0 && isMatrixParams(commands[0])) {
       const p = segmentGroup.segments[startIndex];
-      paths.push(new UrlSegment(p.path, commands[0]));
+      paths.push(new UrlSegment(p.path, stringify(commands[0])));
       i++;
       continue;
     }

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -522,15 +522,15 @@ class UrlParser {
     return new UrlSegment(decode(path), this.parseMatrixParams());
   }
 
-  private parseMatrixParams(): {[key: string]: any} {
-    const params: {[key: string]: any} = {};
+  private parseMatrixParams(): {[key: string]: string} {
+    const params: {[key: string]: string} = {};
     while (this.consumeOptional(';')) {
       this.parseParam(params);
     }
     return params;
   }
 
-  private parseParam(params: {[key: string]: any}): void {
+  private parseParam(params: {[key: string]: string}): void {
     const key = matchSegments(this.remaining);
     if (!key) {
       return;

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -267,6 +267,18 @@ describe('createUrlTree', () => {
     expect(serializer.serialize(t)).toEqual('/a/b;aa=22;bb=33');
   });
 
+  it('should stringify matrix parameters', () => {
+    const pr = serializer.parse('/r');
+    const relative = create(pr.root.children[PRIMARY_OUTLET], 0, pr, [{pp: 22}]);
+    const segmentR = relative.root.children[PRIMARY_OUTLET].segments[0];
+    expect(segmentR.parameterMap.get('pp')).toEqual('22');
+
+    const pa = serializer.parse('/a');
+    const absolute = createRoot(pa, ['/b', {pp: 33}]);
+    const segmentA = absolute.root.children[PRIMARY_OUTLET].segments[0];
+    expect(segmentA.parameterMap.get('pp')).toEqual('33');
+  });
+
   describe('relative navigation', () => {
     it('should work', () => {
       const p = serializer.parse('/a/(c//left:cp)(left:ap)');


### PR DESCRIPTION
Fix a case where matrix parameters weren't stringified when they are passed as a first command
when creating a url tree. Fix return type in parseMatrixParams method
because it always returns {[key: string]: string}

Closes #23165

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Matrix parameters are not stringified when then they are passed as the first command.

Issue Number: #23165

## What is the new behavior?
Matrix parameters are always stringified

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
## Other information
