### PR TITLE
docs(forms) fix bug in cross-fields validation tutorial

### DIFF
--- a/aio/content/guide/form-validation.md
+++ b/aio/content/guide/form-validation.md
@@ -240,7 +240,7 @@ const heroForm = new FormGroup({
   'name': new FormControl(),
   'alterEgo': new FormControl(),
   'power': new FormControl()
-}, { validators: identityRevealedValidator });
+}, { validator: identityRevealedValidator });
 ```
 
 The validator code is as follows:


### PR DESCRIPTION
docs(forms) fix bug in cross-fields validation tutorial

in cross-fields validation, the name of options in the `extra` parameter should be `validator`, not `validators`, and the formal will works,  but the latter will do nothing.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
