### PR TITLE
feat(compiler): adding default encapsulation option

### DIFF
--- a/aio/content/guide/aot-compiler.md
+++ b/aio/content/guide/aot-compiler.md
@@ -248,6 +248,17 @@ for experimentation and testing of Render3 style code generation.
 
 *Note*: Is it not recommended to use this option as it is not yet feature complete with the Render2 code generation.
 
+### defaultEncapsulation
+
+Enables setting a global default view encapsulation when using the AOT compiler.
+
+Valid values are: "None" | "Native" | "Emulated" | "ShadowDom"
+
+*(values extracted from @angular/core/ViewEncapsulation enum)*
+
+By default it will use "Emulated"
+
+
 
 ## Angular Metadata and AOT
 

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -194,6 +194,12 @@ export interface CompilerOptions extends ts.CompilerOptions {
    */
   enableIvy?: boolean|'ngtsc'|'tsc';
 
+  /**
+   * Enables setting a global default view encapsulation when using the AOT compiler.
+   * Valid values are: "None" | "Native" | "Emulated" | "ShadowDom"
+   * Defaults to "Emulated"
+   */
+  defaultEncapsulation?: 'None'|'Native'|'Emulated'|'ShadowDom';
   /** @internal */
   collectAllErrors?: boolean;
 }

--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -975,6 +975,7 @@ function getAotCompilerOptions(options: CompilerOptions): AotCompilerOptions {
     fullTemplateTypeCheck: options.fullTemplateTypeCheck,
     allowEmptyCodegenFiles: options.allowEmptyCodegenFiles,
     enableIvy: options.enableIvy,
+    defaultEncapsulation: options.defaultEncapsulation
   };
 }
 

--- a/packages/compiler/src/aot/compiler_factory.ts
+++ b/packages/compiler/src/aot/compiler_factory.ts
@@ -73,8 +73,23 @@ export function createAotCompiler(
     htmlParser = new I18NHtmlParser(
         new HtmlParser(), translations, options.i18nFormat, options.missingTranslation, console);
   }
+  let encapsulation: ViewEncapsulation;
+  switch (options.defaultEncapsulation) {
+    case 'None':
+      encapsulation = ViewEncapsulation.None;
+      break;
+    case 'Native':
+      encapsulation = ViewEncapsulation.Native;
+      break;
+    case 'ShadowDom':
+      encapsulation = ViewEncapsulation.ShadowDom;
+      break;
+    default:
+      encapsulation = ViewEncapsulation.Emulated;
+      break;
+  }
   const config = new CompilerConfig({
-    defaultEncapsulation: ViewEncapsulation.Emulated,
+    defaultEncapsulation: encapsulation,
     useJit: false,
     missingTranslation: options.missingTranslation,
     preserveWhitespaces: options.preserveWhitespaces,

--- a/packages/compiler/src/aot/compiler_options.ts
+++ b/packages/compiler/src/aot/compiler_options.ts
@@ -19,4 +19,5 @@ export interface AotCompilerOptions {
   allowEmptyCodegenFiles?: boolean;
   strictInjectionParameters?: boolean;
   enableIvy?: boolean|'ngtsc'|'tsc';
+  defaultEncapsulation?: 'None'|'Native'|'Emulated'|'ShadowDom';
 }

--- a/packages/compiler/test/aot/compiler_spec.ts
+++ b/packages/compiler/test/aot/compiler_spec.ts
@@ -613,6 +613,20 @@ describe('compiler (unbundled Angular)', () => {
     });
   });
 
