### PR TITLE
build(bazel): fix bazel types reference directive resolves

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@
 # If you change the `docker_image` version, also change the `cache_key` suffix and the version of
 # `com_github_bazelbuild_buildtools` in the `/WORKSPACE` file.
 var_1: &docker_image angular/ngcontainer:0.4.0
-var_2: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.4.0
+var_2: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-bust1-0.4.0
 
 # Define common ENV vars
 var_3: &define_env_vars

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,9 +12,9 @@ http_archive(
 
 http_archive(
     name = "build_bazel_rules_typescript",
-    url = "https://github.com/bazelbuild/rules_typescript/archive/0.16.1.zip",
-    strip_prefix = "rules_typescript-0.16.1",
-    sha256 = "5b2b0bc63cfcffe7bf97cad2dad3b26a73362f806de66207051f66c87956a995",
+    url = "https://github.com/bazelbuild/rules_typescript/archive/0.16.2.zip",
+    strip_prefix = "rules_typescript-0.16.2",
+    sha256 = "31601b777840fbf600dbd1893ade0d1de37166e7ba52b90735b107cfb67e38c7",
 )
 load("@build_bazel_rules_typescript//:package.bzl", "rules_typescript_dependencies")
 rules_typescript_dependencies()

--- a/integration/bazel/package.json
+++ b/integration/bazel/package.json
@@ -10,7 +10,7 @@
     "zone.js": "file:../../node_modules/zone.js"
   },
   "devDependencies": {
-    "@bazel/typescript": "0.16.1",
+    "@bazel/typescript": "0.16.2",
     "@types/jasmine": "file:../../node_modules/@types/jasmine",
     "@types/source-map": "0.5.1",
     "http-server": "0.11.1",

--- a/integration/bazel/yarn.lock
+++ b/integration/bazel/yarn.lock
@@ -2,12 +2,11 @@
 # yarn lockfile v1
 
 
-"@bazel/typescript@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.16.1.tgz#5a5d145a17898bfadae8268cf942815424119412"
+"@bazel/typescript@0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.16.2.tgz#42474e029b0c6fa42a058fc86e2f593b7a367d56"
   dependencies:
     protobufjs "5.0.0"
-    tsickle "0.32.1"
     tsutils "2.20.0"
 
 "@types/jasmine@file:../../node_modules/@types/jasmine":
@@ -852,16 +851,6 @@ tough-cookie@~2.4.3:
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
-
-tsickle@0.32.1:
-  version "0.32.1"
-  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.32.1.tgz#f16e94ba80b32fc9ebe320dc94fbc2ca7f3521a5"
-  dependencies:
-    jasmine-diff "^0.1.3"
-    minimist "^1.2.0"
-    mkdirp "^0.5.1"
-    source-map "^0.6.0"
-    source-map-support "^0.5.0"
 
 "tsickle@file:../../node_modules/tsickle":
   version "0.32.0"

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
     "prebuildifier": "bazel build --noshow_progress @com_github_bazelbuild_buildtools//buildifier",
     "buildifier": "find . -type f \\( -name \"*.bzl\" -or -name BUILD -or -name BUILD.bazel \\) ! -path \"*/node_modules/*\" | xargs $(bazel info bazel-bin)/external/com_github_bazelbuild_buildtools/buildifier/*/buildifier",
     "preinstall": "node tools/yarn/check-yarn.js",
-    "postinstall": "yarn update-webdriver && node ./tools/postinstall-patches.js && yarn patch-types",
-    "//patch-types": "work-around for issue https://github.com/angular/angular/issues/25051",
-    "patch-types": "node -e \"var sh = require('shelljs'); sh.set('-e'); sh.mkdir('-p', 'node_modules/@types/zone.js'); sh.cp('-f', 'node_modules/zone.js/dist/zone.js.d.ts', 'node_modules/@types/zone.js/index.d.ts')\"",
+    "postinstall": "yarn update-webdriver && node ./tools/postinstall-patches.js",
     "update-webdriver": "webdriver-manager update --gecko false $CHROMEDRIVER_VERSION_ARG",
     "check-env": "gulp check-env",
     "commitmsg": "node ./scripts/git/commit-msg.js"

--- a/packages/bazel/src/ng_setup_workspace.bzl
+++ b/packages/bazel/src/ng_setup_workspace.bzl
@@ -21,4 +21,5 @@ def ng_setup_workspace():
     )
 
     # 0.16.0: minimal version required to work with ng_module
-    check_rules_typescript_version("0.16.0")
+    # 0.16.2: bazel type resolution for zone.js types
+    check_rules_typescript_version("0.16.2")

