### PR TITLE
docs: fix typo in Architecture overview page

### DIFF
--- a/aio/content/guide/architecture.md
+++ b/aio/content/guide/architecture.md
@@ -51,7 +51,7 @@ The `@Component()` decorator identifies the class immediately below it as a comp
 
 A template combines HTML with Angular markup that can modify HTML elements before they are displayed.
 Template *directives* provide program logic, and *binding markup* connects your application data and the DOM.
-There are tow types of data binding:
+There are two types of data binding:
 
 * *Event binding* lets your app respond to user input in the target environment by updating your application data.
 * *Property binding* lets you interpolate values that are computed from your application data into the HTML.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Architecture overview docs has a typo

Issue Number: N/A


## What is the new behavior?
Corrected the typo

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is related to #25413 which is being closed due to messing up the commit history.