### PR TITLE
fix(ivy): expose module injector ivy's TestBed impl

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -101,8 +101,10 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
     let rendererFactory: RendererFactory3;
 
     if (ngModule) {
-      const wrapper = ngModule.injector.get(WRAP_RENDERER_FACTORY2, (v: RendererFactory2) => v);
-      rendererFactory = wrapper(ngModule.injector.get(RendererFactory2)) as RendererFactory3;
+      const wrapper =
+          ngModule.injector.get(WRAP_RENDERER_FACTORY2, (v: RendererFactory2, i: Injector) => v);
+      rendererFactory =
+          wrapper(ngModule.injector.get(RendererFactory2), ngModule.injector) as RendererFactory3;
     } else {
       rendererFactory = domRendererFactory3;
     }

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -109,6 +109,15 @@ describe('TestBed', () => {
     expect(nameInjected).toEqual('World!');
   });
 
+  it('should return test module injector for root node', () => {
+    const hello = TestBed.createComponent(HelloWorld);
+    hello.detectChanges();
+    const injector = hello.debugElement.injector;
+
+    const nameInjected = injector.get(NAME);
+    expect(nameInjected).toEqual('World!');
+  });
+
   it('should give the ability to query by directive', () => {
     const hello = TestBed.createComponent(HelloWorld);
     hello.detectChanges();

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -412,7 +412,8 @@ export class TestBedRender3 implements Injector, TestBed {
 
     const rendererFactoryWrapper = {
       provide: WRAP_RENDERER_FACTORY2,
-      useFactory: () => (rf: RendererFactory2) => new Render3DebugRendererFactory2(rf),
+      useFactory: () => (rf: RendererFactory2, moduleInjector: Injector) =>
+                      new Render3DebugRendererFactory2(rf, moduleInjector),
     };
 
     @NgModule({


### PR DESCRIPTION
This PR changes the ivy's TestBed implementation - previously no injector was available for the root node (one created to contain test component). Now such node gets module injector.

This change unblocks some of the tests for `ngTemplateOutlet`.