### PR TITLE
fix(ivy): walk declaration views in listener

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
@@ -58,4 +58,121 @@ describe('compiler compliance: listen()', () => {
     expectEmit(result.source, template, 'Incorrect template');
   });
 
+  it('should create multiple listener instructions that share a view snapshot', () => {
+    const files = {
+      app: {
+        'spec.ts': `
+              import {Component, NgModule} from '@angular/core';
+              import {CommonModule} from '@angular/common';
+
+              @Component({
+                selector: 'my-component',
+                template: \`
+                  <div *ngIf="showing">
+                    <div (click)="onClick(foo)"></div>
+                    <button (click)="onClick2(bar)"></button>
+                  </div>
+                  
+                \`
+              })
+              export class MyComponent {
+                onClick(name: any) {}
+                onClick2(name: any) {}
+              }
+
+              @NgModule({declarations: [MyComponent], imports: [CommonModule]})
+              export class MyModule {}
+          `
+      }
+    };
+
+    const template = `
+        const $c0$ = ["ngIf",""];
+        
+        function MyComponent_div_Template_0(rf, ctx) {
+          if (rf & 1) {
+            const $s$ = $r3$.ɵgV();
+            $r3$.ɵE(0, "div");
+            $r3$.ɵE(1, "div");
+            $r3$.ɵL("click", function MyComponent_div_Template_0_div_click_listener($event) {
+              $r3$.ɵrV($s$);
+              const $comp$ = $r3$.ɵx();
+              return $comp$.onClick($comp$.foo);
+            });
+            $r3$.ɵe();
+            $r3$.ɵE(2, "button");
+            $r3$.ɵL("click", function MyComponent_div_Template_0_button_click_listener($event) {
+              $r3$.ɵrV($s$);
+              const $comp2$ = $r3$.ɵx();
+              return $comp2$.onClick2($comp2$.bar);
+            });
+            $r3$.ɵe();
+            $r3$.ɵe();
+          }
+        }
+        // ...
+        template: function MyComponent_Template(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵC(0, MyComponent_div_Template_0, null, $c0$);
+          }
+          if (rf & 2) {
+            $i0$.ɵp(0, "ngIf", $i0$.ɵb(ctx.showing));
+          }
+        }
+        `;
+
+    const result = compile(files, angularFiles);
+
+    expectEmit(result.source, template, 'Incorrect template');
+  });
+
+  it('local refs in listeners defined before the local refs', () => {
+    const files = {
+      app: {
+        'spec.ts': `
+            import {Component, NgModule} from '@angular/core';
+
+            @Component({
+              selector: 'my-component', 
+              template: \`
+                <button (click)="onClick(user.value)">Save</button>
+                <input #user>
+              \`
+            })
+            export class MyComponent {}
+
+            @NgModule({declarations: [MyComponent]})
+            export class MyModule {}
+          `
+      }
+    };
+
+    const MyComponentDefinition = `
+        const $c0$ = ["user", ""];
+        …
+        MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
+          type: MyComponent,
+          selectors: [["my-component"]],
+          factory: function MyComponent_Factory() { return new MyComponent(); },
+          template: function MyComponent_Template(rf, ctx) {
+            if (rf & 1) {
+              $r3$.ɵE(0, "button"); 
+                $r3$.ɵL("click", function MyComponent_Template_button_click_listener($event) {
+                   const $user$ = $r3$.ɵr(3);
+                   return ctx.onClick($user$.value);
+                });
+                $r3$.ɵT(1, "Save");
+              $r3$.ɵe();
+              $r3$.ɵEe(2, "input", null, $c0$);
+            }
+          }
+        });
+      `;
+
+    const result = compile(files, angularFiles);
+    const source = result.source;
+
+    expectEmit(source, MyComponentDefinition, 'Incorrect MyComponent.ngComponentDef');
+  });
+
 });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
