### PR TITLE
docs: make the styles section less ambiguous

### DIFF
--- a/aio/content/tutorial/toh-pt0.md
+++ b/aio/content/tutorial/toh-pt0.md
@@ -116,7 +116,7 @@ Most apps strive for a consistent look across the application.
 The CLI generated an empty `styles.css` for this purpose.
 Put your application-wide styles there.
 
-Here's an excerpt from the `styles.css` for the _Tour of Heroes_ sample app.
+Open `src/styles.css` and add the code below to the file.
 
 <code-example path="toh-pt0/src/styles.1.css" header="src/styles.css (excerpt)">
 </code-example>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

The title of the section is "Add application styles" yet the content of the section doesn't tell you to explicitly add the styles to the file. 

Issue Number: N/A


## What is the new behavior?

The section now tells you to copy-paste the content into the file. Also, it tells you the location of the file. At this point in the tutorial, the current working directory is `src/app`. We need to reorient the user so that they know to look for `styles.css` one directory down, i.e. `src/styles.css`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

