### PR TITLE
feat(common): allow multiple values in ngSwitchCase

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -19,7 +19,7 @@ export {registerLocaleData} from './i18n/locale_data';
 export {Plural, NumberFormatStyle, FormStyle, Time, TranslationWidth, FormatWidth, NumberSymbol, WeekDay, getNumberOfCurrencyDigits, getCurrencySymbol, getLocaleDayPeriods, getLocaleDayNames, getLocaleMonthNames, getLocaleId, getLocaleEraNames, getLocaleWeekEndRange, getLocaleFirstDayOfWeek, getLocaleDateFormat, getLocaleDateTimeFormat, getLocaleExtraDayPeriodRules, getLocaleExtraDayPeriods, getLocalePluralCase, getLocaleTimeFormat, getLocaleNumberSymbol, getLocaleNumberFormat, getLocaleCurrencyName, getLocaleCurrencySymbol} from './i18n/locale_data_api';
 export {parseCookieValue as ɵparseCookieValue} from './cookie';
 export {CommonModule, DeprecatedI18NPipesModule} from './common_module';
-export {NgClass, NgForOf, NgForOfContext, NgIf, NgIfContext, NgPlural, NgPluralCase, NgStyle, NgSwitch, NgSwitchCase, NgSwitchDefault, NgTemplateOutlet, NgComponentOutlet} from './directives/index';
+export {NgClass, NgForOf, NgForOfContext, NgIf, NgIfContext, NgPlural, NgPluralCase, NgStyle, NgSwitch, NgSwitchCase, NgSwitchMultipleCase, NgSwitchDefault, NgTemplateOutlet, NgComponentOutlet} from './directives/index';
 export {DOCUMENT} from './dom_tokens';
 export {AsyncPipe, DatePipe, I18nPluralPipe, I18nSelectPipe, JsonPipe, LowerCasePipe, CurrencyPipe, DecimalPipe, PercentPipe, SlicePipe, UpperCasePipe, TitleCasePipe, KeyValuePipe, KeyValue} from './pipes/index';
 export {DeprecatedDatePipe, DeprecatedCurrencyPipe, DeprecatedDecimalPipe, DeprecatedPercentPipe} from './pipes/deprecated/index';

--- a/packages/common/src/directives/index.ts
+++ b/packages/common/src/directives/index.ts
@@ -14,7 +14,7 @@ import {NgForOf, NgForOfContext} from './ng_for_of';
 import {NgIf, NgIfContext} from './ng_if';
 import {NgPlural, NgPluralCase} from './ng_plural';
 import {NgStyle} from './ng_style';
-import {NgSwitch, NgSwitchCase, NgSwitchDefault} from './ng_switch';
+import {NgSwitch, NgSwitchCase, NgSwitchDefault, NgSwitchMultipleCase} from './ng_switch';
 import {NgTemplateOutlet} from './ng_template_outlet';
 
 export {
@@ -30,6 +30,7 @@ export {
   NgSwitch,
   NgSwitchCase,
   NgSwitchDefault,
+  NgSwitchMultipleCase,
   NgTemplateOutlet
 };
 
@@ -48,6 +49,7 @@ export const COMMON_DIRECTIVES: Provider[] = [
   NgStyle,
   NgSwitch,
   NgSwitchCase,
+  NgSwitchMultipleCase,
   NgSwitchDefault,
   NgPlural,
   NgPluralCase,

--- a/packages/common/test/directives/ng_switch_spec.ts
+++ b/packages/common/test/directives/ng_switch_spec.ts
@@ -36,6 +36,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
         const template = '<ul [ngSwitch]="switchValue">' +
             '<li *ngSwitchCase="\'a\'">when a</li>' +
             '<li *ngSwitchCase="\'b\'">when b</li>' +
+            '<li *ngSwitchMultipleCase="[\'c\', \'d\']">when c or d</li>' +
             '</ul>';
 
         fixture = createTestComponent(template);
@@ -47,11 +48,18 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 
         getComponent().switchValue = 'b';
         detectChangesAndExpectText('when b');
+
+        getComponent().switchValue = 'c';
+        detectChangesAndExpectText('when c or d');
+
+        getComponent().switchValue = 'd';
+        detectChangesAndExpectText('when c or d');
       });
 
       it('should switch amongst when values with fallback to default', () => {
         const template = '<ul [ngSwitch]="switchValue">' +
             '<li *ngSwitchCase="\'a\'">when a</li>' +
+            '<li *ngSwitchMultipleCase="[\'b\', \'c\']">when b or c</li>' +
             '<li *ngSwitchDefault>when default</li>' +
             '</ul>';
 
@@ -62,9 +70,15 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
         detectChangesAndExpectText('when a');
 
         getComponent().switchValue = 'b';
-        detectChangesAndExpectText('when default');
+        detectChangesAndExpectText('when b or c');
 
         getComponent().switchValue = 'c';
+        detectChangesAndExpectText('when b or c');
+
+        getComponent().switchValue = 'd';
+        detectChangesAndExpectText('when default');
+
+        getComponent().switchValue = 'e';
         detectChangesAndExpectText('when default');
       });
 
