### PR TITLE
fix(service-worker): handle failure parsing manifest json

### DIFF
--- a/aio/content/guide/service-worker-devops.md
+++ b/aio/content/guide/service-worker-devops.md
@@ -302,9 +302,9 @@ an administrator ever needs to deactivate the service worker quickly.
 
 To deactivate the service worker, remove or rename the
 `ngsw-config.json` file. When the service worker's request
-for `ngsw.json` returns a `404`, then the service worker
-removes all of its caches and de-registers itself,
-essentially self-destructing.
+for `ngsw.json` returns a `404` or fails to parse, then the 
+service worker removes all of its caches and de-registers 
+itself, essentially self-destructing.
 
 ### Safety Worker
 

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -655,7 +655,11 @@ export class Driver implements Debuggable, UpdateSource {
       throw new Error(`Manifest fetch failed! (status: ${res.status})`);
     }
     this.lastUpdateCheck = this.adapter.time;
-    return res.json();
+    return res.json().catch(async(err) => {
+      await this.deleteAllCaches();
+      await this.scope.registration.unregister();
+      throw new Error(`Manifest json parse failed! (status: ${res.status})`);
+    });
   }
 
   private async deleteAllCaches(): Promise<void> {


### PR DESCRIPTION
Update fail-safe to clear caches and de-register when unable to parse
manifest json. Improve support for environments that can't return a
proper 404.

Closes #24827

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #24827

Some environments cannot support a proper 404. To support push state, the common fix is to redirect 404s to 200 index.html. In this scenario, fetching the latest manifest with invalid JSON leads to an error while parsing. 

## What is the new behavior?

This change will invalidate caches and de-register the service worker when it fails to parse the latest manifest.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