--- a/packages/compiler-cli/src/ngtsc/factories/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/factories/src/host.ts
@@ -17,7 +17,16 @@ import {FactoryGenerator} from './generator';
 export class GeneratedFactoryHostWrapper implements ts.CompilerHost {
   constructor(
       private delegate: ts.CompilerHost, private generator: FactoryGenerator,
-      private factoryToSourceMap: Map<string, string>) {}
+      private factoryToSourceMap: Map<string, string>) {
+    if (delegate.resolveTypeReferenceDirectives) {
+      this.resolveTypeReferenceDirectives = (names: string[], containingFile: string) =>
+          delegate.resolveTypeReferenceDirectives !(names, containingFile);
+    }
+  }
+
+  resolveTypeReferenceDirectives?:
+      (names: string[],
+       containingFile: string) => (ts.ResolvedTypeReferenceDirective | undefined)[];
 
   getSourceFile(
       fileName: string, languageVersion: ts.ScriptTarget,

--- a/packages/compiler-cli/src/ngtsc/factories/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/factories/src/host.ts
@@ -19,14 +19,19 @@ export class GeneratedFactoryHostWrapper implements ts.CompilerHost {
       private delegate: ts.CompilerHost, private generator: FactoryGenerator,
       private factoryToSourceMap: Map<string, string>) {
     if (delegate.resolveTypeReferenceDirectives) {
+      // Backward compatibility with TypeScript 2.9 and older since return
+      // type has changed from (ts.ResolvedTypeReferenceDirective | undefined)[]
+      // to ts.ResolvedTypeReferenceDirective[] in Typescript 3.0
+      type ts3ResolveTypeReferenceDirectives = (names: string[], containingFile: string) =>
+          ts.ResolvedTypeReferenceDirective[];
       this.resolveTypeReferenceDirectives = (names: string[], containingFile: string) =>
-          delegate.resolveTypeReferenceDirectives !(names, containingFile);
+          (delegate.resolveTypeReferenceDirectives as ts3ResolveTypeReferenceDirectives) !(
+              names, containingFile);
     }
   }
 
   resolveTypeReferenceDirectives?:
-      (names: string[],
-       containingFile: string) => (ts.ResolvedTypeReferenceDirective | undefined)[];
+      (names: string[], containingFile: string) => ts.ResolvedTypeReferenceDirective[];
 
   getSourceFile(
       fileName: string, languageVersion: ts.ScriptTarget,

--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -79,8 +79,7 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
   // TODO(issue/24571): remove '!'.
   getDirectories !: (path: string) => string[];
   resolveTypeReferenceDirectives?:
-      (names: string[],
-       containingFile: string) => (ts.ResolvedTypeReferenceDirective | undefined)[];
+      (names: string[], containingFile: string) => ts.ResolvedTypeReferenceDirective[];
   directoryExists?: (directoryName: string) => boolean;
 
   constructor(
@@ -106,8 +105,14 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
       this.getDefaultLibLocation = () => context.getDefaultLibLocation !();
     }
     if (context.resolveTypeReferenceDirectives) {
+      // Backward compatibility with TypeScript 2.9 and older since return
+      // type has changed from (ts.ResolvedTypeReferenceDirective | undefined)[]
+      // to ts.ResolvedTypeReferenceDirective[] in Typescript 3.0
+      type ts3ResolveTypeReferenceDirectives = (names: string[], containingFile: string) =>
+          ts.ResolvedTypeReferenceDirective[];
       this.resolveTypeReferenceDirectives = (names: string[], containingFile: string) =>
-          context.resolveTypeReferenceDirectives !(names, containingFile);
+          (context.resolveTypeReferenceDirectives as ts3ResolveTypeReferenceDirectives) !(
+              names, containingFile);
     }
     if (context.trace) {
       this.trace = s => context.trace !(s);

--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -78,6 +78,9 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
   trace !: (s: string) => void;
   // TODO(issue/24571): remove '!'.
   getDirectories !: (path: string) => string[];
+  resolveTypeReferenceDirectives?:
+      (names: string[],
+       containingFile: string) => (ts.ResolvedTypeReferenceDirective | undefined)[];
   directoryExists?: (directoryName: string) => boolean;
 
   constructor(
@@ -101,6 +104,10 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
     }
     if (context.getDefaultLibLocation) {
       this.getDefaultLibLocation = () => context.getDefaultLibLocation !();
+    }
+    if (context.resolveTypeReferenceDirectives) {
+      this.resolveTypeReferenceDirectives = (names: string[], containingFile: string) =>
+          context.resolveTypeReferenceDirectives !(names, containingFile);
     }
     if (context.trace) {
       this.trace = s => context.trace !(s);


### PR DESCRIPTION
Depends on https://github.com/angular/angular/pull/25490 && https://github.com/bazelbuild/rules_typescript/pull/259.

Build will fail with tsickle diagnostics until https://github.com/angular/angular/pull/25490 lands and this is rebased.

Will need to updated to tagged rules_typescript release after https://github.com/bazelbuild/rules_typescript/pull/259 lands.