### PR TITLE
ci: update pullapprove groups and add docs

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -133,65 +133,65 @@ groups:
       files:
         - "packages/core/*"
         - "aio/content/guide/bootstrapping.md"
-        - "aio/content/examples/bootstrapping/"
+        - "aio/content/examples/bootstrapping/*"
         - "aio/content/guide/attribute-directives.md"
-        - "aio/content/examples/attribute-directives/"
-        - "aio/content/images/guide/attribute-directives/"
+        - "aio/content/examples/attribute-directives/*"
+        - "aio/content/images/guide/attribute-directives/*"
         - "aio/content/guide/structural-directives.md"
-        - "aio/content/examples/structural-directives/"
-        - "aio/content/images/guide/structural-directives/"
+        - "aio/content/examples/structural-directives/*"
+        - "aio/content/images/guide/structural-directives/*"
         - "aio/content/guide/dynamic-component-loader.md"
-        - "aio/content/examples/dynamic-component-loader/"
-        - "aio/content/images/guide/dynamic-component-loader/"
+        - "aio/content/examples/dynamic-component-loader/*"
+        - "aio/content/images/guide/dynamic-component-loader/*"
         - "aio/content/guide/template-syntax.md"
-        - "aio/content/examples/template-syntax/"
-        - "aio/content/images/guide/template-syntax/"
+        - "aio/content/examples/template-syntax/*"
+        - "aio/content/images/guide/template-syntax/*"
         - "aio/content/guide/dependency-injection.md"
-        - "aio/content/examples/dependency-injection/"
-        - "aio/content/images/guide/dependency-injection/"
+        - "aio/content/examples/dependency-injection/*"
+        - "aio/content/images/guide/dependency-injection/*"
         - "aio/content/guide/dependency-injection-in-action.md"
-        - "aio/content/examples/dependency-injection-in-action/"
-        - "aio/content/images/guide/dependency-injection-in-action/"
+        - "aio/content/examples/dependency-injection-in-action/*"
+        - "aio/content/images/guide/dependency-injection-in-action/*"
         - "aio/content/guide/hierarchical-dependency-injection.md"
-        - "aio/content/examples/hierarchical-dependency-injection/"
+        - "aio/content/examples/hierarchical-dependency-injection/*"
         - "aio/content/guide/singleton-services.md"
         - "aio/content/guide/dependency-injection-pattern.md"
         - "aio/content/guide/providers.md"
-        - "aio/content/examples/providers/"
+        - "aio/content/examples/providers/*"
         - "aio/content/guide/component-interaction.md"
-        - "aio/content/examples/component-interaction/"
-        - "aio/content/images/guide/component-interaction/"
+        - "aio/content/examples/component-interaction/*"
+        - "aio/content/images/guide/component-interaction/*"
         - "aio/content/guide/component-styles.md"
-        - "aio/content/examples/component-styles/"
+        - "aio/content/examples/component-styles/*"
         - "aio/content/guide/lifecycle-hooks.md"
-        - "aio/content/examples/lifecycle-hooks/"
-        - "aio/content/images/guide/lifecycle-hooks/"
-        - "aio/content/examples/ngcontainer/"
-        - "aio/content/images/guide/ngcontainer/"
+        - "aio/content/examples/lifecycle-hooks/*"
+        - "aio/content/images/guide/lifecycle-hooks/*"
+        - "aio/content/examples/ngcontainer/*"
+        - "aio/content/images/guide/ngcontainer/*"
         - "aio/content/guide/pipes.md"
-        - "aio/content/examples/pipes/"
-        - "aio/content/images/guide/pipes/"
+        - "aio/content/examples/pipes/*"
+        - "aio/content/images/guide/pipes/*"
         - "aio/content/guide/entry-components.md"
         - "aio/content/guide/set-document-title.md"
-        - "aio/content/examples/set-document-title/"
-        - "aio/content/images/guide/set-document-title/"
+        - "aio/content/examples/set-document-title/*"
+        - "aio/content/images/guide/set-document-title/*"
         - "aio/content/guide/ngmodules.md"
