### PR TITLE
build: update to Node 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@
 ## IMPORTANT
 # If you change the `docker_image` version, also change the `cache_key` suffix and the version of
 # `com_github_bazelbuild_buildtools` in the `/WORKSPACE` file.
-var_1: &docker_image angular/ngcontainer:0.4.0
-var_2: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-bust1-0.4.0
+var_1: &docker_image angular/ngcontainer:0.5.0
+var_2: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.5.0
 
 # Define common ENV vars
 var_3: &define_env_vars

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: false
 dist: trusty
 node_js:
-  - '8.9.1'
+  - '10.9.0'
 
 addons:
 #  firefox: "38.0"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -114,6 +114,16 @@ See https://blog.bazel.build/2018/08/22/bazel-homebrew.html
 node_repositories(
   package_json = ["//:package.json"],
   preserve_symlinks = True,
+  node_version = "10.9.0",
+  yarn_version = "1.9.2",
+  node_repositories = {
+    "10.9.0-darwin_amd64": ("node-v10.9.0-darwin-x64.tar.gz", "node-v10.9.0-darwin-x64", "3c4fe75dacfcc495a432a7ba2dec9045cff359af2a5d7d0429c84a424ef686fc"),
+    "10.9.0-linux_amd64": ("node-v10.9.0-linux-x64.tar.xz", "node-v10.9.0-linux-x64", "c5acb8b7055ee0b6ac653dc4e458c5db45348cecc564b388f4ed1def84a329ff"),
+    "10.9.0-windows_amd64": ("node-v10.9.0-win-x64.zip", "node-v10.9.0-win-x64", "6a75cdbb69d62ed242d6cbf0238a470bcbf628567ee339d4d098a5efcda2401e"),
+  },
+  yarn_repositories = {
+    "1.9.2": ("yarn-v1.9.2.tar.gz", "yarn-v1.9.2", "3ad69cc7f68159a562c676e21998eb21b44138cae7e8fe0749a7d620cf940204"),
+  },
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/aio/package.json
+++ b/aio/package.json
@@ -63,8 +63,8 @@
     "post~~build": "yarn build-404-page"
   },
   "engines": {
-    "node": ">=8.9.1 <9.0.0",
-    "yarn": ">=1.3.2 <2.0.0"
+    "node": ">=10.9.0 <11.0.0",
+    "yarn": ">=1.9.2 <2.0.0"
   },
   "private": true,
   "dependencies": {

--- a/aio/tools/examples/shared/package.json
+++ b/aio/tools/examples/shared/package.json
@@ -11,8 +11,8 @@
     "postinstall": "yarn webdriver:update"
   },
   "engines": {
-    "node": ">=8.9.1 <9.0.0",
-    "yarn": ">=1.3.2 <2.0.0"
+    "node": ">=10.9.0 <11.0.0",
+    "yarn": ">=1.9.2 <2.0.0"
   },
   "keywords": [],
   "author": "",

--- a/aio/tools/examples/shared/yarn.lock
+++ b/aio/tools/examples/shared/yarn.lock
@@ -8485,8 +8485,8 @@ untildify@^3.0.2:
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-3.0.2.tgz#7f1f302055b3fea0f3e81dc78eb36766cb65e3f1"
 
 upath@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
 upper-case@^1.1.1:
   version "1.1.3"

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -10590,8 +10590,8 @@ unzip-response@^2.0.1:
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
 upath@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
 update-notifier@^0.5.0:
   version "0.5.0"

--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -3,7 +3,6 @@ workspace(name = "bazel_integration_test")
 #
 # Download Bazel toolchain dependencies as needed by build actions
 #
