### PR TITLE
fix(router): prevent duplicate preload and empty preload stream

### DIFF
--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -8,7 +8,7 @@
 
 import {Compiler, Injectable, Injector, NgModuleFactoryLoader, NgModuleRef, OnDestroy} from '@angular/core';
 import {Observable, Subscription, from, of } from 'rxjs';
-import {catchError, concatMap, filter, map, mergeAll, mergeMap} from 'rxjs/operators';
+import { catchError, concatMap, filter, map, mergeAll, mergeMap, take } from 'rxjs/operators';
 
 import {LoadedRouterConfig, Route, Routes} from './config';
 import {Event, NavigationEnd, RouteConfigLoadEnd, RouteConfigLoadStart} from './events';
@@ -87,7 +87,7 @@ export class RouterPreloader implements OnDestroy {
   setUpPreloading(): void {
     this.subscription =
         this.router.events
-            .pipe(filter((e: Event) => e instanceof NavigationEnd), concatMap(() => this.preload()))
+            .pipe(filter((e: Event) => e instanceof NavigationEnd), take(1), concatMap(() => this.preload()))
             .subscribe(() => {});
   }
 
@@ -117,6 +117,9 @@ export class RouterPreloader implements OnDestroy {
       } else if (route.children) {
         res.push(this.processRoutes(ngModule, route.children));
       }
+    }
+    if (res.length === 0) {
+      res.push(of(null));
     }
     return from(res).pipe(mergeAll(), map((_) => void 0));
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

* multiple NavigationEnd will trigger duplicate preload
* `processRoutes` after one preloaded route may have no child routes to
load which causes a empty stream


## What is the new behavior?

* no duplicate preload
* no empty preload stream

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
may be

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
if someone is relying on the preload trigger every navigation ended, it could break their code.

## Other information
