### PR TITLE
fix(common): add generics to NgIf declaration

### DIFF
--- a/packages/common/src/directives/ng_if.ts
+++ b/packages/common/src/directives/ng_if.ts
@@ -102,14 +102,14 @@ import {Directive, EmbeddedViewRef, Input, TemplateRef, ViewContainerRef, ɵstri
  *
  */
 @Directive({selector: '[ngIf]'})
-export class NgIf {
-  private _context: NgIfContext = new NgIfContext();
-  private _thenTemplateRef: TemplateRef<NgIfContext>|null = null;
-  private _elseTemplateRef: TemplateRef<NgIfContext>|null = null;
-  private _thenViewRef: EmbeddedViewRef<NgIfContext>|null = null;
-  private _elseViewRef: EmbeddedViewRef<NgIfContext>|null = null;
+export class NgIf<T = any> {
+  private _context: NgIfContext<T> = new NgIfContext();
+  private _thenTemplateRef: TemplateRef<NgIfContext<T>>|null = null;
+  private _elseTemplateRef: TemplateRef<NgIfContext<T>>|null = null;
+  private _thenViewRef: EmbeddedViewRef<NgIfContext<T>>|null = null;
+  private _elseViewRef: EmbeddedViewRef<NgIfContext<T>>|null = null;
 
-  constructor(private _viewContainer: ViewContainerRef, templateRef: TemplateRef<NgIfContext>) {
+  constructor(private _viewContainer: ViewContainerRef, templateRef: TemplateRef<NgIfContext<T>>) {
     this._thenTemplateRef = templateRef;
   }
 
@@ -120,7 +120,7 @@ export class NgIf {
   }
 
   @Input()
-  set ngIfThen(templateRef: TemplateRef<NgIfContext>|null) {
+  set ngIfThen(templateRef: TemplateRef<NgIfContext<T>>|null) {
     assertTemplate('ngIfThen', templateRef);
     this._thenTemplateRef = templateRef;
     this._thenViewRef = null;  // clear previous view if any.
@@ -128,7 +128,7 @@ export class NgIf {
   }
 
   @Input()
-  set ngIfElse(templateRef: TemplateRef<NgIfContext>|null) {
+  set ngIfElse(templateRef: TemplateRef<NgIfContext<T>>|null) {
     assertTemplate('ngIfElse', templateRef);
     this._elseTemplateRef = templateRef;
     this._elseViewRef = null;  // clear previous view if any.
@@ -161,9 +161,9 @@ export class NgIf {
   public static ngIfUseIfTypeGuard: void;
 }
 
-export class NgIfContext {
-  public $implicit: any = null;
-  public ngIf: any = null;
+export class NgIfContext<T = any> {
+  public $implicit: T|null = null;
+  public ngIf: T|null = null;
 }
 
 function assertTemplate(property: string, templateRef: TemplateRef<any>| null): void {


### PR DESCRIPTION
This change allows IDE to analyze type of the variable in ngIf context.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The issue has been originally filed with Webstorm - https://youtrack.jetbrains.com/issue/WEB-31760 .

In the following example code (`login$: Observable<Login>`):
```
<div *ngIf="login$ | async as login">
	{{ login. }}
</div>
```
`login` type is detected as `any` and no content assist is available for the variable fields.

## What is the new behavior?

It will be possible to provide content assist by IDE on the `login` fields, similarly to how it's done for `ngFor` template.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
Consumers of ngIf API through templates will not be affected. It is possible that AoT compilation might expose some issues, but I am not familiar with the process, so it's hard for me to tell.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
If PR is accepted it would be good to release the fix on all currently active release branches, so that users can take benefit from the fix even if they are on older version of Angular.