### PR TITLE
fix(ivy): let ngcc replace all switchable declarations for ESM formats

### DIFF
--- a/packages/compiler-cli/src/ngcc/src/analyzer.ts
+++ b/packages/compiler-cli/src/ngcc/src/analyzer.ts
@@ -5,104 +5,67 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ConstantPool} from '@angular/compiler';
-import * as fs from 'fs';
 import * as ts from 'typescript';
 
-import {BaseDefDecoratorHandler, ComponentDecoratorHandler, DirectiveDecoratorHandler, InjectableDecoratorHandler, NgModuleDecoratorHandler, PipeDecoratorHandler, ResourceLoader, SelectorScopeRegistry} from '../../ngtsc/annotations';
-import {CompileResult, DecoratorHandler} from '../../ngtsc/transform';
-
-import {NgccReflectionHost} from './host/ngcc_host';
-import {ParsedClass} from './parsing/parsed_class';
-import {ParsedFile} from './parsing/parsed_file';
+import {DecoratedFile, DecoratorAnalyzer} from './decorator_analyzer';
+import {NgccReflectionHost, SwitchableVariableDeclaration} from './host/ngcc_host';
+import {FileParser} from './parsing/file_parser';
 import {isDefined} from './utils';
 
-export interface AnalyzedClass<A = any, M = any> extends ParsedClass {
-  handler: DecoratorHandler<A, M>;
-  analysis: any;
-  diagnostics?: ts.Diagnostic[];
-  compilation: CompileResult[];
-}
-
 export interface AnalyzedFile {
-  analyzedClasses: AnalyzedClass[];
   sourceFile: ts.SourceFile;
-  constantPool: ConstantPool;
+  decorated?: DecoratedFile;
+  switchable?: SwitchableFile;
 }
 
