### PR TITLE
refactor(ivy): harmonize container and element / elementContainer signatures

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1840,8 +1840,8 @@ export function createLContainer(
  * @param localRefs A set of local reference bindings on the element.
  */
 export function container(
-    index: number, template?: ComponentTemplate<any>, tagName?: string | null, attrs?: TAttributes,
-    localRefs?: string[] | null): void {
+    index: number, template?: ComponentTemplate<any>| null, tagName?: string | null,
+    attrs?: TAttributes | null, localRefs?: string[] | null): void {
   ngDevMode &&
       assertEqual(
           viewData[BINDING_INDEX], -1, 'container nodes should be created before any bindings');

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -1159,7 +1159,7 @@ describe('di', () => {
           /** <div *myIf="showing" dir dirSameInstance #dir="dir"> {{ dir.value }} </div> */
           template: function(rf: RenderFlags, ctx: MyApp) {
             if (rf & RenderFlags.Create) {
-              container(0, C1, undefined, ['myIf', 'showing']);
+              container(0, C1, null, ['myIf', 'showing']);
             }
             if (rf & RenderFlags.Update) {
               containerRefreshStart(0);

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -510,7 +510,7 @@ describe('query', () => {
             'cmpt',
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                container(1, undefined, undefined, undefined, ['foo', '']);
+                container(1, null, null, null, ['foo', '']);
               }
             },
             [], [],
@@ -542,7 +542,7 @@ describe('query', () => {
                'cmpt',
                function(rf: RenderFlags, ctx: any) {
                  if (rf & RenderFlags.Create) {
-                   container(1, undefined, undefined, undefined, ['foo', '']);
+                   container(1, null, null, null, ['foo', '']);
                  }
                },
                [], [],
@@ -577,7 +577,7 @@ describe('query', () => {
             'cmpt',
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                container(1, undefined, undefined, undefined, ['foo', '']);
+                container(1, null, null, null, ['foo', '']);
               }
             },
             [], [],
@@ -609,7 +609,7 @@ describe('query', () => {
             'cmpt',
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                container(1, undefined, undefined, undefined, ['foo', '']);
+                container(1, null, null, null, ['foo', '']);
               }
             },
             [], [],
@@ -1129,7 +1129,7 @@ describe('query', () => {
                      }
                    }, null, []);
 
-                   container(5, undefined, null, [AttributeMarker.SelectOnly, 'vc']);
+                   container(5, null, null, [AttributeMarker.SelectOnly, 'vc']);
                  }
 
                  if (rf & RenderFlags.Update) {
@@ -1221,8 +1221,8 @@ describe('query', () => {
                      }
                    }, null, []);
 
-                   container(2, undefined, null, [AttributeMarker.SelectOnly, 'vc']);
-                   container(3, undefined, null, [AttributeMarker.SelectOnly, 'vc']);
+                   container(2, null, null, [AttributeMarker.SelectOnly, 'vc']);
+                   container(3, null, null, [AttributeMarker.SelectOnly, 'vc']);
                  }
 
                  if (rf & RenderFlags.Update) {
@@ -1288,7 +1288,7 @@ describe('query', () => {
                     element(0, 'span', ['id', 'from_tpl'], ['foo', '']);
                   }
                 }, undefined, undefined, ['tpl', '']);
-                container(3, undefined, null, [AttributeMarker.SelectOnly, 'ngTemplateOutlet']);
+                container(3, null, null, [AttributeMarker.SelectOnly, 'ngTemplateOutlet']);
               }
               if (rf & RenderFlags.Update) {
                 const tplRef = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(1)));

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -163,7 +163,7 @@ describe('ViewContainerRef', () => {
 
       it('should work on containers', () => {
         function createTemplate() {
-          container(0, embeddedTemplate, undefined, ['vcref', '']);
+          container(0, embeddedTemplate, null, ['vcref', '']);
           element(1, 'footer');
         }
 
@@ -246,8 +246,8 @@ describe('ViewContainerRef', () => {
                template: (rf: RenderFlags, cmp: TestComponent) => {
                  if (rf & RenderFlags.Create) {
                    text(0, 'before|');
-                   container(1, EmbeddedTemplateA, undefined, ['testdir', '']);
-                   container(2, EmbeddedTemplateB, undefined, ['testdir', '']);
+                   container(1, EmbeddedTemplateA, null, ['testdir', '']);
+                   container(2, EmbeddedTemplateB, null, ['testdir', '']);
                    text(3, '|after');
                  }
                },
@@ -315,7 +315,7 @@ describe('ViewContainerRef', () => {
                template: (rf: RenderFlags, cmp: TestComponent) => {
                  if (rf & RenderFlags.Create) {
                    text(0, 'before|');
-                   container(1, EmbeddedTemplateA, undefined, ['testdir', '']);
+                   container(1, EmbeddedTemplateA, null, ['testdir', '']);
                    container(2);
                    text(3, '|after');
                  }
@@ -1074,7 +1074,7 @@ describe('ViewContainerRef', () => {
 
       it('should work on containers', () => {
         function createTemplate() {
-          container(0, embeddedTemplate, undefined, ['vcref', '']);
+          container(0, embeddedTemplate, null, ['vcref', '']);
           element(1, 'footer');
         }
 


### PR DESCRIPTION
A small PR that unifies `container(...)`, `element(...)`, `elementStart(...)` and `elementContainer(...)` signatures by accepting `null` where there are no attributes. Before this change  `container(...)` required usage of `undefined`