### PR TITLE
fix(compiler): add hostVars and support pure functions in host bindings

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -590,6 +590,7 @@ describe('compiler compliance', () => {
           hostBindings: function HostBindingDir_HostBindings(dirIndex, elIndex) {
             $r3$.ɵelementProperty(elIndex, "id", $r3$.ɵbind($r3$.ɵloadDirective(dirIndex).dirId));
           },
+          hostVars: 1,
           features: [$r3$.ɵPublicFeature]
         });
       `;
@@ -598,6 +599,53 @@ describe('compiler compliance', () => {
       const source = result.source;
 
       expectEmit(source, HostBindingDirDeclaration, 'Invalid host binding code');
+    });
+
+    it('should support host bindings with pure functions', () => {
+      const files = {
+        app: {
+          'spec.ts': `
+            import {Component, NgModule} from '@angular/core';
+
+            @Component({
+              selector: 'host-binding-comp',
+              host: {
+                '[id]': '["red", id]'
+              },
+              template: ''
+            })
+            export class HostBindingComp {
+              id = 'some id';
+            }
+
+            @NgModule({declarations: [HostBindingComp]})
+            export class MyModule {}
+          `
+        }
+      };
+
+      const HostBindingCompDeclaration = `
+        const $ff$ = function ($v$) { return ["red", $v$]; };
+        …
+        HostBindingComp.ngComponentDef = $r3$.ɵdefineComponent({
+          type: HostBindingComp,
+          selectors: [["host-binding-comp"]],
+          factory: function HostBindingComp_Factory(t) { return new (t || HostBindingComp)(); },
+          hostBindings: function HostBindingComp_HostBindings(dirIndex, elIndex) {
+            $r3$.ɵelementProperty(elIndex, "id", $r3$.ɵbind($r3$.ɵpureFunction1(1, $ff$, $r3$.ɵloadDirective(dirIndex).id)));
+          },
+          hostVars: 3,
+          features: [$r3$.ɵPublicFeature],
+          consts: 0,
+          vars: 0,
+          template: function HostBindingComp_Template(rf, ctx) {}
+        });
+      `;
+
+      const result = compile(files, angularFiles);
+      const source = result.source;
+
+      expectEmit(source, HostBindingCompDeclaration, 'Invalid host binding code');
     });
 
     it('should support structural directives', () => {

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -908,7 +908,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   }
 }
 
-class ValueConverter extends AstMemoryEfficientTransformer {
+export class ValueConverter extends AstMemoryEfficientTransformer {
   private _pipeBindExprs: FunctionCall[] = [];
 
   constructor(


### PR DESCRIPTION
Needs rebase on https://github.com/angular/angular/pull/25607, review only second commit.

This PR adds `hostVars` generation to the template compiler and adds support for array and object literals in host bindings functions.