-export interface MatchingHandler<A, M> {
-  handler: DecoratorHandler<A, M>;
-  match: M;
-}
-
-/**
- * `ResourceLoader` which directly uses the filesystem to resolve resources synchronously.
- */
-export class FileResourceLoader implements ResourceLoader {
-  load(url: string): string { return fs.readFileSync(url, 'utf8'); }
+export interface SwitchableFile {
+  sourceFile: ts.SourceFile;
+  declarations: SwitchableVariableDeclaration[];
 }
 
 export class Analyzer {
-  resourceLoader = new FileResourceLoader();
-  scopeRegistry = new SelectorScopeRegistry(this.typeChecker, this.host);
-  handlers: DecoratorHandler<any, any>[] = [
-    new BaseDefDecoratorHandler(this.typeChecker, this.host),
-    new ComponentDecoratorHandler(
-        this.typeChecker, this.host, this.scopeRegistry, false, this.resourceLoader, this.rootDirs),
-    new DirectiveDecoratorHandler(this.typeChecker, this.host, this.scopeRegistry, false),
-    new InjectableDecoratorHandler(this.host, false),
-    new NgModuleDecoratorHandler(this.typeChecker, this.host, this.scopeRegistry, false),
-    new PipeDecoratorHandler(this.typeChecker, this.host, this.scopeRegistry, false),
-  ];
-
   constructor(
-      private typeChecker: ts.TypeChecker, private host: NgccReflectionHost,
-      private rootDirs: string[]) {}
+      private program: ts.Program, private host: NgccReflectionHost, private parser: FileParser,
+      private decoratorAnalyzer: DecoratorAnalyzer) {}
 
-  /**
-   * Analyize a parsed file to generate the information about decorated classes that
-   * should be converted to use ivy definitions.
-   * @param file The file to be analysed for decorated classes.
-   */
-  analyzeFile(file: ParsedFile): AnalyzedFile {
-    const constantPool = new ConstantPool();
-    const analyzedClasses =
-        file.decoratedClasses.map(clazz => this.analyzeClass(constantPool, clazz))
-            .filter(isDefined);
+  analyzeEntryPoint(entryPointFilePath: string): AnalyzedFile[] {
+    const entryPointFile = this.program.getSourceFile(entryPointFilePath) !;
+    const parsedFiles = this.parser.parseFile(entryPointFile);
 
-    return {
-      analyzedClasses,
-      sourceFile: file.sourceFile, constantPool,
-    };
+    const decoratedFiles =
+        parsedFiles.map(parsedFile => this.decoratorAnalyzer.analyzeFile(parsedFile));
+    const switchableFiles = this.findSwitchableFiles();
+
+    const mergedFiles = new Map<ts.SourceFile, AnalyzedFile>();
+
+    decoratedFiles.forEach(file => mergedFiles.set(file.sourceFile, {
+      sourceFile: file.sourceFile,
+      decorated: file,
+    }));
+
+    switchableFiles.forEach(file => {
+      let mergedFile = mergedFiles.get(file.sourceFile);
+      if (!mergedFile) {
+        mergedFile = {sourceFile: file.sourceFile};
+        mergedFiles.set(file.sourceFile, mergedFile);
+      }
+      mergedFile.switchable = file;
+    });
+
+    return Array.from(mergedFiles.values());
   }
 
-  protected analyzeClass(pool: ConstantPool, clazz: ParsedClass): AnalyzedClass|undefined {
-    const matchingHandlers = this.handlers
-                                 .map(handler => ({
-                                        handler,
-                                        match: handler.detect(clazz.declaration, clazz.decorators),
-                                      }))
-                                 .filter(isMatchingHandler);
-
-    if (matchingHandlers.length > 1) {
-      throw new Error('TODO.Diagnostic: Class has multiple Angular decorators.');
-    }
-
-    if (matchingHandlers.length === 0) {
-      return undefined;
-    }
-
-    const {handler, match} = matchingHandlers[0];
-    const {analysis, diagnostics} = handler.analyze(clazz.declaration, match);
-    let compilation = handler.compile(clazz.declaration, analysis, pool);
-    if (!Array.isArray(compilation)) {
-      compilation = [compilation];
-    }
-    return {...clazz, handler, analysis, diagnostics, compilation};
+  private findSwitchableFiles(): SwitchableFile[] {
+    return this.program.getSourceFiles()
+        .map(sourceFile => this.analyzeFileForSwitches(sourceFile))
+        .filter(isDefined);
   }
-}
 
-function isMatchingHandler<A, M>(handler: Partial<MatchingHandler<A, M>>):
-    handler is MatchingHandler<A, M> {
-  return !!handler.match;
+  private analyzeFileForSwitches(sourceFile: ts.SourceFile): SwitchableFile|undefined {
+    const declarations = this.host.getSwitchableDeclarations(sourceFile);
+
+    if (declarations.length > 0) {
+      return {sourceFile, declarations};
+    }
+  }
 }

--- a/packages/compiler-cli/src/ngcc/src/decorator_analyzer.ts
+++ b/packages/compiler-cli/src/ngcc/src/decorator_analyzer.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {ConstantPool} from '@angular/compiler';
+import * as fs from 'fs';
+import * as ts from 'typescript';
+
+import {BaseDefDecoratorHandler, ComponentDecoratorHandler, DirectiveDecoratorHandler, InjectableDecoratorHandler, NgModuleDecoratorHandler, PipeDecoratorHandler, ResourceLoader, SelectorScopeRegistry} from '../../ngtsc/annotations';
+import {CompileResult, DecoratorHandler} from '../../ngtsc/transform';
+
+import {NgccReflectionHost} from './host/ngcc_host';
+import {ParsedClass} from './parsing/parsed_class';
+import {ParsedFile} from './parsing/parsed_file';
+import {isDefined} from './utils';
+
+export interface DecoratedClass<A = any, M = any> extends ParsedClass {
+  handler: DecoratorHandler<A, M>;
+  analysis: any;
+  diagnostics?: ts.Diagnostic[];
+  compilation: CompileResult[];
+}
+
+export interface DecoratedFile {
+  decoratedClasses: DecoratedClass[];
+  sourceFile: ts.SourceFile;
+  constantPool: ConstantPool;
+}
+
+export interface MatchingHandler<A, M> {
+  handler: DecoratorHandler<A, M>;
+  match: M;
+}
+
+/**
+ * `ResourceLoader` which directly uses the filesystem to resolve resources synchronously.
+ */
+export class FileResourceLoader implements ResourceLoader {
+  load(url: string): string { return fs.readFileSync(url, 'utf8'); }
+}
+
+export class DecoratorAnalyzer {
+  resourceLoader = new FileResourceLoader();
+  scopeRegistry = new SelectorScopeRegistry(this.typeChecker, this.host);
+  handlers: DecoratorHandler<any, any>[] = [
+    new BaseDefDecoratorHandler(this.typeChecker, this.host),
+    new ComponentDecoratorHandler(
+        this.typeChecker, this.host, this.scopeRegistry, false, this.resourceLoader, this.rootDirs),
+    new DirectiveDecoratorHandler(this.typeChecker, this.host, this.scopeRegistry, false),
+    new InjectableDecoratorHandler(this.host, false),
+    new NgModuleDecoratorHandler(this.typeChecker, this.host, this.scopeRegistry, false),
+    new PipeDecoratorHandler(this.typeChecker, this.host, this.scopeRegistry, false),
+  ];
+
+  constructor(
+      private typeChecker: ts.TypeChecker, private host: NgccReflectionHost,
+      private rootDirs: string[]) {}
+
+  /**
+   * Analyze a parsed file to generate the information about decorated classes that
+   * should be converted to use ivy definitions.
+   * @param file The file to be analysed for decorated classes.
+   */
+  analyzeFile(file: ParsedFile): DecoratedFile {
+    const constantPool = new ConstantPool();
+    const analyzedClasses =
+        file.decoratedClasses.map(clazz => this.analyzeClass(constantPool, clazz))
+            .filter(isDefined);
+
+    return {
+      decoratedClasses: analyzedClasses,
+      sourceFile: file.sourceFile, constantPool,
+    };
+  }
+
+  protected analyzeClass(pool: ConstantPool, clazz: ParsedClass): DecoratedClass|undefined {
+    const matchingHandlers = this.handlers
+                                 .map(handler => ({
+                                        handler,
+                                        match: handler.detect(clazz.declaration, clazz.decorators),
+                                      }))
+                                 .filter(isMatchingHandler);
+
+    if (matchingHandlers.length > 1) {
+      throw new Error('TODO.Diagnostic: Class has multiple Angular decorators.');
+    }
+
+    if (matchingHandlers.length === 0) {
+      return undefined;
+    }
+
+    const {handler, match} = matchingHandlers[0];
+    const {analysis, diagnostics} = handler.analyze(clazz.declaration, match);
+    let compilation = handler.compile(clazz.declaration, analysis, pool);
+    if (!Array.isArray(compilation)) {
+      compilation = [compilation];
+    }
+    return {...clazz, handler, analysis, diagnostics, compilation};
+  }
+}
+
+function isMatchingHandler<A, M>(handler: Partial<MatchingHandler<A, M>>):
+    handler is MatchingHandler<A, M> {
+  return !!handler.match;
+}

--- a/packages/compiler-cli/src/ngcc/src/parsing/esm5_parser.ts
+++ b/packages/compiler-cli/src/ngcc/src/parsing/esm5_parser.ts
@@ -15,12 +15,9 @@ import {FileParser} from './file_parser';
 import {ParsedClass} from './parsed_class';
 import {ParsedFile} from './parsed_file';
 
-
-
 /**
- * Parses ESM5 package files for decoratrs classes.
- * ESM5 "classes" are actually functions wrapped by and returned
- * from an IFEE.
+ * Parses ESM5 package files for decorated classes.
+ * ESM5 "classes" are actually functions wrapped by and returned from an IIFE.
  */
 export class Esm5FileParser implements FileParser {
   checker = this.program.getTypeChecker();

--- a/packages/compiler-cli/src/ngcc/src/rendering/esm2015_renderer.ts
+++ b/packages/compiler-cli/src/ngcc/src/rendering/esm2015_renderer.ts
@@ -7,8 +7,7 @@
  */
 import * as ts from 'typescript';
 import MagicString from 'magic-string';
-import {POST_NGCC_MARKER, PRE_NGCC_MARKER} from '../host/ngcc_host';
-import {AnalyzedClass} from '../analyzer';
+import {DecoratedClass} from '../decorator_analyzer';
 import {Renderer} from './renderer';
 
 export class Esm2015Renderer extends Renderer {
@@ -37,7 +36,7 @@ export class Esm2015Renderer extends Renderer {
   /**
    * Add the definitions to each decorated class
    */
-  addDefinitions(output: MagicString, analyzedClass: AnalyzedClass, definitions: string): void {
+  addDefinitions(output: MagicString, analyzedClass: DecoratedClass, definitions: string): void {
     const classSymbol = this.host.getClassSymbol(analyzedClass.declaration);
     if (!classSymbol) {
       throw new Error(`Analyzed class does not have a valid symbol: ${analyzedClass.name}`);
@@ -69,16 +68,6 @@ export class Esm2015Renderer extends Renderer {
           });
         }
       }
-    });
-  }
-
-  rewriteSwitchableDeclarations(outputText: MagicString, sourceFile: ts.SourceFile): void {
-    const declarations = this.host.getSwitchableDeclarations(sourceFile);
-    declarations.forEach(declaration => {
-      const start = declaration.initializer.getStart();
-      const end = declaration.initializer.getEnd();
-      const replacement = declaration.initializer.text.replace(PRE_NGCC_MARKER, POST_NGCC_MARKER);
-      outputText.overwrite(start, end, replacement);
     });
   }
 }

--- a/packages/compiler-cli/src/ngcc/test/decorator_analyzer_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/decorator_analyzer_spec.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {Decorator} from '../../ngtsc/host';
+import {DecoratorHandler} from '../../ngtsc/transform';
+import {DecoratedFile, DecoratorAnalyzer} from '../src/decorator_analyzer';
+import {Fesm2015ReflectionHost} from '../src/host/fesm2015_host';
+import {ParsedClass} from '../src/parsing/parsed_class';
+import {ParsedFile} from '../src/parsing/parsed_file';
+
+import {getDeclaration, makeProgram} from './helpers/utils';
+
+const TEST_PROGRAM = {
+  name: 'test.js',
+  contents: `
+  import {Component, Injectable} from '@angular/core';
+
+  @Component()
+  export class MyComponent {}
+
+  @Injectable()
+  export class MyService {}
+  `
+};
+
+function createTestHandler() {
+  const handler = jasmine.createSpyObj<DecoratorHandler<any, any>>('TestDecoratorHandler', [
+    'detect',
+    'analyze',
+    'compile',
+  ]);
+  // Only detect the Component decorator
+  handler.detect.and.callFake((node: ts.Declaration, decorators: Decorator[]) => {
+    if (!decorators) {
+      return undefined;
+    }
+    return decorators.find(d => d.name === 'Component');
+  });
+  // The "test" analysis is just the name of the decorator being analyzed
+  handler.analyze.and.callFake(
+      ((decl: ts.Declaration, dec: Decorator) => ({analysis: dec.name, diagnostics: null})));
+  // The "test" compilation result is just the name of the decorator being compiled
+  handler.compile.and.callFake(((decl: ts.Declaration, analysis: any) => ({analysis})));
+  return handler;
+}
+
+function createParsedFile(program: ts.Program) {
+  const file = new ParsedFile(program.getSourceFile('test.js') !);
+
+  const componentClass = getDeclaration(program, 'test.js', 'MyComponent', ts.isClassDeclaration);
+  file.decoratedClasses.push(new ParsedClass('MyComponent', {} as any, [{
+                                               name: 'Component',
+                                               import: {from: '@angular/core', name: 'Component'},
+                                               node: null as any,
+                                               args: null
+                                             }]));
+
+  const serviceClass = getDeclaration(program, 'test.js', 'MyService', ts.isClassDeclaration);
+  file.decoratedClasses.push(new ParsedClass('MyService', {} as any, [{
+                                               name: 'Injectable',
+                                               import: {from: '@angular/core', name: 'Injectable'},
+                                               node: null as any,
+                                               args: null
+                                             }]));
+
+  return file;
+}
+
+describe('DecoratorAnalyzer', () => {
+  describe('analyzeFile()', () => {
+    let program: ts.Program;
+    let testHandler: jasmine.SpyObj<DecoratorHandler<any, any>>;
+    let result: DecoratedFile;
+
+    beforeEach(() => {
+      program = makeProgram(TEST_PROGRAM);
+      const file = createParsedFile(program);
+      const analyzer = new DecoratorAnalyzer(
+          program.getTypeChecker(), new Fesm2015ReflectionHost(program.getTypeChecker()), ['']);
+      testHandler = createTestHandler();
+      analyzer.handlers = [testHandler];
+      result = analyzer.analyzeFile(file);
+    });
+
+    it('should return an object containing a reference to the original source file',
+       () => { expect(result.sourceFile).toBe(program.getSourceFile('test.js') !); });
+
+    it('should call detect on the decorator handlers with each class from the parsed file', () => {
+      expect(testHandler.detect).toHaveBeenCalledTimes(2);
+      expect(testHandler.detect.calls.allArgs()[0][1]).toEqual([jasmine.objectContaining(
+          {name: 'Component'})]);
+      expect(testHandler.detect.calls.allArgs()[1][1]).toEqual([jasmine.objectContaining(
+          {name: 'Injectable'})]);
+    });
+
+    it('should return an object containing the classes that were analyzed', () => {
+      expect(result.decoratedClasses.length).toEqual(1);
+      expect(result.decoratedClasses[0].name).toEqual('MyComponent');
+    });
+
+    it('should analyze and compile the classes that are detected', () => {
+      expect(testHandler.analyze).toHaveBeenCalledTimes(1);
+      expect(testHandler.analyze.calls.allArgs()[0][1].name).toEqual('Component');
+
+      expect(testHandler.compile).toHaveBeenCalledTimes(1);
+      expect(testHandler.compile.calls.allArgs()[0][1]).toEqual('Component');
+    });
+  });
+});

--- a/packages/compiler-cli/src/ngcc/test/rendering/esm2015_renderer_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/rendering/esm2015_renderer_spec.ts
@@ -9,6 +9,7 @@ import * as ts from 'typescript';
 import MagicString from 'magic-string';
 import {makeProgram} from '../helpers/utils';
 import {Analyzer} from '../../src/analyzer';
+import {DecoratorAnalyzer} from '../../src/decorator_analyzer';
 import {Fesm2015ReflectionHost} from '../../src/host/fesm2015_host';
 import {Esm2015FileParser} from '../../src/parsing/esm2015_parser';
 import {Esm2015Renderer} from '../../src/rendering/esm2015_renderer';
@@ -17,14 +18,14 @@ function setup(file: {name: string, contents: string}) {
   const program = makeProgram(file);
   const host = new Fesm2015ReflectionHost(program.getTypeChecker());
   const parser = new Esm2015FileParser(program, host);
-  const analyzer = new Analyzer(program.getTypeChecker(), host, ['']);
+  const decoratorAnalyzer = new DecoratorAnalyzer(program.getTypeChecker(), host, ['']);
+  const analyzer = new Analyzer(program, host, parser, decoratorAnalyzer);
   const renderer = new Esm2015Renderer(host);
   return {analyzer, host, parser, program, renderer};
 }
 
-function analyze(parser: Esm2015FileParser, analyzer: Analyzer, file: ts.SourceFile) {
-  const parsedFiles = parser.parseFile(file);
-  return parsedFiles.map(file => analyzer.analyzeFile(file))[0];
+function analyze(analyzer: Analyzer, file: string) {
+  return analyzer.analyzeEntryPoint(file)[0];
 }
 
 const PROGRAM = {
@@ -97,13 +98,14 @@ export class A {}`);
 
   describe('rewriteSwitchableDeclarations', () => {
     it('should switch marked declaration initializers', () => {
-      const {renderer, program} = setup(PROGRAM);
+      const {analyzer, renderer, program} = setup(PROGRAM);
       const file = program.getSourceFile('some/file.js');
       if (file === undefined) {
         throw new Error(`Could not find source file`);
       }
+      const analyzedFile = analyze(analyzer, 'some/file.js');
       const output = new MagicString(PROGRAM.contents);
-      renderer.rewriteSwitchableDeclarations(output, file);
+      renderer.rewriteSwitchableDeclarations(output, analyzedFile.switchable !);
       expect(output.toString())
           .not.toContain(`let compileNgModuleFactory = compileNgModuleFactory__PRE_NGCC__;`);
       expect(output.toString())
@@ -121,10 +123,11 @@ export class A {}`);
 
   describe('addDefinitions', () => {
     it('should insert the definitions directly after the class declaration', () => {
-      const {analyzer, parser, program, renderer} = setup(PROGRAM);
-      const analyzedFile = analyze(parser, analyzer, program.getSourceFile(PROGRAM.name) !);
+      const {analyzer, renderer} = setup(PROGRAM);
+      const analyzedFile = analyze(analyzer, PROGRAM.name);
       const output = new MagicString(PROGRAM.contents);
-      renderer.addDefinitions(output, analyzedFile.analyzedClasses[0], 'SOME DEFINITION TEXT');
+      renderer.addDefinitions(
+          output, analyzedFile.decorated !.decoratedClasses[0], 'SOME DEFINITION TEXT');
       expect(output.toString()).toContain(`
 export class A {}
 SOME DEFINITION TEXT
@@ -138,11 +141,11 @@ A.decorators = [
   describe('removeDecorators', () => {
 
     it('should delete the decorator (and following comma) that was matched in the analysis', () => {
-      const {analyzer, parser, program, renderer} = setup(PROGRAM);
-      const analyzedFile = analyze(parser, analyzer, program.getSourceFile(PROGRAM.name) !);
+      const {analyzer, renderer} = setup(PROGRAM);
+      const analyzedFile = analyze(analyzer, PROGRAM.name);
       const output = new MagicString(PROGRAM.contents);
-      const analyzedClass = analyzedFile.analyzedClasses[0];
-      const decorator = analyzedClass.decorators[0];
+      const decoratedClass = analyzedFile.decorated !.decoratedClasses[0];
+      const decorator = decoratedClass.decorators[0];
       const decoratorsToRemove = new Map<ts.Node, ts.Node[]>();
       decoratorsToRemove.set(decorator.node.parent !, [decorator.node]);
       renderer.removeDecorators(output, decoratorsToRemove);
@@ -156,11 +159,11 @@ A.decorators = [
 
     it('should delete the decorator (but cope with no trailing comma) that was matched in the analysis',
        () => {
-         const {analyzer, parser, program, renderer} = setup(PROGRAM);
-         const analyzedFile = analyze(parser, analyzer, program.getSourceFile(PROGRAM.name) !);
+         const {analyzer, renderer} = setup(PROGRAM);
+         const analyzedFile = analyze(analyzer, PROGRAM.name);
          const output = new MagicString(PROGRAM.contents);
-         const analyzedClass = analyzedFile.analyzedClasses[1];
-         const decorator = analyzedClass.decorators[1];
+         const decoratedClass = analyzedFile.decorated !.decoratedClasses[1];
+         const decorator = decoratedClass.decorators[1];
          const decoratorsToRemove = new Map<ts.Node, ts.Node[]>();
          decoratorsToRemove.set(decorator.node.parent !, [decorator.node]);
          renderer.removeDecorators(output, decoratorsToRemove);
@@ -175,11 +178,11 @@ A.decorators = [
 
     it('should delete the decorator (and its container if there are not other decorators left) that was matched in the analysis',
        () => {
-         const {analyzer, parser, program, renderer} = setup(PROGRAM);
-         const analyzedFile = analyze(parser, analyzer, program.getSourceFile(PROGRAM.name) !);
+         const {analyzer, renderer} = setup(PROGRAM);
+         const analyzedFile = analyze(analyzer, PROGRAM.name);
          const output = new MagicString(PROGRAM.contents);
-         const analyzedClass = analyzedFile.analyzedClasses[2];
-         const decorator = analyzedClass.decorators[0];
+         const decoratedClass = analyzedFile.decorated !.decoratedClasses[2];
+         const decorator = decoratedClass.decorators[0];
          const decoratorsToRemove = new Map<ts.Node, ts.Node[]>();
          decoratorsToRemove.set(decorator.node.parent !, [decorator.node]);
          renderer.removeDecorators(output, decoratorsToRemove);


### PR DESCRIPTION
For the ESM2015/ESM5 formats, PRE_NGCC declarations may exist in files
that would not be considered by FileParser as that is specifically
designed to find files that contain classes with Angular decorators to
transform. Hence, such PRE_NGCC usages would not be rewritten.

This commit moves everything from Analyzer to DecoratorAnalyzer to
perform the existing decorator analysis, and introduces a separate
analysis for PRE_NGCC usages. Both analysis results are merged together
into a single AnalyzedFile object per source file, such that a Renderer
can still apply all analysis results at once per source file.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

ngcc does not replace all PRE_NGCC usages for ESM formats, for instance `ivy_switch_legacy.ts` would not have been converted.

## What is the new behavior?
The analysis for switchable declarations has been separated from the analysis of decorated classes, such that PRE_NGCC usages are rewritten even in files that do not contain decorated classes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

@petebacondarwin PTAL