### PR TITLE
feat(service-worker): expose RegistrationOptions token to allow for runtime configuration

### DIFF
--- a/packages/examples/service-worker/registration-options/BUILD.bazel
+++ b/packages/examples/service-worker/registration-options/BUILD.bazel
@@ -1,0 +1,62 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//packages/bazel:index.bzl", "protractor_web_test_suite")
+load("//tools:defaults.bzl", "ng_module", "ts_library")
+load("@npm_bazel_typescript//:index.bzl", "ts_devserver")
+
+ng_module(
+    name = "sw_registration_options_examples",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*_spec.ts"],
+    ),
+    # TODO: FW-1004 Type checking is currently not complete.
+    type_check = False,
+    deps = [
+        "//packages/core",
+        "//packages/platform-browser",
+        "//packages/platform-browser-dynamic",
+        "//packages/service-worker",
+    ],
+)
+
+ts_library(
+    name = "sw_registration_options_e2e_tests_lib",
+    testonly = True,
+    srcs = glob(["**/e2e_test/*_spec.ts"]),
+    tsconfig = "//packages/examples:tsconfig-e2e.json",
+    deps = [
+        "//packages/examples/test-utils",
+        "//packages/private/testing",
+        "@npm//@types/jasminewd2",
+        "@npm//protractor",
+    ],
+)
+
+ts_devserver(
+    name = "devserver",
+    entry_module = "@angular/examples/service-worker/registration-options/main",
+    index_html = "//packages/examples:index.html",
+    port = 4200,
+    scripts = [
+        "//tools/rxjs:rxjs_umd_modules",
+        "@npm//node_modules/tslib:tslib.js",
+    ],
+    static_files = [
+        "ngsw-worker.js",
+        "@npm//node_modules/zone.js:dist/zone.js",
+    ],
+    deps = [":sw_registration_options_examples"],
+)
+
+protractor_web_test_suite(
+    name = "protractor_tests",
+    data = ["//packages/bazel/src/protractor/utils"],
+    on_prepare = "start-server.js",
+    server = ":devserver",
+    deps = [
+        ":sw_registration_options_e2e_tests_lib",
+        "@npm//protractor",
+        "@npm//selenium-webdriver",
+    ],
+)

--- a/packages/examples/service-worker/registration-options/e2e_test/registration-options_spec.ts
+++ b/packages/examples/service-worker/registration-options/e2e_test/registration-options_spec.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {browser, by, element} from 'protractor';
+import {verifyNoBrowserErrors} from '../../../test-utils';
+
+describe('SW `SwRegistrationOptions` example', () => {
+  const pageUrl = '/registration-options';
+  const appElem = element(by.css('example-app'));
+
+  afterEach(verifyNoBrowserErrors);
+
+  it('not register the SW by default', () => {
+    browser.get(pageUrl);
+    expect(appElem.getText()).toBe('SW enabled: false');
+  });
+
+  it('register the SW when navigating to `?sw=true`', () => {
+    browser.get(`${pageUrl}?sw=true`);
+    expect(appElem.getText()).toBe('SW enabled: true');
+  });
+});

--- a/packages/examples/service-worker/registration-options/main.ts
+++ b/packages/examples/service-worker/registration-options/main.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+import {AppModuleNgFactory} from './module.ngfactory';
+
+platformBrowserDynamic().bootstrapModuleFactory(AppModuleNgFactory);

