### PR TITLE
fix(ivy): update templateRefExtractor on compiler side

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_template_spec.ts
@@ -393,7 +393,8 @@ describe('compiler compliance: template', () => {
 
       template: function MyComponent_Template(rf, ctx) {
         if (rf & 1) {
-          $i0$.ɵtemplate(0, Template_0, 1, 0, null, null, $t0_refs$, $i0$.ɵtemplateRefExtractor);
+          $i0$.ɵtemplate(0, Template_0, 1, 0, null, null, $t0_refs$, 
+          $i0$.ɵtemplateRefExtractor($i0$.TemplateRef, $i0$.ElementRef));
         }
       }`;
 

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -13,6 +13,7 @@ import * as core from '../../core';
 import {AST, AstMemoryEfficientTransformer, BindingPipe, BindingType, FunctionCall, ImplicitReceiver, Interpolation, LiteralArray, LiteralMap, LiteralPrimitive, PropertyRead} from '../../expression_parser/ast';
 import {Lexer} from '../../expression_parser/lexer';
 import {Parser} from '../../expression_parser/parser';
+import {Identifiers as ViewEngine} from '../../identifiers';
 import * as html from '../../ml_parser/ast';
 import {HtmlParser} from '../../ml_parser/html_parser';
 import {WhitespaceVisitor} from '../../ml_parser/html_whitespaces';
@@ -694,7 +695,10 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     // local refs (ex.: <ng-template #foo>)
     if (template.references && template.references.length) {
       parameters.push(this.prepareRefsParameter(template.references));
-      parameters.push(o.importExpr(R3.templateRefExtractor));
+      const templateRefExtractorExpr = o.importExpr(R3.templateRefExtractor).callFn([
+        o.importExpr(ViewEngine.TemplateRef), o.importExpr(ViewEngine.ElementRef)
+      ]);
+      parameters.push(templateRefExtractorExpr);
     }
 
     // handle property bindings e.g. p(1, 'forOf', ɵbind(ctx.items));

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -10,7 +10,8 @@ import {defineInjectable, defineInjector,} from '../../di/defs';
 import {inject} from '../../di/injector';
 import * as r3 from '../index';
 import * as sanitization from '../../sanitization/sanitization';
-
+import {ElementRef} from '../../linker/element_ref';
+import {TemplateRef} from '../../linker/template_ref';
 
 /**
  * A mapping of the @angular/core API surface used in generated expressions to the actual symbols.
@@ -103,5 +104,8 @@ export const angularCoreEnv: {[name: string]: Function} = {
   'ɵdefaultStyleSanitizer': sanitization.defaultStyleSanitizer,
   'ɵsanitizeResourceUrl': sanitization.sanitizeResourceUrl,
   'ɵsanitizeScript': sanitization.sanitizeScript,
-  'ɵsanitizeUrl': sanitization.sanitizeUrl
+  'ɵsanitizeUrl': sanitization.sanitizeUrl,
+
+  'ElementRef': ElementRef,
+  'TemplateRef': TemplateRef
 };


### PR DESCRIPTION
This PR updates the compiler to generate `templateRefExtractor` with its new args.
