### PR TITLE
fix(ivy): project ng-container nodes

### DIFF
--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -708,6 +708,14 @@ export function appendProjectedNode(
     for (let i = 0; i < views.length; i++) {
       addRemoveViewFromContainer(node as LContainerNode, views[i], true, node.native);
     }
+  } else if (node.tNode.type === TNodeType.ElementContainer) {
+    let ngContainerChild = getChildLNode(node as LElementContainerNode);
+    while (ngContainerChild) {
+      appendProjectedNode(
+          ngContainerChild as LElementNode | LElementContainerNode | LTextNode | LContainerNode,
+          currentParent, currentView, renderParent);
+      ngContainerChild = getNextLNode(ngContainerChild);
+    }
   }
   if (node.dynamicLContainerNode) {
     node.dynamicLContainerNode.data[RENDER_PARENT] = renderParent;


### PR DESCRIPTION
This PR ensures that we can project and re-project `<ng-container>`s. Only second commit to be reviewed (first one is part of #25346).