### PR TITLE
docs: add missing semicolon to getHeroes-1 in tutorial pt 6

### DIFF
--- a/aio/content/examples/toh-pt6/src/app/hero.service.ts
+++ b/aio/content/examples/toh-pt6/src/app/hero.service.ts
@@ -36,7 +36,7 @@ export class HeroService {
   /** GET heroes from the server */
   // #docregion getHeroes-2
   getHeroes (): Observable<Hero[]> {
-    return this.http.get<Hero[]>(this.heroesUrl)
+    return this.http.get<Hero[]>(this.heroesUrl);
   // #enddocregion getHeroes-1
       .pipe(
         // #enddocregion getHeroes-2


### PR DESCRIPTION
The return statement in the example is missing a semicolon.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features) => N/A
- [X] Docs have been added / updated (for bug fixes / features) => N/A


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
A semicolon is missing for the return statement in example getHeroes-1

Issue Number: N/A


## What is the new behavior?
The semicolon has been added

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
First pull request - tried to follow your rules, hope I did it correct!