### PR TITLE
fix(bazel): Add support for extending tsconfigs

### DIFF
--- a/integration/bazel/src/BUILD.bazel
+++ b/integration/bazel/src/BUILD.bazel
@@ -1,9 +1,16 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@angular//:index.bzl", "ng_module")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_config")
 
 # Allow targets under sub-packages to reference the tsconfig.json file
 exports_files(["tsconfig.json"])
+
+ts_config(
+    name = "tsconfig",
+    src = "extend.tsconfig.json",
+    deps = ["tsconfig.json"],
+)
 
 ng_module(
     name = "src",
@@ -15,6 +22,7 @@ ng_module(
         "@angular//packages/platform-browser",
         "@npm//@types",
     ],
+    tsconfig = ":tsconfig",
 )
 
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_devserver")

--- a/integration/bazel/src/extend.tsconfig.json
+++ b/integration/bazel/src/extend.tsconfig.json
@@ -1,0 +1,4 @@
+// For testing extending tsconfig.json
+{
+  "extends": "./tsconfig"
+}

--- a/packages/bazel/src/external.bzl
+++ b/packages/bazel/src/external.bzl
@@ -5,6 +5,11 @@ load(
     "@build_bazel_rules_typescript//internal:build_defs.bzl",
     _tsc_wrapped_tsconfig = "tsc_wrapped_tsconfig",
 )
+
+load("@build_bazel_rules_typescript//internal:ts_config.bzl",
+    _TsConfigInfo = "TsConfigInfo",
+)
+
 load(
     "@build_bazel_rules_typescript//internal:common/compilation.bzl",
     _COMMON_ATTRIBUTES = "COMMON_ATTRIBUTES",
@@ -22,6 +27,7 @@ load(
 NodeModuleInfo = _NodeModuleInfo
 collect_node_modules_aspect = _collect_node_modules_aspect
 tsc_wrapped_tsconfig = _tsc_wrapped_tsconfig
+TsConfigInfo = _TsConfigInfo
 COMMON_ATTRIBUTES = _COMMON_ATTRIBUTES
 COMMON_OUTPUTS = _COMMON_OUTPUTS
 compile_ts = _compile_ts

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -14,6 +14,7 @@ load(
     "DEPS_ASPECTS",
     "NodeModuleInfo",
     "collect_node_modules_aspect",
+    "TsConfigInfo",
     "compile_ts",
     "ts_providers_dict_to_struct",
     "tsc_wrapped_tsconfig",
@@ -402,6 +403,8 @@ def _compile_action(ctx, inputs, outputs, messages_out, tsconfig_file, node_opts
     # If the user supplies a tsconfig.json file, the Angular compiler needs to read it
     if hasattr(ctx.attr, "tsconfig") and ctx.file.tsconfig:
         file_inputs.append(ctx.file.tsconfig)
+        if TsConfigInfo in ctx.attr.tsconfig:
+            file_inputs.extend(ctx.attr.tsconfig[TsConfigInfo].deps)
 
     # Also include files from npm fine grained deps as action_inputs.
     # These deps are identified by the NodeModuleInfo provider.

--- a/packages/bazel/src/ngc-wrapped/BUILD.bazel
+++ b/packages/bazel/src/ngc-wrapped/BUILD.bazel
@@ -10,10 +10,7 @@ ts_library(
     module_name = "@angular/bazel",
     node_modules = "@ngdeps//typescript:typescript__typings",
     tsconfig = ":tsconfig.json",
-    visibility = [
-        "//packages/bazel:__pkg__",
-        "//packages/bazel/test/ngc-wrapped:__subpackages__",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         # BEGIN-INTERNAL
         # Only needed when compiling within the Angular repo.


### PR DESCRIPTION
This basically mirrors the way rules_typescript ([build_defs.bzl#L46-L49](https://github.com/bazelbuild/rules_typescript/blob/924782af55f2396d9bdc9e0a9904fe2d4b3b9047/internal/build_defs.bzl#L46-L49)) handles extended tsconfigs.