### PR TITLE
docs: correct path reference in upgrade guide

### DIFF
--- a/aio/content/guide/upgrade.md
+++ b/aio/content/guide/upgrade.md
@@ -1279,7 +1279,7 @@ The arguments are the same as you would pass to `angular.bootstrap` if you were 
 bootstrapping AngularJS: the root element of the application; and an array of the
 AngularJS 1.x modules that you want to load.
 
-Finally, bootstrap the `AppModule` in `src/main.ts`.
+Finally, bootstrap the `AppModule` in `app/main.ts`.
 This file has been configured as the application entrypoint in `systemjs.config.js`,
 so it is already being loaded by the browser.
 


### PR DESCRIPTION
The incorrect path is referenced, this is confusing to users following the "Upgrading from AngularJS" guide.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Fixes #25904.