### PR TITLE
fix(ivy): ngtsc directive compilation should use shared ConstantPool

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -45,13 +45,13 @@ export class DirectiveDecoratorHandler implements DecoratorHandler<R3DirectiveMe
     return {analysis};
   }
 
-  compile(node: ts.ClassDeclaration, analysis: R3DirectiveMetadata): CompileResult {
-    const pool = new ConstantPool();
+  compile(node: ts.ClassDeclaration, analysis: R3DirectiveMetadata, pool: ConstantPool):
+      CompileResult {
     const res = compileDirectiveFromMetadata(analysis, pool, makeBindingParser());
     return {
       name: 'ngDirectiveDef',
       initializer: res.expression,
-      statements: pool.statements,
+      statements: res.statements,
       type: res.type,
     };
   }

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -722,6 +722,29 @@ describe('ngtsc behavioral tests', () => {
         .toContain('function GrandChild_Factory(t) { return new (t || GrandChild)(); }');
   });
 
+  it('generates base factories for directives', () => {
+    writeConfig();
+    write(`test.ts`, `
+        import {Directive} from '@angular/core';
+
+        class Base {}
+
+        @Directive({
+          selector: '[test]',
+        })
+        class Dir extends Base {
+        }
+    `);
+
+
+    const exitCode = main(['-p', basePath], errorSpy);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(exitCode).toBe(0);
+    const jsContents = getContents('test.js');
+
+    expect(jsContents).toContain('var ɵDir_BaseFactory = i0.ɵgetInheritedFactory(Dir)');
+  });
+
   it('should wrap "directives" in component metadata in a closure when forward references are present',
      () => {
        writeConfig();


### PR DESCRIPTION
This fixes a bug in ngtsc where each @Directive was compiled using a
separate ConstantPool. This resulted in two issues:

* Directive constants were not shared across the file
* Extra statements from directive compilation were dropped instead of
added to the file

This commit fixes both issues and adds a test to verify @Directive is
working properly.