--- a/packages/examples/service-worker/registration-options/module.ts
+++ b/packages/examples/service-worker/registration-options/module.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+// tslint:disable: no-duplicate-imports
+import {Component} from '@angular/core';
+// #docregion registration-options
+import {NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {ServiceWorkerModule, SwRegistrationOptions} from '@angular/service-worker';
+// #enddocregion registration-options
+import {SwUpdate} from '@angular/service-worker';
+// tslint:enable: no-duplicate-imports
+
+@Component({
+  selector: 'example-app',
+  template: 'SW enabled: {{ swu.isEnabled }}',
+})
+export class AppComponent {
+  constructor(readonly swu: SwUpdate) {}
+}
+// #docregion registration-options
+
+@NgModule({
+  // #enddocregion registration-options
+  bootstrap: [
+    AppComponent,
+  ],
+  declarations: [
+    AppComponent,
+  ],
+  // #docregion registration-options
+  imports: [
+    BrowserModule,
+    ServiceWorkerModule.register('ngsw-worker.js'),
+  ],
+  providers: [
+    {
+      provide: SwRegistrationOptions,
+      useFactory: () => ({enabled: location.search.includes('sw=true')}),
+    },
+  ],
+})
+export class AppModule {
+}
+// #enddocregion registration-options

--- a/packages/examples/service-worker/registration-options/ngsw-worker.js
+++ b/packages/examples/service-worker/registration-options/ngsw-worker.js
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// Mock `ngsw-worker.js` used for testing the examples.
+// Immediately takes over and unregisters itself.
+self.addEventListener('install', evt => evt.waitUntil(self.skipWaiting()));
+self.addEventListener(
+    'activate',
+    evt => evt.waitUntil(self.clients.claim().then(() => self.registration.unregister())));

--- a/packages/examples/service-worker/registration-options/start-server.js
+++ b/packages/examples/service-worker/registration-options/start-server.js
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+const protractorUtils = require('@angular/bazel/protractor-utils');
+const protractor = require('protractor');
+
+module.exports = async function(config) {
+  const {port} = await protractorUtils.runServer(config.workspace, config.server, '-port', []);
+  const serverUrl = `http://localhost:${port}`;
+
+  protractor.browser.baseUrl = serverUrl;
+};

--- a/packages/service-worker/src/index.ts
+++ b/packages/service-worker/src/index.ts
@@ -15,6 +15,6 @@
 */
 
 export {UpdateActivatedEvent, UpdateAvailableEvent} from './low_level';
-export {ServiceWorkerModule} from './module';
+export {ServiceWorkerModule, SwRegistrationOptions} from './module';
 export {SwPush} from './push';
 export {SwUpdate} from './update';

--- a/packages/service-worker/src/module.ts
+++ b/packages/service-worker/src/module.ts
@@ -14,6 +14,12 @@ import {NgswCommChannel} from './low_level';
 import {SwPush} from './push';
 import {SwUpdate} from './update';
 
+/**
+ * Token that can be used to provide options for `ServiceWorkerModule` outside of
+ * `ServiceWorkerModule.register()`.
+ *
+ * @publicApi
+ */
 export abstract class SwRegistrationOptions {
   scope?: string;
   enabled?: boolean;
@@ -69,7 +75,7 @@ export class ServiceWorkerModule {
    * If `enabled` is set to `false` in the given options, the module will behave as if service
    * workers are not supported by the browser, and the service worker will not be registered.
    */
-  static register(script: string, opts: {scope?: string; enabled?: boolean;} = {}):
+  static register(script: string, opts: SwRegistrationOptions = {}):
       ModuleWithProviders<ServiceWorkerModule> {
     return {
       ngModule: ServiceWorkerModule,

--- a/packages/service-worker/src/module.ts
+++ b/packages/service-worker/src/module.ts
@@ -14,7 +14,7 @@ import {NgswCommChannel} from './low_level';
 import {SwPush} from './push';
 import {SwUpdate} from './update';
 
-export abstract class RegistrationOptions {
+export abstract class SwRegistrationOptions {
   scope?: string;
   enabled?: boolean;
 }
@@ -22,7 +22,7 @@ export abstract class RegistrationOptions {
 export const SCRIPT = new InjectionToken<string>('NGSW_REGISTER_SCRIPT');
 
 export function ngswAppInitializer(
-    injector: Injector, script: string, options: RegistrationOptions,
+    injector: Injector, script: string, options: SwRegistrationOptions,
     platformId: string): Function {
   const initializer = () => {
     const app = injector.get<ApplicationRef>(ApplicationRef);
@@ -50,7 +50,7 @@ export function ngswAppInitializer(
 }
 
 export function ngswCommChannelFactory(
-    opts: RegistrationOptions, platformId: string): NgswCommChannel {
+    opts: SwRegistrationOptions, platformId: string): NgswCommChannel {
   return new NgswCommChannel(
       isPlatformBrowser(platformId) && opts.enabled !== false ? navigator.serviceWorker :
                                                                 undefined);
@@ -75,16 +75,16 @@ export class ServiceWorkerModule {
       ngModule: ServiceWorkerModule,
       providers: [
         {provide: SCRIPT, useValue: script},
-        {provide: RegistrationOptions, useValue: opts},
+        {provide: SwRegistrationOptions, useValue: opts},
         {
           provide: NgswCommChannel,
           useFactory: ngswCommChannelFactory,
-          deps: [RegistrationOptions, PLATFORM_ID]
+          deps: [SwRegistrationOptions, PLATFORM_ID]
         },
         {
           provide: APP_INITIALIZER,
           useFactory: ngswAppInitializer,
-          deps: [Injector, SCRIPT, RegistrationOptions, PLATFORM_ID],
+          deps: [Injector, SCRIPT, SwRegistrationOptions, PLATFORM_ID],
           multi: true,
         },
       ],

--- a/packages/service-worker/src/module.ts
+++ b/packages/service-worker/src/module.ts
@@ -18,11 +18,29 @@ import {SwUpdate} from './update';
  * Token that can be used to provide options for `ServiceWorkerModule` outside of
  * `ServiceWorkerModule.register()`.
  *
+ * You can use this token to define a provider that generates the registration options at runtime,
+ * for example via a function call:
+ *
+ * {@example service-worker/registration-options/module.ts region="registration-options"
+ *     header="app.module.ts" linenums="false"}
+ *
  * @publicApi
  */
 export abstract class SwRegistrationOptions {
-  scope?: string;
+  /**
+   * Whether the ServiceWorker will be registered and the related services (such as `SwPush` and
+   * `SwUpdate`) will attempt to communicate and interact with it.
+   *
+   * Default: true
+   */
   enabled?: boolean;
+
+  /**
+   * A URL that defines the ServiceWorker's registration scope; that is, what range of URLs it can
+   * control. It will be used when calling
+   * [ServiceWorkerContainer#register()](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register).
+   */
+  scope?: string;
 }
 
 export const SCRIPT = new InjectionToken<string>('NGSW_REGISTER_SCRIPT');

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -9,7 +9,7 @@
 import {PLATFORM_ID} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {NgswCommChannel} from '@angular/service-worker/src/low_level';
-import {RegistrationOptions, ngswCommChannelFactory} from '@angular/service-worker/src/module';
+import {SwRegistrationOptions, ngswCommChannelFactory} from '@angular/service-worker/src/module';
 import {SwPush} from '@angular/service-worker/src/push';
 import {SwUpdate} from '@angular/service-worker/src/update';
 import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockServiceWorkerRegistration, patchDecodeBase64} from '@angular/service-worker/testing/mock';
@@ -52,10 +52,10 @@ import {async_fit, async_it} from './async';
         TestBed.configureTestingModule({
           providers: [
             {provide: PLATFORM_ID, useValue: 'server'},
-            {provide: RegistrationOptions, useValue: {enabled: true}}, {
+            {provide: SwRegistrationOptions, useValue: {enabled: true}}, {
               provide: NgswCommChannel,
               useFactory: ngswCommChannelFactory,
-              deps: [RegistrationOptions, PLATFORM_ID]
+              deps: [SwRegistrationOptions, PLATFORM_ID]
             }
           ]
         });
@@ -66,10 +66,10 @@ import {async_fit, async_it} from './async';
         TestBed.configureTestingModule({
           providers: [
             {provide: PLATFORM_ID, useValue: 'browser'},
-            {provide: RegistrationOptions, useValue: {enabled: false}}, {
+            {provide: SwRegistrationOptions, useValue: {enabled: false}}, {
               provide: NgswCommChannel,
               useFactory: ngswCommChannelFactory,
-              deps: [RegistrationOptions, PLATFORM_ID]
+              deps: [SwRegistrationOptions, PLATFORM_ID]
             }
           ]
         });
@@ -80,11 +80,11 @@ import {async_fit, async_it} from './async';
         TestBed.configureTestingModule({
           providers: [
             {provide: PLATFORM_ID, useValue: 'browser'},
-            {provide: RegistrationOptions, useValue: {enabled: true}},
+            {provide: SwRegistrationOptions, useValue: {enabled: true}},
             {
               provide: NgswCommChannel,
               useFactory: ngswCommChannelFactory,
-              deps: [RegistrationOptions, PLATFORM_ID],
+              deps: [SwRegistrationOptions, PLATFORM_ID],
             },
           ],
         });
@@ -110,10 +110,10 @@ import {async_fit, async_it} from './async';
            TestBed.configureTestingModule({
              providers: [
                {provide: PLATFORM_ID, useValue: 'browser'},
-               {provide: RegistrationOptions, useValue: {enabled: true}}, {
+               {provide: SwRegistrationOptions, useValue: {enabled: true}}, {
                  provide: NgswCommChannel,
                  useFactory: ngswCommChannelFactory,
-                 deps: [RegistrationOptions, PLATFORM_ID]
+                 deps: [SwRegistrationOptions, PLATFORM_ID]
                }
              ]
            });

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -9,7 +9,7 @@
 import {PLATFORM_ID} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {NgswCommChannel} from '@angular/service-worker/src/low_level';
-import {ServiceWorkerModule, SwRegistrationOptions, ngswCommChannelFactory} from '@angular/service-worker/src/module';
+import {SwRegistrationOptions, ngswCommChannelFactory} from '@angular/service-worker/src/module';
 import {SwPush} from '@angular/service-worker/src/push';
 import {SwUpdate} from '@angular/service-worker/src/update';
 import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockServiceWorkerRegistration, patchDecodeBase64} from '@angular/service-worker/testing/mock';
@@ -44,45 +44,6 @@ import {async_fit, async_it} from './async';
         (comm as any).registration.subscribe((reg: any) => { done(); });
 
         mock.setupSw();
-      });
-    });
-
-    describe('ServiceWorkerModule config', () => {
-      it('SwUpdate isEnabled is false when configuring via static method', () => {
-        TestBed.configureTestingModule(
-            {imports: [ServiceWorkerModule.register('', {enabled: false})]});
-
-        expect(TestBed.get(SwUpdate).isEnabled).toEqual(false);
-      });
-
-      it('SwUpdate isEnabled is true when configuring via static method', () => {
-        TestBed.configureTestingModule({
-          imports: [ServiceWorkerModule.register('', {enabled: true})],
-          providers: [{provide: NgswCommChannel, useValue: comm}]
-        });
-
-        expect(TestBed.get(SwUpdate).isEnabled).toEqual(true);
-      });
-
-      it('SwUpdate isEnabled is false when configuring directly via token', () => {
-        TestBed.configureTestingModule({
-          imports: [ServiceWorkerModule.register('')],
-          providers: [{provide: SwRegistrationOptions, useFactory: () => ({enabled: false})}]
-        });
-
-        expect(TestBed.get(SwUpdate).isEnabled).toEqual(false);
-      });
-
-      it('SwUpdate isEnabled is true when configuring directly via token', () => {
-        TestBed.configureTestingModule({
-          imports: [ServiceWorkerModule.register('')],
-          providers: [
-            {provide: NgswCommChannel, useValue: comm},
-            {provide: SwRegistrationOptions, useFactory: () => ({enabled: true})}
-          ]
-        });
-
-        expect(TestBed.get(SwUpdate).isEnabled).toEqual(true);
       });
     });
 

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -9,7 +9,7 @@
 import {PLATFORM_ID} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {NgswCommChannel} from '@angular/service-worker/src/low_level';
-import {SwRegistrationOptions, ngswCommChannelFactory} from '@angular/service-worker/src/module';
+import {ServiceWorkerModule, SwRegistrationOptions, ngswCommChannelFactory} from '@angular/service-worker/src/module';
 import {SwPush} from '@angular/service-worker/src/push';
 import {SwUpdate} from '@angular/service-worker/src/update';
 import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockServiceWorkerRegistration, patchDecodeBase64} from '@angular/service-worker/testing/mock';
@@ -44,6 +44,45 @@ import {async_fit, async_it} from './async';
         (comm as any).registration.subscribe((reg: any) => { done(); });
 
         mock.setupSw();
+      });
+    });
+
+    describe('ServiceWorkerModule config', () => {
+      it('SwUpdate isEnabled is false when configuring via static method', () => {
+        TestBed.configureTestingModule(
+            {imports: [ServiceWorkerModule.register('', {enabled: false})]});
+
+        expect(TestBed.get(SwUpdate).isEnabled).toEqual(false);
+      });
+
+      it('SwUpdate isEnabled is true when configuring via static method', () => {
+        TestBed.configureTestingModule({
+          imports: [ServiceWorkerModule.register('', {enabled: true})],
+          providers: [{provide: NgswCommChannel, useValue: comm}]
+        });
+
+        expect(TestBed.get(SwUpdate).isEnabled).toEqual(true);
+      });
+
+      it('SwUpdate isEnabled is false when configuring directly via token', () => {
+        TestBed.configureTestingModule({
+          imports: [ServiceWorkerModule.register('')],
+          providers: [{provide: SwRegistrationOptions, useFactory: () => ({enabled: false})}]
+        });
+
+        expect(TestBed.get(SwUpdate).isEnabled).toEqual(false);
+      });
+
+      it('SwUpdate isEnabled is true when configuring directly via token', () => {
+        TestBed.configureTestingModule({
+          imports: [ServiceWorkerModule.register('')],
+          providers: [
+            {provide: NgswCommChannel, useValue: comm},
+            {provide: SwRegistrationOptions, useFactory: () => ({enabled: true})}
+          ]
+        });
+
+        expect(TestBed.get(SwUpdate).isEnabled).toEqual(true);
       });
     });
 

--- a/packages/service-worker/test/module_spec.ts
+++ b/packages/service-worker/test/module_spec.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ApplicationRef, PLATFORM_ID} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {filter, take} from 'rxjs/operators';
+
+import {ServiceWorkerModule, SwRegistrationOptions} from '../src/module';
+import {SwUpdate} from '../src/update';
+
+
+describe('ServiceWorkerModule', () => {
+  // Skip environments that don't support the minimum APIs needed to run these SW tests.
+  if ((typeof navigator === 'undefined') || (typeof navigator.serviceWorker === 'undefined')) {
+    return;
+  }
+
+  let swRegisterSpy: jasmine.Spy;
+
+  beforeEach(() => swRegisterSpy = spyOn(navigator.serviceWorker, 'register'));
+
+  describe('register()', () => {
+    const configTestBed = async(opts: SwRegistrationOptions) => {
+      TestBed.configureTestingModule({
+        imports: [ServiceWorkerModule.register('sw.js', opts)],
+        providers: [{provide: PLATFORM_ID, useValue: 'browser'}],
+      });
+
+      const appRef: ApplicationRef = TestBed.get(ApplicationRef);
+      await appRef.isStable.pipe(filter(Boolean), take(1)).toPromise();
+    };
+
+    it('sets the registration options', async() => {
+      await configTestBed({enabled: true, scope: 'foo'});
+
+      expect(TestBed.get(SwRegistrationOptions)).toEqual({enabled: true, scope: 'foo'});
+      expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: 'foo'});
+    });
+
+    it('can disable the SW', async() => {
+      await configTestBed({enabled: false});
+
+      expect(TestBed.get(SwUpdate).isEnabled).toBe(false);
+      expect(swRegisterSpy).not.toHaveBeenCalled();
+    });
+
+    it('can enable the SW', async() => {
+      await configTestBed({enabled: true});
+
+      expect(TestBed.get(SwUpdate).isEnabled).toBe(true);
+      expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+    });
+
+    it('defaults to enabling the SW', async() => {
+      await configTestBed({});
+      expect(TestBed.get(SwUpdate).isEnabled).toBe(true);
+      expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+    });
+  });
+
+  describe('SwRegistrationOptions', () => {
+    const configTestBed =
+        async(providerOpts: SwRegistrationOptions, staticOpts?: SwRegistrationOptions) => {
+      TestBed.configureTestingModule({
+        imports: [ServiceWorkerModule.register('sw.js', staticOpts || {scope: 'static'})],
+        providers: [
+          {provide: PLATFORM_ID, useValue: 'browser'},
+          {provide: SwRegistrationOptions, useFactory: () => providerOpts},
+        ],
+      });
+
+      const appRef: ApplicationRef = TestBed.get(ApplicationRef);
+      await appRef.isStable.pipe(filter(Boolean), take(1)).toPromise();
+    };
+
+    it('sets the registration options (and overwrites those set via `.register()`', async() => {
+      await configTestBed({enabled: true, scope: 'provider'});
+
+      expect(TestBed.get(SwRegistrationOptions)).toEqual({enabled: true, scope: 'provider'});
+      expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: 'provider'});
+    });
+
+    it('can disable the SW', async() => {
+      await configTestBed({enabled: false}, {enabled: true});
+
+      expect(TestBed.get(SwUpdate).isEnabled).toBe(false);
+      expect(swRegisterSpy).not.toHaveBeenCalled();
+    });
+
+    it('can enable the SW', async() => {
+      await configTestBed({enabled: true}, {enabled: false});
+
+      expect(TestBed.get(SwUpdate).isEnabled).toBe(true);
+      expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+    });
+
+    it('defaults to enabling the SW', async() => {
+      await configTestBed({}, {enabled: false});
+
+      expect(TestBed.get(SwUpdate).isEnabled).toBe(true);
+      expect(swRegisterSpy).toHaveBeenCalledWith('sw.js', {scope: undefined});
+    });
+  });
+});

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -39,7 +39,7 @@
     "examples/**/e2e_test/*",
     // Exclude the "main.ts" files for each example group because this file is used by
     // Bazel to launch the devserver and uses AOT compilation.