+  xdescribe('ViewEncapsulation', () => {
+    // how do i run these tests?
+    it('should support default view encapsulation', () => {
+      const {genFiles} = compile([ENCAPSULATED, angularFiles], {defaultEncapsulation: 'None'});
+      const file = genFiles.find(f => /app\.component\.ts/.test(f.genFileUrl));
+      expect(/_nghost-/.test(file.source !)).toBe(false);
+    });
+    it('should support Emulated encapsulation for the child component', () => {
+      const {genFiles} = compile([ENCAPSULATED, angularFiles], {defaultEncapsulation: 'None'});
+      const file = genFiles.find(f => /app\.child\.component\.ts/.test(f.genFileUrl));
+      expect(/_nghost-/.test(file.source !)).toBe(true);
+    });
+  });
+
   function inheritanceWithSummariesSpecs(getAngularSummaryFiles: () => MockDirectory) {
     function compileParentAndChild(
         {parentClassDecorator, parentModuleDecorator, childClassDecorator, childModuleDecorator}: {
@@ -915,6 +929,20 @@ describe('compiler (bundled Angular)', () => {
     });
   });
 
+  xdescribe('ViewEncapsulation', () => {
+    // how do i run these tests?
+    it('should support default view encapsulation', () => {
+      const {genFiles} = compile([ENCAPSULATED, angularFiles], {defaultEncapsulation: 'None'});
+      const file = genFiles.find(f => /app\.component\.ts/.test(f.genFileUrl));
+      expect(/_nghost-/.test(file.source !)).toBe(false);
+    });
+    it('should support Emulated encapsulation for the child component', () => {
+      const {genFiles} = compile([ENCAPSULATED, angularFiles], {defaultEncapsulation: 'None'});
+      const file = genFiles.find(f => /app\.child\.component\.ts/.test(f.genFileUrl));
+      expect(/_nghost-/.test(file.source !)).toBe(true);
+    });
+  });
+
   describe('Bundled library', () => {
     let libraryFiles: MockDirectory;
 
@@ -954,6 +982,46 @@ describe('compiler (bundled Angular)', () => {
     it('should compile', () => compile([LIBRARY_USING_APP, libraryFiles, angularFiles]));
   });
 });
+
+const ENCAPSULATED: MockDirectory = {
+  encapsulation: {
+    app: {
+      'app.component.ts': `
+        import {Component} from '@angular/core';
+        @Component({
+          template: '<app-child-component></app-child-component>',
+          styles: 'h1 { font-size: 16px };'
+        })
+        export class AppComponent { }
+      `,
+      'app.child.component.ts': `
+        import {Component, ViewEncapsulation} from '@angular/core';
+        @Component({
+          selector:'app-child-component'
+          template: '<h1>Hello {{name}}</h1>',
+          styles: 'h1 { font-size: 14px };',
+          encapsulation: ViewEncapsulation.Emulated
+        })
+        export class AppChildComponent {
+          name = 'Angular';
+        }
+      `,
+      'app.module.ts': `
+        import { NgModule } from '@angular/core';
+        import { toString } from './utils';
+
+        import { AppComponent }  from './app.component';
+        import { AppChildComponent }  from './app.child.component';
+
+        @NgModule({
+          declarations: [ AppComponent, AppChildComponent ],
+          bootstrap:    [ AppComponent ]
+        })
+        export class AppModule { }
+      `
+    }
+  }
+};
 
 
 const QUICKSTART: MockDirectory = {


### PR DESCRIPTION
allows setting default encapsulation to aot compiler thru tsconfig.json

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

_related to the tests, i've written a very poor spec of what it should do, although i don't know how to run those tests, , see_ 

> packages\compiler\test\aot\compiler_spec.ts ->  describe(ViewEncapsulation)

_**i would happily write them, if someone can give me a little guidance**_

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, there is not way of having a similar behavior as the default encapsulation used in the platformBrowserDynamic bootstraping (used by the JIT compiler)
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/12251


## What is the new behavior?
It allows the developer to set a global encapsulation when using the AOT compiler, to mimic the JIT compiler, by adding a new option on the angularCompilerOptions in the tsconfig.json file 


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
In the linked issue, it says the team is considering adding the defaultEncapsulation at the module level, which i think is great, the module level is great for "external" modules (for example, it could be used by any of the material modules, or any other component-based module for that matter).
if and when that feature is developed, it wont collide with this PR, neither would make it obsolete, i think there are use cases for projects to define a global encapsulation, which would be overwritten  by Component/NgModule level encapsulation


## Unrelated?
I don't think it got broken by this change, or if its the spec, but i could not inherit the angularCompilerOptions value from an extended tsconfig file

Say i have **tsconfig.child.json**, which extends **tsconfig.json**
if i set any value under **angularCompilerOptions** on **tsconfig.json**, and try to compile using the **tsconfig.child.json** config, i do not get those options _(i realized this while debugging, although i might be mistaken)_
