### PR TITLE
build: stop printing source-map-support warning

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,9 +6,9 @@ workspace(name = "angular")
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/archive/0.11.2.zip"],
-    strip_prefix = "rules_nodejs-0.11.2",
-    sha256 = "c00d5381adeefb56e0ef959a7b168cae628535dab933cfad1c2cd1870cd7c9de",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/archive/0.11.4.zip"],
+    strip_prefix = "rules_nodejs-0.11.4",
+    sha256 = "c31c4ead696944a50fad2b3ee9dfbbeffe31a8dcca0b21b9bf5b3e6c6b069801",
 )
 
 http_archive(

--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -6,9 +6,9 @@ workspace(name = "bazel_integration_test")
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/archive/0.11.2.zip"],
-    strip_prefix = "rules_nodejs-0.11.2",
-    sha256 = "c00d5381adeefb56e0ef959a7b168cae628535dab933cfad1c2cd1870cd7c9de",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/archive/0.11.4.zip"],
+    strip_prefix = "rules_nodejs-0.11.4",
+    sha256 = "c31c4ead696944a50fad2b3ee9dfbbeffe31a8dcca0b21b9bf5b3e6c6b069801",
 )
 
 http_archive(

--- a/packages/bazel/src/BUILD.bazel
+++ b/packages/bazel/src/BUILD.bazel
@@ -19,6 +19,7 @@ nodejs_binary(
     # dependency @build_bazel_rules_nodejs_rollup_deps. We don't need any
     # additional npm dependencies when we run rollup or uglify.
     entry_point = "build_bazel_rules_nodejs_rollup_deps/node_modules/rollup/bin/rollup",
+    install_source_map_support = False,
     node_modules = "@build_bazel_rules_nodejs_rollup_deps//:node_modules",
 )
 
@@ -26,4 +27,5 @@ nodejs_binary(
     name = "modify_tsconfig",
     data = ["modify_tsconfig.js"],
     entry_point = "angular/packages/bazel/src/modify_tsconfig.js",
+    install_source_map_support = False,
 )

--- a/packages/bazel/src/ng_package/BUILD.bazel
+++ b/packages/bazel/src/ng_package/BUILD.bazel
@@ -22,5 +22,6 @@ nodejs_binary(
     name = "packager",
     data = ["lib"],
     entry_point = "angular/packages/bazel/src/ng_package/packager.js",
+    install_source_map_support = False,
     node_modules = "@angular_packager_deps//:node_modules",
 )


### PR DESCRIPTION
fixes the issue @vicb raised where our CI logs have piles of

```

INFO: From ng_package: Rollup fesm5 //packages/service-worker:npm_package:

WARNING: source-map-support module not installed.
   Stack traces from languages like TypeScript will point to generated .js files.
   
INFO: From ng_package: Rollup umd //packages/service-worker:npm_package:

WARNING: source-map-support module not installed.
   Stack traces from languages like TypeScript will point to generated .js files.
   
INFO: From ng_package: Rollup umd //packages/service-worker:npm_package:

WARNING: source-map-support module not installed.
   Stack traces from languages like TypeScript will point to generated .js files.
   
INFO: From SkylarkAction packages/service-worker/cli/ngsw_config.
```