### PR TITLE
feat(ivy): add support for local refs on ng-template

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -28,6 +28,7 @@ export {
   injectAttribute as ɵinjectAttribute,
   getFactoryOf as ɵgetFactoryOf,
   getInheritedFactory as ɵgetInheritedFactory,
+  templateRefExtractor as ɵtemplateRefExtractor,
   PublicFeature as ɵPublicFeature,
   InheritDefinitionFeature as ɵInheritDefinitionFeature,
   NgOnChangesFeature as ɵNgOnChangesFeature,

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -27,7 +27,7 @@ import {addToViewTree, assertPreviousIsParent, createEmbeddedViewNode, createLCo
 import {VIEWS} from './interfaces/container';
 import {DirectiveDefInternal, RenderFlags} from './interfaces/definition';
 import {LInjector} from './interfaces/injector';
-import {AttributeMarker, LContainerNode, LElementContainerNode, LElementNode, LNode, LViewNode, TContainerNode, TElementNode, TNodeFlags, TNodeType} from './interfaces/node';
+import {AttributeMarker, LContainerNode, LElementContainerNode, LElementNode, LNode, LNodeWithLocalRefs, LViewNode, TContainerNode, TElementNode, TNodeFlags, TNodeType} from './interfaces/node';
 import {LQueries, QueryReadType} from './interfaces/query';
 import {Renderer3} from './interfaces/renderer';
 import {DIRECTIVES, HOST_NODE, INJECTOR, LViewData, QUERIES, RENDERER, TVIEW, TView} from './interfaces/view';
@@ -813,4 +813,12 @@ class TemplateRef<T> implements viewEngine_TemplateRef<T> {
     viewRef._lViewNode = viewNode;
     return viewRef;
   }
+}
+
+/**
+ * Retrieves `TemplateRef` instance from `Injector` when a local reference is placed on the
+ * `<ng-template>` element.
+ */
+export function templateRefExtractor(lNode: LNodeWithLocalRefs) {
+  return getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(lNode));
 }

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -14,7 +14,7 @@ import {PublicFeature} from './features/public_feature';
 import {BaseDef, ComponentDef, ComponentDefInternal, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefFlags, DirectiveDefInternal, DirectiveType, PipeDef} from './interfaces/definition';
 
 export {ComponentFactory, ComponentFactoryResolver, ComponentRef, WRAP_RENDERER_FACTORY2} from './component_ref';
-export {QUERY_READ_CONTAINER_REF, QUERY_READ_ELEMENT_REF, QUERY_READ_FROM_NODE, QUERY_READ_TEMPLATE_REF, directiveInject, getFactoryOf, getInheritedFactory, injectAttribute, injectChangeDetectorRef, injectComponentFactoryResolver, injectElementRef, injectTemplateRef, injectViewContainerRef} from './di';
+export {QUERY_READ_CONTAINER_REF, QUERY_READ_ELEMENT_REF, QUERY_READ_FROM_NODE, QUERY_READ_TEMPLATE_REF, directiveInject, getFactoryOf, getInheritedFactory, injectAttribute, injectChangeDetectorRef, injectComponentFactoryResolver, injectElementRef, injectTemplateRef, injectViewContainerRef, templateRefExtractor} from './di';
 export {RenderFlags} from './interfaces/definition';
 export {CssSelectorList} from './interfaces/projection';
 

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -524,3 +524,16 @@ export type InitialInputs = string[];
 // Note: This hack is necessary so we don't erroneously get a circular dependency
 // failure based on types.
 export const unusedValueExportToPlacateAjd = 1;
