### PR TITLE
test(ivy): run compiler compliance tests without rebuilding core,common

### DIFF
--- a/packages/compiler-cli/test/compliance/BUILD.bazel
+++ b/packages/compiler-cli/test/compliance/BUILD.bazel
@@ -12,17 +12,14 @@ ts_library(
         "//packages/compiler",
         "//packages/compiler-cli",
         "//packages/compiler/test:test_utils",
-        "//packages/compiler/testing",
-        "//packages/core",
     ],
 )
 
 jasmine_node_test(
     name = "compliance",
-    bootstrap = ["angular/tools/testing/init_node_spec.js"],
+    bootstrap = ["angular/tools/testing/init_node_no_angular_spec.js"],
     data = [
-        "//packages/common:npm_package",
-        "//packages/core:npm_package",
+        "//packages/compiler-cli/test/ngtsc/fake_core:npm_package",
     ],
     tags = [
         "ivy-local",
@@ -30,6 +27,6 @@ jasmine_node_test(
     ],
     deps = [
         ":test_lib",
-        "//tools/testing:node",
+        "//tools/testing:node_no_angular",
     ],
 )

--- a/packages/compiler-cli/test/compliance/mock_compiler_spec.ts
+++ b/packages/compiler-cli/test/compliance/mock_compiler_spec.ts
@@ -14,9 +14,9 @@ describe('mock_compiler', () => {
   // This produces a MockDirectory of the file needed to compile an Angular application.
   // This setup is performed in a beforeAll which populates the map returned.
   const angularFiles = setup({
-    compileAngular: true,
+    compileAngular: false,
+    compileFakeCore: true,
     compileAnimations: false,
-    compileCommon: true,
   });
 
   describe('compiling', () => {

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -17,9 +17,9 @@ import {compile, expectEmit} from './mock_compile';
 describe('compiler compliance', () => {
 
   const angularFiles = setup({
-    compileAngular: true,
+    compileAngular: false,
     compileAnimations: false,
-    compileCommon: true,
+    compileFakeCore: true,
   });
 
   describe('elements', () => {
@@ -1287,7 +1287,6 @@ describe('compiler compliance', () => {
         app: {
           'spec.ts': `
               import {Component, NgModule} from '@angular/core';
-              import {CommonModule} from '@angular/common';
 
               @Component({
                 selector: 'my-component',
@@ -1301,7 +1300,7 @@ describe('compiler compliance', () => {
               })
               export class MyComponent {}
 
-              @NgModule({declarations: [MyComponent], imports: [CommonModule]})
+              @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
         }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -11,9 +11,9 @@ import {compile, expectEmit} from './mock_compile';
 
 describe('compiler compliance: bindings', () => {
   const angularFiles = setup({
-    compileAngular: true,
+    compileAngular: false,
+    compileFakeCore: true,
     compileAnimations: false,
-    compileCommon: false,
   });
 
   describe('text bindings', () => {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
@@ -11,9 +11,9 @@ import {compile, expectEmit} from './mock_compile';
 
 describe('compiler compliance: dependency injection', () => {
   const angularFiles = setup({
-    compileAngular: true,
+    compileAngular: false,
+    compileFakeCore: true,
     compileAnimations: false,
-    compileCommon: true,
   });
 
   it('should create factory methods', () => {
@@ -21,7 +21,6 @@ describe('compiler compliance: dependency injection', () => {
       app: {
         'spec.ts': `
               import {Component, NgModule, Injectable, Attribute, Host, SkipSelf, Self, Optional} from '@angular/core';
-              import {CommonModule} from '@angular/common';
 
               @Injectable()
               export class MyService {}
@@ -42,7 +41,7 @@ describe('compiler compliance: dependency injection', () => {
                 ) {}
               }
 
-              @NgModule({declarations: [MyComponent], imports: [CommonModule], providers: [MyService]})
+              @NgModule({declarations: [MyComponent], providers: [MyService]})
               export class MyModule {}
           `
       }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -13,9 +13,9 @@ const TRANSLATION_NAME_REGEXP = /^MSG_[A-Z0-9]+/;
 
 describe('i18n support in the view compiler', () => {
   const angularFiles = setup({
-    compileAngular: true,
+    compileAngular: false,
+    compileFakeCore: true,
     compileAnimations: false,
-    compileCommon: true,
   });
 
   describe('single text nodes', () => {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_input_outputs_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_input_outputs_spec.ts
@@ -11,9 +11,9 @@ import {compile, expectEmit} from './mock_compile';
 
 describe('compiler compliance: listen()', () => {
   const angularFiles = setup({
-    compileAngular: true,
+    compileAngular: false,
+    compileFakeCore: true,
     compileAnimations: false,
-    compileCommon: true,
   });
 
   it('should create declare inputs/outputs', () => {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
@@ -14,9 +14,9 @@ import {compile, expectEmit} from './mock_compile';
   */
 describe('compiler compliance: listen()', () => {
   const angularFiles = setup({
-    compileAngular: true,
+    compileAngular: false,
+    compileFakeCore: true,
     compileAnimations: false,
-    compileCommon: true,
   });
 
   it('should create listener instruction on element', () => {
@@ -63,7 +63,6 @@ describe('compiler compliance: listen()', () => {
       app: {
         'spec.ts': `
               import {Component, NgModule} from '@angular/core';
-              import {CommonModule} from '@angular/common';
 
               @Component({
                 selector: 'my-component',
@@ -80,7 +79,7 @@ describe('compiler compliance: listen()', () => {
                 onClick2(name: any) {}
               }
 
-              @NgModule({declarations: [MyComponent], imports: [CommonModule]})
+              @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
       }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_spec.ts
@@ -11,9 +11,9 @@ import {compile, expectEmit} from './mock_compile';
 
 describe('r3_view_compiler', () => {
   const angularFiles = setup({
-    compileAngular: true,
+    compileAngular: false,
+    compileFakeCore: true,
     compileAnimations: false,
-    compileCommon: true,
   });
 
   describe('hello world', () => {
@@ -47,7 +47,6 @@ describe('r3_view_compiler', () => {
       app: {
         'example.ts': `
         import {Component, OnInit, OnDestroy, ElementRef, Input, NgModule} from '@angular/core';
-        import {CommonModule} from '@angular/common';
 
         @Component({
           selector: 'my-app',
@@ -83,7 +82,6 @@ describe('r3_view_compiler', () => {
 
         @NgModule({
           declarations: [TodoComponent, MyApp],
-          imports: [CommonModule]
         })
         export class TodoModule{}
         `

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -13,9 +13,9 @@ import {compile, expectEmit} from './mock_compile';
 
 describe('compiler compliance: styling', () => {
   const angularFiles = setup({
-    compileAngular: true,
+    compileAngular: false,
+    compileFakeCore: true,
     compileAnimations: false,
-    compileCommon: true,
   });
 
   describe('[style] and [style.prop]', () => {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
@@ -11,9 +11,9 @@ import {compile, expectEmit} from './mock_compile';
 
 describe('compiler compliance: template', () => {
   const angularFiles = setup({
-    compileAngular: true,
+    compileAngular: false,
+    compileFakeCore: true,
     compileAnimations: false,
-    compileCommon: true,
   });
 
   it('should correctly bind to context in nested template', () => {
@@ -21,7 +21,6 @@ describe('compiler compliance: template', () => {
       app: {
         'spec.ts': `
               import {Component, NgModule} from '@angular/core';
-              import {CommonModule} from '@angular/common';
 
               @Component({
                 selector: 'my-component',
@@ -43,7 +42,7 @@ describe('compiler compliance: template', () => {
                 onClick(outer: any, middle: any, inner: any) { }
               }
 
-              @NgModule({declarations: [MyComponent], imports: [CommonModule]})
+              @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
       }
@@ -122,7 +121,6 @@ describe('compiler compliance: template', () => {
       app: {
         'spec.ts': `
               import {Component, NgModule} from '@angular/core';
-              import {CommonModule} from '@angular/common';
 
               @Component({
                 selector: 'my-component',
@@ -133,7 +131,7 @@ describe('compiler compliance: template', () => {
               })
               export class MyComponent {}
 
-              @NgModule({declarations: [MyComponent], imports: [CommonModule]})
+              @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
       }
@@ -174,7 +172,6 @@ describe('compiler compliance: template', () => {
       app: {
         'spec.ts': `
               import {Component, NgModule} from '@angular/core';
-              import {CommonModule} from '@angular/common';
 
               @Component({
                 selector: 'my-component',
@@ -187,7 +184,7 @@ describe('compiler compliance: template', () => {
               })
               export class MyComponent {}
 
-              @NgModule({declarations: [MyComponent], imports: [CommonModule]})
+              @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
       }
@@ -243,7 +240,6 @@ describe('compiler compliance: template', () => {
       app: {
         'spec.ts': `
               import {Component, NgModule} from '@angular/core';
-              import {CommonModule} from '@angular/common';
 
               @Component({
                 selector: 'my-component',
@@ -258,7 +254,7 @@ describe('compiler compliance: template', () => {
               })
               export class MyComponent {}
 
-              @NgModule({declarations: [MyComponent], imports: [CommonModule]})
+              @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
       }

--- a/packages/compiler-cli/test/ngtsc/fake_core/index.ts
+++ b/packages/compiler-cli/test/ngtsc/fake_core/index.ts
@@ -47,9 +47,11 @@ export type ModuleWithProviders<T> = any;
 export class ChangeDetectorRef {}
 export class ElementRef {}
 export class Injector {}
-export class TemplateRef {}
+export class TemplateRef<T = any> {}
 export class ViewContainerRef {}
 
 export function forwardRef<T>(fn: () => T): T {
   return fn();
 }
+
+export interface SimpleChanges { [propName: string]: any; }

--- a/packages/compiler/test/aot/test_util.ts
+++ b/packages/compiler/test/aot/test_util.ts
@@ -602,12 +602,16 @@ export function isInBazel(): boolean {
   return process.env.TEST_SRCDIR != null;
 }
 
-export function setup(
-    options: {compileAngular: boolean, compileAnimations: boolean, compileCommon?: boolean} = {
-      compileAngular: true,
-      compileAnimations: true,
-      compileCommon: false,
-    }) {
+export function setup(options: {
+  compileAngular: boolean,
+  compileFakeCore?: boolean,
+  compileAnimations: boolean, compileCommon?: boolean
+} = {
+  compileAngular: true,
+  compileAnimations: true,
+  compileCommon: false,
+  compileFakeCore: false,
+}) {
   let angularFiles = new Map<string, string>();
 
   beforeAll(() => {
@@ -625,6 +629,11 @@ export function setup(
         readBazelWrittenFilesFrom(
             path.join(sources, 'angular/packages/core/npm_package'), 'core', angularFiles,
             skipDirs);
+      }
+      if (options.compileFakeCore) {
+        readBazelWrittenFilesFrom(
+            path.join(sources, 'angular/packages/compiler-cli/test/ngtsc/fake_core/npm_package'),
+            'core', angularFiles, skipDirs);
       }
       if (options.compileAnimations) {
         // If this fails please add //packages/animations:npm_package as a test data dependency.


### PR DESCRIPTION
Previously the compiler compliance tests ran and built test code with
real dependencies on @angular/core and @angular/common. This meant that
any changes to the compiler would result in long rebuild processes
for tests to rerun.

This change removes those dependencies and causes test code to be built
against the fake_core stub of @angular/core that the ngtsc tests use.
This change also removes the dependency on @angular/common entirely, as
locality means it's possible to reference *ngIf without needing to link
to an implementation.