-        - "aio/content/examples/ngmodules/"
-        - "aio/content/examples/ngmodule/"
-        - "aio/content/images/guide/ngmodule/"
+        - "aio/content/examples/ngmodules/*"
+        - "aio/content/examples/ngmodule/*"
+        - "aio/content/images/guide/ngmodule/*"
         - "aio/content/guide/ngmodule-faq.md"
-        - "aio/content/examples/ngmodule-faq/"
+        - "aio/content/examples/ngmodule-faq/*"
         - "aio/content/guide/module-types.md"
         - "aio/content/guide/sharing-ngmodules.md"
         - "aio/content/guide/frequent-ngmodules.md"
-        - "aio/content/images/guide/frequent-ngmodules/"
+        - "aio/content/images/guide/frequent-ngmodules/*"
         - "aio/content/guide/ngmodule-api.md"
         - "aio/content/guide/ngmodule-vs-jsmodule.md"
         - "aio/content/guide/feature-modules.md"
-        - "aio/content/examples/feature-modules/"
-        - "aio/content/images/guide/feature-modules/"
+        - "aio/content/examples/feature-modules/*"
+        - "aio/content/images/guide/feature-modules/*"
         - "aio/content/guide/lazy-loading-ngmodules.md"
-        - "aio/content/examples/lazy-loading-ngmodules/"
+        - "aio/content/examples/lazy-loading-ngmodules/*"
         - "aio/content/images/guide/lazy-loading-ngmodules"
     users:
       - mhevery #primary
@@ -207,8 +207,8 @@ groups:
         - "packages/animations/*"
         - "packages/platform-browser/animations/*"
         - "aio/content/guide/animations.md"
-        - "aio/content/examples/animations/"
-        - "aio/content/images/guide/animations/"
+        - "aio/content/examples/animations/*"
+        - "aio/content/images/guide/animations/*"
     users:
       - matsko #primary
       - mhevery #fallback
@@ -220,7 +220,7 @@ groups:
       files:
         - "packages/compiler/src/i18n/*"
         - "aio/content/guide/i18n.md"
-        - "aio/content/examples/i18n/"
+        - "aio/content/examples/i18n/*"
     users:
       - vicb #primary
       - alxhub
@@ -282,17 +282,17 @@ groups:
       files:
         - "packages/forms/*"
         - "aio/content/guide/forms.md"
-        - "aio/content/examples/forms/"
-        - "aio/content/images/guide/forms/"
+        - "aio/content/examples/forms/*"
+        - "aio/content/images/guide/forms/*"
         - "aio/content/guide/form-validation.md"
-        - "aio/content/examples/form-validation/"
-        - "aio/content/images/guide/form-validation/"
+        - "aio/content/examples/form-validation/*"
+        - "aio/content/images/guide/form-validation/*"
         - "aio/content/guide/dynamic-form.md"
-        - "aio/content/examples/dynamic-form/"
-        - "aio/content/images/guide/dynamic-form/"
+        - "aio/content/examples/dynamic-form/*"
+        - "aio/content/images/guide/dynamic-form/*"
         - "aio/content/guide/reactive-forms.md"
-        - "aio/content/examples/reactive-forms/"
-        - "aio/content/images/guide/reactive-forms/"
+        - "aio/content/examples/reactive-forms/*"
+        - "aio/content/images/guide/reactive-forms/*"
     users:
       - kara #primary
       - IgorMinar #fallback
@@ -305,8 +305,8 @@ groups:
         - "packages/common/http/*"
         - "packages/http/*"
         - "aio/content/guide/http.md"
-        - "aio/content/examples/http/"
-        - "aio/content/images/guide/http/"
+        - "aio/content/examples/http/*"
+        - "aio/content/images/guide/http/*"
     users:
       - alxhub #primary
       - IgorMinar
@@ -318,7 +318,7 @@ groups:
       files:
         - "packages/language-service/*"
         - "aio/content/guide/language-service.md"
-        - "aio/content/images/guide/language-service/"
+        - "aio/content/images/guide/language-service/*"
     users:
       - kyliau #primary
       # needs secondary
@@ -332,8 +332,8 @@ groups:
       files:
         - "packages/router/*"
         - "aio/content/guide/router.md"