+
+/**
+ * Type representing a set of LNodes that can have local refs (`#foo`) placed on them.
+ */
+export type LNodeWithLocalRefs = LContainerNode | LElementNode | LElementContainerNode;
+
+/**
+ * Type for a function that extracts a value for a local refs.
+ * Example:
+ * - `<div #nativeDivEl>` - `nativeDivEl` should point to the native `<div>` element;
+ * - `<ng-template #tplRef>` - `tplRef` should point to the `TemplateRef` instance;
+ */
+export type LocalRefExtractor = (lNode: LNodeWithLocalRefs) => any;

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -753,6 +753,9 @@
     "name": "nativeInsertBefore"
   },
   {
+    "name": "nativeNodeLocalRefExtractor"
+  },
+  {
     "name": "nextContext"
   },
   {

--- a/packages/core/test/render3/common_integration_spec.ts
+++ b/packages/core/test/render3/common_integration_spec.ts
@@ -8,8 +8,7 @@
 
 import {NgForOfContext} from '@angular/common';
 
-import {getOrCreateNodeInjectorForNode, getOrCreateTemplateRef} from '../../src/render3/di';
-import {AttributeMarker, defineComponent} from '../../src/render3/index';
+import {AttributeMarker, defineComponent, templateRefExtractor} from '../../src/render3/index';
 import {bind, template, elementEnd, elementProperty, elementStart, getCurrentView, interpolation1, interpolation2, interpolation3, interpolationV, listener, load, nextContext, restoreView, text, textBinding} from '../../src/render3/instructions';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 
@@ -881,11 +880,11 @@ describe('@angular/common integration', () => {
                 if (rf1 & RenderFlags.Create) {
                   text(0, 'from tpl');
                 }
-              }, undefined, undefined, ['tpl', '']);
+              }, undefined, undefined, ['tpl', ''], templateRefExtractor);
               template(2, null, null, [AttributeMarker.SelectOnly, 'ngTemplateOutlet']);
             }
             if (rf & RenderFlags.Update) {
-              const tplRef = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(0)));
+              const tplRef = load(1);
               elementProperty(2, 'ngTemplateOutlet', bind(myApp.showing ? tplRef : null));
             }
           },

--- a/packages/core/test/render3/compiler_canonical/local_reference_spec.ts
+++ b/packages/core/test/render3/compiler_canonical/local_reference_spec.ts
@@ -43,4 +43,42 @@ describe('local references', () => {
     const fixture = new ComponentFixture(MyComponent);
     expect(fixture.html).toEqual(`<input value="World">Hello, World!`);
   });
+
+  it('should expose TemplateRef when a local ref is placed on ng-template', () => {
+    type $MyComponent$ = MyComponent;
+    type $any$ = any;
+
+    @Component({
+      selector: 'my-component',
+      template: `<ng-template #tpl></ng-template>{{isTemplateRef(tpl)}}`
+    })
+    class MyComponent {
+      isTemplateRef(tplRef: any): boolean { return tplRef.createEmbeddedView != null; }
+
+      // NORMATIVE
+      static ngComponentDef = $r3$.ɵdefineComponent({
+        type: MyComponent,
+        selectors: [['my-component']],
+        factory: () => new MyComponent,
+        template: function(rf: $RenderFlags$, ctx: $MyComponent$) {
+          let l1_tpl: any;
+          if (rf & 1) {
+            $r3$.ɵtemplate(
+                0, MyComponent_Template_0, null, null, ['tpl', ''], $r3$.ɵtemplateRefExtractor);
+            $r3$.ɵtext(2);
+          }
+          if (rf & 2) {
+            l1_tpl = $r3$.ɵreference<any>(1);
+            $r3$.ɵtextBinding(2, $r3$.ɵinterpolation1('', ctx.isTemplateRef(l1_tpl), ''));
+          }
+
+          function MyComponent_Template_0(rf1: $RenderFlags$, ctx1: $any$) {}
+        }
+      });
+      // NORMATIVE
+    }
+
+    const fixture = new ComponentFixture(MyComponent);
+    expect(fixture.html).toEqual(`true`);
+  });
 });

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -10,9 +10,9 @@ import {NgForOfContext} from '@angular/common';
 import {ElementRef, TemplateRef, ViewContainerRef} from '@angular/core';
 
 import {EventEmitter} from '../..';
-import {QUERY_READ_CONTAINER_REF, QUERY_READ_ELEMENT_REF, QUERY_READ_FROM_NODE, QUERY_READ_TEMPLATE_REF, getOrCreateNodeInjectorForNode, getOrCreateTemplateRef} from '../../src/render3/di';
+import {QUERY_READ_CONTAINER_REF, QUERY_READ_ELEMENT_REF, QUERY_READ_FROM_NODE, QUERY_READ_TEMPLATE_REF, templateRefExtractor} from '../../src/render3/di';
 import {AttributeMarker, QueryList, defineComponent, defineDirective, detectChanges, injectTemplateRef, injectViewContainerRef} from '../../src/render3/index';
