### PR TITLE
refactor(ivy): remove return type from elementStart(...)

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -653,8 +653,7 @@ export function element(
  * ['id', 'warning5', 'class', 'alert']
  */
 export function elementStart(
-    index: number, name: string, attrs?: TAttributes | null,
-    localRefs?: string[] | null): RElement {
+    index: number, name: string, attrs?: TAttributes | null, localRefs?: string[] | null): void {
   ngDevMode &&
       assertEqual(viewData[BINDING_INDEX], -1, 'elements should be created before any bindings');
 
@@ -673,7 +672,6 @@ export function elementStart(
   }
   appendChild(getParentLNode(node), native, viewData);
   createDirectivesAndLocals(localRefs);
-  return native;
 }
 /**
  * Creates a native element from a tag name, using a renderer.


### PR DESCRIPTION
elementStart() was returning native element for historical reasons.
This commit brings elementStart() instruction in-line with other
instructions.