-        - "aio/content/examples/router/"
-        - "aio/content/images/guide/router/"
+        - "aio/content/examples/router/*"
+        - "aio/content/images/guide/router/*"
     users:
       - jasonaden #primary
       - vicb
@@ -344,10 +344,10 @@ groups:
   testing:
     conditions:
       files:
-        - "*/testing/*
+        - "*/testing/*"
         - "aio/content/guide/testing.md"
-        - "aio/content/examples/testing/"
-        - "aio/content/images/guide/testing/"
+        - "aio/content/examples/testing/*"
+        - "aio/content/images/guide/testing/*"
     users:
       - vikerman
       - IgorMinar #fallback
@@ -359,14 +359,14 @@ groups:
       files:
         - "packages/upgrade/*"
         - "aio/content/guide/upgrade.md"
-        - "aio/content/examples/upgrade-module/"
-        - "aio/content/images/guide/upgrade/"
-        - "aio/content/examples/upgrade-phonecat-1-typescript/"
-        - "aio/content/examples/upgrade-phonecat-2-hybrid/"
-        - "aio/content/examples/upgrade-phonecat-3-final/"
+        - "aio/content/examples/upgrade-module/*"
+        - "aio/content/images/guide/upgrade/*"
+        - "aio/content/examples/upgrade-phonecat-1-typescript/*"
+        - "aio/content/examples/upgrade-phonecat-2-hybrid/*"
+        - "aio/content/examples/upgrade-phonecat-3-final/*"
         - "aio/content/guide/upgrade-performance.md"
         - "aio/content/guide/ajs-quick-reference.md"
-        - "aio/content/examples/ajs-quick-reference/"
+        - "aio/content/examples/ajs-quick-reference/*"
     users:
       - petebacondarwin #primary
       - gkalpak
@@ -389,7 +389,7 @@ groups:
       files:
         - "packages/platform-server/*"
         - "aio/content/guide/universal.md"
-        - "aio/content/examples/universal/"
+        - "aio/content/examples/universal/*"
     users:
       - vikerman #primary
       - alxhub #secondary
@@ -413,12 +413,12 @@ groups:
       files:
         - "packages/service-worker/*"
         - "aio/content/guide/service-worker-getting-started.md"
-        - "aio/content/examples/service-worker-getting-started/"
+        - "aio/content/examples/service-worker-getting-started/*"
         - "aio/content/guide/service-worker-communications.md"
         - "aio/content/guide/service-worker-config.md"
         - "aio/content/guide/service-worker-devops.md"
         - "aio/content/guide/service-worker-intro.md"
-        - "aio/content/images/guide/service-worker/"
+        - "aio/content/images/guide/service-worker/*"
     users:
       - gkalpak #primary
       - alxhub
@@ -430,8 +430,8 @@ groups:
     conditions:
       files:
         - "packages/elements/*"
-        - "aio/content/examples/elements/"
-        - "aio/content/images/guide/elements/"
+        - "aio/content/examples/elements/*"
+        - "aio/content/images/guide/elements/*"
         - "aio/content/guide/elements.md"
     users:
       - andrewseguin #primary
@@ -501,16 +501,16 @@ groups:
   docs/observables:
     conditions:
       files:
-        - "aio/content/examples/observables/"
-        - "aio/content/images/guide/observables/"
+        - "aio/content/examples/observables/*"
+        - "aio/content/images/guide/observables/*"
         - "aio/content/guide/observables.md"
         - "aio/content/guide/comparing-observables.md"
-        - "aio/content/examples/observables-in-angular/"
-        - "aio/content/images/guide/observables-in-angular/"
+        - "aio/content/examples/observables-in-angular/*"
+        - "aio/content/images/guide/observables-in-angular/*"
         - "aio/content/guide/observables-in-angular.md"
-        - "aio/content/examples/practical-observable-usage/"
+        - "aio/content/examples/practical-observable-usage/*"
         - "aio/content/guide/practical-observable-usage.md"
-        - "aio/content/examples/rx-library/"
+        - "aio/content/examples/rx-library/*"
         - "aio/content/guide/rx-library.md"
     users:
       - jasonaden
@@ -526,7 +526,7 @@ groups:
         - "aio/content/guide/browser-support.md"
         - "aio/content/guide/typescript-configuration.md"
         - "aio/content/guide/setup-systemjs-anatomy.md"
