### PR TITLE
docs(http): fix typo in HTTP section

### DIFF
--- a/aio/content/tutorial/toh-pt6.md
+++ b/aio/content/tutorial/toh-pt6.md
@@ -329,7 +329,7 @@ Add the following `addHero()` method to the `HeroService` class.
 `HeroService.addHero()` differs from `updateHero` in two ways.
 
 * it calls `HttpClient.post()` instead of `put()`.
-* it expects the server to generates an id for the new hero, 
+* it expects the server to generate an id for the new hero, 
 which it returns in the `Observable<Hero>` to the caller.
 
 Refresh the browser and add some heroes.


### PR DESCRIPTION
Replaced incorrect 'generates' with 'generate'.

Fixes #25179

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
On the second bullet there is a typo:
"it expects the server to generates an id"

Issue Number: #25179


## What is the new behavior?
New wording:
"it expects the server to generate an id"

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
