### PR TITLE
build: make `postinstall` script compatible with Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "buildifier": "find . -type f \\( -name BUILD -or -name BUILD.bazel \\) ! -path \"*/node_modules/*\" | xargs $(bazel info bazel-bin)/external/com_github_bazelbuild_buildtools/buildifier/*/buildifier",
     "preinstall": "node tools/yarn/check-yarn.js",
     "postinstall": "yarn update-webdriver && node ./tools/postinstall-patches.js && yarn patch-types",
-    "patch-types": "work-around for issue https://github.com/angular/angular/issues/25051",
-    "patch-types": "mkdir -p node_modules/@types/zone.js && cp -f node_modules/zone.js/dist/zone.js.d.ts node_modules/@types/zone.js/index.d.ts",
+    "//patch-types": "work-around for issue https://github.com/angular/angular/issues/25051",
+    "patch-types": "node -e \"var sh = require('shelljs'); sh.set('-e'); sh.mkdir('-p', 'node_modules/@types/zone.js'); sh.cp('-f', 'node_modules/zone.js/dist/zone.js.d.ts', 'node_modules/@types/zone.js/index.d.ts')\"",
     "update-webdriver": "webdriver-manager update --gecko false $CHROMEDRIVER_VERSION_ARG",
     "check-env": "gulp check-env",
     "commitmsg": "node ./scripts/git/commit-msg.js"


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] Build related changes
```

## What is the current behavior?
`postinstall` script fails on Windows.


## What is the new behavior?
`postinstall` script does not fails on Windows.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
Don't break Windows.
