### PR TITLE
[6.1.x] test(docs-infra): fix double-slash in URL of `aio_monitoring` test

### DIFF
--- a/aio/tests/deployment/e2e/redirection.e2e-spec.ts
+++ b/aio/tests/deployment/e2e/redirection.e2e-spec.ts
@@ -3,8 +3,9 @@ import { SitePage } from './site.po';
 
 describe(browser.baseUrl, () => {
   const page = new SitePage();
-  const getCurrentUrl = async () => (await browser.getCurrentUrl()).replace(/\?.*$/, '');
-  const prependBaseUrl = (url: string) => browser.baseUrl.replace(/\/$/, '') + url;
+  const getCurrentUrl = () => browser.getCurrentUrl().then(stripQuery).then(stripTrailingSlash);
+  const stripQuery = (url: string) => url.replace(/\?.*$/, '');
+  const stripTrailingSlash = (url: string) => url.replace(/\/$/, '');
 
   beforeAll(done => page.init().then(done));
 
@@ -16,7 +17,7 @@ describe(browser.baseUrl, () => {
       it(`should not redirect '${url}' (${i + 1}/${page.sitemapUrls.length})`, async () => {
         await page.goTo(url);
 
-        const expectedUrl = prependBaseUrl(url);
+        const expectedUrl = stripTrailingSlash(page.baseUrl + url);
         const actualUrl = await getCurrentUrl();
 
         expect(actualUrl).toBe(expectedUrl);
@@ -29,7 +30,7 @@ describe(browser.baseUrl, () => {
       it(`should redirect '${fromUrl}' to '${toUrl}' (${i + 1}/${page.legacyUrls.length})`, async () => {
         await page.goTo(fromUrl);
 
-        const expectedUrl = /^http/.test(toUrl) ? toUrl : prependBaseUrl(toUrl);
+        const expectedUrl = stripTrailingSlash(/^http/.test(toUrl) ? toUrl : page.baseUrl + toUrl);
         const actualUrl = await getCurrentUrl();
 
         expect(actualUrl).toBe(expectedUrl);
@@ -66,8 +67,8 @@ describe(browser.baseUrl, () => {
       expect(homeNavLink.isPresent()).toBe(true);
 
       await homeNavLink.click();
-      const expectedUrl = browser.baseUrl;
-      const actualUrl = await browser.getCurrentUrl();
+      const expectedUrl = page.baseUrl;
+      const actualUrl = await getCurrentUrl();
 
       expect(actualUrl).toBe(expectedUrl);
     });

--- a/aio/tests/deployment/e2e/redirection.e2e-spec.ts
+++ b/aio/tests/deployment/e2e/redirection.e2e-spec.ts
@@ -3,6 +3,8 @@ import { SitePage } from './site.po';
 
 describe(browser.baseUrl, () => {
   const page = new SitePage();
+  const getCurrentUrl = async () => (await browser.getCurrentUrl()).replace(/\?.*$/, '');
+  const prependBaseUrl = (url: string) => browser.baseUrl.replace(/\/$/, '') + url;
 
   beforeAll(done => page.init().then(done));
 
@@ -14,8 +16,8 @@ describe(browser.baseUrl, () => {
       it(`should not redirect '${url}' (${i + 1}/${page.sitemapUrls.length})`, async () => {
         await page.goTo(url);
 
-        const expectedUrl = browser.baseUrl + url;
-        const actualUrl = (await browser.getCurrentUrl()).replace(/\?.*$/, '');
+        const expectedUrl = prependBaseUrl(url);
+        const actualUrl = await getCurrentUrl();
 
         expect(actualUrl).toBe(expectedUrl);
       });
@@ -27,8 +29,8 @@ describe(browser.baseUrl, () => {
       it(`should redirect '${fromUrl}' to '${toUrl}' (${i + 1}/${page.legacyUrls.length})`, async () => {
         await page.goTo(fromUrl);
 
-        const expectedUrl = (/^http/.test(toUrl) ? '' : browser.baseUrl.replace(/\/$/, '')) + toUrl;
-        const actualUrl = (await browser.getCurrentUrl()).replace(/\?.*$/, '');
+        const expectedUrl = /^http/.test(toUrl) ? toUrl : prependBaseUrl(toUrl);
+        const actualUrl = await getCurrentUrl();
 
         expect(actualUrl).toBe(expectedUrl);
       });

--- a/aio/tests/deployment/e2e/site.po.ts
+++ b/aio/tests/deployment/e2e/site.po.ts
@@ -1,6 +1,9 @@
 import { browser, by, element, ExpectedConditions } from 'protractor';
 
 export class SitePage {
+  /** The base URL with the trailing `/` stripped off (if any). */
+  baseUrl = browser.baseUrl.replace(/\/$/, '');
+
   /** All URLs found in the app's `sitemap.xml` (i.e. valid URLs tha should not be redirected). */
   sitemapUrls: string[] = browser.params.sitemapUrls;
 
@@ -44,7 +47,7 @@ export class SitePage {
         .then(regs => Promise.all(regs.map(reg => reg.unregister())))
         .then(cb);
 
-    await browser.get(url || browser.baseUrl);
+    await browser.get(url || this.baseUrl);
     await browser.executeScript('document.body.classList.add(\'no-animations\')');
     await browser.executeAsyncScript(unregisterServiceWorker);
     await browser.waitForAngular();

--- a/aio/tests/deployment/shared/helpers.ts
+++ b/aio/tests/deployment/shared/helpers.ts
@@ -32,6 +32,7 @@ export function loadLocalSitemapUrls() {
 }
 
 export async function loadRemoteSitemapUrls(host: string) {
+  host = host.replace(/\/$/, '');
   const urlToSiteMap = `${host}/generated/sitemap.xml`;
   const get = /^https:/.test(host) ? httpsGet : httpGet;
 


### PR DESCRIPTION
Backporting #25641 to 6.1.x. This required backporting the [first commit][1] of #19795, which will eventually be backported to 6.1.x anyway.

[1]: https://github.com/angular/angular/pull/19795/commits/5ddc0106deb25721edc3aa23a61dab0bf71f778b