### PR TITLE
build: fix api guardian issues on windows

### DIFF
--- a/tools/ts-api-guardian/index.bzl
+++ b/tools/ts-api-guardian/index.bzl
@@ -19,7 +19,7 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary", "nodejs_test")
 
 COMMON_MODULE_IDENTIFIERS = ["angular", "jasmine", "protractor"]
 
-def ts_api_guardian_test(name, golden, actual, data = [], strip_export_pattern = "^\(__\|ɵ\)", allow_module_identifiers = COMMON_MODULE_IDENTIFIERS, **kwargs):
+def ts_api_guardian_test(name, golden, actual, data = [], strip_export_pattern = ["^__", "^ɵ"], allow_module_identifiers = COMMON_MODULE_IDENTIFIERS, **kwargs):
     """Runs ts_api_guardian
     """
     data += [
@@ -31,9 +31,11 @@ def ts_api_guardian_test(name, golden, actual, data = [], strip_export_pattern =
         # Needed so that node doesn't walk back to the source directory.
         # From there, the relative imports would point to .ts files.
         "--node_options=--preserve-symlinks",
-        "--stripExportPattern",
-        strip_export_pattern,
     ]
+
+    for i in strip_export_pattern:
+        args += ["--stripExportPattern", i]
+
     for i in allow_module_identifiers:
         args += ["--allowModuleIdentifiers", i]
 

--- a/tools/ts-api-guardian/lib/cli.ts
+++ b/tools/ts-api-guardian/lib/cli.ts
@@ -22,7 +22,7 @@ export function startCli() {
   const {argv, mode, errors} = parseArguments(process.argv.slice(2));
 
   const options: SerializationOptions = {
-    stripExportPattern: argv['stripExportPattern'],
+    stripExportPattern: [].concat(argv['stripExportPattern']),
     allowModuleIdentifiers: [].concat(argv['allowModuleIdentifiers']),
   };
 

--- a/tools/ts-api-guardian/lib/serializer.ts
+++ b/tools/ts-api-guardian/lib/serializer.ts
@@ -19,7 +19,7 @@ export interface SerializationOptions {
   /**
    * Removes all exports matching the regular expression.
    */
-  stripExportPattern?: RegExp;
+  stripExportPattern?: RegExp|RegExp[];
   /**
    * Whitelists these identifiers as modules in the output. For example,
    * ```
@@ -88,7 +88,7 @@ class ResolvedDeclarationEmitter {
     resolvedSymbols.sort(symbolCompareFunction);
 
     for (const symbol of resolvedSymbols) {
-      if (this.options.stripExportPattern && symbol.name.match(this.options.stripExportPattern)) {
+      if (this.isExportPatternStripped(symbol.name)) {
         continue;
       }
 
@@ -145,6 +145,10 @@ class ResolvedDeclarationEmitter {
     return output;
   }
 
+  private isExportPatternStripped(symbolName: string): boolean {
+    return [].concat(this.options.stripExportPattern).some(p => !!(p && symbolName.match(p)));
+  }
+
   private getResolvedSymbols(sourceFile: ts.SourceFile): ts.Symbol[] {
     const ms = (<any>sourceFile).symbol;
     const rawSymbols = ms ? (this.typeChecker.getExportsOfModule(ms) || []) : [];
@@ -157,7 +161,7 @@ class ResolvedDeclarationEmitter {
           return s;
         }
         if (resolvedSymbol.name !== s.name) {
-          if (this.options.stripExportPattern && s.name.match(this.options.stripExportPattern)) {
+          if (this.isExportPatternStripped(s.name)) {
             return s;
           }
           throw new Error(


### PR DESCRIPTION
This is a workaround for https://github.com/bazelbuild/rules_nodejs/issues/317