### PR TITLE
refactor(docs-infra): simplify custom-element polyfill setup

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -79,7 +79,7 @@
     "@angular/platform-browser-dynamic": "6.1.0-rc.3",
     "@angular/router": "6.1.0-rc.3",
     "@angular/service-worker": "6.1.0-rc.3",
-    "@webcomponents/custom-elements": "^1.0.8",
+    "@webcomponents/custom-elements": "^1.2.0",
     "classlist.js": "^1.1.20150312",
     "core-js": "^2.4.1",
     "rxjs": "6.2.2",

--- a/aio/scripts/_payload-limits.json
+++ b/aio/scripts/_payload-limits.json
@@ -4,7 +4,7 @@
       "uncompressed": {
         "runtime": 2768,
         "main": 476338,
-        "polyfills": 38453,
+        "polyfills": 53922,
         "prettify": 14913
       }
     }

--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -83,28 +83,6 @@
 
   <script nomodule src="generated/ie-polyfills.min.js"></script>
 
-  <script>
-    //load CE polyfill
-    //HACK: webpack's html plugin mangles the document.write calls if we don't trick it.
-
-    //load the ES5 shim for browsers with native CE support
-    function loadCustomElementsShim(){
-      document.write('<scri' + 'pt src="assets/js/native-shim.js"><' + '/script>');
-    }
-
-    //load the full custom elements polyfill for browsers without support
-    function loadCustomElementsPolyfill(){
-      document.write('<scri' + 'pt src="assets/js/custom-elements.min.js"><' + '/script>');
-    }
-    //detect if we have native CE support
-    if(!window.customElements){
-      loadCustomElementsPolyfill();
-    }
-    else {
-      loadCustomElementsShim();
-    }
-  </script>
-
 </head>
 <body>
 

--- a/aio/src/polyfills.ts
+++ b/aio/src/polyfills.ts
@@ -36,7 +36,8 @@
  * Zone JS is required by Angular itself.
  */
 import 'zone.js/dist/zone';  // Included with Angular CLI.
-
+import '@webcomponents/custom-elements'; //  Custom Elements Polyfill
+import '@webcomponents/custom-elements/src/native-shim';
 
 
 /***************************************************************************************************

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -468,9 +468,9 @@
     "@webassemblyjs/wast-parser" "1.4.3"
     long "^3.2.0"
 
-"@webcomponents/custom-elements@^1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@webcomponents/custom-elements/-/custom-elements-1.0.8.tgz#b7b8ef7248f7681d1ad4286a0ada5fe3c2bc7228"
+"@webcomponents/custom-elements@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@webcomponents/custom-elements/-/custom-elements-1.2.0.tgz#7fc8da6c8243b15b4f69c74c65dfe2a4996c694c"
 
 JSONStream@^1.2.1:
   version "1.3.1"


### PR DESCRIPTION
Simplify the Custom Element polyfills for AIO. Previously, we had to conditionally load either the polyfill (for browsers without CE support) or the es5-shim (for browsers with native CE support to enable ES5 "classes"). The polyfills now are simplified, and shouldn't require conditional loading anymore, so we can shift them to the polyfills.ts file to simplify things.

Assuming this approach is successful, we'll follow this up with a similar change to the `@angular/elements` schematics setup