-        - "aio/content/examples/setup/"
+        - "aio/content/examples/setup/*"
         - "aio/content/guide/setup.md"
         - "aio/content/guide/deployment.md"
         - "aio/content/guide/releases.md"

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -531,9 +531,9 @@ groups:
         - "aio/content/guide/deployment.md"
         - "aio/content/guide/releases.md"
         - "aio/content/guide/updating.md"
-      users:
-        - IgorMinar #primary
-        - alexeagle
-        - hansl
-        - mhevery #fallback
-        - jenniferfell #docs only
+    users:
+      - IgorMinar #primary
+      - alexeagle
+      - hansl
+      - mhevery #fallback
+      - jenniferfell #docs only

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -420,7 +420,7 @@ groups:
         - "aio/content/guide/service-worker-intro.md"
         - "aio/content/images/guide/service-worker/"
     users:
-      - gkalpak#primary
+      - gkalpak #primary
       - alxhub
       - IgorMinar
       - mhevery #fallback
@@ -499,25 +499,25 @@ groups:
       - mhevery #fallback
 
   docs/observables:
-      conditions:
-        files:
-          - "aio/content/examples/observables/"
-          - "aio/content/images/guide/observables/"
-          - "aio/content/guide/observables.md"
-          - "aio/content/guide/comparing-observables.md"
-          - "aio/content/examples/observables-in-angular/"
-          - "aio/content/images/guide/observables-in-angular/"
-          - "aio/content/guide/observables-in-angular.md"
-          - "aio/content/examples/practical-observable-usage/"
-          - "aio/content/guide/practical-observable-usage.md"
-          - "aio/content/examples/rx-library/"
-          - "aio/content/guide/rx-library.md"
-      users:
-        - jasonaden
-        - benlesh
-        - IgorMinar
-        - mhevery
-        - jenniferfell #docs only
+    conditions:
+      files:
+        - "aio/content/examples/observables/"
+        - "aio/content/images/guide/observables/"
+        - "aio/content/guide/observables.md"
+        - "aio/content/guide/comparing-observables.md"
+        - "aio/content/examples/observables-in-angular/"
+        - "aio/content/images/guide/observables-in-angular/"
+        - "aio/content/guide/observables-in-angular.md"
+        - "aio/content/examples/practical-observable-usage/"
+        - "aio/content/guide/practical-observable-usage.md"
+        - "aio/content/examples/rx-library/"
+        - "aio/content/guide/rx-library.md"
+    users:
+      - jasonaden
+      - benlesh
+      - IgorMinar
+      - mhevery
+      - jenniferfell #docs only
 
   docs/packaging:
     conditions:

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -8,6 +8,7 @@
 # alexeagle - Alex Eagle
 # alxhub - Alex Rickabaugh
 # andrewseguin - Andrew Seguin
+# benlesh - Ben Lesh
 # brandonroberts - Brandon Roberts
 # brocco - Mike Brocchi
 # filipesilva - Filipe Silva
@@ -15,7 +16,7 @@
 # hansl - Hans Larsen
 # IgorMinar - Igor Minar
 # jasonaden - Jason Aden
-# kapunahelewong - Kapunahele Wong
+# jenniferfell - Jennifer Fell
 # kara - Kara Erickson
 # kyliau - Keen Yee Liau
 # matsko - Matias Niemelä
@@ -91,6 +92,7 @@ groups:
           - "*.bzl"
           - "packages/bazel/*"
           - "tools/bazel.rc"
+          - "/docs/BAZEL.md"
     users:
       - alexeagle #primary
       - kyliau
@@ -130,42 +132,113 @@ groups:
     conditions:
       files:
         - "packages/core/*"
