### PR TITLE
fix(service-worker): do not blow up when caches are unwritable

### DIFF
--- a/packages/service-worker/worker/src/error.ts
+++ b/packages/service-worker/worker/src/error.ts
@@ -7,3 +7,11 @@
  */
 
 export class SwCriticalError extends Error { readonly isCritical: boolean = true; }
+
+export function errorToString(error: any): string {
+  if (error instanceof Error) {
+    return `${error.message}\n${error.stack}`;
+  } else {
+    return `${error}`;
+  }
+}

--- a/packages/service-worker/worker/testing/cache.ts
+++ b/packages/service-worker/worker/testing/cache.ts
@@ -164,3 +164,20 @@ export class MockCache {
     return dehydrated;
   }
 }
+
+// This can be used to simulate a situation (bug?), where the user clears the caches from DevTools,
+// while the SW is still running (e.g. serving another tab) and keeps references to the deleted
+// caches.
+export async function clearAllCaches(caches: CacheStorage): Promise<void> {
+  const cacheNames = await caches.keys();
+  const cacheInstances = await Promise.all(cacheNames.map(name => caches.open(name)));
+
+  // Delete all cache instances from `CacheStorage`.
+  await Promise.all(cacheNames.map(name => caches.delete(name)));
+
+  // Delete all entries from each cache instance.
+  await Promise.all(cacheInstances.map(async cache => {
+    const keys = await cache.keys();
+    await Promise.all(keys.map(key => cache.delete(key)));
+  }));
+}


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
```
[x] Bugfix
```

## What is the current behavior?
In some cases, example when the user clears the caches in DevTools but the SW remains active on another tab and keeps references to the deleted caches, trying to write to the cache throws errors (e.g. `Entry was not found`).

When this happens, the SW can no longer work correctly and should enter a degraded mode allowing requests to be served from the network.

Possibly related:
- https://github.com/GoogleChrome/workbox/issues/792
- https://bugs.chromium.org/p/chromium/issues/detail?id=639034


## What is the new behavior?
In such situations, the SW will enter the degraded `EXISTING_CLIENTS_ONLY` mode and forward requests to the network.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
