### PR TITLE
build(bazel): use value of /// <amd-module name=“”> directive to convert fileNameToModuleName in ngc-wrapped

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -226,6 +226,15 @@ export function compile({allowNonHermeticReads, allDepsCompiledWithBazel = true,
   const ngHost = ng.createCompilerHost({options: compilerOpts, tsHost: bazelHost});
 
   ngHost.fileNameToModuleName = (importedFilePath: string, containingFilePath: string) => {
+    try {
+      const sourceFile = ngHost.getSourceFile(importedFilePath, ts.ScriptTarget.Latest);
+      if (sourceFile && sourceFile.moduleName) {
+        return sourceFile.moduleName;
+      }
+    } catch (err) {
+      // File does not exist or parse error. Ignore this case and continue onto the
+      // other methods of resolving the module below.
+    }
     if ((compilerOpts.module === ts.ModuleKind.UMD || compilerOpts.module === ts.ModuleKind.AMD) &&
         ngHost.amdModuleName) {
       return ngHost.amdModuleName({ fileName: importedFilePath } as ts.SourceFile);


### PR DESCRIPTION
The work-around that was removed in https://github.com/angular/angular/pull/25604 is still needed for building angular from bazel downstream. I was mistaken in my analysis.

This PR puts the workaround back but adds fixes the module name resolution for cases like `@angular/core.ngfactory` which should actually be resolved to `@angular/core/core.ngfactory`.

This will fix https://github.com/angular/angular-cli/issues/11835 which promted #25604 while not breaking angular building from source downstream.

UPDATE: New approach after talking to @alexeagle and @alxhub. Using the moduleName from the ts.SourceFile will ensure the .ngfactory && .ngsummary files get the correct module names when building angular from source downstream