### PR TITLE
fix(ivy): support tsutils helper decorator definitions

### DIFF
--- a/packages/compiler-cli/src/ngcc/src/host/fesm2015_host.ts
+++ b/packages/compiler-cli/src/ngcc/src/host/fesm2015_host.ts
@@ -336,7 +336,7 @@ export class Fesm2015ReflectionHost extends TypeScriptReflectionHost implements 
           decoratorsIdentifier.parent.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
         // AST of the array of decorator values
         const decoratorsArray = decoratorsIdentifier.parent.right;
-        return this.reflectDecorators(decoratorsArray);
+        return this.reflectDecorators(decoratorsArray).filter(isImportedFromCore);
       }
     }
     return null;
@@ -404,8 +404,12 @@ export class Fesm2015ReflectionHost extends TypeScriptReflectionHost implements 
     const propDecoratorsMap = getPropertyValueFromSymbol(decoratorsProperty);
     if (propDecoratorsMap && ts.isObjectLiteralExpression(propDecoratorsMap)) {
       const propertiesMap = reflectObjectLiteral(propDecoratorsMap);
-      propertiesMap.forEach(
-          (value, name) => { memberDecorators.set(name, this.reflectDecorators(value)); });
+      propertiesMap.forEach((value, name) => {
+        const decorators = this.reflectDecorators(value).filter(isImportedFromCore);
+        if (decorators.length) {
+          memberDecorators.set(name, decorators);
+        }
+      });
     }
     return memberDecorators;
   }
@@ -727,7 +731,8 @@ export class Fesm2015ReflectionHost extends TypeScriptReflectionHost implements 
             .map(paramInfo => {
               const type = paramInfo && paramInfo.get('type') || null;
               const decoratorInfo = paramInfo && paramInfo.get('decorators') || null;
-              const decorators = decoratorInfo && this.reflectDecorators(decoratorInfo);
+              const decorators =
+                  decoratorInfo && this.reflectDecorators(decoratorInfo).filter(isImportedFromCore);
               return {type, decorators};
             });
       }

