### PR TITLE
fix(ivy): use globally unique names for i18n constants

### DIFF
--- a/packages/compiler-cli/src/ngcc/src/analyzer.ts
+++ b/packages/compiler-cli/src/ngcc/src/analyzer.ts
@@ -49,14 +49,16 @@ export class Analyzer {
   handlers: DecoratorHandler<any, any>[] = [
     new BaseDefDecoratorHandler(this.typeChecker, this.host),
     new ComponentDecoratorHandler(
-        this.typeChecker, this.host, this.scopeRegistry, false, this.resourceLoader),
+        this.typeChecker, this.host, this.scopeRegistry, false, this.resourceLoader, this.rootDirs),
     new DirectiveDecoratorHandler(this.typeChecker, this.host, this.scopeRegistry, false),
     new InjectableDecoratorHandler(this.host, false),
     new NgModuleDecoratorHandler(this.typeChecker, this.host, this.scopeRegistry, false),
     new PipeDecoratorHandler(this.typeChecker, this.host, this.scopeRegistry, false),
   ];
 
-  constructor(private typeChecker: ts.TypeChecker, private host: NgccReflectionHost) {}
+  constructor(
+      private typeChecker: ts.TypeChecker, private host: NgccReflectionHost,
+      private rootDirs: string[]) {}
 
   /**
    * Analyize a parsed file to generate the information about decorated classes that

--- a/packages/compiler-cli/src/ngcc/src/transform/package_transformer.ts
+++ b/packages/compiler-cli/src/ngcc/src/transform/package_transformer.ts
@@ -65,13 +65,21 @@ export class PackageTransformer {
       // Create the TS program and necessary helpers.
       // TODO : create a custom compiler host that reads from .bak files if available.
       const host = ts.createCompilerHost(options);
+      let rootDirs: string[]|undefined = undefined;
+      if (options.rootDirs !== undefined) {
+        rootDirs = options.rootDirs;
+      } else if (options.rootDir !== undefined) {
+        rootDirs = [options.rootDir];
+      } else {
+        rootDirs = [host.getCurrentDirectory()];
+      }
       const packageProgram = ts.createProgram([entryPoint.entryFileName], options, host);
       const typeChecker = packageProgram.getTypeChecker();
       const dtsMapper = new DtsMapper(entryPoint.entryRoot, entryPoint.dtsEntryRoot);
       const reflectionHost = this.getHost(format, packageProgram, dtsMapper);
 
       const parser = this.getFileParser(format, packageProgram, reflectionHost);
-      const analyzer = new Analyzer(typeChecker, reflectionHost);
+      const analyzer = new Analyzer(typeChecker, reflectionHost, rootDirs);
       const renderer = this.getRenderer(format, packageProgram, reflectionHost);
 
       // Parse and analyze the files.

--- a/packages/compiler-cli/src/ngcc/test/analyzer_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/analyzer_spec.ts
@@ -80,7 +80,7 @@ describe('Analyzer', () => {
       program = makeProgram(TEST_PROGRAM);
       const file = createParsedFile(program);
       const analyzer = new Analyzer(
-          program.getTypeChecker(), new Fesm2015ReflectionHost(program.getTypeChecker()));
+          program.getTypeChecker(), new Fesm2015ReflectionHost(program.getTypeChecker()), ['']);
       testHandler = createTestHandler();
       analyzer.handlers = [testHandler];
       result = analyzer.analyzeFile(file);

--- a/packages/compiler-cli/src/ngcc/test/rendering/esm2015_renderer_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/rendering/esm2015_renderer_spec.ts
@@ -17,7 +17,7 @@ function setup(file: {name: string, contents: string}) {
   const program = makeProgram(file);
   const host = new Fesm2015ReflectionHost(program.getTypeChecker());
   const parser = new Esm2015FileParser(program, host);
-  const analyzer = new Analyzer(program.getTypeChecker(), host);
+  const analyzer = new Analyzer(program.getTypeChecker(), host, ['']);
   const renderer = new Esm2015Renderer(host);
   return {analyzer, host, parser, program, renderer};
 }

--- a/packages/compiler-cli/src/ngcc/test/rendering/esm5_renderer_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/rendering/esm5_renderer_spec.ts
@@ -17,7 +17,7 @@ function setup(file: {name: string, contents: string}) {
   const program = makeProgram(file);
   const host = new Esm5ReflectionHost(program.getTypeChecker());
   const parser = new Esm5FileParser(program, host);
-  const analyzer = new Analyzer(program.getTypeChecker(), host);
+  const analyzer = new Analyzer(program.getTypeChecker(), host, ['']);
   const renderer = new Esm5Renderer(host);
   return {analyzer, host, parser, program, renderer};
 }

--- a/packages/compiler-cli/src/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/rendering/renderer_spec.ts
@@ -46,7 +46,7 @@ function analyze(file: {name: string, contents: string}) {
   const program = makeProgram(file);
   const host = new Fesm2015ReflectionHost(program.getTypeChecker());
   const parser = new Esm2015FileParser(program, host);
-  const analyzer = new Analyzer(program.getTypeChecker(), host);
+  const analyzer = new Analyzer(program.getTypeChecker(), host, ['']);
 
   const parsedFiles = parser.parseFile(program.getSourceFile(file.name) !);
   return parsedFiles.map(file => analyzer.analyzeFile(file));

--- a/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
@@ -39,7 +39,8 @@ describe('ComponentDecoratorHandler', () => {
     const checker = program.getTypeChecker();
     const host = new TypeScriptReflectionHost(checker);
     const handler = new ComponentDecoratorHandler(
-        checker, host, new SelectorScopeRegistry(checker, host), false, new NoopResourceLoader());
+        checker, host, new SelectorScopeRegistry(checker, host), false, new NoopResourceLoader(),
+        ['']);
     const TestCmp = getDeclaration(program, 'entry.ts', 'TestCmp', ts.isClassDeclaration);
     const detected = handler.detect(TestCmp, host.getDecoratorsOfDeclaration(TestCmp));
     if (detected === undefined) {

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -29,11 +29,20 @@ export class NgtscProgram implements api.Program {
   private _coreImportsFrom: ts.SourceFile|null|undefined = undefined;
   private _reflector: TypeScriptReflectionHost|undefined = undefined;
   private _isCore: boolean|undefined = undefined;
+  private rootDirs: string[];
 
 
   constructor(
       rootNames: ReadonlyArray<string>, private options: api.CompilerOptions,
       host: api.CompilerHost, oldProgram?: api.Program) {
+    this.rootDirs = [];
+    if (options.rootDirs !== undefined) {
+      this.rootDirs.push(...options.rootDirs);
+    } else if (options.rootDir !== undefined) {
+      this.rootDirs.push(options.rootDir);
+    } else {
+      this.rootDirs.push(host.getCurrentDirectory());
+    }
     this.resourceLoader = host.readResource !== undefined ?
         new HostResourceLoader(host.readResource.bind(host)) :
         new FileResourceLoader();
@@ -177,7 +186,7 @@ export class NgtscProgram implements api.Program {
     const handlers = [
       new BaseDefDecoratorHandler(checker, this.reflector),
       new ComponentDecoratorHandler(
-          checker, this.reflector, scopeRegistry, this.isCore, this.resourceLoader),
+          checker, this.reflector, scopeRegistry, this.isCore, this.resourceLoader, this.rootDirs),
       new DirectiveDecoratorHandler(checker, this.reflector, scopeRegistry, this.isCore),
       new InjectableDecoratorHandler(this.reflector, this.isCore),
       new NgModuleDecoratorHandler(checker, this.reflector, scopeRegistry, this.isCore),

--- a/packages/compiler/src/constant_pool.ts
+++ b/packages/compiler/src/constant_pool.ts
@@ -122,7 +122,8 @@ export class ConstantPool {
   //  */
   // const MSG_XYZ = goog.getMsg('message');
   // ```
