### PR TITLE
fix(platform-browser): call HAMMER_LOADER only once

### DIFF
--- a/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
+++ b/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
@@ -99,13 +99,17 @@ import {HammerGestureConfig, HammerGesturesPlugin,} from '@angular/platform-brow
 
       it('should defer registering an event until Hammer is loaded', fakeAsync(() => {
            plugin.addEventListener(someElement, 'swipe', someListener);
+           plugin.addEventListener(someElement, 'swipe', someListener);
            expect(fakeHammerInstance.on).not.toHaveBeenCalled();
+           expect((plugin as any).registerCallbacks.length).toBe(2);
 
            (window as any).Hammer = {};
            resolveLoader();
            tick();
 
            expect(fakeHammerInstance.on).toHaveBeenCalledWith('swipe', jasmine.any(Function));
+           expect(fakeHammerInstance.on).toHaveBeenCalledTimes(2);
+           expect((plugin as any).registerCallbacks.length).toBe(0);
          }));
 
       it('should cancel registration if an event is removed before being added', fakeAsync(() => {
@@ -132,12 +136,17 @@ import {HammerGestureConfig, HammerGesturesPlugin,} from '@angular/platform-brow
 
       it('should log a warning when the loader fails', fakeAsync(() => {
            plugin.addEventListener(someElement, 'swipe', () => {});
+           plugin.addEventListener(someElement, 'swipe', () => {});
+           expect((plugin as any).registerCallbacks.length).toBe(2);
+
            failLoader();
            tick();
 
            expect(fakeConsole.warn)
                .toHaveBeenCalledWith(
                    `The "swipe" event cannot be bound because the custom Hammer.JS loader failed.`);
+           expect(fakeConsole.warn).toHaveBeenCalledTimes(2);
+           expect((plugin as any).registerCallbacks.length).toBe(0);
          }));
 
       it('should load a warning if the loader resolves and Hammer is not present', fakeAsync(() => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #25995 


## What is the new behavior?
HAMMER_LOADER is executed only once, the returned Promise is used internally for all event bindings.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
