### PR TITLE
fix(docs-infra): temporary SW fix (for online mode)

### DIFF
--- a/aio/ngsw-config.json
+++ b/aio/ngsw-config.json
@@ -1,5 +1,5 @@
 {
-  "index": "/index.html",
+  "index": "/",
   "assetGroups": [
     {
       "name": "app-shell",
@@ -7,7 +7,6 @@
       "updateMode": "prefetch",
       "resources": {
         "files": [
-          "/index.html",
           "/pwa-manifest.json",
           "/app/search/search-worker.js",
           "/assets/images/favicons/favicon.ico",


### PR DESCRIPTION
Due to unknown reasons, Firebase seems to return a 301 response for `/index.html`, but without a `Location` header. According to the spec, the browser will not follow the redirect, considering the response as failed, instead.

This commit temporarily removes `index.html` from hashed resources and changes `index` to `/` in `ngsw-config.json`, until we figure out an appropriate long-term solution.
