### PR TITLE
build(ngcontainer): update BAZEL_VERSION to 0.17.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@
 ## IMPORTANT
 # If you change the `docker_image` version, also change the `cache_key` suffix and the version of
 # `com_github_bazelbuild_buildtools` in the `/WORKSPACE` file.
-var_1: &docker_image angular/ngcontainer:0.5.0
-var_2: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.5.0
+var_1: &docker_image angular/ngcontainer:0.6.0
+var_2: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.6.0
 
 # Define common ENV vars
 var_3: &define_env_vars

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,9 +51,9 @@ http_archive(
 # Fetching the Bazel source code allows us to compile the Skylark linter
 http_archive(
     name = "io_bazel",
-    url = "https://github.com/bazelbuild/bazel/archive/968f87900dce45a7af749a965b72dbac51b176b3.zip",
-    strip_prefix = "bazel-968f87900dce45a7af749a965b72dbac51b176b3",
-    sha256 = "e373d2ae24955c1254c495c9c421c009d88966565c35e4e8444c082cb1f0f48f",
+    url = "https://github.com/bazelbuild/bazel/archive/0.17.1.zip",
+    strip_prefix = "bazel-0.17.1",
+    sha256 = "ace8cced3b21e64a8fdad68508e9b0644201ec848ad583651719841d567fc66d",
 )
 
 http_archive(
@@ -106,7 +106,7 @@ local_repository(
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories")
 
-check_bazel_version("0.16.0", """
+check_bazel_version("0.17.0", """
 If you are on a Mac and using Homebrew, there is a breaking change to the installation in Bazel 0.16
 See https://blog.bazel.build/2018/08/22/bazel-homebrew.html
 

--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -37,7 +37,7 @@ local_repository(
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories")
 
-check_bazel_version("0.16.0")
+check_bazel_version("0.17.0")
 node_repositories(
     package_json = ["//:package.json"],
   node_version = "10.9.0",

--- a/packages/compiler-cli/test/BUILD.bazel
+++ b/packages/compiler-cli/test/BUILD.bazel
@@ -65,6 +65,7 @@ ts_library(
 
 jasmine_node_test(
     name = "ngc",
+    timeout = "long",  # 900 seconds
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
     data = [
         "//packages/common:npm_package",

--- a/packages/compiler-cli/test/diagnostics/BUILD.bazel
+++ b/packages/compiler-cli/test/diagnostics/BUILD.bazel
@@ -30,6 +30,7 @@ ts_library(
 
 jasmine_node_test(
     name = "check_types",
+    timeout = "long",  # 900 seconds
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
     data = [
         "//packages/common:npm_package",

--- a/packages/compiler-cli/test/transformers/BUILD.bazel
+++ b/packages/compiler-cli/test/transformers/BUILD.bazel
@@ -18,6 +18,7 @@ ts_library(
 
 jasmine_node_test(
     name = "test",
+    timeout = "long",  # 900 seconds
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
     data = [
         "//packages/common:npm_package",

--- a/tools/ngcontainer/Dockerfile
+++ b/tools/ngcontainer/Dockerfile
@@ -5,7 +5,7 @@ USER root
 ###
 # Bazel install
 # See https://bazel.build/versions/master/docs/install-ubuntu.html#using-bazel-custom-apt-repository-recommended
-RUN BAZEL_VERSION="0.16.1" \
+RUN BAZEL_VERSION="0.17.1" \
  && wget -q -O - https://bazel.build/bazel-release.pub.gpg | apt-key add - \
  && echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/bazel.list \
  && apt-get update \

--- a/tools/ngcontainer/Dockerfile
+++ b/tools/ngcontainer/Dockerfile
@@ -5,6 +5,7 @@ USER root
 ###
 # Bazel install
 # See https://bazel.build/versions/master/docs/install-ubuntu.html#using-bazel-custom-apt-repository-recommended
+# Note, only the latest release is available, see https://github.com/bazelbuild/bazel/issues/4947
 RUN BAZEL_VERSION="0.17.1" \
  && wget -q -O - https://bazel.build/bazel-release.pub.gpg | apt-key add - \
  && echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/bazel.list \

--- a/tools/ngcontainer/README.md
+++ b/tools/ngcontainer/README.md
@@ -6,7 +6,7 @@ This docker container provides everything needed to build and test Angular appli
 - npm 6.2.0
 - yarn 1.9.2
 - Java 8 (for Closure Compiler and Bazel)
-- Bazel build tool v0.16.1 - http://bazel.build
+- Bazel build tool v0.17.1 - http://bazel.build
 - Google Chrome 69.0.3497.81
 - Mozilla Firefox 47.0.1
 - xvfb (virtual framebuffer) for headless testing


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Bazel version '0.16.1' doesn't seem to be available anymore! Updating to 0.17.1 to fix the issue.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Building the `angular/ngcontainer` fails with the following error:

```
E: Version '0.16.1' for 'bazel' was not found
The command '/bin/sh -c BAZEL_VERSION="0.16.1"  && wget -q -O - https://bazel.build/bazel-release.pub.gpg | apt-key add -  && echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/bazel.list  && apt-get update  && apt-get install -y bazel=$BAZEL_VERSION  && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: exit status 100
```

Issue Number: N/A


## What is the new behavior?

The build pass and a docker image is created.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
