### PR TITLE
fix(upgrade): trigger `$destroy` event on upgraded component element

### DIFF
--- a/packages/upgrade/src/common/angular1.ts
+++ b/packages/upgrade/src/common/angular1.ts
@@ -127,6 +127,7 @@ export type IAugmentedJQuery = Node[] & {
   controller?: (name: string) => any;
   isolateScope?: () => IScope;
   injector?: () => IInjectorService;
+  triggerHandler?: (eventTypeOrObject: string | Event, extraParameters?: any[]) => IAugmentedJQuery;
   remove?: () => void;
   removeData?: () => void;
 };

--- a/packages/upgrade/src/common/upgrade_helper.ts
+++ b/packages/upgrade/src/common/upgrade_helper.ts
@@ -119,6 +119,13 @@ export class UpgradeHelper {
     return this.compileHtml(template);
   }
 
+  onDestroy($scope: angular.IScope, controllerInstance?: any) {
+    if (controllerInstance && isFunction(controllerInstance.$onDestroy)) {
+      controllerInstance.$onDestroy();
+    }
+    $scope.$destroy();
+  }
+
   prepareTransclusion(): angular.ILinkFn|undefined {
     const transclude = this.directive.transclude;
     const contentChildNodes = this.extractChildNodes();

--- a/packages/upgrade/src/common/upgrade_helper.ts
+++ b/packages/upgrade/src/common/upgrade_helper.ts
@@ -124,6 +124,7 @@ export class UpgradeHelper {
       controllerInstance.$onDestroy();
     }
     $scope.$destroy();
+    this.$element.triggerHandler !('$destroy');
   }
 
   prepareTransclusion(): angular.ILinkFn|undefined {

--- a/packages/upgrade/src/dynamic/upgrade_ng1_adapter.ts
+++ b/packages/upgrade/src/dynamic/upgrade_ng1_adapter.ts
@@ -262,13 +262,7 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
     }
   }
 
-  ngOnDestroy() {
-    if (this.controllerInstance && isFunction(this.controllerInstance.$onDestroy)) {
-      this.controllerInstance.$onDestroy();
-    }
-
-    this.componentScope.$destroy();
-  }
+  ngOnDestroy() { this.helper.onDestroy(this.componentScope, this.controllerInstance); }
 
   setComponentProperty(name: string, value: any) {
     this.destinationObj ![this.propertyMap[name]] = value;

--- a/packages/upgrade/src/static/upgrade_component.ts
+++ b/packages/upgrade/src/static/upgrade_component.ts
@@ -217,10 +217,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     if (isFunction(this.unregisterDoCheckWatcher)) {
       this.unregisterDoCheckWatcher();
     }
-    if (this.controllerInstance && isFunction(this.controllerInstance.$onDestroy)) {
-      this.controllerInstance.$onDestroy();
-    }
-    this.$componentScope.$destroy();
+    this.helper.onDestroy(this.$componentScope, this.controllerInstance);
   }
 
   private initializeBindings(directive: angular.IDirective) {

--- a/packages/upgrade/test/dynamic/upgrade_spec.ts
+++ b/packages/upgrade/test/dynamic/upgrade_spec.ts
@@ -2145,8 +2145,7 @@ withEachNg1Version(() => {
              }
 
              // On browsers that don't support `requestAnimationFrame` (IE 9, Android <= 4.3),
-             // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
-             // on
+             // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be on
              // the queue at the end of the test, causing it to fail.
              // Mocking animations (via `ngAnimateMock`) avoids the issue.
              angular.module('ng1', ['ngAnimateMock'])
@@ -2190,8 +2189,7 @@ withEachNg1Version(() => {
              }
 
              // On browsers that don't support `requestAnimationFrame` (IE 9, Android <= 4.3),
-             // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
-             // on
+             // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be on
              // the queue at the end of the test, causing it to fail.
              // Mocking animations (via `ngAnimateMock`) avoids the issue.
              angular.module('ng1', ['ngAnimateMock'])

--- a/packages/upgrade/test/dynamic/upgrade_spec.ts
+++ b/packages/upgrade/test/dynamic/upgrade_spec.ts
@@ -2132,6 +2132,98 @@ withEachNg1Version(() => {
            }));
       });
 