@@ -74,6 +88,8 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
             '<li *ngSwitchCase="\'b\'">when b1;</li>' +
             '<li *ngSwitchCase="\'a\'">when a2;</li>' +
             '<li *ngSwitchCase="\'b\'">when b2;</li>' +
+            '<li *ngSwitchMultipleCase="[\'a\',\'b\']">when a or b 1;</li>' +
+            '<li *ngSwitchMultipleCase="[\'a\',\'b\']">when a or b 2;</li>' +
             '<li *ngSwitchDefault>when default1;</li>' +
             '<li *ngSwitchDefault>when default2;</li>' +
             '</ul>';
@@ -82,10 +98,10 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
         detectChangesAndExpectText('when default1;when default2;');
 
         getComponent().switchValue = 'a';
-        detectChangesAndExpectText('when a1;when a2;');
+        detectChangesAndExpectText('when a1;when a2;when a or b 1;when a or b 2;');
 
         getComponent().switchValue = 'b';
-        detectChangesAndExpectText('when b1;when b2;');
+        detectChangesAndExpectText('when b1;when b2;when a or b 1;when a or b 2;');
       });
     });
 
@@ -129,6 +145,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 
         const template = '<div [ngSwitch]="switchValue">' +
             '<div *ngSwitchCase="\'a\'" test="aCase"></div>' +
+            '<div *ngSwitchMultipleCase="[\'b\',\'c\']" test="bcCase"></div>' +
             '<div *ngSwitchDefault test="defaultCase"></div>' +
             '</div>';
 
@@ -141,6 +158,12 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
         fixture.detectChanges();
 
         expect(log).toEqual(['aCase']);
+
+        fixture.componentInstance.switchValue = 'b';
+
+        fixture.detectChanges();
+
+        expect(log).toEqual(['aCase', 'bcCase']);
       });
 
       it('should create the default case if there is no other case', () => {

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -334,6 +334,12 @@ export declare class NgSwitchCase implements DoCheck {
     ngDoCheck(): void;
 }
 
+export declare class NgSwitchMultipleCase implements DoCheck {
+  ngSwitchMultipleCase: any[];
+  constructor(viewContainer: ViewContainerRef, templateRef: TemplateRef<Object>, ngSwitch: NgSwitch);
+  ngDoCheck(): void;
+}
+
 export declare class NgSwitchDefault {
     constructor(viewContainer: ViewContainerRef, templateRef: TemplateRef<Object>, ngSwitch: NgSwitch);
 }


### PR DESCRIPTION
Closes #14659

## PR Checklist
Please check if your PR fulfills the following requirements:

- [✓] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [✓] Tests for the changes have been added (for bug fixes / features)
- [✓] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 14659


## What is the new behavior?
there is a ngSwitchMultipleCase directive now that takes an array

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
