### PR TITLE
build: remove `NGBUILDS_IO_KEY` now that it is not used any more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,7 @@ addons:
     packages:
       # needed to install g++ that is used by npms's native modules
       - g++-4.8
-  # https://docs.travis-ci.com/user/jwt
-  jwt:
-    # SAUCE_ACCESS_KEY<=secret for NGBUILDS_IO_KEY to work around travis-ci/travis-ci#7223, unencrypted value in valentine as NGBUILDS_IO_KEY>
-    # we alias NGBUILDS_IO_KEY to $SAUCE_ACCESS_KEY in env.sh and set the SAUCE_ACCESS_KEY there
-    - secure: "L7nrZwkAtFtYrP2DykPXgZvEKjkv0J/TwQ/r2QGxFTaBq4VZn+2Dw0YS7uCxoMqYzDwH0aAOqxoutibVpk8Z/16nE3tNmU5RzltMd6Xmt3qU2f/JDQLMo6PSlBodnjOUsDHJgmtrcbjhqrx/znA237BkNUu6UZRT7mxhXIZpn0U="
+
 branches:
   except:
     - g3

--- a/scripts/ci/env.sh
+++ b/scripts/ci/env.sh
@@ -82,24 +82,17 @@ if [[ ${TRAVIS:-} ]]; then
   # more info: https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements
   setEnvVar CXX g++-4.8
 
-  # If NGBUILDS_IO_KEY not set yet, export the NGBUILDS_IO_KEY using the JWT token that Travis generated and exported for SAUCE_ACCESS_KEY.
-  # This is a workaround for travis-ci/travis-ci#7223
-  # WARNING: NGBUILDS_IO_KEY should NOT be printed
-  export NGBUILDS_IO_KEY=${NGBUILDS_IO_KEY:-$SAUCE_ACCESS_KEY}
-
   # Used by karma and karma-chrome-launcher
   # In order to have a meaningful SauceLabs badge on the repo page,
   # the angular2-ci account is used only when pushing commits to master;
   # in all other cases, the regular angular-ci account is used.
   if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then
     setEnvVar SAUCE_USERNAME angular2-ci
-    # - not using use setEnvVar so that we don't print the key
-    # - we overwrite the value set by Travis JWT addon here to work around travis-ci/travis-ci#7223 for NGBUILDS_IO_KEY
+    # Not using use `setEnvVar` so that we don't print the key.
     export SAUCE_ACCESS_KEY=693ebc16208a-0b5b-1614-8d66-a2662f4e
   else
     setEnvVar SAUCE_USERNAME angular-ci
-    # - not using use setEnvVar so that we don't print the key
-    # - we overwrite the value set by Travis JWT addon here to work around travis-ci/travis-ci#7223 for NGBUILDS_IO_KEY
+    # Not using use `setEnvVar` so that we don't print the key.
     export SAUCE_ACCESS_KEY=9b988f434ff8-fbca-8aa4-4ae3-35442987
   fi
 


### PR DESCRIPTION
This is a follow-up to #25536.
