### PR TITLE
[IVY] Fix `<ng-template>` and *-attribute parsing

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {MockDirectory, setup} from '@angular/compiler/test/aot/test_util';
+import {setup} from '@angular/compiler/test/aot/test_util';
 import {compile, expectEmit} from './mock_compile';
 
 describe('compiler compliance: template', () => {
@@ -53,7 +53,7 @@ describe('compiler compliance: template', () => {
     const template = `
       const $c0$ = ["ngFor","","ngForOf",""];
       function MyComponent_ul_li_div_Template_1(rf, ctx) {
-        
+
         if (rf & 1) {
           const $s$ = $i0$.ɵgV();
           $i0$.ɵE(0, "div");
@@ -68,7 +68,7 @@ describe('compiler compliance: template', () => {
           $i0$.ɵT(1);
           $i0$.ɵe();
         }
-        
+
         if (rf & 2) {
           const $inner1$ = ctx.$implicit;
           const $middle1$ = $i0$.ɵx().$implicit;
@@ -78,7 +78,7 @@ describe('compiler compliance: template', () => {
           $i0$.ɵt(1, $i0$.ɵi1(" ", $myComp1$.format($outer1$, $middle1$, $inner1$, $myComp1$.component), " "));
         }
       }
-            
+
       function MyComponent_ul_li_Template_1(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵE(0, "li");
@@ -90,7 +90,7 @@ describe('compiler compliance: template', () => {
           $i0$.ɵp(1, "ngForOf", $i0$.ɵb($myComp2$.items));
         }
       }
-      
+
       function MyComponent_ul_Template_0(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵE(0, "ul");
@@ -140,8 +140,8 @@ describe('compiler compliance: template', () => {
     };
 
     const template = `
-      const $c0$ = ["ngFor","","ngForOf",""];
-      
+      const $c0$ = ["ngFor", "", "ngForOf", ""];
+
       function MyComponent_span_Template_0(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵE(0, "span");
@@ -194,9 +194,9 @@ describe('compiler compliance: template', () => {
     };
 
     const template = `
-      const $c0$ = ["ngFor","","ngForOf",""];
-      const $c1$ = ["ngIf",""];
-      
+      const $c0$ = ["ngFor", "", "ngForOf", ""];
+      const $c1$ = ["ngIf", ""];
+
       function MyComponent_div_span_Template_1(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵE(0, "span");
@@ -210,7 +210,7 @@ describe('compiler compliance: template', () => {
           $i0$.ɵt(1, $i0$.ɵi2(" ", $i$, " - ", $item$, " "));
         }
       }
-      
+
       function MyComponent_div_Template_0(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵE(0, "div");
@@ -222,7 +222,7 @@ describe('compiler compliance: template', () => {
           $i0$.ɵp(1, "ngIf", $i0$.ɵb($app$.showing));
         }
       }
-      
+
       // ...
       template:function MyComponent_Template(rf, ctx){
         if (rf & 1) {
@@ -266,7 +266,7 @@ describe('compiler compliance: template', () => {
 
     // The template should look like this (where IDENT is a wild card for an identifier):
     const template = `
-      const $c0$ = ["ngFor","","ngForOf",""];
+      const $c0$ = ["ngFor", "", "ngForOf", ""];
       function MyComponent_div_div_div_Template_1(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵE(0, "div");
@@ -279,7 +279,7 @@ describe('compiler compliance: template', () => {
           $i0$.ɵt(1, $i0$.ɵi2(" ", $middle$.value, " - ", $myComp$.name, " "));
         }
       }
-            
+
       function MyComponent_div_div_Template_1(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵE(0, "div");
@@ -291,7 +291,7 @@ describe('compiler compliance: template', () => {
           $i0$.ɵp(1, "ngForOf", $i0$.ɵb($middle$.items));
         }
       }
-      
+
       function MyComponent_div_Template_0(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵE(0, "div");
@@ -318,4 +318,50 @@ describe('compiler compliance: template', () => {
     expectEmit(result.source, template, 'Incorrect template');
   });
 
+  it('should support <ng-template>', () => {
+    const files = {
+      app: {
+        'spec.ts': `
+              import {Component, NgModule} from '@angular/core';
+              import {CommonModule} from '@angular/common';
+
+              @Component({
+                selector: 'my-component',
+                template: \`
+                  <ng-template [boundAttr]="b" attr="l">
+                    some-content
+                  </ng-template>\`
+              })
+              export class MyComponent {}
+
+              @NgModule({declarations: [MyComponent], imports: [CommonModule]})
+              export class MyModule {}
+          `
+      }
+    };
+
+    const template = `
+      const $c0$ = ["attr", "", "boundAttr", ""];
+
+      function Template_0(rf, ctx) {
+        if (rf & 1) {
+          $i0$.ɵT(0, " some-content ");
+        }
+      }
+
+      // ...
+
+      template: function MyComponent_Template(rf, ctx) {
+        if (rf & 1) {
+          $i0$.ɵC(0, Template_0, null, $c0$);
+        }
+        if (rf & 2) {
+          $i0$.ɵp(0, "boundAttr", $i0$.ɵb(ctx.b));
+        }
+      }`;
+
+    const result = compile(files, angularFiles);
+
+    expectEmit(result.source, template, 'Incorrect template');
+  });
 });

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -9,10 +9,8 @@
 import {BindingType} from '../../src/expression_parser/ast';
 import {Lexer} from '../../src/expression_parser/lexer';
 import {Parser} from '../../src/expression_parser/parser';
-import {visitAll} from '../../src/ml_parser/ast';
 import {HtmlParser} from '../../src/ml_parser/html_parser';
 import {DEFAULT_INTERPOLATION_CONFIG} from '../../src/ml_parser/interpolation_config';
-import {ParseError} from '../../src/parse_util';
 import * as t from '../../src/render3/r3_ast';
 import {Render3ParseResult, htmlAstToRender3Ast} from '../../src/render3/r3_template_transform';
 import {BindingParser} from '../../src/template_parser/binding_parser';
@@ -281,6 +279,22 @@ describe('R3 template transform', () => {
       expectFromHtml('<ng-template let-a="b"></ng-template>').toEqual([
         ['Template'],
         ['Variable', 'a', 'b'],
+      ]);
+    });
+
+    it('should parse attributes', () => {
+      expectFromHtml('<ng-template k1="v1" k2="v2"></ng-template>').toEqual([
+        ['Template'],
+        ['TextAttribute', 'k1', 'v1'],
+        ['TextAttribute', 'k2', 'v2'],
+      ]);
+    });
+
+    it('should parse bound attributes', () => {
+      expectFromHtml('<ng-template [k1]="v1" [k2]="v2"></ng-template>').toEqual([
+        ['Template'],
+        ['BoundAttribute', BindingType.Property, 'k1', 'v1'],
+        ['BoundAttribute', BindingType.Property, 'k2', 'v2'],
       ]);
     });
   });

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -300,6 +300,15 @@ describe('R3 template transform', () => {
   });
 
   describe('inline templates', () => {
+    it('should support attribute and bound attributes', () => {
+      expectFromHtml('<div *ngFor="item of items"></div>').toEqual([
+        ['Template'],
+        ['BoundAttribute', BindingType.Property, 'ngFor', 'item'],
+        ['BoundAttribute', BindingType.Property, 'ngForOf', 'items'],
+        ['Element', 'div'],
+      ]);
+    });
+
     it('should parse variables via let ...', () => {
       expectFromHtml('<div *ngIf="let a=b"></div>').toEqual([
         ['Template'],
@@ -312,7 +321,6 @@ describe('R3 template transform', () => {
     it('should parse variables via as ...', () => {
       expectFromHtml('<div *ngIf="expr as local"></div>').toEqual([
         ['Template'],
-        ['TextAttribute', 'ngIf', 'expr '],
         ['BoundAttribute', BindingType.Property, 'ngIf', 'expr'],
         ['Variable', 'local', 'ngIf'],
         ['Element', 'div'],
@@ -439,7 +447,6 @@ describe('R3 template transform', () => {
 
     it('should parse ngProjectAs as an attribute', () => {
       const res = parse('<ng-content ngProjectAs="a"></ng-content>');
-      const selectors = [''];
       expect(res.hasNgContent).toEqual(true);
       expect(res.ngContentSelectors).toEqual([]);
       expectFromR3Nodes(res.nodes).toEqual([


### PR DESCRIPTION
2 issues fixed in this PR:
- in r3_template_transform: with `'<div *ngIf="expr as local"></div>'` `ngIf` was reported as both a TextAttribute and a BoundProperty
- in the template compiler, bound property on `<ng-template>` were not taken into account to match directive. That is `<ng-template [ngIf]=cond>` would not trigger the `NgIf` directive.