### PR TITLE
error handling during downgraded component bootstrap

### DIFF
--- a/packages/upgrade/src/common/constants.ts
+++ b/packages/upgrade/src/common/constants.ts
@@ -9,6 +9,7 @@
 export const $COMPILE = '$compile';
 export const $CONTROLLER = '$controller';
 export const $DELEGATE = '$delegate';
+export const $EXCEPTION_HANDLER = '$exceptionHandler';
 export const $HTTP_BACKEND = '$httpBackend';
 export const $INJECTOR = '$injector';
 export const $INTERVAL = '$interval';

--- a/packages/upgrade/src/common/downgrade_component.ts
+++ b/packages/upgrade/src/common/downgrade_component.ts
@@ -104,6 +104,13 @@ export function downgradeComponent(info: {
         }
 
         const doDowngrade = (injector: Injector) => {
+          // Downgrading can happen asynchronously; e.g. an Angular module may need to be
+          // bootstrapped first. By the time we get here, the parent component may have been
+          // destroyed, in which case there is no need to instantiate the downgraded component.
+          if (scope.$$destroyed) {
+            return;
+          }
+
           const componentFactoryResolver: ComponentFactoryResolver =
               injector.get(ComponentFactoryResolver);
           const componentFactory: ComponentFactory<any> =


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

2 issues: 

- errors occurring in downgraded component constructor are unhandled and caught in zone.js 
- downgraded component is instantiated after scope is destroyed. In our project, since we are using lazy loading we are getting component factory not found errors.

Issue Number: #25613


## What is the new behavior?

- errors occurring in downgraded component constructor will be forwarded to angular.js $excetionHandler. We have missed some errors as they were not logged in production.
- downgraded component will not be created if scope was destroyed before angular was bootstrapped

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
