### PR TITLE
test(common): fix double instantiation in NgSwitch test

### DIFF
--- a/packages/common/test/directives/ng_switch_spec.ts
+++ b/packages/common/test/directives/ng_switch_spec.ts
@@ -133,9 +133,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
             '</div>';
 
         TestBed.configureTestingModule({declarations: [TestDirective]});
-        TestBed.overrideComponent(TestComponent, {set: {template: template}})
-            .createComponent(TestComponent);
-        const fixture = TestBed.createComponent(TestComponent);
+        const fixture = createTestComponent(template);
         fixture.componentInstance.switchValue = 'a';
 
         fixture.detectChanges();


### PR DESCRIPTION
One of the tests was creating TestComponent instance _and_ using
global state making this test not predictable. Fixing the test
by making sure that TestComponent is instantiated only once.

This PR is needed to unblock `TestBed` tests for ivy.