### PR TITLE
refactor(ivy): remove LNode.view

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -14,13 +14,14 @@ import {Sanitizer} from '../sanitization/security';
 
 import {assertComponentType, assertDefined} from './assert';
 import {queueInitHooks, queueLifecycleHooks} from './hooks';
-import {CLEAN_PROMISE, _getComponentHostLElementNode, baseDirectiveCreate, createLViewData, createTView, detectChangesInternal, enterView, executeInitAndContentHooks, getRootView, hostElement, initChangeDetectorIfExisting, leaveView, locateHostElement, setHostBindings, queueHostBindingForCheck,} from './instructions';
+import {CLEAN_PROMISE, baseDirectiveCreate, createLViewData, createTView, detectChangesInternal, enterView, executeInitAndContentHooks, getRootView, hostElement, initChangeDetectorIfExisting, leaveView, locateHostElement, setHostBindings, queueHostBindingForCheck,} from './instructions';
 import {ComponentDef, ComponentDefInternal, ComponentType} from './interfaces/definition';
 import {LElementNode} from './interfaces/node';
 import {RElement, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
 import {LViewData, LViewFlags, RootContext, INJECTOR, CONTEXT, TVIEW} from './interfaces/view';
 import {stringify} from './util';
 import {getComponentDef} from './definition';
+import {getLElementFromComponent, readPatchedLViewData} from './context_discovery';
 
 
 /** Options that control how the component should be bootstrapped. */
@@ -179,13 +180,12 @@ export function createRootContext(scheduler: (workFn: () => void) => void): Root
  * ```
  */
 export function LifecycleHooksFeature(component: any, def: ComponentDefInternal<any>): void {
-  const elementNode = _getComponentHostLElementNode(component);
+  const rootTView = readPatchedLViewData(component) ![TVIEW];
 
   // Root component is always created at dir index 0
-  const tView = elementNode.view[TVIEW];
-  queueInitHooks(0, def.onInit, def.doCheck, tView);
+  queueInitHooks(0, def.onInit, def.doCheck, rootTView);
   // Directive starting index 0, directive count 1 -> directive flags: 1
-  queueLifecycleHooks(1, tView);
+  queueLifecycleHooks(1, rootTView);
 }
 
 /**
@@ -209,7 +209,7 @@ function getRootContext(component: any): RootContext {
  * @param component Component for which the host element should be retrieved.
  */
 export function getHostElement<T>(component: T): HTMLElement {
-  return _getComponentHostLElementNode(component).native as any;
+  return getLElementFromComponent(component).native as any;
 }
 
 /**

--- a/packages/core/src/render3/context_discovery.ts
+++ b/packages/core/src/render3/context_discovery.ts
@@ -199,7 +199,7 @@ export function getLElementFromRootComponent(rootComponentInstance: {}): LElemen
  * that `getContext` has in the event that an Angular application doesn't need to have
  * any programmatic access to an element's context (only change detection uses this function).
  */
-export function getLElementFromComponent(componentInstance: {}): LElementNode|null {
+export function getLElementFromComponent(componentInstance: {}): LElementNode {
   let lViewData = readPatchedData(componentInstance);
   let lNode: LElementNode;
 
@@ -355,10 +355,9 @@ function getLNodeFromViewData(lViewData: LViewData, lElementIndex: number): LEle
  */
 function discoverDirectiveIndices(lViewData: LViewData, lNodeIndex: number): number[]|null {
   const directivesAcrossView = lViewData[DIRECTIVES];
-  const lNode = getLNodeFromViewData(lViewData, lNodeIndex);
   const tNode = lViewData[TVIEW].data[lNodeIndex] as TNode;
-  if (lNode && directivesAcrossView && directivesAcrossView.length) {
-    // this check for tNode is to determine if the calue is a LEmementNode instance
+  if (directivesAcrossView && directivesAcrossView.length) {
+    // this check for tNode is to determine if the value is a LElementNode instance
     const directiveIndexStart = getDirectiveStartIndex(tNode);
     const directiveIndexEnd = getDirectiveEndIndex(tNode, directiveIndexStart);
     const directiveIndices: number[] = [];

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -256,7 +256,7 @@ function appendI18nNode(
   const viewData = _getViewData();
 
   // On first pass, re-organize node tree to put this node in the correct position.
-  const firstTemplatePass = node.view[TVIEW].firstTemplatePass;
+  const firstTemplatePass = viewData[TVIEW].firstTemplatePass;
   if (firstTemplatePass) {
     if (previousTNode === parentTNode && tNode !== parentTNode.child) {
       tNode.next = parentTNode.child;

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -19,16 +19,16 @@ import {executeHooks, executeInitHooks, queueInitHooks, queueLifecycleHooks} fro
 import {ACTIVE_INDEX, LContainer, RENDER_PARENT, VIEWS} from './interfaces/container';
 import {ComponentDefInternal, ComponentQuery, ComponentTemplate, DirectiveDefInternal, DirectiveDefListOrFactory, InitialStylingFlags, PipeDefListOrFactory, RenderFlags} from './interfaces/definition';
 import {LInjector} from './interfaces/injector';
-import {AttributeMarker, InitialInputData, InitialInputs, LContainerNode, LElementNode, LNode, LNodeWithLocalRefs, LProjectionNode, LTextNode, LViewNode, LocalRefExtractor, PropertyAliasValue, PropertyAliases, TAttributes, TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeFlags, TNodeType, TProjectionNode, TViewNode} from './interfaces/node';
+import {AttributeMarker, InitialInputData, InitialInputs, LContainerNode, LElementContainerNode, LElementNode, LNode, LProjectionNode, LTextNode, LViewNode, LocalRefExtractor, PropertyAliasValue, PropertyAliases, TAttributes, TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeFlags, TNodeType, TProjectionNode, TViewNode} from './interfaces/node';
 import {CssSelectorList, NG_PROJECT_AS_ATTR_NAME} from './interfaces/projection';
 import {LQueries} from './interfaces/query';
 import {ProceduralRenderer3, RComment, RElement, RNode, RText, Renderer3, RendererFactory3, isProceduralRenderer} from './interfaces/renderer';
 import {BINDING_INDEX, CLEANUP, CONTAINER_INDEX, CONTENT_QUERIES, CONTEXT, CurrentMatchesList, DECLARATION_VIEW, DIRECTIVES, FLAGS, HEADER_OFFSET, HOST_NODE, INJECTOR, LViewData, LViewFlags, NEXT, OpaqueViewState, PARENT, QUERIES, RENDERER, RootContext, SANITIZER, TAIL, TVIEW, TView} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
-import {appendChild, appendProjectedNode, createTextNode, findComponentView, getContainerNode, getHostElementNode, getLViewChild, getParentLNode, getParentOrContainerNode, getRenderParent, insertView, removeView} from './node_manipulation';
+import {appendChild, appendProjectedNode, createTextNode, findComponentView, getContainerNode, getHostElementNode, getLViewChild, getParentOrContainerNode, getRenderParent, insertView, removeView} from './node_manipulation';
 import {isNodeMatchingSelectorList, matchingSelectorIndex} from './node_selector_matcher';
 import {StylingContext, allocStylingContext, createStylingContextTemplate, renderStyling as renderElementStyles, updateClassProp as updateElementClassProp, updateStyleProp as updateElementStyleProp, updateStylingMap} from './styling';
-import {assertDataInRangeInternal, isContentQueryHost, isDifferent, loadElementInternal, loadInternal, readElementValue, stringify} from './util';
+import {assertDataInRangeInternal, getLNode, isContentQueryHost, isDifferent, loadElementInternal, loadInternal, readElementValue, stringify} from './util';
 import {ViewRef} from './view_ref';
 
 
@@ -132,7 +132,7 @@ let previousOrParentTNode: TNode;
 export function getPreviousOrParentNode(): LNode|null {
   return previousOrParentTNode == null || previousOrParentTNode === viewData[HOST_NODE] ?
       getHostElementNode(viewData) :
-      readElementValue(viewData[previousOrParentTNode.index]);
+      getLNode(previousOrParentTNode, viewData);
 }
 
 export function getPreviousOrParentTNode(): TNode {
@@ -393,12 +393,10 @@ export function createLViewData<T>(
  * (same properties assigned in the same order).
  */
 export function createLNodeObject(
-    type: TNodeType, currentView: LViewData, nodeInjector: LInjector | null,
-    native: RText | RElement | RComment | null,
+    type: TNodeType, nodeInjector: LInjector | null, native: RText | RElement | RComment | null,
     state: any): LElementNode&LTextNode&LViewNode&LContainerNode&LProjectionNode {
   return {
     native: native as any,
-    view: currentView,
     nodeInjector: nodeInjector,
     data: state,
     dynamicLContainerNode: null
@@ -445,7 +443,7 @@ export function createNodeAtIndex(
   const tParent = parentInSameView ? parent as TElementNode | TContainerNode : null;
 
   const isState = state != null;
-  const node = createLNodeObject(type, viewData, null, native, isState ? state as any : null);
+  const node = createLNodeObject(type, null, native, isState ? state as any : null);
   let tNode: TNode;
 
   if (index === -1 || type === TNodeType.View) {
@@ -780,7 +778,8 @@ export function elementContainerEnd(): void {
   }
 
   ngDevMode && assertNodeType(previousOrParentTNode, TNodeType.ElementContainer);
-  currentQueries && (currentQueries = currentQueries.addNode(previousOrParentTNode));
+  currentQueries &&
+      (currentQueries = currentQueries.addNode(previousOrParentTNode as TElementContainerNode));
 
   queueLifecycleHooks(previousOrParentTNode.flags, tView);
 }
@@ -848,8 +847,8 @@ export function elementCreate(name: string, overriddenRenderer?: Renderer3): REl
   return native;
 }
 
-function nativeNodeLocalRefExtractor(lNode: LNodeWithLocalRefs, tNode: TNode): RNode {
-  return lNode.native;
+function nativeNodeLocalRefExtractor(tNode: TNode, currentView: LViewData): RNode {
+  return getLNode(tNode, currentView).native;
 }
 
 /**
@@ -1018,13 +1017,12 @@ function saveNameToExportMap(
  */
 function saveResolvedLocalsInData(localRefExtractor: LocalRefExtractor): void {
   const localNames = previousOrParentTNode.localNames;
-  const node = getPreviousOrParentNode() as LElementNode;
+  const tNode = previousOrParentTNode as TElementNode | TContainerNode | TElementContainerNode;
   if (localNames) {
     let localIndex = previousOrParentTNode.index + 1;
     for (let i = 0; i < localNames.length; i += 2) {
       const index = localNames[i + 1] as number;
-      const value =
-          index === -1 ? localRefExtractor(node, previousOrParentTNode) : directives ![index];
+      const value = index === -1 ? localRefExtractor(tNode, viewData) : directives ![index];
       viewData[localIndex++] = value;
     }
   }
@@ -1206,7 +1204,6 @@ export function hostElement(
     if (def.diPublic) def.diPublic(def);
     tView.directives = [def];
   }
-
   return viewData[HEADER_OFFSET];
 }
 
@@ -1317,7 +1314,8 @@ export function elementEnd(): void {
     previousOrParentTNode = previousOrParentTNode.parent !;
   }
   ngDevMode && assertNodeType(previousOrParentTNode, TNodeType.Element);
-  currentQueries && (currentQueries = currentQueries.addNode(previousOrParentTNode));
+  currentQueries &&
+      (currentQueries = currentQueries.addNode(previousOrParentTNode as TElementNode));
 
   queueLifecycleHooks(previousOrParentTNode.flags, tView);
   elementDepthCount--;
@@ -1924,7 +1922,8 @@ export function template(
   }
 
   createDirectivesAndLocals(localRefs, localRefExtractor);
-  currentQueries && (currentQueries = currentQueries.addNode(previousOrParentTNode));
+  currentQueries &&
+      (currentQueries = currentQueries.addNode(previousOrParentTNode as TContainerNode));
   queueLifecycleHooks(tNode.flags, tView);
   isParent = false;
 }
@@ -2005,14 +2004,15 @@ export function containerRefreshEnd(): void {
     previousOrParentTNode = previousOrParentTNode.parent !;
   }
 
-  // Inline containers cannot have style bindings, so we can read the value directly
-  const container = viewData[previousOrParentTNode.index];
   ngDevMode && assertNodeType(previousOrParentTNode, TNodeType.Container);
-  const nextIndex = container.data[ACTIVE_INDEX] !;
+
+  // Inline containers cannot have style bindings, so we can read the value directly
+  const lContainer = viewData[previousOrParentTNode.index].data;
+  const nextIndex = lContainer[ACTIVE_INDEX];
 
   // remove extra views at the end of the container
-  while (nextIndex < container.data[VIEWS].length) {
-    removeView(container, previousOrParentTNode as TContainerNode, nextIndex);
+  while (nextIndex < lContainer[VIEWS].length) {
+    removeView(lContainer, previousOrParentTNode as TContainerNode, nextIndex);
   }
 }
 
@@ -2044,22 +2044,23 @@ function refreshDynamicEmbeddedViews(lViewData: LViewData) {
  * Looks for a view with a given view block id inside a provided LContainer.
  * Removes views that need to be deleted in the process.
  *
- * @param containerNode where to search for views
+ * @param lContainer to search for views
+ * @param tContainerNode to search for views
  * @param startIdx starting index in the views array to search from
  * @param viewBlockId exact view block id to look for
  * @returns index of a found view or -1 if not found
  */
 function scanForView(
-    containerNode: LContainerNode, tContainerNode: TContainerNode, startIdx: number,
+    lContainer: LContainer, tContainerNode: TContainerNode, startIdx: number,
     viewBlockId: number): LViewData|null {
-  const views = containerNode.data[VIEWS];
+  const views = lContainer[VIEWS];
   for (let i = startIdx; i < views.length; i++) {
     const viewAtPositionId = views[i][TVIEW].id;
     if (viewAtPositionId === viewBlockId) {
       return views[i];
     } else if (viewAtPositionId < viewBlockId) {
       // found a view that should not be at this position - remove
-      removeView(containerNode, tContainerNode, i);
+      removeView(lContainer, tContainerNode, i);
     } else {
       // found a view with id greater than the one we are searching for
       // which means that required view doesn't exist and can't be found at
@@ -2083,11 +2084,12 @@ export function embeddedViewStart(viewBlockId: number, consts: number, vars: num
       previousOrParentTNode;
   // Inline containers cannot have style bindings, so we can read the value directly
   const container = viewData[containerTNode.index] as LContainerNode;
+  const currentView = viewData;
 
   ngDevMode && assertNodeType(containerTNode, TNodeType.Container);
   const lContainer = container.data;
   let viewToRender = scanForView(
-      container, containerTNode as TContainerNode, lContainer[ACTIVE_INDEX] !, viewBlockId);
+      lContainer, containerTNode as TContainerNode, lContainer[ACTIVE_INDEX] !, viewBlockId);
 
   if (viewToRender) {
     isParent = true;
@@ -2109,7 +2111,7 @@ export function embeddedViewStart(viewBlockId: number, consts: number, vars: num
   if (container) {
     if (creationMode) {
       // it is a new view, insert it into collection of views for a given container
-      insertView(container, viewToRender, lContainer[ACTIVE_INDEX] !, -1);
+      insertView(viewToRender, lContainer, currentView, lContainer[ACTIVE_INDEX] !, -1);
     }
     lContainer[ACTIVE_INDEX] !++;
   }
@@ -2862,13 +2864,6 @@ function assertDataNext(index: number, arr?: any[]) {
   if (arr == null) arr = viewData;
   assertEqual(
       arr.length, index, `index ${index} expected to be at the end of arr (length ${arr.length})`);
-}
-
-export function _getComponentHostLElementNode(component: any): LElementNode {
-  ngDevMode && assertDefined(component, 'expecting component got null');
-  const lElementNode = getLElementFromComponent(component) !;
-  ngDevMode && assertDefined(component, 'object is not a component');
-  return lElementNode;
 }
 
 export const CLEAN_PROMISE = _CLEAN_PROMISE;

--- a/packages/core/src/render3/interfaces/injector.ts
+++ b/packages/core/src/render3/interfaces/injector.ts
@@ -6,12 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+
 import {ChangeDetectorRef} from '../../change_detection/change_detector_ref';
 import {ElementRef} from '../../linker/element_ref';
 import {TemplateRef} from '../../linker/template_ref';
 import {ViewContainerRef} from '../../linker/view_container_ref';
 
-import {LContainerNode, LElementContainerNode, LElementNode, TContainerNode, TElementNode, TNode} from './node';
+import {TContainerNode, TElementContainerNode, TElementNode,} from './node';
+import {LViewData} from './view';
 
 export interface LInjector {
   /**
@@ -20,15 +22,14 @@ export interface LInjector {
    */
   readonly parent: LInjector|null;
 
-  /**
-   * Allows access to the directives array in that node's static data and to
-   * the node's flags (for starting directive index and directive size). Necessary
-   * for DI to retrieve a directive from the data array if injector indicates
-   * it is there.
-   */
-  readonly node: LElementNode|LElementContainerNode|LContainerNode;
+  /** Necessary to find directive indices for a particular node and look up the LNode. */
+  readonly tNode: TElementNode|TElementContainerNode|TContainerNode;
 
-  readonly tNode: TNode;
+  /**
+   * The view where the node is stored. Necessary because as we traverse up the injector
+   * tree the view where we search directives may change.
+   */
+  readonly view: LViewData;
 
   /**
    * The following bloom filter determines whether a directive is available

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -81,13 +81,6 @@ export interface LNode {
    */
   readonly data: LViewData|LContainer|null;
 
-  /**
-   * Each node belongs to a view.
-   *
-   * When the injector is walking up a tree, it needs access to the `directives` (part of view).
-   */
-  readonly view: LViewData;
-
   /** The injector associated with this node. Necessary for DI. */
   nodeInjector: LInjector|null;
 
@@ -530,9 +523,9 @@ export type InitialInputs = string[];
 export const unusedValueExportToPlacateAjd = 1;
 
 /**
- * Type representing a set of LNodes that can have local refs (`#foo`) placed on them.
+ * Type representing a set of TNodes that can have local refs (`#foo`) placed on them.
  */
-export type LNodeWithLocalRefs = LContainerNode | LElementNode | LElementContainerNode;
+export type TNodeWithLocalRefs = TContainerNode | TElementNode | TElementContainerNode;
 
 /**
  * Type for a function that extracts a value for a local refs.
@@ -540,4 +533,4 @@ export type LNodeWithLocalRefs = LContainerNode | LElementNode | LElementContain
  * - `<div #nativeDivEl>` - `nativeDivEl` should point to the native `<div>` element;
  * - `<ng-template #tplRef>` - `tplRef` should point to the `TemplateRef` instance;
  */
-export type LocalRefExtractor = (lNode: LNodeWithLocalRefs, tNode: TNode) => any;
+export type LocalRefExtractor = (tNode: TNodeWithLocalRefs, currentView: LViewData) => any;

--- a/packages/core/src/render3/interfaces/query.ts
+++ b/packages/core/src/render3/interfaces/query.ts
@@ -8,7 +8,7 @@
 
 import {QueryList} from '../../linker';
 import {Type} from '../../type';
-import {TNode} from './node';
+import {TContainerNode, TElementContainerNode, TElementNode, TNode} from './node';
 
 /** Used for tracking queries (e.g. ViewChild, ContentChild). */
 export interface LQueries {
@@ -33,7 +33,7 @@ export interface LQueries {
    * Notify `LQueries` that a new `TNode` has been created and needs to be added to query results
    * if matching query predicate.
    */
-  addNode(tNode: TNode): LQueries|null;
+  addNode(tNode: TElementNode|TContainerNode|TElementContainerNode): LQueries|null;
 
   /**
    * Notify `LQueries` that a new LContainer was added to ivy data structures. As a result we need

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -20,10 +20,10 @@ import {ReadFromInjectorFn, getOrCreateNodeInjectorForNode} from './di';
 import {_getViewData, assertPreviousIsParent, getOrCreateCurrentQueries, store, storeCleanupWithContext} from './instructions';
 import {DirectiveDefInternal, unusedValueExportToPlacateAjd as unused1} from './interfaces/definition';
 import {LInjector, unusedValueExportToPlacateAjd as unused2} from './interfaces/injector';
-import {LContainerNode, LElementNode, TNode, TNodeFlags, unusedValueExportToPlacateAjd as unused3} from './interfaces/node';
+import {LContainerNode, LElementNode, TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeFlags, unusedValueExportToPlacateAjd as unused3} from './interfaces/node';
 import {LQueries, QueryReadType, unusedValueExportToPlacateAjd as unused4} from './interfaces/query';
 import {DIRECTIVES, LViewData, TVIEW} from './interfaces/view';
-import {flatten, isContentQueryHost, readElementValue} from './util';
+import {flatten, getLNode, isContentQueryHost} from './util';
 
 const unusedValueToPlacateAjd = unused1 + unused2 + unused3 + unused4;
 
@@ -121,7 +121,7 @@ export class LQueries_ implements LQueries {
     insertView(index, this.deep);
   }
 
-  addNode(tNode: TNode): LQueries|null {
+  addNode(tNode: TElementNode|TContainerNode|TElementContainerNode): LQueries|null {
     add(this.deep, tNode);
 
     if (isContentQueryHost(tNode)) {
@@ -278,13 +278,13 @@ function readFromNodeInjector(
   return null;
 }
 
-function add(query: LQuery<any>| null, tNode: TNode) {
+function add(
+    query: LQuery<any>| null, tNode: TElementNode | TContainerNode | TElementContainerNode) {
   const currentView = _getViewData();
 
   // TODO: remove this lookup when nodeInjector is removed from LNode
-  const currentNode = readElementValue(currentView[tNode.index]);
   const nodeInjector =
-      getOrCreateNodeInjectorForNode(currentNode as LElementNode | LContainerNode, tNode);
+      getOrCreateNodeInjectorForNode(getLNode(tNode, currentView), tNode, currentView);
 
   while (query) {
     const predicate = query.predicate;

--- a/packages/core/src/render3/util.ts
+++ b/packages/core/src/render3/util.ts
@@ -8,7 +8,7 @@
 
 import {devModeEqual} from '../change_detection/change_detection_util';
 import {assertLessThan} from './assert';
-import {LElementNode, TNode, TNodeFlags} from './interfaces/node';
+import {LContainerNode, LElementContainerNode, LElementNode, TNode, TNodeFlags} from './interfaces/node';
 import {HEADER_OFFSET, LViewData, TData} from './interfaces/view';
 
 /**
@@ -89,6 +89,11 @@ export function loadElementInternal(index: number, arr: LViewData): LElementNode
 
 export function readElementValue(value: LElementNode | any[]): LElementNode {
   return (Array.isArray(value) ? (value as any as any[])[0] : value) as LElementNode;
+}
+
+export function getLNode(tNode: TNode, hostView: LViewData): LElementNode|LContainerNode|
+    LElementContainerNode {
+  return readElementValue(hostView[tNode.index]);
 }
 
 export function isContentQueryHost(tNode: TNode): boolean {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -99,6 +99,9 @@
     "name": "_CLEAN_PROMISE"
   },
   {
+    "name": "_getViewData"
+  },
+  {
     "name": "_renderCompCount"
   },
   {
@@ -223,6 +226,9 @@
   },
   {
     "name": "getHostElementNode"
+  },
+  {
+    "name": "getLNode"
   },
   {
     "name": "getLViewChild"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -609,6 +609,9 @@
     "name": "getLElementFromComponent"
   },
   {
+    "name": "getLNode"
+  },
+  {
     "name": "getLViewChild"
   },
   {

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -1089,9 +1089,6 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
-    "name": "_getComponentHostLElementNode"
-  },
-  {
     "name": "_getViewData"
   },
   {
@@ -1636,6 +1633,9 @@
   },
   {
     "name": "getLElementFromComponent"
+  },
+  {
+    "name": "getLNode"
   },
   {
     "name": "getLViewChild"


### PR DESCRIPTION
This PR removes dependence on `LNode.view`, which is part of a larger effort to remove `LNode`.