### PR TITLE
feat(common): support null / undefined in ngTemplateOutlet (#24926)

### DIFF
--- a/packages/common/src/directives/ng_template_outlet.ts
+++ b/packages/common/src/directives/ng_template_outlet.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, EmbeddedViewRef, Input, OnChanges, SimpleChange, SimpleChanges, TemplateRef, ViewContainerRef} from '@angular/core';
+import {Directive, EmbeddedViewRef, Input, OnChanges, Optional, SimpleChange, SimpleChanges, TemplateRef, ViewContainerRef} from '@angular/core';
 
 /**
  * @ngModule CommonModule
@@ -19,9 +19,15 @@ import {Directive, EmbeddedViewRef, Input, OnChanges, SimpleChange, SimpleChange
  * `[ngTemplateOutletContext]` should be an object, the object's keys will be available for binding
  * by the local template `let` declarations.
  *
+ * If no template is provided, the internal template is used instead. This can be useful for
+ * setting up context in a sub-template.
+ *
  * @usageNotes
  * ```
  * <ng-container *ngTemplateOutlet="templateRefExp; context: contextExp"></ng-container>
+ * <ng-container *ngTemplateOutletContext="contextExp">
+ *   <!-- template defined locally here -->
+ * </ng-container>
  * ```
  *
  * Using the key `$implicit` in the context object will set its value as default.
@@ -31,7 +37,7 @@ import {Directive, EmbeddedViewRef, Input, OnChanges, SimpleChange, SimpleChange
  * {@example common/ngTemplateOutlet/ts/module.ts region='NgTemplateOutlet'}
  *
  */
