### PR TITLE
refactor: remove redundant error in catch

### DIFF
--- a/packages/animations/browser/test/render/css_keyframes/shared.ts
+++ b/packages/animations/browser/test/render/css_keyframes/shared.ts
@@ -23,7 +23,7 @@ export function supportsAnimationEventCreation() {
   try {
     makeAnimationEvent('end', 'test', 0);
     supported = true;
-  } catch (e) {
+  } catch {
   }
   return supported;
 }

--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -149,7 +149,7 @@ export class NgForOf<T> implements DoCheck {
       if (!this._differ && value) {
         try {
           this._differ = this._differs.find(value).create(this.ngForTrackBy);
-        } catch (e) {
+        } catch {
           throw new Error(
               `Cannot find a differ supporting object '${value}' of type '${getTypeNameForDebugging(value)}'. NgFor only supports binding to Iterables such as Arrays.`);
         }

--- a/packages/common/src/viewport_scroller.ts
+++ b/packages/common/src/viewport_scroller.ts
@@ -148,7 +148,7 @@ export class BrowserViewportScroller implements ViewportScroller {
   private supportScrollRestoration(): boolean {
     try {
       return !!this.window && !!this.window.scrollTo;
-    } catch (e) {
+    } catch {
       return false;
     }
   }

--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -246,7 +246,7 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
           if (packageTypings === originalImportedFile) {
             moduleName = importedFilePackageName;
           }
-        } catch (e) {
+        } catch {
           // the above require() will throw if there is no package.json file
           // and this is safe to ignore and correct to keep the longer
           // moduleName in this case
@@ -582,7 +582,7 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
                 result = false;
               }
             }
-          } catch (e) {
+          } catch {
             // If we encounter any errors assume we this isn't a bundle index.
             result = false;
           }

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -334,7 +334,7 @@ class _Tokenizer {
       try {
         const charCode = parseInt(strNum, isHex ? 16 : 10);
         return String.fromCharCode(charCode);
-      } catch (e) {
+      } catch {
         const entity = this._input.substring(start.offset + 1, this._index - 1);
         throw this._createError(_unknownEntityErrorMsg(entity), this._getSpan(start));
       }

--- a/packages/core/src/sanitization/inert_body.ts
+++ b/packages/core/src/sanitization/inert_body.ts
@@ -74,7 +74,7 @@ export class InertBodyHelper {
     html = '<body><remove></remove>' + html + '</body>';
     try {
       html = encodeURI(html);
-    } catch (e) {
+    } catch {
       return null;
     }
     const xhr = new XMLHttpRequest();
@@ -103,7 +103,7 @@ export class InertBodyHelper {
                        .body as HTMLBodyElement;
       body.removeChild(body.firstChild !);
       return body;
-    } catch (e) {
+    } catch {
       return null;
     }
   }
@@ -169,7 +169,7 @@ export class InertBodyHelper {
 function isDOMParserAvailable() {
   try {
     return !!(window as any).DOMParser;
-  } catch (e) {
+  } catch {
     return false;
   }
 }

--- a/packages/core/testing/src/testing_internal.ts
+++ b/packages/core/testing/src/testing_internal.ts
@@ -169,7 +169,7 @@ export class SpyObject {
         let m: any = null;
         try {
           m = type.prototype[prop];
-        } catch (e) {
+        } catch {
           // As we are creating spys for abstract classes,
           // these classes might have getters that throw when they are accessed.
           // As we are only auto creating spys for methods, this

--- a/packages/elements/schematics/ng-add/index.ts
+++ b/packages/elements/schematics/ng-add/index.ts
@@ -64,7 +64,7 @@ function addScript(options: Schema) {
         scripts.push({input: script});
         host.overwrite('angular.json', JSON.stringify(json, null, 2));
       }
-    } catch (e) {
+    } catch {
       context.logger.log(
           'warn', 'Failed to add the polyfill document-register-element.js to scripts');
     }

--- a/packages/http/test/backends/xhr_backend_spec.ts
+++ b/packages/http/test/backends/xhr_backend_spec.ts
@@ -327,7 +327,7 @@ class MockBrowserXHR extends BrowserXhr {
           let newBlob: Blob;
           try {
             newBlob = new Blob(data || [], datatype ? {type: datatype} : {});
-          } catch (e) {
+          } catch {
             const BlobBuilder = (<any>global).BlobBuilder || (<any>global).WebKitBlobBuilder ||
                 (<any>global).MozBlobBuilder || (<any>global).MSBlobBuilder;
             const builder = new BlobBuilder();

--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -295,7 +295,7 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   getBoundingClientRect(el: Element): any {
     try {
       return el.getBoundingClientRect();
-    } catch (e) {
+    } catch {
       return {top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0};
     }
   }

--- a/packages/platform-browser/src/browser/generic_browser_adapter.ts
+++ b/packages/platform-browser/src/browser/generic_browser_adapter.ts
@@ -48,7 +48,7 @@ export abstract class GenericBrowserDomAdapter extends DomAdapter {
           this._transitionEnd = transEndEventNames[key];
         }
       });
-    } catch (e) {
+    } catch {
       this._animationPrefix = null;
       this._transitionEnd = null;
     }

--- a/packages/platform-webworker/src/worker_render.ts
+++ b/packages/platform-webworker/src/worker_render.ts
@@ -133,7 +133,7 @@ function initWebWorkerRenderPlatform(injector: Injector): () => void {
     let scriptUri: string;
     try {
       scriptUri = injector.get(WORKER_SCRIPT);
-    } catch (e) {
+    } catch {
       throw new Error(
           'You must provide your WebWorker\'s initialization script with the WORKER_SCRIPT token');
     }

--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -212,7 +212,7 @@ export abstract class AssetGroup {
           // Check the metadata table. If a timestamp is there, use it.
           const metaTable = await this.metadata;
           ts = (await metaTable.read<UrlMetadata>(req.url)).ts;
-        } catch (e) {
+        } catch {
           // Otherwise, look for a Date header.
           const date = res.headers.get('Date');
           if (date === null) {
@@ -224,7 +224,7 @@ export abstract class AssetGroup {
         }
         const age = this.adapter.time - ts;
         return age < 0 || age > maxAge;
-      } catch (e) {
+      } catch {
         // Assume stale.
         return true;
       }
@@ -235,7 +235,7 @@ export abstract class AssetGroup {
         // The request needs to be revalidated if the current time is later than the expiration
         // time, if it parses correctly.
         return this.adapter.time > Date.parse(expiresStr);
-      } catch (e) {
+      } catch {
         // The expiration date failed to parse, so revalidate as a precaution.
         return true;
       }
@@ -263,7 +263,7 @@ export abstract class AssetGroup {
     let metadata: UrlMetadata|undefined = undefined;
     try {
       metadata = await metaTable.read<UrlMetadata>(url);
-    } catch (e) {
+    } catch {
       // Do nothing, not found. This shouldn't happen, but it can be handled.
     }
 
@@ -487,7 +487,7 @@ export abstract class AssetGroup {
   protected async safeFetch(req: Request): Promise<Response> {
     try {
       return await this.scope.fetch(req);
-    } catch (err) {
+    } catch {
       return this.adapter.newResponse('', {
         status: 504,
         statusText: 'Gateway Timeout',

--- a/packages/service-worker/worker/src/data.ts
+++ b/packages/service-worker/worker/src/data.ts
@@ -258,7 +258,7 @@ export class DataGroup {
       const table = await this.lruTable;
       try {
         this._lru = new LruList(await table.read<LruState>('lru'));
-      } catch (e) {
+      } catch {
         this._lru = new LruList();
       }
     }
@@ -371,7 +371,7 @@ export class DataGroup {
     // If that fetch errors, treat it as a timed out request.
     try {
       res = await timeoutFetch;
-    } catch (e) {
+    } catch {
       res = undefined;
     }
 
@@ -407,7 +407,7 @@ export class DataGroup {
       const safeNetworkFetch = (async() => {
         try {
           return await networkFetch;
-        } catch (err) {
+        } catch {
           return this.adapter.newResponse(null, {
             status: 504,
             statusText: 'Gateway Timeout',
@@ -417,7 +417,7 @@ export class DataGroup {
       const networkFetchUndefinedError = (async() => {
         try {
           return await networkFetch;
-        } catch (err) {
+        } catch {
           return undefined;
         }
       })();
@@ -436,7 +436,7 @@ export class DataGroup {
   private async safeCacheResponse(req: Request, res: Promise<Response>): Promise<void> {
     try {
       await this.cacheResponse(req, await res, await this.lru());
-    } catch (e) {
+    } catch {
       // TODO: handle this error somehow?
     }
   }
@@ -460,7 +460,7 @@ export class DataGroup {
         }
 
         // Otherwise, or if there was an error, assume the response is expired, and evict it.
-      } catch (e) {
+      } catch {
         // Some error getting the age for the response. Assume it's expired.
       }
 
@@ -546,7 +546,7 @@ export class DataGroup {
   private async safeFetch(req: Request): Promise<Response> {
     try {
       return this.scope.fetch(req);
-    } catch (err) {
+    } catch {
       return this.adapter.newResponse(null, {
         status: 504,
         statusText: 'Gateway Timeout',

--- a/packages/upgrade/src/common/angular1.ts
+++ b/packages/upgrade/src/common/angular1.ts
@@ -250,7 +250,7 @@ try {
   if (window.hasOwnProperty('angular')) {
     angular = (<any>window).angular;
   }
-} catch (e) {
+} catch {
   // ignore in CJS mode.
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Remove redundant error parameter in catch as this is no longer required when it's unused.