### PR TITLE
fix(upgrade): throw clear error when calling `downgradeModule()` twice

### DIFF
--- a/packages/upgrade/src/common/angular1.ts
+++ b/packages/upgrade/src/common/angular1.ts
@@ -12,6 +12,12 @@ export type Ng1Expression = string | Function;
 
 export interface IAnnotatedFunction extends Function { $inject?: ReadonlyArray<Ng1Token>; }
 
+export interface IServiceFactory { (...args: any[]): any; }
+
+export interface IServiceProvider { $get: IServiceFactory|(Ng1Token|IServiceFactory)[]; }
+
+export interface IServiceProviderFactory { new (...args: any[]): IServiceProvider; }
+
 export type IInjectable = (Ng1Token | Function)[] | IAnnotatedFunction;
 
 export type SingleOrListOrMap<T> = T | T[] | {[key: string]: T};
@@ -26,6 +32,9 @@ export interface IModule {
   factory(key: Ng1Token, factoryFn: IInjectable): IModule;
   value(key: Ng1Token, value: any): IModule;
   constant(token: Ng1Token, value: any): IModule;
+  provider(key: Ng1Token, provider: IServiceProvider): IModule;
+  provider(key: Ng1Token, provider: IServiceProviderFactory): IModule;
+  provider(key: Ng1Token, provider: (Ng1Token|IServiceProviderFactory)[]): IModule;
   run(a: IInjectable): IModule;
 }
 export interface ICompileService {

--- a/packages/upgrade/test/static/integration/downgrade_module_spec.ts
+++ b/packages/upgrade/test/static/integration/downgrade_module_spec.ts
@@ -25,7 +25,7 @@ withEachNg1Version(() => {
 
       beforeEach(() => destroyPlatform());
 
-      it('should throw if called for more than one Angular modules', async(() => {
+      it('should throw if called for more than one Angular module', async(() => {
            @Component({selector: 'ng2A', template: 'a'})
            class Ng2ComponentA {
            }


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] Bugfix
```

## What is the current behavior?
Calling `downgradeModule()` more than once is not supported (and will not work correctly), but it fails silently. An error will only be thrown if a downgraded component from any but the last downgraded module needs to be instantiated. Even then, the error message is unclear and not actionable.

Issue Number: #26062


## What is the new behavior?
Calling `downgradeModule()` more than once will throw a clear, actionable error message as soon as the AngularJS app is bootstrapped.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
Fixes #26062.
This is an alternative to #26217.