### PR TITLE
build: skip ivy builds when not publishing

### DIFF
--- a/scripts/build-packages-dist.sh
+++ b/scripts/build-packages-dist.sh
@@ -25,13 +25,13 @@ echo "scripts/build-packages-dist.sh:"
 echo "  building @angular/* npm packages"
 echo "  mode: ${desc}"
 echo "##################################"
-  
+
   echo "$targets" | xargs bazel build --define=compile=$compileMode
-  
+
   [ -d "${basedir}/${destPath}" ] || mkdir -p $basedir/${destPath}
-  
+
   dirs=`echo "$targets" | grep '//packages/[^/]*:npm_package' | sed -e 's/\/\/packages\/\(.*\):npm_package/\1/'`
-  
+
   for pkg in $dirs; do
     # Skip any that don't have an "npm_package" target
     srcDir="${bin}/packages/${pkg}/npm_package"
@@ -50,10 +50,19 @@ echo "##################################"
 # Until then, we have to manually run bazel first to create the npm packages we
 # want to test.
 LEGACY_TARGETS=`bazel query --output=label 'kind(.*_package, //packages/...)'`
+buildTargetPackages "$LEGACY_TARGETS" "dist/packages-dist" "legacy" "Production"
+
+# We don't use the ivy build in the integration tests, only when publishing
+# snapshots.
+# This logic matches what we use in the .circleci/config.yml file to short-
+# circuit execution of the publish-packages job.
+[[  -v CIRCLE_PR_NUMBER
+    || "$CIRCLE_PROJECT_USERNAME" != "angular"
+    || "$CIRCLE_PROJECT_REPONAME" != "angular"
+]] && exit 0
+
 IVY_JIT_TARGETS=`bazel query --output=label 'attr("tags", "\[.*ivy-jit.*\]", //packages/...) intersect kind(".*_package", //packages/...)'`
 IVY_LOCAL_TARGETS=`bazel query --output=label 'attr("tags", "\[.*ivy-local.*\]", //packages/...) intersect kind(".*_package", //packages/...)'`
-
-buildTargetPackages "$LEGACY_TARGETS" "dist/packages-dist" "legacy" "Production"
 buildTargetPackages "$IVY_JIT_TARGETS" "dist/packages-dist-ivy-jit" "jit" "Ivy JIT"
 buildTargetPackages "$IVY_LOCAL_TARGETS" "dist/packages-dist-ivy-local" "local" "Ivy AOT"
 


### PR DESCRIPTION
The `build-packages-dist` job went from 19m to 54m because we build three different distros in sequence. Then we don't use two of them for PR builds anyway.