### PR TITLE
build: refactor ambient node & jasmine types so they are only included where needed

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -112,7 +112,7 @@
     "cross-spawn": "^5.1.0",
     "css-selector-parser": "^1.3.0",
     "dgeni": "^0.4.7",
-    "dgeni-packages": "^0.26.2",
+    "dgeni-packages": "^0.26.3",
     "entities": "^1.1.1",
     "eslint": "^3.19.0",
     "eslint-plugin-jasmine": "^2.2.0",

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -3086,9 +3086,9 @@ devtools-timeline-model@1.1.6:
     chrome-devtools-frontend "1.0.401423"
     resolve "1.1.7"
 
-dgeni-packages@^0.26.2:
-  version "0.26.2"
-  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.26.2.tgz#dac22d7e861d4d72ed42af5272714f42b6b5bf3d"
+dgeni-packages@^0.26.3:
+  version "0.26.3"
+  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.26.3.tgz#fdc1299389e7cb1b1946926fd1f5970f3a6e0838"
   dependencies:
     canonical-path "0.0.2"
     catharsis "^0.8.1"

--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -2,6 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "tsconfig-build.json",
+    "tsconfig-test.json",
     "tsconfig.json",
 ])
 

--- a/packages/animations/browser/src/render/shared.ts
+++ b/packages/animations/browser/src/render/shared.ts
@@ -10,6 +10,11 @@ import {AUTO_STYLE, AnimationEvent, AnimationPlayer, NoopAnimationPlayer, ɵAnim
 import {AnimationStyleNormalizer} from '../../src/dsl/style_normalization/animation_style_normalizer';
 import {AnimationDriver} from '../../src/render/animation_driver';
 
+// We don't include ambient node types here since @angular/animations/browser
+// is meant to target the browser so technically it should not depend on node
+// types. `process` is just declared locally here as a result.
+declare const process: any;
+
 export function isBrowser() {
   return (typeof window !== 'undefined' && typeof window.document !== 'undefined');
 }

--- a/packages/bazel/test/ng_package/BUILD.bazel
+++ b/packages/bazel/test/ng_package/BUILD.bazel
@@ -37,6 +37,7 @@ jasmine_node_test(
 
 ts_library(
     name = "example_spec_lib",
+    testonly = True,
     srcs = ["example_package.spec.ts"],
     deps = ["//packages:types"],
 )
@@ -55,6 +56,7 @@ jasmine_node_test(
 
 nodejs_binary(
     name = "example_package.accept",
+    testonly = True,
     data = [
         "example_package.golden",
         ":example_spec_lib",

--- a/packages/benchpress/index.ts
+++ b/packages/benchpress/index.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 // Must be imported first, because Angular decorators throw on load.
 import 'reflect-metadata';
 

--- a/packages/compiler-cli/src/ngtsc/annotations/index.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/index.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 export {ResourceLoader} from './src/api';
 export {ComponentDecoratorHandler} from './src/component';
 export {DirectiveDecoratorHandler} from './src/directive';

--- a/packages/compiler-cli/src/ngtsc/factories/index.ts
+++ b/packages/compiler-cli/src/ngtsc/factories/index.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 export {FactoryGenerator} from './src/generator';
 export {GeneratedFactoryHostWrapper} from './src/host';
 export {FactoryInfo, generatedFactoryTransform} from './src/transform';

--- a/packages/compiler-cli/src/ngtsc/metadata/index.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/index.ts
@@ -6,5 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 export {TypeScriptReflectionHost, filterToMembersWithDecorator, findMember, reflectObjectLiteral, reflectTypeEntityToDeclaration} from './src/reflector';
 export {AbsoluteReference, ImportMode, Reference, ResolvedReference, ResolvedValue, isDynamicValue, staticallyResolve} from './src/resolver';

--- a/packages/compiler-cli/src/ngtsc/util/src/path.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/path.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 import * as path from 'path';
 
 const TS_DTS_EXTENSION = /(\.d)?\.ts$/;

--- a/packages/compiler/test/BUILD.bazel
+++ b/packages/compiler/test/BUILD.bazel
@@ -13,6 +13,7 @@ UTILS = [
 
 ts_library(
     name = "test_utils",
+    testonly = True,
     srcs = UTILS,
     visibility = [
         "//packages/compiler-cli/test:__subpackages__",

--- a/packages/compiler/testing/public_api.ts
+++ b/packages/compiler/testing/public_api.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 /**
  * @module
  * @description

--- a/packages/core/testing/public_api.ts
+++ b/packages/core/testing/public_api.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="jasmine" />
+
 /**
  * @module
  * @description

--- a/packages/language-service/language-service.ts
+++ b/packages/language-service/language-service.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 /**
  * @module
  * @description

--- a/packages/platform-browser/testing/public_api.ts
+++ b/packages/platform-browser/testing/public_api.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="jasmine" />
+
 /**
  * @module
  * @description

--- a/packages/platform-server/public_api.ts
+++ b/packages/platform-server/public_api.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/// <reference types="node" />
+
 /**
  * @module
  * @description

--- a/packages/private/testing/BUILD.bazel
+++ b/packages/private/testing/BUILD.bazel
@@ -6,6 +6,7 @@ load("//tools:defaults.bzl", "ng_module")
 
 ng_module(
     name = "testing",
+    testonly = True,
     srcs = glob(
         ["**/*.ts"],
     ),

--- a/packages/tsconfig-test.json
+++ b/packages/tsconfig-test.json
@@ -1,0 +1,9 @@
+/**
+ * Root tsconfig file for use in all tests.
+ */
+{
+  "extends": "./tsconfig-build.json",
+  "compilerOptions": {
+    "types": ["node", "jasmine"],
+  },
+}

--- a/packages/types.d.ts
+++ b/packages/types.d.ts
@@ -9,12 +9,17 @@
 // This file contains all ambient imports needed to compile the packages/ source code
 
 /// <reference types="hammerjs" />
-/// <reference types="jasmine" />
-/// <reference types="node" />
 /// <reference types="zone.js" />
 /// <reference path="./es6-subset.d.ts" />
 /// <reference path="./goog.d.ts" />
 /// <reference path="./system.d.ts" />
+
+// Do not included "node" and "jasmine" types here as we don't
+// want these ambient types to be included everywhere.
+// Tests will bring in ambient node & jasmine types with
+// /packages/tsconfig-test.json when `testonly = True` is set
+// and packages such as platform-server that need these types should
+// use `/// <reference types="x">` in their main entry points
 
 declare let isNode: boolean;
 declare let isBrowser: boolean;

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -5,7 +5,8 @@ load("@build_bazel_rules_typescript//:defs.bzl", _ts_library = "ts_library", _ts
 load("//packages/bazel:index.bzl", _ng_module = "ng_module", _ng_package = "ng_package")
 load("//packages/bazel/src:ng_module.bzl", _internal_global_ng_module = "internal_global_ng_module")
 
-DEFAULT_TSCONFIG = "//packages:tsconfig-build.json"
+DEFAULT_TSCONFIG_BUILD = "//packages:tsconfig-build.json"
+DEFAULT_TSCONFIG_TEST = "//packages:tsconfig-test.json"
 DEFAULT_NODE_MODULES = "@angular_deps//:node_modules"
 
 # Packages which are versioned together on npm
@@ -39,27 +40,36 @@ PKG_GROUP_REPLACEMENTS = {
     ]""" % ",\n      ".join(["\"%s\"" % s for s in ANGULAR_SCOPED_PACKAGES]),
 }
 
-def ts_library(tsconfig = None, node_modules = DEFAULT_NODE_MODULES, **kwargs):
+def ts_library(tsconfig = None, node_modules = DEFAULT_NODE_MODULES, testonly = False, **kwargs):
     if not tsconfig:
-        tsconfig = DEFAULT_TSCONFIG
-    _ts_library(tsconfig = tsconfig, node_modules = node_modules, **kwargs)
+        if testonly:
+            tsconfig = DEFAULT_TSCONFIG_TEST
+        else:
+            tsconfig = DEFAULT_TSCONFIG_BUILD
+    _ts_library(tsconfig = tsconfig, node_modules = node_modules, testonly = testonly, **kwargs)
 
-def ng_module(name, tsconfig = None, entry_point = None, node_modules = DEFAULT_NODE_MODULES, **kwargs):
+def ng_module(name, tsconfig = None, entry_point = None, node_modules = DEFAULT_NODE_MODULES, testonly = False, **kwargs):
     if not tsconfig:
-        tsconfig = DEFAULT_TSCONFIG
+        if testonly:
+            tsconfig = DEFAULT_TSCONFIG_TEST
+        else:
+            tsconfig = DEFAULT_TSCONFIG_BUILD
     if not entry_point:
         entry_point = "public_api.ts"
-    _ng_module(name = name, flat_module_out_file = name, tsconfig = tsconfig, entry_point = entry_point, node_modules = node_modules, **kwargs)
+    _ng_module(name = name, flat_module_out_file = name, tsconfig = tsconfig, entry_point = entry_point, node_modules = node_modules, testonly = testonly, **kwargs)
 
 # ivy_ng_module behaves like ng_module, and under --define=compile=legacy it runs ngc with global
 # analysis but produces Ivy outputs. Under other compile modes, it behaves as ng_module.
 # TODO(alxhub): remove when ngtsc supports the same use cases.
-def ivy_ng_module(name, tsconfig = None, entry_point = None, **kwargs):
+def ivy_ng_module(name, tsconfig = None, entry_point = None, testonly = False, **kwargs):
     if not tsconfig:
-        tsconfig = DEFAULT_TSCONFIG
+        if testonly:
+            tsconfig = DEFAULT_TSCONFIG_TEST
+        else:
+            tsconfig = DEFAULT_TSCONFIG_BUILD
     if not entry_point:
         entry_point = "public_api.ts"
-    _internal_global_ng_module(name = name, flat_module_out_file = name, tsconfig = tsconfig, entry_point = entry_point, **kwargs)
+    _internal_global_ng_module(name = name, flat_module_out_file = name, tsconfig = tsconfig, entry_point = entry_point, testonly = testonly, **kwargs)
 
 def ng_package(name, readme_md = None, license_banner = None, **kwargs):
     if not readme_md:

--- a/tools/symbol-extractor/BUILD.bazel
+++ b/tools/symbol-extractor/BUILD.bazel
@@ -5,6 +5,7 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 ts_library(
     name = "lib",
+    testonly = True,
     srcs = glob(
         ["**/*.ts"],
         exclude = [

--- a/tools/symbol-extractor/index.bzl
+++ b/tools/symbol-extractor/index.bzl
@@ -28,6 +28,7 @@ def js_expected_symbol_test(name, src, golden, **kwargs):
 
     nodejs_binary(
         name = name + ".accept",
+        testonly = True,
         data = all_data,
         entry_point = entry_point,
         templated_args = ["$(location %s)" % src, "$(location %s)" % golden, "--accept"],

--- a/tools/ts-api-guardian/index.bzl
+++ b/tools/ts-api-guardian/index.bzl
@@ -50,6 +50,7 @@ def ts_api_guardian_test(name, golden, actual, data = [], **kwargs):
 
     nodejs_binary(
         name = name + ".accept",
+        testonly = True,
         data = data,
         node_modules = "@ts-api-guardian_runtime_deps//:node_modules",
         entry_point = "angular/tools/ts-api-guardian/bin/ts-api-guardian",


### PR DESCRIPTION
Replaces https://github.com/angular/angular/pull/25471.

This solves a downstream build issue with Material 2 getting node types includes in its build from `angular/packages/types.d.ts`.