### PR TITLE
docs-infra: 'suggest edit' redirect to contributing guidelines

### DIFF
--- a/aio/tools/transforms/templates/api/lib/githubLinks.html
+++ b/aio/tools/transforms/templates/api/lib/githubLinks.html
@@ -13,7 +13,7 @@ https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInf
 
 {% macro githubLinks(doc, versionInfo) -%}
 <div class="github-links">
-  <a href="{$ githubEditHref(doc, versionInfo) $}" aria-label="Suggest Edits" title="Suggest Edits"><i class="material-icons" aria-hidden="true" role="img">mode_edit</i></a>
+  <a href="https://github.com/angular/angular/blob/master/CONTRIBUTING.md" aria-label="Suggest Edits" title="Suggest Edits"><i class="material-icons" aria-hidden="true" role="img">mode_edit</i></a>
   <a href="{$ githubViewHref(doc, versionInfo) $}" aria-label="View Source" title="View Source"><i class="material-icons" aria-hidden="true" role="img">code</i></a>
 </div>
 {%- endmacro -%}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[x] Other... Please describe: docs-infra
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #25722


## What is the new behavior?
When the user clicks on 'Suggest Edit' he will be forwarded directly to the contribution guidelines(CONTRIBUTING.md).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Unfortunately, I cannot test these changes locally due to an error in the mentioned 'General Setup'. For this I already created an issue #25759 

EDIT: After the solution for the issue #25759 was found, I tested the changes and they work as expected. 