### PR TITLE
docs: correct reattach example in ChangeDetectorRef

### DIFF
--- a/packages/core/src/change_detection/change_detector_ref.ts
+++ b/packages/core/src/change_detection/change_detector_ref.ts
@@ -44,7 +44,7 @@
  * when the `live` property is set to false, and reattaches it when the property
  * becomes true.
  *
- * <code-example path="core/ts/change_detect/change-detection.ts" region="detach"></code-example>
+ * <code-example path="core/ts/change_detect/change-detection.ts" region="reattach"></code-example>
  *
  */
 export abstract class ChangeDetectorRef {


### PR DESCRIPTION
change the reattach api example. The attach api example was shown as the reattach example.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The "reattach" API example shows the "attach" API example.

Issue Number: N/A


## What is the new behavior?
The "reattach" API example works the "reattach" API example.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
