### PR TITLE
Misc updates / refactoring

### DIFF
--- a/packages/compiler-cli/src/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/rendering/renderer_spec.ts
@@ -123,7 +123,7 @@ describe('Renderer', () => {
              .toBe(analyzedFile.analyzedClasses[0]);
          expect(renderer.addDefinitions.calls.first().args[2])
              .toEqual(
-                 `A.ngDirectiveDef = ɵngcc0.ɵdefineDirective({ type: A, selectors: [["", "a", ""]], factory: function A_Factory() { return new A(); } });`);
+                 `A.ngDirectiveDef = ɵngcc0.ɵdefineDirective({ type: A, selectors: [["", "a", ""]], factory: function A_Factory() { return new A(); }, features: [ɵngcc0.ɵPublicFeature] });`);
        });
 
     it('should call removeDecorators with the source code, a map of class decorators that have been analyzed',

--- a/packages/compiler-cli/test/compliance/mock_compile.ts
+++ b/packages/compiler-cli/test/compliance/mock_compile.ts
@@ -74,8 +74,14 @@ export function expectEmit(
       const m = source.match(regexp);
       const expectedPiece = pieces[i - 1] == IDENTIFIER ? '<IDENT>' : pieces[i - 1];
       if (!m) {
+        // display at most `contextLength` characters of the line preceding the error location
+        const contextLength = 50;
+        const fullContext = source.substring(source.lastIndexOf('\n', last) + 1, last);
+        const context = fullContext.length > contextLength ?
+            `...${fullContext.substr(-contextLength)}` :
+            fullContext;
         fail(
-            `${description}: Expected to find ${expectedPiece} '${source.substr(0,last)}[<---HERE expected "${expectedPiece}"]${source.substr(last)}'`);
+            `${description}: Failed to find "${expectedPiece}" after "${context}" in:\n'${source.substr(0,last)}[<---HERE expected "${expectedPiece}"]${source.substr(last)}'`);
         return;
       } else {
         last = (m.index || 0) + m[0].length;

--- a/packages/compiler-cli/test/compliance/mock_compiler_spec.ts
+++ b/packages/compiler-cli/test/compliance/mock_compiler_spec.ts
@@ -7,7 +7,7 @@
  */
 
 
-import {MockDirectory, setup} from '@angular/compiler/test/aot/test_util';
+import {setup} from '@angular/compiler/test/aot/test_util';
 import {compile, expectEmit} from './mock_compile';
 
 describe('mock_compiler', () => {

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {InitialStylingFlags} from '@angular/compiler/src/core';
-import {MockDirectory, setup} from '@angular/compiler/test/aot/test_util';
+import {setup} from '@angular/compiler/test/aot/test_util';
 import {compile, expectEmit} from './mock_compile';
 
 
@@ -333,9 +333,11 @@ describe('compiler compliance', () => {
         const _c1 = ["background-color"];
         …
         MyComponent.ngComponentDef = i0.ɵdefineComponent({type:MyComponent,selectors:[["my-component"]],
-            factory:function MyComponent_Factory(){
+            factory: function MyComponent_Factory(){
               return new MyComponent();
-            },template:function MyComponent_Template(rf,ctx){
+            },
+            features: [$r3$.ɵPublicFeature],
+            template:function MyComponent_Template(rf,ctx){
               if (rf & 1) {
                 $r3$.ɵE(0, "div");
                 $r3$.ɵs(_c0, _c1);
@@ -387,6 +389,7 @@ describe('compiler compliance', () => {
           type: ChildComponent,
           selectors: [["child"]],
           factory: function ChildComponent_Factory() { return new ChildComponent(); },
+          features: [$r3$.ɵPublicFeature],
           template: function ChildComponent_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵT(0, "child-view");
@@ -399,7 +402,8 @@ describe('compiler compliance', () => {
         SomeDirective.ngDirectiveDef = $r3$.ɵdefineDirective({
           type: SomeDirective,
           selectors: [["", "some-directive", ""]],
-          factory: function SomeDirective_Factory() {return new SomeDirective(); }
+          factory: function SomeDirective_Factory() {return new SomeDirective(); },
+          features: [$r3$.ɵPublicFeature]
         });
       `;
 
@@ -411,6 +415,7 @@ describe('compiler compliance', () => {
           type: MyComponent,
           selectors: [["my-component"]],
           factory: function MyComponent_Factory() { return new MyComponent(); },
+          features: [$r3$.ɵPublicFeature],
           template: function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵEe(0, "child", $c1$);
@@ -453,7 +458,8 @@ describe('compiler compliance', () => {
         SomeDirective.ngDirectiveDef = $r3$.ɵdefineDirective({
           type: SomeDirective,
           selectors: [["div", "some-directive", "", 8, "foo", 3, "title", "", 9, "baz"]],
-          factory: function SomeDirective_Factory() {return new SomeDirective(); }
+          factory: function SomeDirective_Factory() {return new SomeDirective(); },
+          features: [$r3$.ɵPublicFeature]
         });
       `;
 
@@ -462,7 +468,8 @@ describe('compiler compliance', () => {
         OtherDirective.ngDirectiveDef = $r3$.ɵdefineDirective({
           type: OtherDirective,
           selectors: [["", 5, "span", "title", "", 9, "baz"]],
-          factory: function OtherDirective_Factory() {return new OtherDirective(); }
+          factory: function OtherDirective_Factory() {return new OtherDirective(); },
+          features: [$r3$.ɵPublicFeature]
         });
       `;
 
@@ -497,7 +504,8 @@ describe('compiler compliance', () => {
           factory: function HostBindingDir_Factory() { return new HostBindingDir(); },
           hostBindings: function HostBindingDir_HostBindings(dirIndex, elIndex) {
             $r3$.ɵp(elIndex, "id", $r3$.ɵb($r3$.ɵd(dirIndex).dirId));
-          }
+          },
+          features: [$r3$.ɵPublicFeature]
         });
       `;
 
@@ -536,7 +544,8 @@ describe('compiler compliance', () => {
         IfDirective.ngDirectiveDef = $r3$.ɵdefineDirective({
           type: IfDirective,
           selectors: [["", "if", ""]],
-          factory: function IfDirective_Factory() { return new IfDirective($r3$.ɵinjectTemplateRef()); }
+          factory: function IfDirective_Factory() { return new IfDirective($r3$.ɵinjectTemplateRef()); },
+          features: [$r3$.ɵPublicFeature]
         });`;
       const MyComponentDefinition = `
         const $c1$ = ["foo", ""];
@@ -558,6 +567,7 @@ describe('compiler compliance', () => {
           type: MyComponent,
           selectors: [["my-component"]],
           factory: function MyComponent_Factory() { return new MyComponent(); },
+          features: [$r3$.ɵPublicFeature],
           template: function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵE(0, "ul", null, $c1$);
@@ -617,6 +627,7 @@ describe('compiler compliance', () => {
             type: MyApp,
             selectors: [["my-app"]],
             factory: function MyApp_Factory() { return new MyApp(); },
+            features: [$r3$.ɵPublicFeature],
             template: function MyApp_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵEe(0, "my-comp");
@@ -696,6 +707,7 @@ describe('compiler compliance', () => {
             type: MyApp,
             selectors: [["my-app"]],
             factory: function MyApp_Factory() { return new MyApp(); },
+            features: [$r3$.ɵPublicFeature],
             template: function MyApp_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵEe(0, "my-comp");
@@ -757,6 +769,7 @@ describe('compiler compliance', () => {
             type: MyApp,
             selectors: [["my-app"]],
             factory: function MyApp_Factory() { return new MyApp(); },
+            features: [$r3$.ɵPublicFeature],
             template: function MyApp_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵEe(0, "object-comp");
@@ -822,6 +835,7 @@ describe('compiler compliance', () => {
             type: MyApp,
             selectors: [["my-app"]],
             factory: function MyApp_Factory() { return new MyApp(); },
+            features: [$r3$.ɵPublicFeature],
             template: function MyApp_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵEe(0, "nested-comp");
@@ -879,6 +893,7 @@ describe('compiler compliance', () => {
           type: SimpleComponent,
           selectors: [["simple"]],
           factory: function SimpleComponent_Factory() { return new SimpleComponent(); },
+          features: [$r3$.ɵPublicFeature],
           template: function SimpleComponent_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵpD();
@@ -899,6 +914,7 @@ describe('compiler compliance', () => {
           type: ComplexComponent,
           selectors: [["complex"]],
           factory: function ComplexComponent_Factory() { return new ComplexComponent(); },
+          features: [$r3$.ɵPublicFeature],
           template: function ComplexComponent_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵpD($c1$, $c2$);
@@ -964,6 +980,7 @@ describe('compiler compliance', () => {
             type: ViewQueryComponent,
             selectors: [["view-query-component"]],
             factory: function ViewQueryComponent_Factory() { return new ViewQueryComponent(); },
+            features: [$r3$.ɵPublicFeature],
             viewQuery: function ViewQueryComponent_Query(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵQ(0, SomeDirective, true);
@@ -1028,17 +1045,18 @@ describe('compiler compliance', () => {
             selectors: [["content-query-component"]],
             factory: function ContentQueryComponent_Factory() {
               return new ContentQueryComponent();
-            },            
+            },
             contentQueries: function ContentQueryComponent_ContentQueries() {
               $r3$.ɵQr($r3$.ɵQ(null, SomeDirective, true));
               $r3$.ɵQr($r3$.ɵQ(null, SomeDirective, false));
             },
-            contentQueriesRefresh: function ContentQueryComponent_ContentQueriesRefresh(dirIndex, queryStartIndex) {  
+            contentQueriesRefresh: function ContentQueryComponent_ContentQueriesRefresh(dirIndex, queryStartIndex) {
               const instance = $r3$.ɵd(dirIndex);
               var $tmp$;
               ($r3$.ɵqR(($tmp$ = $r3$.ɵql(queryStartIndex))) && ($instance$.someDir = $tmp$.first));
               ($r3$.ɵqR(($tmp$ = $r3$.ɵql((queryStartIndex + 1)))) && ($instance$.someDirList = $tmp$));
             },
+            features: [$r3$.ɵPublicFeature],
             template: function ContentQueryComponent_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵpD();
@@ -1098,8 +1116,12 @@ describe('compiler compliance', () => {
 
       it('should render pipes', () => {
         const MyPipeDefinition = `
-            MyPipe.ngPipeDef = $r3$.ɵdefinePipe(
-                {name: "myPipe", type: MyPipe, factory: function MyPipe_Factory() { return new MyPipe(); }, pure: false});
+            MyPipe.ngPipeDef = $r3$.ɵdefinePipe({
+              name: "myPipe",
+              type: MyPipe,
+              factory: function MyPipe_Factory() { return new MyPipe(); },
+              pure: false
+            });
         `;
 
         const MyPurePipeDefinition = `
@@ -1119,6 +1141,7 @@ describe('compiler compliance', () => {
               type: MyApp,
               selectors: [["my-app"]],
               factory: function MyApp_Factory() { return new MyApp(); },
+              features: [$r3$.ɵPublicFeature],
               template: function MyApp_Template(rf, ctx) {
                 if (rf & 1) {
                   $r3$.ɵT(0);
@@ -1169,6 +1192,7 @@ describe('compiler compliance', () => {
           type: MyComponent,
           selectors: [["my-component"]],
           factory: function MyComponent_Factory() { return new MyComponent(); },
+          features: [$r3$.ɵPublicFeature],
           template: function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵEe(0, "input", null, $c1$);
@@ -1260,6 +1284,7 @@ describe('compiler compliance', () => {
           type: MyComponent,
           selectors: [["my-component"]],
           factory: function MyComponent_Factory() { return new MyComponent(); },
+          features: [$r3$.ɵPublicFeature],
           template: function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵEe(0, "div", null, $c1$);
@@ -1310,7 +1335,7 @@ describe('compiler compliance', () => {
       const $c0$ = ["ngFor","","ngForOf",""];
       const $c1$ = ["foo", ""];
       const $c2$ = ["ngIf",""];
-      
+
       function MyComponent_div_span_Template_3(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵE(0, "span");
@@ -1323,7 +1348,7 @@ describe('compiler compliance', () => {
           $i0$.ɵt(1, $i0$.ɵi2(" ", $foo$, " - ", $item$, " "));
         }
       }
-      
+
       function MyComponent_div_Template_0(rf, ctx) {
         if (rf & 1) {
           $i0$.ɵE(0, "div");
@@ -1336,7 +1361,7 @@ describe('compiler compliance', () => {
           $i0$.ɵp(3, "ngIf", $i0$.ɵb($app$.showing));
         }
       }
-      
+
       // ...
       template:function MyComponent_Template(rf, ctx){
         if (rf & 1) {
@@ -1403,7 +1428,7 @@ describe('compiler compliance', () => {
             selectors: [["lifecycle-comp"]],
             factory: function LifecycleComp_Factory() { return new LifecycleComp(); },
             inputs: {nameMin: "name"},
-            features: [$r3$.ɵNgOnChangesFeature],
+            features: [$r3$.ɵPublicFeature, $r3$.ɵNgOnChangesFeature],
             template: function LifecycleComp_Template(rf, ctx) {}
           });`;
 
@@ -1412,6 +1437,7 @@ describe('compiler compliance', () => {
             type: SimpleLayout,
             selectors: [["simple-layout"]],
             factory: function SimpleLayout_Factory() { return new SimpleLayout(); },
+            features: [$r3$.ɵPublicFeature],
             template: function SimpleLayout_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵEe(0, "lifecycle-comp");
@@ -1519,7 +1545,7 @@ describe('compiler compliance', () => {
                 factory: function ForOfDirective_Factory() {
                   return new ForOfDirective($r3$.ɵinjectViewContainerRef(), $r3$.ɵinjectTemplateRef());
                 },
-                features: [$r3$.ɵNgOnChangesFeature],
+                features: [$r3$.ɵPublicFeature, $r3$.ɵNgOnChangesFeature],
                 inputs: {forOf: "forOf"}
               });
             `;
@@ -1539,6 +1565,7 @@ describe('compiler compliance', () => {
                 type: MyComponent,
                 selectors: [["my-component"]],
                 factory: function MyComponent_Factory() { return new MyComponent(); },
+                features: [$r3$.ɵPublicFeature],
                 template: function MyComponent_Template(rf, ctx){
                   if (rf & 1) {
                     $r3$.ɵNS();
@@ -1592,7 +1619,7 @@ describe('compiler compliance', () => {
             factory: function ForOfDirective_Factory() {
               return new ForOfDirective($r3$.ɵinjectViewContainerRef(), $r3$.ɵinjectTemplateRef());
             },
-            features: [$r3$.ɵNgOnChangesFeature],
+            features: [$r3$.ɵPublicFeature, $r3$.ɵNgOnChangesFeature],
             inputs: {forOf: "forOf"}
           });
         `;
@@ -1615,6 +1642,7 @@ describe('compiler compliance', () => {
             type: MyComponent,
             selectors: [["my-component"]],
             factory: function MyComponent_Factory() { return new MyComponent(); },
+            features: [$r3$.ɵPublicFeature],
             template: function MyComponent_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵE(0, "ul");
@@ -1688,7 +1716,7 @@ describe('compiler compliance', () => {
               $r3$.ɵt(1, $r3$.ɵi2(" ", $item$.name, ": ", $info$.description, " "));
             }
           }
-          
+
           function MyComponent_li_Template_1(rf, ctx) {
             if (rf & 1) {
               $r3$.ɵE(0, "li");
@@ -1706,12 +1734,13 @@ describe('compiler compliance', () => {
               $r3$.ɵp(4, "forOf", $r3$.ɵb(IDENT.infos));
             }
           }
-         
+
           …
           MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
             type: MyComponent,
             selectors: [["my-component"]],
             factory: function MyComponent_Factory() { return new MyComponent(); },
+            features: [$r3$.ɵPublicFeature],
             template: function MyComponent_Template(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵE(0, "ul");

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
@@ -71,7 +71,7 @@ describe('compiler compliance: listen()', () => {
                     <div (click)="onClick(foo)"></div>
                     <button (click)="onClick2(bar)"></button>
                   </div>
-                  
+
                 \`
               })
               export class MyComponent {
@@ -87,7 +87,7 @@ describe('compiler compliance: listen()', () => {
 
     const template = `
         const $c0$ = ["ngIf",""];
-        
+
         function MyComponent_div_Template_0(rf, ctx) {
           if (rf & 1) {
             const $s$ = $r3$.ɵgV();
@@ -132,7 +132,7 @@ describe('compiler compliance: listen()', () => {
             import {Component, NgModule} from '@angular/core';
 
             @Component({
-              selector: 'my-component', 
+              selector: 'my-component',
               template: \`
                 <button (click)="onClick(user.value)">Save</button>
                 <input #user>
@@ -153,9 +153,10 @@ describe('compiler compliance: listen()', () => {
           type: MyComponent,
           selectors: [["my-component"]],
           factory: function MyComponent_Factory() { return new MyComponent(); },
+          features: [$r3$.ɵPublicFeature],
           template: function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
-              $r3$.ɵE(0, "button"); 
+              $r3$.ɵE(0, "button");
                 $r3$.ɵL("click", function MyComponent_Template_button_click_listener($event) {
                    const $user$ = $r3$.ɵr(3);
                    return ctx.onClick($user$.value);

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -87,12 +87,13 @@ describe('compiler compliance: styling', () => {
          const template = `
           const _c0 = ["opacity","width","height",${InitialStylingFlags.VALUES_MODE},"opacity","1"];
           …
-          MyComponent.ngComponentDef = i0.ɵdefineComponent({
+          MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
               type: MyComponent,
               selectors:[["my-component"]],
               factory:function MyComponent_Factory(){
                 return new MyComponent();
               },
+              features: [$r3$.ɵPublicFeature],
               template: function MyComponent_Template(rf, $ctx$) {
                 if (rf & 1) {
                   $r3$.ɵE(0, "div");
@@ -143,21 +144,22 @@ describe('compiler compliance: styling', () => {
               }
           }
 
-          MyComponent.ngComponentDef = i0.ɵdefineComponent({
+          MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
             type: MyComponent,
             selectors: [["my-component"]],
             factory: function MyComponent_Factory() {
               return new MyComponent();
             },
+            features: [$r3$.ɵPublicFeature],
             template: function MyComponent_Template(rf, ctx) {
               if (rf & 1) {
-                i0.ɵE(0, "div");
-                i0.ɵs(null, _c0, i0.ɵzss);
-                i0.ɵe();
+                $r3$.ɵE(0, "div");
+                $r3$.ɵs(null, _c0, $r3$.ɵzss);
+                $r3$.ɵe();
               }
               if (rf & 2) {
-                i0.ɵsp(0, 0, ctx.myImage);
-                i0.ɵsa(0);
+                $r3$.ɵsp(0, 0, ctx.myImage);
+                $r3$.ɵsa(0);
               }
             }
           });
@@ -237,12 +239,13 @@ describe('compiler compliance: styling', () => {
          const template = `
           const _c0 = ["grape","apple","orange",${InitialStylingFlags.VALUES_MODE},"grape",true];
           …
-          MyComponent.ngComponentDef = i0.ɵdefineComponent({
+          MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
               type: MyComponent,
               selectors:[["my-component"]],
               factory:function MyComponent_Factory(){
                 return new MyComponent();
               },
+              features: [$r3$.ɵPublicFeature],
               template: function MyComponent_Template(rf, $ctx$) {
                 if (rf & 1) {
                   $r3$.ɵE(0, "div");
@@ -290,12 +293,13 @@ describe('compiler compliance: styling', () => {
           const _c0 = ["foo",${InitialStylingFlags.VALUES_MODE},"foo",true];
           const _c1 = ["width",${InitialStylingFlags.VALUES_MODE},"width","100px"];
           …
-          MyComponent.ngComponentDef = i0.ɵdefineComponent({
+          MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
               type: MyComponent,
               selectors:[["my-component"]],
               factory:function MyComponent_Factory(){
                 return new MyComponent();
               },
+              features: [$r3$.ɵPublicFeature],
               template: function MyComponent_Template(rf, $ctx$) {
                 if (rf & 1) {
                   $r3$.ɵE(0, "div");

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
@@ -319,7 +319,6 @@ describe('compiler compliance: template', () => {
       app: {
         'spec.ts': `
               import {Component, NgModule} from '@angular/core';
-              import {CommonModule} from '@angular/common';
 
               @Component({
                 selector: 'my-component',

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -158,6 +158,8 @@ export class Identifiers {
   static InheritDefinitionFeature:
       o.ExternalReference = {name: 'ɵInheritDefinitionFeature', moduleName: CORE};
 
+  static PublicFeature: o.ExternalReference = {name: 'ɵPublicFeature', moduleName: CORE};
+
   static listener: o.ExternalReference = {name: 'ɵL', moduleName: CORE};
 
   // Reserve slots for pure functions

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -67,6 +67,9 @@ function baseDirectiveFields(
   // e.g. `features: [NgOnChangesFeature]`
   const features: o.Expression[] = [];
 
+  // TODO: add `PublicFeature` so that directives get registered to the DI - make this configurable
+  features.push(o.importExpr(R3.PublicFeature));
+
   if (meta.usesInheritance) {
     features.push(o.importExpr(R3.InheritDefinitionFeature));
   }

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -17,19 +17,13 @@ export class EventListener {
  * @experimental All debugging apis are currently experimental.
  */
 export class DebugNode {
-  nativeNode: any;
-  listeners: EventListener[];
-  // TODO(issue/24571): remove '!'.
-  parent !: DebugElement | null;
+  listeners: EventListener[] = [];
+  parent: DebugElement|null = null;
 
-  constructor(nativeNode: any, parent: DebugNode|null, private _debugContext: DebugContext) {
-    this.nativeNode = nativeNode;
+  constructor(public nativeNode: any, parent: DebugNode|null, private _debugContext: DebugContext) {
     if (parent && parent instanceof DebugElement) {
       parent.addChild(this);
-    } else {
-      this.parent = null;
     }
-    this.listeners = [];
   }
 
   get injector(): Injector { return this._debugContext.injector; }
@@ -47,22 +41,16 @@ export class DebugNode {
  * @experimental All debugging apis are currently experimental.
  */
 export class DebugElement extends DebugNode {
-  // TODO(issue/24571): remove '!'.
   name !: string;
-  properties: {[key: string]: any};
-  attributes: {[key: string]: string | null};
-  classes: {[key: string]: boolean};
-  styles: {[key: string]: string | null};
-  childNodes: DebugNode[];
+  properties: {[key: string]: any} = {};
+  attributes: {[key: string]: string | null} = {};
+  classes: {[key: string]: boolean} = {};
+  styles: {[key: string]: string | null} = {};
+  childNodes: DebugNode[] = [];
   nativeElement: any;
 
   constructor(nativeNode: any, parent: any, _debugContext: DebugContext) {
     super(nativeNode, parent, _debugContext);
-    this.properties = {};
-    this.attributes = {};
-    this.classes = {};
-    this.styles = {};
-    this.childNodes = [];
     this.nativeElement = nativeNode;
   }
 

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -394,10 +394,6 @@ function isFactoryProvider(value: SingleProvider): value is FactoryProvider {
   return !!(value as FactoryProvider).useFactory;
 }
 
-function isClassProvider(value: SingleProvider): value is ClassProvider {
-  return !!(value as ClassProvider).useClass;
-}
-
 function isTypeProvider(value: SingleProvider): value is TypeProvider {
   return typeof value === 'function';
 }

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -99,7 +99,7 @@ export function renderComponent<T>(
   const componentDef =
       (componentType as ComponentType<T>).ngComponentDef as ComponentDefInternal<T>;
   if (componentDef.type != componentType) componentDef.type = componentType;
-  let component: T;
+
   // The first index of the first selector is the tag name.
   const componentTag = componentDef.selectors ![0] ![0] as string;
   const hostNode = locateHostElement(rendererFactory, opts.host || componentTag);
@@ -113,6 +113,7 @@ export function renderComponent<T>(
 
   const oldView = enterView(rootView, null !);
   let elementNode: LElementNode;
+  let component: T;
   try {
     if (rendererFactory.begin) rendererFactory.begin();
 
@@ -120,8 +121,8 @@ export function renderComponent<T>(
     elementNode = hostElement(componentTag, hostNode, componentDef, sanitizer);
 
     // Create directive instance with factory() and store at index 0 in directives array
-    rootContext.components.push(
-        component = baseDirectiveCreate(0, componentDef.factory(), componentDef) as T);
+    component = baseDirectiveCreate(0, componentDef.factory() as T, componentDef);
+    rootContext.components.push(component);
 
     (elementNode.data as LViewData)[CONTEXT] = component;
     initChangeDetectorIfExisting(elementNode.nodeInjector, component, elementNode.data !);

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -6,17 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {SimpleChange} from '../change_detection/change_detection_util';
 import {ChangeDetectionStrategy} from '../change_detection/constants';
 import {Provider} from '../core';
-import {OnChanges, SimpleChanges} from '../metadata/lifecycle_hooks';
 import {NgModuleDef, NgModuleDefInternal} from '../metadata/ng_module';
 import {RendererType2} from '../render/api';
 import {Type} from '../type';
 import {resolveRendererType2} from '../view/util';
 
-import {diPublic} from './di';
-import {BaseDef, ComponentDefFeature, ComponentDefInternal, ComponentQuery, ComponentTemplate, ComponentType, DirectiveDefFeature, DirectiveDefInternal, DirectiveDefListOrFactory, DirectiveType, DirectiveTypesOrFactory, PipeDefInternal, PipeType, PipeTypesOrFactory} from './interfaces/definition';
+import {BaseDef, ComponentDefFeature, ComponentDefInternal, ComponentQuery, ComponentTemplate, ComponentType, DirectiveDefFeature, DirectiveDefInternal, DirectiveType, DirectiveTypesOrFactory, PipeDefInternal, PipeType, PipeTypesOrFactory} from './interfaces/definition';
 import {CssSelectorList, SelectorFlags} from './interfaces/projection';
 
 

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -772,13 +772,9 @@ export function getOrCreateTemplateRef<T>(di: LInjector): viewEngine.TemplateRef
 }
 
 class TemplateRef<T> implements viewEngine.TemplateRef<T> {
-  readonly elementRef: viewEngine.ElementRef;
-
   constructor(
-      private _declarationParentView: LViewData, elementRef: viewEngine.ElementRef,
-      private _tView: TView, private _renderer: Renderer3, private _queries: LQueries|null) {
-    this.elementRef = elementRef;
-  }
+      private _declarationParentView: LViewData, readonly elementRef: viewEngine.ElementRef,
+      private _tView: TView, private _renderer: Renderer3, private _queries: LQueries|null) {}
 
   createEmbeddedView(context: T, containerNode?: LContainerNode, index?: number):
       viewEngine.EmbeddedViewRef<T> {

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -11,7 +11,6 @@ import {defineBase, defineComponent, defineDirective, defineNgModule, definePipe
 import {InheritDefinitionFeature} from './features/inherit_definition_feature';
 import {NgOnChangesFeature} from './features/ng_onchanges_feature';
 import {PublicFeature} from './features/public_feature';
-import {I18nExpInstruction, I18nInstruction, i18nExpMapping, i18nInterpolation1, i18nInterpolation2, i18nInterpolation3, i18nInterpolation4, i18nInterpolation5, i18nInterpolation6, i18nInterpolation7, i18nInterpolation8, i18nInterpolationV} from './i18n';
 import {ComponentDef, ComponentDefInternal, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefFlags, DirectiveDefInternal, DirectiveType, PipeDef} from './interfaces/definition';
 
 export {ComponentFactory, ComponentFactoryResolver, ComponentRef} from './component_ref';

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -12,7 +12,7 @@ import {Sanitizer} from '../../sanitization/security';
 
 import {LContainer} from './container';
 import {ComponentQuery, ComponentTemplate, DirectiveDefInternal, DirectiveDefList, PipeDefInternal, PipeDefList} from './definition';
-import {LContainerNode, LElementNode, LViewNode, TNode} from './node';
+import {LElementNode, LViewNode, TNode} from './node';
 import {LQueries} from './query';
 import {Renderer3} from './renderer';
 

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -32,6 +32,7 @@ export const angularCoreEnv: {[name: string]: Function} = {
   'ɵinjectTemplateRef': r3.injectTemplateRef,
   'ɵinjectViewContainerRef': r3.injectViewContainerRef,
   'ɵNgOnChangesFeature': r3.NgOnChangesFeature,
+  'ɵPublicFeature': r3.PublicFeature,
   'ɵInheritDefinitionFeature': r3.InheritDefinitionFeature,
   'ɵa': r3.a,
   'ɵb': r3.b,

--- a/packages/core/src/render3/jit/injectable.ts
+++ b/packages/core/src/render3/jit/injectable.ts
@@ -22,11 +22,9 @@ import {convertDependencies, reflectDependencies} from './util';
  * Compile an Angular injectable according to its `Injectable` metadata, and patch the resulting
  * `ngInjectableDef` onto the injectable type.
  */
-export function compileInjectable(type: Type<any>, meta?: Injectable): void {
-  // TODO(alxhub): handle JIT of bare @Injectable().
-  if (!meta) {
-    return;
-  }
+export function compileInjectable(type: Type<any>, srcMeta?: Injectable): void {
+  // Allow the compilation of a class with a `@Injectable()` decorator without parameters
+  const meta: Injectable = srcMeta || {providedIn: null};
 
   let def: any = null;
   Object.defineProperty(type, NG_INJECTABLE_DEF, {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -6,6 +6,9 @@
     "name": "BINDING_INDEX"
   },
   {
+    "name": "BLOOM_MASK"
+  },
+  {
     "name": "CLEAN_PROMISE"
   },
   {
@@ -45,6 +48,9 @@
     "name": "NEXT"
   },
   {
+    "name": "NG_ELEMENT_ID"
+  },
+  {
     "name": "NG_HOST_SYMBOL"
   },
   {
@@ -52,6 +58,9 @@
   },
   {
     "name": "PARENT"
+  },
+  {
+    "name": "PublicFeature"
   },
   {
     "name": "QUERIES"
@@ -96,6 +105,9 @@
     "name": "baseDirectiveCreate"
   },
   {
+    "name": "bloomAdd"
+  },
+  {
     "name": "callHooks"
   },
   {
@@ -138,6 +150,12 @@
     "name": "detectChangesInternal"
   },
   {
+    "name": "diPublic"
+  },
+  {
+    "name": "diPublicInInjector"
+  },
+  {
     "name": "domRendererFactory3"
   },
   {
@@ -168,10 +186,19 @@
     "name": "getLViewChild"
   },
   {
+    "name": "getOrCreateNodeInjector"
+  },
+  {
+    "name": "getOrCreateNodeInjectorForNode"
+  },
+  {
     "name": "getOrCreateTView"
   },
   {
     "name": "getParentLNode"
+  },
+  {
+    "name": "getPreviousOrParentNode"
   },
   {
     "name": "getRenderFlags"
@@ -205,6 +232,9 @@
   },
   {
     "name": "nativeInsertBefore"
+  },
+  {
+    "name": "nextNgElementId"
   },
   {
     "name": "readElementValue"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -120,6 +120,9 @@
     "name": "PARENT"
   },
   {
+    "name": "PublicFeature"
+  },
+  {
     "name": "QUERIES"
   },
   {
@@ -333,6 +336,9 @@
     "name": "bindingUpdated"
   },
   {
+    "name": "bloomAdd"
+  },
+  {
     "name": "bloomFindPossibleInjector"
   },
   {
@@ -433,6 +439,12 @@
   },
   {
     "name": "detectChangesInternal"
+  },
+  {
+    "name": "diPublic"
+  },
+  {
+    "name": "diPublicInInjector"
   },
   {
     "name": "directiveCreate"
@@ -739,6 +751,9 @@
   },
   {
     "name": "nextContext"
+  },
+  {
+    "name": "nextNgElementId"
   },
   {
     "name": "pointers"

--- a/packages/platform-browser-dynamic/src/compiler_reflector.ts
+++ b/packages/platform-browser-dynamic/src/compiler_reflector.ts
@@ -13,9 +13,8 @@ export const MODULE_SUFFIX = '';
 const builtinExternalReferences = createBuiltinExternalReferencesMap();
 
 export class JitReflector implements CompileReflector {
-  private reflectionCapabilities: ReflectionCapabilities;
-  private builtinExternalReferences = new Map<ExternalReference, any>();
-  constructor() { this.reflectionCapabilities = new ReflectionCapabilities(); }
+  private reflectionCapabilities: ReflectionCapabilities = new ReflectionCapabilities();
+
   componentModuleUrl(type: any, cmpMetadata: Component): string {
     const moduleId = cmpMetadata.moduleId;
 

--- a/packages/platform-browser-dynamic/testing/src/platform_core_dynamic_testing.ts
+++ b/packages/platform-browser-dynamic/testing/src/platform_core_dynamic_testing.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {COMPILER_OPTIONS, CompilerFactory, Injector, PlatformRef, StaticProvider, createPlatformFactory} from '@angular/core';
-import {TestComponentRenderer, ɵTestingCompilerFactory as TestingCompilerFactory} from '@angular/core/testing';
+import {COMPILER_OPTIONS, CompilerFactory, Injector, PlatformRef, createPlatformFactory} from '@angular/core';
+import {ɵTestingCompilerFactory as TestingCompilerFactory} from '@angular/core/testing';
 import {ɵplatformCoreDynamic as platformCoreDynamic} from '@angular/platform-browser-dynamic';
 
 import {COMPILER_PROVIDERS, TestingCompilerFactoryImpl} from './compiler_factory';

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -7,20 +7,17 @@
  */
 
 import {CommonModule, PlatformLocation, ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {APP_ID, ApplicationModule, ClassProvider, ConstructorSansProvider, ErrorHandler, ExistingProvider, FactoryProvider, Inject, InjectionToken, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, PlatformRef, RendererFactory2, RootRenderer, Sanitizer, SkipSelf, StaticProvider, Testability, TypeProvider, ValueProvider, createPlatformFactory, platformCore, ɵAPP_ROOT as APP_ROOT, ɵConsole as Console} from '@angular/core';
+import {APP_ID, ApplicationModule, ErrorHandler, Inject, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, PlatformRef, RendererFactory2, Sanitizer, SkipSelf, StaticProvider, Testability, createPlatformFactory, platformCore, ɵAPP_ROOT as APP_ROOT, ɵConsole as Console} from '@angular/core';
 
 import {BrowserDomAdapter} from './browser/browser_adapter';
 import {BrowserPlatformLocation} from './browser/location/browser_platform_location';
-import {Meta} from './browser/meta';
 import {SERVER_TRANSITION_PROVIDERS, TRANSITION_ID} from './browser/server-transition';
 import {BrowserGetTestability} from './browser/testability';
-import {Title} from './browser/title';
 import {ELEMENT_PROBE_PROVIDERS} from './dom/debug/ng_probe';
-import {getDOM} from './dom/dom_adapter';
 import {DomRendererFactory2} from './dom/dom_renderer';
 import {DOCUMENT} from './dom/dom_tokens';
 import {DomEventsPlugin} from './dom/events/dom_events';
-import {EVENT_MANAGER_PLUGINS, EventManager, EventManagerPlugin} from './dom/events/event_manager';
+import {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 import {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HammerGestureConfig, HammerGesturesPlugin} from './dom/events/hammer_gestures';
 import {KeyEventsPlugin} from './dom/events/key_events';
 import {DomSharedStylesHost, SharedStylesHost} from './dom/shared_styles_host';


### PR DESCRIPTION
The first commit add the `PublicFeature` to all directives (including components) so that it's possible to inject them by default. This behavior matches the View Engine behavior but should be made configurable later on to enable tree shaking when the app does not use any public directives.

