### PR TITLE
Revert module name resolve in ngc-wrapped compiler host via sourceFile.moduleName

### DIFF
--- a/integration/bazel/test/e2e/BUILD.bazel
+++ b/integration/bazel/test/e2e/BUILD.bazel
@@ -16,14 +16,16 @@ ts_library(
     deps = ["@angular//packages/bazel/src/protractor/utils"],
 )
 
-protractor_web_test_suite(
-    name = "devserver_test",
-    configuration = "//:protractor.conf.js",
-    data = ["@angular//packages/bazel/src/protractor/utils"],
-    on_prepare = ":ts_on_prepare",
-    server = "//src:devserver",
-    deps = [":e2e"],
-)
+# TODO(gregmagolan): re-enable once for proper fix ngfactory & ngsummary module
+# names lands (see https://github.com/angular/angular/pull/25726 for context)
+# protractor_web_test_suite(
+#     name = "devserver_test",
+#     configuration = "//:protractor.conf.js",
+#     data = ["@angular//packages/bazel/src/protractor/utils"],
+#     on_prepare = ":ts_on_prepare",
+#     server = "//src:devserver",
+#     deps = [":e2e"],
+# )
 
 protractor_web_test_suite(
     name = "prodserver_test",

--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -231,17 +231,20 @@ export function compile({allowNonHermeticReads, allDepsCompiledWithBazel = true,
     // For performance, we only do this for .d.ts files, to avoid parsing lots of
     // additional files that were not in the program.
     // (We don't have the ts.Program available in this codepath)
-    if (importedFilePath.endsWith('.d.ts')) {
-      try {
-        const sourceFile = ngHost.getSourceFile(importedFilePath, ts.ScriptTarget.Latest);
-        if (sourceFile && sourceFile.moduleName) {
-          return sourceFile.moduleName;
-        }
-      } catch (err) {
-        // File does not exist or parse error. Ignore this case and continue onto the
-        // other methods of resolving the module below.
-      }
-    }
+    // TODO(gregmagolan): the performance regression is not acceptable with this
+    // put this back in to fix angular building from source downstream once we
+    // find a way to improve its performance (perhaps with using ts.Program)
+    // if (importedFilePath.endsWith('.d.ts')) {
+    //   try {
+    //     const sourceFile = ngHost.getSourceFile(importedFilePath, ts.ScriptTarget.Latest);
+    //     if (sourceFile && sourceFile.moduleName) {
+    //       return sourceFile.moduleName;
+    //     }
+    //   } catch (err) {
+    //     // File does not exist or parse error. Ignore this case and continue onto the
+    //     // other methods of resolving the module below.
+    //   }
+    // }
     if ((compilerOpts.module === ts.ModuleKind.UMD || compilerOpts.module === ts.ModuleKind.AMD) &&
         ngHost.amdModuleName) {
       return ngHost.amdModuleName({ fileName: importedFilePath } as ts.SourceFile);


### PR DESCRIPTION
Resolves the performance regression in g3.

Will also need to comment out one or more integration/bazel tests that will be broken for the time being.

