### PR TITLE
test(ivy): remove unnecessary common import

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
@@ -330,7 +330,7 @@ describe('compiler compliance: template', () => {
               })
               export class MyComponent {}
 
-              @NgModule({declarations: [MyComponent], imports: [CommonModule]})
+              @NgModule({declarations: [MyComponent]})
               export class MyModule {}
           `
       }


### PR DESCRIPTION
This PR fixes compliance tests in master (https://github.com/angular/angular/pull/25248 conflicted with https://github.com/angular/angular/pull/25272, but individually they passed tests).