### PR TITLE
fix(ivy): export NgModuleFactory via r3_symbols for core factories

### DIFF
--- a/packages/compiler-cli/src/ngtsc/transform/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/translator.ts
@@ -46,6 +46,7 @@ const CORE_SUPPORTED_SYMBOLS = new Set<string>([
   'ɵInjectableDef',
   'ɵInjectorDef',
   'ɵNgModuleDef',
+  'ɵNgModuleFactory',
 ]);
 
 export class ImportManager {

--- a/packages/core/src/r3_symbols.ts
+++ b/packages/core/src/r3_symbols.ts
@@ -23,7 +23,7 @@ export {InjectableDef as ɵInjectableDef, InjectorDef as ɵInjectorDef, defineIn
 export {inject} from './di/injector';
 export {NgModuleDef as ɵNgModuleDef} from './metadata/ng_module';
 export {defineNgModule as ɵdefineNgModule} from './render3/definition';
-
+export {NgModuleFactory as ɵNgModuleFactory} from './render3/ng_module_ref';
 
 /**
  * The existence of this constant (in this particular file) informs the Angular compiler that the


### PR DESCRIPTION
When @angular/core is compiled by ngtsc, a factory file is generated
for ApplicationModule, that is currently invalid because r3_symbols
does not export NgModuleFactory. This change fixes that issue and
ensures the generated ngfactory file for @angular/core is valid.
