### PR TITLE
feat(ivy): enable inheritance of factory functions in definitions

### DIFF
--- a/packages/compiler-cli/src/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/rendering/renderer_spec.ts
@@ -123,7 +123,7 @@ describe('Renderer', () => {
              .toBe(analyzedFile.analyzedClasses[0]);
          expect(renderer.addDefinitions.calls.first().args[2])
              .toEqual(
-                 `A.ngDirectiveDef = ɵngcc0.ɵdefineDirective({ type: A, selectors: [["", "a", ""]], factory: function A_Factory() { return new A(); }, features: [ɵngcc0.ɵPublicFeature] });`);
+                 `A.ngDirectiveDef = ɵngcc0.ɵdefineDirective({ type: A, selectors: [["", "a", ""]], factory: function A_Factory(t) { return new (t || A)(); }, features: [ɵngcc0.ɵPublicFeature] });`);
        });
 
     it('should call removeDecorators with the source code, a map of class decorators that have been analyzed',

--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -13,10 +13,17 @@ import {Decorator, ReflectionHost} from '../../host';
 import {AbsoluteReference, ImportMode, Reference} from '../../metadata';
 
 export function getConstructorDependencies(
-    clazz: ts.ClassDeclaration, reflector: ReflectionHost,
-    isCore: boolean): R3DependencyMetadata[] {
+    clazz: ts.ClassDeclaration, reflector: ReflectionHost, isCore: boolean): R3DependencyMetadata[]|
+    null {
   const useType: R3DependencyMetadata[] = [];
-  const ctorParams = reflector.getConstructorParameters(clazz) || [];
+  let ctorParams = reflector.getConstructorParameters(clazz);
+  if (ctorParams === null) {
+    if (reflector.hasBaseClass(clazz)) {
+      return null;
+    } else {
+      ctorParams = [];
+    }
+  }
   ctorParams.forEach((param, idx) => {
     let tokenExpr = param.type;
     let optional = false, self = false, skipSelf = false, host = false;

--- a/packages/compiler-cli/src/ngtsc/host/src/reflection.ts
+++ b/packages/compiler-cli/src/ngtsc/host/src/reflection.ts
@@ -338,4 +338,6 @@ export interface ReflectionHost {
    * Check whether the given declaration node actually represents a class.
    */
   isClass(node: ts.Declaration): boolean;
+
+  hasBaseClass(node: ts.Declaration): boolean;
 }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/reflector.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/reflector.ts
@@ -132,6 +132,11 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     return ts.isClassDeclaration(node);
   }
 
+  hasBaseClass(node: ts.Declaration): boolean {
+    return ts.isClassDeclaration(node) && node.heritageClauses !== undefined &&
+        node.heritageClauses.some(clause => clause.token === ts.SyntaxKind.ExtendsKeyword);
+  }
+
   getDeclarationOfIdentifier(id: ts.Identifier): Declaration|null {
     // Resolve the identifier to a Symbol, and return the declaration of that.
     let symbol: ts.Symbol|undefined = this.checker.getSymbolAtLocation(id);

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -42,7 +42,8 @@ describe('compiler compliance', () => {
       };
 
       // The factory should look like this:
-      const factory = 'factory: function MyComponent_Factory() { return new MyComponent(); }';
+      const factory =
+          'factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -93,7 +94,8 @@ describe('compiler compliance', () => {
       };
 
       // The factory should look like this:
-      const factory = 'factory: function MyComponent_Factory() { return new MyComponent(); }';
+      const factory =
+          'factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -143,7 +145,8 @@ describe('compiler compliance', () => {
       };
 
       // The factory should look like this:
-      const factory = 'factory: function MyComponent_Factory() { return new MyComponent(); }';
+      const factory =
+          'factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -192,7 +195,8 @@ describe('compiler compliance', () => {
       };
 
       // The factory should look like this:
-      const factory = 'factory: function MyComponent_Factory() { return new MyComponent(); }';
+      const factory =
+          'factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
 
       // The template should look like this (where IDENT is a wild card for an identifier):
       const template = `
@@ -238,7 +242,8 @@ describe('compiler compliance', () => {
         }
       };
 
-      const factory = 'factory: function MyComponent_Factory() { return new MyComponent(); }';
+      const factory =
+          'factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
       const template = `
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
@@ -282,7 +287,8 @@ describe('compiler compliance', () => {
         }
       };
 
-      const factory = 'factory: function MyComponent_Factory() { return new MyComponent(); }';
+      const factory =
+          'factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
       const template = `
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
@@ -327,14 +333,15 @@ describe('compiler compliance', () => {
         }
       };
 
-      const factory = 'factory: function MyComponent_Factory() { return new MyComponent(); }';
+      const factory =
+          'factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); }';
       const template = `
         const _c0 = ["error"];
         const _c1 = ["background-color"];
         …
         MyComponent.ngComponentDef = i0.ɵdefineComponent({type:MyComponent,selectors:[["my-component"]],
-            factory: function MyComponent_Factory(){
-              return new MyComponent();
+            factory: function MyComponent_Factory(t){
+              return new (t || MyComponent)();
             },
             features: [$r3$.ɵPublicFeature],
             template:function MyComponent_Template(rf,ctx){
@@ -388,7 +395,7 @@ describe('compiler compliance', () => {
         ChildComponent.ngComponentDef = $r3$.ɵdefineComponent({
           type: ChildComponent,
           selectors: [["child"]],
-          factory: function ChildComponent_Factory() { return new ChildComponent(); },
+          factory: function ChildComponent_Factory(t) { return new (t || ChildComponent)(); },
           features: [$r3$.ɵPublicFeature],
           template: function ChildComponent_Template(rf, ctx) {
             if (rf & 1) {
@@ -402,7 +409,7 @@ describe('compiler compliance', () => {
         SomeDirective.ngDirectiveDef = $r3$.ɵdefineDirective({
           type: SomeDirective,
           selectors: [["", "some-directive", ""]],
-          factory: function SomeDirective_Factory() {return new SomeDirective(); },
+          factory: function SomeDirective_Factory(t) {return new (t || SomeDirective)(); },
           features: [$r3$.ɵPublicFeature]
         });
       `;
@@ -414,7 +421,7 @@ describe('compiler compliance', () => {
         MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
           type: MyComponent,
           selectors: [["my-component"]],
-          factory: function MyComponent_Factory() { return new MyComponent(); },
+          factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
           features: [$r3$.ɵPublicFeature],
           template: function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
@@ -458,7 +465,7 @@ describe('compiler compliance', () => {
         SomeDirective.ngDirectiveDef = $r3$.ɵdefineDirective({
           type: SomeDirective,
           selectors: [["div", "some-directive", "", 8, "foo", 3, "title", "", 9, "baz"]],
-          factory: function SomeDirective_Factory() {return new SomeDirective(); },
+          factory: function SomeDirective_Factory(t) {return new (t || SomeDirective)(); },
           features: [$r3$.ɵPublicFeature]
         });
       `;
@@ -468,7 +475,7 @@ describe('compiler compliance', () => {
         OtherDirective.ngDirectiveDef = $r3$.ɵdefineDirective({
           type: OtherDirective,
           selectors: [["", 5, "span", "title", "", 9, "baz"]],
-          factory: function OtherDirective_Factory() {return new OtherDirective(); },
+          factory: function OtherDirective_Factory(t) {return new (t || OtherDirective)(); },
           features: [$r3$.ɵPublicFeature]
         });
       `;
@@ -501,7 +508,7 @@ describe('compiler compliance', () => {
         HostBindingDir.ngDirectiveDef = $r3$.ɵdefineDirective({
           type: HostBindingDir,
           selectors: [["", "hostBindingDir", ""]],
-          factory: function HostBindingDir_Factory() { return new HostBindingDir(); },
+          factory: function HostBindingDir_Factory(t) { return new (t || HostBindingDir)(); },
           hostBindings: function HostBindingDir_HostBindings(dirIndex, elIndex) {
             $r3$.ɵp(elIndex, "id", $r3$.ɵb($r3$.ɵd(dirIndex).dirId));
           },
@@ -544,7 +551,7 @@ describe('compiler compliance', () => {
         IfDirective.ngDirectiveDef = $r3$.ɵdefineDirective({
           type: IfDirective,
           selectors: [["", "if", ""]],
-          factory: function IfDirective_Factory() { return new IfDirective($r3$.ɵinjectTemplateRef()); },
+          factory: function IfDirective_Factory(t) { return new (t || IfDirective)($r3$.ɵinjectTemplateRef()); },
           features: [$r3$.ɵPublicFeature]
         });`;
       const MyComponentDefinition = `
@@ -566,7 +573,7 @@ describe('compiler compliance', () => {
         MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
           type: MyComponent,
           selectors: [["my-component"]],
-          factory: function MyComponent_Factory() { return new MyComponent(); },
+          factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
           features: [$r3$.ɵPublicFeature],
           template: function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
@@ -626,7 +633,7 @@ describe('compiler compliance', () => {
           MyApp.ngComponentDef = $r3$.ɵdefineComponent({
             type: MyApp,
             selectors: [["my-app"]],
-            factory: function MyApp_Factory() { return new MyApp(); },
+            factory: function MyApp_Factory(t) { return new (t || MyApp)(); },
             features: [$r3$.ɵPublicFeature],
             template: function MyApp_Template(rf, ctx) {
               if (rf & 1) {
@@ -706,7 +713,7 @@ describe('compiler compliance', () => {
           MyApp.ngComponentDef = $r3$.ɵdefineComponent({
             type: MyApp,
             selectors: [["my-app"]],
-            factory: function MyApp_Factory() { return new MyApp(); },
+            factory: function MyApp_Factory(t) { return new (t || MyApp)(); },
             features: [$r3$.ɵPublicFeature],
             template: function MyApp_Template(rf, ctx) {
               if (rf & 1) {
@@ -768,7 +775,7 @@ describe('compiler compliance', () => {
           MyApp.ngComponentDef = $r3$.ɵdefineComponent({
             type: MyApp,
             selectors: [["my-app"]],
-            factory: function MyApp_Factory() { return new MyApp(); },
+            factory: function MyApp_Factory(t) { return new (t || MyApp)(); },
             features: [$r3$.ɵPublicFeature],
             template: function MyApp_Template(rf, ctx) {
               if (rf & 1) {
@@ -834,7 +841,7 @@ describe('compiler compliance', () => {
           MyApp.ngComponentDef = $r3$.ɵdefineComponent({
             type: MyApp,
             selectors: [["my-app"]],
-            factory: function MyApp_Factory() { return new MyApp(); },
+            factory: function MyApp_Factory(t) { return new (t || MyApp)(); },
             features: [$r3$.ɵPublicFeature],
             template: function MyApp_Template(rf, ctx) {
               if (rf & 1) {
@@ -892,7 +899,7 @@ describe('compiler compliance', () => {
         SimpleComponent.ngComponentDef = $r3$.ɵdefineComponent({
           type: SimpleComponent,
           selectors: [["simple"]],
-          factory: function SimpleComponent_Factory() { return new SimpleComponent(); },
+          factory: function SimpleComponent_Factory(t) { return new (t || SimpleComponent)(); },
           features: [$r3$.ɵPublicFeature],
           template: function SimpleComponent_Template(rf, ctx) {
             if (rf & 1) {
@@ -913,7 +920,7 @@ describe('compiler compliance', () => {
         ComplexComponent.ngComponentDef = $r3$.ɵdefineComponent({
           type: ComplexComponent,
           selectors: [["complex"]],
-          factory: function ComplexComponent_Factory() { return new ComplexComponent(); },
+          factory: function ComplexComponent_Factory(t) { return new (t || ComplexComponent)(); },
           features: [$r3$.ɵPublicFeature],
           template: function ComplexComponent_Template(rf, ctx) {
             if (rf & 1) {
@@ -979,7 +986,7 @@ describe('compiler compliance', () => {
           ViewQueryComponent.ngComponentDef = $r3$.ɵdefineComponent({
             type: ViewQueryComponent,
             selectors: [["view-query-component"]],
-            factory: function ViewQueryComponent_Factory() { return new ViewQueryComponent(); },
+            factory: function ViewQueryComponent_Factory(t) { return new (t || ViewQueryComponent)(); },
             features: [$r3$.ɵPublicFeature],
             viewQuery: function ViewQueryComponent_Query(rf, ctx) {
               if (rf & 1) {
@@ -1043,8 +1050,8 @@ describe('compiler compliance', () => {
           ContentQueryComponent.ngComponentDef = $r3$.ɵdefineComponent({
             type: ContentQueryComponent,
             selectors: [["content-query-component"]],
-            factory: function ContentQueryComponent_Factory() {
-              return new ContentQueryComponent();
+            factory: function ContentQueryComponent_Factory(t) {
+              return new (t || ContentQueryComponent)();
             },
             contentQueries: function ContentQueryComponent_ContentQueries() {
               $r3$.ɵQr($r3$.ɵQ(null, SomeDirective, true));
@@ -1119,7 +1126,7 @@ describe('compiler compliance', () => {
             MyPipe.ngPipeDef = $r3$.ɵdefinePipe({
               name: "myPipe",
               type: MyPipe,
-              factory: function MyPipe_Factory() { return new MyPipe(); },
+              factory: function MyPipe_Factory(t) { return new (t || MyPipe)(); },
               pure: false
             });
         `;
@@ -1128,7 +1135,7 @@ describe('compiler compliance', () => {
             MyPurePipe.ngPipeDef = $r3$.ɵdefinePipe({
               name: "myPurePipe",
               type: MyPurePipe,
-              factory: function MyPurePipe_Factory() { return new MyPurePipe(); },
+              factory: function MyPurePipe_Factory(t) { return new (t || MyPurePipe)(); },
               pure: true
             });`;
 
@@ -1140,7 +1147,7 @@ describe('compiler compliance', () => {
             MyApp.ngComponentDef = $r3$.ɵdefineComponent({
               type: MyApp,
               selectors: [["my-app"]],
-              factory: function MyApp_Factory() { return new MyApp(); },
+              factory: function MyApp_Factory(t) { return new (t || MyApp)(); },
               features: [$r3$.ɵPublicFeature],
               template: function MyApp_Template(rf, ctx) {
                 if (rf & 1) {
@@ -1191,7 +1198,7 @@ describe('compiler compliance', () => {
         MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
           type: MyComponent,
           selectors: [["my-component"]],
-          factory: function MyComponent_Factory() { return new MyComponent(); },
+          factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
           features: [$r3$.ɵPublicFeature],
           template: function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
@@ -1283,7 +1290,7 @@ describe('compiler compliance', () => {
         MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
           type: MyComponent,
           selectors: [["my-component"]],
-          factory: function MyComponent_Factory() { return new MyComponent(); },
+          factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
           features: [$r3$.ɵPublicFeature],
           template: function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
@@ -1426,7 +1433,7 @@ describe('compiler compliance', () => {
           LifecycleComp.ngComponentDef = $r3$.ɵdefineComponent({
             type: LifecycleComp,
             selectors: [["lifecycle-comp"]],
-            factory: function LifecycleComp_Factory() { return new LifecycleComp(); },
+            factory: function LifecycleComp_Factory(t) { return new (t || LifecycleComp)(); },
             inputs: {nameMin: "name"},
             features: [$r3$.ɵPublicFeature, $r3$.ɵNgOnChangesFeature],
             template: function LifecycleComp_Template(rf, ctx) {}
@@ -1436,7 +1443,7 @@ describe('compiler compliance', () => {
           SimpleLayout.ngComponentDef = $r3$.ɵdefineComponent({
             type: SimpleLayout,
             selectors: [["simple-layout"]],
-            factory: function SimpleLayout_Factory() { return new SimpleLayout(); },
+            factory: function SimpleLayout_Factory(t) { return new (t || SimpleLayout)(); },
             features: [$r3$.ɵPublicFeature],
             template: function SimpleLayout_Template(rf, ctx) {
               if (rf & 1) {
@@ -1542,8 +1549,8 @@ describe('compiler compliance', () => {
               ForOfDirective.ngDirectiveDef = $r3$.ɵdefineDirective({
                 type: ForOfDirective,
                 selectors: [["", "forOf", ""]],
-                factory: function ForOfDirective_Factory() {
-                  return new ForOfDirective($r3$.ɵinjectViewContainerRef(), $r3$.ɵinjectTemplateRef());
+                factory: function ForOfDirective_Factory(t) {
+                  return new (t || ForOfDirective)($r3$.ɵinjectViewContainerRef(), $r3$.ɵinjectTemplateRef());
                 },
                 features: [$r3$.ɵPublicFeature, $r3$.ɵNgOnChangesFeature],
                 inputs: {forOf: "forOf"}
@@ -1564,7 +1571,7 @@ describe('compiler compliance', () => {
               MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
                 type: MyComponent,
                 selectors: [["my-component"]],
-                factory: function MyComponent_Factory() { return new MyComponent(); },
+                factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
                 features: [$r3$.ɵPublicFeature],
                 template: function MyComponent_Template(rf, ctx){
                   if (rf & 1) {
@@ -1616,8 +1623,8 @@ describe('compiler compliance', () => {
           ForOfDirective.ngDirectiveDef = $r3$.ɵdefineDirective({
             type: ForOfDirective,
             selectors: [["", "forOf", ""]],
-            factory: function ForOfDirective_Factory() {
-              return new ForOfDirective($r3$.ɵinjectViewContainerRef(), $r3$.ɵinjectTemplateRef());
+            factory: function ForOfDirective_Factory(t) {
+              return new (t || ForOfDirective)($r3$.ɵinjectViewContainerRef(), $r3$.ɵinjectTemplateRef());
             },
             features: [$r3$.ɵPublicFeature, $r3$.ɵNgOnChangesFeature],
             inputs: {forOf: "forOf"}
@@ -1641,7 +1648,7 @@ describe('compiler compliance', () => {
           MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
             type: MyComponent,
             selectors: [["my-component"]],
-            factory: function MyComponent_Factory() { return new MyComponent(); },
+            factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
             features: [$r3$.ɵPublicFeature],
             template: function MyComponent_Template(rf, ctx) {
               if (rf & 1) {
@@ -1739,7 +1746,7 @@ describe('compiler compliance', () => {
           MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
             type: MyComponent,
             selectors: [["my-component"]],
-            factory: function MyComponent_Factory() { return new MyComponent(); },
+            factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
             features: [$r3$.ɵPublicFeature],
             template: function MyComponent_Template(rf, ctx) {
               if (rf & 1) {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_di_spec.ts
@@ -48,8 +48,8 @@ describe('compiler compliance: dependency injection', () => {
     };
 
     const factory = `
-      factory: function MyComponent_Factory() {
-        return new MyComponent(
+      factory: function MyComponent_Factory(t) {
+        return new (t || MyComponent)(
           $r3$.ɵinjectAttribute('name'),
           $r3$.ɵdirectiveInject(MyService), 
           $r3$.ɵdirectiveInject(MyService, 1),

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
@@ -152,7 +152,7 @@ describe('compiler compliance: listen()', () => {
         MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
           type: MyComponent,
           selectors: [["my-component"]],
-          factory: function MyComponent_Factory() { return new MyComponent(); },
+          factory: function MyComponent_Factory(t) { return new (t || MyComponent)(); },
           features: [$r3$.ɵPublicFeature],
           template: function MyComponent_Template(rf, ctx) {
             if (rf & 1) {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -90,8 +90,8 @@ describe('compiler compliance: styling', () => {
           MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
               type: MyComponent,
               selectors:[["my-component"]],
-              factory:function MyComponent_Factory(){
-                return new MyComponent();
+              factory:function MyComponent_Factory(t){
+                return new (t || MyComponent)();
               },
               features: [$r3$.ɵPublicFeature],
               template: function MyComponent_Template(rf, $ctx$) {
@@ -147,8 +147,8 @@ describe('compiler compliance: styling', () => {
           MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
             type: MyComponent,
             selectors: [["my-component"]],
-            factory: function MyComponent_Factory() {
-              return new MyComponent();
+            factory: function MyComponent_Factory(t) {
+              return new (t || MyComponent)();
             },
             features: [$r3$.ɵPublicFeature],
             template: function MyComponent_Template(rf, ctx) {
@@ -242,8 +242,8 @@ describe('compiler compliance: styling', () => {
           MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
               type: MyComponent,
               selectors:[["my-component"]],
-              factory:function MyComponent_Factory(){
-                return new MyComponent();
+              factory:function MyComponent_Factory(t){
+                return new (t || MyComponent)();
               },
               features: [$r3$.ɵPublicFeature],
               template: function MyComponent_Template(rf, $ctx$) {
@@ -296,8 +296,8 @@ describe('compiler compliance: styling', () => {
           MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
               type: MyComponent,
               selectors:[["my-component"]],
-              factory:function MyComponent_Factory(){
-                return new MyComponent();
+              factory:function MyComponent_Factory(t){
+                return new (t || MyComponent)();
               },
               features: [$r3$.ɵPublicFeature],
               template: function MyComponent_Template(rf, $ctx$) {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -237,7 +237,7 @@ describe('ngtsc behavioral tests', () => {
     expect(jsContents)
         .toContain(
             `TestModule.ngInjectorDef = i0.defineInjector({ factory: ` +
-            `function TestModule_Factory() { return new TestModule(); }, providers: [{ provide: ` +
+            `function TestModule_Factory(t) { return new (t || TestModule)(); }, providers: [{ provide: ` +
             `Token, useValue: 'test' }], imports: [[OtherModule]] });`);
 
     const dtsContents = getContents('test.d.ts');
@@ -328,7 +328,7 @@ describe('ngtsc behavioral tests', () => {
     expect(jsContents)
         .toContain(
             'TestPipe.ngPipeDef = i0.ɵdefinePipe({ name: "test-pipe", type: TestPipe, ' +
-            'factory: function TestPipe_Factory() { return new TestPipe(); }, pure: false })');
+            'factory: function TestPipe_Factory(t) { return new (t || TestPipe)(); }, pure: false })');
     expect(dtsContents).toContain('static ngPipeDef: i0.ɵPipeDef<TestPipe, \'test-pipe\'>;');
   });
 
@@ -353,7 +353,7 @@ describe('ngtsc behavioral tests', () => {
     expect(jsContents)
         .toContain(
             'TestPipe.ngPipeDef = i0.ɵdefinePipe({ name: "test-pipe", type: TestPipe, ' +
-            'factory: function TestPipe_Factory() { return new TestPipe(); }, pure: true })');
+            'factory: function TestPipe_Factory(t) { return new (t || TestPipe)(); }, pure: true })');
     expect(dtsContents).toContain('static ngPipeDef: i0.ɵPipeDef<TestPipe, \'test-pipe\'>;');
   });
 
@@ -378,7 +378,7 @@ describe('ngtsc behavioral tests', () => {
     expect(exitCode).toBe(0);
 
     const jsContents = getContents('test.js');
-    expect(jsContents).toContain('return new TestPipe(i0.ɵdirectiveInject(Dep));');
+    expect(jsContents).toContain('return new (t || TestPipe)(i0.ɵdirectiveInject(Dep));');
   });
 
   it('should include @Pipes in @NgModule scopes', () => {
@@ -474,7 +474,7 @@ describe('ngtsc behavioral tests', () => {
     const jsContents = getContents('test.js');
     expect(jsContents)
         .toContain(
-            `factory: function FooCmp_Factory() { return new FooCmp(i0.ɵinjectAttribute("test"), i0.ɵinjectChangeDetectorRef(), i0.ɵinjectElementRef(), i0.ɵdirectiveInject(i0.INJECTOR), i0.ɵinjectTemplateRef(), i0.ɵinjectViewContainerRef()); }`);
+            `factory: function FooCmp_Factory(t) { return new (t || FooCmp)(i0.ɵinjectAttribute("test"), i0.ɵinjectChangeDetectorRef(), i0.ɵinjectElementRef(), i0.ɵdirectiveInject(i0.INJECTOR), i0.ɵinjectTemplateRef(), i0.ɵinjectViewContainerRef()); }`);
   });
 
   it('should generate queries for components', () => {
@@ -656,5 +656,43 @@ describe('ngtsc behavioral tests', () => {
     const exitCode = main(['-p', basePath], errorSpy);
     expect(errorSpy).not.toHaveBeenCalled();
     expect(exitCode).toBe(0);
+  });
+
+  it('generates inherited factory definitions', () => {
+    writeConfig();
+    write(`test.ts`, `
+        import {Injectable} from '@angular/core';
+
+        class Dep {}
+
+        @Injectable()
+        class Base {
+          constructor(dep: Dep) {}
+        }
+
+        @Injectable()
+        class Child extends Base {}
+
+        @Injectable()
+        class GrandChild extends Child {
+          constructor() {
+            super(null!);
+          }
+        }
+    `);
+
+
+    const exitCode = main(['-p', basePath], errorSpy);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(exitCode).toBe(0);
+    const jsContents = getContents('test.js');
+
+    expect(jsContents)
+        .toContain('function Base_Factory(t) { return new (t || Base)(i0.inject(Dep)); }');
+    expect(jsContents).toContain('var ɵChild_BaseFactory = i0.ɵgetInheritedFactory(Child)');
+    expect(jsContents)
+        .toContain('function Child_Factory(t) { return ɵChild_BaseFactory((t || Child)); }');
+    expect(jsContents)
+        .toContain('function GrandChild_Factory(t) { return new (t || GrandChild)(); }');
   });
 });

--- a/packages/compiler/src/injectable_compiler_2.ts
+++ b/packages/compiler/src/injectable_compiler_2.ts
@@ -9,103 +9,99 @@
 import {InjectFlags} from './core';
 import {Identifiers} from './identifiers';
 import * as o from './output/output_ast';
-import {R3DependencyMetadata, compileFactoryFunction} from './render3/r3_factory';
+import {R3DependencyMetadata, R3FactoryMetadata, compileFactoryFunction} from './render3/r3_factory';
 import {mapToMapExpression} from './render3/util';
 
 export interface InjectableDef {
   expression: o.Expression;
   type: o.Type;
+  statements: o.Statement[];
 }
 
 export interface R3InjectableMetadata {
   name: string;
   type: o.Expression;
+  ctorDeps: R3DependencyMetadata[]|null;
   providedIn: o.Expression;
   useClass?: o.Expression;
   useFactory?: o.Expression;
   useExisting?: o.Expression;
   useValue?: o.Expression;
-  deps?: R3DependencyMetadata[];
+  userDeps?: R3DependencyMetadata[];
 }
 
 export function compileInjectable(meta: R3InjectableMetadata): InjectableDef {
-  let factory: o.Expression = o.NULL_EXPR;
+  let result: {factory: o.Expression, statements: o.Statement[]}|null = null;
 
   function makeFn(ret: o.Expression): o.Expression {
     return o.fn([], [new o.ReturnStatement(ret)], undefined, undefined, `${meta.name}_Factory`);
   }
 
-  if (meta.useClass !== undefined || meta.useFactory !== undefined) {
-    // First, handle useClass and useFactory together, since both involve a similar call to
-    // `compileFactoryFunction`. Either dependencies are explicitly specified, in which case
-    // a factory function call is generated, or they're not specified and the calls are special-
-    // cased.
-    if (meta.deps !== undefined) {
-      // Either call `new meta.useClass(...)` or `meta.useFactory(...)`.
-      const fnOrClass: o.Expression = meta.useClass || meta.useFactory !;
+  const factoryMeta = {
+    name: meta.name,
+    type: meta.type,
+    deps: meta.ctorDeps,
+    injectFn: Identifiers.inject,
+  };
 
-      // useNew: true if meta.useClass, false for meta.useFactory.
-      const useNew = meta.useClass !== undefined;
+  if (meta.useClass !== undefined) {
+    // meta.useClass has two modes of operation. Either deps are specified, in which case `new` is
+    // used to instantiate the class with dependencies injected, or deps are not specified and
+    // the factory of the class is used to instantiate it.
+    //
+    // A special case exists for useClass: Type where Type is the injectable type itself, in which
+    // case omitting deps just uses the constructor dependencies instead.
 
-      factory = compileFactoryFunction({
-        name: meta.name,
-        fnOrClass,
-        useNew,
-        injectFn: Identifiers.inject,
-        deps: meta.deps,
+    const useClassOnSelf = meta.useClass.isEquivalent(meta.type);
+    const deps = meta.userDeps || (useClassOnSelf && meta.ctorDeps) || undefined;
+
+    if (deps !== undefined) {
+      // factory: () => new meta.useClass(...deps)
+      result = compileFactoryFunction({
+        ...factoryMeta,
+        delegate: meta.useClass,
+        delegateDeps: deps,
+        useNewForDelegate: true,
       });
-    } else if (meta.useClass !== undefined) {
-      // Special case for useClass where the factory from the class's ngInjectableDef is used.
-      if (meta.useClass.isEquivalent(meta.type)) {
-        // For the injectable compiler, useClass represents a foreign type that should be
-        // instantiated to satisfy construction of the given type. It's not valid to specify
-        // useClass === type, since the useClass type is expected to already be compiled.
-        throw new Error(
-            `useClass is the same as the type, but no deps specified, which is invalid.`);
-      }
-      factory =
-          makeFn(new o.ReadPropExpr(new o.ReadPropExpr(meta.useClass, 'ngInjectableDef'), 'factory')
-                     .callFn([]));
-    } else if (meta.useFactory !== undefined) {
-      // Special case for useFactory where no arguments are passed.
-      factory = meta.useFactory.callFn([]);
     } else {
-      // Can't happen - outer conditional guards against both useClass and useFactory being
-      // undefined.
-      throw new Error('Reached unreachable block in injectable compiler.');
+      result = compileFactoryFunction(factoryMeta);
     }
+  } else if (meta.useFactory !== undefined) {
+    result = compileFactoryFunction({
+      ...factoryMeta,
+      delegate: meta.useFactory,
+      delegateDeps: meta.userDeps || [],
+      useNewForDelegate: false,
+    });
   } else if (meta.useValue !== undefined) {
     // Note: it's safe to use `meta.useValue` instead of the `USE_VALUE in meta` check used for
     // client code because meta.useValue is an Expression which will be defined even if the actual
     // value is undefined.
-    factory = makeFn(meta.useValue);
+    result = compileFactoryFunction({
+      ...factoryMeta,
+      expression: meta.useValue,
+    });
   } else if (meta.useExisting !== undefined) {
     // useExisting is an `inject` call on the existing token.
-    factory = makeFn(o.importExpr(Identifiers.inject).callFn([meta.useExisting]));
-  } else {
-    // A strict type is compiled according to useClass semantics, except the dependencies are
-    // required.
-    if (meta.deps === undefined) {
-      throw new Error(`Type compilation of an injectable requires dependencies.`);
-    }
-    factory = compileFactoryFunction({
-      name: meta.name,
-      fnOrClass: meta.type,
-      useNew: true,
-      injectFn: Identifiers.inject,
-      deps: meta.deps,
+    result = compileFactoryFunction({
+      ...factoryMeta,
+      expression: o.importExpr(Identifiers.inject).callFn([meta.useExisting]),
     });
+  } else {
+    result = compileFactoryFunction(factoryMeta);
   }
 
   const token = meta.type;
   const providedIn = meta.providedIn;
 
   const expression = o.importExpr(Identifiers.defineInjectable).callFn([mapToMapExpression(
-      {token, factory, providedIn})]);
+      {token, factory: result.factory, providedIn})]);
   const type = new o.ExpressionType(
       o.importExpr(Identifiers.InjectableDef, [new o.ExpressionType(meta.type)]));
 
   return {
-      expression, type,
+    expression,
+    type,
+    statements: result.statements,
   };
 }

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -162,6 +162,16 @@ export class Identifiers {
 
   static listener: o.ExternalReference = {name: 'ɵL', moduleName: CORE};
 
+  static getFactoryOf: o.ExternalReference = {
+    name: 'ɵgetFactoryOf',
+    moduleName: CORE,
+  };
+
+  static getInheritedFactory: o.ExternalReference = {
+    name: 'ɵgetInheritedFactory',
+    moduleName: CORE,
+  };
+
   // Reserve slots for pure functions
   static reserveSlots: o.ExternalReference = {name: 'ɵrS', moduleName: CORE};
 

--- a/packages/compiler/src/render3/r3_pipe_compiler.ts
+++ b/packages/compiler/src/render3/r3_pipe_compiler.ts
@@ -19,13 +19,14 @@ export interface R3PipeMetadata {
   name: string;
   type: o.Expression;
   pipeName: string;
-  deps: R3DependencyMetadata[];
+  deps: R3DependencyMetadata[]|null;
   pure: boolean;
 }
 
 export interface R3PipeDef {
   expression: o.Expression;
   type: o.Type;
+  statements: o.Statement[];
 }
 
 export function compilePipeFromMetadata(metadata: R3PipeMetadata) {
@@ -39,12 +40,11 @@ export function compilePipeFromMetadata(metadata: R3PipeMetadata) {
 
   const templateFactory = compileFactoryFunction({
     name: metadata.name,
-    fnOrClass: metadata.type,
+    type: metadata.type,
     deps: metadata.deps,
-    useNew: true,
     injectFn: R3.directiveInject,
   });
-  definitionMapValues.push({key: 'factory', value: templateFactory, quoted: false});
+  definitionMapValues.push({key: 'factory', value: templateFactory.factory, quoted: false});
 
   // e.g. `pure: true`
   definitionMapValues.push({key: 'pure', value: o.literal(metadata.pure), quoted: false});
@@ -54,7 +54,7 @@ export function compilePipeFromMetadata(metadata: R3PipeMetadata) {
     new o.ExpressionType(metadata.type),
     new o.ExpressionType(new o.LiteralExpr(metadata.pipeName)),
   ]));
-  return {expression, type};
+  return {expression, type, statements: templateFactory.statements};
 }
 
 /**

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -38,7 +38,7 @@ export interface R3DirectiveMetadata {
   /**
    * Dependencies of the directive's constructor.
    */
-  deps: R3DependencyMetadata[];
+  deps: R3DependencyMetadata[]|null;
 
   /**
    * Unparsed selector of the directive, or `null` if there was no selector.
@@ -177,6 +177,7 @@ export interface R3QueryMetadata {
 export interface R3DirectiveDef {
   expression: o.Expression;
   type: o.Type;
+  statements: o.Statement[];
 }
 
 /**
@@ -185,4 +186,5 @@ export interface R3DirectiveDef {
 export interface R3ComponentDef {
   expression: o.Expression;
   type: o.Type;
+  statements: o.Statement[];
 }

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -23,6 +23,8 @@ export {
   injectViewContainerRef as ɵinjectViewContainerRef,
   injectChangeDetectorRef as ɵinjectChangeDetectorRef,
   injectAttribute as ɵinjectAttribute,
+  getFactoryOf as ɵgetFactoryOf,
+  getInheritedFactory as ɵgetInheritedFactory,
   PublicFeature as ɵPublicFeature,
   InheritDefinitionFeature as ɵInheritDefinitionFeature,
   NgOnChangesFeature as ɵNgOnChangesFeature,

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -771,6 +771,25 @@ export function getOrCreateTemplateRef<T>(di: LInjector): viewEngine.TemplateRef
   return di.templateRef;
 }
 
+export function getFactoryOf<T>(type: Type<any>): ((type?: Type<T>) => T)|null {
+  const typeAny = type as any;
+  const def = typeAny.ngComponentDef || typeAny.ngDirectiveDef || typeAny.ngPipeDef ||
+      typeAny.ngInjectableDef || typeAny.ngInjectorDef;
+  if (def === undefined || def.factory === undefined) {
+    return null;
+  }
+  return def.factory;
+}
+
+export function getInheritedFactory<T>(type: Type<any>): (type: Type<T>) => T {
+  const proto = Object.getPrototypeOf(type.prototype).constructor as Type<any>;
+  const factory = getFactoryOf<T>(proto);
+  if (factory === null) {
+    throw new Error(`Type ${proto.name} does not support inheritance`);
+  }
+  return factory;
+}
+
 class TemplateRef<T> implements viewEngine.TemplateRef<T> {
   constructor(
       private _declarationParentView: LViewData, readonly elementRef: viewEngine.ElementRef,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -14,7 +14,7 @@ import {PublicFeature} from './features/public_feature';
 import {ComponentDef, ComponentDefInternal, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefFlags, DirectiveDefInternal, DirectiveType, PipeDef} from './interfaces/definition';
 
 export {ComponentFactory, ComponentFactoryResolver, ComponentRef} from './component_ref';
-export {QUERY_READ_CONTAINER_REF, QUERY_READ_ELEMENT_REF, QUERY_READ_FROM_NODE, QUERY_READ_TEMPLATE_REF, directiveInject, injectAttribute, injectChangeDetectorRef, injectComponentFactoryResolver, injectElementRef, injectTemplateRef, injectViewContainerRef} from './di';
+export {QUERY_READ_CONTAINER_REF, QUERY_READ_ELEMENT_REF, QUERY_READ_FROM_NODE, QUERY_READ_TEMPLATE_REF, directiveInject, getFactoryOf, getInheritedFactory, injectAttribute, injectChangeDetectorRef, injectComponentFactoryResolver, injectElementRef, injectTemplateRef, injectViewContainerRef} from './di';
 export {RenderFlags} from './interfaces/definition';
 export {CssSelectorList} from './interfaces/projection';
 

--- a/packages/core/src/render3/jit/injectable.ts
+++ b/packages/core/src/render3/jit/injectable.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Expression, LiteralExpr, R3DependencyMetadata, WrappedNodeExpr, compileInjectable as compileR3Injectable, jitExpression} from '@angular/compiler';
+import {Expression, LiteralExpr, R3DependencyMetadata, R3InjectableMetadata, WrappedNodeExpr, compileInjectable as compileR3Injectable, jitExpression} from '@angular/compiler';
 
 import {Injectable} from '../../di/injectable';
 import {ClassSansProvider, ExistingSansProvider, FactorySansProvider, StaticClassSansProvider, ValueProvider, ValueSansProvider} from '../../di/provider';
@@ -16,6 +16,7 @@ import {getClosureSafeProperty} from '../../util/property';
 import {angularCoreEnv} from './environment';
 import {NG_INJECTABLE_DEF} from './fields';
 import {convertDependencies, reflectDependencies} from './util';
+
 
 
 /**
@@ -34,13 +35,11 @@ export function compileInjectable(type: Type<any>, srcMeta?: Injectable): void {
         const hasAProvider = isUseClassProvider(meta) || isUseFactoryProvider(meta) ||
             isUseValueProvider(meta) || isUseExistingProvider(meta);
 
-        let deps: R3DependencyMetadata[]|undefined = undefined;
-        if (!hasAProvider || (isUseClassProvider(meta) && type === meta.useClass)) {
-          deps = reflectDependencies(type);
-        } else if (isUseClassProvider(meta)) {
-          deps = meta.deps && convertDependencies(meta.deps);
-        } else if (isUseFactoryProvider(meta)) {
-          deps = meta.deps && convertDependencies(meta.deps) || [];
+        const ctorDeps = reflectDependencies(type);
+
+        let userDeps: R3DependencyMetadata[]|undefined = undefined;
+        if ((isUseClassProvider(meta) || isUseFactoryProvider(meta)) && meta.deps !== undefined) {
+          userDeps = convertDependencies(meta.deps);
         }
 
         // Decide which flavor of factory to generate, based on the provider specified.
@@ -81,7 +80,8 @@ export function compileInjectable(type: Type<any>, srcMeta?: Injectable): void {
           useFactory,
           useValue,
           useExisting,
-          deps,
+          ctorDeps,
+          userDeps,
         });
 
         def = jitExpression(expression, angularCoreEnv, `ng://${type.name}/ngInjectableDef.js`);


### PR DESCRIPTION
This commit creates an API for factory functions which allows them
to be inherited from one another. To do so, it differentiates between
the factory function as a wrapper for a constructor and the factory
function in ngInjectableDefs which is determined by a default
provider.

The new form is:

factory: (t?) => new (t || SomeType)(inject(Dep1), inject(Dep2))

The 't' parameter allows for constructor inheritance. A subclass with
no declared constructor inherits its constructor from the superclass.
With the 't' parameter, a subclass can call the superclass' factory
function and use it to create an instance of the subclass.

For @Injectables with configured providers, the factory function is
of the form:

factory: (t?) => t ? constructorInject(t) : provider();

where constructorInject(t) creates an instance of 't' using the
naturally declared constructor of the type, and where provider()
creates an instance of the base type using the special declared
provider on @Injectable.
