### PR TITLE
fix(router): mount correct component if router outlet was not instantiated and if using a route reuse strategy

### DIFF
--- a/packages/platform-browser/testing/BUILD.bazel
+++ b/packages/platform-browser/testing/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
     module_name = "@angular/platform-browser/testing",
     deps = [
         "//packages/core",
+        "//packages/core/testing",
         "//packages/platform-browser",
         "@rxjs",
     ],

--- a/packages/platform-browser/testing/rollup.config.js
+++ b/packages/platform-browser/testing/rollup.config.js
@@ -11,6 +11,7 @@ const sourcemaps = require('rollup-plugin-sourcemaps');
 
 const globals = {
   '@angular/core': 'ng.core',
+  '@angular/core/testing': 'ng.core.testing',
   '@angular/common': 'ng.common',
   '@angular/platform-browser': 'ng.platformBrowser'
 };

--- a/packages/platform-browser/testing/src/matchers.ts
+++ b/packages/platform-browser/testing/src/matchers.ts
@@ -7,8 +7,9 @@
  */
 
 
-import {ɵglobal as global} from '@angular/core';
-import {ɵgetDOM as getDOM} from '@angular/platform-browser';
+import {Type, ɵglobal as global} from '@angular/core';
+import {ComponentFixture} from '@angular/core/testing';
+import {By, ɵgetDOM as getDOM} from '@angular/platform-browser';
 
 
 
