### PR TITLE
refactor(ivy): traverse tNode tree directly

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -734,7 +734,7 @@ class ViewContainerRef implements viewEngine_ViewContainerRef {
     const beforeNode = adjustedIdx + 1 < views.length ?
         (getChildLNode(views[adjustedIdx + 1]) !).native :
         this._lContainerNode.native;
-    addRemoveViewFromContainer(this._lContainerNode, lViewNode, true, beforeNode);
+    addRemoveViewFromContainer(this._lContainerNode, lViewNode.data, true, beforeNode);
 
     (viewRef as ViewRef<any>).attachToViewContainerRef(this);
     this._viewRefs.splice(adjustedIdx, 0, viewRef);

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -579,9 +579,6 @@
     "name": "getMultiStartIndex"
   },
   {
-    "name": "getNextLNode"
-  },
-  {
     "name": "getOrCreateChangeDetectorRef"
   },
   {
@@ -969,7 +966,7 @@
     "name": "viewAttached"
   },
   {
-    "name": "walkLNodeTree"
+    "name": "walkTNodeTree"
   },
   {
     "name": "walkUpViews"

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -1656,9 +1656,6 @@
     "name": "getNamedFormat"
   },
   {
-    "name": "getNextLNode"
-  },
-  {
     "name": "getNgZone"
   },
   {
@@ -2409,7 +2406,7 @@
     "name": "viewAttached"
   },
   {
-    "name": "walkLNodeTree"
+    "name": "walkTNodeTree"
   },
   {
     "name": "walkUpViews"


### PR DESCRIPTION
This PR moves us off of traversing the node tree through `LNodes`, since `LNodes` are not going to be around much longer. Now the traversal occurs through `TNodes`. This change will help prepare us for removing `node.tNode`.