### PR TITLE
fix(ivy): host bindings should support array/object literals

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -112,7 +112,6 @@ export function renderComponent<T>(
   rootView[INJECTOR] = opts.injector || null;
 
   const oldView = enterView(rootView, null !);
-  rootView[BINDING_INDEX] = rootView[TVIEW].bindingStartIndex;
   let elementNode: LElementNode;
   let component: T;
   try {

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -127,7 +127,6 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
 
     // rootView is the parent when bootstrapping
     const oldView = enterView(rootView, null !);
-    rootView[BINDING_INDEX] = rootView[TVIEW].bindingStartIndex;
 
     let component: T;
     let elementNode: LElementNode;

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -56,7 +56,7 @@ export function defineComponent<T>(componentDefinition: {
   /**
    * The number of nodes, local refs, and pipes in this component template.
    *
-   * Used to calculate the length of the component's LViewData array, so we
+   * Used to calculate the length of this component's LViewData array, so we
    * can pre-fill the array and set the binding start index.
    */
   // TODO(kara): remove queries from this count
@@ -65,10 +65,18 @@ export function defineComponent<T>(componentDefinition: {
   /**
    * The number of bindings in this component template (including pure fn bindings).
    *
-   * Used to calculate the length of the component's LViewData array, so we
+   * Used to calculate the length of this component's LViewData array, so we
    * can pre-fill the array and set the host binding start index.
    */
   vars: number;
+
+  /**
+   * The number of host bindings (including pure fn bindings) in this component.
+   *
+   * Used to calculate the length of the LViewData array for the *parent* component
+   * of this component.
+   */
+  hostVars?: number;
 
   /**
    * Static attributes to set on host element.
@@ -264,6 +272,7 @@ export function defineComponent<T>(componentDefinition: {
     diPublic: null,
     consts: componentDefinition.consts,
     vars: componentDefinition.vars,
+    hostVars: componentDefinition.hostVars || 0,
     factory: componentDefinition.factory,
     template: componentDefinition.template || null !,
     hostBindings: componentDefinition.hostBindings || null,
@@ -576,6 +585,14 @@ export const defineDirective = defineComponent as any as<T>(directiveDefinition:
    * See: {@link NgOnChangesFeature}, {@link PublicFeature}, {@link InheritDefinitionFeature}
    */
   features?: DirectiveDefFeature[];
+
+  /**
+   * The number of host bindings (including pure fn bindings) in this directive.
+   *
+   * Used to calculate the length of the LViewData array for the *parent* component
+   * of this directive.
+   */
+  hostVars?: number;
 
   /**
    * Function executed by the parent template to allow child directive to apply host bindings.

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -141,6 +141,14 @@ export interface DirectiveDef<T, Selector extends string> extends BaseDef<T> {
   /** Refreshes content queries associated with directives in a given view */
   contentQueriesRefresh: ((directiveIndex: number, queryIndex: number) => void)|null;
 
+  /**
+   * The number of host bindings (including pure fn bindings) in this directive/component.
+   *
+   * Used to calculate the length of the LViewData array for the *parent* component
+   * of this directive/component.
+   */
+  hostVars: number;
+
   /** Refreshes host bindings on the associated directive. */
   hostBindings: ((directiveIndex: number, elementIndex: number) => void)|null;
 

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -290,6 +290,13 @@ export interface TView {
   bindingStartIndex: number;
 
   /**
+   * The index at which the data array begins to store host bindings for components
+   * or directives in its template. Saving this value ensures that we can set the
+   * binding root and binding index correctly before checking host bindings.
+   */
+  hostBindingStartIndex: number;
+
+  /**
    * Index of the host node of the first LView or LContainer beneath this LView in
    * the hierarchy.
    *

--- a/packages/core/src/render3/pure_function.ts
+++ b/packages/core/src/render3/pure_function.ts
@@ -6,20 +6,22 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {bindingUpdated, bindingUpdated2, bindingUpdated4, updateBinding, getBinding, getCreationMode, getTView, bindingUpdated3,} from './instructions';
+import {bindingUpdated, bindingUpdated2, bindingUpdated4, updateBinding, getBinding, getCreationMode, bindingUpdated3, getBindingRoot, getTView,} from './instructions';
 
 /**
  * Bindings for pure functions are stored after regular bindings.
  *
- *  ----------------------------------------------------------------------------
- *  |  LNodes / local refs / pipes ... | regular bindings / interpolations | pure function bindings
- *  ----------------------------------------------------------------------------
- *                                     ^
- *                          TView.bindingStartIndex
+ * |--------consts--------|----------------vars----------------|------ hostVars (dir1) ------|
+ * ---------------------------------------------------------------------------------------------
+ * | nodes / refs / pipes | bindings | pure function bindings  | host bindings  | host slots |
+ * ---------------------------------------------------------------------------------------------
+ *                        ^                                    ^
+ *             TView.bindingStartIndex            TView.hostBindingStartIndex
  *
- * Pure function instructions are given an offset from TView.bindingStartIndex.
- * Adding the offset to TView.bindingStartIndex gives the first index where the bindings
- * are stored.
+ * Pure function instructions are given an offset from the binding root. Adding the offset to the
+ * binding root gives the first index where the bindings are stored. In component views, the binding
+ * root is the bindingStartIndex. In host bindings, the binding root is the hostBindingStartIndex +
+ * any hostVars in directives evaluated before it.
  */
 
 /**
@@ -33,7 +35,7 @@ import {bindingUpdated, bindingUpdated2, bindingUpdated4, updateBinding, getBind
  */
 export function pureFunction0<T>(slotOffset: number, pureFn: () => T, thisArg?: any): T {
   // TODO(kara): use bindingRoot instead of bindingStartIndex when implementing host bindings
-  const bindingIndex = getTView().bindingStartIndex + slotOffset;
+  const bindingIndex = getBindingRoot() + slotOffset;
   return getCreationMode() ?
       updateBinding(bindingIndex, thisArg ? pureFn.call(thisArg) : pureFn()) :
       getBinding(bindingIndex);
@@ -52,7 +54,7 @@ export function pureFunction0<T>(slotOffset: number, pureFn: () => T, thisArg?: 
 export function pureFunction1(
     slotOffset: number, pureFn: (v: any) => any, exp: any, thisArg?: any): any {
   // TODO(kara): use bindingRoot instead of bindingStartIndex when implementing host bindings
-  const bindingIndex = getTView().bindingStartIndex + slotOffset;
+  const bindingIndex = getBindingRoot() + slotOffset;
   return bindingUpdated(bindingIndex, exp) ?
       updateBinding(bindingIndex + 1, thisArg ? pureFn.call(thisArg, exp) : pureFn(exp)) :
       getBinding(bindingIndex + 1);
@@ -73,7 +75,7 @@ export function pureFunction2(
     slotOffset: number, pureFn: (v1: any, v2: any) => any, exp1: any, exp2: any,
     thisArg?: any): any {
   // TODO(kara): use bindingRoot instead of bindingStartIndex when implementing host bindings
-  const bindingIndex = getTView().bindingStartIndex + slotOffset;
+  const bindingIndex = getBindingRoot() + slotOffset;
   return bindingUpdated2(bindingIndex, exp1, exp2) ?
       updateBinding(
           bindingIndex + 2, thisArg ? pureFn.call(thisArg, exp1, exp2) : pureFn(exp1, exp2)) :
@@ -96,7 +98,7 @@ export function pureFunction3(
     slotOffset: number, pureFn: (v1: any, v2: any, v3: any) => any, exp1: any, exp2: any, exp3: any,
     thisArg?: any): any {
   // TODO(kara): use bindingRoot instead of bindingStartIndex when implementing host bindings
-  const bindingIndex = getTView().bindingStartIndex + slotOffset;
+  const bindingIndex = getBindingRoot() + slotOffset;
   return bindingUpdated3(bindingIndex, exp1, exp2, exp3) ?
       updateBinding(
           bindingIndex + 3,
@@ -121,7 +123,7 @@ export function pureFunction4(
     slotOffset: number, pureFn: (v1: any, v2: any, v3: any, v4: any) => any, exp1: any, exp2: any,
     exp3: any, exp4: any, thisArg?: any): any {
   // TODO(kara): use bindingRoot instead of bindingStartIndex when implementing host bindings
-  const bindingIndex = getTView().bindingStartIndex + slotOffset;
+  const bindingIndex = getBindingRoot() + slotOffset;
   return bindingUpdated4(bindingIndex, exp1, exp2, exp3, exp4) ?
       updateBinding(
           bindingIndex + 4,
@@ -147,7 +149,7 @@ export function pureFunction5(
     slotOffset: number, pureFn: (v1: any, v2: any, v3: any, v4: any, v5: any) => any, exp1: any,
     exp2: any, exp3: any, exp4: any, exp5: any, thisArg?: any): any {
   // TODO(kara): use bindingRoot instead of bindingStartIndex when implementing host bindings
-  const bindingIndex = getTView().bindingStartIndex + slotOffset;
+  const bindingIndex = getBindingRoot() + slotOffset;
   const different = bindingUpdated4(bindingIndex, exp1, exp2, exp3, exp4);
   return bindingUpdated(bindingIndex + 4, exp5) || different ?
       updateBinding(
@@ -175,7 +177,7 @@ export function pureFunction6(
     slotOffset: number, pureFn: (v1: any, v2: any, v3: any, v4: any, v5: any, v6: any) => any,
     exp1: any, exp2: any, exp3: any, exp4: any, exp5: any, exp6: any, thisArg?: any): any {
   // TODO(kara): use bindingRoot instead of bindingStartIndex when implementing host bindings
-  const bindingIndex = getTView().bindingStartIndex + slotOffset;
+  const bindingIndex = getBindingRoot() + slotOffset;
   const different = bindingUpdated4(bindingIndex, exp1, exp2, exp3, exp4);
   return bindingUpdated2(bindingIndex + 4, exp5, exp6) || different ?
       updateBinding(
@@ -205,7 +207,7 @@ export function pureFunction7(
     pureFn: (v1: any, v2: any, v3: any, v4: any, v5: any, v6: any, v7: any) => any, exp1: any,
     exp2: any, exp3: any, exp4: any, exp5: any, exp6: any, exp7: any, thisArg?: any): any {
   // TODO(kara): use bindingRoot instead of bindingStartIndex when implementing host bindings
-  const bindingIndex = getTView().bindingStartIndex + slotOffset;
+  const bindingIndex = getBindingRoot() + slotOffset;
   let different = bindingUpdated4(bindingIndex, exp1, exp2, exp3, exp4);
   return bindingUpdated3(bindingIndex + 4, exp5, exp6, exp7) || different ?
       updateBinding(
@@ -238,7 +240,7 @@ export function pureFunction8(
     exp1: any, exp2: any, exp3: any, exp4: any, exp5: any, exp6: any, exp7: any, exp8: any,
     thisArg?: any): any {
   // TODO(kara): use bindingRoot instead of bindingStartIndex when implementing host bindings
-  const bindingIndex = getTView().bindingStartIndex + slotOffset;
+  const bindingIndex = getBindingRoot() + slotOffset;
   const different = bindingUpdated4(bindingIndex, exp1, exp2, exp3, exp4);
   return bindingUpdated4(bindingIndex + 4, exp5, exp6, exp7, exp8) || different ?
       updateBinding(
@@ -264,7 +266,7 @@ export function pureFunction8(
 export function pureFunctionV(
     slotOffset: number, pureFn: (...v: any[]) => any, exps: any[], thisArg?: any): any {
   // TODO(kara): use bindingRoot instead of bindingStartIndex when implementing host bindings
-  let bindingIndex = getTView().bindingStartIndex + slotOffset;
+  let bindingIndex = getBindingRoot() + slotOffset;
   let different = false;
   for (let i = 0; i < exps.length; i++) {
     bindingUpdated(bindingIndex++, exps[i]) && (different = true);

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -99,6 +99,9 @@
     "name": "baseDirectiveCreate"
   },
   {
+    "name": "bindingRootIndex"
+  },
+  {
     "name": "bloomAdd"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -327,6 +327,9 @@
     "name": "bind"
   },
   {
+    "name": "bindingRootIndex"
+  },
+  {
     "name": "bindingUpdated"
   },
   {

--- a/packages/core/test/render3/directive_spec.ts
+++ b/packages/core/test/render3/directive_spec.ts
@@ -15,36 +15,6 @@ import {TemplateFixture} from './render_util';
 
 describe('directive', () => {
 
-  describe('host', () => {
-
-    it('should support host bindings in directives', () => {
-      let directiveInstance: Directive|undefined;
-
-      class Directive {
-        klass = 'foo';
-        static ngDirectiveDef = defineDirective({
-          type: Directive,
-          selectors: [['', 'dir', '']],
-          factory: () => directiveInstance = new Directive,
-          hostBindings: (directiveIndex: number, elementIndex: number) => {
-            elementProperty(
-                elementIndex, 'className', bind(loadDirective<Directive>(directiveIndex).klass));
-          }
-        });
-      }
-
-      function Template() { element(0, 'span', [AttributeMarker.SelectOnly, 'dir']); }
-
-      const fixture = new TemplateFixture(Template, () => {}, 1, 0, [Directive]);
-      expect(fixture.html).toEqual('<span class="foo"></span>');
-
-      directiveInstance !.klass = 'bar';
-      fixture.update();
-      expect(fixture.html).toEqual('<span class="bar"></span>');
-    });
-
-  });
-
   describe('selectors', () => {
 
     it('should match directives with attribute selectors on bindings', () => {


### PR DESCRIPTION
This PR adds runtime support for array/object literals in host bindings. It adds a `hostVars` count to component/directive defs that is used to set the correct "binding root" for each directive with a host binding.

```
|--consts--|----------------vars----------------|-------------hostVars--------------|
|  nodes   |   bindings  |   pure fn bindings   |   host bindings   | host pure fns
           ^                                    ^
   bindingStartIndex            hostBindingStartIndex
```

Still TODO:
- Generate `LViewData` from a blueprint
- Update compiler with `hostVars` and new slot allocation scheme
- Flatten queries into `LViewData` and counts