### PR TITLE
fix(ivy): reexport __POST_NGCC__ symbols as private to prevent DCE in FESM

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -165,4 +165,17 @@ export {
   ElementContext as ɵElementContext,
   getElementContext as ɵgetElementContext
 } from './render3/element_discovery';
+
+// we reexport these symbols just so that they are retained during the dead code elimination
+// performed by rollup while it's creating fesm files.
+//
+// no code actually imports these symbols from the @angular/core entry point
+export {
+  R3_COMPILE_COMPONENT__POST_NGCC__ as ɵR3_COMPILE_COMPONENT__POST_NGCC__,
+  R3_COMPILE_DIRECTIVE__POST_NGCC__ as ɵR3_COMPILE_DIRECTIVE__POST_NGCC__,
+  R3_COMPILE_INJECTABLE__POST_NGCC__ as ɵR3_COMPILE_INJECTABLE__POST_NGCC__,
+  R3_COMPILE_NGMODULE__POST_NGCC__ as ɵR3_COMPILE_NGMODULE__POST_NGCC__,
+  R3_COMPILE_PIPE__POST_NGCC__ as ɵR3_COMPILE_PIPE__POST_NGCC__,
+  ivyEnable__POST_NGCC__ as ɵivyEnable__POST_NGCC__
+} from './ivy_switch_legacy';
 // clang-format on

--- a/packages/core/src/ivy_switch_legacy.ts
+++ b/packages/core/src/ivy_switch_legacy.ts
@@ -22,7 +22,7 @@ export interface DirectiveCompiler { (type: any, meta: any): void; }
 
 export const R3_COMPILE_COMPONENT__POST_NGCC__: DirectiveCompiler = ivyOn.R3_COMPILE_COMPONENT;
 export const R3_COMPILE_DIRECTIVE__POST_NGCC__: DirectiveCompiler = ivyOn.R3_COMPILE_DIRECTIVE;
-export const R3_COMPILE_INJECTABLE__POST_NGCC__: DirectiveCompiler= ivyOn.R3_COMPILE_INJECTABLE;
+export const R3_COMPILE_INJECTABLE__POST_NGCC__: DirectiveCompiler = ivyOn.R3_COMPILE_INJECTABLE;
 export const R3_COMPILE_NGMODULE__POST_NGCC__: DirectiveCompiler = ivyOn.R3_COMPILE_NGMODULE;
 export const R3_COMPILE_PIPE__POST_NGCC__: DirectiveCompiler = ivyOn.R3_COMPILE_PIPE;
 export const ivyEnable__POST_NGCC__: boolean = ivyOn.ivyEnabled;

--- a/packages/core/src/ivy_switch_legacy.ts
+++ b/packages/core/src/ivy_switch_legacy.ts
@@ -20,12 +20,12 @@ function noop() {}
 
 export interface DirectiveCompiler { (type: any, meta: any): void; }
 
-const R3_COMPILE_COMPONENT__POST_NGCC__ = ivyOn.R3_COMPILE_COMPONENT;
-const R3_COMPILE_DIRECTIVE__POST_NGCC__ = ivyOn.R3_COMPILE_DIRECTIVE;
-const R3_COMPILE_INJECTABLE__POST_NGCC__ = ivyOn.R3_COMPILE_INJECTABLE;
-const R3_COMPILE_NGMODULE__POST_NGCC__ = ivyOn.R3_COMPILE_NGMODULE;
-const R3_COMPILE_PIPE__POST_NGCC__ = ivyOn.R3_COMPILE_PIPE;
-const ivyEnable__POST_NGCC__ = ivyOn.ivyEnabled;
+export const R3_COMPILE_COMPONENT__POST_NGCC__ = ivyOn.R3_COMPILE_COMPONENT;
+export const R3_COMPILE_DIRECTIVE__POST_NGCC__ = ivyOn.R3_COMPILE_DIRECTIVE;
+export const R3_COMPILE_INJECTABLE__POST_NGCC__ = ivyOn.R3_COMPILE_INJECTABLE;
+export const R3_COMPILE_NGMODULE__POST_NGCC__ = ivyOn.R3_COMPILE_NGMODULE;
+export const R3_COMPILE_PIPE__POST_NGCC__ = ivyOn.R3_COMPILE_PIPE;
+export const ivyEnable__POST_NGCC__ = ivyOn.ivyEnabled;
 
 const compileComponentQueue: any[] = [];
 const compileDirectiveQueue: any[] = [];

