### PR TITLE
feat(router): Not run deactivate guards whenever a child fails

### DIFF
--- a/packages/router/src/pre_activation.ts
+++ b/packages/router/src/pre_activation.ts
@@ -8,7 +8,7 @@
 
 import {Injector} from '@angular/core';
 import {Observable, from, of } from 'rxjs';
-import {concatMap, every, first, last, map, mergeMap, reduce} from 'rxjs/operators';
+import {concatMap, every, first, last, map, mergeMap, reduce, takeWhile, count} from 'rxjs/operators';
 
 import {LoadedRouterConfig, ResolveData, RunGuardsAndResolvers} from './config';
 import {ActivationStart, ChildActivationStart, Event} from './events';
@@ -188,8 +188,12 @@ export class PreActivation {
   private runCanDeactivateChecks(): Observable<boolean> {
     return from(this.canDeactivateChecks)
         .pipe(
-            mergeMap((check: CanDeactivate) => this.runCanDeactivate(check.component, check.route)),
-            every((result: boolean) => result === true));
+            concatMap(
+                (check: CanDeactivate) => this.runCanDeactivate(check.component, check.route)),
+            takeWhile((result: boolean) => result === true),
+            count(),
+            map((counter: number) => counter === this.canDeactivateChecks.length)
+        );
   }
 
   private runCanActivateChecks(): Observable<boolean> {

--- a/packages/router/test/router.spec.ts
+++ b/packages/router/test/router.spec.ts
@@ -415,6 +415,38 @@ describe('Router', () => {
           expect(logger.logs).toEqual([CDA_CHILD_FALSE]);
         });
       });
+
+      // https://github.com/angular/angular/issues/25086
+      it('should not run child deactivate if grandchild deactivate fails', () => {
+        /**
+         *      R     -->      R
+         *     /
+         *    child (CDA)
+         *   /
+         *  grandchild(CDA)
+         */
+
+        const prevChildSnapshot = createActivatedRouteSnapshot(
+            {component: 'child', routeConfig: {canDeactivate: [CDA_CHILD]}});
+        const prevGrandchildSnapshot = createActivatedRouteSnapshot(
+            {component: 'grandchild', routeConfig: {canDeactivate: [CDA_GRANDCHILD_FALSE]}});
+
+        const currentState = new (RouterStateSnapshot as any)(
+            'prev', new TreeNode(empty.root, [
+                new TreeNode(prevChildSnapshot, [new TreeNode(prevGrandchildSnapshot, [])])
+            ]));
+
+        const futureState = new (RouterStateSnapshot as any)(
+            'url',
+            new TreeNode(
+                empty.root, []));
+
+        checkGuards(futureState, currentState, TestBed, (result) => {
+            expect(result).toBe(false);
+            expect(logger.logs).toEqual([CDA_GRANDCHILD_FALSE]);
+        });
+      });
+
       it('should deactivate from bottom up, then activate top down', () => {
         /**
          *      R     -->      R


### PR DESCRIPTION
feat(router): Stop running deactivate guards whenever a child deactivate guard fails

When navigate way from a route, the current implementation is running all deactivate guards,
even though a guards fails. The router should stop running canDeactivate guards and return false,
every time a child guard fails.

Closes #25086

BREAKING CHANGE: The code inside a parent guard will not run when a child canDeactivate
guard fails.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #25086


## What is the new behavior?
When the router is checking canDeactivate, it should not continue running canDeactivate upwards when a canDeactivate router node fails. 

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
If there is some logic in the canDeactivate guard upwards and a deactivate node fails, it will not run anymore.

## Other information
