### PR TITLE
fix(bazel): move bazel managed runtime deps for downstream usage

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -113,7 +113,7 @@ local_repository(
 # Load and install our dependencies downloaded above.
 #
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories", "yarn_install")
+load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories")
 
 check_bazel_version("0.15.0")
 node_repositories(
@@ -141,24 +141,6 @@ ts_setup_workspace()
 load("@angular//:index.bzl", "ng_setup_workspace")
 
 ng_setup_workspace()
-
-#
-# Ask Bazel to manage these toolchain dependencies for us.
-# Bazel will run `yarn install` when one of these toolchains is requested during
-# a build.
-#
-
-yarn_install(
-    name = "ts-api-guardian_runtime_deps",
-    package_json = "//tools/ts-api-guardian:package.json",
-    yarn_lock = "//tools/ts-api-guardian:yarn.lock",
-)
-
-yarn_install(
-    name = "http-server_runtime_deps",
-    package_json = "//tools/http-server:package.json",
-    yarn_lock = "//tools/http-server:yarn.lock",
-)
 
 ##################################
 # Skylark documentation generation

--- a/tools/ng_setup_workspace.bzl
+++ b/tools/ng_setup_workspace.bzl
@@ -242,4 +242,16 @@ filegroup(
 """,
     )
 
+    yarn_install(
+        name = "ts-api-guardian_runtime_deps",
+        package_json = "//tools/ts-api-guardian:package.json",
+        yarn_lock = "//tools/ts-api-guardian:yarn.lock",
+    )
+
+    yarn_install(
+        name = "http-server_runtime_deps",
+        package_json = "//tools/http-server:package.json",
+        yarn_lock = "//tools/http-server:yarn.lock",
+    )
+
     _ng_setup_workspace()


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
At the moment downstream (NG CLI) we are having this error 
```
ERROR: /home/circleci/ng/etc/api/BUILD:3:2: no such package '@ts-api-guardian_runtime_deps//': The repository could not be resolved and referenced by '//etc/api:angular_devkit_architect_testing_api.accept'
```

## What is the new behavior?
Move mananged runtime deps into `ng_setup_workspace `

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

//cc @alexeagle 