### PR TITLE
fix(core): values provided in root no longer available in test bed

### DIFF
--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -6,12 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Inject, InjectionToken, NgModule, Optional} from '@angular/core';
+import {Component, Inject, Injectable, InjectionToken, NgModule, Optional} from '@angular/core';
 import {TestBed, getTestBed} from '@angular/core/testing/src/test_bed';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 const NAME = new InjectionToken<string>('name');
+
+@Injectable({providedIn: 'root'})
+export class TestService {
+  test = 1;
+}
 
 // -- module: HWModule
 @Component({
@@ -146,4 +151,13 @@ describe('TestBed', () => {
     hello.detectChanges();
     expect(hello.nativeElement).toHaveText('Hello injected World !');
   });
+
+  it('should not provide test service and fallback to not found value', () => {
+    const notFound = {test: 2};
+    const hello = TestBed.createComponent(HelloWorld);
+    expect(hello.componentRef.injector.get(TestService, notFound)).toBe(notFound);
+  });
+
+  it('should throw when getting the test service',
+     () => { expect(() => { TestBed.get(TestService); }).toThrow(); });
 });

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -13,6 +13,7 @@ import {MetadataOverride} from './metadata_override';
 import {ComponentResolver, DirectiveResolver, NgModuleResolver, PipeResolver, Resolver} from './resolvers';
 import {TestBed} from './test_bed';
 import {ComponentFixtureAutoDetect, TestBedStatic, TestComponentRenderer, TestModuleMetadata} from './test_bed_common';
+import {TestInjector} from './test_injector';
 
 let _nextRootElementId = 0;
 
@@ -378,8 +379,8 @@ export class TestBedRender3 implements Injector, TestBed {
     compileNgModule(testModuleType, resolvers);
 
     const parentInjector = this.platform.injector;
-    this._moduleRef = new NgModuleRef(testModuleType, parentInjector);
-
+    this._moduleRef = new NgModuleRef(testModuleType, new TestInjector(parentInjector));
+    TestInjector.patchModuleRef(this._moduleRef);
     this._instantiated = true;
   }
 

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -14,6 +14,7 @@ import {MetadataOverride} from './metadata_override';
 import {TestBedRender3, _getTestBedRender3} from './r3_test_bed';
 import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, TestBedStatic, TestComponentRenderer, TestModuleMetadata} from './test_bed_common';
 import {TestingCompiler, TestingCompilerFactory} from './test_compiler';
+import {TestInjector} from './test_injector';
 
 const UNDEFINED = new Object();
 
@@ -417,10 +418,11 @@ export class TestBedViewEngine implements Injector, TestBed {
     const providers: StaticProvider[] = [{provide: NgZone, useValue: ngZone}];
     const ngZoneInjector = Injector.create({
       providers: providers,
-      parent: this.platform.injector,
+      parent: new TestInjector(this.platform.injector),
       name: this._moduleFactory.moduleType.name
     });
     this._moduleRef = this._moduleFactory.create(ngZoneInjector);
+    TestInjector.patchModuleRef(this._moduleRef);
     // ApplicationInitStatus.runInitializers() is marked @internal to core. So casting to any
     // before accessing it.
     (this._moduleRef.injector.get(ApplicationInitStatus) as any).runInitializers();

--- a/packages/core/testing/src/test_injector.ts
+++ b/packages/core/testing/src/test_injector.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injector, NgModuleRef, ɵgetInjectableDef as getInjectableDef} from '@angular/core';
+
+/**
+ *
+ */
+export class TestInjector implements Injector {
+  constructor(private parent: Injector) {}
+
+  get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND, _flags?: any) {
+    return getImpl(
+        token, notFoundValue, () => { return this.parent.get(token, notFoundValue, _flags); });
+  }
+
+  static patchModuleRef(moduleRef: NgModuleRef<any>) {
+    const module = moduleRef as any as TestInjector;
+    const originalGet = module.get;
+    // overwrite get method on `NgModuleRef_` defined in refs.ts
+    // and make sure that values provided in root will not be resolved
+    module.get = function(token: any, notFoundValue: any) {
+      const args = arguments;
+      return getImpl(token, notFoundValue, () => { return originalGet.apply(moduleRef, args); });
+    };
+  }
+}
+
+function getImpl(token: any, notFoundValue: any, callback: () => any) {
+  const injectableDef = getInjectableDef(token);
+  if (injectableDef && injectableDef.providedIn === 'root') {
+    if (notFoundValue !== Injector.THROW_IF_NOT_FOUND) {
+      return notFoundValue;
+    }
+    throw new Error(`${token} is not provided in test bed`);
+  }
+  return callback();
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #25593

```
@Injectable({providedIn: 'root'})
export class TestService {}
```
All values using new tree-shakable API are also available in test bed. 

## What is the new behavior?

Such values are no longer available in test bed and throws an error.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
[x] Maybe
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Some tests may break, but I'd argue that these would show actual errors / incomplete mocks

## Other information
