### PR TITLE
fix(ivy): no more ReferenceError when ngDevMode is not defined

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -19,8 +19,10 @@ import {CssSelectorList, SelectorFlags} from './interfaces/projection';
 
 const EMPTY: {} = {};
 const EMPTY_ARRAY: any[] = [];
-ngDevMode && Object.freeze(EMPTY);
-ngDevMode && Object.freeze(EMPTY_ARRAY);
+if (typeof ngDevMode !== 'undefined') {
+  Object.freeze(EMPTY);
+  Object.freeze(EMPTY_ARRAY);
+}
 let _renderCompCount = 0;
 
 /**

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -19,7 +19,7 @@ import {CssSelectorList, SelectorFlags} from './interfaces/projection';
 
 const EMPTY: {} = {};
 const EMPTY_ARRAY: any[] = [];
-if (typeof ngDevMode !== 'undefined') {
+if (typeof ngDevMode !== 'undefined' && ngDevMode) {
   Object.freeze(EMPTY);
   Object.freeze(EMPTY_ARRAY);
 }


### PR DESCRIPTION
This resolves an issue caused by [this commit](https://github.com/angular/angular/commit/2016afdbff384be93ee4cb785531506406792d73#diff-1b0b9ae5757060000a8411b2ab9a7f54R22), where, if `ngDevMode` isn't defined, you get a `ReferenceError`.