-  getTranslation(message: string, meta: {description?: string, meaning?: string}): o.Expression {
+  getTranslation(message: string, meta: {description?: string, meaning?: string}, suffix: string):
+      o.Expression {
     // The identity of an i18n message depends on the message and its meaning
     const key = meta.meaning ? `${message}\u0000\u0000${meta.meaning}` : message;
 
@@ -138,7 +139,7 @@ export class ConstantPool {
     }
 
     // Call closure to get the translation
-    const variable = o.variable(this.freshTranslationName());
+    const variable = o.variable(this.freshTranslationName(suffix));
     const fnCall = o.variable(GOOG_GET_MSG).callFn([o.literal(message)]);
     const msgStmt = variable.set(fnCall).toDeclStmt(o.INFERRED_TYPE, [o.StmtModifier.Final]);
     this.statements.push(msgStmt);
@@ -257,8 +258,8 @@ export class ConstantPool {
 
   private freshName(): string { return this.uniqueName(CONSTANT_PREFIX); }
 
-  private freshTranslationName(): string {
-    return this.uniqueName(TRANSLATION_PREFIX).toUpperCase();
+  private freshTranslationName(suffix: string): string {
+    return this.uniqueName(TRANSLATION_PREFIX + suffix).toUpperCase();
   }
 
   private keyOf(expression: o.Expression) {

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -127,6 +127,13 @@ export interface R3ComponentMetadata extends R3DirectiveMetadata {
      * Selectors found in the <ng-content> tags in the template.
      */
     ngContentSelectors: string[];
+
+    /**
+     * Path to the .ts file in which this template's generated code will be included, relative to
+     * the compilation root. This will be used to generate identifiers that need to be globally
+     * unique in certain contexts (such as g3).
+     */
+    relativeContextFilePath: string;
   };
 
   /**

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -209,7 +209,8 @@ export function compileComponentFromMetadata(
   const template = meta.template;
   const templateBuilder = new TemplateDefinitionBuilder(
       constantPool, BindingScope.ROOT_SCOPE, 0, templateTypeName, templateName, meta.viewQueries,
-      directiveMatcher, directivesUsed, meta.pipes, pipesUsed, R3.namespaceHTML);
+      directiveMatcher, directivesUsed, meta.pipes, pipesUsed, R3.namespaceHTML,
+      meta.template.relativeContextFilePath);
 
   const templateFunctionExpression = templateBuilder.buildTemplateFunction(
       template.nodes, [], template.hasNgContent, template.ngContentSelectors);
@@ -309,6 +310,7 @@ export function compileComponentFromRender2(
       nodes: render3Ast.nodes,
       hasNgContent: render3Ast.hasNgContent,
       ngContentSelectors: render3Ast.ngContentSelectors,
+      relativeContextFilePath: '',
     },
     directives: typeMapToExpressionMap(directiveTypeBySel, outputCtx),
     pipes: typeMapToExpressionMap(pipeTypeByName, outputCtx),

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -54,10 +54,11 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
         const constantPool = new ConstantPool();
 
         // Parse the template and check for errors.
-        const template =
-            parseTemplate(metadata.template !, `ng://${stringify(type)}/template.html`, {
+        const template = parseTemplate(
+            metadata.template !, `ng://${stringify(type)}/template.html`, {
               preserveWhitespaces: metadata.preserveWhitespaces || false,
-            });
+            },
+            '');
         if (template.errors !== undefined) {
           const errors = template.errors.map(err => err.toString()).join(', ');
           throw new Error(


### PR DESCRIPTION
Closure compiler requires that the i18n message constants of the form

const MSG_XYZ = goog.getMessage('...');

have names that are unique across an entire compilation, even if the
variables themselves are local to a given module. This means that in
practice these names must be unique in a codebase.

The best way to guarantee this requirement is met is to encode the
relative file name of the file into which the constant is being written
into the constant name itself. This commit implements that solution.
