### PR TITLE
fix(ivy): default to `ngDevMode = true`

### DIFF
--- a/packages/core/src/render3/ng_dev_mode.ts
+++ b/packages/core/src/render3/ng_dev_mode.ts
@@ -72,4 +72,8 @@ export function ngDevModeResetPerfCounters() {
  * set `ngDevMode == false` we should be helping the developer by providing
  * as much early warning and errors as possible.
  */
-typeof ngDevMode === 'undefined' && ngDevModeResetPerfCounters();
+if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  ngDevModeResetPerfCounters();
+  // In ie console is not present unless devtools are open.
+  console && console.warn('Angular is running in the development mode.');
+}

--- a/packages/core/src/render3/ng_dev_mode.ts
+++ b/packages/core/src/render3/ng_dev_mode.ts
@@ -74,6 +74,4 @@ export function ngDevModeResetPerfCounters() {
  */
 if (typeof ngDevMode === 'undefined' || ngDevMode) {
   ngDevModeResetPerfCounters();
-  // In ie console is not present unless devtools are open.
-  console && console.warn('Angular is running in the development mode.');
 }

--- a/packages/core/src/render3/ng_dev_mode.ts
+++ b/packages/core/src/render3/ng_dev_mode.ts
@@ -35,32 +35,41 @@ declare global {
 
 
 declare let global: any;
-export const ngDevModeResetPerfCounters: () => void =
-    (typeof ngDevMode == 'undefined' && (function(global: {ngDevMode: NgDevModePerfCounters}) {
-       function ngDevModeResetPerfCounters() {
-         global['ngDevMode'] = {
-           firstTemplatePass: 0,
-           tNode: 0,
-           tView: 0,
-           rendererCreateTextNode: 0,
-           rendererSetText: 0,
-           rendererCreateElement: 0,
-           rendererAddEventListener: 0,
-           rendererSetAttribute: 0,
-           rendererRemoveAttribute: 0,
-           rendererSetProperty: 0,
-           rendererSetClassName: 0,
-           rendererAddClass: 0,
-           rendererRemoveClass: 0,
-           rendererSetStyle: 0,
-           rendererRemoveStyle: 0,
-           rendererDestroy: 0,
-           rendererDestroyNode: 0,
-           rendererMoveNode: 0,
-           rendererRemoveNode: 0,
-         };
-       }
-       ngDevModeResetPerfCounters();
-       return ngDevModeResetPerfCounters;
-     })(typeof window != 'undefined' && window || typeof self != 'undefined' && self ||
-        typeof global != 'undefined' && global)) as() => void;
+
+const __global: {ngDevMode: NgDevModePerfCounters | boolean} =
+    typeof window != 'undefined' && window || typeof self != 'undefined' && self ||
+    typeof global != 'undefined' && global;
+
+export function ngDevModeResetPerfCounters() {
+  __global.ngDevMode = {
+    firstTemplatePass: 0,
+    tNode: 0,
+    tView: 0,
+    rendererCreateTextNode: 0,
+    rendererSetText: 0,
+    rendererCreateElement: 0,
+    rendererAddEventListener: 0,
+    rendererSetAttribute: 0,
+    rendererRemoveAttribute: 0,
+    rendererSetProperty: 0,
+    rendererSetClassName: 0,
+    rendererAddClass: 0,
+    rendererRemoveClass: 0,
+    rendererSetStyle: 0,
+    rendererRemoveStyle: 0,
+    rendererDestroy: 0,
+    rendererDestroyNode: 0,
+    rendererMoveNode: 0,
+    rendererRemoveNode: 0,
+  };
+}
+
+/**
+ * This checks to see if the `ngDevMode` has been set. If yes,
+ * than we honor it, otherwise we default to dev mode with additional checks.
+ *
+ * The idea is that unless we are doing production build where we explicitly
+ * set `ngDevMode == false` we should be helping the developer by providing
+ * as much early warning and errors as possible.
+ */
+typeof ngDevMode === 'undefined' && ngDevModeResetPerfCounters();


### PR DESCRIPTION
Before the `ngDevMode` had to be set explicitly or it would throw
an exception at runtime. This changes it so that if `ngDevModu` is
`undefined` than we default to `ngDevMode = true`. In other words
unless the developer has explicitly asked to make a prodution build
by setting `ngDevMode = false` as compilation constant, the default
is `ngDevMode = true`.

This also fixes a minor bug where the setup code would read
`global['ngDevMode']` but all other code would read `global.ngDevMode`.
This would cause issues with closure compiler since the
reading of the `ngDevMode` must be consistent.
