### PR TITLE
fix(ivy): add typeof guard around ngDevMode for instances where we ca…

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -19,8 +19,10 @@ import {CssSelectorList, SelectorFlags} from './interfaces/projection';
 
 const EMPTY: {} = {};
 const EMPTY_ARRAY: any[] = [];
-ngDevMode && Object.freeze(EMPTY);
-ngDevMode && Object.freeze(EMPTY_ARRAY);
+if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+  Object.freeze(EMPTY);
+  Object.freeze(EMPTY_ARRAY);
+}
 let _renderCompCount = 0;
 
 /**


### PR DESCRIPTION
Another alternative to the `ngDevMode` `ReferenceError` issue in `Node` in google3... add a `typeof` guard around the place we're checking it. It's inelegant, but I'm just trying to unblock the sync.