### PR TITLE
fix(compiler-cli): fix crash when compiling with aot

### DIFF
--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -622,7 +622,7 @@ function addReferencesToSourceFile(sf: ts.SourceFile, genFileNames: string[]) {
     originalReferencedFiles = sf.referencedFiles;
     (sf as any).originalReferencedFiles = originalReferencedFiles;
   }
-  const newReferencedFiles = [...originalReferencedFiles];
+  const newReferencedFiles = [...(originalReferencedFiles || [])];
   genFileNames.forEach(gf => newReferencedFiles.push({fileName: gf, pos: 0, end: 0}));
   sf.referencedFiles = newReferencedFiles;
 }

--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -1940,6 +1940,37 @@ describe('ngc transformer command-line', () => {
       `);
       expect(main(['-p', path.join(basePath, 'src/tsconfig.json')])).toBe(0);
     });
+
+    // Regression test for #25456
+    it('should work with typescript json module', () => {
+      write('src/tsconfig.json', `{
+        "extends": "../tsconfig-base.json",
+        "files": ["test-module.ts"],
+        "compilerOptions": {
+          "module": "commonjs",
+          "resolveJsonModule": true,
+          "allowSyntheticDefaultImports": true
+        }
+      }`);
+
+      write('src/test.json', `{
+        "foo": "bar"
+      }`);
+
+      write('src/test-module.ts', `
+        import { NgModule, Component } from '@angular/core';
+        import Foo from './test.json'
+
+        @Component({template: '{{name}}'})
+        export class TestComponent {
+          name: string = Foo.foo;
+        }
+
+        @NgModule({declarations: [TestComponent]})
+        export class TestModule {}
+      `);
+      expect(main(['-p', path.join(basePath, 'src/tsconfig.json')])).toBe(0);
+    });
   });
 
   describe('formatted messages', () => {


### PR DESCRIPTION
add a guard to handle unexpected originalReferencedFiles value

Closes #25456

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

compiler broken with aot and ts json module

Issue Number: #25456


## What is the new behavior?

it works

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

the borken is because `SourceFile.referencedFiles` is undefined  


