### PR TITLE
fix(router): make relativeLinkResolution corrected by default

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -443,7 +443,7 @@ export class Router {
    * Enables a bug fix that corrects relative link resolution in components with empty paths.
    * @see `RouterModule`
    */
-  relativeLinkResolution: 'legacy'|'corrected' = 'legacy';
+  relativeLinkResolution: 'legacy'|'corrected' = 'corrected';
 
   /**
    * Creates the router service.

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -425,8 +425,9 @@ export interface ExtraOptions {
    *
    * `<a [routerLink]="['../a']">Link to A</a>`
    *
-   * In other words, you're required to use `../` rather than `./`. This is currently the default
-   * behavior. Setting this option to `corrected` enables the fix.
+   * In other words, you're required to use `../` rather than `./`.
+   *
+   * The default in v11 is `corrected`.
    */
   relativeLinkResolution?: 'legacy'|'corrected';
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[X] Bugfix
```

## What is the current behavior?
To apply the fix of https://github.com/angular/angular/pull/22394 in Angular 6.x, you have to set `relativeLinkResolution` to  `corrected`.


## What is the new behavior?
This PR makes this the default for Angular 7.

## Does this PR introduce a breaking change?
```
[X] Yes
[ ] No
```
Routing behaviour will be affected for empty path routes.

## Other information
See https://github.com/angular/angular/pull/22394/files.

Credits to @adriensamson.