### PR TITLE
fix(ivy): support ng-container at the root of a view with delayed insertion

### DIFF
--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -111,6 +111,12 @@
     "name": "callHooks"
   },
   {
+    "name": "canInsertNativeChildOfElement"
+  },
+  {
+    "name": "canInsertNativeChildOfView"
+  },
+  {
     "name": "canInsertNativeNode"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -354,6 +354,12 @@
     "name": "callHooks"
   },
   {
+    "name": "canInsertNativeChildOfElement"
+  },
+  {
+    "name": "canInsertNativeChildOfView"
+  },
+  {
     "name": "canInsertNativeNode"
   },
   {


### PR DESCRIPTION
This PR handles the following case:

```html
<ng-template #tpl>
  <ng-container>
    content
  </ng-container>
</ng-template>
```

where `#tpl` is not inserted into the DOM immediately. This might happen where the `TemplateRef.createEmbeddedView(...)` is called to create view instance and then this view is inserted (or not) at the later time.  