### PR TITLE
fix(router): evaluate routerLinkActive state when routerLink changes

### DIFF
--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -104,8 +104,17 @@ export class RouterLinkActive implements OnChanges,
 
 
   ngAfterContentInit(): void {
-    this.links.changes.subscribe(_ => this.update());
-    this.linksWithHrefs.changes.subscribe(_ => this.update());
+    this.links.changes.subscribe(_ => {
+      this.connectWithContentChildrenLinks();
+      this.update();
+    });
+    this.linksWithHrefs.changes.subscribe(_ => {
+      this.connectWithContentChildrenLinks();
+      this.update();
+    });
+
+    this.connectWithInjectedLinks();
+    this.connectWithContentChildrenLinks();
     this.update();
   }
 
@@ -118,7 +127,8 @@ export class RouterLinkActive implements OnChanges,
   ngOnChanges(changes: SimpleChanges): void { this.update(); }
   ngOnDestroy(): void { this.subscription.unsubscribe(); }
 
-  private update(): void {
+  /** @internal */
+  update(): void {
     if (!this.links || !this.linksWithHrefs || !this.router.navigated) return;
     Promise.resolve().then(() => {
       const hasActiveLinks = this.hasActiveLinks();
@@ -133,6 +143,16 @@ export class RouterLinkActive implements OnChanges,
         });
       }
     });
+  }
+
+  private connectWithInjectedLinks() {
+    if (this.link) this.link.addRouterLinkActive(this);
+    if (this.linkWithHref) this.linkWithHref.addRouterLinkActive(this);
+  }
+
+  private connectWithContentChildrenLinks() {
+    this.links.forEach(link => link.addRouterLinkActive(this));
+    this.linksWithHrefs.forEach(linkWithHref => linkWithHref.addRouterLinkActive(this));
   }
 
   private isLinkActive(router: Router): (link: (RouterLink|RouterLinkWithHref)) => boolean {

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -366,7 +366,7 @@ export declare class RouterEvent {
     url: string);
 }
 
-export declare class RouterLink {
+export declare class RouterLink implements OnChanges {
     fragment: string;
     preserveFragment: boolean;
     /** @deprecated */ preserveQueryParams: boolean;
@@ -382,6 +382,7 @@ export declare class RouterLink {
     };
     readonly urlTree: UrlTree;
     constructor(router: Router, route: ActivatedRoute, tabIndex: string, renderer: Renderer2, el: ElementRef);
+    ngOnChanges(changes: SimpleChanges): void;
     onClick(): boolean;
 }
 
@@ -417,7 +418,7 @@ export declare class RouterLinkWithHref implements OnChanges, OnDestroy {
     target: string;
     readonly urlTree: UrlTree;
     constructor(router: Router, route: ActivatedRoute, locationStrategy: LocationStrategy);
-    ngOnChanges(changes: {}): any;
+    ngOnChanges(changes: SimpleChanges): any;
     ngOnDestroy(): any;
     onClick(button: number, ctrlKey: boolean, metaKey: boolean, shiftKey: boolean): boolean;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
[routerLink] with async/observable property assignment does not re-evaluate [routerLinkActive] when the observable emits a new value.

Issue Number: #13865


## What is the new behavior?
When the value emitted to [routerLink] changes, [routerLinkActive] re-evaluate against the newly emitted value whether or not the link is "active."

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
