### PR TITLE
fix(service-worker): ignore passive mixed content requests

### DIFF
--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -176,11 +176,12 @@ export class Driver implements Debuggable, UpdateSource {
    */
   private onFetch(event: FetchEvent): void {
     const req = event.request;
+    const scopeUrl = this.scope.registration.scope;
+    const requestUrlObj = this.adapter.parseUrl(req.url, scopeUrl);
 
     // The only thing that is served unconditionally is the debug page.
-    if (this.adapter.parseUrl(req.url, this.scope.registration.scope).path === '/ngsw/state') {
-      // Allow the debugger to handle the request, but don't affect SW state in any
-      // other way.
+    if (requestUrlObj.path === '/ngsw/state') {
+      // Allow the debugger to handle the request, but don't affect SW state in any other way.
       event.respondWith(this.debugger.handleFetch(req));
       return;
     }
@@ -197,6 +198,16 @@ export class Driver implements Debuggable, UpdateSource {
       return;
     }
 
+    // Although "passive mixed content" (like images) only produces a warning without a
+    // ServiceWorker, fetching it via a ServiceWorker results in an error. Let such requests be
+    // handled by the browser, since handling with the ServiceWorker would fail anyway.
+    // See https://github.com/angular/angular/issues/23012#issuecomment-376430187 for more details.
+    if (requestUrlObj.origin.startsWith('http:') && scopeUrl.startsWith('https:')) {
+      // Still, log the incident for debugging purposes.
+      this.debugger.log(`Ignoring passive mixed content request: Driver.fetch(${req.url})`);
+      return;
+    }
+
     // When opening DevTools in Chrome, a request is made for the current URL (and possibly related
     // resources, e.g. scripts) with `cache: 'only-if-cached'` and `mode: 'no-cors'`. These request
     // will eventually fail, because `only-if-cached` is only allowed to be used with
@@ -204,7 +215,7 @@ export class Driver implements Debuggable, UpdateSource {
     // This is likely a bug in Chrome DevTools. Avoid handling such requests.
     // (See also https://github.com/angular/angular/issues/22362.)
     // TODO(gkalpak): Remove once no longer necessary (i.e. fixed in Chrome DevTools).
-    if ((req.cache as string) === 'only-if-cached' && req.mode !== 'same-origin') {
+    if (req.cache === 'only-if-cached' && req.mode !== 'same-origin') {
       // Log the incident only the first time it happens, to avoid spamming the logs.
       if (!this.loggedInvalidOnlyIfCachedRequest) {
         this.loggedInvalidOnlyIfCachedRequest = true;

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -181,7 +181,7 @@ export class SwTestHarness implements ServiceWorkerGlobalScope, Adapter, Context
       return {origin: obj.origin, path: obj.pathname};
     } else {
       const obj = require('url').parse(url);
-      return {origin: obj.origin, path: obj.pathname};
+      return {origin: `${obj.protocol}//${obj.host}`, path: obj.pathname};
     }
   }
 


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] Bugfix
```

## What is the current behavior?
[Passive mixed content][1] requests (like images) result in an error. This is a ServiceWorker limitation. Without the ServiceWorker, such requests only produce a warning. See https://github.com/angular/angular/issues/23012#issuecomment-376430187 for more details.

Issue Number: #23012


## What is the new behavior?
The ServiceWorker will ignore such requests and let them be handled by the browser directly.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
Fixes #23012.

[1]: https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content#passive_mixed_content