### PR TITLE
feat(common): http client request metadata for use in interceptors

### DIFF
--- a/goldens/public-api/common/http/http.d.ts
+++ b/goldens/public-api/common/http/http.d.ts
@@ -10,6 +10,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -22,6 +23,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -34,6 +36,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -47,6 +50,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -59,6 +63,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -71,6 +76,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -83,6 +89,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -95,6 +102,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | (string | number | boolean)[];
         };
@@ -107,6 +115,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -119,6 +128,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -131,6 +141,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -143,6 +154,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -155,6 +167,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -166,6 +179,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -178,6 +192,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -190,6 +205,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -202,6 +218,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -214,6 +231,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -227,6 +245,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -239,6 +258,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -251,6 +271,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -263,6 +284,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -275,6 +297,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -287,6 +310,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -299,6 +323,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -311,6 +336,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -323,6 +349,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -335,6 +362,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -346,6 +374,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -358,6 +387,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -370,6 +400,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -382,6 +413,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -394,6 +426,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -407,6 +440,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -419,6 +453,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -431,6 +466,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -443,6 +479,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -455,6 +492,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -467,6 +505,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -479,6 +518,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -491,6 +531,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -503,6 +544,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -515,6 +557,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -526,6 +569,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -538,6 +582,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -552,6 +597,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -564,6 +610,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -576,6 +623,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -589,6 +637,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -601,6 +650,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -613,6 +663,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -625,6 +676,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -637,6 +689,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -649,6 +702,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -661,6 +715,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -673,6 +728,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -685,6 +741,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -697,6 +754,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -708,6 +766,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -720,6 +779,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -732,6 +792,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -744,6 +805,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -756,6 +818,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -769,6 +832,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -781,6 +845,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -793,6 +858,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -805,6 +871,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -817,6 +884,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -829,6 +897,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -841,6 +910,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -853,6 +923,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -865,6 +936,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -877,6 +949,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -888,6 +961,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -900,6 +974,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -912,6 +987,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -924,6 +1000,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -936,6 +1013,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -949,6 +1027,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -961,6 +1040,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -973,6 +1053,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -985,6 +1066,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -997,6 +1079,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1009,6 +1092,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1021,6 +1105,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1033,6 +1118,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1045,6 +1131,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1057,6 +1144,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1068,6 +1156,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -1080,6 +1169,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -1092,6 +1182,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -1104,6 +1195,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -1116,6 +1208,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -1129,6 +1222,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1141,6 +1235,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1153,6 +1248,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1165,6 +1261,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1177,6 +1274,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1189,6 +1287,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1201,6 +1300,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1213,6 +1313,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1225,6 +1326,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1237,6 +1339,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1248,6 +1351,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -1260,6 +1364,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -1274,6 +1379,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -1287,6 +1393,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -1300,6 +1407,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -1313,6 +1421,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1327,6 +1436,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1340,6 +1450,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'events';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1352,6 +1463,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         reportProgress?: boolean;
         observe: 'events';
         params?: HttpParams | {
@@ -1365,6 +1477,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         reportProgress?: boolean;
         observe: 'events';
         params?: HttpParams | {
@@ -1379,6 +1492,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1392,6 +1506,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1405,6 +1520,7 @@ export declare class HttpClient {
             [header: string]: string | string[];
         };
         observe: 'response';
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1417,6 +1533,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         reportProgress?: boolean;
         observe: 'response';
         params?: HttpParams | {
@@ -1430,6 +1547,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         reportProgress?: boolean;
         observe: 'response';
         params?: HttpParams | {
@@ -1443,6 +1561,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -1456,6 +1575,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         observe?: 'body';
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
@@ -1469,6 +1589,7 @@ export declare class HttpClient {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
+        context?: HttpContext;
         params?: HttpParams | {
             [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
         };
@@ -1491,6 +1612,18 @@ export declare class HttpClientXsrfModule {
         cookieName?: string;
         headerName?: string;
     }): ModuleWithProviders<HttpClientXsrfModule>;
+}
+
+export declare class HttpContext {
+    delete(token: HttpContextToken<unknown>): HttpContext;
+    get<T>(token: HttpContextToken<T>): T;
+    keys(): IterableIterator<HttpContextToken<unknown>>;
+    set<T>(token: HttpContextToken<T>, value: T): HttpContext;
+}
+
+export declare class HttpContextToken<T> {
+    readonly defaultValue: () => T;
+    constructor(defaultValue: () => T);
 }
 
 export declare interface HttpDownloadProgressEvent extends HttpProgressEvent {
@@ -1598,6 +1731,7 @@ export declare interface HttpProgressEvent {
 
 export declare class HttpRequest<T> {
     readonly body: T | null;
+    readonly context: HttpContext;
     readonly headers: HttpHeaders;
     readonly method: string;
     readonly params: HttpParams;
@@ -1608,6 +1742,7 @@ export declare class HttpRequest<T> {
     readonly withCredentials: boolean;
     constructor(method: 'DELETE' | 'GET' | 'HEAD' | 'JSONP' | 'OPTIONS', url: string, init?: {
         headers?: HttpHeaders;
+        context?: HttpContext;
         reportProgress?: boolean;
         params?: HttpParams;
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
@@ -1615,6 +1750,7 @@ export declare class HttpRequest<T> {
     });
     constructor(method: 'POST' | 'PUT' | 'PATCH', url: string, body: T | null, init?: {
         headers?: HttpHeaders;
+        context?: HttpContext;
         reportProgress?: boolean;
         params?: HttpParams;
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
@@ -1622,6 +1758,7 @@ export declare class HttpRequest<T> {
     });
     constructor(method: string, url: string, body: T | null, init?: {
         headers?: HttpHeaders;
+        context?: HttpContext;
         reportProgress?: boolean;
         params?: HttpParams;
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
@@ -1630,6 +1767,7 @@ export declare class HttpRequest<T> {
     clone(): HttpRequest<T>;
     clone(update: {
         headers?: HttpHeaders;
+        context?: HttpContext;
         reportProgress?: boolean;
         params?: HttpParams;
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
@@ -1646,6 +1784,7 @@ export declare class HttpRequest<T> {
     }): HttpRequest<T>;
     clone<V>(update: {
         headers?: HttpHeaders;
+        context?: HttpContext;
         reportProgress?: boolean;
         params?: HttpParams;
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,8 +12,8 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3033,
-        "main-es2015": 451402,
-        "polyfills-es2015": 52215
+        "main-es2015": 452165,
+        "polyfills-es2015": 52493
       }
     }
   },
@@ -21,8 +21,8 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 3153,
-        "main-es2015": 437005,
-        "polyfills-es2015": 52215
+        "main-es2015": 437810,
+        "polyfills-es2015": 52493
       }
     }
   }

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -8,6 +8,7 @@
 
 export {HttpBackend, HttpHandler} from './src/backend';
 export {HttpClient} from './src/client';
+export {HttpContext, HttpContextToken} from './src/context';
 export {HttpHeaders} from './src/headers';
 export {HTTP_INTERCEPTORS, HttpInterceptor} from './src/interceptor';
 export {JsonpClientBackend, JsonpInterceptor} from './src/jsonp';

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -11,6 +11,7 @@ import {Observable, of} from 'rxjs';
 import {concatMap, filter, map} from 'rxjs/operators';
 
 import {HttpHandler} from './backend';
+import {HttpContext} from './context';
 import {HttpHeaders} from './headers';
 import {HttpParams, HttpParamsOptions} from './params';
 import {HttpRequest} from './request';
@@ -30,6 +31,7 @@ import {HttpEvent, HttpResponse} from './response';
 function addBody<T>(
     options: {
       headers?: HttpHeaders|{[header: string]: string | string[]},
+      context?: HttpContext,
       observe?: 'body'|'events'|'response',
       params?: HttpParams|
             {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -41,6 +43,7 @@ function addBody<T>(
   return {
     body,
     headers: options.headers,
+    context: options.context,
     observe: options.observe,
     params: options.params,
     reportProgress: options.reportProgress,
@@ -129,6 +132,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -149,6 +153,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -169,6 +174,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -190,6 +196,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
           observe: 'events',
@@ -211,6 +218,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -231,6 +239,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -251,6 +260,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     reportProgress?: boolean, observe: 'events',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -272,6 +282,7 @@ export class HttpClient {
   request<R>(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     reportProgress?: boolean, observe: 'events',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -292,6 +303,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -310,6 +322,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -329,6 +342,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -349,6 +363,7 @@ export class HttpClient {
   request(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     reportProgress?: boolean, observe: 'response',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -369,6 +384,7 @@ export class HttpClient {
   request<R>(method: string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     reportProgress?: boolean, observe: 'response',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -389,6 +405,7 @@ export class HttpClient {
   request(method: string, url: string, options?: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -410,6 +427,7 @@ export class HttpClient {
   request<R>(method: string, url: string, options?: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -430,6 +448,7 @@ export class HttpClient {
   request(method: string, url: string, options?: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     observe?: 'body'|'events'|'response',
@@ -467,6 +486,7 @@ export class HttpClient {
   request(first: string|HttpRequest<any>, url?: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body'|'events'|'response',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -506,6 +526,7 @@ export class HttpClient {
       // Construct the request.
       req = new HttpRequest(first, url!, (options.body !== undefined ? options.body : null), {
         headers,
+        context: options.context,
         params,
         reportProgress: options.reportProgress,
         // By default, JSON is assumed to be returned for all calls.
@@ -592,6 +613,7 @@ export class HttpClient {
    */
   delete(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -611,6 +633,7 @@ export class HttpClient {
    */
   delete(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -629,6 +652,7 @@ export class HttpClient {
    */
   delete(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -648,6 +672,7 @@ export class HttpClient {
    */
   delete(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -666,6 +691,7 @@ export class HttpClient {
    */
   delete(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -684,6 +710,7 @@ export class HttpClient {
    */
   delete(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -702,6 +729,7 @@ export class HttpClient {
    */
   delete(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -721,6 +749,7 @@ export class HttpClient {
    */
   delete<T>(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | (string | number | boolean)[]},
     reportProgress?: boolean,
@@ -739,6 +768,7 @@ export class HttpClient {
    */
   delete(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -756,6 +786,7 @@ export class HttpClient {
    */
   delete(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -773,6 +804,7 @@ export class HttpClient {
    */
   delete(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -791,6 +823,7 @@ export class HttpClient {
    */
   delete(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -809,6 +842,7 @@ export class HttpClient {
    */
   delete<T>(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -827,6 +861,7 @@ export class HttpClient {
    */
   delete(url: string, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -846,6 +881,7 @@ export class HttpClient {
    */
   delete<T>(url: string, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -865,6 +901,7 @@ export class HttpClient {
    */
   delete(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body'|'events'|'response',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -887,6 +924,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -905,6 +943,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -923,6 +962,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -942,6 +982,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -959,6 +1000,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -976,6 +1018,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -993,6 +1036,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -1011,6 +1055,7 @@ export class HttpClient {
    */
   get<T>(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -1030,6 +1075,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -1048,6 +1094,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -1066,6 +1113,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -1084,6 +1132,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -1103,6 +1152,7 @@ export class HttpClient {
    */
   get<T>(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -1122,6 +1172,7 @@ export class HttpClient {
    */
   get(url: string, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1141,6 +1192,7 @@ export class HttpClient {
    */
   get<T>(url: string, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1156,6 +1208,7 @@ export class HttpClient {
    */
   get(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body'|'events'|'response',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1178,6 +1231,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1197,6 +1251,7 @@ export class HttpClient {
 
   head(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1215,6 +1270,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1234,6 +1290,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -1252,6 +1309,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -1270,6 +1328,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -1288,6 +1347,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -1307,6 +1367,7 @@ export class HttpClient {
    */
   head<T>(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -1326,6 +1387,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -1344,6 +1406,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -1362,6 +1425,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -1380,6 +1444,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -1399,6 +1464,7 @@ export class HttpClient {
    */
   head<T>(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -1417,6 +1483,7 @@ export class HttpClient {
    */
   head(url: string, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1437,6 +1504,7 @@ export class HttpClient {
    */
   head<T>(url: string, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1454,6 +1522,7 @@ export class HttpClient {
    */
   head(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body'|'events'|'response',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1525,6 +1594,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1543,6 +1613,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1561,6 +1632,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1580,6 +1652,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -1598,6 +1671,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -1616,6 +1690,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -1634,6 +1709,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -1653,6 +1729,7 @@ export class HttpClient {
    */
   options<T>(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -1672,6 +1749,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -1690,6 +1768,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -1708,6 +1787,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -1726,6 +1806,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -1745,6 +1826,7 @@ export class HttpClient {
    */
   options<T>(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -1763,6 +1845,7 @@ export class HttpClient {
    */
   options(url: string, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1782,6 +1865,7 @@ export class HttpClient {
    */
   options<T>(url: string, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1799,6 +1883,7 @@ export class HttpClient {
    */
   options(url: string, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body'|'events'|'response',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1821,6 +1906,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1840,6 +1926,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1859,6 +1946,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -1880,6 +1968,7 @@ export class HttpClient {
 
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -1899,6 +1988,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -1918,6 +2008,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -1937,6 +2028,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -1957,6 +2049,7 @@ export class HttpClient {
    */
   patch<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -1977,6 +2070,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -1996,6 +2090,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -2015,6 +2110,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -2034,6 +2130,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -2054,6 +2151,7 @@ export class HttpClient {
    */
   patch<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -2073,6 +2171,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -2094,6 +2193,7 @@ export class HttpClient {
    */
   patch<T>(url: string, body: any|null, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -2109,6 +2209,7 @@ export class HttpClient {
    */
   patch(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body'|'events'|'response',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -2131,6 +2232,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -2150,6 +2252,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -2169,6 +2272,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -2189,6 +2293,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -2207,6 +2312,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -2226,6 +2332,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -2245,6 +2352,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -2265,6 +2373,7 @@ export class HttpClient {
    */
   post<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -2285,6 +2394,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -2304,6 +2414,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -2323,6 +2434,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -2342,6 +2454,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -2363,6 +2476,7 @@ export class HttpClient {
    */
   post<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -2382,6 +2496,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -2403,6 +2518,7 @@ export class HttpClient {
    */
   post<T>(url: string, body: any|null, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -2419,6 +2535,7 @@ export class HttpClient {
    */
   post(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body'|'events'|'response',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -2441,6 +2558,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -2460,6 +2578,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -2479,6 +2598,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -2499,6 +2619,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -2518,6 +2639,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -2537,6 +2659,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -2556,6 +2679,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -2576,6 +2700,7 @@ export class HttpClient {
    */
   put<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -2596,6 +2721,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'arraybuffer',
@@ -2615,6 +2741,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'blob',
@@ -2634,6 +2761,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean, responseType: 'text',
@@ -2653,6 +2781,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -2673,6 +2802,7 @@ export class HttpClient {
    */
   put<T>(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
+    context?: HttpContext,
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
     reportProgress?: boolean,
@@ -2692,6 +2822,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -2712,6 +2843,7 @@ export class HttpClient {
    */
   put<T>(url: string, body: any|null, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},
@@ -2728,6 +2860,7 @@ export class HttpClient {
    */
   put(url: string, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
+    context?: HttpContext,
     observe?: 'body'|'events'|'response',
     params?: HttpParams|
           {[param: string]: string | number | boolean | ReadonlyArray<string|number|boolean>},

--- a/packages/common/http/src/context.ts
+++ b/packages/common/http/src/context.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * A token used to manipulate and access values stored in `HttpContext`.
+ *
+ * @publicApi
+ */
+export class HttpContextToken<T> {
+  constructor(public readonly defaultValue: () => T) {}
+}
+
+/**
+ * Http context stores arbitrary user defined values and ensures type safety without
+ * actually knowing the types. It is backed by a `Map` and guarantees that keys do not clash.
+ *
+ * This context is mutable and is shared between cloned requests unless explicitly specified.
+ *
+ * @usageNotes
+ *
+ * ### Usage Example
+ *
+ * ```typescript
+ * // inside cache.interceptors.ts
+ * export const IS_CACHE_ENABLED = new HttpContextToken<boolean>(() => false);
+ *
+ * export class CacheInterceptor implements HttpInterceptor {
+ *
+ *   intercept(req: HttpRequest<any>, delegate: HttpHandler): Observable<HttpEvent<any>> {
+ *     if (req.context.get(IS_CACHE_ENABLED) === true) {
+ *       return ...;
+ *     }
+ *     return delegate.handle(req);
+ *   }
+ * }
+ *
+ * // inside a service
+ *
+ * this.httpClient.get('/api/weather', {
+ *   context: new HttpContext().set(IS_CACHE_ENABLED, true)
+ * }).subscribe(...);
+ * ```
+ *
+ * @publicApi
+ */
+export class HttpContext {
+  private readonly map = new Map<HttpContextToken<unknown>, unknown>();
+
+  /**
+   * Store a value in the context. If a value is already present it will be overwritten.
+   *
+   * @param token The reference to an instance of `HttpContextToken`.
+   * @param value The value to store.
+   *
+   * @returns A reference to itself for easy chaining.
+   */
+  set<T>(token: HttpContextToken<T>, value: T): HttpContext {
+    this.map.set(token, value);
+    return this;
+  }
+
+  /**
+   * Retrieve the value associated with the given token.
+   *
+   * @param token The reference to an instance of `HttpContextToken`.
+   *
+   * @returns The stored value or default if one is defined.
+   */
+  get<T>(token: HttpContextToken<T>): T {
+    if (!this.map.has(token)) {
+      this.map.set(token, token.defaultValue());
+    }
+    return this.map.get(token) as T;
+  }
+
+  /**
+   * Delete the value associated with the given token.
+   *
+   * @param token The reference to an instance of `HttpContextToken`.
+   *
+   * @returns A reference to itself for easy chaining.
+   */
+  delete(token: HttpContextToken<unknown>): HttpContext {
+    this.map.delete(token);
+    return this;
+  }
+
+  /**
+   * @returns a list of tokens currently stored in the context.
+   */
+  keys(): IterableIterator<HttpContextToken<unknown>> {
+    return this.map.keys();
+  }
+}

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {HttpContext} from './context';
 import {HttpHeaders} from './headers';
 import {HttpParams} from './params';
+
 
 /**
  * Construction interface for `HttpRequest`s.
@@ -16,6 +18,7 @@ import {HttpParams} from './params';
  */
 interface HttpRequestInit {
   headers?: HttpHeaders;
+  context?: HttpContext;
   reportProgress?: boolean;
   params?: HttpParams;
   responseType?: 'arraybuffer'|'blob'|'json'|'text';
@@ -92,6 +95,11 @@ export class HttpRequest<T> {
   readonly headers!: HttpHeaders;
 
   /**
+   * Shared and mutable context that can be used by interceptors
+   */
+  readonly context!: HttpContext;
+
+  /**
    * Whether this request should be made in a way that exposes progress events.
    *
    * Progress events are expensive (change detection runs on each event) and so
@@ -137,6 +145,7 @@ export class HttpRequest<T> {
 
   constructor(method: 'DELETE'|'GET'|'HEAD'|'JSONP'|'OPTIONS', url: string, init?: {
     headers?: HttpHeaders,
+    context?: HttpContext,
     reportProgress?: boolean,
     params?: HttpParams,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
@@ -144,6 +153,7 @@ export class HttpRequest<T> {
   });
   constructor(method: 'POST'|'PUT'|'PATCH', url: string, body: T|null, init?: {
     headers?: HttpHeaders,
+    context?: HttpContext,
     reportProgress?: boolean,
     params?: HttpParams,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
@@ -151,6 +161,7 @@ export class HttpRequest<T> {
   });
   constructor(method: string, url: string, body: T|null, init?: {
     headers?: HttpHeaders,
+    context?: HttpContext,
     reportProgress?: boolean,
     params?: HttpParams,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
@@ -159,6 +170,7 @@ export class HttpRequest<T> {
   constructor(
       method: string, readonly url: string, third?: T|{
         headers?: HttpHeaders,
+        context?: HttpContext,
         reportProgress?: boolean,
         params?: HttpParams,
         responseType?: 'arraybuffer'|'blob'|'json'|'text',
@@ -166,6 +178,7 @@ export class HttpRequest<T> {
       }|null,
       fourth?: {
         headers?: HttpHeaders,
+        context?: HttpContext,
         reportProgress?: boolean,
         params?: HttpParams,
         responseType?: 'arraybuffer'|'blob'|'json'|'text',
@@ -203,6 +216,10 @@ export class HttpRequest<T> {
         this.headers = options.headers;
       }
 
+      if (!!options.context) {
+        this.context = options.context;
+      }
+
       if (!!options.params) {
         this.params = options.params;
       }
@@ -211,6 +228,11 @@ export class HttpRequest<T> {
     // If no headers have been passed in, construct a new HttpHeaders instance.
     if (!this.headers) {
       this.headers = new HttpHeaders();
+    }
+
+    // If no context have been passed in, construct a new HttpContext instance.
+    if (!this.context) {
+      this.context = new HttpContext();
     }
 
     // If no parameters have been passed in, construct a new HttpUrlEncodedParams instance.
@@ -312,6 +334,7 @@ export class HttpRequest<T> {
   clone(): HttpRequest<T>;
   clone(update: {
     headers?: HttpHeaders,
+    context?: HttpContext,
     reportProgress?: boolean,
     params?: HttpParams,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
@@ -324,6 +347,7 @@ export class HttpRequest<T> {
   }): HttpRequest<T>;
   clone<V>(update: {
     headers?: HttpHeaders,
+    context?: HttpContext,
     reportProgress?: boolean,
     params?: HttpParams,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
@@ -336,6 +360,7 @@ export class HttpRequest<T> {
   }): HttpRequest<V>;
   clone(update: {
     headers?: HttpHeaders,
+    context?: HttpContext,
     reportProgress?: boolean,
     params?: HttpParams,
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
@@ -370,6 +395,9 @@ export class HttpRequest<T> {
     let headers = update.headers || this.headers;
     let params = update.params || this.params;
 
+    // Pass on context if needed
+    const context = update.context ?? this.context;
+
     // Check whether the caller has asked to add headers.
     if (update.setHeaders !== undefined) {
       // Set every requested header.
@@ -389,6 +417,7 @@ export class HttpRequest<T> {
     return new HttpRequest(method, url, body, {
       params,
       headers,
+      context,
       reportProgress,
       responseType,
       withCredentials,

--- a/packages/common/http/test/context_spec.ts
+++ b/packages/common/http/test/context_spec.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HttpContext, HttpContextToken} from '../src/context';
+
+const IS_ENABLED = new HttpContextToken<boolean>(() => false);
+const CACHE_OPTION =
+    new HttpContextToken<{cache: boolean, expiresIn?: number}>(() => ({cache: false}));
+
+describe('HttpContext', () => {
+  let context: HttpContext;
+
+  beforeEach(() => {
+    context = new HttpContext();
+  });
+
+  describe('with basic value', () => {
+    it('should test public api', () => {
+      expect(context.get(IS_ENABLED)).toBe(false);
+      expect([...context.keys()]).toEqual([
+        IS_ENABLED
+      ]);  // value from factory function is stored in the map upon access
+
+      context.set(IS_ENABLED, true);
+      expect(context.get(IS_ENABLED)).toBe(true);
+      expect([...context.keys()]).toEqual([IS_ENABLED]);
+
+      context.delete(IS_ENABLED);
+      expect([...context.keys()]).toEqual([]);
+    });
+  });
+
+  describe('with complex value', () => {
+    it('should test public api', () => {
+      expect(context.get(CACHE_OPTION)).toEqual({cache: false});
+      expect([...context.keys()]).toEqual([CACHE_OPTION]);
+
+      const value = {cache: true, expiresIn: 30};
+      context.set(CACHE_OPTION, value);
+      expect(context.get(CACHE_OPTION)).toBe(value);
+      expect([...context.keys()]).toEqual([CACHE_OPTION]);
+
+      context.delete(CACHE_OPTION);
+      expect([...context.keys()]).toEqual([]);
+    });
+
+    it('should ensure that same reference is returned for default value between multiple accesses',
+       () => {
+         const value = context.get(CACHE_OPTION);  // will get default value
+         expect(value).toEqual({cache: false});
+         expect(context.get(CACHE_OPTION)).toBe(value);
+       });
+  });
+});

--- a/packages/common/http/test/module_spec.ts
+++ b/packages/common/http/test/module_spec.ts
@@ -8,6 +8,7 @@
 
 import {HttpHandler} from '@angular/common/http/src/backend';
 import {HttpClient} from '@angular/common/http/src/client';
+import {HttpContext, HttpContextToken} from '@angular/common/http/src/context';
 import {HTTP_INTERCEPTORS, HttpInterceptor} from '@angular/common/http/src/interceptor';
 import {HttpRequest} from '@angular/common/http/src/request';
 import {HttpEvent, HttpResponse} from '@angular/common/http/src/response';
@@ -18,6 +19,8 @@ import {Injectable, Injector} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
+
+const IS_INTERCEPTOR_C_ENABLED = new HttpContextToken<boolean|undefined>(() => undefined);
 
 class TestInterceptor implements HttpInterceptor {
   constructor(private value: string) {}
@@ -49,6 +52,19 @@ class InterceptorB extends TestInterceptor {
   }
 }
 
+class InterceptorC extends TestInterceptor {
+  constructor() {
+    super('C');
+  }
+
+  intercept(req: HttpRequest<any>, delegate: HttpHandler): Observable<HttpEvent<any>> {
+    if (req.context.get(IS_INTERCEPTOR_C_ENABLED) === true) {
+      return super.intercept(req, delegate);
+    }
+    return delegate.handle(req);
+  }
+}
+
 @Injectable()
 class ReentrantInterceptor implements HttpInterceptor {
   constructor(private client: HttpClient) {}
@@ -58,54 +74,66 @@ class ReentrantInterceptor implements HttpInterceptor {
   }
 }
 
-{
-  describe('HttpClientModule', () => {
-    let injector: Injector;
-    beforeEach(() => {
-      injector = TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule],
-        providers: [
-          {provide: HTTP_INTERCEPTORS, useClass: InterceptorA, multi: true},
-          {provide: HTTP_INTERCEPTORS, useClass: InterceptorB, multi: true},
-        ],
-      });
-    });
-    it('initializes HttpClient properly', done => {
-      injector.get(HttpClient).get('/test', {responseType: 'text'}).subscribe((value: string) => {
-        expect(value).toBe('ok!');
-        done();
-      });
-      injector.get(HttpTestingController).expectOne('/test').flush('ok!');
-    });
-    it('intercepts outbound responses in the order in which interceptors were bound', done => {
-      injector.get(HttpClient)
-          .get('/test', {observe: 'response', responseType: 'text'})
-          .subscribe(() => done());
-      const req = injector.get(HttpTestingController).expectOne('/test') as TestRequest;
-      expect(req.request.headers.get('Intercepted')).toEqual('A,B');
-      req.flush('ok!');
-    });
-    it('intercepts inbound responses in the right (reverse binding) order', done => {
-      injector.get(HttpClient)
-          .get('/test', {observe: 'response', responseType: 'text'})
-          .subscribe((value: HttpResponse<string>) => {
-            expect(value.headers.get('Intercepted')).toEqual('B,A');
-            done();
-          });
-      injector.get(HttpTestingController).expectOne('/test').flush('ok!');
-    });
-    it('allows interceptors to inject HttpClient', done => {
-      TestBed.resetTestingModule();
-      injector = TestBed.configureTestingModule({
-        imports: [HttpClientTestingModule],
-        providers: [
-          {provide: HTTP_INTERCEPTORS, useClass: ReentrantInterceptor, multi: true},
-        ],
-      });
-      injector.get(HttpClient).get('/test').subscribe(() => {
-        done();
-      });
-      injector.get(HttpTestingController).expectOne('/test').flush('ok!');
+describe('HttpClientModule', () => {
+  let injector: Injector;
+  beforeEach(() => {
+    injector = TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        {provide: HTTP_INTERCEPTORS, useClass: InterceptorA, multi: true},
+        {provide: HTTP_INTERCEPTORS, useClass: InterceptorB, multi: true},
+        {provide: HTTP_INTERCEPTORS, useClass: InterceptorC, multi: true},
+      ],
     });
   });
-}
+  it('initializes HttpClient properly', done => {
+    injector.get(HttpClient).get('/test', {responseType: 'text'}).subscribe((value: string) => {
+      expect(value).toBe('ok!');
+      done();
+    });
+    injector.get(HttpTestingController).expectOne('/test').flush('ok!');
+  });
+  it('intercepts outbound responses in the order in which interceptors were bound', done => {
+    injector.get(HttpClient)
+        .get('/test', {observe: 'response', responseType: 'text'})
+        .subscribe(() => done());
+    const req = injector.get(HttpTestingController).expectOne('/test') as TestRequest;
+    expect(req.request.headers.get('Intercepted')).toEqual('A,B');
+    req.flush('ok!');
+  });
+  it('intercepts outbound responses in the order in which interceptors were bound and include specifically enabled interceptor',
+     done => {
+       injector.get(HttpClient)
+           .get('/test', {
+             observe: 'response',
+             responseType: 'text',
+             context: new HttpContext().set(IS_INTERCEPTOR_C_ENABLED, true)
+           })
+           .subscribe(value => done());
+       const req = injector.get(HttpTestingController).expectOne('/test') as TestRequest;
+       expect(req.request.headers.get('Intercepted')).toEqual('A,B,C');
+       req.flush('ok!');
+     });
+  it('intercepts inbound responses in the right (reverse binding) order', done => {
+    injector.get(HttpClient)
+        .get('/test', {observe: 'response', responseType: 'text'})
+        .subscribe((value: HttpResponse<string>) => {
+          expect(value.headers.get('Intercepted')).toEqual('B,A');
+          done();
+        });
+    injector.get(HttpTestingController).expectOne('/test').flush('ok!');
+  });
+  it('allows interceptors to inject HttpClient', done => {
+    TestBed.resetTestingModule();
+    injector = TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        {provide: HTTP_INTERCEPTORS, useClass: ReentrantInterceptor, multi: true},
+      ],
+    });
+    injector.get(HttpClient).get('/test').subscribe(() => {
+      done();
+    });
+    injector.get(HttpTestingController).expectOne('/test').flush('ok!');
+  });
+});

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {HttpContext} from '@angular/common/http/src/context';
 import {HttpHeaders} from '@angular/common/http/src/headers';
 import {HttpParams} from '@angular/common/http/src/params';
 import {HttpRequest} from '@angular/common/http/src/request';
@@ -56,6 +57,11 @@ const TEST_STRING = `I'm a body!`;
         const req = new HttpRequest('GET', TEST_URL, {headers});
         expect(req.headers).toBe(headers);
       });
+      it('uses the provided context if passed', () => {
+        const context = new HttpContext();
+        const req = new HttpRequest('GET', TEST_URL, {context});
+        expect(req.context).toBe(context);
+      });
       it('defaults to Json', () => {
         const req = new HttpRequest('GET', TEST_URL);
         expect(req.responseType).toBe('json');
@@ -65,8 +71,10 @@ const TEST_STRING = `I'm a body!`;
       const headers = new HttpHeaders({
         'Test': 'Test header',
       });
+      const context = new HttpContext();
       const req = new HttpRequest('POST', TEST_URL, 'test body', {
         headers,
+        context,
         reportProgress: true,
         responseType: 'text',
         withCredentials: true,
@@ -79,6 +87,8 @@ const TEST_STRING = `I'm a body!`;
         // Headers should be the same, as the headers are sealed.
         expect(clone.headers).toBe(headers);
         expect(clone.headers.get('Test')).toBe('Test header');
+
+        expect(clone.context).toBe(context);
       });
       it('and updates the url', () => {
         expect(req.clone({url: '/changed'}).url).toBe('/changed');
@@ -88,6 +98,10 @@ const TEST_STRING = `I'm a body!`;
       });
       it('and updates the body', () => {
         expect(req.clone({body: 'changed body'}).body).toBe('changed body');
+      });
+      it('and updates the context', () => {
+        const newContext = new HttpContext();
+        expect(req.clone({context: newContext}).context).toBe(newContext);
       });
     });
     describe('content type detection', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently there is no way to configure interceptors in http client on per request basis and people (including myself) are abusing headers to disable / customize the behavior of certain interceptor (e.g. logging / authentication). 

Issue Number: Fixes #18155


## What is the new behavior?
This PR introduces a `context` option to any request that allows you to supply arbitrary data in a type safe way:
```
export const CacheInterceptorOptions = new HttpContextToken<{cache: boolean}>({ cache: false });
// compiles
this.http.get('/path', { context: new HttpContext().set(CacheInterceptorOptions, { cache: true }) })
this.http.get('/path', { context: new HttpContext().set(CacheInterceptorOptions, { cache: false }) })

// error
this.http.get('/path', { context: new HttpContext().set(CacheInterceptorOptions, { 
  foo: 123 // Argument of type '{ foo: number; }' is not assignable to parameter of type '{ cache: boolean; }'.
})}) 
```
There are also `get`, `delete`, and `keys` methods on `HttpContext`. `set` and `remove` can be chained to simplify usage.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

~~There is another PR open since last year but have seen no activity since January - probably due to other comments on the issue and lost type safety. ~~

~~Also, `HttpInterceptorMetadata` class is very generic (except for the name), maybe something like that could belong in core (or common?) package if there is a need?~~

EDIT: Description has been updated to match latest implementation