### PR TITLE
ci: ensure aio_preview job has needed node_modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,7 @@ jobs:
           <<: *post_checkout
       - restore_cache:
           key: *cache_key
+      - run: yarn install --frozen-lockfile --non-interactive
       - run: ./aio/scripts/build-artifacts.sh $AIO_SNAPSHOT_ARTIFACT_PATH
       - store_artifacts:
           path: *aio_preview_artifact_path


### PR DESCRIPTION
Fixes aio_preview job failure caused by #25491