### PR TITLE
test: remove deprecated Buffer usage in sourcemap test

### DIFF
--- a/modules/playground/e2e_test/sourcemap/sourcemap_spec.ts
+++ b/modules/playground/e2e_test/sourcemap/sourcemap_spec.ts
@@ -43,7 +43,7 @@ describe('sourcemaps', function() {
       const marker = '//# sourceMappingURL=data:application/json;base64,';
       const index = content.indexOf(marker);
       const sourceMapData =
-          new Buffer(content.substring(index + marker.length), 'base64').toString('utf8');
+          Buffer.from(content.substring(index + marker.length), 'base64').toString('utf8');
 
       const decoder = new sourceMap.SourceMapConsumer(JSON.parse(sourceMapData));
 


### PR DESCRIPTION
`new Buffer()` was deprecated in Node for security reasons. Update to non-deprecated `Buffer.from()` API.

Closes #25707 