### PR TITLE
refactor(ivy): migrate previousOrParentNode to use TNodes

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -111,7 +111,7 @@ export function renderComponent<T>(
       componentDef.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways);
   rootView[INJECTOR] = opts.injector || null;
 
-  const oldView = enterView(rootView, null !);
+  const oldView = enterView(rootView, null);
   let elementNode: LElementNode;
   let component: T;
   try {
@@ -121,7 +121,7 @@ export function renderComponent<T>(
     elementNode = hostElement(componentTag, hostNode, componentDef, sanitizer);
 
     // Create directive instance with factory() and store at index 0 in directives array
-    component = baseDirectiveCreate(0, componentDef.factory() as T, componentDef);
+    component = baseDirectiveCreate(0, componentDef.factory() as T, componentDef, elementNode);
     if (componentDef.hostBindings) {
       queueHostBindingForCheck(0, componentDef.hostVars);
     }

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -126,7 +126,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
     rootView[INJECTOR] = ngModule && ngModule.injector || null;
 
     // rootView is the parent when bootstrapping
-    const oldView = enterView(rootView, null !);
+    const oldView = enterView(rootView, null);
 
     let component: T;
     let elementNode: LElementNode;
@@ -137,7 +137,8 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
       elementNode = hostElement(componentTag, hostNode, this.componentDef);
 
       // Create directive instance with factory() and store at index 0 in directives array
-      component = baseDirectiveCreate(0, this.componentDef.factory(), this.componentDef);
+      component =
+          baseDirectiveCreate(0, this.componentDef.factory(), this.componentDef, elementNode);
       if (this.componentDef.hostBindings) {
         queueHostBindingForCheck(0, this.componentDef.hostVars);
       }

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -12,7 +12,7 @@ import {Sanitizer} from '../../sanitization/security';
 
 import {LContainer} from './container';
 import {ComponentQuery, ComponentTemplate, DirectiveDefInternal, DirectiveDefList, PipeDefInternal, PipeDefList} from './definition';
-import {LElementNode, LViewNode, TNode} from './node';
+import {LElementNode, LViewNode, TElementNode, TNode, TViewNode} from './node';
 import {LQueries} from './query';
 import {Renderer3} from './renderer';
 
@@ -277,9 +277,15 @@ export interface TView {
    * We need this pointer to be able to efficiently find this node when inserting the view
    * into an anchor.
    *
-   * If this is a `TNode` for an `LElementNode`, this is the TView of a component.
+   * If this is a `TElementNode`, this is the view of a root component. It has exactly one
+   * root TNode.
+   *
+   * If this is null, this is the view of a component that is not at root. We do not store
+   * the host TNodes for child component views because they can potentially have several
+   * different host TNodes, depending on where the component is being used. These host
+   * TNodes cannot be shared (due to different indices, etc).
    */
-  node: TNode;
+  node: TViewNode|TElementNode|null;
 
   /** Whether or not this template has been processed. */
   firstTemplatePass: boolean;

--- a/packages/core/src/render3/node_assert.ts
+++ b/packages/core/src/render3/node_assert.ts
@@ -7,19 +7,19 @@
  */
 
 import {assertDefined, assertEqual} from './assert';
-import {LNode, TNodeType} from './interfaces/node';
+import {LNode, TNode, TNodeType} from './interfaces/node';
 
-export function assertNodeType(node: LNode, type: TNodeType) {
-  assertDefined(node, 'should be called with a node');
-  assertEqual(node.tNode.type, type, `should be a ${typeName(type)}`);
+export function assertNodeType(tNode: TNode, type: TNodeType) {
+  assertDefined(tNode, 'should be called with a TNode');
+  assertEqual(tNode.type, type, `should be a ${typeName(type)}`);
 }
 
-export function assertNodeOfPossibleTypes(node: LNode, ...types: TNodeType[]) {
-  assertDefined(node, 'should be called with a node');
-  const found = types.some(type => node.tNode.type === type);
+export function assertNodeOfPossibleTypes(tNode: TNode, ...types: TNodeType[]) {
+  assertDefined(tNode, 'should be called with a TNode');
+  const found = types.some(type => tNode.type === type);
   assertEqual(
       found, true,
-      `Should be one of ${types.map(typeName).join(', ')} but got ${typeName(node.tNode.type)}`);
+      `Should be one of ${types.map(typeName).join(', ')} but got ${typeName(tNode.type)}`);
 }
 
 function typeName(type: TNodeType): string {

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -13,7 +13,7 @@ import {LContainer, RENDER_PARENT, VIEWS, unusedValueExportToPlacateAjd as unuse
 import {LContainerNode, LElementContainerNode, LElementNode, LNode, LProjectionNode, LTextNode, LViewNode, TNode, TNodeFlags, TNodeType, unusedValueExportToPlacateAjd as unused2} from './interfaces/node';
 import {unusedValueExportToPlacateAjd as unused3} from './interfaces/projection';
 import {ProceduralRenderer3, RComment, RElement, RNode, RText, Renderer3, isProceduralRenderer, unusedValueExportToPlacateAjd as unused4} from './interfaces/renderer';
-import {CLEANUP, CONTAINER_INDEX, DIRECTIVES, FLAGS, HEADER_OFFSET, HOST_NODE, HookData, LViewData, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, TVIEW, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
+import {CLEANUP, CONTAINER_INDEX, DECLARATION_VIEW, DIRECTIVES, FLAGS, HEADER_OFFSET, HOST_NODE, HookData, LViewData, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, TVIEW, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
 import {readElementValue, stringify} from './util';
 
@@ -194,7 +194,7 @@ export function findComponentHost(lViewData: LViewData): LElementNode {
     viewRootLNode = lViewData[HOST_NODE];
   }
 
-  ngDevMode && assertNodeType(viewRootLNode, TNodeType.Element);
+  ngDevMode && assertNodeType(viewRootLNode.tNode, TNodeType.Element);
   ngDevMode && assertDefined(viewRootLNode.data, 'node.data');
 
   return viewRootLNode as LElementNode;
@@ -246,8 +246,8 @@ export function addRemoveViewFromContainer(
 export function addRemoveViewFromContainer(
     container: LContainerNode, rootNode: LViewNode, insertMode: boolean,
     beforeNode?: RNode | null): void {
-  ngDevMode && assertNodeType(container, TNodeType.Container);
-  ngDevMode && assertNodeType(rootNode, TNodeType.View);
+  ngDevMode && assertNodeType(container.tNode, TNodeType.Container);
+  ngDevMode && assertNodeType(rootNode.tNode, TNodeType.View);
   const parentNode = container.data[RENDER_PARENT];
   const parent = parentNode ? parentNode.native : null;
   if (parent) {
@@ -544,7 +544,7 @@ function canInsertNativeChildOfElement(parent: LElementNode, currentView: LViewD
  * the container itself has it render parent determined.
  */
 function canInsertNativeChildOfView(parent: LViewNode): boolean {
-  ngDevMode && assertNodeType(parent, TNodeType.View);
+  ngDevMode && assertNodeType(parent.tNode, TNodeType.View);
 
   // Because we are inserting into a `View` the `View` may be disconnected.
   const grandParentContainer = getParentLNode(parent) as LContainerNode;
@@ -552,7 +552,7 @@ function canInsertNativeChildOfView(parent: LViewNode): boolean {
     // The `View` is not inserted into a `Container` we have to delay insertion.
     return false;
   }
-  ngDevMode && assertNodeType(grandParentContainer, TNodeType.Container);
+  ngDevMode && assertNodeType(grandParentContainer.tNode, TNodeType.Container);
   if (grandParentContainer.data[RENDER_PARENT] == null) {
     // The parent `Container` itself is disconnected. So we have to delay.
     return false;
@@ -584,7 +584,7 @@ function canInsertNativeChildOfView(parent: LViewNode): boolean {
 export function canInsertNativeNode(parent: LNode, currentView: LViewData): boolean {
   // We can only insert into a Component or View. Any other type should be an Error.
   ngDevMode && assertNodeOfPossibleTypes(
-                   parent, TNodeType.Element, TNodeType.ElementContainer, TNodeType.View);
+                   parent.tNode, TNodeType.Element, TNodeType.ElementContainer, TNodeType.View);
 
   if (parent.tNode.type === TNodeType.Element) {
     // Parent is a regular element or a component

--- a/packages/core/src/render3/util.ts
+++ b/packages/core/src/render3/util.ts
@@ -8,7 +8,7 @@
 import {devModeEqual} from '../change_detection/change_detection_util';
 import {assertLessThan} from './assert';
 import {LElementNode} from './interfaces/node';
-import {HEADER_OFFSET, LViewData} from './interfaces/view';
+import {HEADER_OFFSET, LViewData, TData} from './interfaces/view';
 
 /**
  * Returns wether the values are different from a change detection stand point.
@@ -66,8 +66,8 @@ export function flatten(list: any[]): any[] {
   return result;
 }
 
-/** Retrieves a value from any `LViewData`. */
-export function loadInternal<T>(index: number, arr: LViewData): T {
+/** Retrieves a value from any `LViewData` or `TData`. */
+export function loadInternal<T>(index: number, arr: LViewData | TData): T {
   ngDevMode && assertDataInRangeInternal(index + HEADER_OFFSET, arr);
   return arr[index + HEADER_OFFSET];
 }

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -1722,6 +1722,9 @@
     "name": "getPreviousOrParentNode"
   },
   {
+    "name": "getPreviousOrParentTNode"
+  },
+  {
     "name": "getPromiseCtor"
   },
   {

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -1501,7 +1501,7 @@ describe('di', () => {
     it('should handle initial undefined state', () => {
       const contentView = createLViewData(
           null !, createTView(-1, null, 1, 0, null, null, null), null, LViewFlags.CheckAlways);
-      const oldView = enterView(contentView, null !);
+      const oldView = enterView(contentView, null);
       try {
         const parent = createLNode(0, TNodeType.Element, null, null, null, null);
 


### PR DESCRIPTION
This PR moves us off of saving `LNode` instances in `previousOrParentNode`, as part of a larger effort to remove reliance on `LNode` and reduce memory pressure. 

In its place, we now have `previousOrParentTNode`, which stores the last `TNode`. Most of the time, we're using the `TNode` anyway, but for those cases where we aren't, it's possible to look the `LNode` up (and these cases should continue to decrease in follow-up PRs). This PR also paves the way for removing the `LNode.tNode` property, which was heavily used as `previousOrParentNode.tNode`.

Still TODO:
- Remove `LNode.tNode`