### PR TITLE
fix(service-worker): `Cache-Control: no-cache` on assets breaks service worker

### DIFF
--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -193,9 +193,10 @@ export abstract class AssetGroup {
       cacheDirectives.forEach(v => v[0] = v[0].toLowerCase());
 
       // Find the max-age directive, if one exists.
-      const cacheAge = cacheDirectives.filter(v => v[0] === 'max-age').map(v => v[1])[0];
+      const maxAgeDirective = cacheDirectives.find(v => v[0] === 'max-age');
+      const cacheAge = maxAgeDirective ? maxAgeDirective[1] : undefined;
 
-      if (cacheAge.length === 0) {
+      if (!cacheAge) {
         // No usable TTL defined. Must assume that the response is stale.
         return true;
       }

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -28,6 +28,7 @@ const dist =
         .addFile('/lazy/unchanged1.txt', 'this is unchanged (1)')
         .addFile('/lazy/unchanged2.txt', 'this is unchanged (2)')
         .addUnhashedFile('/unhashed/a.txt', 'this is unhashed', {'Cache-Control': 'max-age=10'})
+        .addUnhashedFile('/unhashed/b.txt', 'this is unhashed b', {'Cache-Control': 'no-cache'})
         .build();
 
 const distUpdate =
@@ -618,6 +619,13 @@ const manifestUpdateHash = sha1(JSON.stringify(manifestUpdate));
         expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
         server.assertSawRequestFor('/unhashed/a.txt');
         expect(await makeRequest(scope, '/unhashed/a.txt')).toEqual('this is unhashed');
+        server.assertNoOtherRequests();
+      });
+
+      async_it(`doesn't error when 'Cache-Control' is 'no-cache'`, async() => {
+        expect(await makeRequest(scope, '/unhashed/b.txt')).toEqual('this is unhashed b');
+        server.assertSawRequestFor('/unhashed/b.txt');
+        expect(await makeRequest(scope, '/unhashed/b.txt')).toEqual('this is unhashed b');
         server.assertNoOtherRequests();
       });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
At the moment `cacheAge` can be undefined and when it is so, it causes `cannot read `length` of `undefined` when having `Cache-Control` set to `no-cache` due the mapping method in `needToRevalidate`


Issue Number: N/A


## What is the new behavior?
No error

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Closes #25442