### PR TITLE
build: move ambient node types declarations to leafs

### DIFF
--- a/packages/animations/browser/src/render/shared.ts
+++ b/packages/animations/browser/src/render/shared.ts
@@ -5,6 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+
+/// <reference types="node" />
+
 import {AUTO_STYLE, AnimationEvent, AnimationPlayer, NoopAnimationPlayer, ɵAnimationGroupPlayer, ɵPRE_STYLE as PRE_STYLE, ɵStyleData} from '@angular/animations';
 
 import {AnimationStyleNormalizer} from '../../src/dsl/style_normalization/animation_style_normalizer';

--- a/packages/bazel/test/ng_package/example_package.spec.ts
+++ b/packages/bazel/test/ng_package/example_package.spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {createPatch} from 'diff';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/packages/benchpress/src/common_options.ts
+++ b/packages/benchpress/src/common_options.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {InjectionToken} from '@angular/core';
 import * as fs from 'fs';
 

--- a/packages/benchpress/src/firefox_extension/lib/main.ts
+++ b/packages/benchpress/src/firefox_extension/lib/main.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 const {Cc, Ci, Cu} = require('chrome');
 const os = Cc['@mozilla.org/observer-service;1'].getService(Ci.nsIObserverService);
 const ParserUtil = require('./parser_util');

--- a/packages/benchpress/src/firefox_extension/lib/test_helper.ts
+++ b/packages/benchpress/src/firefox_extension/lib/test_helper.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 const q = require('q');
 const FirefoxProfile = require('firefox-profile');
 const jpm = require('jpm/lib/xpi');

--- a/packages/benchpress/src/webdriver/selenium_webdriver_adapter.ts
+++ b/packages/benchpress/src/webdriver/selenium_webdriver_adapter.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {StaticProvider} from '@angular/core';
 
 import {WebDriverAdapter} from '../web_driver_adapter';
-
 
 /**
  * Adapter for the selenium-webdriver.

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {ConstantPool, Expression, R3ComponentMetadata, R3DirectiveMetadata, WrappedNodeExpr, compileComponentFromMetadata, makeBindingParser, parseTemplate} from '@angular/compiler';
 import * as path from 'path';
 import * as ts from 'typescript';

--- a/packages/compiler-cli/src/ngtsc/factories/src/generator.ts
+++ b/packages/compiler-cli/src/ngtsc/factories/src/generator.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as path from 'path';
 import * as ts from 'typescript';
 

--- a/packages/compiler-cli/src/ngtsc/factories/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/factories/src/host.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as path from 'path';
 import * as ts from 'typescript';
 

--- a/packages/compiler-cli/src/ngtsc/metadata/src/resolver.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/resolver.ts
@@ -11,6 +11,8 @@
  * values where possible and returning a `DynamicValue` signal when not.
  */
 
+/// <reference types="node" />
+
 import {Expression, ExternalExpr, ExternalReference, WrappedNodeExpr} from '@angular/compiler';
 import * as path from 'path';
 import * as ts from 'typescript';

--- a/packages/compiler-cli/src/ngtsc/testing/in_memory_typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/in_memory_typescript.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as path from 'path';
 import * as ts from 'typescript';
 

--- a/packages/compiler-cli/src/ngtsc/util/src/path.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/path.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as path from 'path';
 
 const TS_DTS_EXTENSION = /(\.d)?\.ts$/;

--- a/packages/compiler-cli/test/diagnostics/check_types_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/check_types_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as ng from '@angular/compiler-cli';
 import * as fs from 'fs';
 import * as os from 'os';

--- a/packages/compiler-cli/test/diagnostics/mocks.ts
+++ b/packages/compiler-cli/test/diagnostics/mocks.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {AotCompilerHost, AotSummaryResolver, CompileMetadataResolver, CompilerConfig, DEFAULT_INTERPOLATION_CONFIG, DirectiveNormalizer, DirectiveResolver, DomElementSchemaRegistry, HtmlParser, I18NHtmlParser, InterpolationConfig, JitSummaryResolver, Lexer, NgAnalyzedModules, NgModuleResolver, ParseTreeResult, Parser, PipeResolver, ResourceLoader, StaticReflector, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, StaticSymbolResolverHost, SummaryResolver, TemplateParser, analyzeNgModules, createOfflineCompileUrlResolver} from '@angular/compiler';
 import {ViewEncapsulation, ɵConsole as Console} from '@angular/core';
 import * as fs from 'fs';

--- a/packages/compiler-cli/test/extract_i18n_spec.ts
+++ b/packages/compiler-cli/test/extract_i18n_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';

--- a/packages/compiler-cli/test/metadata/evaluator_spec.ts
+++ b/packages/compiler-cli/test/metadata/evaluator_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as fs from 'fs';
 import * as ts from 'typescript';
 

--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';

