### PR TITLE
fix(ivy): inject attributes for directives on ng-template / ng-container

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -268,12 +268,12 @@ const componentFactoryResolver: ComponentFactoryResolver = new ComponentFactoryR
  * @experimental
  */
 export function injectAttribute(attrNameToInject: string): string|undefined {
-  ngDevMode && assertPreviousIsParent();
-  const lElement = getPreviousOrParentNode() as LElementNode;
-  ngDevMode && assertNodeType(lElement, TNodeType.Element);
-  const tElement = lElement.tNode;
-  ngDevMode && assertDefined(tElement, 'expecting tNode');
-  const attrs = tElement.attrs;
+  const lNode = getPreviousOrParentNode();
+  ngDevMode && assertNodeOfPossibleTypes(
+                   lNode, TNodeType.Container, TNodeType.Element, TNodeType.ElementContainer);
+  const tNode = lNode.tNode;
+  ngDevMode && assertDefined(tNode, 'expecting tNode');
+  const attrs = tNode.attrs;
   if (attrs) {
     for (let i = 0; i < attrs.length; i = i + 2) {
       const attrName = attrs[i];


### PR DESCRIPTION
Previously it was only possible to inject `@Attribute(...)` on element nodes but in reality we need to support injection on elements, `<ng-template>` and `<ng-container>` ([example](https://github.com/angular/angular/blob/0024d68add9268044093fc09ca9bfc3c0cbfb8e6/packages/common/src/directives/ng_plural.ts#L97-L108)).

This unblocks tests for the `NgPlural` directive.