### PR TITLE
feat(common): Add InjectionToken for window.

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -20,7 +20,7 @@ export {Plural, NumberFormatStyle, FormStyle, Time, TranslationWidth, FormatWidt
 export {parseCookieValue as ɵparseCookieValue} from './cookie';
 export {CommonModule, DeprecatedI18NPipesModule} from './common_module';
 export {NgClass, NgForOf, NgForOfContext, NgIf, NgIfContext, NgPlural, NgPluralCase, NgStyle, NgSwitch, NgSwitchCase, NgSwitchDefault, NgTemplateOutlet, NgComponentOutlet} from './directives/index';
-export {DOCUMENT} from './dom_tokens';
+export {DOCUMENT, WINDOW} from './dom_tokens';
 export {AsyncPipe, DatePipe, I18nPluralPipe, I18nSelectPipe, JsonPipe, LowerCasePipe, CurrencyPipe, DecimalPipe, PercentPipe, SlicePipe, UpperCasePipe, TitleCasePipe, KeyValuePipe, KeyValue} from './pipes/index';
 export {DeprecatedDatePipe, DeprecatedCurrencyPipe, DeprecatedDecimalPipe, DeprecatedPercentPipe} from './pipes/deprecated/index';
 export {PLATFORM_BROWSER_ID as ɵPLATFORM_BROWSER_ID, PLATFORM_SERVER_ID as ɵPLATFORM_SERVER_ID, PLATFORM_WORKER_APP_ID as ɵPLATFORM_WORKER_APP_ID, PLATFORM_WORKER_UI_ID as ɵPLATFORM_WORKER_UI_ID, isPlatformBrowser, isPlatformServer, isPlatformWorkerApp, isPlatformWorkerUi} from './platform_id';

--- a/packages/common/src/dom_tokens.ts
+++ b/packages/common/src/dom_tokens.ts
@@ -17,3 +17,8 @@ import {InjectionToken} from '@angular/core';
  *
  */
 export const DOCUMENT = new InjectionToken<Document>('DocumentToken');
+
+/**
+ * DI token for Window instance for easier mocking in Angular tests.
+ */
+export const WINDOW = new InjectionToken<Window>('WindowToken');

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -1635,6 +1635,9 @@
     "name": "ViewRef_"
   },
   {
+    "name": "WINDOW"
+  },
+  {
     "name": "WS_CHARS"
   },
   {
@@ -2215,6 +2218,9 @@
   },
   {
     "name": "_visitor"
+  },
+  {
+    "name": "_window"
   },
   {
     "name": "add32"

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CommonModule, PlatformLocation, ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
+import {CommonModule, DOCUMENT, PlatformLocation, WINDOW, ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
 import {APP_ID, ApplicationModule, ErrorHandler, Inject, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, PlatformRef, RendererFactory2, Sanitizer, SkipSelf, StaticProvider, Testability, createPlatformFactory, platformCore, ɵAPP_ROOT as APP_ROOT, ɵConsole as Console} from '@angular/core';
 
 import {BrowserDomAdapter} from './browser/browser_adapter';
@@ -15,7 +15,6 @@ import {SERVER_TRANSITION_PROVIDERS, TRANSITION_ID} from './browser/server-trans
 import {BrowserGetTestability} from './browser/testability';
 import {ELEMENT_PROBE_PROVIDERS} from './dom/debug/ng_probe';
 import {DomRendererFactory2} from './dom/dom_renderer';
-import {DOCUMENT} from './dom/dom_tokens';
 import {DomEventsPlugin} from './dom/events/dom_events';
 import {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 import {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HammerGestureConfig, HammerGesturesPlugin} from './dom/events/hammer_gestures';
@@ -28,6 +27,7 @@ export const INTERNAL_BROWSER_PLATFORM_PROVIDERS: StaticProvider[] = [
   {provide: PLATFORM_INITIALIZER, useValue: initDomAdapter, multi: true},
   {provide: PlatformLocation, useClass: BrowserPlatformLocation, deps: [DOCUMENT]},
   {provide: DOCUMENT, useFactory: _document, deps: []},
+  {provide: WINDOW, useFactory: _window, deps: []},
 ];
 
 /**
@@ -53,8 +53,12 @@ export function errorHandler(): ErrorHandler {
   return new ErrorHandler();
 }
 
-export function _document(): any {
+export function _document(): Document {
   return document;
+}
+
+export function _window(): Window {
+  return window;
 }
 
 export const BROWSER_MODULE_PROVIDERS: StaticProvider[] = [

--- a/packages/platform-server/src/domino_adapter.ts
+++ b/packages/platform-server/src/domino_adapter.ts
@@ -22,10 +22,16 @@ function setDomTypes() {
 /**
  * Parses a document string to a Document object.
  */
-export function parseDocument(html: string, url = '/') {
-  let window = domino.createWindow(html, url);
-  let doc = window.document;
-  return doc;
+export function parseDocument(html: string, url = '/'): Document {
+  const window = parseDocumentToWindow(html, url);
+  return window.document;
+}
+
+/**
+ * Parses a document string and returns the window object that contains it.
+ */
+export function parseDocumentToWindow(html: string, url = '/'): Window {
+  return domino.createWindow(html, url);
 }
 
 /**

--- a/packages/platform-webworker/src/worker_app.ts
+++ b/packages/platform-webworker/src/worker_app.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CommonModule, ViewportScroller, ɵNullViewportScroller as NullViewportScroller, ɵPLATFORM_WORKER_APP_ID as PLATFORM_WORKER_APP_ID} from '@angular/common';
+import {CommonModule, DOCUMENT, ViewportScroller, WINDOW, ɵNullViewportScroller as NullViewportScroller, ɵPLATFORM_WORKER_APP_ID as PLATFORM_WORKER_APP_ID} from '@angular/common';
 import {APP_INITIALIZER, ApplicationModule, ErrorHandler, NgModule, NgZone, PLATFORM_ID, PlatformRef, RendererFactory2, RootRenderer, StaticProvider, createPlatformFactory, platformCore} from '@angular/core';
-import {DOCUMENT, ɵBROWSER_SANITIZATION_PROVIDERS as BROWSER_SANITIZATION_PROVIDERS} from '@angular/platform-browser';
+import {ɵBROWSER_SANITIZATION_PROVIDERS as BROWSER_SANITIZATION_PROVIDERS} from '@angular/platform-browser';
 
 import {ON_WEB_WORKER} from './web_workers/shared/api';
 import {ClientMessageBrokerFactory} from './web_workers/shared/client_message_broker';
@@ -62,6 +62,7 @@ export function setupWebWorker(): void {
     BROWSER_SANITIZATION_PROVIDERS,
     Serializer,
     {provide: DOCUMENT, useValue: null},
+    {provide: WINDOW, useValue: null},
     ClientMessageBrokerFactory,
     ServiceMessageBrokerFactory,
     WebWorkerRendererFactory2,

--- a/packages/platform-webworker/src/worker_render.ts
+++ b/packages/platform-webworker/src/worker_render.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CommonModule, ɵPLATFORM_WORKER_UI_ID as PLATFORM_WORKER_UI_ID} from '@angular/common';
+import {CommonModule, DOCUMENT, WINDOW, ɵPLATFORM_WORKER_UI_ID as PLATFORM_WORKER_UI_ID} from '@angular/common';
 import {ErrorHandler, Injectable, InjectionToken, Injector, NgZone, PLATFORM_ID, PLATFORM_INITIALIZER, PlatformRef, RendererFactory2, RootRenderer, StaticProvider, Testability, createPlatformFactory, isDevMode, platformCore, ɵAPP_ID_RANDOM_PROVIDER as APP_ID_RANDOM_PROVIDER} from '@angular/core';
-import {DOCUMENT, EVENT_MANAGER_PLUGINS, EventManager, HAMMER_GESTURE_CONFIG, HammerGestureConfig, ɵBROWSER_SANITIZATION_PROVIDERS as BROWSER_SANITIZATION_PROVIDERS, ɵBrowserDomAdapter as BrowserDomAdapter, ɵBrowserGetTestability as BrowserGetTestability, ɵDomEventsPlugin as DomEventsPlugin, ɵDomRendererFactory2 as DomRendererFactory2, ɵDomSharedStylesHost as DomSharedStylesHost, ɵHammerGesturesPlugin as HammerGesturesPlugin, ɵKeyEventsPlugin as KeyEventsPlugin, ɵSharedStylesHost as SharedStylesHost, ɵgetDOM as getDOM} from '@angular/platform-browser';
+import {EVENT_MANAGER_PLUGINS, EventManager, HAMMER_GESTURE_CONFIG, HammerGestureConfig, ɵBROWSER_SANITIZATION_PROVIDERS as BROWSER_SANITIZATION_PROVIDERS, ɵBrowserDomAdapter as BrowserDomAdapter, ɵBrowserGetTestability as BrowserGetTestability, ɵDomEventsPlugin as DomEventsPlugin, ɵDomRendererFactory2 as DomRendererFactory2, ɵDomSharedStylesHost as DomSharedStylesHost, ɵHammerGesturesPlugin as HammerGesturesPlugin, ɵKeyEventsPlugin as KeyEventsPlugin, ɵSharedStylesHost as SharedStylesHost, ɵgetDOM as getDOM} from '@angular/platform-browser';
 
 import {ON_WEB_WORKER} from './web_workers/shared/api';
 import {ClientMessageBrokerFactory} from './web_workers/shared/client_message_broker';
@@ -65,6 +65,7 @@ export const _WORKER_UI_PLATFORM_PROVIDERS: StaticProvider[] = [
   BROWSER_SANITIZATION_PROVIDERS,
   {provide: ErrorHandler, useFactory: _exceptionHandler, deps: []},
   {provide: DOCUMENT, useFactory: _document, deps: []},
+  {provide: WINDOW, useFactory: _window, deps: []},
   // TODO(jteplitz602): Investigate if we definitely need EVENT_MANAGER on the render thread
   // #5298
   {
@@ -155,8 +156,12 @@ function _exceptionHandler(): ErrorHandler {
   return new ErrorHandler();
 }
 
-function _document(): any {
+function _document(): Document {
   return document;
+}
+
+function _window(): Window {
+  return window;
 }
 
 function createNgZone(): NgZone {


### PR DESCRIPTION
Some components may use the "window" for things like getting the browser
width. Testing the window is error prone but DI saves the day.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Components that may use `window` can be hard to test because there is no way to provide a fake window through DI unless I create this injector in EVERY app. Interestingly enough, there is an injector for `DOCUMENT` already built in.

Issue Number: N/A

## What is the new behavior?
Just like `DOCUMENT`, there is now a `WINDOW` InjectionToken

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

There are 6 tests that failed with `bazel` and 2 that failed with `./test.sh`, those were already failing in the master branch.