### PR TITLE
refactor(ivy): special injection tokens should not be cached

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -14,7 +14,7 @@ import {Sanitizer} from '../sanitization/security';
 
 import {assertComponentType, assertDefined} from './assert';
 import {queueInitHooks, queueLifecycleHooks} from './hooks';
-import {CLEAN_PROMISE, baseDirectiveCreate, createLViewData, createTView, detectChangesInternal, enterView, executeInitAndContentHooks, getRootView, hostElement, initChangeDetectorIfExisting, leaveView, locateHostElement, setHostBindings, queueHostBindingForCheck,} from './instructions';
+import {CLEAN_PROMISE, baseDirectiveCreate, createLViewData, createTView, detectChangesInternal, enterView, executeInitAndContentHooks, getRootView, hostElement, leaveView, locateHostElement, setHostBindings, queueHostBindingForCheck,} from './instructions';
 import {ComponentDef, ComponentDefInternal, ComponentType} from './interfaces/definition';
 import {LElementNode} from './interfaces/node';
 import {RElement, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
@@ -150,7 +150,6 @@ export function createRootComponent<T>(
   if (componentDef.hostBindings) queueHostBindingForCheck(0, componentDef.hostVars);
   rootContext.components.push(component);
   (elementNode.data as LViewData)[CONTEXT] = component;
-  initChangeDetectorIfExisting(elementNode.nodeInjector, component, elementNode.data as LViewData);
 
   hostFeatures && hostFeatures.forEach((feature) => feature(component, componentDef));
   setHostBindings(rootView[TVIEW].hostBindings);

--- a/packages/core/src/render3/interfaces/injector.ts
+++ b/packages/core/src/render3/interfaces/injector.ts
@@ -70,22 +70,6 @@ export interface LInjector {
   cbf5: number;
   cbf6: number;
   cbf7: number;
-
-  /** Stores the TemplateRef so subsequent injections of the TemplateRef get the same instance. */
-  templateRef: TemplateRef<any>|null;
-
-  /** Stores the ViewContainerRef so subsequent injections of the ViewContainerRef get the same
-   * instance. */
-  viewContainerRef: ViewContainerRef|null;
-
-  /** Stores the ElementRef so subsequent injections of the ElementRef get the same instance. */
-  elementRef: ElementRef|null;
-
-  /**
-   * Stores the ChangeDetectorRef so subsequent injections of the ChangeDetectorRef get the
-   * same instance.
-   */
-  changeDetectorRef: ChangeDetectorRef|null;
 }
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -265,10 +265,10 @@ function getIdxOfMatchingDirective(tNode: TNode, currentView: LViewData, type: T
 }
 
 function readFromNodeInjector(
-    nodeInjector: LInjector, tNode: TNode, currentView: LViewData,
-    read: QueryReadType<any>| Type<any>, directiveIdx: number): any {
+    tNode: TNode, currentView: LViewData, read: QueryReadType<any>| Type<any>,
+    directiveIdx: number): any {
   if (read instanceof ReadFromInjectorFn) {
-    return read.read(nodeInjector, tNode, directiveIdx);
+    return read.read(tNode, currentView, directiveIdx);
   } else {
     const matchingIdx = getIdxOfMatchingDirective(tNode, currentView, read as Type<any>);
     if (matchingIdx !== null) {
@@ -282,10 +282,6 @@ function add(
     query: LQuery<any>| null, tNode: TElementNode | TContainerNode | TElementContainerNode) {
   const currentView = _getViewData();
 
-  // TODO: remove this lookup when nodeInjector is removed from LNode
-  const nodeInjector =
-      getOrCreateNodeInjectorForNode(getLNode(tNode, currentView), tNode, currentView);
-
   while (query) {
     const predicate = query.predicate;
     const type = predicate.type;
@@ -294,8 +290,8 @@ function add(
       if (directiveIdx !== null) {
         // a node is matching a predicate - determine what to read
         // if read token and / or strategy is not specified, use type as read token
-        const result = readFromNodeInjector(
-            nodeInjector, tNode, currentView, predicate.read || type, directiveIdx);
+        const result =
+            readFromNodeInjector(tNode, currentView, predicate.read || type, directiveIdx);
         if (result !== null) {
           addMatch(query, result);
         }
@@ -308,8 +304,7 @@ function add(
           // a node is matching a predicate - determine what to read
           // note that queries using name selector must specify read strategy
           ngDevMode && assertDefined(predicate.read, 'the node should have a predicate');
-          const result = readFromNodeInjector(
-              nodeInjector, tNode, currentView, predicate.read !, directiveIdx);
+          const result = readFromNodeInjector(tNode, currentView, predicate.read !, directiveIdx);
           if (result !== null) {
             addMatch(query, result);
           }

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -267,9 +267,6 @@
     "name": "hostElement"
   },
   {
-    "name": "initChangeDetectorIfExisting"
-  },
-  {
     "name": "invertObject"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -405,7 +405,13 @@
     "name": "contextViewData"
   },
   {
+    "name": "createContainerRef"
+  },
+  {
     "name": "createDirectivesAndLocals"
+  },
+  {
+    "name": "createElementRef"
   },
   {
     "name": "createEmbeddedViewAndNode"
@@ -444,6 +450,9 @@
     "name": "createTView"
   },
   {
+    "name": "createTemplateRef"
+  },
+  {
     "name": "createTextNode"
   },
   {
@@ -451,6 +460,9 @@
   },
   {
     "name": "createViewQuery"
+  },
+  {
+    "name": "createViewRef"
   },
   {
     "name": "defineComponent"
@@ -621,18 +633,6 @@
     "name": "getMultiStartIndex"
   },
   {
-    "name": "getOrCreateChangeDetectorRef"
-  },
-  {
-    "name": "getOrCreateContainerRef"
-  },
-  {
-    "name": "getOrCreateElementRef"
-  },
-  {
-    "name": "getOrCreateHostChangeDetector"
-  },
-  {
     "name": "getOrCreateInjectable"
   },
   {
@@ -646,9 +646,6 @@
   },
   {
     "name": "getOrCreateTView"
-  },
-  {
-    "name": "getOrCreateTemplateRef"
   },
   {
     "name": "getParentLNode"
@@ -718,9 +715,6 @@
   },
   {
     "name": "hostElement"
-  },
-  {
-    "name": "initChangeDetectorIfExisting"
   },
   {
     "name": "inject"

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -1275,7 +1275,13 @@
     "name": "couldBeInjectableType"
   },
   {
+    "name": "createContainerRef"
+  },
+  {
     "name": "createDirectivesAndLocals"
+  },
+  {
+    "name": "createElementRef"
   },
   {
     "name": "createEmbeddedViewAndNode"
@@ -1326,6 +1332,9 @@
     "name": "createTView"
   },
   {
+    "name": "createTemplateRef"
+  },
+  {
     "name": "createTextNode"
   },
   {
@@ -1333,6 +1342,9 @@
   },
   {
     "name": "createViewQuery"
+  },
+  {
+    "name": "createViewRef"
   },
   {
     "name": "dateGetter"
@@ -1707,18 +1719,6 @@
     "name": "getNumberOfCurrencyDigits"
   },
   {
-    "name": "getOrCreateChangeDetectorRef"
-  },
-  {
-    "name": "getOrCreateContainerRef"
-  },
-  {
-    "name": "getOrCreateElementRef"
-  },
-  {
-    "name": "getOrCreateHostChangeDetector"
-  },
-  {
     "name": "getOrCreateInjectable"
   },
   {
@@ -1732,9 +1732,6 @@
   },
   {
     "name": "getOrCreateTView"
-  },
-  {
-    "name": "getOrCreateTemplateRef"
   },
   {
     "name": "getOriginalError"
@@ -1843,9 +1840,6 @@
   },
   {
     "name": "identity"
-  },
-  {
-    "name": "initChangeDetectorIfExisting"
   },
   {
     "name": "initDomAdapter"

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -10,7 +10,7 @@ import {ElementRef, TemplateRef, ViewContainerRef} from '@angular/core';
 import {RenderFlags} from '@angular/core/src/render3';
 
 import {RendererStyleFlags2, RendererType2} from '../../src/render/api';
-import {getOrCreateNodeInjectorForNode, getOrCreateTemplateRef} from '../../src/render3/di';
+import {createTemplateRef, getOrCreateNodeInjectorForNode} from '../../src/render3/di';
 import {AttributeMarker, defineComponent, defineDirective, injectElementRef, injectTemplateRef, injectViewContainerRef} from '../../src/render3/index';
 
 import {NO_CHANGE, bind, container, containerRefreshEnd, containerRefreshStart, element, elementAttribute, elementClassProp, elementContainerEnd, elementContainerStart, elementEnd, elementProperty, elementStart, elementStyleProp, elementStyling, elementStylingApply, embeddedViewEnd, embeddedViewStart, interpolation1, interpolation2, interpolation3, interpolation4, interpolation5, interpolation6, interpolation7, interpolation8, interpolationV, listener, load, loadDirective, projection, projectionDef, text, textBinding, template} from '../../src/render3/instructions';


### PR DESCRIPTION
This PR removes special objects like `ElementRef` and `TemplateRef` from `LInjector`. This is the first step towards making these symbols less "special" from a compiler viewpoint.

See https://github.com/angular/angular/blob/master/packages/core/src/render3/VIEW_DATA.md#expando-and-injecting-special-objects.

TODO: Convert `injectElementRef` calls to `inject(ElementRef)`