### PR TITLE
docs: add missing word in outputs description.

### DIFF
--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -137,7 +137,7 @@ export interface Directive {
    * Enumerates the set of event-bound output properties.
    *
    * When an output property emits an event, an event handler attached to that event
-   * the template is invoked.
+   * in the template is invoked.
    *
    * The `outputs` property defines a set of `directiveProperty` to `bindingProperty`
    * configuration:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Word missing in docs.

Issue Number: N/A

## What is the new behavior?
Added missing word "in" in the outputs description.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