-@Directive({selector: '[ngTemplateOutlet]'})
+@Directive({selector: '[ngTemplateOutlet],[ngTemplateOutletContext]'})
 export class NgTemplateOutlet implements OnChanges {
   // TODO(issue/24571): remove '!'.
   private _viewRef !: EmbeddedViewRef<any>;
@@ -42,7 +48,9 @@ export class NgTemplateOutlet implements OnChanges {
   // TODO(issue/24571): remove '!'.
   @Input() public ngTemplateOutlet !: TemplateRef<any>;
 
-  constructor(private _viewContainerRef: ViewContainerRef) {}
+  constructor(
+      private _viewContainerRef: ViewContainerRef,
+      @Optional() private _templateRef: TemplateRef<any>) {}
 
   ngOnChanges(changes: SimpleChanges) {
     const recreateView = this._shouldRecreateView(changes);
@@ -52,9 +60,9 @@ export class NgTemplateOutlet implements OnChanges {
         this._viewContainerRef.remove(this._viewContainerRef.indexOf(this._viewRef));
       }
 
-      if (this.ngTemplateOutlet) {
+      if (this.ngTemplateOutlet || this._templateRef) {
         this._viewRef = this._viewContainerRef.createEmbeddedView(
-            this.ngTemplateOutlet, this.ngTemplateOutletContext);
+            this.ngTemplateOutlet || this._templateRef, this.ngTemplateOutletContext);
       }
     } else {
       if (this._viewRef && this.ngTemplateOutletContext) {

--- a/packages/common/test/directives/ng_template_outlet_spec.ts
+++ b/packages/common/test/directives/ng_template_outlet_spec.ts
@@ -41,10 +41,10 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
          detectChangesAndExpectText('bar');
        }));
 
-    it('should do nothing if templateRef is `null`', async(() => {
-         const template = `<ng-container [ngTemplateOutlet]="null"></ng-container>`;
+    it('should include internal template if templateRef is `null`', async(() => {
+         const template = `<ng-template [ngTemplateOutlet]="null">Internal text</ng-template>`;
          fixture = createTestComponent(template);
-         detectChangesAndExpectText('');
+         detectChangesAndExpectText('Internal text');
        }));
 
     it('should insert content specified by TemplateRef', async(() => {

--- a/packages/core/test/render3/common_integration_spec.ts
+++ b/packages/core/test/render3/common_integration_spec.ts
@@ -882,7 +882,11 @@ describe('@angular/common integration', () => {
                   text(0, 'from tpl');
                 }
               }, undefined, undefined, ['tpl', '']);
-              container(2, undefined, null, [AttributeMarker.SelectOnly, 'ngTemplateOutlet']);
+              container(2, (rf2: RenderFlags) => {
+                if (rf2 & RenderFlags.Create) {
+                  text(0, '');
+                }
+              }, null, [AttributeMarker.SelectOnly, 'ngTemplateOutlet']);
             }
             if (rf & RenderFlags.Update) {
               const tplRef = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(0)));

--- a/packages/core/test/render3/common_with_def.ts
+++ b/packages/core/test/render3/common_with_def.ts
@@ -37,7 +37,7 @@ NgForOf.ngDirectiveDef = defineDirective({
 (NgTemplateOutlet as any).ngDirectiveDef = defineDirective({
   type: NgTemplateOutletDef,
   selectors: [['', 'ngTemplateOutlet', '']],
-  factory: () => new NgTemplateOutletDef(injectViewContainerRef()),
+  factory: () => new NgTemplateOutletDef(injectViewContainerRef(), injectTemplateRef()),
   features: [NgOnChangesFeature],
   inputs:
       {ngTemplateOutlet: 'ngTemplateOutlet', ngTemplateOutletContext: 'ngTemplateOutletContext'}

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -1212,7 +1212,8 @@ describe('query', () => {
             selectors: [['my-app']],
             /**
              * <ng-template #tpl><span #foo id="from_tpl">from tpl</span></ng-template>
-             * <ng-template [ngTemplateOutlet]="show ? tpl : null"></ng-template>
+             * <ng-template [ngTemplateOutlet]="show ? tpl : null"><span
+             * id="internal"></span></ng-template>
              */
             template: (rf: RenderFlags, myApp: MyApp) => {
               if (rf & RenderFlags.Create) {
@@ -1221,7 +1222,11 @@ describe('query', () => {
                     element(0, 'span', ['id', 'from_tpl'], ['foo', '']);
                   }
                 }, undefined, undefined, ['tpl', '']);
-                container(3, undefined, null, [AttributeMarker.SelectOnly, 'ngTemplateOutlet']);
+                container(3, (rf3: RenderFlags) => {
+                  if (rf3 & RenderFlags.Create) {
+                    element(0, 'span', ['id', 'internal'], ['foo', '']);
+                  }
+                }, null, [AttributeMarker.SelectOnly, 'ngTemplateOutlet']);
               }
               if (rf & RenderFlags.Update) {
                 const tplRef = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(1)));
@@ -1245,7 +1250,8 @@ describe('query', () => {
         const fixture = new ComponentFixture(MyApp);
         const qList = fixture.component.query;
 
-        expect(qList.length).toBe(0);
+        expect(qList.length).toBe(1);
+        expect(qList.first.nativeElement.id).toBe('internal');
 
         fixture.component.show = true;
         fixture.update();
@@ -1254,7 +1260,8 @@ describe('query', () => {
 
         fixture.component.show = false;
         fixture.update();
-        expect(qList.length).toBe(0);
+        expect(qList.length).toBe(1);
+        expect(qList.first.nativeElement.id).toBe('internal');
       });
 
     });

--- a/tools/public_api_guard/common/common.d.ts
+++ b/tools/public_api_guard/common/common.d.ts
@@ -341,7 +341,7 @@ export declare class NgSwitchDefault {
 export declare class NgTemplateOutlet implements OnChanges {
     ngTemplateOutlet: TemplateRef<any>;
     ngTemplateOutletContext: Object;
-    constructor(_viewContainerRef: ViewContainerRef);
+    constructor(_viewContainerRef: ViewContainerRef, _templateRef: TemplateRef<any>);
     ngOnChanges(changes: SimpleChanges): void;
 }
 


### PR DESCRIPTION
PR Close #24926

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 24926

Introduce a convenient way to define context in a sub-template.


## What is the new behavior?

ngTemplateOutlet supports null / undefined values, with the fallback to internal template.


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No (in my opinion)
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

although it changes behavior in some rare cases (using *ngTemplateOutlet="null" to comment-out template part).



## Other information
