### PR TITLE
build(bazel): update to rules_nodejs 0.11.2 and latest rules_typescript

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,9 +6,16 @@ workspace(name = "angular")
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    url = "https://github.com/bazelbuild/rules_nodejs/archive/20ff5892612f8359aec8aaf26dd3902a24976ada.zip",
-    strip_prefix = "rules_nodejs-20ff5892612f8359aec8aaf26dd3902a24976ada",
-    sha256 = "07da9d4c3e688a02745d0f50709a87744706d4f5d1959b799b0ac38e97acd622",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/archive/0.11.2.zip"],
+    strip_prefix = "rules_nodejs-0.11.2",
+    sha256 = "c00d5381adeefb56e0ef959a7b168cae628535dab933cfad1c2cd1870cd7c9de",
+)
+
+http_archive(
+    name = "bazel_skylib",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.3.1.zip"],
+    strip_prefix = "bazel-skylib-0.3.1",
+    sha256 = "95518adafc9a2b656667bbf517a952e54ce7f350779d0dd95133db4eb5c27fb1",
 )
 
 http_archive(
@@ -20,9 +27,9 @@ http_archive(
 
 http_archive(
     name = "build_bazel_rules_typescript",
-    url = "https://github.com/bazelbuild/rules_typescript/archive/0.15.3.zip",
-    strip_prefix = "rules_typescript-0.15.3",
-    sha256 = "a2b26ac3fc13036011196063db1bf7f1eae81334449201dc28087ebfa3708c99",
+    url = "https://github.com/bazelbuild/rules_typescript/archive/1d9a4b0087f307e31af91e2b221a6447288994c6.zip",
+    strip_prefix = "rules_typescript-1d9a4b0087f307e31af91e2b221a6447288994c6",
+    sha256 = "e17ac3f33d5d3cd2a0c385c4fd28b814d0ad46c6c67ccaef97160be99d7a24eb",
 )
 
 http_archive(

--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -6,9 +6,16 @@ workspace(name = "bazel_integration_test")
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    url = "https://github.com/bazelbuild/rules_nodejs/archive/0.10.1.zip",
-    strip_prefix = "rules_nodejs-0.10.1",
-    sha256 = "634206524d90dc03c52392fa3f19a16637d2bcf154910436fe1d669a0d9d7b9c",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/archive/0.11.2.zip"],
+    strip_prefix = "rules_nodejs-0.11.2",
+    sha256 = "c00d5381adeefb56e0ef959a7b168cae628535dab933cfad1c2cd1870cd7c9de",
+)
+
+http_archive(
+    name = "bazel_skylib",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.3.1.zip"],
+    strip_prefix = "bazel-skylib-0.3.1",
+    sha256 = "95518adafc9a2b656667bbf517a952e54ce7f350779d0dd95133db4eb5c27fb1",
 )
 
 http_archive(
@@ -20,9 +27,9 @@ http_archive(
 
 http_archive(
     name = "build_bazel_rules_typescript",
-    url = "https://github.com/bazelbuild/rules_typescript/archive/0.15.0.zip",
-    strip_prefix = "rules_typescript-0.15.0",
-    sha256 = "1aa75917330b820cb239b3c10a936a10f0a46fe215063d4492dd76dc6e1616f4",
+    url = "https://github.com/bazelbuild/rules_typescript/archive/1d9a4b0087f307e31af91e2b221a6447288994c6.zip",
+    strip_prefix = "rules_typescript-1d9a4b0087f307e31af91e2b221a6447288994c6",
+    sha256 = "e17ac3f33d5d3cd2a0c385c4fd28b814d0ad46c6c67ccaef97160be99d7a24eb",
 )
 
 http_archive(

--- a/integration/bazel/src/hello-world/BUILD.bazel
+++ b/integration/bazel/src/hello-world/BUILD.bazel
@@ -32,6 +32,7 @@ ts_library(
     name = "test_lib",
     testonly = 1,
     srcs = glob(["*.spec.ts"]),
+    tsconfig = "//src:tsconfig.json",
     deps = [":hello-world"],
 )
 

--- a/integration/bazel/test/e2e/BUILD.bazel
+++ b/integration/bazel/test/e2e/BUILD.bazel
@@ -5,6 +5,7 @@ ts_library(
     name = "e2e",
     testonly = 1,
     srcs = ["app.spec.ts"],
+    tsconfig = ":tsconfig.json",
 )
 
 ts_library(

--- a/integration/bazel/yarn.lock
+++ b/integration/bazel/yarn.lock
@@ -3,24 +3,24 @@
 
 
 "@angular/animations@file:../../dist/packages-dist/animations":
-  version "6.1.0-beta.3"
+  version "6.1.0"
   dependencies:
     tslib "^1.9.0"
 
 "@angular/bazel@file:../../dist/packages-dist/bazel":
-  version "6.1.0-beta.3"
+  version "6.1.0"
   dependencies:
     "@bazel/typescript" "^0.15.0"
     "@types/node" "6.0.84"
     protobufjs "5.0.0"
 
 "@angular/common@file:../../dist/packages-dist/common":
-  version "6.1.0-beta.3"
+  version "6.1.0"
   dependencies:
     tslib "^1.9.0"
 
 "@angular/compiler-cli@file:../../dist/packages-dist/compiler-cli":
-  version "6.1.0-beta.3"
+  version "6.1.0"
   dependencies:
     chokidar "^1.4.2"
     convert-source-map "^1.5.1"
@@ -31,22 +31,22 @@
     tsickle "^0.32.1"
 
 "@angular/compiler@file:../../dist/packages-dist/compiler":
-  version "6.1.0-beta.3"
+  version "6.1.0"
   dependencies:
     tslib "^1.9.0"
 
 "@angular/core@file:../../dist/packages-dist/core":
-  version "6.1.0-beta.3"
+  version "6.1.0"
   dependencies:
     tslib "^1.9.0"
 
 "@angular/platform-browser-dynamic@file:../../dist/packages-dist/platform-browser-dynamic":
-  version "6.1.0-beta.3"
+  version "6.1.0"
   dependencies:
     tslib "^1.9.0"
 
 "@angular/platform-browser@file:../../dist/packages-dist/platform-browser":
-  version "6.1.0-beta.3"
+  version "6.1.0"
   dependencies:
     tslib "^1.9.0"
 
@@ -1236,7 +1236,7 @@ rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1:
     glob "^7.0.5"
 
 "rxjs@file:../../node_modules/rxjs":
-  version "6.0.0"
+  version "6.2.1"
   dependencies:
     tslib "^1.9.0"
 
@@ -1410,9 +1410,9 @@ tough-cookie@~2.3.3:
   dependencies:
     punycode "^1.4.1"
 
-tsickle@^0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.30.0.tgz#7941146ae92933854a8742fa1047606c4536649b"
+tsickle@^0.32.1:
+  version "0.32.1"
+  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.32.1.tgz#f16e94ba80b32fc9ebe320dc94fbc2ca7f3521a5"
   dependencies:
     jasmine-diff "^0.1.3"
     minimist "^1.2.0"

--- a/packages/bazel/src/ngc-wrapped/BUILD.bazel
+++ b/packages/bazel/src/ngc-wrapped/BUILD.bazel
@@ -30,7 +30,7 @@ nodejs_binary(
     name = "ngc-wrapped",
     data = [
         ":ngc_lib",
-        "@build_bazel_rules_typescript//internal:worker_protocol.proto",
+        "@build_bazel_rules_typescript//third_party/github.com/bazelbuild/bazel/src/main/protobuf:worker_protocol.proto",
     ],
     entry_point = "angular/packages/bazel/src/ngc-wrapped/index.js",
     visibility = ["//visibility:public"],

--- a/packages/bazel/test/ngc-wrapped/BUILD.bazel
+++ b/packages/bazel/test/ngc-wrapped/BUILD.bazel
@@ -30,6 +30,6 @@ jasmine_node_test(
         ":angular_core",
         "//packages/bazel/test/ngc-wrapped/empty:empty_tsconfig.json",
         "//packages/bazel/test/ngc-wrapped/empty:tsconfig.json",
-        "@build_bazel_rules_typescript//internal:worker_protocol.proto",
+        "@build_bazel_rules_typescript//third_party/github.com/bazelbuild/bazel/src/main/protobuf:worker_protocol.proto",
     ],
 )

--- a/packages/bazel/test/protractor-2/BUILD.bazel
+++ b/packages/bazel/test/protractor-2/BUILD.bazel
@@ -6,6 +6,7 @@ load("//tools/http-server:http_server.bzl", "http_server")
 ts_library(
     name = "app",
     srcs = ["app.ts"],
+    tsconfig = ":tsconfig.json",
 )
 
 ts_devserver(
@@ -33,6 +34,7 @@ ts_library(
     name = "ts_spec",
     testonly = True,
     srcs = ["test.spec.ts"],
+    tsconfig = ":tsconfig.json",
 )
 
 protractor_web_test_suite(

--- a/packages/bazel/test/protractor-2/tsconfig.json
+++ b/packages/bazel/test/protractor-2/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "compilerOptions": {
-    "lib": ["es2015"]
+    "lib": ["dom", "es2015"]
   }
 }

--- a/packages/bazel/test/protractor/BUILD.bazel
+++ b/packages/bazel/test/protractor/BUILD.bazel
@@ -5,6 +5,7 @@ ts_library(
     name = "ts_spec",
     testonly = True,
     srcs = ["test.spec.ts"],
+    tsconfig = ":tsconfig.json",
 )
 
 ts_library(

--- a/tools/ts-api-guardian/BUILD.bazel
+++ b/tools/ts-api-guardian/BUILD.bazel
@@ -46,6 +46,7 @@ ts_library(
     name = "test_lib",
     testonly = True,
     srcs = glob(["test/*.ts"]),
+    tsconfig = "//tools:tsconfig.json",
     deps = [":lib"],
 )
 


### PR DESCRIPTION
This PR is to get https://github.com/angular/angular/pull/25169 onto the 6.1.x branch. It includes an update to the rules_typescript protocol_worker.proto reference that is needed on the 6.1.x branch to work with the latest rules_typescript.

https://github.com/alexeagle/angular-bazel-example/pull/160 can be updated to pull angular from the 6.1.x branch after this lands.