### PR TITLE
fix(common): return correct week of year number for date pipe

### DIFF
--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -351,6 +351,9 @@ const MS_PER_DAY = 86400000;
  * [ISO 8601](https://en.wikipedia.org/wiki/ISO_week_date): weeks start on Monday and the first week
  * of the year is the one with 4th of January.
  *
+ * Most of the code comes from [Closure
+ * `getWeekNumber`](https://github.com/google/closure-library/blob/master/closure/goog/date/date.js)
+ *
  * @param size Number of digits to return, 1 (not zero padded) or 2 (zero padded)
  * @param monthBased Whether we want the week number of the year (default) or of the month
  */
@@ -359,12 +362,13 @@ function weekGetter(size: number, monthBased = false): DateFormatter {
     // Get the current day number as an ISO weekday (Monday = 0)
     const isoDay = (d.getDay() + 6) % 7 + 1;
     // Set the date to Thursday of the current week because week 1 has the 1st Thursday of the year
-    d = new Date(d);
-    d.setDate(d.getDate() + THURSDAY - isoDay);
-    const start = new Date(d.getFullYear(), monthBased ? d.getMonth() : JANUARY, 1).getTime();
+    const thursday = new Date(d);
+    thursday.setDate(thursday.getDate() + THURSDAY - isoDay);
+    const start =
+        new Date(thursday.getFullYear(), monthBased ? thursday.getMonth() : JANUARY, 1).getTime();
     // There might be +-1 hour shift in the result due to the daylight saving, but it doesn't affect
     // the end result because we use Math.round().
-    const result = Math.floor(Math.round((d.getTime() - start) / MS_PER_DAY) / 7) + 1;
+    const result = Math.floor(Math.round((thursday.getTime() - start) / MS_PER_DAY) / 7) + 1;
 
     return padNumber(result, size, getLocaleNumberSymbol(locale, NumberSymbol.MinusSign));
   };

--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -75,9 +75,9 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  *  |                    | LLL         | Abbreviated                                                   | Sep                                                        |
  *  |                    | LLLL        | Wide                                                          | September                                                  |
  *  |                    | LLLLL       | Narrow                                                        | S                                                          |
- *  | Week of year       | w           | Numeric: minimum digits                                       | 1... 53                                                    |
+ *  | Week of year²      | w           | Numeric: minimum digits                                       | 1... 53                                                    |
  *  |                    | ww          | Numeric: 2 digits + zero padded                               | 01... 53                                                   |
- *  | Week of month      | W           | Numeric: 1 digit                                              | 1... 5                                                     |
+ *  | Week of month²     | W           | Numeric: 1 digit                                              | 1... 5                                                     |
  *  | Day of month       | d           | Numeric: minimum digits                                       | 1                                                          |
  *  |                    | dd          | Numeric: 2 digits + zero padded                               | 01                                                          |
  *  | Week day           | E, EE & EEE | Abbreviated                                                   | Tue                                                        |
@@ -113,6 +113,9 @@ import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
  *  |                    | OOOO        | Long localized GMT format                                     | GMT-08:00                                                  |
  *
  * Note that timezone correction is not applied to an ISO string that has no time component, such as "2016-09-19"
+ *
+ * ² Follows [ISO 8601 Week Date](https://en.wikipedia.org/wiki/ISO_week_date) rules where weeks
+ * start on Monday and the first week of the year is the one with 4th of January.
  *
  * ### Format examples
  *

--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -324,5 +324,47 @@ describe('Format date', () => {
       expect(formatDate(3001, 'm:ss.SS', 'en')).toEqual('0:03.00');
       expect(formatDate(3001, 'm:ss.SSS', 'en')).toEqual('0:03.001');
     });
+
+    it('should return the correct week of the year', () => {
+      expect(formatDate('2018-03-11', 'w', 'en')).toEqual('10');
+      expect(formatDate('2011-01-02', 'w', 'en')).toEqual('52');
+      expect(formatDate('2017-07-17T00:00:00.000Z', 'w', 'en', '+0000')).toEqual('29');
+      expect(formatDate('2017-07-23T23:59:59.000Z', 'w', 'en', '+0000')).toEqual('29');
+      expect(formatDate('2021-01-04T00:00:00.000Z', 'w', 'en', '+0000')).toEqual('1');
+      expect(formatDate('2015-12-31', 'w', 'en')).toEqual('53');
+      expect(formatDate('2021-02-22', 'w', 'en')).toEqual('8');
+
+      // Set date to Monday of the first week of 2017
+      let testDate = new Date('2017-01-02T00:00:01.000Z');
+      const maxDate = new Date('2018-01-01T00:00:00.000Z');
+      const DAY_IN_MS = 86400000;
+      let n = 1;
+      while (testDate < maxDate) {
+        expect(formatDate(testDate, 'w', 'en', '+0000')).toEqual(n.toString());
+        // Set date to Sunday 23:59:59 of the same week
+        testDate = new Date(testDate.getTime() + 7 * DAY_IN_MS - 2000);
+        // Set date to Monday 00:00:01 of the next week
+        expect(formatDate(testDate, 'w', 'en', '+0000')).toEqual(n.toString());
+        testDate = new Date(testDate.getTime() + 2000);
+        n++;
+      }
+    });
+
+    it('should return the correct week of the month', () => {
+      // Set date to Monday of the first week of 2017
+      let testDate = new Date('2017-01-02T00:00:01.000Z');
+      const maxDate = new Date('2017-01-30T00:00:00.000Z');
+      const DAY_IN_MS = 86400000;
+      let n = 1;
+      while (testDate < maxDate) {
+        expect(formatDate(testDate, 'W', 'en', '+0000')).toEqual(n.toString());
+        // Set date to Sunday 23:59:59 of the same week
+        testDate = new Date(testDate.getTime() + 7 * DAY_IN_MS - 2000);
+        // Set date to Monday 00:00:01 of the next week
+        expect(formatDate(testDate, 'W', 'en', '+0000')).toEqual(n.toString());
+        testDate = new Date(testDate.getTime() + 2000);
+        n++;
+      }
+    });
   });
 });

--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -365,6 +365,9 @@ describe('Format date', () => {
         testDate = new Date(testDate.getTime() + 2000);
         n++;
       }
+
+      // 2017-01-01 is a Sunday and is part of the last week of December 2016
+      expect(formatDate('2017-01-01T00:00:00.000Z', 'W', 'en', '+0000')).toEqual('5');
     });
   });
 });


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
[ISO 8601](https://en.wikipedia.org/wiki/ISO_week_date) states that weeks should start with a monday. Also sometimes the number could be wrong due to daylight saving times.

Issue Number: #25380

## What is the new behavior?
We set the dates to UTC and the first day of week to monday for this calculation only.


## Does this PR introduce a breaking change?
```
[x] Yes
```