@@ -78,6 +79,11 @@ export interface NgMatchers<T = any> extends jasmine.Matchers<T> {
    * {@example testing/ts/matchers.ts region='toContainError'}
    */
   toContainError(expected: any): boolean;
+
+  /**
+   * Expect a component of the given type to show.
+   */
+  toShow(expectedComponentType: Type<any>, expectationFailOutput?: any): boolean;
 
   /**
    * Invert the matchers.
@@ -233,6 +239,29 @@ _global.beforeEach(function() {
                   missedMethods.join(', ');
             }
           };
+        }
+      };
+    },
+
+    toShow: function() {
+      return {
+        compare: function(actualFixture: any, expectedComponentType: Type<any>) {
+          const failOutput = arguments[2];
+          const msgFn = (msg: string): string => [msg, failOutput].filter(Boolean).join(', ');
+
+          // verify correct actual type
+          if (!(actualFixture instanceof ComponentFixture)) {
+            return {
+              pass: false,
+              message: msgFn(
+                  `Expected actual to be of type \'ComponentFixture\' [actual=${actualFixture.constructor.name}]`)
+            };
+          }
+
+          const found = !!actualFixture.debugElement.query(By.directive(expectedComponentType));
+          return found ?
+              {pass: true} :
+              {pass: false, message: msgFn(`Expected ${expectedComponentType.name} to show`)};
         }
       };
     }

--- a/packages/platform-browser/testing/src/matchers.ts
+++ b/packages/platform-browser/testing/src/matchers.ts
@@ -83,7 +83,7 @@ export interface NgMatchers<T = any> extends jasmine.Matchers<T> {
   /**
    * Expect a component of the given type to show.
    */
-  toShow(expectedComponentType: Type<any>, expectationFailOutput?: any): boolean;
+  toContainComponent(expectedComponentType: Type<any>, expectationFailOutput?: any): boolean;
 
   /**
    * Invert the matchers.
@@ -243,7 +243,7 @@ _global.beforeEach(function() {
       };
     },
 
-    toShow: function() {
+    toContainComponent: function() {
       return {
         compare: function(actualFixture: any, expectedComponentType: Type<any>) {
           const failOutput = arguments[2];

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1040,6 +1040,7 @@ class ActivateRoutes {
           const config = parentLoadedConfig(future.snapshot);
           const cmpFactoryResolver = config ? config.module.componentFactoryResolver : null;
 
+          context.attachRef = null;
           context.route = future;
           context.resolver = cmpFactoryResolver;
           if (context.outlet) {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -8,13 +8,13 @@
 
 import {CommonModule, Location} from '@angular/common';
 import {SpyLocation} from '@angular/common/testing';
-import {ChangeDetectionStrategy, Component, Injectable, NgModule, NgModuleFactoryLoader, NgModuleRef, NgZone, ɵConsole as Console, ɵNoopNgZone as NoopNgZone} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Injectable, NgModule, NgModuleFactoryLoader, NgModuleRef, NgZone, OnDestroy, ɵConsole as Console, ɵNoopNgZone as NoopNgZone} from '@angular/core';
 import {ComponentFixture, TestBed, fakeAsync, inject, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, PRIMARY_OUTLET, ParamMap, Params, PreloadAllModules, PreloadingStrategy, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouteReuseStrategy, Router, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
-import {Observable, Observer, of } from 'rxjs';
-import {map} from 'rxjs/operators';
+import {Observable, Observer, Subscription, of } from 'rxjs';
+import {filter, map} from 'rxjs/operators';
 
 import {forEach} from '../src/utils/collection';
 import {RouterTestingModule, SpyNgModuleFactoryLoader} from '../testing';
@@ -4022,6 +4022,82 @@ describe('Integration', () => {
          const simpleCmp2 = fixture.debugElement.children[1].componentInstance;
          expect(simpleCmp1).not.toBe(simpleCmp2);
        })));
+
+    it('should not mount the component of the previously reused route when the outlet was not instantiated at the time of route activation',
+       fakeAsync(() => {
+         @Component({
+           selector: 'root-cmp',
+           template:
+               '<div *ngIf="isToolpanelShowing"><router-outlet name="toolpanel"></router-outlet></div>'
+         })
+         class RootCmpWithCondOutlet implements OnDestroy {
+           private subscription: Subscription;
+           public isToolpanelShowing: boolean = false;
+
+           constructor(router: Router) {
+             this.subscription =
+                 router.events.pipe(filter(event => event instanceof NavigationEnd))
+                     .subscribe(
+                         () => this.isToolpanelShowing =
+                             !!router.parseUrl(router.url).root.children['toolpanel']);
+           }
+
+           public ngOnDestroy(): void { this.subscription.unsubscribe(); }
+         }
+
+         @Component({selector: 'tool-1-cmp', template: 'Tool 1 showing'})
+         class Tool1Component {
+         }
+
+         @Component({selector: 'tool-2-cmp', template: 'Tool 2 showing'})
+         class Tool2Component {
+         }
+
+         @NgModule({
+           declarations: [RootCmpWithCondOutlet, Tool1Component, Tool2Component],
+           imports: [
+             CommonModule,
+             RouterTestingModule.withRoutes([
+               {path: 'a', outlet: 'toolpanel', component: Tool1Component},
+               {path: 'b', outlet: 'toolpanel', component: Tool2Component},
+             ]),
+           ],
+         })
+         class TestModule {
+         }
+
+         TestBed.configureTestingModule({imports: [TestModule]});
+
+         const router: Router = TestBed.get(Router);
+         router.routeReuseStrategy = new AttachDetachReuseStrategy();
+
+         const fixture = createRoot(router, RootCmpWithCondOutlet);
+
+         // Activate 'tool-1'
+         router.navigate([{outlets: {toolpanel: 'a'}}]);
+         advance(fixture);
+         expect(fixture).toShow(Tool1Component, '(a)');
+
+         // Deactivate 'tool-1'
+         router.navigate([{outlets: {toolpanel: null}}]);
+         advance(fixture);
+         expect(fixture).not.toShow(Tool1Component, '(b)');
+
+         // Activate 'tool-1'
+         router.navigate([{outlets: {toolpanel: 'a'}}]);
+         advance(fixture);
+         expect(fixture).toShow(Tool1Component, '(c)');
+
+         // Deactivate 'tool-1'
+         router.navigate([{outlets: {toolpanel: null}}]);
+         advance(fixture);
+         expect(fixture).not.toShow(Tool1Component, '(d)');
+
+         // Activate 'tool-2'
+         router.navigate([{outlets: {toolpanel: 'b'}}]);
+         advance(fixture);
+         expect(fixture).toShow(Tool2Component, '(e)');
+       }));
   });
 });
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -4076,27 +4076,27 @@ describe('Integration', () => {
          // Activate 'tool-1'
          router.navigate([{outlets: {toolpanel: 'a'}}]);
          advance(fixture);
-         expect(fixture).toShow(Tool1Component, '(a)');
+         expect(fixture).toContainComponent(Tool1Component, '(a)');
 
          // Deactivate 'tool-1'
          router.navigate([{outlets: {toolpanel: null}}]);
          advance(fixture);
-         expect(fixture).not.toShow(Tool1Component, '(b)');
+         expect(fixture).not.toContainComponent(Tool1Component, '(b)');
 
          // Activate 'tool-1'
          router.navigate([{outlets: {toolpanel: 'a'}}]);
          advance(fixture);
-         expect(fixture).toShow(Tool1Component, '(c)');
+         expect(fixture).toContainComponent(Tool1Component, '(c)');
 
          // Deactivate 'tool-1'
          router.navigate([{outlets: {toolpanel: null}}]);
          advance(fixture);
-         expect(fixture).not.toShow(Tool1Component, '(d)');
+         expect(fixture).not.toContainComponent(Tool1Component, '(d)');
 
          // Activate 'tool-2'
          router.navigate([{outlets: {toolpanel: 'b'}}]);
          advance(fixture);
-         expect(fixture).toShow(Tool2Component, '(e)');
+         expect(fixture).toContainComponent(Tool2Component, '(e)');
        }));
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #25313

If using a custom route reuse strategy and if the router outlet was not instantiated at the time the route got activated (ie inside a NgIf), the previous activated component is mounted.

## What is the new behavior?
The component of the currently activated route is mounted.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
* added new Jasmine custom matcher in `platform-browser\testing\src\matchers.ts` to expect a component of a given type to show; used by spec of this PR