### PR TITLE
build(docs-infra): do not include license comment in first API doc

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -107,7 +107,7 @@
     "cross-spawn": "^5.1.0",
     "css-selector-parser": "^1.3.0",
     "dgeni": "^0.4.7",
-    "dgeni-packages": "^0.26.3",
+    "dgeni-packages": "^0.26.9",
     "entities": "^1.1.1",
     "eslint": "^3.19.0",
     "eslint-plugin-jasmine": "^2.2.0",

--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -126,10 +126,12 @@ module.exports = new Package('angular-api', [basePackage, typeScriptPackage])
   })
 
   // Configure jsdoc-style tag parsing
-  .config(function(parseTagsProcessor, getInjectables) {
+  .config(function(parseTagsProcessor, getInjectables, tsHost) {
     // Load up all the tag definitions in the tag-defs folder
     parseTagsProcessor.tagDefinitions =
         parseTagsProcessor.tagDefinitions.concat(getInjectables(requireFolder(__dirname, './tag-defs')));
+    // We don't want license headers to be joined to the first API item's comment
+    tsHost.concatMultipleLeadingComments = false;
   })
 
   .config(function(computeStability, splitDescription, addNotYetDocumentedProperty, API_DOC_TYPES_TO_RENDER, API_DOC_TYPES) {

--- a/aio/tools/transforms/angular-base-package/index.js
+++ b/aio/tools/transforms/angular-base-package/index.js
@@ -65,7 +65,6 @@ module.exports = new Package('angular-base', [
   // Where do we write the output files?
   .config(function(writeFilesProcessor) { writeFilesProcessor.outputFolder = DOCS_OUTPUT_PATH; })
 
-
   // Target environments
   .config(function(targetEnvironments) {
     const ALLOWED_LANGUAGES = ['ts', 'js', 'dart'];

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -3193,9 +3193,9 @@ devtools-timeline-model@1.1.6:
     chrome-devtools-frontend "1.0.401423"
     resolve "1.1.7"
 
-dgeni-packages@^0.26.3:
-  version "0.26.3"
-  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.26.3.tgz#fdc1299389e7cb1b1946926fd1f5970f3a6e0838"
+dgeni-packages@^0.26.9:
+  version "0.26.9"
+  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.26.9.tgz#64d0eb89046bcaec8417036c18002bdbd5062dbc"
   dependencies:
     canonical-path "0.0.2"
     catharsis "^0.8.1"


### PR DESCRIPTION
The default dgeni config is to concatenate leading comments in front of API items.

In the case that you have an API item that starts a file with no import statements,
the license comment at the top of the file was being added to the front of the
API item's comment. SInce the license comment includes the `@license` tag
and the API item's comment did not start with `@description` the content of
the API item's comment was being put inside the `@license` tag, and no
description was being extracted from the API item's comment.

This commit updates to a version of dgeni-packages that has a switch to turn off
this concatenation, and then also configures this switch.

Closes #26045
