### PR TITLE
refactor(ivy): remove superfluous Array check

### DIFF
--- a/packages/core/src/render3/features/inherit_definition_feature.ts
+++ b/packages/core/src/render3/features/inherit_definition_feature.ts
@@ -179,7 +179,7 @@ function maybeUnwrapEmpty<T>(value: T): T;
 function maybeUnwrapEmpty(value: any): any {
   if (value === EMPTY) {
     return {};
-  } else if (Array.isArray(value) && value === EMPTY_ARRAY) {
+  } else if (value === EMPTY_ARRAY) {
     return [];
   } else {
     return value;


### PR DESCRIPTION
related #25755

Simply removes an unnecessary `Array.isArray` check that was left in from a previous change.