+      describe('destroying the upgraded component', () => {
+        it('should destroy `componentScope`', fakeAsync(() => {
+             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+             const scopeDestroyListener = jasmine.createSpy('scopeDestroyListener');
+             let ng2ComponentInstance: Ng2Component;
+
+             @Component({selector: 'ng2', template: '<div *ngIf="!ng2Destroy"><ng1></ng1></div>'})
+             class Ng2Component {
+               ng2Destroy: boolean = false;
+               constructor() { ng2ComponentInstance = this; }
+             }
+
+             // On browsers that don't support `requestAnimationFrame` (IE 9, Android <= 4.3),
+             // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
+             // on
+             // the queue at the end of the test, causing it to fail.
+             // Mocking animations (via `ngAnimateMock`) avoids the issue.
+             angular.module('ng1', ['ngAnimateMock'])
+                 .component('ng1', {
+                   controller: function($scope: angular.IScope) {
+                     $scope.$on('$destroy', scopeDestroyListener);
+                   },
+                 })
+                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+
+             @NgModule({
+               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+               imports: [BrowserModule],
+             })
+             class Ng2Module {
+             }
+
+             const element = html('<ng2></ng2>');
+             adapter.bootstrap(element, ['ng1']).ready((ref) => {
+               const $rootScope = ref.ng1RootScope as any;
+
+               expect(scopeDestroyListener).not.toHaveBeenCalled();
+
+               ng2ComponentInstance.ng2Destroy = true;
+               tick();
+               $rootScope.$digest();
+
+               expect(scopeDestroyListener).toHaveBeenCalledTimes(1);
+             });
+           }));
+
+        it('should emit `$destroy` on `$element`', fakeAsync(() => {
+             const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+             const elementDestroyListener = jasmine.createSpy('elementDestroyListener');
+             let ng2ComponentInstance: Ng2Component;
+
+             @Component({selector: 'ng2', template: '<div *ngIf="!ng2Destroy"><ng1></ng1></div>'})
+             class Ng2Component {
+               ng2Destroy: boolean = false;
+               constructor() { ng2ComponentInstance = this; }
+             }
+
+             // On browsers that don't support `requestAnimationFrame` (IE 9, Android <= 4.3),
+             // `$animate` will use `setTimeout(..., 16.6)` instead. This timeout will still be
+             // on
+             // the queue at the end of the test, causing it to fail.
+             // Mocking animations (via `ngAnimateMock`) avoids the issue.
+             angular.module('ng1', ['ngAnimateMock'])
+                 .component('ng1', {
+                   controller: function($element: angular.IAugmentedJQuery) {
+                     $element.on !('$destroy', elementDestroyListener);
+                   },
+                 })
+                 .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
+
+             @NgModule({
+               declarations: [adapter.upgradeNg1Component('ng1'), Ng2Component],
+               imports: [BrowserModule],
+             })
+             class Ng2Module {
+             }
+
+             const element = html('<ng2></ng2>');
+             adapter.bootstrap(element, ['ng1']).ready((ref) => {
+               const $rootScope = ref.ng1RootScope as any;
+
+               expect(elementDestroyListener).not.toHaveBeenCalled();
+
+               ng2ComponentInstance.ng2Destroy = true;
+               tick();
+               $rootScope.$digest();
+
+               expect(elementDestroyListener).toHaveBeenCalledTimes(1);
+             });
+           }));
+      });
+
       describe('linking', () => {
         it('should run the pre-linking after instantiating the controller', async(() => {
              const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] Bugfix
```


## What is the current behavior?
Destroying an upgraded component, does not trigger `$destroy` on the element.

Issue Number: #25334


## What is the new behavior?
Destroying an upgraded component, triggers `$destroy` on the element (as would happen in an AngularJS app).


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No (afaict :grin:)
```


## Other information
Fixes #25334.
