### PR TITLE
build: remove obsolete comment in `env.sh`

### DIFF
--- a/scripts/ci/env.sh
+++ b/scripts/ci/env.sh
@@ -36,9 +36,7 @@ fi
 
 setEnvVar NODE_VERSION 10.9.0
 setEnvVar YARN_VERSION 1.9.2
-# Pin to a Chromium version that does not cause the aio e2e tests to flake. (See https://github.com/angular/angular/pull/20403.)
-# Revision 494239 (which was part of Chrome 62.0.3186.0) is the last version that does not cause flakes. (Latest revision checked: 508578)
-setEnvVar CHROMIUM_VERSION 561733 # Chrome 68 linux stable, see https://www.chromium.org/developers/calendar
+setEnvVar CHROMIUM_VERSION 561733  # Chrome 68 linux stable, see https://www.chromium.org/developers/calendar
 setEnvVar CHROMEDRIVER_VERSION_ARG "--versions.chrome 2.41"
 setEnvVar SAUCE_CONNECT_VERSION 4.4.9
 setEnvVar ANGULAR_CLI_VERSION 1.6.3


### PR DESCRIPTION
The comment is no longer true since #25602.