-    "examples/*/main.ts",
+    "examples/**/main.ts",
     "platform-server/integrationtest",
     "router/test/aot_ngsummary_test",
   ]

--- a/tools/public_api_guard/service-worker/service-worker.d.ts
+++ b/tools/public_api_guard/service-worker/service-worker.d.ts
@@ -1,8 +1,5 @@
 export declare class ServiceWorkerModule {
-    static register(script: string, opts?: {
-        scope?: string;
-        enabled?: boolean;
-    }): ModuleWithProviders<ServiceWorkerModule>;
+    static register(script: string, opts?: SwRegistrationOptions): ModuleWithProviders<ServiceWorkerModule>;
 }
 
 export declare class SwPush {
@@ -20,6 +17,11 @@ export declare class SwPush {
         serverPublicKey: string;
     }): Promise<PushSubscription>;
     unsubscribe(): Promise<void>;
+}
+
+export declare abstract class SwRegistrationOptions {
+    enabled?: boolean;
+    scope?: string;
 }
 
 export declare class SwUpdate {


### PR DESCRIPTION
Expose the RegistrationOptions DI token to allow for runtime configuration of ServiceWorkerModule. At the moment there is no way to mark ServiceWorkerModule as enabled at runtime since the configuration values are set at build time.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
At the moment there is no way to mark the sw module as enabled at runtime.  For example if you use global variables for environment variables.

```TS

@NgModule({
  imports: [
    // this does not work since the configuration happens at compile time.
    ServiceWorkerModule.register('/sw/script.js', { enabled: window['isProdMode'] })
  ]
])
class AppModule {}
```

Issue Number: #22796


## What is the new behavior?
Exposing this token will allow folks to configure the sw with useFactory making runtime config possible.

```TS
export function swConfigFactory() {
  return { enabled: window['isProdMode'] }
}

@NgModule({
  imports: [ServiceWorkerModule.register('/sw/script.js')],
  providers: [
    { provide: RegistrationOptions, useFactory: swConfigFactory }
  ]
])
class AppModule {}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
