### PR TITLE
Revert "build: update Bazel to 0.16 (#25316)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@
 ## IMPORTANT
 # If you change the `docker_image` version, also change the `cache_key` suffix and the version of
 # `com_github_bazelbuild_buildtools` in the `/WORKSPACE` file.
-var_1: &docker_image angular/ngcontainer:0.4.0
-var_2: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.4.0
+var_1: &docker_image angular/ngcontainer:0.3.3
+var_2: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.3.3
 
 # Define common ENV vars
 var_3: &define_env_vars

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -100,7 +100,7 @@ local_repository(
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories", "yarn_install")
 
-check_bazel_version("0.16.0")
+check_bazel_version("0.15.0")
 node_repositories(
   package_json = ["//:package.json"],
   preserve_symlinks = True,

--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -65,7 +65,7 @@ local_repository(
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories")
 
-check_bazel_version("0.16.0")
+check_bazel_version("0.15.0")
 node_repositories(package_json = ["//:package.json"])
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/tools/ngcontainer/Dockerfile
+++ b/tools/ngcontainer/Dockerfile
@@ -19,7 +19,7 @@ RUN JAVA_DEBIAN_VERSION="8u131-b11-1~bpo8+1" \
 ###
 # Bazel install
 # See https://bazel.build/versions/master/docs/install-ubuntu.html#using-bazel-custom-apt-repository-recommended
-RUN BAZEL_VERSION="0.16.0" \
+RUN BAZEL_VERSION="0.15.0" \
  && wget -q -O - https://bazel.build/bazel-release.pub.gpg | apt-key add - \
  && echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/bazel.list \
  && apt-get update \

--- a/tools/ngcontainer/README.md
+++ b/tools/ngcontainer/README.md
@@ -6,7 +6,7 @@ This docker container provides everything needed to build and test Angular appli
 - npm 5.5.1
 - yarn 1.3.2
 - Java 8 (for Closure Compiler and Bazel)
-- Bazel build tool v0.16.0 - http://bazel.build
+- Bazel build tool v0.15.0 - http://bazel.build
 - Google Chrome 63.0.3239.84
 - Mozilla Firefox 47.0.1
 - xvfb (virtual framebuffer) for headless testing


### PR DESCRIPTION
This reverts commit 4eb8ac6de945bbc0d425e97d9f034ed68b307c50, as it's blocking release.