### PR TITLE
docs(aio): Add GitHub notification bar

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -11,7 +11,7 @@
       expirationDate="2018-09-01"
       [dismissOnContentClick]="true"
       (dismissed)="notificationDismissed()">
-      <a href="https://github.com/angular/angular" target="_blank">
+      <a href="https://github.com/angular/angular" target="_blank" (click)="githubStarClicked()">
         <span class="message">Give our repo a star if you love Angular as much as we do!</span>
         <div class="action-button action-button-github">
           <mat-icon class="icon" svgIcon="star_rate" aria-label="GitHub Star Icon"> </mat-icon>

--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -7,14 +7,16 @@
 <mat-toolbar color="primary" class="app-toolbar no-print" [class.transitioning]="isTransitioning">
   <mat-toolbar-row class="notification-container">
     <aio-notification
-      notificationId="angular-v6-announcement"
-      expirationDate="2018-07-01"
+      notificationId="angular-github-stars-campaign-201808"
+      expirationDate="2018-09-01"
       [dismissOnContentClick]="true"
       (dismissed)="notificationDismissed()">
-      <a href="https://blog.angular.io/version-6-0-0-of-angular-now-available-cc56b0efa7a4">
-        <mat-icon class="icon" svgIcon="insert_comment" aria-label="Announcement"></mat-icon>
-        <span class="message">Version 6 of Angular Now Available!</span>
-        <span class="action-button">Learn More</span>
+      <a href="https://github.com/angular/angular" target="_blank">
+        <span class="message">Give our repo a star if you love Angular as much as we do!</span>
+        <div class="action-button action-button-github">
+          <mat-icon class="icon" svgIcon="star_rate" aria-label="GitHub Star Icon"> </mat-icon>
+          <span> Star</span>
+        </div>
       </a>
     </aio-notification>
   </mat-toolbar-row>

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { MatSidenav } from '@angular/material/sidenav';
 import { CurrentNodes, NavigationService, NavigationNode, VersionInfo } from 'app/navigation/navigation.service';
 import { DocumentService, DocumentContents } from 'app/documents/document.service';
 import { Deployment } from 'app/shared/deployment.service';
+import { GaService } from 'app/shared/ga.service';
 import { LocationService } from 'app/shared/location.service';
 import { NotificationComponent } from 'app/layout/notification/notification.component';
 import { ScrollService } from 'app/shared/scroll.service';
@@ -99,6 +100,7 @@ export class AppComponent implements OnInit {
     public deployment: Deployment,
     private documentService: DocumentService,
     private hostElement: ElementRef,
+    private gaService: GaService,
     private locationService: LocationService,
     private navigationService: NavigationService,
     private scrollService: ScrollService,
@@ -298,6 +300,10 @@ export class AppComponent implements OnInit {
       // - aio/src/app/layout/notification/notification.component.ts
       setTimeout(() => this.notificationAnimating = false, 250);
     this.updateHostClasses();
+  }
+
+  githubStarClicked() {
+    this.gaService.sendEvent('Github Star Button', 'click', 'Summer 2018 - Star Campaign');
   }
 
   updateHostClasses() {

--- a/aio/src/app/app.module.ts
+++ b/aio/src/app/app.module.ts
@@ -83,6 +83,18 @@ export const svgIconProviders = [
       '</svg>'
     },
     multi: true
+  },
+  {
+    provide: SVG_ICONS,
+    useValue: {
+      name: 'star_rate',
+      svgSource:
+      '<svg width="32" height="32" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" >' +
+        '<path d="M9 11.3l3.71 2.7-1.42-4.36L15 7h-4.55L9 2.5 7.55 7H3l3.71 2.64L5.29 14z"/>' +
+        '<path fill="none" d="M0 0h18v18H0z"/>' +
+      '</svg>'
+    },
+    multi: true
   }
 ];
 

--- a/aio/src/styles/2-modules/_notification.scss
+++ b/aio/src/styles/2-modules/_notification.scss
@@ -39,8 +39,13 @@ aio-notification {
       display: flex;
     }
 
+    a {
+      align-items: center;
+    }
+
     .icon {
       margin-right: 10px;
+
       @media (max-width: 464px) {
         display: none;
       }
@@ -50,6 +55,7 @@ aio-notification {
       overflow: hidden;
       text-overflow: ellipsis;
       margin-right: 10px;
+      text-transform: none;
     }
 
     .action-button {
@@ -58,8 +64,28 @@ aio-notification {
       text-transform: uppercase;
       padding: 0 10px;
       font-size: 12px;
+
       @media (max-width: 780px) {
         display: none;
+      }
+
+      &.action-button-github {
+        background-color: #EFF3F6;
+        border: 1px solid #D1D2D3;
+        color: #24292E;
+        text-transform: none;
+        border-radius: 2px;
+        font-size: 14px;
+        font-weight: 500;
+        display: flex;
+        align-items: center;
+        padding: 4px 8px;
+
+        .icon {
+          color: $darkgray;
+          height: 24px;
+          margin-right: 2px;
+        }
       }
     }
   }


### PR DESCRIPTION
Adding GitHub notification bar and corresponding custom styles.

I would expect the `action-button-github` class to be deleted once the notification bar is no longer needed (or maybe stored somewhere?).

Needs - svg Icon working and Google Analytics hooking up

Issue: #24140

<hr>
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```