### PR TITLE
fix(router): lazy loaded empty root path loads with auxiliary outlet

### DIFF
--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -174,7 +174,7 @@ class ApplyRedirects {
   private expandSegmentAgainstRoute(
       ngModule: NgModuleRef<any>, segmentGroup: UrlSegmentGroup, routes: Route[], route: Route,
       paths: UrlSegment[], outlet: string, allowRedirects: boolean): Observable<UrlSegmentGroup> {
-    if (getOutlet(route) !== outlet) {
+    if (getOutlet(route) !== outlet && !isLazyRootWithEmptyPath(route)) {
       return noMatch(segmentGroup);
     }
 
@@ -518,6 +518,10 @@ function isEmptyPathRedirect(
   }
 
   return r.path === '' && r.redirectTo !== undefined;
+}
+
+function isLazyRootWithEmptyPath(route: Route): boolean {
+  return !!route.loadChildren && route.path === '' && getOutlet(route) === PRIMARY_OUTLET;
 }
 
 function getOutlet(route: Route): string {

--- a/packages/router/test/apply_redirects.spec.ts
+++ b/packages/router/test/apply_redirects.spec.ts
@@ -367,6 +367,23 @@ describe('applyRedirects', () => {
       applyRedirects(testModule.injector, <any>loader, serializer, tree('xyz'), config)
           .forEach(r => { expect((config[0] as any)._loadedConfig).toBe(loadedConfig); });
     });
+
+    it('should load the configuration of empty root path if the entry point is an auxiliary outlet',
+       () => {
+         const loadedConfig =
+             new LoadedRouterConfig([{path: '', component: ComponentA}], testModule);
+         const loader = {load: (injector: any, p: any) => { return of (loadedConfig); }};
+
+         const config: Routes = [
+           {path: '', loadChildren: 'root'}, {path: 'modal', loadChildren: 'aux', outlet: 'popup'}
+         ];
+
+         applyRedirects(testModule.injector, <any>loader, serializer, tree('(popup:modal)'), config)
+             .forEach(r => {
+               expectTreeToBe(r, '/(popup:modal)');
+               expect((config[0] as any)._loadedConfig).toBe(loadedConfig);
+             });
+       });
   });
 
   describe('empty paths', () => {


### PR DESCRIPTION
Initial page load with secondary outlet and lazy loaded root with empty path '/(aux:path)' causes error, because the empty root path is not matched and '_loadedConfig' is undefined. This works fine if the root path is not empty or the root is not a lazy loaded module.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Given the following route configuration: 
```
[
    {path: '', loadChildren: 'children'},
    {path: 'a', loadChildren: 'otherChildren', outlet: 'aux'}
]
```
With this configuration, using the outlet as an entry point to the application, the root module will not load properly and results in the following error:

`
TypeError: Cannot read property 'routes' of undefined at getChildConfig (router.js:3041)
`

The `_loadedConfig` property of the route remains `undefined` as the `expandSegmentAgainstRoute()` returns with `noMatch()`.

This issue is only present if the root has a lazy loaded module, works fine with a component or even with a lazy loaded module if the root path is not empty.

Issue Number: N/A

## What is the new behavior?

The above mentioned issue is fixed in this pull request, the config is properly loaded and the outlet can be used as an entry point.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
