### PR TITLE
docs(bazel): add info on options for nodejs_test rule

### DIFF
--- a/docs/BAZEL.md
+++ b/docs/BAZEL.md
@@ -75,6 +75,7 @@ If you're experiencing problems with seemingly unrelated tests failing, it may b
 See also: [`//tools/bazel.rc`](https://github.com/angular/angular/blob/master/tools/bazel.rc) where `--define=ivy=false` is defined as default.
 
 - `--config=debug`: build and launch in debug mode (see [debugging](#debugging) instructions below)
+- `--test_arg=--node_options=--inspect=9228`: change the inspector port.
 - `--define=compile=<option>` Controls if ivy or legacy mode is enabled. This is done by generating the [`src/ivy_switch.ts`](https://github.com/angular/angular/blob/master/packages/core/src/ivy_switch.ts) file from [`ivy_switch_legacy.ts`](https://github.com/angular/angular/blob/master/packages/core/src/ivy_switch_legacy.ts) (default), [`ivy_switch_jit.ts`](https://github.com/angular/angular/blob/master/packages/core/src/ivy_switch_jit.ts), or [`ivy_switch_local.ts`](https://github.com/angular/angular/blob/master/packages/core/src/ivy_switch_local.ts).
     - `legacy`: (default behavior) compile against View Engine, e.g. `--define=compile=legacy`
     - `jit`: Compile in ivy JIT mode, e.g. `--define=compile=jit`
@@ -93,7 +94,7 @@ of your rules in any given `BUILD.bazel`.
 - Click on  `Open dedicated DevTools for Node` to launch a debugger.
 - Run test: `bazel test packages/core/test:test --config=debug`
 
-The process should automatically connect to the debugger.
+The process should automatically connect to the debugger. For additional info and testing options, see the [nodejs_test documentation](https://bazelbuild.github.io/rules_nodejs/node/node.html#nodejs_test).
 
 ### Debugging a Node Test in VSCode
 


### PR DESCRIPTION
Add this info to the doc so it's easily accessible.