### PR TITLE
Make compilerHost.readResource injectable, so scss preprocess is possible via the API

### DIFF
--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -23,18 +23,18 @@ import {performWatchCompilation, createPerformWatchHost} from './perform_watch'
 
 export function main(
     args: string[], consoleError: (s: string) => void = console.error,
-    config?: NgcParsedConfiguration): number {
+    config?: NgcParsedConfiguration, readResource?: (path: string) => Promise<string>): number {
   let {project, rootNames, options, errors: configErrors, watch, emitFlags} =
       config || readNgcCommandLineAndConfiguration(args);
   if (configErrors.length) {
     return reportErrorsAndExit(configErrors, /*options*/ undefined, consoleError);
   }
   if (watch) {
-    const result = watchMode(project, options, consoleError);
+    const result = watchMode(project, options, consoleError, readResource);
     return reportErrorsAndExit(result.firstCompileResult, options, consoleError);
   }
   const {diagnostics: compileDiags} = performCompilation(
-      {rootNames, options, emitFlags, emitCallback: createEmitCallback(options)});
+      {rootNames, options, emitFlags, emitCallback: createEmitCallback(options), readResource});
   return reportErrorsAndExit(compileDiags, options, consoleError);
 }
 
@@ -154,10 +154,11 @@ function reportErrorsAndExit(
 }
 
 export function watchMode(
-    project: string, options: api.CompilerOptions, consoleError: (s: string) => void) {
+    project: string, options: api.CompilerOptions, consoleError: (s: string) => void,
+    readResource?: (path: string) => Promise<string>) {
   return performWatchCompilation(createPerformWatchHost(project, diagnostics => {
-    consoleError(formatDiagnostics(diagnostics));
-  }, options, options => createEmitCallback(options)));
+                                   consoleError(formatDiagnostics(diagnostics));
+                                 }, options, options => createEmitCallback(options)), readResource);
 }
 
 // CLI entry point

--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -186,12 +186,13 @@ export function exitCodeFromResult(diags: Diagnostics | undefined): number {
 }
 
 export function performCompilation({rootNames, options, host, oldProgram, emitCallback,
-                                    mergeEmitResultsCallback,
+                                    mergeEmitResultsCallback, readResource,
                                     gatherDiagnostics = defaultGatherDiagnostics,
                                     customTransformers, emitFlags = api.EmitFlags.Default}: {
   rootNames: string[],
   options: api.CompilerOptions,
   host?: api.CompilerHost,
+  readResource?: (path: string) => Promise<string>,
   oldProgram?: api.Program,
   emitCallback?: api.TsEmitCallback,
   mergeEmitResultsCallback?: api.TsMergeEmitResultsCallback,
@@ -205,6 +206,7 @@ export function performCompilation({rootNames, options, host, oldProgram, emitCa
   try {
     if (!host) {
       host = ng.createCompilerHost({options});
+      if (readResource) host.readResource = readResource;
     }
 
     program = ng.createProgram({rootNames, host, options, oldProgram});

--- a/packages/compiler-cli/src/perform_watch.ts
+++ b/packages/compiler-cli/src/perform_watch.ts
@@ -106,7 +106,8 @@ interface CacheEntry {
 /**
  * The logic in this function is adapted from `tsc.ts` from TypeScript.
  */
-export function performWatchCompilation(host: PerformWatchHost):
+export function performWatchCompilation(
+    host: PerformWatchHost, readResource?: (path: string) => Promise<string>):
     {close: () => void, ready: (cb: () => void) => void, firstCompileResult: Diagnostics} {
   let cachedProgram: api.Program|undefined;            // Program cached from last compilation
   let cachedCompilerHost: api.CompilerHost|undefined;  // CompilerHost cached from last compilation
@@ -158,6 +159,7 @@ export function performWatchCompilation(host: PerformWatchHost):
     const startTime = Date.now();
     if (!cachedCompilerHost) {
       cachedCompilerHost = host.createCompilerHost(cachedOptions.options);
+      if (readResource) cachedCompilerHost.readResource = readResource;
       const originalWriteFileCallback = cachedCompilerHost.writeFile;
       cachedCompilerHost.writeFile = function(
           fileName: string, data: string, writeByteOrderMark: boolean,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Feature
```

## What is the current behavior?
It's not possible to preprocess the loaded resources during compilation.


## What is the new behavior?
This PR adds an option to process scss files and inject the desired css (using the the API), so there is no need for extra watch step and temporary files.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
Example usage:
```
main(['-p', './src/tsconfig.json'], undefined, path => {
  if (path.endsWith('.scss')) {
    const result = node_sass.renderSync({
      file: path,
      outputStyle: 'compressed',
      sourceMap: false,
    });
    return postcss([autoprefixer]).process(result.css.toString('utf8'), { from: undefined }).css;
  }
  return fs.readFileSync(path).toString('utf8');
});
```