+        - "aio/content/guide/bootstrapping.md"
+        - "aio/content/examples/bootstrapping/"
+        - "aio/content/guide/attribute-directives.md"
+        - "aio/content/examples/attribute-directives/"
+        - "aio/content/images/guide/attribute-directives/"
+        - "aio/content/guide/structural-directives.md"
+        - "aio/content/examples/structural-directives/"
+        - "aio/content/images/guide/structural-directives/"
+        - "aio/content/guide/dynamic-component-loader.md"
+        - "aio/content/examples/dynamic-component-loader/"
+        - "aio/content/images/guide/dynamic-component-loader/"
+        - "aio/content/guide/template-syntax.md"
+        - "aio/content/examples/template-syntax/"
+        - "aio/content/images/guide/template-syntax/"
+        - "aio/content/guide/dependency-injection.md"
+        - "aio/content/examples/dependency-injection/"
+        - "aio/content/images/guide/dependency-injection/"
+        - "aio/content/guide/dependency-injection-in-action.md"
+        - "aio/content/examples/dependency-injection-in-action/"
+        - "aio/content/images/guide/dependency-injection-in-action/"
+        - "aio/content/guide/hierarchical-dependency-injection.md"
+        - "aio/content/examples/hierarchical-dependency-injection/"
+        - "aio/content/guide/singleton-services.md"
+        - "aio/content/guide/dependency-injection-pattern.md"
+        - "aio/content/guide/providers.md"
+        - "aio/content/examples/providers/"
+        - "aio/content/guide/component-interaction.md"
+        - "aio/content/examples/component-interaction/"
+        - "aio/content/images/guide/component-interaction/"
+        - "aio/content/guide/component-styles.md"
+        - "aio/content/examples/component-styles/"
+        - "aio/content/guide/lifecycle-hooks.md"
+        - "aio/content/examples/lifecycle-hooks/"
+        - "aio/content/images/guide/lifecycle-hooks/"
+        - "aio/content/examples/ngcontainer/"
+        - "aio/content/images/guide/ngcontainer/"
+        - "aio/content/guide/pipes.md"
+        - "aio/content/examples/pipes/"
+        - "aio/content/images/guide/pipes/"
+        - "aio/content/guide/entry-components.md"
+        - "aio/content/guide/set-document-title.md"
+        - "aio/content/examples/set-document-title/"
+        - "aio/content/images/guide/set-document-title/"
+        - "aio/content/guide/ngmodules.md"
+        - "aio/content/examples/ngmodules/"
+        - "aio/content/examples/ngmodule/"
+        - "aio/content/images/guide/ngmodule/"
+        - "aio/content/guide/ngmodule-faq.md"
+        - "aio/content/examples/ngmodule-faq/"
+        - "aio/content/guide/module-types.md"
+        - "aio/content/guide/sharing-ngmodules.md"
+        - "aio/content/guide/frequent-ngmodules.md"
+        - "aio/content/images/guide/frequent-ngmodules/"
+        - "aio/content/guide/ngmodule-api.md"
+        - "aio/content/guide/ngmodule-vs-jsmodule.md"
+        - "aio/content/guide/feature-modules.md"
+        - "aio/content/examples/feature-modules/"
+        - "aio/content/images/guide/feature-modules/"
+        - "aio/content/guide/lazy-loading-ngmodules.md"
+        - "aio/content/examples/lazy-loading-ngmodules/"
+        - "aio/content/images/guide/lazy-loading-ngmodules
     users:
       - mhevery #primary
       - jasonaden
       - kara
       - vicb
-      - IgorMinar #fallback
+      - IgorMinar
+      - jenniferfell #docs only
 
   animations:
     conditions:
       files:
         - "packages/animations/*"
         - "packages/platform-browser/animations/*"
+        - "aio/content/guide/animations.md"
+        - "aio/content/examples/animations/"
+        - "aio/content/images/guide/animations/"
     users:
       - matsko #primary
       - mhevery #fallback
       - IgorMinar #fallback
+      - jenniferfell #docs only
 
   compiler/i18n:
     conditions:
       files:
         - "packages/compiler/src/i18n/*"
+        - "aio/content/guide/i18n.md"
+        - "aio/content/examples/i18n/"
     users:
       - vicb #primary
       - alxhub
       - IgorMinar #fallback
       - mhevery #fallback
+      - jenniferfell #docs only
 
   compiler:
     conditions:
       files:
         - "packages/compiler/*"
+        - "aio/content/guide/aot-compiler.md"
     users:
       - alxhub #primary
       - vicb
       - mhevery
       - IgorMinar #fallback
