### PR TITLE
build(bazel): support TsConfigInfo provider in ng_module tsconfig attribute

### DIFF
--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -2,7 +2,6 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "tsconfig-build.json",
-    "tsconfig-test.json",
     "tsconfig.json",
 ])
 
@@ -21,3 +20,13 @@ exports_files([
     "license-banner.txt",
     "README.md",
 ])
+
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_config")
+
+ts_config(
+    name = "tsconfig-test",
+    src = ":tsconfig-test.json",
+    deps = [
+        ":tsconfig-build.json",
+    ],
+)

--- a/packages/bazel/src/external.bzl
+++ b/packages/bazel/src/external.bzl
@@ -18,6 +18,10 @@ load(
     _NodeModuleInfo = "NodeModuleInfo",
     _collect_node_modules_aspect = "collect_node_modules_aspect",
 )
+load(
+    "@build_bazel_rules_typescript//internal:ts_config.bzl",
+    _TsConfigInfo = "TsConfigInfo",
+)
 
 NodeModuleInfo = _NodeModuleInfo
 collect_node_modules_aspect = _collect_node_modules_aspect
@@ -27,6 +31,7 @@ COMMON_OUTPUTS = _COMMON_OUTPUTS
 compile_ts = _compile_ts
 DEPS_ASPECTS = _DEPS_ASPECTS
 ts_providers_dict_to_struct = _ts_providers_dict_to_struct
+TsConfigInfo = _TsConfigInfo
 
 DEFAULT_NG_COMPILER = "@angular//:@angular/bazel/ngc-wrapped"
 DEFAULT_NG_XI18N = "@npm//@angular/bazel/bin:xi18n"

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -13,6 +13,7 @@ load(
     "DEFAULT_NG_XI18N",
     "DEPS_ASPECTS",
     "NodeModuleInfo",
+    "TsConfigInfo",
     "collect_node_modules_aspect",
     "compile_ts",
     "ts_providers_dict_to_struct",
@@ -402,6 +403,8 @@ def _compile_action(ctx, inputs, outputs, messages_out, tsconfig_file, node_opts
     # If the user supplies a tsconfig.json file, the Angular compiler needs to read it
     if hasattr(ctx.attr, "tsconfig") and ctx.file.tsconfig:
         file_inputs.append(ctx.file.tsconfig)
+        if TsConfigInfo in ctx.attr.tsconfig:
+            file_inputs += ctx.attr.tsconfig[TsConfigInfo].deps
 
     # Also include files from npm fine grained deps as action_inputs.
     # These deps are identified by the NodeModuleInfo provider.

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -7,7 +7,7 @@ load("//packages/bazel/src:ng_module.bzl", _internal_global_ng_module = "interna
 load("//packages/bazel/src:ng_rollup_bundle.bzl", _ng_rollup_bundle = "ng_rollup_bundle")
 
 _DEFAULT_TSCONFIG_BUILD = "//packages:tsconfig-build.json"
-_DEFAULT_TSCONFIG_TEST = "//packages:tsconfig-test.json"
+_DEFAULT_TSCONFIG_TEST = "//packages:tsconfig-test"
 _DEFAULT_TS_TYPINGS = "@ngdeps//typescript:typescript__typings"
 _INTERNAL_NG_MODULE_COMPILER = "//packages/bazel/src/ngc-wrapped"
 _INTERNAL_NG_MODULE_XI18N = "//packages/bazel/src/ngc-wrapped:xi18n"


### PR DESCRIPTION
This is already handled in ts_library the same way. Bringing the same logic to ng_module.