### PR TITLE
fix(docs-infra): ensure that only search is removed from URL on click

### DIFF
--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -721,6 +721,15 @@ describe('AppComponent', () => {
           expect(component.showSearchResults).toBe(false);
         });
 
+        it('should clear "only" the search query param from the URL', () => {
+          // Mock out the current state of the URL query params
+          locationService.search.and.returnValue({ a: 'some-A', b: 'some-B', search: 'some-C'});
+          // docViewer is a commonly-clicked, non-search element
+          docViewer.click();
+          // Check that the query params were updated correctly
+          expect(locationService.setSearch).toHaveBeenCalledWith('', { a: 'some-A', b: 'some-B', search: undefined });
+        });
+
         it('should not intercept clicks on the searchResults', () => {
           component.showSearchResults = true;
           fixture.detectChanges();

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -384,7 +384,7 @@ export class AppComponent implements OnInit {
 
   hideSearchResults() {
     this.showSearchResults = false;
-    this.locationService.setSearch('', {});
+    this.locationService.setSearch('', { ...this.locationService.search(), search: undefined });
   }
 
   focusSearchBox() {


### PR DESCRIPTION
When we have navigated to the site via a URL that contains a search
query param, the site shows the search results.

We want to remove that query param from the URL when the search
results are closed, but the current implementation is also removing
other query params unnecessarily.

Now only the search param is removed when the search results are
closed.

See https://github.com/angular/angular/pull/25479/files#r219497804
for more context.
