### PR TITLE
fix(ivy): take components into account when discovering directives

### DIFF
--- a/packages/core/src/render3/discovery_utils.ts
+++ b/packages/core/src/render3/discovery_utils.ts
@@ -95,10 +95,11 @@ export function getInjector(target: {}): Injector|null {
 }
 
 /**
- * Returns a list of all the directives that are associated
- * with the underlying target element.
+ * Returns a list of all the directives that are associated with the underlying target element.
+ * Accepts an optional argument to indicate if component instances should be returned as well (false
+ * by default).
  */
-export function getDirectives(target: {}): Array<{}> {
+export function getDirectives(target: {}, includeComponents?: boolean): Array<{}> {
   const context = loadContext(target) !;
 
   if (context.directives === undefined) {
@@ -108,7 +109,14 @@ export function getDirectives(target: {}): Array<{}> {
         null;
   }
 
-  return context.directives || [];
+  const result = context.directives || [];
+
+  // discard first directive if it is a component and we should not include components
+  if (!includeComponents && result.length && isComponentInstance(result[0])) {
+    return result.slice(1);
+  }
+
+  return result;
 }
 
 function loadContext(target: {}): LContext {

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -660,10 +660,10 @@
     "name": "getRendererFactory"
   },
   {
-    "name": "getRootContext$1"
+    "name": "getRootContext"
   },
   {
-    "name": "getRootView$1"
+    "name": "getRootView"
   },
   {
     "name": "getStyleSanitizer"
@@ -724,6 +724,9 @@
   },
   {
     "name": "isClassBased"
+  },
+  {
+    "name": "isComponent"
   },
   {
     "name": "isComponentInstance"

--- a/packages/core/test/render3/discovery_utils_spec.ts
+++ b/packages/core/test/render3/discovery_utils_spec.ts
@@ -169,6 +169,48 @@ describe('discovery utils', () => {
       const elm2Dirs = getDirectives(elm2);
       expect(elm2Dirs).toContain(myDir3Instance !);
     });
+
+    it('should return a component as part of a directives list when asked for it', () => {
+      class MyDir {
+        static ngDirectiveDef = defineDirective(
+            {type: MyDir, selectors: [['', 'my-dir', '']], factory: () => new MyDir()});
+      }
+
+      class MyCmpt {
+        static ngComponentDef = defineComponent({
+          type: MyCmpt,
+          selectors: [['my-cmpt']],
+          factory: () => new MyCmpt(),
+          consts: 0,
+          vars: 0,
+          template: (rf: RenderFlags, ctx: MyCmpt) => {}
+        });
+      }
+
+      class TestComp {
+        static ngComponentDef = defineComponent({
+          type: TestComp,
+          selectors: [['comp']],
+          factory: () => new TestComp(),
+          consts: 1,
+          vars: 0,
+          template: (rf: RenderFlags, ctx: TestComp) => {
+            if (rf & RenderFlags.Create) {
+              element(0, 'my-cmpt', ['my-dir']);
+            }
+          },
+          directives: [MyCmpt, MyDir]
+        });
+      }
+
+      const fixture = new ComponentFixture(TestComp);
+      fixture.update();
+
+      const myCmptEl = fixture.hostElement.querySelector('my-cmpt');
+
+      expect(getDirectives(myCmptEl !, false).length).toBe(1);
+      expect(getDirectives(myCmptEl !, true).length).toBe(2);
+    });
   });
 
   describe('getHostComponent()', () => {

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -2219,22 +2219,22 @@ describe('render3 integration test', () => {
          assertMonkeyPatchValueIsLViewData(childComponentInstance);
 
          expect(getContext(myDir1Instance)).toBe(childNodeContext);
-         expect(childNodeContext.component).toBeFalsy();
-         expect(childNodeContext.directives !.length).toEqual(2);
+         expect(childNodeContext.component).toBeTruthy();
+         expect(childNodeContext.directives !.length).toEqual(3);
          assertMonkeyPatchValueIsLViewData(myDir1Instance, false);
          assertMonkeyPatchValueIsLViewData(myDir2Instance, false);
-         assertMonkeyPatchValueIsLViewData(childComponentInstance);
+         assertMonkeyPatchValueIsLViewData(childComponentInstance, false);
 
          expect(getContext(myDir2Instance)).toBe(childNodeContext);
-         expect(childNodeContext.component).toBeFalsy();
-         expect(childNodeContext.directives !.length).toEqual(2);
+         expect(childNodeContext.component).toBeTruthy();
+         expect(childNodeContext.directives !.length).toEqual(3);
          assertMonkeyPatchValueIsLViewData(myDir1Instance, false);
          assertMonkeyPatchValueIsLViewData(myDir2Instance, false);
-         assertMonkeyPatchValueIsLViewData(childComponentInstance);
+         assertMonkeyPatchValueIsLViewData(childComponentInstance, false);
 
          expect(getContext(childComponentInstance)).toBe(childNodeContext);
          expect(childNodeContext.component).toBeTruthy();
-         expect(childNodeContext.directives !.length).toEqual(2);
+         expect(childNodeContext.directives !.length).toEqual(3);
          assertMonkeyPatchValueIsLViewData(myDir1Instance, false);
          assertMonkeyPatchValueIsLViewData(myDir2Instance, false);
          assertMonkeyPatchValueIsLViewData(childComponentInstance, false);


### PR DESCRIPTION
This PR fixes an issue where the includeComponents argument to the
discoverDirectiveIndices was not taken into account.

Additionally it returns components as part of directives list when
calling getDirectives (please not that we can't parametrize this
function with includeComponents as results are cached).
