### PR TITLE
feat(ivy): implement the getters of ViewContainerRef

### DIFF
--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -41,6 +41,7 @@ export abstract class ViewContainerRef {
 
   abstract get injector(): Injector;
 
+  /** @deprecated No replacement */
   abstract get parentInjector(): Injector;
 
   /**

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -11,7 +11,7 @@
 
 import {ChangeDetectorRef as viewEngine_ChangeDetectorRef} from '../change_detection/change_detector_ref';
 import {InjectionToken} from '../di/injection_token';
-import {InjectFlags, Injector, inject, setCurrentInjector} from '../di/injector';
+import {InjectFlags, Injector, NullInjector, inject, setCurrentInjector} from '../di/injector';
 import * as viewEngine from '../linker';
 import {Type} from '../type';
 
@@ -649,7 +649,7 @@ class ViewContainerRef implements viewEngine.ViewContainerRef {
   /** @deprecated No replacement */
   get parentInjector(): Injector {
     const parentLInjector = getParentLNode(this._hostNode).nodeInjector;
-    return parentLInjector ? new NodeInjector(parentLInjector) : Injector.NULL;
+    return parentLInjector ? new NodeInjector(parentLInjector) : new NullInjector();
   }
 
   clear(): void {

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -636,14 +636,17 @@ class NodeInjector implements Injector {
 class ViewContainerRef implements viewEngine.ViewContainerRef {
   private _viewRefs: viewEngine.ViewRef[] = [];
 
-
   constructor(
       private _lContainerNode: LContainerNode, private _hostNode: LElementNode|LContainerNode) {}
 
-  get element(): ElementRef { return new ElementRef(this._hostNode.native); }
+  get element(): ElementRef {
+    const injector = getOrCreateNodeInjectorForNode(this._hostNode);
+    return getOrCreateElementRef(injector);
+  }
 
   get injector(): Injector {
-    return new NodeInjector(getOrCreateNodeInjectorForNode(this._hostNode));
+    const injector = getOrCreateNodeInjectorForNode(this._hostNode);
+    return new NodeInjector(injector);
   }
 
   /** @deprecated No replacement */

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -336,7 +336,7 @@ export function createLViewData<T>(
     null,                                                                        // directives
     null,                                                                        // cleanupInstances
     context,                                                                     // context
-    viewData && viewData[INJECTOR],                                              // injector
+    viewData && viewData[INJECTOR] || null,                                      // injector
     renderer,                                                                    // renderer
     sanitizer || null,                                                           // sanitizer
     null,                                                                        // tail

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -336,7 +336,7 @@ export function createLViewData<T>(
     null,                                                                        // directives
     null,                                                                        // cleanupInstances
     context,                                                                     // context
-    viewData && viewData[INJECTOR] || null,                                      // injector
+    viewData ? viewData[INJECTOR] : null,                                        // injector
     renderer,                                                                    // renderer
     sanitizer || null,                                                           // sanitizer
     null,                                                                        // tail

--- a/packages/core/src/view/refs.ts
+++ b/packages/core/src/view/refs.ts
@@ -138,6 +138,7 @@ class ViewContainerRef_ implements ViewContainerData {
 
   get injector(): Injector { return new Injector_(this._view, this._elDef); }
 
+  /** @deprecated No replacement */
   get parentInjector(): Injector {
     let view = this._view;
     let elDef = this._elDef.parent;

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -45,6 +45,9 @@
     "name": "EMPTY_RENDERER_TYPE_ID"
   },
   {
+    "name": "ElementRef"
+  },
+  {
     "name": "ElementRef$1"
   },
   {
@@ -97,6 +100,12 @@
   },
   {
     "name": "NgModuleRef"
+  },
+  {
+    "name": "NodeInjector"
+  },
+  {
+    "name": "NullInjector"
   },
   {
     "name": "Optional"
@@ -174,6 +183,9 @@
     "name": "ViewContainerRef$1"
   },
   {
+    "name": "ViewContainerRef$1"
+  },
+  {
     "name": "ViewEncapsulation$1"
   },
   {
@@ -190,6 +202,9 @@
   },
   {
     "name": "_ROOT_DIRECTIVE_INDICES"
+  },
+  {
+    "name": "_THROW_IF_NOT_FOUND"
   },
   {
     "name": "__read"
@@ -495,6 +510,9 @@
     "name": "getCleanup"
   },
   {
+    "name": "getClosestComponentAncestor"
+  },
+  {
     "name": "getCurrentSanitizer"
   },
   {
@@ -516,10 +534,16 @@
     "name": "getNextLNode"
   },
   {
+    "name": "getOrCreateChangeDetectorRef"
+  },
+  {
     "name": "getOrCreateContainerRef"
   },
   {
     "name": "getOrCreateElementRef"
+  },
+  {
+    "name": "getOrCreateHostChangeDetector"
   },
   {
     "name": "getOrCreateInjectable"
@@ -616,6 +640,9 @@
   },
   {
     "name": "invertObject"
+  },
+  {
+    "name": "isComponent"
   },
   {
     "name": "isContextDirty"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -27,6 +27,9 @@
     "name": "ChangeDetectionStrategy"
   },
   {
+    "name": "ChangeDetectorRef"
+  },
+  {
     "name": "DECLARATION_VIEW"
   },
   {
@@ -148,6 +151,9 @@
   },
   {
     "name": "TemplateRef"
+  },
+  {
+    "name": "TemplateRef$1"
   },
   {
     "name": "ToDoAppComponent_footer_Template_6"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -147,7 +147,7 @@
     "name": "TVIEW"
   },
   {
-    "name": "TemplateRef$1"
+    "name": "TemplateRef"
   },
   {
     "name": "ToDoAppComponent_footer_Template_6"
@@ -180,7 +180,7 @@
     "name": "VIEWS"
   },
   {
-    "name": "ViewContainerRef$1"
+    "name": "ViewContainerRef"
   },
   {
     "name": "ViewContainerRef$1"

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -1039,10 +1039,8 @@ describe('ViewContainerRef', () => {
     describe('getters', () => {
       it('should work on elements', () => {
         function createTemplate() {
-          elementStart(0, 'header', ['vcref', '']);
-          elementEnd();
-          elementStart(1, 'footer');
-          elementEnd();
+          element(0, 'header', ['vcref', '']);
+          element(1, 'footer');
         }
 
         new TemplateFixture(createTemplate, undefined, [DirectiveWithVCRef]);
@@ -1060,10 +1058,8 @@ describe('ViewContainerRef', () => {
             createComponent('header-cmp', function(rf: RenderFlags, ctx: any) {});
 
         function createTemplate() {
-          elementStart(0, 'header-cmp', ['vcref', '']);
-          elementEnd();
-          elementStart(1, 'footer');
-          elementEnd();
+          element(0, 'header-cmp', ['vcref', '']);
+          element(1, 'footer');
         }
 
         new TemplateFixture(createTemplate, undefined, [HeaderComponent, DirectiveWithVCRef]);
@@ -1079,8 +1075,7 @@ describe('ViewContainerRef', () => {
       it('should work on containers', () => {
         function createTemplate() {
           container(0, embeddedTemplate, undefined, ['vcref', '']);
-          elementStart(1, 'footer');
-          elementEnd();
+          element(1, 'footer');
         }
 
         function updateTemplate() {

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ComponentFactoryResolver, Directive, EmbeddedViewRef, NgModuleRef, Pipe, PipeTransform, RendererFactory2, TemplateRef, ViewContainerRef, createInjector, defineInjector, ɵAPP_ROOT as APP_ROOT, ɵNgModuleDef as NgModuleDef} from '../../src/core';
+import {Component, ComponentFactoryResolver, ElementRef, EmbeddedViewRef, NgModuleRef, Pipe, PipeTransform, RendererFactory2, TemplateRef, ViewContainerRef, createInjector, defineInjector, ɵAPP_ROOT as APP_ROOT, ɵNgModuleDef as NgModuleDef} from '../../src/core';
 import {getOrCreateNodeInjectorForNode, getOrCreateTemplateRef} from '../../src/render3/di';
 import {AttributeMarker, NgOnChangesFeature, defineComponent, defineDirective, definePipe, injectComponentFactoryResolver, injectTemplateRef, injectViewContainerRef} from '../../src/render3/index';
 import {bind, container, containerRefreshEnd, containerRefreshStart, element, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, interpolation1, interpolation3, load, loadDirective, nextContext, projection, projectionDef, reserveSlots, text, textBinding} from '../../src/render3/instructions';
@@ -1033,6 +1033,66 @@ describe('ViewContainerRef', () => {
         expect(fixture.html)
             .toEqual(
                 '<p vcref=""></p><embedded-cmp-with-ngcontent>12<hr>34</embedded-cmp-with-ngcontent>');
+      });
+    });
+
+    describe('getters', () => {
+      it('should work on elements', () => {
+        function createTemplate() {
+          elementStart(0, 'header', ['vcref', '']);
+          elementEnd();
+          elementStart(1, 'footer');
+          elementEnd();
+        }
+
+        new TemplateFixture(createTemplate, undefined, [DirectiveWithVCRef]);
+
+        expect(directiveInstance !.vcref.element.nativeElement.tagName.toLowerCase())
+            .toEqual('header');
+        expect(
+            directiveInstance !.vcref.injector.get(ElementRef).nativeElement.tagName.toLowerCase())
+            .toEqual('header');
+        expect(() => directiveInstance !.vcref.parentInjector.get(ElementRef)).toThrow();
+      });
+
+      it('should work on components', () => {
+        const HeaderComponent =
+            createComponent('header-cmp', function(rf: RenderFlags, ctx: any) {});
+
+        function createTemplate() {
+          elementStart(0, 'header-cmp', ['vcref', '']);
+          elementEnd();
+          elementStart(1, 'footer');
+          elementEnd();
+        }
+
+        new TemplateFixture(createTemplate, undefined, [HeaderComponent, DirectiveWithVCRef]);
+
+        expect(directiveInstance !.vcref.element.nativeElement.tagName.toLowerCase())
+            .toEqual('header-cmp');
+        expect(
+            directiveInstance !.vcref.injector.get(ElementRef).nativeElement.tagName.toLowerCase())
+            .toEqual('header-cmp');
+        expect(() => directiveInstance !.vcref.parentInjector.get(ElementRef)).toThrow();
+      });
+
+      it('should work on containers', () => {
+        function createTemplate() {
+          container(0, embeddedTemplate, undefined, ['vcref', '']);
+          elementStart(1, 'footer');
+          elementEnd();
+        }
+
+        function updateTemplate() {
+          containerRefreshStart(0);
+          containerRefreshEnd();
+        }
+
+        new TemplateFixture(createTemplate, updateTemplate, [DirectiveWithVCRef]);
+        expect(directiveInstance !.vcref.element.nativeElement.textContent).toEqual('container');
+        expect(directiveInstance !.vcref.injector.get(ElementRef).nativeElement.textContent)
+            .toEqual('container');
+        expect(() => directiveInstance !.vcref.parentInjector.get(ElementRef)).toThrow();
       });
     });
   });

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -922,7 +922,7 @@ export declare abstract class ViewContainerRef {
     abstract readonly element: ElementRef;
     abstract readonly injector: Injector;
     abstract readonly length: number;
-    abstract readonly parentInjector: Injector;
+    /** @deprecated */ abstract readonly parentInjector: Injector;
     abstract clear(): void;
     abstract createComponent<C>(componentFactory: ComponentFactory<C>, index?: number, injector?: Injector, projectableNodes?: any[][], ngModule?: NgModuleRef<any>): ComponentRef<C>;
     abstract createEmbeddedView<C>(templateRef: TemplateRef<C>, context?: C, index?: number): EmbeddedViewRef<C>;


### PR DESCRIPTION
supersedes #25092 

_(Rebased after recent changes to di.ts)_

_~edit 7/29: added a second commit for misc refactoring + fix CI (had to revert a change I did on Friday as `import * as viewEngine` breaks tree shaking).~_

_edit 7/30:  As noted by @marclaval below, it was using `Injector.NULL` not `import * as viewEngine` that was breaking tree shaking. Updated the 2nd commit_