### PR TITLE
fix(core): set attributes before mounting element

### DIFF
--- a/packages/core/src/view/element.ts
+++ b/packages/core/src/view/element.ts
@@ -152,16 +152,14 @@ export function createElement(view: ViewData, renderHost: any, def: NodeDef): El
   const rootSelectorOrNode = view.root.selectorOrNode;
   const renderer = view.renderer;
   let el: any;
+  let parentEl: any;
   if (view.parent || !rootSelectorOrNode) {
     if (elDef.name) {
       el = renderer.createElement(elDef.name, elDef.ns);
     } else {
       el = renderer.createComment('');
     }
-    const parentEl = getParentRenderElement(view, renderHost, def);
-    if (parentEl) {
-      renderer.appendChild(parentEl, el);
-    }
+    parentEl = getParentRenderElement(view, renderHost, def);
   } else {
     el = renderer.selectRootElement(rootSelectorOrNode);
   }
@@ -170,6 +168,9 @@ export function createElement(view: ViewData, renderHost: any, def: NodeDef): El
       const [ns, name, value] = elDef.attrs[i];
       renderer.setAttribute(el, name, value, ns);
     }
+  }
+  if (parentEl) {
+    renderer.appendChild(parentEl, el);
   }
   return el;
 }


### PR DESCRIPTION
closes #16689, closes #18909

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/16689, https://github.com/angular/angular/issues/18909

Static attributes are set after appending to parent.

## What is the new behavior?

Static attributes are set before appending to parent.

This is a more correct behavior and what happens in Ivy:

https://github.com/angular/angular/blob/c8a4fb1fafc2f15db63b70159678229fc58e639d/packages/core/src/render3/instructions.ts#L725-L728

This PR is going to apply same behavior to view engine.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
