### PR TITLE
fix(router): better ngZone checking for warning

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -491,7 +491,7 @@ export class Router {
     this.ngModule = injector.get(NgModuleRef);
     this.console = injector.get(Console);
     const ngZone = injector.get(NgZone);
-    this.isNgZoneEnabled = ngZone instanceof NgZone;
+    this.isNgZoneEnabled = ngZone instanceof NgZone && NgZone.isInAngularZone();
 
     this.resetConfig(config);
     this.currentUrlTree = createEmptyUrlTree();

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -306,7 +306,9 @@ describe('Integration', () => {
   });
 
   describe('navigation warning', () => {
+    const isInAngularZoneFn = NgZone.isInAngularZone;
     let warnings: string[] = [];
+    let isInAngularZone = true;
 
     class MockConsole {
       warn(message: string) {
@@ -316,15 +318,20 @@ describe('Integration', () => {
 
     beforeEach(() => {
       warnings = [];
+      isInAngularZone = true;
+      NgZone.isInAngularZone = () => isInAngularZone;
       TestBed.overrideProvider(Console, {useValue: new MockConsole()});
+    });
+
+    afterEach(() => {
+      NgZone.isInAngularZone = isInAngularZoneFn;
     });
 
     describe('with NgZone enabled', () => {
       it('should warn when triggered outside Angular zone',
-         fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-           ngZone.runOutsideAngular(() => {
-             router.navigateByUrl('/simple');
-           });
+         fakeAsync(inject([Router], (router: Router) => {
+           isInAngularZone = false;
+           router.navigateByUrl('/simple');
 
            expect(warnings.length).toBe(1);
            expect(warnings[0])
@@ -333,10 +340,8 @@ describe('Integration', () => {
          })));
 
       it('should not warn when triggered inside Angular zone',
-         fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-           ngZone.run(() => {
-             router.navigateByUrl('/simple');
-           });
+         fakeAsync(inject([Router], (router: Router) => {
+           router.navigateByUrl('/simple');
 
            expect(warnings.length).toBe(0);
          })));
@@ -348,10 +353,9 @@ describe('Integration', () => {
       });
 
       it('should not warn when triggered outside Angular zone',
-         fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-           ngZone.runOutsideAngular(() => {
-             router.navigateByUrl('/simple');
-           });
+         fakeAsync(inject([Router], (router: Router) => {
+           isInAngularZone = false;
+           router.navigateByUrl('/simple');
 
            expect(warnings.length).toBe(0);
          })));


### PR DESCRIPTION
Closes #25837

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/25837

`NgZone.isInAngularZone()` results to `false` in testing, and cause warning.

## What is the new behavior?

Checking `NgZone.isInAngularZone()` when constructing `Router`, considering `NgZone` not enabled when result being `false`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
