### PR TITLE
refactor(animations): do not use short parameter names

### DIFF
--- a/packages/animations/src/players/animation_player.ts
+++ b/packages/animations/src/players/animation_player.ts
@@ -26,7 +26,7 @@ export interface AnimationPlayer {
   finish(): void;
   destroy(): void;
   reset(): void;
-  setPosition(p: any /** TODO #9100 */): void;
+  setPosition(position: any /** TODO #9100 */): void;
   getPosition(): number;
   parentPlayer: AnimationPlayer|null;
   readonly totalTime: number;
@@ -93,7 +93,7 @@ export class NoopAnimationPlayer implements AnimationPlayer {
     }
   }
   reset(): void {}
-  setPosition(p: number): void {}
+  setPosition(position: number): void {}
   getPosition(): number { return 0; }
 
   /** @internal */

--- a/tools/public_api_guard/animations/animations.d.ts
+++ b/tools/public_api_guard/animations/animations.d.ts
@@ -102,7 +102,7 @@ export interface AnimationPlayer {
     play(): void;
     reset(): void;
     restart(): void;
-    setPosition(p: any /** TODO #9100 */): void;
+    setPosition(position: any /** TODO #9100 */): void;
 }
 
 export interface AnimationQueryMetadata extends AnimationMetadata {
@@ -191,7 +191,7 @@ export declare class NoopAnimationPlayer implements AnimationPlayer {
     play(): void;
     reset(): void;
     restart(): void;
-    setPosition(p: number): void;
+    setPosition(position: number): void;
 }
 
 export declare function query(selector: string, animation: AnimationMetadata | AnimationMetadata[], options?: AnimationQueryOptions | null): AnimationQueryMetadata;


### PR DESCRIPTION
This PR fixes the last docs issues in the `animations` package.