### PR TITLE
fix(core): add missing `peerDependency ` to `@angular/compiler`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
     "tslib": "^1.9.0"
   },
   "peerDependencies": {
+    "@angular/compiler": "0.0.0-PLACEHOLDER",
     "rxjs": "^6.0.0",
     "zone.js": "~0.8.26"
   },


### PR DESCRIPTION
In https://github.com/angular/angular/commit/919f42fea1df4b9e38b7d688aef5f2de668e9d3e#diff-58563046c4439699f2e6a89187099a54 a dependency to the compiler was added. However the peerDependency was not added.

//cc @alxhub 
