### PR TITLE
feat(service-worker): handle 'notificationclick' events

### DIFF
--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -52,8 +52,6 @@ interface StatusEvent {
   error?: string;
 }
 
-export interface NotificationObject extends NotificationOptions { title: string; }
-
 
 function errorObservable(message: string): Observable<any> {
   return defer(() => throwError(new Error(message)));

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -52,9 +52,7 @@ interface StatusEvent {
   error?: string;
 }
 
-export interface NotificationObject extends NotificationOptions {
-  title: string; 
-}
+export interface NotificationObject extends NotificationOptions { title: string; }
 
 
 function errorObservable(message: string): Observable<any> {

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -52,6 +52,10 @@ interface StatusEvent {
   error?: string;
 }
 
+export interface NotificationObject extends NotificationOptions {
+  title: string; 
+}
+
 
 function errorObservable(message: string): Observable<any> {
   return defer(() => throwError(new Error(message)));

--- a/packages/service-worker/src/push.ts
+++ b/packages/service-worker/src/push.ts
@@ -27,15 +27,14 @@ export class SwPush {
 
   /**
    * Emits the payloads of the received push notification messages as well as the action the user
-   * interacted with.
-   * If no action was used the action property will be an empty string `''`.
+   * interacted with. If no action was used the action property will be an empty string `''`.
    *
-   * Note that the `notification` property is **not** a
-   * [Notification](https://developer.mozilla.org/en-US/docs/Web/API/Notification) object but rather
-   * a
+   * Note that the `notification` property is **not** a [Notification][Mozilla Notification] object
+   * but rather a
    * [NotificationOptions](https://notifications.spec.whatwg.org/#dictdef-notificationoptions)
-   * object that also includes the `title` of the
-   * [Notification](https://developer.mozilla.org/en-US/docs/Web/API/Notification) object.
+   * object that also includes the `title` of the [Notification][Mozilla Notification] object.
+   *
+   * [Mozilla Notification]: https://developer.mozilla.org/en-US/docs/Web/API/Notification
    */
   readonly notificationClicks: Observable < {
     action: string;

--- a/packages/service-worker/src/push.ts
+++ b/packages/service-worker/src/push.ts
@@ -10,7 +10,7 @@ import {Injectable} from '@angular/core';
 import {NEVER, Observable, Subject, merge} from 'rxjs';
 import {map, switchMap, take} from 'rxjs/operators';
 
-import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, NotificationObject, PushEvent} from './low_level';
+import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, PushEvent} from './low_level';
 
 
 /**
@@ -30,14 +30,16 @@ export class SwPush {
    * interacted with.
    * If no action was used the action property will be an empty string `''`.
    *
-   * Note that the `notification` property is __not__ a
-   * [Notification](https://developer.mozilla.org/en-US/docs/Web/API/Notification) but rather a
+   * Note that the `notification` property is **not** a
+   * [Notification](https://developer.mozilla.org/en-US/docs/Web/API/Notification) object but rather
+   * a
    * [NotificationOptions](https://notifications.spec.whatwg.org/#dictdef-notificationoptions)
-   * object that also includes the notification `title`.
+   * object that also includes the `title` of the
+   * [Notification](https://developer.mozilla.org/en-US/docs/Web/API/Notification) object.
    */
-  readonly messagesClicked: Observable < {
+  readonly notificationClicks: Observable < {
     action: string;
-    notification: NotificationObject
+    notification: NotificationOptions&{ title: string }
   }
   > ;
 
@@ -61,14 +63,14 @@ export class SwPush {
   constructor(private sw: NgswCommChannel) {
     if (!sw.isEnabled) {
       this.messages = NEVER;
-      this.messagesClicked = NEVER;
+      this.notificationClicks = NEVER;
       this.subscription = NEVER;
       return;
     }
 
     this.messages = this.sw.eventsOfType<PushEvent>('PUSH').pipe(map(message => message.data));
 
-    this.messagesClicked =
+    this.notificationClicks =
         this.sw.eventsOfType('NOTIFICATION_CLICK').pipe(map((message: any) => message.data));
 
     this.pushManager = this.sw.registration.pipe(map(registration => registration.pushManager));

--- a/packages/service-worker/src/push.ts
+++ b/packages/service-worker/src/push.ts
@@ -10,7 +10,7 @@ import {Injectable} from '@angular/core';
 import {NEVER, Observable, Subject, merge} from 'rxjs';
 import {map, switchMap, take} from 'rxjs/operators';
 
-import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, PushEvent} from './low_level';
+import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, NotificationObject, PushEvent} from './low_level';
 
 
 /**
@@ -25,7 +25,21 @@ export class SwPush {
    */
   readonly messages: Observable<object>;
 
-  readonly messagesClicked: Observable<object>;
+  /**
+   * Emits the payloads of the received push notification messages as well as the action the user
+   * interacted with.
+   * If no action was used the action property will be an empty string `''`.
+   *
+   * Note that the `notification` property is __not__ a
+   * [Notification](https://developer.mozilla.org/en-US/docs/Web/API/Notification) but rather a
+   * [NotificationOptions](https://notifications.spec.whatwg.org/#dictdef-notificationoptions)
+   * object that also includes the notification `title`.
+   */
+  readonly messagesClicked: Observable < {
+    action: string;
+    notification: NotificationObject
+  }
+  > ;
 
   /**
    * Emits the currently active

--- a/packages/service-worker/src/push.ts
+++ b/packages/service-worker/src/push.ts
@@ -25,6 +25,8 @@ export class SwPush {
    */
   readonly messages: Observable<object>;
 
+  readonly messagesClicked: Observable<object>;
+
   /**
    * Emits the currently active
    * [PushSubscription](https://developer.mozilla.org/en-US/docs/Web/API/PushSubscription)
@@ -45,11 +47,15 @@ export class SwPush {
   constructor(private sw: NgswCommChannel) {
     if (!sw.isEnabled) {
       this.messages = NEVER;
+      this.messagesClicked = NEVER;
       this.subscription = NEVER;
       return;
     }
 
     this.messages = this.sw.eventsOfType<PushEvent>('PUSH').pipe(map(message => message.data));
+
+    this.messagesClicked =
+        this.sw.eventsOfType('NOTIFICATION_CLICK').pipe(map((message: any) => message.data));
 
     this.pushManager = this.sw.registration.pipe(map(registration => registration.pushManager));
 

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -313,7 +313,7 @@ import {async_fit, async_it} from './async';
               (msg: {message: string}) => receivedMessages.push(msg.message));
 
           sendMessage('NOTIFICATION_CLICK', 'this was a click');
-          sendMessage('NOT_OTIFICATION_CLICK', 'this was not a click');
+          sendMessage('NOT_IFICATION_CLICK', 'this was not a click');
           sendMessage('NOTIFICATION_CLICK', 'this was a click too');
           sendMessage('KCILC_NOITACIFITON', 'this was a KCILC_NOITACIFITON message');
 

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -303,6 +303,26 @@ import {async_fit, async_it} from './async';
           ]);
         });
       });
+      describe('messagesClicked', () => {
+        it('receives notification clicked messages', () => {
+          const sendMessage = (type: string, message: string) =>
+              mock.sendMessage({type, data: {message}});
+
+          const receivedMessages: string[] = [];
+          push.messagesClicked.subscribe(
+              (msg: {message: string}) => receivedMessages.push(msg.message));
+
+          sendMessage('NOTIFICATION_CLICK', 'this was a click');
+          sendMessage('NOT_OTIFICATION_CLICK', 'this was not a click');
+          sendMessage('NOTIFICATION_CLICK', 'this was a click too');
+          sendMessage('KCILC_NOITACIFITON', 'this was a KCILC_NOITACIFITON message');
+
+          expect(receivedMessages).toEqual([
+            'this was a click',
+            'this was a click too',
+          ]);
+        });
+      });
 
       describe('subscription', () => {
         let nextSubEmitResolve: () => void;
@@ -367,6 +387,7 @@ import {async_fit, async_it} from './async';
 
         it('does not crash on subscription to observables', () => {
           push.messages.toPromise().catch(err => fail(err));
+          push.messagesClicked.toPromise().catch(err => fail(err));
           push.subscription.toPromise().catch(err => fail(err));
         });
 

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -304,13 +304,13 @@ import {async_fit, async_it} from './async';
         });
       });
 
-      describe('messagesClicked', () => {
+      describe('notificationClicks', () => {
         it('receives notification clicked messages', () => {
           const sendMessage = (type: string, action: string) =>
               mock.sendMessage({type, data: {action}});
 
           const receivedMessages: string[] = [];
-          push.messagesClicked.subscribe(
+          push.notificationClicks.subscribe(
               (msg: {action: string}) => receivedMessages.push(msg.action));
 
           sendMessage('NOTIFICATION_CLICK', 'this was a click');
@@ -388,7 +388,7 @@ import {async_fit, async_it} from './async';
 
         it('does not crash on subscription to observables', () => {
           push.messages.toPromise().catch(err => fail(err));
-          push.messagesClicked.toPromise().catch(err => fail(err));
+          push.notificationClicks.toPromise().catch(err => fail(err));
           push.subscription.toPromise().catch(err => fail(err));
         });
 

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -303,14 +303,15 @@ import {async_fit, async_it} from './async';
           ]);
         });
       });
+
       describe('messagesClicked', () => {
         it('receives notification clicked messages', () => {
-          const sendMessage = (type: string, message: string) =>
-              mock.sendMessage({type, data: {message}});
+          const sendMessage = (type: string, action: string) =>
+              mock.sendMessage({type, data: {action}});
 
           const receivedMessages: string[] = [];
           push.messagesClicked.subscribe(
-              (msg: {message: string}) => receivedMessages.push(msg.message));
+              (msg: {action: string}) => receivedMessages.push(msg.action));
 
           sendMessage('NOTIFICATION_CLICK', 'this was a click');
           sendMessage('NOT_IFICATION_CLICK', 'this was not a click');

--- a/packages/service-worker/test/integration_spec.ts
+++ b/packages/service-worker/test/integration_spec.ts
@@ -88,7 +88,7 @@ const serverUpdate =
       scope.clients.getMock('default') !.queue.subscribe(msg => { mock.sendMessage(msg); });
 
       mock.messages.subscribe(msg => { scope.handleMessage(msg, 'default'); });
-      mock.messagesClicked.subscribe(msg => { scope.handleMessage(msg, 'default'); });
+      mock.notificationClicks.subscribe(msg => { scope.handleMessage(msg, 'default'); });
 
       mock.setupSw();
       reg = mock.mockRegistration !;
@@ -135,7 +135,7 @@ const serverUpdate =
       scope.updateServerState(serverUpdate);
 
       const gotNotificationClick = (async() => {
-        const event: any = await obsToSinglePromise(push.messagesClicked);
+        const event: any = await obsToSinglePromise(push.notificationClicks);
         expect(event.action).toEqual('clicked');
         expect(event.notification.title).toEqual('This is a test');
       })();

--- a/packages/service-worker/test/integration_spec.ts
+++ b/packages/service-worker/test/integration_spec.ts
@@ -88,6 +88,7 @@ const serverUpdate =
       scope.clients.getMock('default') !.queue.subscribe(msg => { mock.sendMessage(msg); });
 
       mock.messages.subscribe(msg => { scope.handleMessage(msg, 'default'); });
+      mock.messagesClicked.subscribe(msg => { scope.handleMessage(msg, 'default'); });
 
       mock.setupSw();
       reg = mock.mockRegistration !;
@@ -127,6 +128,19 @@ const serverUpdate =
         test: 'success',
       });
       await gotPushNotice;
+    });
+
+    async_it('receives push message click events', async() => {
+      const push = new SwPush(comm);
+      scope.updateServerState(serverUpdate);
+
+      const gotNotificationClick = (async() => {
+        const event = await obsToSinglePromise(push.messagesClicked);
+        expect(event).toEqual({action: 'clicked', notification: {clicked: true}});
+      })();
+
+      await scope.handleClick({clicked: true}, 'clicked');
+      await gotNotificationClick;
     });
   });
 })();

--- a/packages/service-worker/test/integration_spec.ts
+++ b/packages/service-worker/test/integration_spec.ts
@@ -135,11 +135,12 @@ const serverUpdate =
       scope.updateServerState(serverUpdate);
 
       const gotNotificationClick = (async() => {
-        const event = await obsToSinglePromise(push.messagesClicked);
-        expect(event).toEqual({action: 'clicked', notification: {clicked: true}});
+        const event: any = await obsToSinglePromise(push.messagesClicked);
+        expect(event.action).toEqual('clicked');
+        expect(event.notification.title).toEqual('This is a test');
       })();
 
-      await scope.handleClick({clicked: true}, 'clicked');
+      await scope.handleClick({title: 'This is a test'}, 'clicked');
       await gotNotificationClick;
     });
   });

--- a/packages/service-worker/testing/mock.ts
+++ b/packages/service-worker/testing/mock.ts
@@ -28,7 +28,7 @@ export class MockServiceWorkerContainer {
   mockRegistration: MockServiceWorkerRegistration|null = null;
   controller: MockServiceWorker|null = null;
   messages = new Subject();
-  messagesClicked = new Subject();
+  notificationClicks = new Subject();
 
   addEventListener(event: 'controllerchange'|'message', handler: Function) {
     if (event === 'controllerchange') {

--- a/packages/service-worker/testing/mock.ts
+++ b/packages/service-worker/testing/mock.ts
@@ -28,6 +28,7 @@ export class MockServiceWorkerContainer {
   mockRegistration: MockServiceWorkerRegistration|null = null;
   controller: MockServiceWorker|null = null;
   messages = new Subject();
+  messagesClicked = new Subject();
 
   addEventListener(event: 'controllerchange'|'message', handler: Function) {
     if (event === 'controllerchange') {

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -29,13 +29,9 @@ const IDLE_THRESHOLD = 5000;
 
 const SUPPORTED_CONFIG_VERSION = 1;
 
-const NOTIFICATION_OPTION_NAMES = [
-  'actions', 'badge', 'body', 'dir', 'icon', 'lang', 'renotify', 'requireInteraction', 'tag',
-  'vibrate', 'data'
-];
-const NOTIFICATION_CLICK_OPTION_NAMES = [
-  'actions', 'badge', 'title', 'body', 'dir', 'icon', 'image', 'lang', 'renotify',
-  'requireInteraction', 'tag', 'timestamp', 'vibrate', 'data'
+const NOTIFICATION_OPTION_NAMES: (keyof Notification)[] = [
+  'actions', 'badge', 'body', 'data', 'dir', 'icon', 'image', 'lang', 'renotify',
+  'requireInteraction', 'silent', 'tag', 'timestamp', 'title', 'vibrate'
 ];
 
 interface LatestEntry {
@@ -312,10 +308,9 @@ export class Driver implements Debuggable, UpdateSource {
   private async handleClick(notification: Notification, action?: string): Promise<void> {
     notification.close();
 
-    const desc = notification as any;
-    let options: {[key: string]: string | undefined} = {};
-    NOTIFICATION_CLICK_OPTION_NAMES.filter(name => desc.hasOwnProperty(name))
-        .forEach(name => options[name] = desc[name]);
+    const options: {-readonly[K in keyof Notification]?: Notification[K]} = {};
+    NOTIFICATION_OPTION_NAMES.filter(name => name in notification)
+        .forEach(name => options[name] = notification[name]);
 
     await this.broadcast({
       type: 'NOTIFICATION_CLICK',

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -309,6 +309,8 @@ export class Driver implements Debuggable, UpdateSource {
     notification.close();
 
     const options: {-readonly[K in keyof Notification]?: Notification[K]} = {};
+    // The filter uses `name in notification` because the properties are on the prototype so
+    // hasOwnProperty does not work here
     NOTIFICATION_OPTION_NAMES.filter(name => name in notification)
         .forEach(name => options[name] = notification[name]);
 

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -34,8 +34,8 @@ const NOTIFICATION_OPTION_NAMES = [
   'vibrate', 'data'
 ];
 const NOTIFICATION_CLICK_OPTION_NAMES = [
-  'actions', 'badge', 'title', 'body', 'dir', 'icon', 'lang', 'renotify', 'requireInteraction',
-  'tag', 'vibrate', 'data'
+  'actions', 'badge', 'title', 'body', 'dir', 'icon', 'image', 'lang', 'renotify',
+  'requireInteraction', 'tag', 'timestamp', 'vibrate', 'data'
 ];
 
 interface LatestEntry {
@@ -309,15 +309,15 @@ export class Driver implements Debuggable, UpdateSource {
     await this.scope.registration.showNotification(desc['title'] !, options);
   }
 
-  private async handleClick(notification: any, action?: string): Promise<void> {
-    (notification as Notification).close();
+  private async handleClick(notification: Notification, action?: string): Promise<void> {
+    notification.close();
 
-    const desc = notification as{[key: string]: string | undefined};
+    const desc = notification as any;
     let options: {[key: string]: string | undefined} = {};
     NOTIFICATION_CLICK_OPTION_NAMES.filter(name => desc.hasOwnProperty(name))
         .forEach(name => options[name] = desc[name]);
 
-    await this.broadcastAndFocus({
+    await this.broadcast({
       type: 'NOTIFICATION_CLICK',
       data: {action, notification: options},
     });
@@ -1005,18 +1005,6 @@ export class Driver implements Debuggable, UpdateSource {
       client.postMessage(notice);
 
     }, Promise.resolve());
-  }
-
-  async broadcastAndFocus(msg: Object): Promise<void> {
-    const clients = await this.scope.clients.matchAll();
-    clients.forEach((client: any) => {
-      if ('focus' in client) {
-        if (!client.focused) {
-          client.focus();
-        }
-      }
-      client.postMessage(msg);
-    });
   }
 
   async broadcast(msg: Object): Promise<void> {

--- a/packages/service-worker/worker/src/service-worker.d.ts
+++ b/packages/service-worker/worker/src/service-worker.d.ts
@@ -83,6 +83,8 @@ interface PushEvent extends ExtendableEvent {
   data: PushMessageData;
 }
 
+interface NotificationClickEvent extends NotificationEvent, ExtendableEvent {}
+
 interface PushMessageData {
   arrayBuffer(): ArrayBuffer;
   blob(): Blob;
@@ -114,6 +116,7 @@ interface ServiceWorkerGlobalScope {
   addEventListener(event: 'fetch', fn: (event?: FetchEvent) => any): void;
   addEventListener(event: 'install', fn: (event?: ExtendableEvent) => any): void;
   addEventListener(event: 'push', fn: (event?: PushEvent) => any): void;
+  addEventListener(event: 'notificationclick', fn: (event?: NotificationClickEvent) => any): void;
   addEventListener(event: 'sync', fn: (event?: SyncEvent) => any): void;
 
   fetch(request: Request|string): Promise<Response>;

--- a/packages/service-worker/worker/src/service-worker.d.ts
+++ b/packages/service-worker/worker/src/service-worker.d.ts
@@ -72,7 +72,7 @@ interface ActivateEvent extends ExtendableEvent {}
 
 // Notification API
 
-interface NotificationEvent {
+interface NotificationEvent extends ExtendableEvent {
   action: string;
   notification: Notification;
 }
@@ -82,8 +82,6 @@ interface NotificationEvent {
 interface PushEvent extends ExtendableEvent {
   data: PushMessageData;
 }
-
-interface NotificationClickEvent extends NotificationEvent, ExtendableEvent {}
 
 interface PushMessageData {
   arrayBuffer(): ArrayBuffer;
@@ -116,7 +114,7 @@ interface ServiceWorkerGlobalScope {
   addEventListener(event: 'fetch', fn: (event?: FetchEvent) => any): void;
   addEventListener(event: 'install', fn: (event?: ExtendableEvent) => any): void;
   addEventListener(event: 'push', fn: (event?: PushEvent) => any): void;
-  addEventListener(event: 'notificationclick', fn: (event?: NotificationClickEvent) => any): void;
+  addEventListener(event: 'notificationclick', fn: (event?: NotificationEvent) => any): void;
   addEventListener(event: 'sync', fn: (event?: SyncEvent) => any): void;
 
   fetch(request: Request|string): Promise<Response>;

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -593,10 +593,12 @@ const manifestUpdateHash = sha1(JSON.stringify(manifestUpdate));
       expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
       await driver.initialized;
       await scope.handleClick({title: 'This is a test', body: 'Test body'}, 'button');
-      expect(scope.clients.getMock('default') !.messages).toEqual([{
-        type: 'NOTIFICATION_CLICK',
-        data: {action: 'button', notification: {title: 'This is a test', body: 'Test body'}}
-      }]);
+      const message: any = scope.clients.getMock('default') !.messages[0];
+
+      expect(message.type).toEqual('NOTIFICATION_CLICK');
+      expect(message.data.action).toEqual('button');
+      expect(message.data.notification.title).toEqual('This is a test');
+      expect(message.data.notification.body).toEqual('Test body');
     });
 
     async_it('prefetches updates to lazy cache when set', async() => {

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -576,7 +576,7 @@ const manifestUpdateHash = sha1(JSON.stringify(manifestUpdate));
       });
       expect(scope.notifications).toEqual([{
         title: 'This is a test',
-        options: {body: 'Test body'},
+        options: {title: 'This is a test', body: 'Test body'},
       }]);
       expect(scope.clients.getMock('default') !.messages).toEqual([{
         type: 'PUSH',

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -589,6 +589,16 @@ const manifestUpdateHash = sha1(JSON.stringify(manifestUpdate));
       }]);
     });
 
+    async_it('broadcasts notification click events', async() => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+      await scope.handleClick({title: 'This is a test', body: 'Test body'}, 'button');
+      expect(scope.clients.getMock('default') !.messages).toEqual([{
+        type: 'NOTIFICATION_CLICK',
+        data: {action: 'button', notification: {title: 'This is a test', body: 'Test body'}}
+      }]);
+    });
+
     async_it('prefetches updates to lazy cache when set', async() => {
       expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
       await driver.initialized;

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -589,16 +589,30 @@ const manifestUpdateHash = sha1(JSON.stringify(manifestUpdate));
       }]);
     });
 
-    async_it('broadcasts notification click events', async() => {
+    async_it('broadcasts notification click events with action', async() => {
       expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
       await driver.initialized;
-      await scope.handleClick({title: 'This is a test', body: 'Test body'}, 'button');
+      await scope.handleClick(
+          {title: 'This is a test with action', body: 'Test body with action'}, 'button');
       const message: any = scope.clients.getMock('default') !.messages[0];
 
       expect(message.type).toEqual('NOTIFICATION_CLICK');
       expect(message.data.action).toEqual('button');
-      expect(message.data.notification.title).toEqual('This is a test');
-      expect(message.data.notification.body).toEqual('Test body');
+      expect(message.data.notification.title).toEqual('This is a test with action');
+      expect(message.data.notification.body).toEqual('Test body with action');
+    });
+
+    async_it('broadcasts notification click events without action', async() => {
+      expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+      await driver.initialized;
+      await scope.handleClick(
+          {title: 'This is a test without action', body: 'Test body without action'});
+      const message: any = scope.clients.getMock('default') !.messages[0];
+
+      expect(message.type).toEqual('NOTIFICATION_CLICK');
+      expect(message.data.action).toBeUndefined();
+      expect(message.data.notification.title).toEqual('This is a test without action');
+      expect(message.data.notification.body).toEqual('Test body without action');
     });
 
     async_it('prefetches updates to lazy cache when set', async() => {

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -351,7 +351,7 @@ class MockPushEvent extends MockExtendableEvent {
 }
 class MockNotificationEvent extends MockExtendableEvent {
   constructor(private _notification: any, readonly action?: string) { super(); }
-  readonly notification = {...this._notification, close: () => { return; }};
+  readonly notification = {...this._notification, close: () => undefined};
 }
 
 class MockInstallEvent extends MockExtendableEvent {}

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -232,7 +232,7 @@ export class SwTestHarness implements ServiceWorkerGlobalScope, Adapter, Context
     if (!this.eventHandlers.has('notificationclick')) {
       throw new Error('No notificationclick handler registered');
     }
-    const event = new MockNotificationClickEvent(notification, action);
+    const event = new MockNotificationEvent(notification, action);
     this.eventHandlers.get('notificationclick') !.call(this, event);
     return event.ready;
   }
@@ -349,8 +349,9 @@ class MockPushEvent extends MockExtendableEvent {
     json: () => this._data,
   };
 }
-class MockNotificationClickEvent extends MockExtendableEvent {
-  constructor(readonly notification: Object, readonly action?: string) { super(); }
+class MockNotificationEvent extends MockExtendableEvent {
+  constructor(private _notification: any, readonly action?: string) { super(); }
+  readonly notification = {...this._notification, close: () => { return; }};
 }
 
 class MockInstallEvent extends MockExtendableEvent {}

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -228,6 +228,15 @@ export class SwTestHarness implements ServiceWorkerGlobalScope, Adapter, Context
     return event.ready;
   }
 
+  handleClick(notification: Object, action?: string): Promise<void> {
+    if (!this.eventHandlers.has('notificationclick')) {
+      throw new Error('No notificationclick handler registered');
+    }
+    const event = new MockNotificationClickEvent(notification, action);
+    this.eventHandlers.get('notificationclick') !.call(this, event);
+    return event.ready;
+  }
+
   timeout(ms: number): Promise<void> {
     const promise = new Promise<void>(resolve => {
       this.timers.push({
@@ -339,6 +348,9 @@ class MockPushEvent extends MockExtendableEvent {
   data = {
     json: () => this._data,
   };
+}
+class MockNotificationClickEvent extends MockExtendableEvent {
+  constructor(readonly notification: Object, readonly action?: string) { super(); }
 }
 
 class MockInstallEvent extends MockExtendableEvent {}

--- a/tools/public_api_guard/service-worker/service-worker.d.ts
+++ b/tools/public_api_guard/service-worker/service-worker.d.ts
@@ -8,6 +8,7 @@ export declare class ServiceWorkerModule {
 export declare class SwPush {
     readonly isEnabled: boolean;
     readonly messages: Observable<object>;
+    readonly messagesClicked: Observable<object>;
     readonly subscription: Observable<PushSubscription | null>;
     constructor(sw: NgswCommChannel);
     requestSubscription(options: {

--- a/tools/public_api_guard/service-worker/service-worker.d.ts
+++ b/tools/public_api_guard/service-worker/service-worker.d.ts
@@ -8,7 +8,7 @@ export declare class ServiceWorkerModule {
 export declare class SwPush {
     readonly isEnabled: boolean;
     readonly messages: Observable<object>;
-    readonly messagesClicked: Observable<object>;
+    readonly messagesClicked: Observable<{ action: string; notification: NotificationObject }>;
     readonly subscription: Observable<PushSubscription | null>;
     constructor(sw: NgswCommChannel);
     requestSubscription(options: {

--- a/tools/public_api_guard/service-worker/service-worker.d.ts
+++ b/tools/public_api_guard/service-worker/service-worker.d.ts
@@ -8,7 +8,12 @@ export declare class ServiceWorkerModule {
 export declare class SwPush {
     readonly isEnabled: boolean;
     readonly messages: Observable<object>;
-    readonly messagesClicked: Observable<{ action: string; notification: NotificationObject }>;
+    readonly notificationClicks: Observable<{
+        action: string;
+        notification: NotificationOptions & {
+            title: string;
+        };
+    }>;
     readonly subscription: Observable<PushSubscription | null>;
     constructor(sw: NgswCommChannel);
     requestSubscription(options: {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The current version of the service worker does not allow to handle clicks on the notification or be informed which notification or action was clicked.

Issue Number: #20956, #22311


## What is the new behavior?
The new behaviour also listens for the 'notificationclick' event and provides an observable of all messages that were clicked in the `SwPush` service.

```ts
swPush.messagesClicked.pipe(
  ...
);
```

The emitted values will be of the following type:
```ts
{
  action: string,
  notification: NotificationObject
}
```
where `NotificationObject` is the following interface:
```ts
export interface NotificationObject extends NotificationOptions { title: string; }
```

If no custom actions are defined in the notification, action will be `undefined`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