@@ -55,12 +55,14 @@ describe('compiler compliance: template', () => {
       function MyComponent_ul_li_div_Template_1(rf, ctx) {
         
         if (rf & 1) {
-          const $inner$ = ctx.$implicit;
-          const $middle$ = $i0$.ɵx().$implicit;
-          const $outer$ = $i0$.ɵx().$implicit;
-          const $myComp$ = $i0$.ɵx();
+          const $s$ = $i0$.ɵgV();
           $i0$.ɵE(0, "div");
           $i0$.ɵL("click", function MyComponent_ul_li_div_Template_1_div_click_listener($event){
+            $i0$.ɵrV($s$);
+            const $inner$ = ctx.$implicit;
+            const $middle$ = $i0$.ɵx().$implicit;
+            const $outer$ = $i0$.ɵx().$implicit;
+            const $myComp$ = $i0$.ɵx();
             return $myComp$.onClick($outer$, $middle$, $inner$);
           });
           $i0$.ɵT(1);

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -53,6 +53,10 @@ export class Identifiers {
 
   static bind: o.ExternalReference = {name: 'ɵb', moduleName: CORE};
 
+  static getCurrentView: o.ExternalReference = {name: 'ɵgV', moduleName: CORE};
+
+  static restoreView: o.ExternalReference = {name: 'ɵrV', moduleName: CORE};
+
   static interpolation1: o.ExternalReference = {name: 'ɵi1', moduleName: CORE};
   static interpolation2: o.ExternalReference = {name: 'ɵi2', moduleName: CORE};
   static interpolation3: o.ExternalReference = {name: 'ɵi3', moduleName: CORE};

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -70,6 +70,8 @@ export {
   f7 as ɵf7,
   f8 as ɵf8,
   fV as ɵfV,
+  gV as ɵgV,
+  rV as ɵrV,
   cR as ɵcR,
   cr as ɵcr,
   qR as ɵqR,

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -7,7 +7,7 @@
  */
 
 import {assertEqual, assertLessThan} from './assert';
-import {NO_CHANGE, bindingUpdated, bindingUpdated2, bindingUpdated4, createLNode, getPreviousOrParentNode, getRenderer, getViewData, load, resetApplicationState} from './instructions';
+import {NO_CHANGE, bindingUpdated, bindingUpdated2, bindingUpdated4, createLNode, getCurrentView, getPreviousOrParentNode, getRenderer, load, resetApplicationState} from './instructions';
 import {RENDER_PARENT} from './interfaces/container';
 import {LContainerNode, LNode, TContainerNode, TElementNode, TNodeType} from './interfaces/node';
 import {BINDING_INDEX, HEADER_OFFSET, TVIEW} from './interfaces/view';
@@ -250,7 +250,7 @@ function appendI18nNode(node: LNode, parentNode: LNode, previousNode: LNode) {
     ngDevMode.rendererMoveNode++;
   }
 
-  const viewData = getViewData();
+  const viewData = getCurrentView();
 
   appendChild(parentNode, node.native || null, viewData);
 
@@ -291,7 +291,7 @@ function appendI18nNode(node: LNode, parentNode: LNode, previousNode: LNode) {
  * @param instructions The list of instructions to apply on the current view.
  */
 export function i18nApply(startIndex: number, instructions: I18nInstruction[]): void {
-  const viewData = getViewData();
+  const viewData = getCurrentView();
   if (ngDevMode) {
     assertEqual(viewData[BINDING_INDEX], -1, 'i18nApply should be called before any binding');
   }

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -7,7 +7,7 @@
  */
 
 import {assertEqual, assertLessThan} from './assert';
-import {NO_CHANGE, bindingUpdated, bindingUpdated2, bindingUpdated4, createLNode, getCurrentView, getPreviousOrParentNode, getRenderer, load, resetApplicationState} from './instructions';
+import {NO_CHANGE, _getViewData, bindingUpdated, bindingUpdated2, bindingUpdated4, createLNode, getPreviousOrParentNode, getRenderer, load, resetApplicationState} from './instructions';
 import {RENDER_PARENT} from './interfaces/container';
 import {LContainerNode, LNode, TContainerNode, TElementNode, TNodeType} from './interfaces/node';
 import {BINDING_INDEX, HEADER_OFFSET, TVIEW} from './interfaces/view';
@@ -250,7 +250,7 @@ function appendI18nNode(node: LNode, parentNode: LNode, previousNode: LNode) {
     ngDevMode.rendererMoveNode++;
   }
 
-  const viewData = getCurrentView();
+  const viewData = _getViewData();
 
   appendChild(parentNode, node.native || null, viewData);
 
@@ -291,7 +291,7 @@ function appendI18nNode(node: LNode, parentNode: LNode, previousNode: LNode) {
  * @param instructions The list of instructions to apply on the current view.
  */
 export function i18nApply(startIndex: number, instructions: I18nInstruction[]): void {
-  const viewData = getCurrentView();
+  const viewData = _getViewData();
   if (ngDevMode) {
     assertEqual(viewData[BINDING_INDEX], -1, 'i18nApply should be called before any binding');
   }

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -63,6 +63,9 @@ export {
   elementStyleProp as sp,
   elementStylingApply as sa,
 
+  getCurrentView as gV,
+  restoreView as rV,
+
   listener as L,
   store as st,
   load as ld,

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -108,9 +108,29 @@ export function getCurrentSanitizer(): Sanitizer|null {
   return viewData && viewData[SANITIZER];
 }
 
-export function getViewData(): LViewData {
+/**
+ * Returns the current LViewData instance.
+ *
+ * Used in conjunction with the restoreView() instruction to save a snapshot
+ * of the current view and restore it when listeners are invoked. This allows
+ * walking the declaration view tree in listeners to get vars from parent views.
+ */
+export function getCurrentView(): LViewData {
   // top level variables should not be exported for performance reasons (PERF_NOTES.md)
   return viewData;
+}
+
+/**
+ * Restores `contextViewData` to the given LViewData instance.
+ *
+ * Used in conjunction with the getCurrentView() instruction to save a snapshot
+ * of the current view and restore it when listeners are invoked. This allows
+ * walking the declaration view tree in listeners to get vars from parent views.
+ *
+ * @param viewToRestore The LViewData instance to restore.
+ */
+export function restoreView(viewToRestore: LViewData) {
+  contextViewData = viewToRestore;
 }
 
 /** Used to set the parent property when nodes are created. */
@@ -583,9 +603,9 @@ export function renderEmbeddedTemplate<T>(
  * @param level The relative level of the view from which to grab context compared to contextVewData
  * @returns context
  */
-export function nextContext(level: number = 1): any {
+export function nextContext<T = any>(level: number = 1): T {
   contextViewData = walkUpViews(level, contextViewData !);
-  return contextViewData[CONTEXT];
+  return contextViewData[CONTEXT] as T;
 }
 
 export function renderComponentOrTemplate<T>(

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -22,7 +22,7 @@ import {AttributeMarker, InitialInputData, InitialInputs, LContainerNode, LEleme
 import {CssSelectorList, NG_PROJECT_AS_ATTR_NAME} from './interfaces/projection';
 import {LQueries} from './interfaces/query';
 import {ProceduralRenderer3, RComment, RElement, RText, Renderer3, RendererFactory3, RendererStyleFlags3, isProceduralRenderer} from './interfaces/renderer';
-import {BINDING_INDEX, CLEANUP, CONTAINER_INDEX, CONTENT_QUERIES, CONTEXT, CurrentMatchesList, DECLARATION_VIEW, DIRECTIVES, FLAGS, HEADER_OFFSET, HOST_NODE, INJECTOR, LViewData, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, RootContext, SANITIZER, TAIL, TData, TVIEW, TView} from './interfaces/view';
+import {BINDING_INDEX, CLEANUP, CONTAINER_INDEX, CONTENT_QUERIES, CONTEXT, CurrentMatchesList, DECLARATION_VIEW, DIRECTIVES, FLAGS, HEADER_OFFSET, HOST_NODE, INJECTOR, LViewData, LViewFlags, NEXT, OpaqueViewState, PARENT, QUERIES, RENDERER, RootContext, SANITIZER, TAIL, TData, TVIEW, TView} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
 import {appendChild, appendProjectedNode, canInsertNativeNode, createTextNode, findComponentHost, getChildLNode, getLViewChild, getNextLNode, getParentLNode, insertView, removeView} from './node_manipulation';
 import {isNodeMatchingSelectorList, matchingSelectorIndex} from './node_selector_matcher';
@@ -109,19 +109,28 @@ export function getCurrentSanitizer(): Sanitizer|null {
 }
 
 /**
- * Returns the current LViewData instance.
+ * Returns the current OpaqueViewState instance.
  *
  * Used in conjunction with the restoreView() instruction to save a snapshot
  * of the current view and restore it when listeners are invoked. This allows
  * walking the declaration view tree in listeners to get vars from parent views.
  */
-export function getCurrentView(): LViewData {
+export function getCurrentView(): OpaqueViewState {
+  return (viewData as any) as OpaqueViewState;
+}
+
+/**
+ * Internal function that returns the current LViewData instance.
+ *
+ * The getCurrentView() instruction should be used for anything public.
+ */
+export function _getViewData(): LViewData {
   // top level variables should not be exported for performance reasons (PERF_NOTES.md)
   return viewData;
 }
 
 /**
- * Restores `contextViewData` to the given LViewData instance.
+ * Restores `contextViewData` to the given OpaqueViewState instance.
  *
  * Used in conjunction with the getCurrentView() instruction to save a snapshot
  * of the current view and restore it when listeners are invoked. This allows
@@ -129,8 +138,8 @@ export function getCurrentView(): LViewData {
  *
  * @param viewToRestore The LViewData instance to restore.
  */
-export function restoreView(viewToRestore: LViewData) {
-  contextViewData = viewToRestore;
+export function restoreView(viewToRestore: OpaqueViewState) {
+  contextViewData = (viewToRestore as any) as LViewData;
 }
 
 /** Used to set the parent property when nodes are created. */

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -40,6 +40,14 @@ export const CONTAINER_INDEX = 14;
 export const CONTENT_QUERIES = 15;
 export const DECLARATION_VIEW = 16;
 
+// This interface replaces the real LViewData interface if it is an arg or a
+// return value of a public instruction. This ensures we don't need to expose
+// the actual interface, which should be kept private.
+export interface OpaqueViewState {
+  '__brand__': 'Brand for OpaqueViewState that nothing will match';
+}
+
+
 /**
  * `LViewData` stores all of the information needed to process the instructions as
  * they are invoked from the template. Each embedded view and component view has its

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -57,6 +57,8 @@ export const angularCoreEnv: {[name: string]: Function} = {
   'ɵf7': r3.f7,
   'ɵf8': r3.f8,
   'ɵfV': r3.fV,
+  'ɵgV': r3.gV,
+  'ɵrV': r3.rV,
   'ɵi1': r3.i1,
   'ɵi2': r3.i2,
   'ɵi3': r3.i3,

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -522,6 +522,9 @@
     "name": "getCurrentSanitizer"
   },
   {
+    "name": "getCurrentView"
+  },
+  {
     "name": "getInitialIndex"
   },
   {
@@ -762,6 +765,9 @@
     "name": "readElementValue"
   },
   {
+    "name": "reference"
+  },
+  {
     "name": "refreshChildComponents"
   },
   {
@@ -799,6 +805,9 @@
   },
   {
     "name": "resolveRendererType2"
+  },
+  {
+    "name": "restoreView"
   },
   {
     "name": "sameHostView"

--- a/packages/core/test/render3/common_integration_spec.ts
+++ b/packages/core/test/render3/common_integration_spec.ts
@@ -10,7 +10,7 @@ import {NgForOfContext} from '@angular/common';
 
 import {getOrCreateNodeInjectorForNode, getOrCreateTemplateRef} from '../../src/render3/di';
 import {AttributeMarker, defineComponent} from '../../src/render3/index';
-import {bind, container, elementEnd, elementProperty, elementStart, interpolation1, interpolation2, interpolation3, interpolationV, listener, load, nextContext, text, textBinding} from '../../src/render3/instructions';
+import {bind, container, elementEnd, elementProperty, elementStart, getCurrentView, interpolation1, interpolation2, interpolation3, interpolationV, listener, load, nextContext, restoreView, text, textBinding} from '../../src/render3/instructions';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 
 import {NgForOf, NgIf, NgTemplateOutlet} from './common_with_def';
@@ -337,13 +337,17 @@ describe('@angular/common integration', () => {
 
       function pTemplate(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
-          const row = nextContext().$implicit as any;
-          const app = nextContext();
+          const state = getCurrentView();
           elementStart(0, 'p');
           {
             elementStart(1, 'span');
             {
-              listener('click', () => { app.onClick(row.value, app.name); });
+              listener('click', () => {
+                restoreView(state);
+                const row = nextContext().$implicit as any;
+                const app = nextContext();
+                app.onClick(row.value, app.name);
+              });
             }
             elementEnd();
             text(2);

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -233,7 +233,7 @@ describe('event listeners', () => {
   it('should destroy listeners in views with renderer2', () => {
 
     /**
-     * % if (ctx.showing) {
+       * % if (ctx.showing) {
        *  <button (click)="onClick()"> Click me </button>
        * % }
      */
@@ -292,7 +292,7 @@ describe('event listeners', () => {
   it('should destroy listeners in for loops', () => {
 
     /**
-     * % for (let i = 0; i < ctx.buttons; i++) {
+       * % for (let i = 0; i < ctx.buttons; i++) {
        *  <button (click)="onClick(i)"> Click me </button>
        * % }
      */
@@ -353,7 +353,7 @@ describe('event listeners', () => {
   it('should destroy listeners in for loops with renderer2', () => {
 
     /**
-     * % for (let i = 0; i < ctx.buttons; i++) {
+       * % for (let i = 0; i < ctx.buttons; i++) {
        *  <button (click)="onClick(i)"> Click me </button>
        * % }
      */
@@ -449,7 +449,7 @@ describe('event listeners', () => {
   it('should destroy listeners in nested views', () => {
 
     /**
-     * % if (showing) {
+       * % if (showing) {
        *    Hello
        *    % if (button) {
        *      <button (click)="onClick()"> Click </button>
@@ -511,7 +511,7 @@ describe('event listeners', () => {
   it('should destroy listeners in component views', () => {
 
     /**
-     * % if (showing) {
+       * % if (showing) {
        *    Hello
        *    <comp></comp>
        *    <comp></comp>


### PR DESCRIPTION
This PR moves `nextContext` calls from the top of creation mode to listener functions. This ensures that we're not doing more work than we have to in creation mode (e.g. listener may never fire, save startup time).

In order to move the context instructions into the handler, the previous view must be restored. Since handlers don't fire during change detection, the normal current view won't be available.

There are two new instructions: 
- `getCurrentView`: returns a snapshot of the current view in creation mode
- `restoreView`: restores the given view as `contextViewData`