-import {bind, container, containerRefreshEnd, containerRefreshStart, element, elementContainerEnd, elementContainerStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, load, loadDirective, loadElement, loadQueryList, registerContentQuery, template} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, element, elementContainerEnd, elementContainerStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, load, loadDirective, loadElement, loadQueryList, reference, registerContentQuery, template} from '../../src/render3/instructions';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {query, queryRefresh} from '../../src/render3/query';
 
@@ -1116,25 +1116,25 @@ describe('query', () => {
                      if (rf & RenderFlags.Update) {
                        elementProperty(0, 'id', bind('foo1_' + ctx.idx));
                      }
-                   }, null, []);
+                   }, null, null, ['tpl1', ''], templateRefExtractor);
 
-                   element(2, 'div', ['id', 'middle'], ['foo', '']);
+                   element(3, 'div', ['id', 'middle'], ['foo', '']);
 
-                   template(4, (rf: RenderFlags, ctx: {idx: number}) => {
+                   template(5, (rf: RenderFlags, ctx: {idx: number}) => {
                      if (rf & RenderFlags.Create) {
                        element(0, 'div', null, ['foo', '']);
                      }
                      if (rf & RenderFlags.Update) {
                        elementProperty(0, 'id', bind('foo2_' + ctx.idx));
                      }
-                   }, null, []);
+                   }, null, null, ['tpl2', ''], templateRefExtractor);
 
-                   template(5, null, null, [AttributeMarker.SelectOnly, 'vc']);
+                   template(7, null, null, [AttributeMarker.SelectOnly, 'vc']);
                  }
 
                  if (rf & RenderFlags.Update) {
-                   tpl1 = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(1)));
-                   tpl2 = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(4)));
+                   tpl1 = reference(2);
+                   tpl2 = reference(6);
                  }
 
                },
@@ -1219,14 +1219,14 @@ describe('query', () => {
                      if (rf & RenderFlags.Update) {
                        elementProperty(0, 'id', bind('foo_' + ctx.container_idx + '_' + ctx.idx));
                      }
-                   }, null, []);
+                   }, null, [], ['tpl', ''], templateRefExtractor);
 
-                   template(2, null, null, [AttributeMarker.SelectOnly, 'vc']);
                    template(3, null, null, [AttributeMarker.SelectOnly, 'vc']);
+                   template(4, null, null, [AttributeMarker.SelectOnly, 'vc']);
                  }
 
                  if (rf & RenderFlags.Update) {
-                   tpl = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(1)));
+                   tpl = reference(2);
                  }
 
                },
@@ -1287,11 +1287,11 @@ describe('query', () => {
                   if (rf1 & RenderFlags.Create) {
                     element(0, 'span', ['id', 'from_tpl'], ['foo', '']);
                   }
-                }, undefined, undefined, ['tpl', '']);
+                }, undefined, undefined, ['tpl', ''], templateRefExtractor);
                 template(3, null, null, [AttributeMarker.SelectOnly, 'ngTemplateOutlet']);
               }
               if (rf & RenderFlags.Update) {
-                const tplRef = getOrCreateTemplateRef(getOrCreateNodeInjectorForNode(load(1)));
+                const tplRef = reference(2);
                 elementProperty(3, 'ngTemplateOutlet', bind(myApp.show ? tplRef : null));
               }
             },


### PR DESCRIPTION
This PR adds support for local refs on templates (ex.: `<ng-template #tplRef>`) to ngIvy runtime.

In contrast to local refs placed on elements, ones sitting on to of `<ng-template>` need to point to a `TemplateRef` instance. As such this PR ensures that we abstract away resolution of local refs by introducing a strategy function. This way we can have different strategy for elements and different for  `<ng-template>`. The mentioned strategy function is passed down from the generated code to make it tree-shakable.

This is just one way of going about `<ng-template #tplRef>` and different solutions were pondered in #23316. The initial though was to introduce a new instruction but finally it seems like this solution here has less code impact and better tree-shakability. Of course we can iterate on the proposal.

This PR changes runtime only. compiler change will follow as soon as runtime is sorted out.