--- a/packages/compiler-cli/test/ngtools_api_spec.ts
+++ b/packages/compiler-cli/test/ngtools_api_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {__NGTOOLS_PRIVATE_API_2 as NgTools_InternalApi_NG_2} from '@angular/compiler-cli';
 import * as path from 'path';
 import * as ts from 'typescript';

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';

--- a/packages/compiler-cli/test/perform_watch_spec.ts
+++ b/packages/compiler-cli/test/perform_watch_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';

--- a/packages/compiler-cli/test/test_support.ts
+++ b/packages/compiler-cli/test/test_support.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';

--- a/packages/compiler-cli/test/transformers/node_emitter_spec.ts
+++ b/packages/compiler-cli/test/transformers/node_emitter_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '@angular/compiler';
 import * as o from '@angular/compiler/src/output/output_ast';
 import * as ts from 'typescript';

--- a/packages/compiler-cli/test/transformers/program_spec.ts
+++ b/packages/compiler-cli/test/transformers/program_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as ng from '@angular/compiler-cli';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/packages/compiler/test/aot/summary_resolver_spec.ts
+++ b/packages/compiler/test/aot/summary_resolver_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {AotSummaryResolver, AotSummaryResolverHost, CompileSummaryKind, CompileTypeSummary, ResolvedStaticSymbol, StaticSymbol, StaticSymbolCache, StaticSymbolResolver} from '@angular/compiler';
 import {deserializeSummaries, serializeSummaries} from '@angular/compiler/src/aot/summary_serializer';
 import {ConstantPool} from '@angular/compiler/src/constant_pool';

--- a/packages/compiler/test/aot/test_util.ts
+++ b/packages/compiler/test/aot/test_util.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {AotCompilerHost, AotCompilerOptions, GeneratedFile, createAotCompiler, toTypeScript} from '@angular/compiler';
 import {MetadataBundlerHost} from '@angular/compiler-cli/src/metadata/bundler';
 import {MetadataCollector} from '@angular/compiler-cli/src/metadata/collector';

--- a/packages/compiler/test/schema/schema_extractor.ts
+++ b/packages/compiler/test/schema/schema_extractor.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 const SVG_PREFIX = ':svg:';
 
 // Element | Node interfaces

--- a/packages/compiler/testing/src/output/source_map_util.ts
+++ b/packages/compiler/testing/src/output/source_map_util.ts
@@ -6,7 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {SourceMap} from '@angular/compiler';
+
 const b64 = require('base64-js');
 const SourceMapConsumer = require('source-map').SourceMapConsumer;
 

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, Compiler, CompilerFactory, Component, NgModule, NgZone, PlatformRef, TemplateRef, Type, ViewChild, ViewContainerRef} from '@angular/core';
 import {ApplicationRef} from '@angular/core/src/application_ref';
 import {ErrorHandler} from '@angular/core/src/error_handler';

--- a/packages/core/test/bundling/hello_world/treeshaking_spec.ts
+++ b/packages/core/test/bundling/hello_world/treeshaking_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {withBody} from '@angular/private/testing';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/packages/core/test/bundling/hello_world_r2/treeshaking_spec.ts
+++ b/packages/core/test/bundling/hello_world_r2/treeshaking_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as fs from 'fs';
 import * as path from 'path';
 

--- a/packages/core/test/bundling/injection/treeshaking_spec.ts
+++ b/packages/core/test/bundling/injection/treeshaking_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as fs from 'fs';
 import * as path from 'path';
 

--- a/packages/core/test/bundling/todo/todo_e2e_spec.ts
+++ b/packages/core/test/bundling/todo/todo_e2e_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {ɵwhenRendered as whenRendered} from '@angular/core';
 import {withBody} from '@angular/private/testing';
 import * as fs from 'fs';

--- a/packages/core/test/render3/load_domino.ts
+++ b/packages/core/test/render3/load_domino.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 // Needed to run animation tests
 require('zone.js/dist/zone-node.js');
 

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {stringifyElement} from '@angular/platform-browser/testing/src/browser_util';
 
 import {Injector} from '../../src/di/injector';

--- a/packages/http/test/backends/xhr_backend_spec.ts
+++ b/packages/http/test/backends/xhr_backend_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {Injectable} from '@angular/core';
 import {AsyncTestCompleter, SpyObject, afterEach, beforeEach, beforeEachProviders, describe, expect, inject, it} from '@angular/core/testing/src/testing_internal';
 import {BrowserXhr} from '@angular/http/src/backends/browser_xhr';

--- a/packages/language-service/src/reflector_host.ts
+++ b/packages/language-service/src/reflector_host.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {StaticSymbolResolverHost} from '@angular/compiler';
 import {CompilerOptions, MetadataCollector, MetadataReaderCache, MetadataReaderHost, createMetadataReaderCache, readMetadata} from '@angular/compiler-cli/src/language_services';
 import * as path from 'path';

