### PR TITLE
Form Reset() and Default triggering of validation

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -542,27 +542,31 @@ export abstract class AbstractControl {
    * When false, no events are emitted.
    */
   updateValueAndValidity(opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
-    this._setInitialStatus();
-    this._updateValue();
+    
+    if(!(this.pristine && this.untouched)){
+        this._setInitialStatus();
+        this._updateValue();
 
-    if (this.enabled) {
-      this._cancelExistingSubscription();
-      (this as{errors: ValidationErrors | null}).errors = this._runValidator();
-      (this as{status: string}).status = this._calculateStatus();
+        if (this.enabled) {
+          this._cancelExistingSubscription();
+          (this as{errors: ValidationErrors | null}).errors = this._runValidator();
+          (this as{status: string}).status = this._calculateStatus();
 
-      if (this.status === VALID || this.status === PENDING) {
-        this._runAsyncValidator(opts.emitEvent);
-      }
-    }
+          if (this.status === VALID || this.status === PENDING) {
+            this._runAsyncValidator(opts.emitEvent);
+          }
+        }
 
-    if (opts.emitEvent !== false) {
-      (this.valueChanges as EventEmitter<any>).emit(this.value);
-      (this.statusChanges as EventEmitter<string>).emit(this.status);
-    }
+        if (opts.emitEvent !== false) {
+          (this.valueChanges as EventEmitter<any>).emit(this.value);
+          (this.statusChanges as EventEmitter<string>).emit(this.status);
+        }
 
-    if (this._parent && !opts.onlySelf) {
-      this._parent.updateValueAndValidity(opts);
-    }
+        if (this._parent && !opts.onlySelf) {
+          this._parent.updateValueAndValidity(opts);
+        }
+     }
+    
   }
 
   /** @internal */
@@ -980,6 +984,7 @@ export class FormControl extends AbstractControl {
     this._applyFormState(formState);
     this.markAsPristine(options);
     this.markAsUntouched(options);
+    this.status = undefined;
     this.setValue(this.value, options);
     this._pendingChange = false;
   }

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -544,6 +544,7 @@ export abstract class AbstractControl {
   updateValueAndValidity(opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
     
     if(!(this.pristine && this.untouched)){
+    
         this._setInitialStatus();
         this._updateValue();
 


### PR DESCRIPTION
ng-invalid class to be removed when ngForm is reset. And when loading form for first time with values, validations should not be triggered.

For resetting of form, Pristine and Untouched were set to default (Pristine: true, Untouched: true). Same conditions are used to restrict validations on reset of form.

status of Control is set to undefined when loading of form is done for first load.

e.g. this.status = undefined;

updateValueAndValidity is check for pristine and untouched values.

ng-invalid and ng-valid classes are removed when form is reset.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
