### PR TITLE
fix(ivy): events should not mark views dirty by default

### DIFF
--- a/packages/core/src/render3/context_discovery.ts
+++ b/packages/core/src/render3/context_discovery.ts
@@ -29,7 +29,7 @@ export const MONKEY_PATCH_KEY_NAME = '__ngContext__';
  * of the context.
  */
 export interface LContext {
-  /** The component\'s view data */
+  /** The component's parent view data */
   lViewData: LViewData;
 
   /** The index instance of the LNode */

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1237,7 +1237,7 @@ export function listener(
       const cleanupFn = renderer.listen(node.native, eventName, listenerFn);
       storeCleanupFn(viewData, cleanupFn);
     } else {
-      const wrappedListener = wrapListenerWithDirtyAndDefault(viewData, listenerFn);
+      const wrappedListener = wrapListenerWithPreventDefault(listenerFn);
       node.native.addEventListener(eventName, wrappedListener, useCapture);
       const cleanupInstances = getCleanup(viewData);
       cleanupInstances.push(wrappedListener);
@@ -2330,13 +2330,9 @@ export function markDirtyIfOnPush(node: LElementNode): void {
   }
 }
 
-/**
- * Wraps an event listener so its host view and its ancestor views will be marked dirty
- * whenever the event fires. Also wraps with preventDefault behavior.
- */
-export function wrapListenerWithDirtyAndDefault(
-    view: LViewData, listenerFn: (e?: any) => any): EventListener {
-  return function wrapListenerIn_markViewDirty(e: Event) {
+/** Wraps an event listener with preventDefault behavior. */
+export function wrapListenerWithPreventDefault(listenerFn: (e?: any) => any): EventListener {
+  return function wrapListenerIn_preventDefault(e: Event) {
     if (listenerFn(e) === false) {
       e.preventDefault();
       // Necessary for legacy browsers that don't support preventDefault (e.g. IE)

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1234,8 +1234,7 @@ export function listener(
     // In order to match current behavior, native DOM event listeners must be added for all
     // events (including outputs).
     if (isProceduralRenderer(renderer)) {
-      const wrappedListener = wrapListenerWithDirtyLogic(viewData, listenerFn);
-      const cleanupFn = renderer.listen(node.native, eventName, wrappedListener);
+      const cleanupFn = renderer.listen(node.native, eventName, listenerFn);
       storeCleanupFn(viewData, cleanupFn);
     } else {
       const wrappedListener = wrapListenerWithDirtyAndDefault(viewData, listenerFn);
@@ -2333,24 +2332,11 @@ export function markDirtyIfOnPush(node: LElementNode): void {
 
 /**
  * Wraps an event listener so its host view and its ancestor views will be marked dirty
- * whenever the event fires. Necessary to support OnPush components.
- */
-export function wrapListenerWithDirtyLogic(
-    view: LViewData, listenerFn: (e?: any) => any): (e: Event) => any {
-  return function(e: any) {
-    markViewDirty(view);
-    return listenerFn(e);
-  };
-}
-
-/**
- * Wraps an event listener so its host view and its ancestor views will be marked dirty
  * whenever the event fires. Also wraps with preventDefault behavior.
  */
 export function wrapListenerWithDirtyAndDefault(
     view: LViewData, listenerFn: (e?: any) => any): EventListener {
   return function wrapListenerIn_markViewDirty(e: Event) {
-    markViewDirty(view);
     if (listenerFn(e) === false) {
       e.preventDefault();
       // Necessary for legacy browsers that don't support preventDefault (e.g. IE)
@@ -2548,8 +2534,8 @@ function updateViewQuery<T>(viewQuery: ComponentQuery<{}>| null, component: T): 
  */
 export function markDirty<T>(component: T) {
   ngDevMode && assertDefined(component, 'component');
-  const lViewData = readPatchedLViewData(component) !;
-  markViewDirty(lViewData);
+  const elementNode = getLElementFromComponent(component) !;
+  markViewDirty(elementNode.data as LViewData);
 }
 
 ///////////////////////////////

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1026,6 +1026,6 @@
     "name": "walkUpViews"
   },
   {
-    "name": "wrapListenerWithDirtyAndDefault"
+    "name": "wrapListenerWithPreventDefault"
   }
 ]

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -813,6 +813,9 @@
     "name": "makeParamDecorator"
   },
   {
+    "name": "markDirty"
+  },
+  {
     "name": "markDirtyIfOnPush"
   },
   {
@@ -1024,8 +1027,5 @@
   },
   {
     "name": "wrapListenerWithDirtyAndDefault"
-  },
-  {
-    "name": "wrapListenerWithDirtyLogic"
   }
 ]

--- a/packages/core/test/bundling/todo/index.ts
+++ b/packages/core/test/bundling/todo/index.ts
@@ -9,7 +9,7 @@
 import '@angular/core/test/bundling/util/src/reflect_metadata';
 
 import {CommonModule} from '@angular/common';
-import {Component, Injectable, NgModule, ViewEncapsulation, ɵrenderComponent as renderComponent} from '@angular/core';
+import {Component, Injectable, NgModule, ViewEncapsulation, ɵmarkDirty as markDirty, ɵrenderComponent as renderComponent} from '@angular/core';
 
 class Todo {
   editing: boolean;
@@ -66,13 +66,13 @@ class TodoStore {
       <h1>todos</h1>
       <input class="new-todo" placeholder="What needs to be done?" autofocus=""
              [value]="newTodoText"
-             (keyup)="$event.code == 'Enter' ? addTodo() : newTodoText = $event.target.value">
+             (keyup)="$event.code == 'Enter' ? addTodo() : updateNewTodoValue($event.target.value)">
     </header>
     <section *ngIf="todoStore.todos.length > 0" class="main">
       <input *ngIf="todoStore.todos.length"
              #toggleall class="toggle-all" type="checkbox"
              [checked]="todoStore.allCompleted()"
-             (click)="todoStore.setAllTo(toggleall.checked)">
+             (click)="toggleAllTodos(toggleall.checked)">
       <ul class="todo-list">
         <li *ngFor="let todo of todoStore.todos"
             [class.completed]="todo.completed"
@@ -87,8 +87,8 @@ class TodoStore {
           <input *ngIf="todo.editing"
                  class="edit" #editedtodo
                  [value]="todo.title"
-                 (blur)="stopEditing(todo, editedtodo.value)"
-                 (keyup)="todo.title = $event.target.value"
+                 (blur)="updateEditingTodo(todo, editedtodo.value)"
+                 (keyup)="updateEditedTodoValue($event.target.value)"
                  (keyup)="$event.code == 'Enter' && updateEditingTodo(todo, editedtodo.value)"
                  (keyup)="$event.code == 'Escape' && cancelEditingTodo(todo)">
         </li>
@@ -115,37 +115,63 @@ class ToDoAppComponent {
 
   constructor(public todoStore: TodoStore) {}
 
-  stopEditing(todo: Todo, editedTitle: string) {
-    todo.title = editedTitle;
+  cancelEditingTodo(todo: Todo) {
     todo.editing = false;
+    markDirty(this);
   }
 
-  cancelEditingTodo(todo: Todo) { todo.editing = false; }
-
-  updateEditingTodo(todo: Todo, editedTitle: string) {
+  finishUpdatingTodo(todo: Todo, editedTitle: string) {
     editedTitle = editedTitle.trim();
-    todo.editing = false;
 
     if (editedTitle.length === 0) {
-      return this.todoStore.remove(todo);
+      this.remove(todo);
     }
 
     todo.title = editedTitle;
+    this.cancelEditingTodo(todo);
   }
 
-  editTodo(todo: Todo) { todo.editing = true; }
+  editTodo(todo: Todo) {
+    todo.editing = true;
+    markDirty(this);
+  }
 
-  removeCompleted() { this.todoStore.removeCompleted(); }
+  removeCompleted() {
+    this.todoStore.removeCompleted();
+    markDirty(this);
+  }
 
-  toggleCompletion(todo: Todo) { this.todoStore.toggleCompletion(todo); }
+  toggleCompletion(todo: Todo) {
+    this.todoStore.toggleCompletion(todo);
+    markDirty(this);
+  }
 
-  remove(todo: Todo) { this.todoStore.remove(todo); }
+  remove(todo: Todo) {
+    this.todoStore.remove(todo);
+    markDirty(this);
+  }
 
   addTodo() {
     if (this.newTodoText.trim().length) {
       this.todoStore.add(this.newTodoText);
       this.newTodoText = '';
     }
+    markDirty(this);
+  }
+
+  toggleAllTodos(checked: boolean) {
+    this.todoStore.setAllTo(checked);
+    markDirty(this);
+  }
+
+  updateEditedTodoValue(todo: Todo, value: string) {
+    todo.title = value;
+    markDirty(this);
+  }
+
+  updateNewTodoValue(value: string) {
+    this.newTodoText = value;
+    markDirty(this);
   }
 }
 

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -2469,9 +2469,6 @@
     "name": "wrapListenerWithDirtyAndDefault"
   },
   {
-    "name": "wrapListenerWithDirtyLogic"
-  },
-  {
     "name": "wtfCreateScope"
   },
   {

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -2466,7 +2466,7 @@
     "name": "weekGetter"
   },
   {
-    "name": "wrapListenerWithDirtyAndDefault"
+    "name": "wrapListenerWithPreventDefault"
   },
   {
     "name": "wtfCreateScope"


### PR DESCRIPTION
This PR changes the default behavior for onPush components in Ivy. Previously, event handlers would automatically mark their parent views (and all ancestors up the tree) dirty and schedule a change detection run for the tree. There wasn't any way to turn this off.

With this change, event handlers do not mark views dirty or schedule a change detection run by default, so developers have a bit more control over when change detection runs. If it should run, a `markDirty()` call should be added to the event handler directly. 