### PR TITLE
build: add support for running builds outside of sandbox on Mac.

### DIFF
--- a/packages/bazel/src/esm5.bzl
+++ b/packages/bazel/src/esm5.bzl
@@ -90,6 +90,7 @@ def _esm5_outputs_aspect(target, ctx):
             # TODO(alexeagle): enable worker mode for these compilations
             "supports-workers": "0",
         },
+        mnemonic = "ESM5",
     )
 
     root_dir = _join([


### PR DESCRIPTION
build: add support for running builds outside of sandbox on Mac.

Add following to your `~/.bazelrc`. This will run the build faster locally
(outside of sandbox), but continue running the builds with sandboxing
on CI.

```
build --spawn_strategy=standalone --strategy=ESM5=sandboxed
```