--- a/packages/core/src/ivy_switch_legacy.ts
+++ b/packages/core/src/ivy_switch_legacy.ts
@@ -20,12 +20,12 @@ function noop() {}
 
 export interface DirectiveCompiler { (type: any, meta: any): void; }
 
-export const R3_COMPILE_COMPONENT__POST_NGCC__ = ivyOn.R3_COMPILE_COMPONENT;
-export const R3_COMPILE_DIRECTIVE__POST_NGCC__ = ivyOn.R3_COMPILE_DIRECTIVE;
-export const R3_COMPILE_INJECTABLE__POST_NGCC__ = ivyOn.R3_COMPILE_INJECTABLE;
-export const R3_COMPILE_NGMODULE__POST_NGCC__ = ivyOn.R3_COMPILE_NGMODULE;
-export const R3_COMPILE_PIPE__POST_NGCC__ = ivyOn.R3_COMPILE_PIPE;
-export const ivyEnable__POST_NGCC__ = ivyOn.ivyEnabled;
+export const R3_COMPILE_COMPONENT__POST_NGCC__: DirectiveCompiler = ivyOn.R3_COMPILE_COMPONENT;
+export const R3_COMPILE_DIRECTIVE__POST_NGCC__: DirectiveCompiler = ivyOn.R3_COMPILE_DIRECTIVE;
+export const R3_COMPILE_INJECTABLE__POST_NGCC__: DirectiveCompiler= ivyOn.R3_COMPILE_INJECTABLE;
+export const R3_COMPILE_NGMODULE__POST_NGCC__: DirectiveCompiler = ivyOn.R3_COMPILE_NGMODULE;
+export const R3_COMPILE_PIPE__POST_NGCC__: DirectiveCompiler = ivyOn.R3_COMPILE_PIPE;
+export const ivyEnable__POST_NGCC__: boolean = ivyOn.ivyEnabled;
 
 const R3_COMPILE_COMPONENT__PRE_NGCC__: DirectiveCompiler = noop;
 const R3_COMPILE_DIRECTIVE__PRE_NGCC__: DirectiveCompiler = noop;

--- a/packages/core/src/ivy_switch_legacy.ts
+++ b/packages/core/src/ivy_switch_legacy.ts
@@ -27,12 +27,6 @@ export const R3_COMPILE_NGMODULE__POST_NGCC__ = ivyOn.R3_COMPILE_NGMODULE;
 export const R3_COMPILE_PIPE__POST_NGCC__ = ivyOn.R3_COMPILE_PIPE;
 export const ivyEnable__POST_NGCC__ = ivyOn.ivyEnabled;
 
-const compileComponentQueue: any[] = [];
-const compileDirectiveQueue: any[] = [];
-const compileInjectableQueue: any[] = [];
-const compileNgModuleQueue: any[] = [];
-const compilePipeQueue: any[] = [];
-
 const R3_COMPILE_COMPONENT__PRE_NGCC__: DirectiveCompiler = noop;
 const R3_COMPILE_DIRECTIVE__PRE_NGCC__: DirectiveCompiler = noop;
 const R3_COMPILE_INJECTABLE__PRE_NGCC__: DirectiveCompiler = preR3InjectableCompile;


### PR DESCRIPTION
While creating FESM files, rollup usually drops all unused symbols.
All *__POST_NGCC__ are unused unless ngcc rewires stuff. To prevent this DCE
we reexport them as private symbols. If ngcc is not used, these symbols will
be dropped when we optimize an application bundle.

We don't have an infrastructure to test this fix, so I just manually inspected
the bundles before and after to verify that the fix works.