### PR TITLE
refactor(ivy): remove obsolete types

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -515,7 +515,7 @@ export const defineDirective = defineComponent as any as<T>(directiveDefinition:
   /**
    * Factory method used to create an instance of directive.
    */
-  factory: () => T | ({0: T} & any[]); /* trying to say T | [T, ...any] */
+  factory: () => T;
 
   /**
    * Static attributes to set on host element.

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -127,11 +127,8 @@ export interface DirectiveDef<T, Selector extends string> extends BaseDef<T> {
 
   /**
    * Factory function used to create a new directive instance.
-   *
-   * Usually returns the directive instance, but if the directive has a content query,
-   * it instead returns an array that contains the instance as well as content query data.
    */
-  factory(): T|[T];
+  factory(): T;
 
   /**
    * Function to create instances of content queries associated with a given directive.


### PR DESCRIPTION
In the past factories could return an array with content queries
but we no longer manage queries in factory functions.