+      - jenniferfell #docs only
 
   compiler-cli/ngtools:
     conditions:
@@ -174,7 +247,6 @@ groups:
     users:
       - hansl
       - filipesilva #fallback
-      - brocco #fallback
       - IgorMinar #fallback
 
   compiler-cli:
@@ -210,56 +282,97 @@ groups:
       files:
         - "packages/forms/*"
         - "aio/content/guide/forms.md"
+        - "aio/content/examples/forms/"
+        - "aio/content/images/guide/forms/"
         - "aio/content/guide/form-validation.md"
+        - "aio/content/examples/form-validation/"
+        - "aio/content/images/guide/form-validation/"
+        - "aio/content/guide/dynamic-form.md"
+        - "aio/content/examples/dynamic-form/"
+        - "aio/content/images/guide/dynamic-form/"
         - "aio/content/guide/reactive-forms.md"
-        - "aio/content/examples/forms/*"
-        - "aio/content/examples/form-validation/*"
-        - "aio/content/examples/reactive-forms/*"
+        - "aio/content/examples/reactive-forms/"
+        - "aio/content/images/guide/reactive-forms/"
     users:
       - kara #primary
       - IgorMinar #fallback
       - mhevery #fallback
+      - jenniferfell #docs only
 
   http:
     conditions:
       files:
         - "packages/common/http/*"
         - "packages/http/*"
+        - "aio/content/guide/http.md"
+        - "aio/content/examples/http/"
+        - "aio/content/images/guide/http/"
     users:
       - alxhub #primary
       - IgorMinar
       - mhevery #fallback
+      - jenniferfell #docs only
 
   language-service:
     conditions:
       files:
         - "packages/language-service/*"
+        - "aio/content/guide/language-service.md"
+        - "aio/content/images/guide/language-service/"
     users:
       - kyliau #primary
       # needs secondary
       - vicb
       - IgorMinar #fallback
       - mhevery #fallback
+      - jenniferfell #docs only
 
   router:
     conditions:
       files:
         - "packages/router/*"
+        - "aio/content/guide/router.md"
+        - "aio/content/examples/router/"
+        - "aio/content/images/guide/router/"
     users:
       - jasonaden #primary
       - vicb
       - IgorMinar #fallback
       - mhevery #fallback
+      - jenniferfell #docs only
+
+  testing:
+    conditions:
+      files:
+        - "*/testing/*
+        - "aio/content/guide/testing.md"
+        - "aio/content/examples/testing/"
+        - "aio/content/images/guide/testing/"
+    users:
+      - vikerman
+      - IgorMinar #fallback
+      - mhevery #fallback
+      - jenniferfell #docs only
 
   upgrade:
     conditions:
       files:
         - "packages/upgrade/*"
+        - "aio/content/guide/upgrade.md"
+        - "aio/content/examples/upgrade-module/"
+        - "aio/content/images/guide/upgrade/"
+        - "aio/content/examples/upgrade-phonecat-1-typescript/"
+        - "aio/content/examples/upgrade-phonecat-2-hybrid/"
+        - "aio/content/examples/upgrade-phonecat-3-final/"
+        - "aio/content/guide/upgrade-performance.md"
+        - "aio/content/guide/ajs-quick-reference.md"
+        - "aio/content/examples/ajs-quick-reference/"
     users:
       - petebacondarwin #primary
       - gkalpak
       - IgorMinar #fallback
       - mhevery #fallback
+      - jenniferfell #docs only
 
   platform-browser:
     conditions:
@@ -275,12 +388,15 @@ groups:
     conditions:
       files:
         - "packages/platform-server/*"
+        - "aio/content/guide/universal.md"
+        - "aio/content/examples/universal/"
     users:
       - vikerman #primary
       - alxhub #secondary
       - vicb
       - IgorMinar #fallback
       - mhevery #fallback
+      - jenniferfell #docs only
 
   platform-webworker:
     conditions:
@@ -296,22 +412,34 @@ groups:
     conditions:
       files:
         - "packages/service-worker/*"
