### PR TITLE
fix(ivy): support directive outputs on ng-template

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
@@ -401,4 +401,43 @@ describe('compiler compliance: template', () => {
 
     expectEmit(result.source, template, 'Incorrect template');
   });
+
+  it('should support directive outputs on <ng-template>', () => {
+
+    const files = {
+      app: {
+        'spec.ts': `
+              import {Component, NgModule} from '@angular/core';
+
+              @Component({
+                selector: 'my-component',
+                template: '<ng-template (outDirective)="$event.doSth()"></ng-template>';
+              })
+              export class MyComponent {}
+
+              @NgModule({declarations: [MyComponent]})
+              export class MyModule {}
+          `
+      }
+    };
+
+    const template = `
+      const $t0_attrs$ = [${AttributeMarker.SelectOnly}, "outDirective"];
+
+      function Template_0(rf, ctx) { }
+
+      // ...
+
+      template: function MyComponent_Template(rf, ctx) {
+        if (rf & 1) {
+          $i0$.ɵtemplate(0, Template_0, 0, 0, null, $t0_attrs$);
+          $i0$.ɵlistener("outDirective", function MyComponent_Template_ng_template_outDirective_listener($event) { return $event.doSth(); });
+        }
+      }`;
+
+    const result = compile(files, angularFiles);
+
+    expectEmit(result.source, template, 'Incorrect template');
+
+  });
 });

--- a/packages/core/src/render3/STATUS.md
+++ b/packages/core/src/render3/STATUS.md
@@ -158,7 +158,7 @@ The goal is for the `@Component` (and friends) to be the compiler of template. S
 | `<div (keyup.enter)>`                       |  ❌     |  ❌      |  ❌      |
 | `<div (hammer.js)>`                         |  ❌     |  ❌      |  ❌      |
 | [`<div (directiveOut)>`][gh23560]           |  ✅     |  ✅      |  ✅     |
-| [`<ng-template (directiveOut)>`][gh23561]   |  ❌     |  ❌      |  ❌      |
+| [`<ng-template (directiveOut)>`][gh23561]   |  ✅     |  ✅      |  ✅      |
 | [`<ng-container>`][gh24381]                 |  ✅     |  ✅      |  ✅      |
 
 [gh23560]: https://github.com/angular/angular/issues/23560


### PR DESCRIPTION
Compiler part of #25698
Fixes #25697
