### PR TITLE
fix: add mappings for ngfactory & ngsummary files to module names in aot summary resolver

### DIFF
--- a/packages/compiler/src/aot/summary_resolver.ts
+++ b/packages/compiler/src/aot/summary_resolver.ts
@@ -120,6 +120,16 @@ export class AotSummaryResolver implements SummaryResolver<StaticSymbol> {
       summaries.forEach((summary) => this.summaryCache.set(summary.symbol, summary));
       if (moduleName) {
         this.knownFileNameToModuleNames.set(filePath, moduleName);
+        if (filePath.endsWith('.d.ts')) {
+          // Also add entries to map the ngfactory & ngsummary files to their module names.
+          // This is necessary to resolve ngfactory & ngsummary files to their AMD module
+          // names when building angular with Bazel from source downstream.
+          // See https://github.com/bazelbuild/rules_typescript/pull/223 for context.
+          this.knownFileNameToModuleNames.set(
+              filePath.replace(/\.d\.ts$/, '.ngfactory.d.ts'), moduleName + '.ngfactory');
+          this.knownFileNameToModuleNames.set(
+              filePath.replace(/\.d\.ts$/, '.ngsummary.d.ts'), moduleName + '.ngsummary');
+        }
       }
       importAs.forEach((importAs) => { this.importAs.set(importAs.symbol, importAs.importAs); });
     }


### PR DESCRIPTION
When building angular from source using bazel downstream, the ngfactory & ngsummary files generated in the angular build also need to be mapped to their module names.

This PR makes https://github.com/bazelbuild/rules_typescript/pull/223 unnecessary.