--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {AotSummaryResolver, CompileMetadataResolver, CompilerConfig, DEFAULT_INTERPOLATION_CONFIG, DirectiveNormalizer, DirectiveResolver, DomElementSchemaRegistry, FormattedError, FormattedMessageChain, HtmlParser, InterpolationConfig, JitSummaryResolver, NgAnalyzedModules, NgModuleResolver, ParseTreeResult, PipeResolver, ResourceLoader, StaticReflector, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, SummaryResolver, analyzeNgModules, createOfflineCompileUrlResolver, isFormattedError} from '@angular/compiler';
 import {CompilerOptions, getClassMembersFromDeclaration, getPipesTable, getSymbolQuery} from '@angular/compiler-cli/src/language_services';
 import {ViewEncapsulation, ɵConsole as Console} from '@angular/core';

--- a/packages/language-service/test/reflector_host_spec.ts
+++ b/packages/language-service/test/reflector_host_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as path from 'path';
 import * as ts from 'typescript';
 

--- a/packages/language-service/test/test_utils.ts
+++ b/packages/language-service/test/test_utils.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {isInBazel, setup} from '@angular/compiler-cli/test/test_support';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/packages/platform-server/src/domino_adapter.ts
+++ b/packages/platform-server/src/domino_adapter.ts
@@ -5,6 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+
+/// <reference types="node" />
+
 const domino = require('domino');
 
 import {ɵBrowserDomAdapter as BrowserDomAdapter, ɵsetRootDomAdapter as setRootDomAdapter} from '@angular/platform-browser';

--- a/packages/platform-server/src/http.ts
+++ b/packages/platform-server/src/http.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 const xhr2: any = require('xhr2');
 
 import {Injectable, Injector, Optional, Provider, InjectFlags} from '@angular/core';

--- a/packages/platform-server/src/location.ts
+++ b/packages/platform-server/src/location.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {LocationChangeEvent, LocationChangeListener, PlatformLocation} from '@angular/common';
 import {Inject, Injectable, Optional} from '@angular/core';
 import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/platform-browser';

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {AnimationBuilder, animate, state, style, transition, trigger} from '@angular/animations';
 import {APP_BASE_HREF, PlatformLocation, isPlatformServer} from '@angular/common';
 import {HTTP_INTERCEPTORS, HttpClient, HttpClientModule, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';

--- a/packages/private/testing/src/render3.ts
+++ b/packages/private/testing/src/render3.ts
@@ -35,6 +35,9 @@
 * @param blockFn function to wrap. The function can return promise or be `async`.
 * @experimental
 */
+
+/// <reference types="node" />
+
 export function withBody<T extends Function>(html: string, blockFn: T): T {
   return function(done: DoneFn) {
     ensureDocument();

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {PLATFORM_ID} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 

--- a/packages/service-worker/testing/mock.ts
+++ b/packages/service-worker/testing/mock.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {Subject} from 'rxjs';
 
 export const patchDecodeBase64 = (proto: {decodeBase64: typeof atob}) => {

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import {Subject} from 'rxjs';
 
 import {Adapter, Context} from '../src/adapter';

--- a/packages/types.d.ts
+++ b/packages/types.d.ts
@@ -10,11 +10,14 @@
 
 /// <reference types="hammerjs" />
 /// <reference types="jasmine" />
-/// <reference types="node" />
 /// <reference types="zone.js" />
 /// <reference path="./es6-subset.d.ts" />
 /// <reference path="./goog.d.ts" />
 /// <reference path="./system.d.ts" />
+
+// Do not included `reference types="node"` here as we don't
+// want node types to be included everywhere as they conflict
+// with browser definitions for functions like setTimeout()
 
 declare let isNode: boolean;
 declare let isBrowser: boolean;

--- a/tools/symbol-extractor/symbol_extractor.ts
+++ b/tools/symbol-extractor/symbol_extractor.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as fs from 'fs';
-import * as ts from 'typescript';
+/// <reference types="node" />
 
+import * as ts from 'typescript';
 
 export interface Symbol { name: string; }
 

--- a/tools/symbol-extractor/symbol_extractor_spec.ts
+++ b/tools/symbol-extractor/symbol_extractor_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';

--- a/tools/testing/init_node_no_angular_spec.ts
+++ b/tools/testing/init_node_no_angular_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 // This hack is needed to get jasmine, node and zone working inside bazel.
 // 1) we load `jasmine-core` which contains the ENV: it, describe etc...
 const jasmineCore: any = require('jasmine-core');

--- a/tools/testing/init_node_spec.ts
+++ b/tools/testing/init_node_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import 'zone.js/dist/zone-node.js';
 import 'zone.js/dist/long-stack-trace-zone.js';
 import 'zone.js/dist/proxy.js';


### PR DESCRIPTION
This solves a downstream build issue with Material 2 getting node types includes in its build from `angular/packages/types.d.ts`. Moving the `//<reference types="node">` declarations to leaf nodes fixes the Material 2 build with angular build from source.