-
 local_repository(
     name = "build_bazel_rules_typescript",
     path = "node_modules/@bazel/typescript",
@@ -39,7 +38,19 @@ local_repository(
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories")
 
 check_bazel_version("0.16.0")
-node_repositories(package_json = ["//:package.json"])
+node_repositories(
+    package_json = ["//:package.json"],
+  node_version = "10.9.0",
+  yarn_version = "1.9.2",
+  node_repositories = {
+    "10.9.0-darwin_amd64": ("node-v10.9.0-darwin-x64.tar.gz", "node-v10.9.0-darwin-x64", "3c4fe75dacfcc495a432a7ba2dec9045cff359af2a5d7d0429c84a424ef686fc"),
+    "10.9.0-linux_amd64": ("node-v10.9.0-linux-x64.tar.xz", "node-v10.9.0-linux-x64", "c5acb8b7055ee0b6ac653dc4e458c5db45348cecc564b388f4ed1def84a329ff"),
+    "10.9.0-windows_amd64": ("node-v10.9.0-win-x64.zip", "node-v10.9.0-win-x64", "6a75cdbb69d62ed242d6cbf0238a470bcbf628567ee339d4d098a5efcda2401e"),
+  },
+  yarn_repositories = {
+    "1.9.2": ("yarn-v1.9.2.tar.gz", "yarn-v1.9.2", "3ad69cc7f68159a562c676e21998eb21b44138cae7e8fe0749a7d620cf940204"),
+  },
+)
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 

--- a/integration/cli-hello-world/yarn.lock
+++ b/integration/cli-hello-world/yarn.lock
@@ -6711,8 +6711,8 @@ unset-value@^1.0.0:
     isobject "^3.0.0"
 
 upath@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
 upper-case@^1.1.1:
   version "1.1.3"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "bugs": "https://github.com/angular/angular/issues",
   "license": "MIT",
   "engines": {
-    "node": ">=8.9.1 <9.0.0",
-    "yarn": ">=1.3.2 <2.0.0"
+    "node": ">=10.9.0 <11.0.0",
+    "yarn": ">=1.9.2 <2.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -172,7 +172,7 @@ describe('ngc transformer command-line', () => {
       const exitCode = main(['-p', 'not-exist'], errorSpy);
       expect(errorSpy).toHaveBeenCalledTimes(1);
       expect(errorSpy.calls.mostRecent().args[0]).toContain('no such file or directory');
-      expect(errorSpy.calls.mostRecent().args[0]).toContain('at Object.fs.lstatSync');
+      expect(errorSpy.calls.mostRecent().args[0]).toMatch(/at Object\.(fs\.)?lstatSync/);
       expect(exitCode).toEqual(2);
     });
 

--- a/scripts/ci/env.sh
+++ b/scripts/ci/env.sh
@@ -34,8 +34,8 @@ fi
 #    CUSTOM GLOBALS   #
 #######################
 
-setEnvVar NODE_VERSION 8.9.1
-setEnvVar YARN_VERSION 1.3.2
+setEnvVar NODE_VERSION 10.9.0
+setEnvVar YARN_VERSION 1.9.2
 # Pin to a Chromium version that does not cause the aio e2e tests to flake. (See https://github.com/angular/angular/pull/20403.)
 # Revision 494239 (which was part of Chrome 62.0.3186.0) is the last version that does not cause flakes. (Latest revision checked: 508578)
 setEnvVar CHROMIUM_VERSION 561733 # Chrome 68 linux stable, see https://www.chromium.org/developers/calendar

--- a/tools/check-environment.js
+++ b/tools/check-environment.js
@@ -22,11 +22,6 @@ var checkNodeModules;
 var semver;
 var issues = [];
 
-// coarse Node version check
-if (+process.version[1] < 5) {
-  issues.push('Angular build currently requires Node 5+. Use nvm to update your node version.');
-}
-
 try {
   semver = require('semver');
 } catch (e) {

--- a/tools/ngcontainer/Dockerfile
+++ b/tools/ngcontainer/Dockerfile
@@ -3,23 +3,9 @@ FROM circleci/node:10.9.0-browsers
 USER root
 
 ###
-# Java install
-# See https://github.com/docker-library/openjdk/blob/415b0cc42d91ef5d70597d8a24d942967728242b/8-jdk/Dockerfile
-# see https://bugs.debian.org/775775
-# and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-RUN JAVA_DEBIAN_VERSION="8u131-b11-1~bpo8+1" \
- && CA_CERTIFICATES_JAVA_VERSION="20161107~bpo8+1" \
- && echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list \
- && apt-get update \
- && apt-get install -y \
-    openjdk-8-jre-headless="$JAVA_DEBIAN_VERSION" \
-    ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
- && rm -rf /var/lib/apt/lists/*
-
-###
 # Bazel install
 # See https://bazel.build/versions/master/docs/install-ubuntu.html#using-bazel-custom-apt-repository-recommended
-RUN BAZEL_VERSION="0.16.0" \
+RUN BAZEL_VERSION="0.16.1" \
  && wget -q -O - https://bazel.build/bazel-release.pub.gpg | apt-key add - \
  && echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/bazel.list \
  && apt-get update \

--- a/tools/ngcontainer/README.md
+++ b/tools/ngcontainer/README.md
@@ -6,7 +6,7 @@ This docker container provides everything needed to build and test Angular appli
 - npm 6.2.0
 - yarn 1.9.2
 - Java 8 (for Closure Compiler and Bazel)
-- Bazel build tool v0.16.0 - http://bazel.build
+- Bazel build tool v0.16.1 - http://bazel.build
 - Google Chrome 69.0.3497.81
 - Mozilla Firefox 47.0.1
 - xvfb (virtual framebuffer) for headless testing


### PR DESCRIPTION
Note, this also fixes an error in the ngcontainer which didn't build - the jre is already included in the new base image.