### PR TITLE
fix(core): change return type of DebugElement.query

### DIFF
--- a/packages/compiler/test/i18n/integration_common.ts
+++ b/packages/compiler/test/i18n/integration_common.ts
@@ -57,35 +57,35 @@ export function validateHtml(
 
   cmp.count = 0;
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-7')).nativeElement).toHaveText('zero');
-  expect(el.query(By.css('#i18n-14')).nativeElement).toHaveText('zero');
+  expect(el.query(By.css('#i18n-7')) !.nativeElement).toHaveText('zero');
+  expect(el.query(By.css('#i18n-14')) !.nativeElement).toHaveText('zero');
   cmp.count = 1;
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-7')).nativeElement).toHaveText('un');
-  expect(el.query(By.css('#i18n-14')).nativeElement).toHaveText('un');
-  expect(el.query(By.css('#i18n-17')).nativeElement).toHaveText('un');
+  expect(el.query(By.css('#i18n-7')) !.nativeElement).toHaveText('un');
+  expect(el.query(By.css('#i18n-14')) !.nativeElement).toHaveText('un');
+  expect(el.query(By.css('#i18n-17')) !.nativeElement).toHaveText('un');
   cmp.count = 2;
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-7')).nativeElement).toHaveText('deux');
-  expect(el.query(By.css('#i18n-14')).nativeElement).toHaveText('deux');
-  expect(el.query(By.css('#i18n-17')).nativeElement).toHaveText('deux');
+  expect(el.query(By.css('#i18n-7')) !.nativeElement).toHaveText('deux');
+  expect(el.query(By.css('#i18n-14')) !.nativeElement).toHaveText('deux');
+  expect(el.query(By.css('#i18n-17')) !.nativeElement).toHaveText('deux');
   cmp.count = 3;
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-7')).nativeElement).toHaveText('beaucoup');
-  expect(el.query(By.css('#i18n-14')).nativeElement).toHaveText('beaucoup');
-  expect(el.query(By.css('#i18n-17')).nativeElement).toHaveText('beaucoup');
+  expect(el.query(By.css('#i18n-7')) !.nativeElement).toHaveText('beaucoup');
+  expect(el.query(By.css('#i18n-14')) !.nativeElement).toHaveText('beaucoup');
+  expect(el.query(By.css('#i18n-17')) !.nativeElement).toHaveText('beaucoup');
 
   cmp.sex = 'male';
   cmp.sexB = 'female';
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-8')).nativeElement).toHaveText('homme');
-  expect(el.query(By.css('#i18n-8b')).nativeElement).toHaveText('femme');
+  expect(el.query(By.css('#i18n-8')) !.nativeElement).toHaveText('homme');
+  expect(el.query(By.css('#i18n-8b')) !.nativeElement).toHaveText('femme');
   cmp.sex = 'female';
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-8')).nativeElement).toHaveText('femme');
+  expect(el.query(By.css('#i18n-8')) !.nativeElement).toHaveText('femme');
   cmp.sex = '0';
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-8')).nativeElement).toHaveText('autre');
+  expect(el.query(By.css('#i18n-8')) !.nativeElement).toHaveText('autre');
 
   cmp.count = 123;
   tb.detectChanges();
@@ -105,7 +105,7 @@ export function validateHtml(
 }
 
 function expectHtml(el: DebugElement, cssSelector: string): any {
-  return expect(stringifyElement(el.query(By.css(cssSelector)).nativeElement));
+  return expect(stringifyElement(el.query(By.css(cssSelector)) !.nativeElement));
 }
 
 export const HTML = `

--- a/packages/compiler/test/integration_spec.ts
+++ b/packages/compiler/test/integration_spec.ts
@@ -34,7 +34,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
            const template = `<div [dot.name]="'foo'"></div>`;
            fixture = createTestComponent(template);
            fixture.detectChanges();
-           const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
+           const myDir = fixture.debugElement.query(By.directive(MyDir)) !.injector.get(MyDir);
            expect(myDir.value).toEqual('foo');
          }));
     });

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -95,7 +95,7 @@ export class DebugElement extends DebugNode {
     }
   }
 
-  query(predicate: Predicate<DebugElement>): DebugElement {
+  query(predicate: Predicate<DebugElement>): DebugElement|null {
     const results = this.queryAll(predicate);
     return results[0] || null;
   }

--- a/packages/core/test/linker/change_detection_integration_spec.ts
+++ b/packages/core/test/linker/change_detection_integration_spec.ts
@@ -1391,8 +1391,8 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
                         {declarations: [MainComp, OuterComp, InnerComp, DummyDirective]})
                     .createComponent(MainComp);
           mainComp = ctx.componentInstance;
-          outerComp = ctx.debugElement.query(By.directive(OuterComp)).injector.get(OuterComp);
-          innerComp = ctx.debugElement.query(By.directive(InnerComp)).injector.get(InnerComp);
+          outerComp = ctx.debugElement.query(By.directive(OuterComp)) !.injector.get(OuterComp);
+          innerComp = ctx.debugElement.query(By.directive(InnerComp)) !.injector.get(InnerComp);
         });
 
         it('should dirty check projected views in regular order', () => {

--- a/packages/core/test/linker/projection_integration_spec.ts
+++ b/packages/core/test/linker/projection_integration_spec.ts
@@ -352,14 +352,14 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 
       expect(main.nativeElement).toHaveText('TREE(0:)');
 
-      const tree = main.debugElement.query(By.directive(Tree));
+      const tree = main.debugElement.query(By.directive(Tree)) !;
       let manualDirective: ManualViewportDirective = tree.queryAllNodes(By.directive(
           ManualViewportDirective))[0].injector.get(ManualViewportDirective);
       manualDirective.show();
       main.detectChanges();
       expect(main.nativeElement).toHaveText('TREE(0:TREE2(1:))');
 
-      const tree2 = main.debugElement.query(By.directive(Tree2));
+      const tree2 = main.debugElement.query(By.directive(Tree2)) !;
       manualDirective = tree2.queryAllNodes(By.directive(ManualViewportDirective))[0].injector.get(
           ManualViewportDirective);
       manualDirective.show();
@@ -485,7 +485,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
       });
       const main = TestBed.createComponent(MainComp);
 
-      const conditionalComp = main.debugElement.query(By.directive(ConditionalContentComponent));
+      const conditionalComp = main.debugElement.query(By.directive(ConditionalContentComponent)) !;
 
       const viewViewportDir =
           conditionalComp.queryAllNodes(By.directive(ManualViewportDirective))[0].injector.get(

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -94,7 +94,8 @@ function declareTests({useJit}: {useJit: boolean}) {
 
            TestBed.configureTestingModule({declarations: [MyDir, MyComp]});
            const fixture = TestBed.createComponent(MyComp);
-           const dir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir) as MyDir;
+           const dir =
+               fixture.debugElement.query(By.directive(MyDir)) !.injector.get(MyDir) as MyDir;
 
            fixture.detectChanges();
            expect(dir.setterCalls).toEqual({'a': null, 'b': 2});
@@ -280,7 +281,7 @@ function declareTests({useJit}: {useJit: boolean}) {
 
       const ctx =
           TestBed.configureTestingModule({declarations: [MyComp, MyDir]}).createComponent(MyComp);
-      const dir = <MyDir>ctx.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
+      const dir = <MyDir>ctx.debugElement.query(By.directive(MyDir)) !.injector.get(MyDir);
 
       expect(dir.template).toBeUndefined();
 

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -77,7 +77,7 @@ describe('TestBed', () => {
     const hello = TestBed.createComponent(HelloWorld);
     hello.detectChanges();
 
-    const greetingByCss = hello.debugElement.query(By.css('greeting-cmp'));
+    const greetingByCss = hello.debugElement.query(By.css('greeting-cmp')) !;
     expect(greetingByCss.nativeElement).toHaveText('Hello World!');
     expect(greetingByCss.componentInstance).toBeAnInstanceOf(GreetingCmp);
   });
@@ -86,7 +86,7 @@ describe('TestBed', () => {
     const hello = TestBed.createComponent(HelloWorld);
 
     hello.detectChanges();
-    const greetingByCss = hello.debugElement.query(By.css('greeting-cmp'));
+    const greetingByCss = hello.debugElement.query(By.css('greeting-cmp')) !;
     expect(greetingByCss.nativeElement).toHaveText('Hello World!');
 
     greetingByCss.componentInstance.name = 'TestBed!';
@@ -98,7 +98,7 @@ describe('TestBed', () => {
   it('should give access to the node injector', () => {
     const hello = TestBed.createComponent(HelloWorld);
     hello.detectChanges();
-    const injector = hello.debugElement.query(By.css('greeting-cmp')).injector;
+    const injector = hello.debugElement.query(By.css('greeting-cmp')) !.injector;
 
     // from the node injector
     const helloInjected = injector.get(HelloWorld);
@@ -113,7 +113,7 @@ describe('TestBed', () => {
     const hello = TestBed.createComponent(HelloWorld);
     hello.detectChanges();
 
-    const greetingByDirective = hello.debugElement.query(By.directive(GreetingCmp));
+    const greetingByDirective = hello.debugElement.query(By.directive(GreetingCmp)) !;
     expect(greetingByDirective.componentInstance).toBeAnInstanceOf(GreetingCmp);
   });
 

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -34,7 +34,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.detectChanges();
 
         // model -> view
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input')) !;
         expect(input.nativeElement.value).toEqual('old value');
 
         input.nativeElement.value = 'updated value';
@@ -49,7 +49,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input')) !;
         expect(input.nativeElement.value).toEqual('loginValue');
       });
 
@@ -58,7 +58,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
         fixture.detectChanges();
 
-        const form = fixture.debugElement.query(By.css('form'));
+        const form = fixture.debugElement.query(By.css('form')) !;
         expect(form.nativeElement.getAttribute('novalidate')).toEqual('');
       });
 
@@ -68,7 +68,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input')) !;
         input.nativeElement.value = 'updatedValue';
         dispatchEvent(input.nativeElement, 'input');
 
@@ -87,7 +87,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = new FormGroup({'login': new FormControl('newValue')});
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input')) !;
         expect(input.nativeElement.value).toEqual('newValue');
       });
 
@@ -100,7 +100,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = newForm;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input')) !;
         input.nativeElement.value = 'Nancy';
         dispatchEvent(input.nativeElement, 'input');
         fixture.detectChanges();
@@ -196,7 +196,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         form.addControl('email', new FormControl('email'));
         fixture.detectChanges();
 
-        let emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'));
+        let emailInput = fixture.debugElement.query(By.css('[formControlName="email"]')) !;
         expect(emailInput.nativeElement.value).toEqual('email');
 
         const newForm = new FormGroup({
@@ -206,7 +206,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = newForm;
         fixture.detectChanges();
 
-        emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'));
+        emailInput = fixture.debugElement.query(By.css('[formControlName="email"]')) !;
         expect(emailInput as any).toBe(null);  // TODO: Review use of `any` here (#19904)
       });
 
@@ -248,7 +248,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           form.addControl('login', new FormControl('newValue'));
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input')) !;
           expect(input.nativeElement.value).toEqual('newValue');
 
           input.nativeElement.value = 'user input';
@@ -306,7 +306,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           form.addControl('cities', new FormArray([new FormControl('LA')]));
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input')) !;
           expect(input.nativeElement.value).toEqual('LA');
 
           input.nativeElement.value = 'MTV';
@@ -352,7 +352,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           newArr.removeAt(0);
           fixture.detectChanges();
 
-          firstInput = fixture.debugElement.query(By.css('input')).nativeElement;
+          firstInput = fixture.debugElement.query(By.css('input')) !.nativeElement;
           firstInput.value = 'last one';
           dispatchEvent(firstInput, 'input');
           fixture.detectChanges();
@@ -362,7 +362,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           newArr.get([0]) !.setValue('set value');
           fixture.detectChanges();
 
-          firstInput = fixture.debugElement.query(By.css('input')).nativeElement;
+          firstInput = fixture.debugElement.query(By.css('input')) !.nativeElement;
           expect(firstInput.value).toEqual('set value');
         });
 
@@ -384,7 +384,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           newArr.removeAt(0);
           fixture.detectChanges();
 
-          const formEl = fixture.debugElement.query(By.css('form'));
+          const formEl = fixture.debugElement.query(By.css('form')) !;
           expect(() => dispatchEvent(formEl.nativeElement, 'submit')).not.toThrowError();
         });
 
@@ -508,7 +508,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         login.setValue('newValue');
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input')) !;
         expect(input.nativeElement.value).toEqual('newValue');
       });
 
@@ -520,7 +520,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
              fixture.componentInstance.control = control;
              fixture.detectChanges();
 
-             const input = fixture.debugElement.query(By.css('input'));
+             const input = fixture.debugElement.query(By.css('input')) !;
              expect(input.nativeElement.disabled).toBe(true);
 
              control.enable();
@@ -535,7 +535,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input')) !;
           expect(input.nativeElement.disabled).toBe(true);
 
           control.enable();
@@ -553,7 +553,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
              control.disable();
              fixture.detectChanges();
 
-             const input = fixture.debugElement.query(By.css('input'));
+             const input = fixture.debugElement.query(By.css('input')) !;
              expect(input.nativeElement.disabled).toBe(true);
 
              control.enable();
@@ -589,7 +589,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           control.disable();
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('my-input'));
+          const input = fixture.debugElement.query(By.css('my-input')) !;
           expect(input.nativeElement.getAttribute('disabled')).toBe(null);
         });
 
@@ -606,7 +606,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const loginEl = fixture.debugElement.query(By.css('input'));
+        const loginEl = fixture.debugElement.query(By.css('input')) !;
         expect(login.touched).toBe(false);
 
         dispatchEvent(loginEl.nativeElement, 'blur');
@@ -623,7 +623,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.event = null !;
         fixture.detectChanges();
 
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form')) !.nativeElement;
         dispatchEvent(formEl, 'submit');
 
         fixture.detectChanges();
@@ -638,7 +638,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
         expect(formGroupDir.submitted).toBe(false);
 
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form')) !.nativeElement;
         dispatchEvent(formEl, 'submit');
 
         fixture.detectChanges();
@@ -652,7 +652,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        const loginEl = fixture.debugElement.query(By.css('input')) !.nativeElement;
         expect(loginEl.value).toBe('some value');
 
         form.reset({'login': 'reset value'});
@@ -666,7 +666,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        const loginEl = fixture.debugElement.query(By.css('input')) !.nativeElement;
         expect(loginEl.value).toBe('some value');
 
         form.reset();
@@ -685,7 +685,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
         login.valueChanges.subscribe(() => { expect(login.dirty).toBe(true); });
 
-        const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        const loginEl = fixture.debugElement.query(By.css('input')) !.nativeElement;
         loginEl.value = 'newValue';
 
         dispatchEvent(loginEl, 'input');
@@ -699,7 +699,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            fixture.componentInstance.form = form;
            fixture.detectChanges();
 
-           const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+           const loginEl = fixture.debugElement.query(By.css('input')) !.nativeElement;
            loginEl.value = 'newValue';
            dispatchEvent(loginEl, 'input');
 
@@ -719,7 +719,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.control = control;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
         expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
         dispatchEvent(input, 'blur');
@@ -740,7 +740,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            fixture.debugElement.componentInstance.control = control;
            fixture.detectChanges();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
            expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-untouched']);
 
            dispatchEvent(input, 'blur');
@@ -762,7 +762,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            fixture.debugElement.componentInstance.control = control;
            fixture.detectChanges();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
            expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
            dispatchEvent(input, 'blur');
@@ -794,7 +794,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
         expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
         dispatchEvent(input, 'blur');
@@ -815,8 +815,8 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form')) !.nativeElement;
 
         expect(sortedClassList(formEl)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
@@ -844,7 +844,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -867,7 +867,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = form;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -893,7 +893,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           control.setValue('Nancy');
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           expect(input.value).toEqual('Nancy', 'Expected value to propagate to view immediately.');
           expect(control.value).toEqual('Nancy', 'Expected model value to update immediately.');
           expect(control.valid).toBe(true, 'Expected validation to run immediately.');
@@ -907,7 +907,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
           expect(control.dirty).toBe(false, 'Expected control to start out pristine.');
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -928,7 +928,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
           expect(control.touched).toBe(false, 'Expected control to start out untouched.');
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           dispatchEvent(input, 'blur');
           fixture.detectChanges();
 
@@ -943,7 +943,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           dispatchEvent(input, 'blur');
           fixture.detectChanges();
 
@@ -969,7 +969,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'aa';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -990,7 +990,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
 
           expect(input.value).toEqual('Nancy', 'Expected value to be set in the view.');
           expect(control.value).toEqual('Nancy', 'Expected initial model value to be set.');
@@ -1003,7 +1003,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'aa';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1032,7 +1032,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           const sub =
               merge(control.valueChanges, control.statusChanges).subscribe(val => values.push(val));
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1058,7 +1058,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           const sub =
               merge(control.valueChanges, control.statusChanges).subscribe(val => values.push(val));
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           dispatchEvent(input, 'blur');
           fixture.detectChanges();
           expect(values).toEqual(
@@ -1103,7 +1103,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'aa';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1127,7 +1127,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1153,7 +1153,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.cityArray = cityArray;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1221,7 +1221,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = form;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           expect(input.value).toEqual('Nancy', 'Expected initial value to propagate to view.');
           expect(form.value).toEqual({login: 'Nancy'}, 'Expected initial value to be set.');
           expect(form.valid).toBe(true, 'Expected form to run validation on initial value.');
@@ -1234,7 +1234,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1250,7 +1250,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
               .toEqual({login: ''}, 'Expected form value to remain unchanged on blur.');
           expect(formGroup.valid).toBe(false, 'Expected form validation not to run on blur.');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form')) !.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1266,12 +1266,12 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form')) !.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1302,7 +1302,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           formGroup.setValue({login: 'Nancy'});
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           expect(input.value).toEqual('Nancy', 'Expected view value to update immediately.');
           expect(formGroup.value)
               .toEqual({login: 'Nancy'}, 'Expected form value to update immediately.');
@@ -1315,7 +1315,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           dispatchEvent(input, 'input');
           fixture.detectChanges();
 
@@ -1326,7 +1326,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
           expect(formGroup.dirty).toBe(false, 'Expected dirty not to change on blur.');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form')) !.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1339,13 +1339,13 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           dispatchEvent(input, 'blur');
           fixture.detectChanges();
 
           expect(formGroup.touched).toBe(false, 'Expected touched not to change until submit.');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form')) !.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1359,7 +1359,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1375,7 +1375,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           expect(formGroup.dirty).toBe(false, 'Expected dirty to stay false on reset.');
           expect(formGroup.touched).toBe(false, 'Expected touched to stay false on reset.');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form')) !.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1399,7 +1399,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
               formGroup.statusChanges);
           const sub = streams.subscribe(val => values.push(val));
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1411,7 +1411,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
           expect(values).toEqual([], 'Expected no valueChanges or statusChanges on blur');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form')) !.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1436,13 +1436,13 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
               formGroup.statusChanges);
           const sub = streams.subscribe(val => values.push(val));
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form')) !.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
           expect(values).toEqual(
               [], 'Expected no valueChanges or statusChanges if value unchanged.');
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1496,7 +1496,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           formGroup.get('signin.login') !.setValidators(validatorSpy);
           formGroup.get('signin') !.setValidators(groupValidatorSpy);
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form')) !.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1511,7 +1511,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           dispatchEvent(input, 'blur');
           fixture.detectChanges();
 
@@ -1520,7 +1520,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
           expect(formGroup.touched).toBe(false, 'Expected group to become untouched.');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form')) !.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1534,7 +1534,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1548,7 +1548,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           expect(control.value).toEqual('', 'Expected value to remain unchanged until submit.');
           expect(control.valid).toBe(false, 'Expected no validation to occur until submit.');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form')) !.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1566,7 +1566,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           fixture.componentInstance.cityArray = cityArray;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1575,7 +1575,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           expect(control.valid).toBe(false, 'Expected no validation to occur until submit.');
 
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form')) !.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1612,7 +1612,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
           expect(passwordControl.valid)
               .toBe(false, 'Expected no validation to occur until submit.');
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form')) !.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1721,7 +1721,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
            expect(input.value).toEqual('oldValue');
 
            input.value = 'updatedValue';
@@ -1739,7 +1739,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
            expect(input.value).toEqual('oldValue');
 
            input.value = 'updatedValue';
@@ -1757,7 +1757,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
            input.value = 'aa';
            input.setSelectionRange(1, 2);
            dispatchEvent(input, 'input');
@@ -1778,7 +1778,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
            input.value = 'Nancy';
            dispatchEvent(input, 'input');
            fixture.detectChanges();
@@ -1787,7 +1787,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
            expect(fixture.componentInstance.login)
                .toEqual('initial', 'Expected ngModel value to remain unchanged on input.');
 
-           const form = fixture.debugElement.query(By.css('form')).nativeElement;
+           const form = fixture.debugElement.query(By.css('form')) !.nativeElement;
            dispatchEvent(form, 'submit');
            fixture.detectChanges();
            tick();
@@ -1806,7 +1806,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.control = control;
         fixture.detectChanges();
 
-        const checkbox = fixture.debugElement.query(By.css('input'));
+        const checkbox = fixture.debugElement.query(By.css('input')) !;
         expect(checkbox.nativeElement.checked).toBe(false);
         expect(control.hasError('required')).toEqual(true);
 
@@ -1829,10 +1829,10 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const required = fixture.debugElement.query(By.css('[required]'));
-        const minLength = fixture.debugElement.query(By.css('[minlength]'));
-        const maxLength = fixture.debugElement.query(By.css('[maxlength]'));
-        const pattern = fixture.debugElement.query(By.css('[pattern]'));
+        const required = fixture.debugElement.query(By.css('[required]')) !;
+        const minLength = fixture.debugElement.query(By.css('[minlength]')) !;
+        const maxLength = fixture.debugElement.query(By.css('[maxlength]')) !;
+        const pattern = fixture.debugElement.query(By.css('[pattern]')) !;
 
         required.nativeElement.value = '';
         minLength.nativeElement.value = '1';
@@ -1878,10 +1878,10 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.pattern = '.{3,}';
         fixture.detectChanges();
 
-        const required = fixture.debugElement.query(By.css('[name=required]'));
-        const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-        const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+        const required = fixture.debugElement.query(By.css('[name=required]')) !;
+        const minLength = fixture.debugElement.query(By.css('[name=minlength]')) !;
+        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]')) !;
+        const pattern = fixture.debugElement.query(By.css('[name=pattern]')) !;
 
         required.nativeElement.value = '';
         minLength.nativeElement.value = '1';
@@ -1922,10 +1922,10 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const required = fixture.debugElement.query(By.css('[name=required]'));
-        const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-        const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+        const required = fixture.debugElement.query(By.css('[name=required]')) !;
+        const minLength = fixture.debugElement.query(By.css('[name=minlength]')) !;
+        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]')) !;
+        const pattern = fixture.debugElement.query(By.css('[name=pattern]')) !;
 
         required.nativeElement.value = '';
         minLength.nativeElement.value = '1';
@@ -2035,7 +2035,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
            expect(form.hasError('uniqLogin', ['login'])).toEqual(true);
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input')) !;
            input.nativeElement.value = 'expected';
            dispatchEvent(input.nativeElement, 'input');
            tick(100);
@@ -2050,7 +2050,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.detectChanges();
         expect(form.valid).toEqual(true);
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input')) !;
         input.nativeElement.value = '';
         dispatchEvent(input.nativeElement, 'input');
 
@@ -2068,7 +2068,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
            expect(form.hasError('required', ['login'])).toEqual(true);
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input')) !;
            input.nativeElement.value = 'wrong value';
            dispatchEvent(input.nativeElement, 'input');
 
@@ -2094,7 +2094,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
            expect(control.hasError('required')).toEqual(true);
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input')) !;
            input.nativeElement.value = 'expected';
            dispatchEvent(input.nativeElement, 'input');
 
@@ -2117,7 +2117,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
 
            expect(resultArr.length).toEqual(1, `Expected source observable to emit once on init.`);
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input')) !;
            input.nativeElement.value = 'a';
            dispatchEvent(input.nativeElement, 'input');
            fixture.detectChanges();
@@ -2345,7 +2345,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.control = new FormControl('oldValue');
         fixture.detectChanges();
 
-        const inputEl = fixture.debugElement.query(By.css('input'));
+        const inputEl = fixture.debugElement.query(By.css('input')) !;
         const inputNativeEl = inputEl.nativeElement;
         expect(inputNativeEl.value).toEqual('oldValue');
 
@@ -2376,7 +2376,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.control = new FormControl('oldValue');
         fixture.detectChanges();
 
-        const inputEl = fixture.debugElement.query(By.css('input'));
+        const inputEl = fixture.debugElement.query(By.css('input')) !;
         const inputNativeEl = inputEl.nativeElement;
         expect(inputNativeEl.value).toEqual('oldValue');
 
@@ -2404,7 +2404,7 @@ import {MyInput, MyInputForm} from './value_accessor_integration_spec';
         fixture.componentInstance.control = new FormControl('oldValue');
         fixture.detectChanges();
 
-        const inputEl = fixture.debugElement.query(By.css('input'));
+        const inputEl = fixture.debugElement.query(By.css('input')) !;
         const inputNativeEl = inputEl.nativeElement;
         expect(inputNativeEl.value).toEqual('oldValue');
 

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -34,7 +34,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            // model -> view
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
            expect(input.value).toEqual('oldValue');
 
            input.value = 'updatedValue';
@@ -63,7 +63,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const form = fixture.debugElement.query(By.css('form'));
+           const form = fixture.debugElement.query(By.css('form')) !;
            expect(form.nativeElement.getAttribute('novalidate')).toEqual('');
          }));
 
@@ -73,7 +73,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const form = fixture.debugElement.query(By.css('form'));
+           const form = fixture.debugElement.query(By.css('form')) !;
            expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
          }));
 
@@ -155,7 +155,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.whenStable().then(() => {
              fixture.detectChanges();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
              dispatchEvent(input, 'blur');
@@ -176,7 +176,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.whenStable().then(() => {
              fixture.detectChanges();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-untouched']);
 
              dispatchEvent(input, 'blur');
@@ -198,9 +198,9 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.componentInstance.first = '';
            fixture.detectChanges();
 
-           const form = fixture.debugElement.query(By.css('form')).nativeElement;
-           const modelGroup = fixture.debugElement.query(By.css('[ngModelGroup]')).nativeElement;
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const form = fixture.debugElement.query(By.css('form')) !.nativeElement;
+           const modelGroup = fixture.debugElement.query(By.css('[ngModelGroup]')) !.nativeElement;
+           const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
 
            // ngModelGroup creates its control asynchronously
            fixture.whenStable().then(() => {
@@ -237,7 +237,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
       it('should not add novalidate when ngNoForm is used', () => {
         const fixture = initTest(NgNoFormComp);
         fixture.detectChanges();
-        const form = fixture.debugElement.query(By.css('form'));
+        const form = fixture.debugElement.query(By.css('form')) !;
         expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
       });
     });
@@ -320,7 +320,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              expect(input.value).toEqual('Nancy Drew', 'Expected initial view value to be set.');
              expect(form.value)
@@ -339,7 +339,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              expect(input.value)
                  .toEqual('Carson', 'Expected view value to update on programmatic change.');
@@ -357,7 +357,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -383,7 +383,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -416,7 +416,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -438,7 +438,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -466,7 +466,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              const sub = merge(form.valueChanges !, form.statusChanges !)
                              .subscribe(val => values.push(val));
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -494,7 +494,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              expect(fixture.componentInstance.events)
                  .toEqual([], 'Expected ngModelChanges not to fire.');
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              dispatchEvent(input, 'blur');
              fixture.detectChanges();
 
@@ -566,7 +566,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              expect(input.value).toEqual('Nancy Drew', 'Expected initial view value to be set.');
              expect(form.value)
@@ -585,7 +585,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              expect(input.value)
                  .toEqual('Carson', 'Expected view value to update on programmatic change.');
@@ -604,7 +604,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -623,7 +623,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                  .toEqual('Carson', 'Expected value not to update on blur.');
              expect(form.valid).toBe(false, 'Expected validation not to run on blur.');
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form')) !.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -639,13 +639,13 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
              tick();
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form')) !.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
              tick();
@@ -682,7 +682,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              form.control.get('name') !.setValidators(groupValidatorSpy);
              form.control.get('name.last') !.setValidators(validatorSpy);
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form')) !.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -697,7 +697,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -712,7 +712,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
 
              expect(form.dirty).toBe(false, 'Expected dirtiness not to update on blur.');
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form')) !.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -726,7 +726,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -739,7 +739,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              expect(form.touched).toBe(false, 'Expected touched not to update on blur.');
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form')) !.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -753,7 +753,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -773,7 +773,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              expect(form.dirty).toBe(false, 'Expected dirty to stay false on reset.');
              expect(form.touched).toBe(false, 'Expected touched to stay false on reset.');
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form')) !.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -798,7 +798,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              const sub = merge(form.valueChanges !, form.statusChanges !)
                              .subscribe(val => values.push(val));
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -812,7 +812,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
 
              expect(values).toEqual([], 'Expected no valueChanges or statusChanges on blur.');
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form')) !.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -830,14 +830,14 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form')) !.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
              expect(fixture.componentInstance.events)
                  .toEqual([], 'Expected ngModelChanges not to fire if value unchanged.');
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              input.value = 'Carson';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -908,7 +908,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -1005,7 +1005,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            const fixture = initTest(NgModelForm);
            fixture.componentInstance.event = null !;
 
-           const form = fixture.debugElement.query(By.css('form'));
+           const form = fixture.debugElement.query(By.css('form')) !;
            dispatchEvent(form.nativeElement, 'submit');
            tick();
 
@@ -1019,7 +1019,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            const form = fixture.debugElement.children[0].injector.get(NgForm);
            expect(form.submitted).toBe(false);
 
-           const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+           const formEl = fixture.debugElement.query(By.css('form')) !.nativeElement;
            dispatchEvent(formEl, 'submit');
            tick();
 
@@ -1033,8 +1033,8 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const formEl = fixture.debugElement.query(By.css('form'));
-           const input = fixture.debugElement.query(By.css('input'));
+           const formEl = fixture.debugElement.query(By.css('form')) !;
+           const input = fixture.debugElement.query(By.css('input')) !;
 
            expect(input.nativeElement.value).toBe('should be cleared');       // view value
            expect(fixture.componentInstance.name).toBe('should be cleared');  // ngModel value
@@ -1052,7 +1052,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
       it('should reset the form submit state when reset button is clicked', fakeAsync(() => {
            const fixture = initTest(NgModelForm);
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const formEl = fixture.debugElement.query(By.css('form'));
+           const formEl = fixture.debugElement.query(By.css('form')) !;
 
            dispatchEvent(formEl.nativeElement, 'submit');
            fixture.detectChanges();
@@ -1098,7 +1098,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            form.get('name') !.valueChanges.subscribe(
                () => { expect(form.get('name') !.dirty).toBe(true); });
 
-           const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+           const inputEl = fixture.debugElement.query(By.css('input')) !.nativeElement;
            inputEl.value = 'newValue';
 
            dispatchEvent(inputEl, 'input');
@@ -1111,8 +1111,8 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm).form;
-           const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-           const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+           const formEl = fixture.debugElement.query(By.css('form')) !.nativeElement;
+           const inputEl = fixture.debugElement.query(By.css('input')) !.nativeElement;
 
            inputEl.value = 'newValue';
            dispatchEvent(inputEl, 'input');
@@ -1163,7 +1163,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css(`[name="first"]`));
+           const input = fixture.debugElement.query(By.css(`[name="first"]`)) !;
            expect(input.nativeElement.disabled).toBe(true);
          }));
 
@@ -1178,7 +1178,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                const form = fixture.debugElement.children[0].injector.get(NgForm);
                expect(form.control.get('name') !.disabled).toBe(true);
 
-               const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
+               const customInput = fixture.debugElement.query(By.css('[name="custom"]')) !;
                expect(customInput.nativeElement.disabled).toEqual(true);
              });
            });
@@ -1200,7 +1200,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            const form = fixture.debugElement.children[0].injector.get(NgForm);
            expect(form.control.get('name') !.disabled).toBe(true);
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input')) !;
            expect(input.nativeElement.disabled).toEqual(true);
 
            form.control.enable();
@@ -1221,7 +1221,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            const control =
                fixture.debugElement.children[0].injector.get(NgForm).control.get('checkbox') !;
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input')) !;
            expect(input.nativeElement.checked).toBe(false);
            expect(control.hasError('required')).toBe(false);
 
@@ -1257,7 +1257,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            const control =
                fixture.debugElement.children[0].injector.get(NgForm).control.get('email') !;
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input')) !;
            expect(control.hasError('email')).toBe(false);
 
            fixture.componentInstance.validatorEnabled = true;
@@ -1300,10 +1300,10 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const required = fixture.debugElement.query(By.css('[name=required]'));
-           const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-           const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-           const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+           const required = fixture.debugElement.query(By.css('[name=required]')) !;
+           const minLength = fixture.debugElement.query(By.css('[name=minlength]')) !;
+           const maxLength = fixture.debugElement.query(By.css('[name=maxlength]')) !;
+           const pattern = fixture.debugElement.query(By.css('[name=pattern]')) !;
 
            required.nativeElement.value = '';
            minLength.nativeElement.value = '1';
@@ -1343,7 +1343,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input')) !;
 
            input.nativeElement.value = '';
            dispatchEvent(input.nativeElement, 'input');
@@ -1365,7 +1365,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input')) !;
 
            input.nativeElement.value = '';
            dispatchEvent(input.nativeElement, 'input');
@@ -1387,7 +1387,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input')) !;
 
            input.nativeElement.value = '';
            dispatchEvent(input.nativeElement, 'input');
@@ -1407,10 +1407,10 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const required = fixture.debugElement.query(By.css('[name=required]'));
-           const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-           const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-           const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+           const required = fixture.debugElement.query(By.css('[name=required]')) !;
+           const minLength = fixture.debugElement.query(By.css('[name=minlength]')) !;
+           const maxLength = fixture.debugElement.query(By.css('[name=maxlength]')) !;
+           const pattern = fixture.debugElement.query(By.css('[name=pattern]')) !;
 
            required.nativeElement.value = '';
            minLength.nativeElement.value = '1';
@@ -1474,7 +1474,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
 
       it('should update control status', fakeAsync(() => {
            const fixture = initTest(NgModelChangeState);
-           const inputEl = fixture.debugElement.query(By.css('input'));
+           const inputEl = fixture.debugElement.query(By.css('input')) !;
            const inputNativeEl = inputEl.nativeElement;
            const onNgModelChange = jasmine.createSpy('onNgModelChange');
            fixture.componentInstance.onNgModelChange = onNgModelChange;
@@ -1507,7 +1507,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
     describe('IME events', () => {
       it('should determine IME event handling depending on platform by default', fakeAsync(() => {
            const fixture = initTest(StandaloneNgModel);
-           const inputEl = fixture.debugElement.query(By.css('input'));
+           const inputEl = fixture.debugElement.query(By.css('input')) !;
            const inputNativeEl = inputEl.nativeElement;
            fixture.componentInstance.name = 'oldValue';
            fixture.detectChanges();
@@ -1542,7 +1542,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                StandaloneNgModel,
                {set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: true}]}});
            const fixture = initTest(StandaloneNgModel);
-           const inputEl = fixture.debugElement.query(By.css('input'));
+           const inputEl = fixture.debugElement.query(By.css('input')) !;
            const inputNativeEl = inputEl.nativeElement;
            fixture.componentInstance.name = 'oldValue';
            fixture.detectChanges();
@@ -1574,7 +1574,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                {set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: false}]}});
            const fixture = initTest(StandaloneNgModel);
 
-           const inputEl = fixture.debugElement.query(By.css('input'));
+           const inputEl = fixture.debugElement.query(By.css('input')) !;
            const inputNativeEl = inputEl.nativeElement;
            fixture.componentInstance.name = 'oldValue';
            fixture.detectChanges();
@@ -1601,7 +1601,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input')) !.nativeElement;
            input.value = 'aa';
            input.selectionStart = 1;
            dispatchEvent(input, 'input');

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -30,7 +30,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       fixture.detectChanges();
 
       // model -> view
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input')) !;
       expect(input.nativeElement.value).toEqual('old');
 
       input.nativeElement.value = 'new';
@@ -47,7 +47,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       fixture.detectChanges();
 
       // model -> view
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input')) !;
       expect(input.nativeElement.value).toEqual('old');
 
       input.nativeElement.value = 'new';
@@ -63,7 +63,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       fixture.componentInstance.form = form;
       fixture.detectChanges();
 
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input')) !;
       form.valueChanges.subscribe({next: (value) => { throw 'Should not happen'; }});
       input.nativeElement.value = 'updatedValue';
 
@@ -79,7 +79,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       fixture.detectChanges();
 
       // model -> view
-      const textarea = fixture.debugElement.query(By.css('textarea'));
+      const textarea = fixture.debugElement.query(By.css('textarea')) !;
       expect(textarea.nativeElement.value).toEqual('old');
 
       textarea.nativeElement.value = 'new';
@@ -98,7 +98,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       fixture.detectChanges();
 
       // model -> view
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input')) !;
       expect(input.nativeElement.checked).toBe(true);
 
       input.nativeElement.checked = false;
@@ -116,7 +116,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
         fixture.detectChanges();
 
         // model -> view
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input')) !;
         expect(input.nativeElement.value).toEqual('10');
 
         input.nativeElement.value = '20';
@@ -132,7 +132,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
         fixture.componentInstance.control = control;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input')) !;
         input.nativeElement.value = '';
         dispatchEvent(input.nativeElement, 'input');
 
@@ -154,7 +154,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
         control.setValue(null);
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input')) !;
         expect(input.nativeElement.value).toEqual('');
       });
     });
@@ -169,8 +169,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           fixture.detectChanges();
 
           // model -> view
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
+          const select = fixture.debugElement.query(By.css('select')) !;
+          const sfOption = fixture.debugElement.query(By.css('option')) !;
           expect(select.nativeElement.value).toEqual('SF');
           expect(sfOption.nativeElement.selected).toBe(true);
 
@@ -189,8 +189,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           fixture.detectChanges();
 
           // model -> view
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
+          const select = fixture.debugElement.query(By.css('select')) !;
+          const sfOption = fixture.debugElement.query(By.css('option')) !;
           expect(select.nativeElement.value).toEqual('0: Object');
           expect(sfOption.nativeElement.selected).toBe(true);
         });
@@ -207,8 +207,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           const fixture = initTest(FormControlSelectWithCompareFn);
           fixture.detectChanges();
 
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
+          const select = fixture.debugElement.query(By.css('select')) !;
+          const sfOption = fixture.debugElement.query(By.css('option')) !;
           expect(select.nativeElement.value).toEqual('0: Object');
           expect(sfOption.nativeElement.selected).toBe(true);
         });
@@ -220,7 +220,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
           // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
           // will select the second option (NY).
-          const select = fixture.debugElement.query(By.css('select'));
+          const select = fixture.debugElement.query(By.css('select')) !;
           select.nativeElement.value = '1: Object';
           dispatchEvent(select.nativeElement, 'change');
           fixture.detectChanges();
@@ -251,7 +251,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select')) !;
              const nycOption = fixture.debugElement.queryAll(By.css('option'))[1];
 
              // model -> view
@@ -281,7 +281,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select')) !;
              const buffalo = fixture.debugElement.queryAll(By.css('option'))[2];
              expect(select.nativeElement.value).toEqual('2: Object');
              expect(buffalo.nativeElement.selected).toBe(true);
@@ -295,7 +295,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select')) !;
              expect(select.nativeElement.value).toEqual('1: Object');
 
              comp.cities.pop();
@@ -317,7 +317,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select')) !;
              const secondNYC = fixture.debugElement.queryAll(By.css('option'))[2];
              expect(select.nativeElement.value).toEqual('2: Object');
              expect(secondNYC.nativeElement.selected).toBe(true);
@@ -330,7 +330,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              comp.selectedCity = null;
              fixture.detectChanges();
 
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select')) !;
 
              select.nativeElement.value = '2: Object';
              dispatchEvent(select.nativeElement, 'change');
@@ -362,8 +362,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
-             const sfOption = fixture.debugElement.query(By.css('option'));
+             const select = fixture.debugElement.query(By.css('select')) !;
+             const sfOption = fixture.debugElement.query(By.css('option')) !;
              expect(select.nativeElement.value).toEqual('0: Object');
              expect(sfOption.nativeElement.selected).toBe(true);
            }));
@@ -378,7 +378,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
              // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
              // will select the second option (NY).
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select')) !;
              select.nativeElement.value = '1: Object';
              dispatchEvent(select.nativeElement, 'change');
              fixture.detectChanges();
@@ -413,8 +413,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           const fixture = initTest(FormControlSelectMultiple);
           fixture.detectChanges();
 
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
+          const select = fixture.debugElement.query(By.css('select')) !;
+          const sfOption = fixture.debugElement.query(By.css('option')) !;
           expect(select.nativeElement.value).toEqual(`0: 'SF'`);
           expect(sfOption.nativeElement.selected).toBe(true);
         });
@@ -424,8 +424,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           const fixture = initTest(FormControlSelectMultipleNgValue);
           fixture.detectChanges();
 
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
+          const select = fixture.debugElement.query(By.css('select')) !;
+          const sfOption = fixture.debugElement.query(By.css('option')) !;
           expect(select.nativeElement.value).toEqual('0: Object');
           expect(sfOption.nativeElement.selected).toBe(true);
         });
@@ -443,8 +443,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
-             const sfOption = fixture.debugElement.query(By.css('option'));
+             const select = fixture.debugElement.query(By.css('select')) !;
+             const sfOption = fixture.debugElement.query(By.css('option')) !;
              expect(select.nativeElement.value).toEqual('0: Object');
              expect(sfOption.nativeElement.selected).toBe(true);
            }));
@@ -472,7 +472,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
         };
 
         const selectOptionViaUI = (valueString: string): void => {
-          const select = fixture.debugElement.query(By.css('select'));
+          const select = fixture.debugElement.query(By.css('select')) !;
           select.nativeElement.value = valueString;
           dispatchEvent(select.nativeElement, 'change');
           detectChangesAndTick();
@@ -534,8 +534,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
            fixture.detectChanges();
            tick();
 
-           const select = fixture.debugElement.query(By.css('select'));
-           const sfOption = fixture.debugElement.query(By.css('option'));
+           const select = fixture.debugElement.query(By.css('select')) !;
+           const sfOption = fixture.debugElement.query(By.css('option')) !;
            expect(select.nativeElement.value).toEqual('0: Object');
            expect(sfOption.nativeElement.selected).toBe(true);
          }));
@@ -665,7 +665,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           });
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('[value="no"]'));
+          const input = fixture.debugElement.query(By.css('[value="no"]')) !;
           dispatchEvent(input.nativeElement, 'change');
 
           fixture.detectChanges();
@@ -844,7 +844,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const form = fixture.debugElement.query(By.css('form'));
+             const form = fixture.debugElement.query(By.css('form')) !;
              dispatchEvent(form.nativeElement, 'reset');
              fixture.detectChanges();
              tick();
@@ -927,7 +927,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           fixture.detectChanges();
 
           // model -> view
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input')) !;
           expect(input.nativeElement.value).toEqual('10');
 
           input.nativeElement.value = '20';
@@ -943,7 +943,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input')) !;
           input.nativeElement.value = '';
           dispatchEvent(input.nativeElement, 'input');
 
@@ -965,7 +965,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
           control.setValue(null);
 
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input')) !;
           expect(input.nativeElement.value).toEqual('');
         });
 
@@ -978,7 +978,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.componentInstance.val = 4;
              fixture.detectChanges();
              tick();
-             const input = fixture.debugElement.query(By.css('input'));
+             const input = fixture.debugElement.query(By.css('input')) !;
              expect(input.nativeElement.value).toBe('4');
              fixture.detectChanges();
              tick();
@@ -1004,7 +1004,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           fixture.detectChanges();
 
           // model -> view
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input')) !;
           expect(input.nativeElement.value).toEqual('!aa!');
 
           input.nativeElement.value = '!bb!';
@@ -1025,7 +1025,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.componentInstance.form = new FormGroup({'login': new FormControl('aa')});
              fixture.detectChanges();
 
-             const input = fixture.debugElement.query(By.css('my-input'));
+             const input = fixture.debugElement.query(By.css('my-input')) !;
              expect(input.componentInstance.value).toEqual('!aa!');
 
              input.componentInstance.value = '!bb!';
@@ -1066,7 +1066,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
                fixture.detectChanges();
                fixture.whenStable().then(() => {
                  // model -> view
-                 const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
+                 const customInput = fixture.debugElement.query(By.css('[name="custom"]')) !;
                  expect(customInput.nativeElement.value).toEqual('Nancy');
 
                  customInput.nativeElement.value = 'Carson';

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -92,7 +92,7 @@ import {NAMESPACE_URIS} from '../../src/dom/dom_renderer';
          () => {
            const fixture = TestBed.createComponent(SomeApp);
 
-           const cmp = fixture.debugElement.query(By.css('cmp-native')).nativeElement;
+           const cmp = fixture.debugElement.query(By.css('cmp-native')) !.nativeElement;
 
 
            const native = cmp.shadowRoot.querySelector('.native');

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1432,7 +1432,7 @@ describe('Integration', () => {
 
          teamCmp.routerLink = ['/team/0'];
          advance(fixture);
-         const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
+         const anchor = fixture.debugElement.query(By.css('a')) !.nativeElement;
          anchor.click();
          advance(fixture);
          expect(fixture.nativeElement).toHaveText('team 0 [ , right:  ]');
@@ -1440,7 +1440,7 @@ describe('Integration', () => {
 
          teamCmp.routerLink = ['/team/1'];
          advance(fixture);
-         const button = fixture.debugElement.query(By.css('button')).nativeElement;
+         const button = fixture.debugElement.query(By.css('button')) !.nativeElement;
          button.click();
          advance(fixture);
          expect(fixture.nativeElement).toHaveText('team 1 [ , right:  ]');
@@ -3176,8 +3176,8 @@ describe('Integration', () => {
              expect(location.path()).toEqual('/lazy/parent/child');
              expect(fixture.nativeElement).toHaveText('parent[child]');
 
-             const pInj = fixture.debugElement.query(By.directive(Parent)).injector !;
-             const cInj = fixture.debugElement.query(By.directive(Child)).injector !;
+             const pInj = fixture.debugElement.query(By.directive(Parent)) !.injector !;
+             const cInj = fixture.debugElement.query(By.directive(Child)) !.injector !;
 
              expect(pInj.get('moduleName')).toEqual('parent');
              expect(pInj.get('fromParent')).toEqual('from parent');
@@ -3290,7 +3290,7 @@ describe('Integration', () => {
 
              expect(fixture.nativeElement).toHaveText('lazy');
              const lzc =
-                 fixture.debugElement.query(By.directive(LazyLoadedComponent)).componentInstance;
+                 fixture.debugElement.query(By.directive(LazyLoadedComponent)) !.componentInstance;
              expect(lzc.injectedService).toBe(lzc.resolvedService);
            })));
 


### PR DESCRIPTION
The result of DebugElement.query can actually be null so the return
type was adjusted accordingly.

Closes #22449

BREAKING CHANGE: change of return type of DebugElement.query

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #22449

## What is the new behavior?

No behavior change.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Angular users need to fix the places where the result `DebugElement.query` is used without null check.