### PR TITLE
fix(compiler-cli): Return original sourceFile instead of redirected sourceFile

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/host.ts
@@ -39,6 +39,13 @@ export class TypeCheckProgramHost implements ts.CompilerHost {
       sf = this.delegate.getSourceFile(
           fileName, languageVersion, onError, shouldCreateNewSourceFile);
       sf && this.sfMap.set(fileName, sf);
+    } else {
+      // TypeScript doesn't allow returning redirect source files. To avoid unforseen errors we
+      // return the original source file instead of the redirect target.
+      const redirectInfo = (sf as any).redirectInfo;
+      if (redirectInfo !== undefined) {
+        sf = redirectInfo.unredirected;
+      }
     }
     return sf;
   }

--- a/packages/compiler-cli/src/transformers/compiler_host.ts
+++ b/packages/compiler-cli/src/transformers/compiler_host.ts
@@ -441,6 +441,12 @@ export class TsCompilerAotCompilerTypeCheckHostAdapter implements ts.CompilerHos
               fileName, summary.text, this.options.target || ts.ScriptTarget.Latest);
         }
         sf = summary.sourceFile;
+        // TypeScript doesn't allow returning redirect source files. To avoid unforseen errors we
+        // return the original source file instead of the redirect target.
+        const redirectInfo = (sf as any).redirectInfo;
+        if (redirectInfo !== undefined) {
+          sf = redirectInfo.unredirected;
+        }
         genFileNames = [];
       }
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using webpack dev server and AngularCompilerPlugin (maybe other combinations as well) all but the first compile always fails with the the following error:
```
Host should not return a redirect source file from `getSourceFile`
```
The problem is causes by duplicated definition files with different paths.
Example:
```
C:/Users/me/repo/web-app-angular/node_modules/@types/webpack/node_modules/source-map/source-map.d.ts
C:/Users/me/repo/web-app-angular/node_modules/@types/uglify-js/node_modules/source-map/source-map.d.ts
```
Typescript expects the redirect's target instead of the redirects source.
This fix solves that.
Issue Number: https://github.com/angular/angular/issues/22524


## What is the new behavior?
The error message is not thrown. Fix is borrowed from here: https://github.com/ng-packagr/ng-packagr/commit/c1fced0873e5007474e4c411a258d9955e996fe0

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is definitely a hotfix. I don't have enough knowledge about TypeScript to solve the root cause. But this has been stopping our project since March, and based ont he up votes on the issue I'm not the only one.