+        - "aio/content/guide/service-worker-getting-started.md"
+        - "aio/content/examples/service-worker-getting-started/"
+        - "aio/content/guide/service-worker-communications.md"
+        - "aio/content/guide/service-worker-config.md"
+        - "aio/content/guide/service-worker-devops.md"
+        - "aio/content/guide/service-worker-intro.md"
+        - "aio/content/images/guide/service-worker/"
     users:
-      - alxhub #primary
-      - gkalpak
-      - IgorMinar #fallback
+      - gkalpak#primary
+      - alxhub
+      - IgorMinar
       - mhevery #fallback
+      - jenniferfell #docs only
 
   elements:
     conditions:
       files:
         - "packages/elements/*"
+        - "aio/content/examples/elements/"
+        - "aio/content/images/guide/elements/"
+        - "aio/content/guide/elements.md"
     users:
       - andrewseguin #primary
       - gkalpak
       - robwormald
       - IgorMinar #fallback
       - mhevery #fallback
+      - jenniferfell #docs only
 
   benchpress:
     conditions:
@@ -323,7 +451,7 @@ groups:
       - IgorMinar #fallback
       - mhevery #fallback
 
-  angular.io:
+  docs-infra:
     conditions:
       files:
         include:
@@ -336,7 +464,7 @@ groups:
       - gkalpak
       - mhevery #fallback
 
-  angular.io-guide-and-tutorial:
+  docs/guide-and-tutorial:
     conditions:
       files:
         include:
@@ -346,19 +474,20 @@ groups:
           - "aio/content/navigation.json"
           - "aio/content/license.md"
     users:
-      - kapunahelewong
       - stephenfluin
+      - jenniferfell
+      - brandonroberts
       - petebacondarwin
       - gkalpak
       - IgorMinar
-      - brandonroberts
       - mhevery #fallback
 
-  angular.io-marketing:
+  docs/marketing:
     conditions:
       files:
         include:
           - "aio/content/marketing/*"
+          - "aio/content/images/marketing/*"
           - "aio/content/navigation.json"
           - "aio/content/license.md"
     users:
@@ -368,3 +497,43 @@ groups:
       - IgorMinar
       - robwormald
       - mhevery #fallback
+
+  docs/observables:
+      conditions:
+        files:
+          - "aio/content/examples/observables/"
+          - "aio/content/images/guide/observables/"
+          - "aio/content/guide/observables.md"
+          - "aio/content/guide/comparing-observables.md"
+          - "aio/content/examples/observables-in-angular/"
+          - "aio/content/images/guide/observables-in-angular/"
+          - "aio/content/guide/observables-in-angular.md"
+          - "aio/content/examples/practical-observable-usage/"
+          - "aio/content/guide/practical-observable-usage.md"
+          - "aio/content/examples/rx-library/"
+          - "aio/content/guide/rx-library.md"
+      users:
+        - jasonaden
+        - benlesh
+        - IgorMinar
+        - mhevery
+        - jenniferfell #docs only
+
+  docs/packaging:
+    conditions:
+      files:
+        - "aio/content/guide/npm-packages.md"
+        - "aio/content/guide/browser-support.md"
+        - "aio/content/guide/typescript-configuration.md"
+        - "aio/content/guide/setup-systemjs-anatomy.md"
+        - "aio/content/examples/setup/"
+        - "aio/content/guide/setup.md"
+        - "aio/content/guide/deployment.md"
+        - "aio/content/guide/releases.md"
+        - "aio/content/guide/updating.md"
+      users:
+        - IgorMinar #primary
+        - alexeagle
+        - hansl
+        - mhevery #fallback
+        - jenniferfell #docs only

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -192,7 +192,7 @@ groups:
         - "aio/content/images/guide/feature-modules/"
         - "aio/content/guide/lazy-loading-ngmodules.md"
         - "aio/content/examples/lazy-loading-ngmodules/"
-        - "aio/content/images/guide/lazy-loading-ngmodules
+        - "aio/content/images/guide/lazy-loading-ngmodules"
     users:
       - mhevery #primary
       - jasonaden


### PR DESCRIPTION
With this update to permissions the docs team can easily identify the technical reviewer for a particular doc, which should streamline the reviews.

I also added Jennifer into all groups that contain docs, so that she can approve changes that contain only editorial changes.

Closes #21692