### PR TITLE
fix(router): validate lazy-loaded routes and allow canActivate routes

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -437,9 +437,10 @@ function validateNode(route: Route, fullPath: string): void {
     throw new Error(
         `Invalid configuration of route '${fullPath}': path and matcher cannot be used together`);
   }
-  if (route.redirectTo === void 0 && !route.component && !route.children && !route.loadChildren) {
+  if (route.redirectTo === void 0 && !route.component && !route.canActivate && !route.children &&
+      !route.loadChildren) {
     throw new Error(
-        `Invalid configuration of route '${fullPath}'. One of the following must be provided: component, redirectTo, children or loadChildren`);
+        `Invalid configuration of route '${fullPath}'. One of the following must be provided: component, canActivate, redirectTo, children or loadChildren`);
   }
   if (route.path === void 0 && route.matcher === void 0) {
     throw new Error(

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -10,7 +10,7 @@ import {Compiler, InjectionToken, Injector, NgModuleFactory, NgModuleFactoryLoad
 // TODO(i): switch to fromPromise once it's expored in rxjs
 import {Observable, from, of } from 'rxjs';
 import {map, mergeMap} from 'rxjs/operators';
-import {LoadChildren, LoadedRouterConfig, Route, standardizeConfig} from './config';
+import {LoadChildren, LoadedRouterConfig, Route, standardizeConfig, validateConfig} from './config';
 import {flatten, wrapIntoObservable} from './utils/collection';
 
 /**
@@ -38,9 +38,11 @@ export class RouterConfigLoader {
       }
 
       const module = factory.create(parentInjector);
+      const config = flatten(module.injector.get(ROUTES)).map(standardizeConfig);
 
-      return new LoadedRouterConfig(
-          flatten(module.injector.get(ROUTES)).map(standardizeConfig), module);
+      validateConfig(config);
+
+      return new LoadedRouterConfig(config, module);
     }));
   }
 

--- a/packages/router/test/config.spec.ts
+++ b/packages/router/test/config.spec.ts
@@ -62,7 +62,7 @@ describe('config', () => {
     it('should validate children and report full path', () => {
       expect(() => validateConfig([{path: 'a', children: [{path: 'b'}]}]))
           .toThrowError(
-              `Invalid configuration of route 'a/b'. One of the following must be provided: component, redirectTo, children or loadChildren`);
+              `Invalid configuration of route 'a/b'. One of the following must be provided: component, canActivate, redirectTo, children or loadChildren`);
     });
 
     it('should properly report deeply nested path', () => {
@@ -71,7 +71,7 @@ describe('config', () => {
                children: [{path: 'b', children: [{path: 'c', children: [{path: 'd'}]}]}]
              }]))
           .toThrowError(
-              `Invalid configuration of route 'a/b/c/d'. One of the following must be provided: component, redirectTo, children or loadChildren`);
+              `Invalid configuration of route 'a/b/c/d'. One of the following must be provided: component, canActivate, redirectTo, children or loadChildren`);
     });
 
     it('should throw when redirectTo and loadChildren are used together', () => {
@@ -107,7 +107,13 @@ describe('config', () => {
     it('should throw when none of component and children or direct are missing', () => {
       expect(() => { validateConfig([{path: 'a'}]); })
           .toThrowError(
-              `Invalid configuration of route 'a'. One of the following must be provided: component, redirectTo, children or loadChildren`);
+              `Invalid configuration of route 'a'. One of the following must be provided: component, canActivate, redirectTo, children or loadChildren`);
+    });
+
+    it('should not throw when component is missing but canActivate is provided', () => {
+      expect(() => { validateConfig([{path: 'a', canActivate: [{} as any]}]); })
+          .not.toThrowError(
+              `Invalid configuration of route 'a'. One of the following must be provided: component, canActivate, redirectTo, children or loadChildren`);
     });
 
     it('should throw when path starts with a slash', () => {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -3614,6 +3614,30 @@ describe('Integration', () => {
              ]);
            })));
 
+    // https://github.com/angular/angular/issues/25431
+    it('should emit an error when the lazily-loaded config is not valid',
+       fakeAsync(inject(
+           [Router, Location, NgModuleFactoryLoader],
+           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+             @NgModule({imports: [RouterModule.forChild([{path: 'loaded'}])]})
+             class LoadedModule {
+             }
+
+             loader.stubbedModules = {expected: LoadedModule};
+
+             const fixture = createRoot(router, RootCmp);
+
+             router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
+
+             let recordedError: any = null;
+             router.navigateByUrl('/lazy/loaded') !.catch(err => recordedError = err);
+             advance(fixture);
+
+             expect(recordedError.message)
+                 .toEqual(
+                     `Invalid configuration of route 'loaded'. One of the following must be provided: component, canActivate, redirectTo, children or loadChildren`);
+           })));
+
     it('should work with complex redirect rules',
        fakeAsync(inject(
            [Router, Location, NgModuleFactoryLoader],


### PR DESCRIPTION
Closes #25431.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[X] Bugfix
```

## What is the current behavior?
Routes in lazy-loaded modules are not validated, opposed to "normal" routes. Also, routes with just "path" and "canActivate" are not allowed, which means you _have_ to provide a component (e.g. dummy), even when the guard _always_ performs a redirect action.

Issue Number: https://github.com/angular/angular/issues/25431


## What is the new behavior?
With this PR, lazy-loaded route configuration is validated as well (when they are loaded). Also, component-less routes with CanActivate guards are now allowed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No (validation is less strict so it won't break anything)
```
