### PR TITLE
 fix(ivy): <ng-container> fixes

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -557,17 +557,21 @@ export const QUERY_READ_ELEMENT_REF =
 
 export const QUERY_READ_FROM_NODE =
     (new ReadFromInjectorFn<any>((injector: LInjector, node: LNode, directiveIdx: number) => {
-      ngDevMode && assertNodeOfPossibleTypes(node, TNodeType.Container, TNodeType.Element);
+      ngDevMode && assertNodeOfPossibleTypes(
+                       node, TNodeType.Container, TNodeType.Element, TNodeType.ElementContainer);
       if (directiveIdx > -1) {
         return node.view[DIRECTIVES] ![directiveIdx];
       }
-      if (node.tNode.type === TNodeType.Element) {
+      if (node.tNode.type === TNodeType.Element || node.tNode.type === TNodeType.ElementContainer) {
         return getOrCreateElementRef(injector);
       }
       if (node.tNode.type === TNodeType.Container) {
         return getOrCreateTemplateRef(injector);
       }
-      throw new Error('fail');
+      if (ngDevMode) {
+        // should never happen
+        throw new Error(`Unexpected node type: ${node.tNode.type}`);
+      }
     }) as any as QueryReadType<any>);
 
 /** A ref to a node's native element. */

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -586,7 +586,8 @@ export function getOrCreateContainerRef(di: LInjector): viewEngine_ViewContainer
   if (!di.viewContainerRef) {
     const vcRefHost = di.node;
 
-    ngDevMode && assertNodeOfPossibleTypes(vcRefHost, TNodeType.Container, TNodeType.Element);
+    ngDevMode && assertNodeOfPossibleTypes(
+                     vcRefHost, TNodeType.Container, TNodeType.Element, TNodeType.ElementContainer);
     const hostParent = getParentLNode(vcRefHost) !;
     const lContainer = createLContainer(hostParent, vcRefHost.view, true);
     const comment = vcRefHost.view[RENDERER].createComment(ngDevMode ? 'container' : '');

--- a/packages/core/src/render3/node_assert.ts
+++ b/packages/core/src/render3/node_assert.ts
@@ -17,7 +17,9 @@ export function assertNodeType(node: LNode, type: TNodeType) {
 export function assertNodeOfPossibleTypes(node: LNode, ...types: TNodeType[]) {
   assertDefined(node, 'should be called with a node');
   const found = types.some(type => node.tNode.type === type);
-  assertEqual(found, true, `Should be one of ${types.map(typeName).join(', ')}`);
+  assertEqual(
+      found, true,
+      `Should be one of ${types.map(typeName).join(', ')} but got ${typeName(node.tNode.type)}`);
 }
 
 function typeName(type: TNodeType): string {
@@ -25,5 +27,6 @@ function typeName(type: TNodeType): string {
   if (type == TNodeType.Container) return 'Container';
   if (type == TNodeType.View) return 'View';
   if (type == TNodeType.Element) return 'Element';
+  if (type == TNodeType.ElementContainer) return 'ElementContainer';
   return '<unknown>';
 }

--- a/packages/core/test/render3/common_integration_spec.ts
+++ b/packages/core/test/render3/common_integration_spec.ts
@@ -9,7 +9,7 @@
 import {NgForOfContext} from '@angular/common';
 
 import {AttributeMarker, defineComponent, templateRefExtractor} from '../../src/render3/index';
-import {bind, template, elementEnd, elementProperty, elementStart, getCurrentView, interpolation1, interpolation2, interpolation3, interpolationV, listener, load, nextContext, restoreView, text, textBinding, elementContainerStart, elementContainerEnd} from '../../src/render3/instructions';
+import {bind, template, elementEnd, elementProperty, elementStart, getCurrentView, interpolation1, interpolation2, interpolation3, interpolationV, listener, load, nextContext, restoreView, text, textBinding, elementContainerStart, elementContainerEnd, reference} from '../../src/render3/instructions';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 
 import {NgForOf, NgIf, NgTemplateOutlet} from './common_with_def';
@@ -948,7 +948,7 @@ describe('@angular/common integration', () => {
               elementContainerEnd();
             }
             if (rf & RenderFlags.Update) {
-              const tplRef = load(1);
+              const tplRef = reference(1);
               elementProperty(2, 'ngTemplateOutlet', bind(myApp.showing ? tplRef : null));
             }
           },

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -370,7 +370,7 @@ describe('query', () => {
            /**
             * <ng-container #foo></ng-container>
             * class Cmpt {
-            *  @ViewChildren('foo') query;
+            *  @ViewChildren('foo', {read: ElementRef}) query;
             * }
             */
            const Cmpt = createComponent(
@@ -400,6 +400,41 @@ describe('query', () => {
            expect(isElementRef(qList.first)).toBeTruthy();
            expect(qList.first.nativeElement).toEqual(elToQuery);
          });
+
+      it('should query for <ng-container> and read ElementRef without explicit read option', () => {
+        let elToQuery;
+        /**
+         * <ng-container #foo></ng-container>
+         * class Cmpt {
+         *  @ViewChildren('foo') query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                elementContainerStart(1, null, ['foo', '']);
+                elToQuery = loadElement(1).native;
+                elementContainerEnd();
+              }
+            },
+            3, 0, [], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], true, QUERY_READ_FROM_NODE);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(1);
+        expect(isElementRef(qList.first)).toBeTruthy();
+        expect(qList.first.nativeElement).toEqual(elToQuery);
+      });
 
       /**
        * BREAKING CHANGE: this tests asserts different behaviour as compared to Renderer2 when it


### PR DESCRIPTION
This PR contains fixes for 2 issues discovered when running TestBed spec on the existing tests from the `common` package.

In both cases the issue boiled down to taking new node type into account when doing checks.