--- a/packages/compiler-cli/src/ngcc/src/rendering/esm2015_renderer.ts
+++ b/packages/compiler-cli/src/ngcc/src/rendering/esm2015_renderer.ts
@@ -54,11 +54,11 @@ export class Esm2015Renderer extends Renderer {
       if (ts.isArrayLiteralExpression(containerNode)) {
         const items = containerNode.elements;
         if (items.length === nodesToRemove.length) {
-          // remove any trailing semi-colon
-          const end = (output.slice(containerNode.getEnd(), containerNode.getEnd() + 1) === ';') ?
-              containerNode.getEnd() + 1 :
-              containerNode.getEnd();
-          output.remove(containerNode.parent !.getFullStart(), end);
+          // Remove the entire statement
+          const statement = findStatement(containerNode);
+          if (statement) {
+            output.remove(statement.getFullStart(), statement.getEnd());
+          }
         } else {
           nodesToRemove.forEach(node => {
             // remove any trailing comma
@@ -81,4 +81,14 @@ export class Esm2015Renderer extends Renderer {
       outputText.overwrite(start, end, replacement);
     });
   }
+}
+
+function findStatement(node: ts.Node) {
+  while (node) {
+    if (ts.isExpressionStatement(node)) {
+      return node;
+    }
+    node = node.parent;
+  }
+  return undefined;
 }

--- a/packages/compiler-cli/src/ngcc/test/helpers/utils.ts
+++ b/packages/compiler-cli/src/ngcc/test/helpers/utils.ts
@@ -11,7 +11,8 @@ import {makeProgram as _makeProgram} from '../../../ngtsc/testing/in_memory_type
 export {getDeclaration} from '../../../ngtsc/testing/in_memory_typescript';
 
 export function makeProgram(...files: {name: string, contents: string}[]): ts.Program {
-  return _makeProgram([getFakeCore(), ...files], {allowJs: true, checkJs: false}).program;
+  return _makeProgram([getFakeCore(), getFakeTslib(), ...files], {allowJs: true, checkJs: false})
+      .program;
 }
 
 // TODO: unify this with the //packages/compiler-cli/test/ngtsc/fake_core package
@@ -51,6 +52,17 @@ export function getFakeCore() {
   };
 }
 
+export function getFakeTslib() {
+  return {
+    name: 'node_modules/tslib/index.ts',
+    contents: `
+    export function __decorate(decorators: any[], target: any, key?: string | symbol, desc?: any) {}
+    export function __param(paramIndex: number, decorator: any) {}
+    export function __metadata(metadataKey: any, metadataValue: any) {}
+    `
+  };
+}
+
 export function convertToDirectTsLibImport(filesystem: {name: string, contents: string}[]) {
   return filesystem.map(file => {
     const contents =
@@ -58,7 +70,7 @@ export function convertToDirectTsLibImport(filesystem: {name: string, contents: 
             .replace(
                 `import * as tslib_1 from 'tslib';`,
                 `import { __decorate, __metadata, __read, __values, __param, __extends, __assign } from 'tslib';`)
-            .replace('tslib_1.', '');
+            .replace(/tslib_1\./g, '');
     return {...file, contents};
   });
 }

--- a/packages/compiler-cli/src/ngcc/test/helpers/utils.ts
+++ b/packages/compiler-cli/src/ngcc/test/helpers/utils.ts
@@ -50,3 +50,15 @@ export function getFakeCore() {
     `
   };
 }
+
+export function convertToDirectTsLibImport(filesystem: {name: string, contents: string}[]) {
+  return filesystem.map(file => {
+    const contents =
+        file.contents
+            .replace(
+                `import * as tslib_1 from 'tslib';`,
+                `import { __decorate, __metadata, __read, __values, __param, __extends, __assign } from 'tslib';`)
+            .replace('tslib_1.', '');
+    return {...file, contents};
+  });
+}

--- a/packages/compiler-cli/src/ngcc/test/host/esm5_host_import_helper_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/host/esm5_host_import_helper_spec.ts
@@ -1,0 +1,396 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {ClassMemberKind, Import} from '../../../ngtsc/host';
+import {Esm5ReflectionHost} from '../../src/host/esm5_host';
+import {convertToDirectTsLibImport, getDeclaration, makeProgram} from '../helpers/utils';
+
+const FILES = [
+  {
+    name: '/some_directive.js',
+    contents: `
+  import * as tslib_1 from "tslib";
+  import { Directive, Inject, InjectionToken, Input } from '@angular/core';
+  var INJECTED_TOKEN = new InjectionToken('injected');
+  var ViewContainerRef = /** @class */ (function () {
+      function ViewContainerRef() {
+      }
+      return ViewContainerRef;
+  }());
+  var TemplateRef = /** @class */ (function () {
+      function TemplateRef() {
+      }
+      return TemplateRef;
+  }());
+  var SomeDirective = /** @class */ (function () {
+      function SomeDirective(_viewContainer, _template, injected) {
+          this.instanceProperty = 'instance';
+          this.input1 = '';
+          this.input2 = 0;
+      }
+      SomeDirective.prototype.instanceMethod = function () { };
+      SomeDirective.staticMethod = function () { };
+      SomeDirective.staticProperty = 'static';
+      tslib_1.__decorate([
+          Input(),
+          tslib_1.__metadata("design:type", String)
+      ], SomeDirective.prototype, "input1", void 0);
+      tslib_1.__decorate([
+          Input(),
+          tslib_1.__metadata("design:type", Number)
+      ], SomeDirective.prototype, "input2", void 0);
+      SomeDirective = tslib_1.__decorate([
+          Directive({ selector: '[someDirective]' }),
+          tslib_1.__param(2, Inject(INJECTED_TOKEN)),
+          tslib_1.__metadata("design:paramtypes", [ViewContainerRef,
+              TemplateRef, String])
+      ], SomeDirective);
+      return SomeDirective;
+  }());
+  export { SomeDirective };
+  `,
+  },
+  {
+    name: '/node_modules/@angular/core/some_directive.js',
+    contents: `
+  import * as tslib_1 from "tslib";
+  import { Directive, Input } from './directives';
+  var SomeDirective = /** @class */ (function () {
+    function SomeDirective() {
+        this.input1 = '';
+    }
+    tslib_1.__decorate([
+        Input(),
+        tslib_1.__metadata("design:type", String)
+    ], SomeDirective.prototype, "input1", void 0);
+    SomeDirective = tslib_1.__decorate([
+        Directive({ selector: '[someDirective]' }),
+    ], SomeDirective);
+    return SomeDirective;
+}());
+export { SomeDirective };
+`,
+  },
+  {
+    name: '/ngmodule.js',
+    contents: `
+    import * as tslib_1 from "tslib";
+    import { NgModule } from '@angular/core';
+      var HttpClientXsrfModule = /** @class */ (function () {
+        function HttpClientXsrfModule() {
+        }
+        HttpClientXsrfModule_1 = HttpClientXsrfModule;
+        HttpClientXsrfModule.withOptions = function (options) {
+            if (options === void 0) { options = {}; }
+            return {
+                ngModule: HttpClientXsrfModule_1,
+                providers: [],
+            };
+        };
+        var HttpClientXsrfModule_1;
+        HttpClientXsrfModule = HttpClientXsrfModule_1 = tslib_1.__decorate([
+            NgModule({
+                providers: [],
+            })
+        ], HttpClientXsrfModule);
+        return HttpClientXsrfModule;
+    }());
+    var missingValue;
+    var nonDecoratedVar;
+    nonDecoratedVar = 43;
+    export { HttpClientXsrfModule };
+    `
+  },
+];
+
+describe('Esm5ReflectionHost [import helper style]', () => {
+  [{files: FILES, label: 'namespaced'},
+   {files: convertToDirectTsLibImport(FILES), label: 'direct import'},
+  ].forEach(fileSystem => {
+    describe(`[${fileSystem.label}]`, () => {
+
+      describe('getDecoratorsOfDeclaration()', () => {
+        it('should find the decorators on a class', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Esm5ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+          const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+
+          expect(decorators).toBeDefined();
+          expect(decorators.length).toEqual(1);
+
+          const decorator = decorators[0];
+          expect(decorator.name).toEqual('Directive');
+          expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+          expect(decorator.args !.map(arg => arg.getText())).toEqual([
+            '{ selector: \'[someDirective]\' }',
+          ]);
+        });
+
+        it('should use `getImportOfIdentifier()` to retrieve import info', () => {
+          const mockImportInfo = {} as Import;
+          const spy = spyOn(Esm5ReflectionHost.prototype, 'getImportOfIdentifier')
+                          .and.callFake(
+                              (identifier: ts.Identifier) => identifier.getText() === 'Directive' ?
+                                  {from: '@angular/core', name: 'Directive'} :
+                                  {});
+
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Esm5ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+
+          const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+
+          expect(decorators.length).toEqual(1);
+          expect(decorators[0].import).toEqual({from: '@angular/core', name: 'Directive'});
+
+          const identifiers = spy.calls.all().map(call => (call.args[0] as ts.Identifier).text);
+          expect(identifiers.some(identifier => identifier === 'Directive')).toBeTruthy();
+        });
+
+        it('should support decorators being used inside @angular/core', () => {
+          const program = makeProgram(fileSystem.files[1]);
+          const host = new Esm5ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/node_modules/@angular/core/some_directive.js', 'SomeDirective',
+              ts.isVariableDeclaration);
+          const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+
+          expect(decorators).toBeDefined();
+          expect(decorators.length).toEqual(1);
+
+          const decorator = decorators[0];
+          expect(decorator.name).toEqual('Directive');
+          expect(decorator.import).toEqual({name: 'Directive', from: './directives'});
+          expect(decorator.args !.map(arg => arg.getText())).toEqual([
+            '{ selector: \'[someDirective]\' }',
+          ]);
+        });
+      });
+
+      describe('getMembersOfClass()', () => {
+        it('should find decorated members on a class', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Esm5ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+          const members = host.getMembersOfClass(classNode);
+
+          const input1 = members.find(member => member.name === 'input1') !;
+          expect(input1.kind).toEqual(ClassMemberKind.Property);
+          expect(input1.isStatic).toEqual(false);
+          expect(input1.decorators !.map(d => d.name)).toEqual(['Input']);
+
+          const input2 = members.find(member => member.name === 'input2') !;
+          expect(input2.kind).toEqual(ClassMemberKind.Property);
+          expect(input2.isStatic).toEqual(false);
+          expect(input1.decorators !.map(d => d.name)).toEqual(['Input']);
+        });
+
+        it('should find non decorated properties on a class', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Esm5ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+          const members = host.getMembersOfClass(classNode);
+
+          const instanceProperty = members.find(member => member.name === 'instanceProperty') !;
+          expect(instanceProperty.kind).toEqual(ClassMemberKind.Property);
+          expect(instanceProperty.isStatic).toEqual(false);
+          expect(ts.isBinaryExpression(instanceProperty.implementation !)).toEqual(true);
+          expect(instanceProperty.value !.getText()).toEqual(`'instance'`);
+        });
+
+        it('should find static methods on a class', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Esm5ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+          const members = host.getMembersOfClass(classNode);
+
+          const staticMethod = members.find(member => member.name === 'staticMethod') !;
+          expect(staticMethod.kind).toEqual(ClassMemberKind.Method);
+          expect(staticMethod.isStatic).toEqual(true);
+          expect(ts.isFunctionExpression(staticMethod.implementation !)).toEqual(true);
+        });
+
+        it('should find static properties on a class', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Esm5ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+          const members = host.getMembersOfClass(classNode);
+
+          const staticProperty = members.find(member => member.name === 'staticProperty') !;
+          expect(staticProperty.kind).toEqual(ClassMemberKind.Property);
+          expect(staticProperty.isStatic).toEqual(true);
+          expect(ts.isPropertyAccessExpression(staticProperty.implementation !)).toEqual(true);
+          expect(staticProperty.value !.getText()).toEqual(`'static'`);
+        });
+
+        it('should use `getImportOfIdentifier()` to retrieve import info', () => {
+          const spy =
+              spyOn(Esm5ReflectionHost.prototype, 'getImportOfIdentifier').and.returnValue({});
+
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Esm5ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+
+          host.getMembersOfClass(classNode);
+          const identifiers = spy.calls.all().map(call => (call.args[0] as ts.Identifier).text);
+          expect(identifiers.some(identifier => identifier === 'Input')).toBeTruthy();
+        });
+
+        it('should support decorators being used inside @angular/core', () => {
+          const program = makeProgram(fileSystem.files[1]);
+          const host = new Esm5ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/node_modules/@angular/core/some_directive.js', 'SomeDirective',
+              ts.isVariableDeclaration);
+          const members = host.getMembersOfClass(classNode);
+
+          const input1 = members.find(member => member.name === 'input1') !;
+          expect(input1.kind).toEqual(ClassMemberKind.Property);
+          expect(input1.isStatic).toEqual(false);
+          expect(input1.decorators !.map(d => d.name)).toEqual(['Input']);
+        });
+      });
+
+      describe('getConstructorParameters', () => {
+        it('should find the decorated constructor parameters', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Esm5ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+          const parameters = host.getConstructorParameters(classNode);
+
+          expect(parameters).toBeDefined();
+          expect(parameters !.map(parameter => parameter.name)).toEqual([
+            '_viewContainer', '_template', 'injected'
+          ]);
+          expect(parameters !.map(parameter => parameter.type !.getText())).toEqual([
+            'ViewContainerRef', 'TemplateRef', 'String'
+          ]);
+        });
+
+        describe('(returned parameters `decorators`)', () => {
+          it('should use `getImportOfIdentifier()` to retrieve import info', () => {
+            const mockImportInfo = {} as Import;
+            const spy = spyOn(Esm5ReflectionHost.prototype, 'getImportOfIdentifier')
+                            .and.returnValue(mockImportInfo);
+
+            const program = makeProgram(fileSystem.files[0]);
+            const host = new Esm5ReflectionHost(program.getTypeChecker());
+            const classNode = getDeclaration(
+                program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+            const parameters = host.getConstructorParameters(classNode);
+            const decorators = parameters ![2].decorators !;
+
+            expect(decorators.length).toEqual(1);
+            expect(decorators[0].import).toBe(mockImportInfo);
+
+            const typeIdentifier = spy.calls.mostRecent().args[0] as ts.Identifier;
+            expect(typeIdentifier.text).toBe('Inject');
+          });
+        });
+      });
+
+      describe('getDeclarationOfIdentifier', () => {
+        it('should return the declaration of a locally defined identifier', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Esm5ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+          const ctrDecorators = host.getConstructorParameters(classNode) !;
+          const identifierOfViewContainerRef = ctrDecorators[0].type !as ts.Identifier;
+
+          const expectedDeclarationNode = getDeclaration(
+              program, '/some_directive.js', 'ViewContainerRef', ts.isVariableDeclaration);
+          const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfViewContainerRef);
+          expect(actualDeclaration).not.toBe(null);
+          expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
+          expect(actualDeclaration !.viaModule).toBe(null);
+        });
+
+        it('should return the declaration of an externally defined identifier', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Esm5ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+          const classDecorators = host.getDecoratorsOfDeclaration(classNode) !;
+          const decoratorNode = classDecorators[0].node;
+
+          const identifierOfDirective =
+              ts.isCallExpression(decoratorNode) && ts.isIdentifier(decoratorNode.expression) ?
+              decoratorNode.expression :
+              null;
+
+          const expectedDeclarationNode = getDeclaration(
+              program, 'node_modules/@angular/core/index.ts', 'Directive',
+              ts.isVariableDeclaration);
+          const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective !);
+          expect(actualDeclaration).not.toBe(null);
+          expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
+          expect(actualDeclaration !.viaModule).toBe('@angular/core');
+        });
+      });
+    });
+
+    describe('getVariableValue', () => {
+      it('should find the "actual" declaration of an aliased variable identifier', () => {
+        const program = makeProgram(fileSystem.files[2]);
+        const host = new Esm5ReflectionHost(program.getTypeChecker());
+        const ngModuleRef = findVariableDeclaration(
+            program.getSourceFile(fileSystem.files[2].name) !, 'HttpClientXsrfModule_1');
+
+        const value = host.getVariableValue(ngModuleRef !);
+        expect(value).not.toBe(null);
+        if (!value || !ts.isFunctionDeclaration(value.parent)) {
+          throw new Error(
+              `Expected result to be a function declaration: ${value && value.getText()}.`);
+        }
+        expect(value.getText()).toBe('HttpClientXsrfModule');
+      });
+
+      it('should return undefined if the variable has no assignment', () => {
+        const program = makeProgram(fileSystem.files[2]);
+        const host = new Esm5ReflectionHost(program.getTypeChecker());
+        const missingValue = findVariableDeclaration(
+            program.getSourceFile(fileSystem.files[2].name) !, 'missingValue');
+        const value = host.getVariableValue(missingValue !);
+        expect(value).toBe(null);
+      });
+
+      it('should return null if the variable is not assigned from a call to __decorate', () => {
+        const program = makeProgram(fileSystem.files[2]);
+        const host = new Esm5ReflectionHost(program.getTypeChecker());
+        const nonDecoratedVar = findVariableDeclaration(
+            program.getSourceFile(fileSystem.files[2].name) !, 'nonDecoratedVar');
+        const value = host.getVariableValue(nonDecoratedVar !);
+        expect(value).toBe(null);
+      });
+    });
+  });
+
+  function findVariableDeclaration(
+      node: ts.Node | undefined, variableName: string): ts.VariableDeclaration|undefined {
+    if (!node) {
+      return;
+    }
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) &&
+        node.name.text === variableName) {
+      return node;
+    }
+    return node.forEachChild(node => findVariableDeclaration(node, variableName));
+  }
+});

--- a/packages/compiler-cli/src/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/host/esm5_host_spec.ts
@@ -1164,18 +1164,20 @@ describe('Esm5ReflectionHost', () => {
       expect(host.getClassSymbol(innerNode)).toBeDefined();
     });
 
-    it('should return the same class symbol for outer and inner declarations', () => {
-      const program = makeProgram(SIMPLE_CLASS_FILE);
-      const host = new Esm5ReflectionHost(program.getTypeChecker());
-      const outerNode =
-          getDeclaration(program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
-      const innerNode =
-          (((outerNode.initializer as ts.ParenthesizedExpression).expression as ts.CallExpression)
-               .expression as ts.FunctionExpression)
-              .body.statements.find(ts.isFunctionDeclaration) !;
+    it('should return the same class symbol (of the inner declaration) for outer and inner declarations',
+       () => {
+         const program = makeProgram(SIMPLE_CLASS_FILE);
+         const host = new Esm5ReflectionHost(program.getTypeChecker());
+         const outerNode = getDeclaration(
+             program, SIMPLE_CLASS_FILE.name, 'EmptyClass', ts.isVariableDeclaration);
+         const innerNode = (((outerNode.initializer as ts.ParenthesizedExpression)
+                                 .expression as ts.CallExpression)
+                                .expression as ts.FunctionExpression)
+                               .body.statements.find(ts.isFunctionDeclaration) !;
 
-      expect(host.getClassSymbol(innerNode)).toBe(host.getClassSymbol(outerNode));
-    });
+         expect(host.getClassSymbol(innerNode)).toBe(host.getClassSymbol(outerNode));
+         expect(host.getClassSymbol(innerNode) !.valueDeclaration).toBe(innerNode);
+       });
 
     it('should return undefined if node is not an ES5 class', () => {
       const program = makeProgram(FOO_FUNCTION_FILE);

--- a/packages/compiler-cli/src/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/host/esm5_host_spec.ts
@@ -79,46 +79,42 @@ const FOO_FUNCTION_FILE = {
 const INVALID_DECORATORS_FILE = {
   name: '/invalid_decorators.js',
   contents: `
-    var NotArrayLiteralDecorator = {};
+    import { Directive } from '@angular/core';
     var NotArrayLiteral = (function() {
       function NotArrayLiteral() {
       }
       NotArrayLiteral.decorators = () => [
-        { type: NotArrayLiteralDecorator, args: [{ selector: '[ignored]' },] },
+        { type: Directive, args: [{ selector: '[ignored]' },] },
       ];
       return NotArrayLiteral;
     }());
 
-    var NotObjectLiteralDecorator = {};
     var NotObjectLiteral = (function() {
       function NotObjectLiteral() {
       }
       NotObjectLiteral.decorators = [
         "This is not an object literal",
-        { type: NotObjectLiteralDecorator },
+        { type: Directive },
       ];
       return NotObjectLiteral;
     }());
 
-    var NoTypePropertyDecorator1 = {};
-    var NoTypePropertyDecorator2 = {};
     var NoTypeProperty = (function() {
       function NoTypeProperty() {
       }
       NoTypeProperty.decorators = [
-        { notType: NoTypePropertyDecorator1 },
-        { type: NoTypePropertyDecorator2 },
+        { notType: Directive },
+        { type: Directive },
       ];
       return NoTypeProperty;
     }());
 
-    var NotIdentifierDecorator = {};
     var NotIdentifier = (function() {
       function NotIdentifier() {
       }
       NotIdentifier.decorators = [
         { type: 'StringsLiteralsAreNotIdentifiers' },
-        { type: NotIdentifierDecorator },
+        { type: Directive },
       ];
       return NotIdentifier;
     }());
@@ -128,33 +124,31 @@ const INVALID_DECORATORS_FILE = {
 const INVALID_DECORATOR_ARGS_FILE = {
   name: '/invalid_decorator_args.js',
   contents: `
-    var NoArgsPropertyDecorator = {};
+    import { Directive } from '@angular/core';
     var NoArgsProperty = (function() {
       function NoArgsProperty() {
       }
       NoArgsProperty.decorators = [
-        { type: NoArgsPropertyDecorator },
+        { type: Directive },
       ];
       return NoArgsProperty;
     }());
 
-    var NoPropertyAssignmentDecorator = {};
     var args = [{ selector: '[ignored]' },];
     var NoPropertyAssignment = (function() {
       function NoPropertyAssignment() {
       }
       NoPropertyAssignment.decorators = [
-        { type: NoPropertyAssignmentDecorator, args },
+        { type: Directive, args },
       ];
       return NoPropertyAssignment;
     }());
 
-    var NotArrayLiteralDecorator = {};
     var NotArrayLiteral = (function() {
       function NotArrayLiteral() {
       }
       NotArrayLiteral.decorators = [
-        { type: NotArrayLiteralDecorator, args: () => [{ selector: '[ignored]' },] },
+        { type: Directive, args: () => [{ selector: '[ignored]' },] },
       ];
       return NotArrayLiteral;
     }());
@@ -164,51 +158,47 @@ const INVALID_DECORATOR_ARGS_FILE = {
 const INVALID_PROP_DECORATORS_FILE = {
   name: '/invalid_prop_decorators.js',
   contents: `
-    var NotObjectLiteralDecorator = {};
+    import { Input } from '@angular/core';
     var NotObjectLiteral = (function() {
       function NotObjectLiteral() {
       }
       NotObjectLiteral.propDecorators = () => ({
-        "prop": [{ type: NotObjectLiteralDecorator },]
+        "prop": [{ type: Input },]
       });
       return NotObjectLiteral;
     }());
 
-    var NotObjectLiteralPropDecorator = {};
     var NotObjectLiteralProp = (function() {
       function NotObjectLiteralProp() {
       }
       NotObjectLiteralProp.propDecorators = {
         "prop": [
           "This is not an object literal",
-          { type: NotObjectLiteralPropDecorator },
+          { type: Input },
         ]
       };
       return NotObjectLiteralProp;
     }());
 
-    var NoTypePropertyDecorator1 = {};
-    var NoTypePropertyDecorator2 = {};
     var NoTypeProperty = (function() {
       function NoTypeProperty() {
       }
       NoTypeProperty.propDecorators = {
         "prop": [
-          { notType: NoTypePropertyDecorator1 },
-          { type: NoTypePropertyDecorator2 },
+          { notType: Input },
+          { type: Input },
         ]
       };
       return NoTypeProperty;
     }());
 
-    var NotIdentifierDecorator = {};
     var NotIdentifier = (function() {
       function NotIdentifier() {
       }
       NotIdentifier.propDecorators = {
         "prop": [
           { type: 'StringsLiteralsAreNotIdentifiers' },
-          { type: NotIdentifierDecorator },
+          { type: Input },
         ]
       };
       return NotIdentifier;
@@ -219,33 +209,31 @@ const INVALID_PROP_DECORATORS_FILE = {
 const INVALID_PROP_DECORATOR_ARGS_FILE = {
   name: '/invalid_prop_decorator_args.js',
   contents: `
-    var NoArgsPropertyDecorator = {};
+    import { Input } from '@angular/core';
     var NoArgsProperty = (function() {
       function NoArgsProperty() {
       }
       NoArgsProperty.propDecorators = {
-        "prop": [{ type: NoArgsPropertyDecorator },]
+        "prop": [{ type: Input },]
       };
       return NoArgsProperty;
     }());
 
-    var NoPropertyAssignmentDecorator = {};
     var args = [{ selector: '[ignored]' },];
     var NoPropertyAssignment = (function() {
       function NoPropertyAssignment() {
       }
       NoPropertyAssignment.propDecorators = {
-        "prop": [{ type: NoPropertyAssignmentDecorator, args },]
+        "prop": [{ type: Input, args },]
       };
       return NoPropertyAssignment;
     }());
 
-    var NotArrayLiteralDecorator = {};
     var NotArrayLiteral = (function() {
       function NotArrayLiteral() {
       }
       NotArrayLiteral.propDecorators = {
-        "prop": [{ type: NotArrayLiteralDecorator, args: () => [{ selector: '[ignored]' },] },],
+        "prop": [{ type: Input, args: () => [{ selector: '[ignored]' },] },],
       };
       return NotArrayLiteral;
     }());
@@ -255,23 +243,22 @@ const INVALID_PROP_DECORATOR_ARGS_FILE = {
 const INVALID_CTOR_DECORATORS_FILE = {
   name: '/invalid_ctor_decorators.js',
   contents: `
+    import { Inject } from '@angular/core';
     var NoParametersDecorator = {};
     var NoParameters = (function() {
       function NoParameters() {}
       return NoParameters;
     }());
 
-    var ArrowFunctionDecorator = {};
     var ArrowFunction = (function() {
       function ArrowFunction(arg1) {
       }
       ArrowFunction.ctorParameters = () => [
-        { type: 'ParamType', decorators: [{ type: ArrowFunctionDecorator },] }
+        { type: 'ParamType', decorators: [{ type: Inject },] }
       ];
       return ArrowFunction;
     }());
 
-    var NotArrayLiteralDecorator = {};
     var NotArrayLiteral = (function() {
       function NotArrayLiteral(arg1) {
       }
@@ -279,19 +266,16 @@ const INVALID_CTOR_DECORATORS_FILE = {
       return NotArrayLiteral;
     }());
 
-    var NotObjectLiteralDecorator = {};
     var NotObjectLiteral = (function() {
       function NotObjectLiteral(arg1, arg2) {
       }
       NotObjectLiteral.ctorParameters = function() { return [
         "This is not an object literal",
-        { type: 'ParamType', decorators: [{ type: NotObjectLiteralDecorator },] },
+        { type: 'ParamType', decorators: [{ type: Inject },] },
       ]; };
       return NotObjectLiteral;
     }());
 
-    var NoTypePropertyDecorator1 = {};
-    var NoTypePropertyDecorator2 = {};
     var NoTypeProperty = (function() {
       function NoTypeProperty(arg1, arg2) {
       }
@@ -299,15 +283,14 @@ const INVALID_CTOR_DECORATORS_FILE = {
         {
           type: 'ParamType',
           decorators: [
-            { notType: NoTypePropertyDecorator1 },
-            { type: NoTypePropertyDecorator2 },
+            { notType: Inject },
+            { type: Inject },
           ]
         },
       ]; };
       return NoTypeProperty;
     }());
 
-    var NotIdentifierDecorator = {};
     var NotIdentifier = (function() {
       function NotIdentifier(arg1, arg2) {
       }
@@ -316,7 +299,7 @@ const INVALID_CTOR_DECORATORS_FILE = {
           type: 'ParamType',
           decorators: [
             { type: 'StringsLiteralsAreNotIdentifiers' },
-            { type: NotIdentifierDecorator },
+            { type: Inject },
           ]
         },
       ]; };
@@ -328,33 +311,31 @@ const INVALID_CTOR_DECORATORS_FILE = {
 const INVALID_CTOR_DECORATOR_ARGS_FILE = {
   name: '/invalid_ctor_decorator_args.js',
   contents: `
-    var NoArgsPropertyDecorator = {};
+    import { Inject } from '@angular/core';
     var NoArgsProperty = (function() {
       function NoArgsProperty(arg1) {
       }
       NoArgsProperty.ctorParameters = function() { return [
-        { type: 'ParamType', decorators: [{ type: NoArgsPropertyDecorator },] },
+        { type: 'ParamType', decorators: [{ type: Inject },] },
       ]; };
       return NoArgsProperty;
     }());
 
-    var NoPropertyAssignmentDecorator = {};
     var args = [{ selector: '[ignored]' },];
     var NoPropertyAssignment = (function() {
       function NoPropertyAssignment(arg1) {
       }
       NoPropertyAssignment.ctorParameters = function() { return [
-        { type: 'ParamType', decorators: [{ type: NoPropertyAssignmentDecorator, args },] },
+        { type: 'ParamType', decorators: [{ type: Inject, args },] },
       ]; };
       return NoPropertyAssignment;
     }());
 
-    var NotArrayLiteralDecorator = {};
     var NotArrayLiteral = (function() {
       function NotArrayLiteral(arg1) {
       }
       NotArrayLiteral.ctorParameters = function() { return [
-        { type: 'ParamType', decorators: [{ type: NotArrayLiteralDecorator, args: () => [{ selector: '[ignored]' },] },] },
+        { type: 'ParamType', decorators: [{ type: Inject, args: () => [{ selector: '[ignored]' },] },] },
       ]; };
       return NotArrayLiteral;
     }());
@@ -502,7 +483,7 @@ describe('Esm5ReflectionHost', () => {
       const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
       expect(decorators.length).toBe(1);
-      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'NotObjectLiteralDecorator'}));
+      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
     });
 
     it('should ignore decorator elements that have no `type` property', () => {
@@ -513,7 +494,7 @@ describe('Esm5ReflectionHost', () => {
       const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
       expect(decorators.length).toBe(1);
-      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'NoTypePropertyDecorator2'}));
+      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
     });
 
     it('should ignore decorator elements whose `type` value is not an identifier', () => {
@@ -524,11 +505,11 @@ describe('Esm5ReflectionHost', () => {
       const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
       expect(decorators.length).toBe(1);
-      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'NotIdentifierDecorator'}));
+      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
     });
 
     it('should use `getImportOfIdentifier()` to retrieve import info', () => {
-      const mockImportInfo = {} as Import;
+      const mockImportInfo = { name: 'mock', from: '@angular/core' } as Import;
       const spy = spyOn(Esm5ReflectionHost.prototype, 'getImportOfIdentifier')
                       .and.returnValue(mockImportInfo);
 
@@ -554,7 +535,7 @@ describe('Esm5ReflectionHost', () => {
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NoArgsPropertyDecorator');
+        expect(decorators[0].name).toBe('Directive');
         expect(decorators[0].args).toEqual([]);
       });
 
@@ -567,7 +548,7 @@ describe('Esm5ReflectionHost', () => {
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NoPropertyAssignmentDecorator');
+        expect(decorators[0].name).toBe('Directive');
         expect(decorators[0].args).toEqual([]);
       });
 
@@ -579,7 +560,7 @@ describe('Esm5ReflectionHost', () => {
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NotArrayLiteralDecorator');
+        expect(decorators[0].name).toBe('Directive');
         expect(decorators[0].args).toEqual([]);
       });
     });
@@ -688,9 +669,7 @@ describe('Esm5ReflectionHost', () => {
       const decorators = prop.decorators !;
 
       expect(decorators.length).toBe(1);
-      expect(decorators[0]).toEqual(jasmine.objectContaining({
-        name: 'NotObjectLiteralPropDecorator'
-      }));
+      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Input'}));
     });
 
     it('should ignore prop decorator elements that have no `type` property', () => {
@@ -703,7 +682,7 @@ describe('Esm5ReflectionHost', () => {
       const decorators = prop.decorators !;
 
       expect(decorators.length).toBe(1);
-      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'NoTypePropertyDecorator2'}));
+      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Input'}));
     });
 
     it('should ignore prop decorator elements whose `type` value is not an identifier', () => {
@@ -716,14 +695,14 @@ describe('Esm5ReflectionHost', () => {
       const decorators = prop.decorators !;
 
       expect(decorators.length).toBe(1);
-      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'NotIdentifierDecorator'}));
+      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Input'}));
     });
 
     it('should use `getImportOfIdentifier()` to retrieve import info', () => {
       let callCount = 0;
       const spy = spyOn(Esm5ReflectionHost.prototype, 'getImportOfIdentifier').and.callFake(() => {
         callCount++;
-        return {name: `name${callCount}`, from: `from${callCount}`};
+        return {name: `name${callCount}`, from: `@angular/core`};
       });
 
       const program = makeProgram(SOME_DIRECTIVE_FILE);
@@ -737,7 +716,7 @@ describe('Esm5ReflectionHost', () => {
 
       const index = members.findIndex(member => member.name === 'input1');
       expect(members[index].decorators !.length).toBe(1);
-      expect(members[index].decorators ![0].import).toEqual({name: 'name1', from: 'from1'});
+      expect(members[index].decorators ![0].import).toEqual({name: 'name1', from: '@angular/core'});
     });
 
     describe('(returned prop decorators `args`)', () => {
@@ -752,7 +731,7 @@ describe('Esm5ReflectionHost', () => {
         const decorators = prop.decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NoArgsPropertyDecorator');
+        expect(decorators[0].name).toBe('Input');
         expect(decorators[0].args).toEqual([]);
       });
 
@@ -767,7 +746,7 @@ describe('Esm5ReflectionHost', () => {
         const decorators = prop.decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NoPropertyAssignmentDecorator');
+        expect(decorators[0].name).toBe('Input');
         expect(decorators[0].args).toEqual([]);
       });
 
@@ -782,7 +761,7 @@ describe('Esm5ReflectionHost', () => {
         const decorators = prop.decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NotArrayLiteralDecorator');
+        expect(decorators[0].name).toBe('Input');
         expect(decorators[0].args).toEqual([]);
       });
     });
@@ -887,7 +866,7 @@ describe('Esm5ReflectionHost', () => {
         const decorators = parameters ![0].decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'NoTypePropertyDecorator2'}));
+        expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Inject'}));
       });
 
       it('should ignore param decorator elements whose `type` value is not an identifier', () => {
@@ -899,11 +878,11 @@ describe('Esm5ReflectionHost', () => {
         const decorators = parameters ![0].decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'NotIdentifierDecorator'}));
+        expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Inject'}));
       });
 
       it('should use `getImportOfIdentifier()` to retrieve import info', () => {
-        const mockImportInfo = {} as Import;
+        const mockImportInfo = { name: 'mock', from: '@angulare/core' } as Import;
         const spy = spyOn(Esm5ReflectionHost.prototype, 'getImportOfIdentifier')
                         .and.returnValue(mockImportInfo);
 
@@ -934,7 +913,7 @@ describe('Esm5ReflectionHost', () => {
         const decorators = parameters ![0].decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NoArgsPropertyDecorator');
+        expect(decorators[0].name).toBe('Inject');
         expect(decorators[0].args).toEqual([]);
       });
 
@@ -948,7 +927,7 @@ describe('Esm5ReflectionHost', () => {
         const decorators = parameters ![0].decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NoPropertyAssignmentDecorator');
+        expect(decorators[0].name).toBe('Inject');
         expect(decorators[0].args).toEqual([]);
       });
 
@@ -962,7 +941,7 @@ describe('Esm5ReflectionHost', () => {
         const decorators = parameters ![0].decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NotArrayLiteralDecorator');
+        expect(decorators[0].name).toBe('Inject');
         expect(decorators[0].args).toEqual([]);
       });
     });

--- a/packages/compiler-cli/src/ngcc/test/host/fesm2015_host_import_helper_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/host/fesm2015_host_import_helper_spec.ts
@@ -1,0 +1,379 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {ClassMemberKind, Import} from '../../../ngtsc/host';
+import {Fesm2015ReflectionHost} from '../../src/host/fesm2015_host';
+import {convertToDirectTsLibImport, getDeclaration, makeProgram} from '../helpers/utils';
+
+const FILES = [
+  {
+    name: '/some_directive.js',
+    contents: `
+  import * as tslib_1 from 'tslib';
+  import { Directive, Inject, InjectionToken, Input } from '@angular/core';
+  const INJECTED_TOKEN = new InjectionToken('injected');
+  class ViewContainerRef {
+  }
+  class TemplateRef {
+  }
+  let SomeDirective = class SomeDirective {
+      constructor(_viewContainer, _template, injected) {
+          this.instanceProperty = 'instance';
+          this.input1 = '';
+          this.input2 = 0;
+      }
+      instanceMethod() { }
+      static staticMethod() { }
+  };
+  SomeDirective.staticProperty = 'static';
+  tslib_1.__decorate([
+      Input(),
+      tslib_1.__metadata("design:type", String)
+  ], SomeDirective.prototype, "input1", void 0);
+  tslib_1.__decorate([
+      Input(),
+      tslib_1.__metadata("design:type", Number)
+  ], SomeDirective.prototype, "input2", void 0);
+  SomeDirective = tslib_1.__decorate([
+      Directive({ selector: '[someDirective]' }),
+      tslib_1.__param(2, Inject(INJECTED_TOKEN)),
+      tslib_1.__metadata("design:paramtypes", [ViewContainerRef,
+          TemplateRef, String])
+  ], SomeDirective);
+  export { SomeDirective };
+  `,
+  },
+  {
+    name: '/node_modules/@angular/core/some_directive.js',
+    contents: `
+  import * as tslib_1 from 'tslib';
+  import { Directive, Input } from './directives';
+  let SomeDirective = class SomeDirective {
+    constructor() { this.input1 = ''; }
+  };
+  tslib_1.__decorate([
+      Input(),
+      tslib_1.__metadata("design:type", String)
+  ], SomeDirective.prototype, "input1", void 0);
+  SomeDirective = tslib_1.__decorate([
+    Directive({ selector: '[someDirective]' }),
+  ], SomeDirective);
+  export { SomeDirective };
+  `,
+  },
+  {
+    name: 'ngmodule.js',
+    contents: `
+    import * as tslib_1 from 'tslib';
+    import { NgModule } from './directives';
+    var HttpClientXsrfModule_1;
+    let HttpClientXsrfModule = HttpClientXsrfModule_1 = class HttpClientXsrfModule {
+      static withOptions(options = {}) {
+        return {
+          ngModule: HttpClientXsrfModule_1,
+          providers: [],
+        };
+      }
+    };
+    HttpClientXsrfModule = HttpClientXsrfModule_1 = tslib_1.__decorate([
+      NgModule({
+        providers: [],
+      })
+    ], HttpClientXsrfModule);
+    let missingValue;
+    let nonDecoratedVar;
+    nonDecoratedVar = 43;
+    export { HttpClientXsrfModule };
+    `
+  },
+];
+
+describe('Fesm2015ReflectionHost [import helper style]', () => {
+  [{files: FILES, label: 'namespaced'},
+   {files: convertToDirectTsLibImport(FILES), label: 'direct import'},
+  ].forEach(fileSystem => {
+    describe(`[${fileSystem.label}]`, () => {
+
+      describe('getDecoratorsOfDeclaration()', () => {
+        it('should find the decorators on a class', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+          const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+
+          expect(decorators).toBeDefined();
+          expect(decorators.length).toEqual(1);
+
+          const decorator = decorators[0];
+          expect(decorator.name).toEqual('Directive');
+          expect(decorator.import).toEqual({name: 'Directive', from: '@angular/core'});
+          expect(decorator.args !.map(arg => arg.getText())).toEqual([
+            '{ selector: \'[someDirective]\' }',
+          ]);
+        });
+
+        it('should use `getImportOfIdentifier()` to retrieve import info', () => {
+          const spy = spyOn(Fesm2015ReflectionHost.prototype, 'getImportOfIdentifier')
+                          .and.callFake(
+                              (identifier: ts.Identifier) => identifier.getText() === 'Directive' ?
+                                  {from: '@angular/core', name: 'Directive'} :
+                                  {});
+
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+
+          const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+
+          expect(decorators.length).toEqual(1);
+          expect(decorators[0].import).toEqual({from: '@angular/core', name: 'Directive'});
+
+          const identifiers = spy.calls.all().map(call => (call.args[0] as ts.Identifier).text);
+          expect(identifiers.some(identifier => identifier === 'Directive')).toBeTruthy();
+        });
+
+        it('should support decorators being used inside @angular/core', () => {
+          const program = makeProgram(fileSystem.files[1]);
+          const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/node_modules/@angular/core/some_directive.js', 'SomeDirective',
+              ts.isVariableDeclaration);
+          const decorators = host.getDecoratorsOfDeclaration(classNode) !;
+
+          expect(decorators).toBeDefined();
+          expect(decorators.length).toEqual(1);
+
+          const decorator = decorators[0];
+          expect(decorator.name).toEqual('Directive');
+          expect(decorator.import).toEqual({name: 'Directive', from: './directives'});
+          expect(decorator.args !.map(arg => arg.getText())).toEqual([
+            '{ selector: \'[someDirective]\' }',
+          ]);
+        });
+      });
+
+      describe('getMembersOfClass()', () => {
+        it('should find decorated members on a class', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+          const members = host.getMembersOfClass(classNode);
+
+          const input1 = members.find(member => member.name === 'input1') !;
+          expect(input1.kind).toEqual(ClassMemberKind.Property);
+          expect(input1.isStatic).toEqual(false);
+          expect(input1.decorators !.map(d => d.name)).toEqual(['Input']);
+
+          const input2 = members.find(member => member.name === 'input2') !;
+          expect(input2.kind).toEqual(ClassMemberKind.Property);
+          expect(input2.isStatic).toEqual(false);
+          expect(input1.decorators !.map(d => d.name)).toEqual(['Input']);
+        });
+
+        it('should find non decorated properties on a class', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+          const members = host.getMembersOfClass(classNode);
+
+          const instanceProperty = members.find(member => member.name === 'instanceProperty') !;
+          expect(instanceProperty.kind).toEqual(ClassMemberKind.Property);
+          expect(instanceProperty.isStatic).toEqual(false);
+          expect(ts.isBinaryExpression(instanceProperty.implementation !)).toEqual(true);
+          expect(instanceProperty.value !.getText()).toEqual(`'instance'`);
+        });
+
+        it('should find static methods on a class', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+          const members = host.getMembersOfClass(classNode);
+
+          const staticMethod = members.find(member => member.name === 'staticMethod') !;
+          expect(staticMethod.kind).toEqual(ClassMemberKind.Method);
+          expect(staticMethod.isStatic).toEqual(true);
+          expect(ts.isMethodDeclaration(staticMethod.implementation !)).toEqual(true);
+        });
+
+        it('should find static properties on a class', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+
+          const members = host.getMembersOfClass(classNode);
+          const staticProperty = members.find(member => member.name === 'staticProperty') !;
+          expect(staticProperty.kind).toEqual(ClassMemberKind.Property);
+          expect(staticProperty.isStatic).toEqual(true);
+          expect(ts.isPropertyAccessExpression(staticProperty.implementation !)).toEqual(true);
+          expect(staticProperty.value !.getText()).toEqual(`'static'`);
+        });
+
+        it('should use `getImportOfIdentifier()` to retrieve import info', () => {
+          const spy =
+              spyOn(Fesm2015ReflectionHost.prototype, 'getImportOfIdentifier').and.returnValue({});
+
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+
+          host.getMembersOfClass(classNode);
+          const identifiers = spy.calls.all().map(call => (call.args[0] as ts.Identifier).text);
+          expect(identifiers.some(identifier => identifier === 'Input')).toBeTruthy();
+        });
+
+        it('should support decorators being used inside @angular/core', () => {
+          const program = makeProgram(fileSystem.files[1]);
+          const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/node_modules/@angular/core/some_directive.js', 'SomeDirective',
+              ts.isVariableDeclaration);
+          const members = host.getMembersOfClass(classNode);
+
+          const input1 = members.find(member => member.name === 'input1') !;
+          expect(input1.kind).toEqual(ClassMemberKind.Property);
+          expect(input1.isStatic).toEqual(false);
+          expect(input1.decorators !.map(d => d.name)).toEqual(['Input']);
+        });
+      });
+
+      describe('getConstructorParameters', () => {
+        it('should find the decorated constructor parameters', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+          const parameters = host.getConstructorParameters(classNode);
+
+          expect(parameters).toBeDefined();
+          expect(parameters !.map(parameter => parameter.name)).toEqual([
+            '_viewContainer', '_template', 'injected'
+          ]);
+          expect(parameters !.map(parameter => parameter.type !.getText())).toEqual([
+            'ViewContainerRef', 'TemplateRef', 'String'
+          ]);
+        });
+
+        describe('(returned parameters `decorators`)', () => {
+          it('should use `getImportOfIdentifier()` to retrieve import info', () => {
+            const mockImportInfo = {} as Import;
+            const spy = spyOn(Fesm2015ReflectionHost.prototype, 'getImportOfIdentifier')
+                            .and.returnValue(mockImportInfo);
+
+            const program = makeProgram(fileSystem.files[0]);
+            const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+            const classNode = getDeclaration(
+                program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+            const parameters = host.getConstructorParameters(classNode);
+            const decorators = parameters ![2].decorators !;
+
+            expect(decorators.length).toEqual(1);
+            expect(decorators[0].import).toBe(mockImportInfo);
+
+            const typeIdentifier = spy.calls.mostRecent().args[0] as ts.Identifier;
+            expect(typeIdentifier.text).toBe('Inject');
+          });
+        });
+      });
+
+      describe('getDeclarationOfIdentifier', () => {
+        it('should return the declaration of a locally defined identifier', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+          const ctrDecorators = host.getConstructorParameters(classNode) !;
+          const identifierOfViewContainerRef = ctrDecorators[0].type !as ts.Identifier;
+
+          const expectedDeclarationNode = getDeclaration(
+              program, '/some_directive.js', 'ViewContainerRef', ts.isClassDeclaration);
+          const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfViewContainerRef);
+          expect(actualDeclaration).not.toBe(null);
+          expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
+          expect(actualDeclaration !.viaModule).toBe(null);
+        });
+
+        it('should return the declaration of an externally defined identifier', () => {
+          const program = makeProgram(fileSystem.files[0]);
+          const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+          const classNode = getDeclaration(
+              program, '/some_directive.js', 'SomeDirective', ts.isVariableDeclaration);
+          const classDecorators = host.getDecoratorsOfDeclaration(classNode) !;
+          const decoratorNode = classDecorators[0].node;
+          const identifierOfDirective =
+              ts.isCallExpression(decoratorNode) && ts.isIdentifier(decoratorNode.expression) ?
+              decoratorNode.expression :
+              null;
+
+          const expectedDeclarationNode = getDeclaration(
+              program, 'node_modules/@angular/core/index.ts', 'Directive',
+              ts.isVariableDeclaration);
+          const actualDeclaration = host.getDeclarationOfIdentifier(identifierOfDirective !);
+          expect(actualDeclaration).not.toBe(null);
+          expect(actualDeclaration !.node).toBe(expectedDeclarationNode);
+          expect(actualDeclaration !.viaModule).toBe('@angular/core');
+        });
+      });
+
+      describe('getVariableValue', () => {
+        it('should find the "actual" declaration of an aliased variable identifier', () => {
+          const program = makeProgram(fileSystem.files[2]);
+          const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+          const ngModuleRef = findVariableDeclaration(
+              program.getSourceFile(fileSystem.files[2].name) !, 'HttpClientXsrfModule_1');
+
+          const value = host.getVariableValue(ngModuleRef !);
+          expect(value).not.toBe(null);
+          if (!value || !ts.isClassExpression(value)) {
+            throw new Error(
+                `Expected value to be a class expression: ${value && value.getText()}.`);
+          }
+          expect(value.name !.text).toBe('HttpClientXsrfModule');
+        });
+
+        it('should return null if the variable has no assignment', () => {
+          const program = makeProgram(fileSystem.files[2]);
+          const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+          const missingValue = findVariableDeclaration(
+              program.getSourceFile(fileSystem.files[2].name) !, 'missingValue');
+          const value = host.getVariableValue(missingValue !);
+          expect(value).toBe(null);
+        });
+
+        it('should return null if the variable is not assigned from a call to __decorate', () => {
+          const program = makeProgram(fileSystem.files[2]);
+          const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+          const nonDecoratedVar = findVariableDeclaration(
+              program.getSourceFile(fileSystem.files[2].name) !, 'nonDecoratedVar');
+          const value = host.getVariableValue(nonDecoratedVar !);
+          expect(value).toBe(null);
+        });
+      });
+    });
+  });
+
+  function findVariableDeclaration(
+      node: ts.Node | undefined, variableName: string): ts.VariableDeclaration|undefined {
+    if (!node) {
+      return;
+    }
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) &&
+        node.name.text === variableName) {
+      return node;
+    }
+    return node.forEachChild(node => findVariableDeclaration(node, variableName));
+  }
+});

--- a/packages/compiler-cli/src/ngcc/test/host/fesm2015_host_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/host/fesm2015_host_spec.ts
@@ -76,36 +76,32 @@ const FOO_FUNCTION_FILE = {
 const INVALID_DECORATORS_FILE = {
   name: '/invalid_decorators.js',
   contents: `
-    const NotArrayLiteralDecorator = {};
+    import {Directive} from '@angular/core';
     class NotArrayLiteral {
     }
     NotArrayLiteral.decorators = () => [
-      { type: NotArrayLiteralDecorator, args: [{ selector: '[ignored]' },] },
+      { type: Directive, args: [{ selector: '[ignored]' },] },
     ];
 
-    const NotObjectLiteralDecorator = {};
     class NotObjectLiteral {
     }
     NotObjectLiteral.decorators = [
       "This is not an object literal",
-      { type: NotObjectLiteralDecorator },
+      { type: Directive },
     ];
 
-    const NoTypePropertyDecorator1 = {};
-    const NoTypePropertyDecorator2 = {};
     class NoTypeProperty {
     }
     NoTypeProperty.decorators = [
-      { notType: NoTypePropertyDecorator1 },
-      { type: NoTypePropertyDecorator2 },
+      { notType: Directive },
+      { type: Directive },
     ];
 
-    const NotIdentifierDecorator = {};
     class NotIdentifier {
     }
     NotIdentifier.decorators = [
       { type: 'StringsLiteralsAreNotIdentifiers' },
-      { type: NotIdentifierDecorator },
+      { type: Directive },
     ];
   `,
 };
@@ -113,26 +109,24 @@ const INVALID_DECORATORS_FILE = {
 const INVALID_DECORATOR_ARGS_FILE = {
   name: '/invalid_decorator_args.js',
   contents: `
-    const NoArgsPropertyDecorator = {};
+    import {Directive} from '@angular/core';
     class NoArgsProperty {
     }
     NoArgsProperty.decorators = [
-      { type: NoArgsPropertyDecorator },
+      { type: Directive },
     ];
 
-    const NoPropertyAssignmentDecorator = {};
     const args = [{ selector: '[ignored]' },];
     class NoPropertyAssignment {
     }
     NoPropertyAssignment.decorators = [
-      { type: NoPropertyAssignmentDecorator, args },
+      { type: Directive, args },
     ];
 
-    const NotArrayLiteralDecorator = {};
     class NotArrayLiteral {
     }
     NotArrayLiteral.decorators = [
-      { type: NotArrayLiteralDecorator, args: () => [{ selector: '[ignored]' },] },
+      { type: Directive, args: () => [{ selector: '[ignored]' },] },
     ];
   `,
 };
@@ -140,41 +134,37 @@ const INVALID_DECORATOR_ARGS_FILE = {
 const INVALID_PROP_DECORATORS_FILE = {
   name: '/invalid_prop_decorators.js',
   contents: `
-    const NotObjectLiteralDecorator = {};
+    import {Input} from '@angular/core';
     class NotObjectLiteral {
     }
     NotObjectLiteral.propDecorators = () => ({
-      "prop": [{ type: NotObjectLiteralDecorator },]
+      "prop": [{ type: Input },]
     });
 
-    const NotObjectLiteralPropDecorator = {};
     class NotObjectLiteralProp {
     }
     NotObjectLiteralProp.propDecorators = {
       "prop": [
         "This is not an object literal",
-        { type: NotObjectLiteralPropDecorator },
+        { type: Input },
       ]
     };
 
-    const NoTypePropertyDecorator1 = {};
-    const NoTypePropertyDecorator2 = {};
     class NoTypeProperty {
     }
     NoTypeProperty.propDecorators = {
       "prop": [
-        { notType: NoTypePropertyDecorator1 },
-        { type: NoTypePropertyDecorator2 },
+        { notType: Input },
+        { type: Input },
       ]
     };
 
-    const NotIdentifierDecorator = {};
     class NotIdentifier {
     }
     NotIdentifier.propDecorators = {
       "prop": [
         { type: 'StringsLiteralsAreNotIdentifiers' },
-        { type: NotIdentifierDecorator },
+        { type: Input },
       ]
     };
   `,
@@ -183,26 +173,24 @@ const INVALID_PROP_DECORATORS_FILE = {
 const INVALID_PROP_DECORATOR_ARGS_FILE = {
   name: '/invalid_prop_decorator_args.js',
   contents: `
-    const NoArgsPropertyDecorator = {};
+    import {Input} from '@angular/core';
     class NoArgsProperty {
     }
     NoArgsProperty.propDecorators = {
-      "prop": [{ type: NoArgsPropertyDecorator },]
+      "prop": [{ type: Input },]
     };
 
-    const NoPropertyAssignmentDecorator = {};
     const args = [{ selector: '[ignored]' },];
     class NoPropertyAssignment {
     }
     NoPropertyAssignment.propDecorators = {
-      "prop": [{ type: NoPropertyAssignmentDecorator, args },]
+      "prop": [{ type: Input, args },]
     };
 
-    const NotArrayLiteralDecorator = {};
     class NotArrayLiteral {
     }
     NotArrayLiteral.propDecorators = {
-      "prop": [{ type: NotArrayLiteralDecorator, args: () => [{ selector: '[ignored]' },] },],
+      "prop": [{ type: Input, args: () => [{ selector: '[ignored]' },] },],
     };
   `,
 };
@@ -210,40 +198,44 @@ const INVALID_PROP_DECORATOR_ARGS_FILE = {
 const INVALID_CTOR_DECORATORS_FILE = {
   name: '/invalid_ctor_decorators.js',
   contents: `
-    const NoParametersDecorator = {};
+    import {Inject} from '@angular/core';
     class NoParameters {
       constructor() {
       }
     }
 
-    const NotArrowFunctionDecorator = {};
+    const NotFromCoreDecorator = {};
+    class NotFromCore {
+      constructor(arg1) {
+      }
+    }
+    NotFromCore.ctorParameters = () => [
+      { type: 'ParamType', decorators: [{ type: NotFromCoreDecorator },] },
+    ]
+
     class NotArrowFunction {
       constructor(arg1) {
       }
     }
     NotArrowFunction.ctorParameters = function() {
-      return { type: 'ParamType', decorators: [{ type: NotArrowFunctionDecorator },] };
+      return { type: 'ParamType', decorators: [{ type: Inject },] };
     };
 
-    const NotArrayLiteralDecorator = {};
     class NotArrayLiteral {
       constructor(arg1) {
       }
     }
     NotArrayLiteral.ctorParameters = () => 'StringsAreNotArrayLiterals';
 
-    const NotObjectLiteralDecorator = {};
     class NotObjectLiteral {
       constructor(arg1, arg2) {
       }
     }
     NotObjectLiteral.ctorParameters = () => [
       "This is not an object literal",
-      { type: 'ParamType', decorators: [{ type: NotObjectLiteralDecorator },] },
+      { type: 'ParamType', decorators: [{ type: Inject },] },
     ];
 
-    const NoTypePropertyDecorator1 = {};
-    const NoTypePropertyDecorator2 = {};
     class NoTypeProperty {
       constructor(arg1, arg2) {
       }
@@ -252,13 +244,12 @@ const INVALID_CTOR_DECORATORS_FILE = {
       {
         type: 'ParamType',
         decorators: [
-          { notType: NoTypePropertyDecorator1 },
-          { type: NoTypePropertyDecorator2 },
+          { notType: Inject },
+          { type: Inject },
         ]
       },
     ];
 
-    const NotIdentifierDecorator = {};
     class NotIdentifier {
       constructor(arg1, arg2) {
       }
@@ -268,7 +259,7 @@ const INVALID_CTOR_DECORATORS_FILE = {
         type: 'ParamType',
         decorators: [
           { type: 'StringsLiteralsAreNotIdentifiers' },
-          { type: NotIdentifierDecorator },
+          { type: Inject },
         ]
       },
     ];
@@ -278,32 +269,30 @@ const INVALID_CTOR_DECORATORS_FILE = {
 const INVALID_CTOR_DECORATOR_ARGS_FILE = {
   name: '/invalid_ctor_decorator_args.js',
   contents: `
-    const NoArgsPropertyDecorator = {};
+    import {Inject} from '@angular/core';
     class NoArgsProperty {
       constructor(arg1) {
       }
     }
     NoArgsProperty.ctorParameters = () => [
-      { type: 'ParamType', decorators: [{ type: NoArgsPropertyDecorator },] },
+      { type: 'ParamType', decorators: [{ type: Inject },] },
     ];
 
-    const NoPropertyAssignmentDecorator = {};
     const args = [{ selector: '[ignored]' },];
     class NoPropertyAssignment {
       constructor(arg1) {
       }
     }
     NoPropertyAssignment.ctorParameters = () => [
-      { type: 'ParamType', decorators: [{ type: NoPropertyAssignmentDecorator, args },] },
+      { type: 'ParamType', decorators: [{ type: Inject, args },] },
     ];
 
-    const NotArrayLiteralDecorator = {};
     class NotArrayLiteral {
       constructor(arg1) {
       }
     }
     NotArrayLiteral.ctorParameters = () => [
-      { type: 'ParamType', decorators: [{ type: NotArrayLiteralDecorator, args: () => [{ selector: '[ignored]' },] },] },
+      { type: 'ParamType', decorators: [{ type: Inject, args: () => [{ selector: '[ignored]' },] },] },
     ];
   `,
 };
@@ -459,7 +448,7 @@ describe('Fesm2015ReflectionHost', () => {
       const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
       expect(decorators.length).toBe(1);
-      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'NotObjectLiteralDecorator'}));
+      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
     });
 
     it('should ignore decorator elements that have no `type` property', () => {
@@ -470,7 +459,7 @@ describe('Fesm2015ReflectionHost', () => {
       const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
       expect(decorators.length).toBe(1);
-      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'NoTypePropertyDecorator2'}));
+      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
     });
 
     it('should ignore decorator elements whose `type` value is not an identifier', () => {
@@ -481,11 +470,11 @@ describe('Fesm2015ReflectionHost', () => {
       const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
       expect(decorators.length).toBe(1);
-      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'NotIdentifierDecorator'}));
+      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Directive'}));
     });
 
     it('should use `getImportOfIdentifier()` to retrieve import info', () => {
-      const mockImportInfo = {} as Import;
+      const mockImportInfo = { from: '@angular/core' } as Import;
       const spy = spyOn(Fesm2015ReflectionHost.prototype, 'getImportOfIdentifier')
                       .and.returnValue(mockImportInfo);
 
@@ -511,7 +500,7 @@ describe('Fesm2015ReflectionHost', () => {
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NoArgsPropertyDecorator');
+        expect(decorators[0].name).toBe('Directive');
         expect(decorators[0].args).toEqual([]);
       });
 
@@ -524,7 +513,7 @@ describe('Fesm2015ReflectionHost', () => {
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NoPropertyAssignmentDecorator');
+        expect(decorators[0].name).toBe('Directive');
         expect(decorators[0].args).toEqual([]);
       });
 
@@ -536,7 +525,7 @@ describe('Fesm2015ReflectionHost', () => {
         const decorators = host.getDecoratorsOfDeclaration(classNode) !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NotArrayLiteralDecorator');
+        expect(decorators[0].name).toBe('Directive');
         expect(decorators[0].args).toEqual([]);
       });
     });
@@ -644,9 +633,7 @@ describe('Fesm2015ReflectionHost', () => {
       const decorators = prop.decorators !;
 
       expect(decorators.length).toBe(1);
-      expect(decorators[0]).toEqual(jasmine.objectContaining({
-        name: 'NotObjectLiteralPropDecorator'
-      }));
+      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Input'}));
     });
 
     it('should ignore prop decorator elements that have no `type` property', () => {
@@ -659,7 +646,7 @@ describe('Fesm2015ReflectionHost', () => {
       const decorators = prop.decorators !;
 
       expect(decorators.length).toBe(1);
-      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'NoTypePropertyDecorator2'}));
+      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Input'}));
     });
 
     it('should ignore prop decorator elements whose `type` value is not an identifier', () => {
@@ -672,7 +659,7 @@ describe('Fesm2015ReflectionHost', () => {
       const decorators = prop.decorators !;
 
       expect(decorators.length).toBe(1);
-      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'NotIdentifierDecorator'}));
+      expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Input'}));
     });
 
     it('should use `getImportOfIdentifier()` to retrieve import info', () => {
@@ -680,7 +667,7 @@ describe('Fesm2015ReflectionHost', () => {
       const spy =
           spyOn(Fesm2015ReflectionHost.prototype, 'getImportOfIdentifier').and.callFake(() => {
             callCount++;
-            return {name: `name${callCount}`, from: `from${callCount}`};
+            return {name: `name${callCount}`, from: '@angular/core'};
           });
 
       const program = makeProgram(SOME_DIRECTIVE_FILE);
@@ -698,9 +685,9 @@ describe('Fesm2015ReflectionHost', () => {
         'HostListener',
       ]);
 
-      const index = members.findIndex(member => member.name === 'input1');
-      expect(members[index].decorators !.length).toBe(1);
-      expect(members[index].decorators ![0].import).toEqual({name: 'name1', from: 'from1'});
+      const member = members.find(member => member.name === 'input1') !;
+      expect(member.decorators !.length).toBe(1);
+      expect(member.decorators ![0].import).toEqual({name: 'name1', from: '@angular/core'});
     });
 
     describe('(returned prop decorators `args`)', () => {
@@ -715,7 +702,7 @@ describe('Fesm2015ReflectionHost', () => {
         const decorators = prop.decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NoArgsPropertyDecorator');
+        expect(decorators[0].name).toBe('Input');
         expect(decorators[0].args).toEqual([]);
       });
 
@@ -730,7 +717,7 @@ describe('Fesm2015ReflectionHost', () => {
         const decorators = prop.decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NoPropertyAssignmentDecorator');
+        expect(decorators[0].name).toBe('Input');
         expect(decorators[0].args).toEqual([]);
       });
 
@@ -745,7 +732,7 @@ describe('Fesm2015ReflectionHost', () => {
         const decorators = prop.decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NotArrayLiteralDecorator');
+        expect(decorators[0].name).toBe('Input');
         expect(decorators[0].args).toEqual([]);
       });
     });
@@ -757,13 +744,13 @@ describe('Fesm2015ReflectionHost', () => {
       const host = new Fesm2015ReflectionHost(program.getTypeChecker());
       const classNode =
           getDeclaration(program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', ts.isClassDeclaration);
-      const parameters = host.getConstructorParameters(classNode);
+      const parameters = host.getConstructorParameters(classNode) !;
 
       expect(parameters).toBeDefined();
-      expect(parameters !.map(parameter => parameter.name)).toEqual([
+      expect(parameters.map(parameter => parameter.name)).toEqual([
         '_viewContainer', '_template', 'injected'
       ]);
-      expect(parameters !.map(parameter => parameter.type !.getText())).toEqual([
+      expect(parameters.map(parameter => parameter.type !.getText())).toEqual([
         'ViewContainerRef', 'TemplateRef', 'undefined'
       ]);
     });
@@ -792,12 +779,12 @@ describe('Fesm2015ReflectionHost', () => {
       const host = new Fesm2015ReflectionHost(program.getTypeChecker());
       const classNode = getDeclaration(
           program, SIMPLE_CLASS_FILE.name, 'NoDecoratorConstructorClass', ts.isClassDeclaration);
-      const parameters = host.getConstructorParameters(classNode);
+      const parameters = host.getConstructorParameters(classNode) !;
 
       expect(parameters).toEqual(jasmine.any(Array));
-      expect(parameters !.length).toEqual(1);
-      expect(parameters ![0].name).toEqual('foo');
-      expect(parameters ![0].decorators).toBe(null);
+      expect(parameters.length).toEqual(1);
+      expect(parameters[0].name).toEqual('foo');
+      expect(parameters[0].decorators).toBe(null);
     });
 
     it('should return an empty array if there are no constructor parameters', () => {
@@ -810,15 +797,29 @@ describe('Fesm2015ReflectionHost', () => {
       expect(parameters).toEqual([]);
     });
 
+    it('should ignore decorators that are not imported from core', () => {
+      const program = makeProgram(INVALID_CTOR_DECORATORS_FILE);
+      const host = new Fesm2015ReflectionHost(program.getTypeChecker());
+      const classNode = getDeclaration(
+          program, INVALID_CTOR_DECORATORS_FILE.name, 'NotFromCore', ts.isClassDeclaration);
+      const parameters = host.getConstructorParameters(classNode) !;
+
+      expect(parameters.length).toBe(1);
+      expect(parameters[0]).toEqual(jasmine.objectContaining({
+        name: 'arg1',
+        decorators: [],
+      }));
+    });
+
     it('should ignore `ctorParameters` if it is not an arrow function', () => {
       const program = makeProgram(INVALID_CTOR_DECORATORS_FILE);
       const host = new Fesm2015ReflectionHost(program.getTypeChecker());
       const classNode = getDeclaration(
           program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrowFunction', ts.isClassDeclaration);
-      const parameters = host.getConstructorParameters(classNode);
+      const parameters = host.getConstructorParameters(classNode) !;
 
-      expect(parameters !.length).toBe(1);
-      expect(parameters ![0]).toEqual(jasmine.objectContaining({
+      expect(parameters.length).toBe(1);
+      expect(parameters[0]).toEqual(jasmine.objectContaining({
         name: 'arg1',
         decorators: null,
       }));
@@ -829,10 +830,10 @@ describe('Fesm2015ReflectionHost', () => {
       const host = new Fesm2015ReflectionHost(program.getTypeChecker());
       const classNode = getDeclaration(
           program, INVALID_CTOR_DECORATORS_FILE.name, 'NotArrayLiteral', ts.isClassDeclaration);
-      const parameters = host.getConstructorParameters(classNode);
+      const parameters = host.getConstructorParameters(classNode) !;
 
-      expect(parameters !.length).toBe(1);
-      expect(parameters ![0]).toEqual(jasmine.objectContaining({
+      expect(parameters.length).toBe(1);
+      expect(parameters[0]).toEqual(jasmine.objectContaining({
         name: 'arg1',
         decorators: null,
       }));
@@ -866,7 +867,7 @@ describe('Fesm2015ReflectionHost', () => {
         const decorators = parameters ![0].decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'NoTypePropertyDecorator2'}));
+        expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Inject'}));
       });
 
       it('should ignore param decorator elements whose `type` value is not an identifier', () => {
@@ -878,11 +879,11 @@ describe('Fesm2015ReflectionHost', () => {
         const decorators = parameters ![0].decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'NotIdentifierDecorator'}));
+        expect(decorators[0]).toEqual(jasmine.objectContaining({name: 'Inject'}));
       });
 
       it('should use `getImportOfIdentifier()` to retrieve import info', () => {
-        const mockImportInfo = {} as Import;
+        const mockImportInfo: Import = {name: 'mock', from: '@angular/core'};
         const spy = spyOn(Fesm2015ReflectionHost.prototype, 'getImportOfIdentifier')
                         .and.returnValue(mockImportInfo);
 
@@ -890,8 +891,8 @@ describe('Fesm2015ReflectionHost', () => {
         const host = new Fesm2015ReflectionHost(program.getTypeChecker());
         const classNode = getDeclaration(
             program, SOME_DIRECTIVE_FILE.name, 'SomeDirective', ts.isClassDeclaration);
-        const parameters = host.getConstructorParameters(classNode);
-        const decorators = parameters ![2].decorators !;
+        const parameters = host.getConstructorParameters(classNode) !;
+        const decorators = parameters[2].decorators !;
 
         expect(decorators.length).toEqual(1);
         expect(decorators[0].import).toBe(mockImportInfo);
@@ -913,7 +914,7 @@ describe('Fesm2015ReflectionHost', () => {
         const decorators = parameters ![0].decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NoArgsPropertyDecorator');
+        expect(decorators[0].name).toBe('Inject');
         expect(decorators[0].args).toEqual([]);
       });
 
@@ -927,7 +928,7 @@ describe('Fesm2015ReflectionHost', () => {
         const decorators = parameters ![0].decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NoPropertyAssignmentDecorator');
+        expect(decorators[0].name).toBe('Inject');
         expect(decorators[0].args).toEqual([]);
       });
 
@@ -941,7 +942,7 @@ describe('Fesm2015ReflectionHost', () => {
         const decorators = parameters ![0].decorators !;
 
         expect(decorators.length).toBe(1);
-        expect(decorators[0].name).toBe('NotArrayLiteralDecorator');
+        expect(decorators[0].name).toBe('Inject');
         expect(decorators[0].args).toEqual([]);
       });
     });

--- a/packages/compiler-cli/src/ngcc/test/parsing/esm5_parser_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/parsing/esm5_parser_spec.ts
@@ -15,6 +15,7 @@ import {makeProgram} from '../helpers/utils';
 const BASIC_FILE = {
   name: '/primary.js',
   contents: `
+  import {Directive} from '@angular/core';
   var A = (function() {
     function A() {}
     A.decorators = [

--- a/packages/compiler-cli/src/ngcc/test/rendering/esm2015_renderer_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/rendering/esm2015_renderer_spec.ts
@@ -200,7 +200,7 @@ A.decorators = [
            const analyzedFile = analyze(parser, analyzer, program.getSourceFile(PROGRAM.name) !);
            const output = new MagicString(PROGRAM.contents);
            const analyzedClass = analyzedFile.analyzedClasses[1];
-           const decorator = analyzedClass.decorators[1];
+           const decorator = analyzedClass.decorators[0];
            const decoratorsToRemove = new Map<ts.Node, ts.Node[]>();
            decoratorsToRemove.set(decorator.node.parent !, [decorator.node]);
            renderer.removeDecorators(output, decoratorsToRemove);

--- a/packages/compiler-cli/src/ngcc/test/rendering/esm5_renderer_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/rendering/esm5_renderer_spec.ts
@@ -223,7 +223,7 @@ SOME DEFINITION TEXT
          const analyzedFile = analyze(parser, analyzer, program.getSourceFile(PROGRAM.name) !);
          const output = new MagicString(PROGRAM.contents);
          const analyzedClass = analyzedFile.analyzedClasses[1];
-         const decorator = analyzedClass.decorators[1];
+         const decorator = analyzedClass.decorators[0];
          const decoratorsToRemove = new Map<ts.Node, ts.Node[]>();
          decoratorsToRemove.set(decorator.node.parent !, [decorator.node]);
          renderer.removeDecorators(output, decoratorsToRemove);

--- a/packages/compiler-cli/src/ngcc/test/rendering/esm5_renderer_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/rendering/esm5_renderer_spec.ts
@@ -74,6 +74,57 @@ function compileNgModuleFactory__POST_NGCC__(injector, options, moduleType) {
 export {A, B, C};`
 };
 
+const PROGRAM_DECORATE_HELPER = {
+  name: 'some/file.js',
+  contents: `
+import * as tslib_1 from "tslib";
+/* A copyright notice */
+import { Directive } from '@angular/core';
+var OtherA = function () { return function (node) { }; };
+var OtherB = function () { return function (node) { }; };
+var A = /** @class */ (function () {
+    function A() {
+    }
+    A = tslib_1.__decorate([
+        Directive({ selector: '[a]' }),
+        OtherA()
+    ], A);
+    return A;
+}());
+export { A };
+var B = /** @class */ (function () {
+    function B() {
+    }
+    B = tslib_1.__decorate([
+        OtherB(),
+        Directive({ selector: '[b]' })
+    ], B);
+    return B;
+}());
+export { B };
+var C = /** @class */ (function () {
+    function C() {
+    }
+    C = tslib_1.__decorate([
+        Directive({ selector: '[c]' })
+    ], C);
+    return C;
+}());
+export { C };
+var D = /** @class */ (function () {
+    function D() {
+    }
+    D_1 = D;
+    var D_1;
+    D = D_1 = tslib_1.__decorate([
+        Directive({ selector: '[d]', providers: [D_1] })
+    ], D);
+    return D;
+}());
+export { D };
+// Some other content`
+};
+
 describe('Esm5Renderer', () => {
 
   describe('addImports', () => {
@@ -204,5 +255,63 @@ SOME DEFINITION TEXT
 ];`);
        });
 
+  });
+
+  describe('[__decorate declarations]', () => {
+    it('should delete the decorator (and following comma) that was matched in the analysis', () => {
+      const {analyzer, parser, program, renderer} = setup(PROGRAM_DECORATE_HELPER);
+      const analyzedFile =
+          analyze(parser, analyzer, program.getSourceFile(PROGRAM_DECORATE_HELPER.name) !);
+      const output = new MagicString(PROGRAM_DECORATE_HELPER.contents);
+      const analyzedClass = analyzedFile.analyzedClasses.find(c => c.name === 'A') !;
+      const decorator = analyzedClass.decorators.find(d => d.name === 'Directive') !;
+      const decoratorsToRemove = new Map<ts.Node, ts.Node[]>();
+      decoratorsToRemove.set(decorator.node.parent !, [decorator.node]);
+      renderer.removeDecorators(output, decoratorsToRemove);
+      expect(output.toString()).not.toContain(`Directive({ selector: '[a]' }),`);
+      expect(output.toString()).toContain(`OtherA()`);
+      expect(output.toString()).toContain(`Directive({ selector: '[b]' })`);
+      expect(output.toString()).toContain(`OtherB()`);
+      expect(output.toString()).toContain(`Directive({ selector: '[c]' })`);
+    });
+
+    it('should delete the decorator (but cope with no trailing comma) that was matched in the analysis',
+       () => {
+         const {analyzer, parser, program, renderer} = setup(PROGRAM_DECORATE_HELPER);
+         const analyzedFile =
+             analyze(parser, analyzer, program.getSourceFile(PROGRAM_DECORATE_HELPER.name) !);
+         const output = new MagicString(PROGRAM_DECORATE_HELPER.contents);
+         const analyzedClass = analyzedFile.analyzedClasses.find(c => c.name === 'B') !;
+         const decorator = analyzedClass.decorators.find(d => d.name === 'Directive') !;
+         const decoratorsToRemove = new Map<ts.Node, ts.Node[]>();
+         decoratorsToRemove.set(decorator.node.parent !, [decorator.node]);
+         renderer.removeDecorators(output, decoratorsToRemove);
+         expect(output.toString()).toContain(`Directive({ selector: '[a]' }),`);
+         expect(output.toString()).toContain(`OtherA()`);
+         expect(output.toString()).not.toContain(`Directive({ selector: '[b]' })`);
+         expect(output.toString()).toContain(`OtherB()`);
+         expect(output.toString()).toContain(`Directive({ selector: '[c]' })`);
+       });
+
+
+    it('should delete the decorator (and its container if there are no other decorators left) that was matched in the analysis',
+       () => {
+         const {analyzer, parser, program, renderer} = setup(PROGRAM_DECORATE_HELPER);
+         const analyzedFile =
+             analyze(parser, analyzer, program.getSourceFile(PROGRAM_DECORATE_HELPER.name) !);
+         const output = new MagicString(PROGRAM_DECORATE_HELPER.contents);
+         const analyzedClass = analyzedFile.analyzedClasses.find(c => c.name === 'C') !;
+         const decorator = analyzedClass.decorators.find(d => d.name === 'Directive') !;
+         const decoratorsToRemove = new Map<ts.Node, ts.Node[]>();
+         decoratorsToRemove.set(decorator.node.parent !, [decorator.node]);
+         renderer.removeDecorators(output, decoratorsToRemove);
+         expect(output.toString()).toContain(`Directive({ selector: '[a]' }),`);
+         expect(output.toString()).toContain(`OtherA()`);
+         expect(output.toString()).toContain(`Directive({ selector: '[b]' })`);
+         expect(output.toString()).toContain(`OtherB()`);
+         expect(output.toString()).not.toContain(`Directive({ selector: '[c]' })`);
+         expect(output.toString()).not.toContain(`C = tslib_1.__decorate([`);
+         expect(output.toString()).toContain(`function C() {\n    }\n    return C;`);
+       });
   });
 });

--- a/packages/compiler-cli/src/ngtsc/host/src/reflection.ts
+++ b/packages/compiler-cli/src/ngtsc/host/src/reflection.ts
@@ -419,4 +419,16 @@ export interface ReflectionHost {
    * is not a class or has an unknown number of type parameters.
    */
   getGenericArityOfClass(clazz: ts.Declaration): number|null;
+
+  /**
+   * Find the assigned value of a variable declaration.
+   *
+   * Normally this will be the initializer of the declaration, but where the variable is
+   * not a `const` we may need to look elsewhere for the variable's value.
+   *
+   * @param declaration a TypeScript variable declaration, whose value we want.
+   * @returns the value of the variable, as a TypeScript expression node, or `undefined`
+   * if the value cannot be computed.
+   */
+  getVariableValue(declaration: ts.VariableDeclaration): ts.Expression|null;
 }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/reflector.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/reflector.ts
@@ -166,6 +166,10 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     return clazz.typeParameters !== undefined ? clazz.typeParameters.length : 0;
   }
 
+  getVariableValue(declaration: ts.VariableDeclaration): ts.Expression|null {
+    return declaration.initializer || null;
+  }
+
   /**
    * Resolve a `ts.Symbol` to its declaration, keeping track of the `viaModule` along the way.
    *

--- a/packages/compiler-cli/src/ngtsc/metadata/src/resolver.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/resolver.ts
@@ -454,8 +454,9 @@ class StaticInterpreter {
   }
 
   private visitVariableDeclaration(node: ts.VariableDeclaration, context: Context): ResolvedValue {
-    if (node.initializer !== undefined) {
-      return this.visitExpression(node.initializer, context);
+    const value = this.host.getVariableValue(node);
+    if (value !== null) {
+      return this.visitExpression(value, context);
     } else if (isVariableDeclarationDeclared(node)) {
       return this.getReference(node, context);
     } else {


### PR DESCRIPTION
FW-379 #resolve 

**TODO:**
* [x] implement `__decorate` decorator removal

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See FW-379


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
