### PR TITLE
build(bazel): remove workaround no longer needed for module names for ngfactory & ngsummary files

### DIFF
--- a/packages/compiler/src/aot/summary_resolver.ts
+++ b/packages/compiler/src/aot/summary_resolver.ts
@@ -120,16 +120,6 @@ export class AotSummaryResolver implements SummaryResolver<StaticSymbol> {
       summaries.forEach((summary) => this.summaryCache.set(summary.symbol, summary));
       if (moduleName) {
         this.knownFileNameToModuleNames.set(filePath, moduleName);
-        if (filePath.endsWith('.d.ts')) {
-          // Also add entries to map the ngfactory & ngsummary files to their module names.
-          // This is necessary to resolve ngfactory & ngsummary files to their AMD module
-          // names when building angular with Bazel from source downstream.
-          // See https://github.com/bazelbuild/rules_typescript/pull/223 for context.
-          this.knownFileNameToModuleNames.set(
-              filePath.replace(/\.d\.ts$/, '.ngfactory.d.ts'), moduleName + '.ngfactory');
-          this.knownFileNameToModuleNames.set(
-              filePath.replace(/\.d\.ts$/, '.ngsummary.d.ts'), moduleName + '.ngsummary');
-        }
       }
       importAs.forEach((importAs) => { this.importAs.set(importAs.symbol, importAs.importAs); });
     }


### PR DESCRIPTION
Resolves https://github.com/angular/angular-cli/issues/11835.

The underlying issue in the compiler that required this workaround to give ngfactory & ngsummary files proper AMD names has been resolved so it is no longer needed.
