### PR TITLE
build: introduce a package.bzl

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,88 +1,19 @@
 workspace(name = "angular")
 
-#
-# Download Bazel toolchain dependencies as needed by build actions
-#
-http_archive(
-    name = "build_bazel_rules_typescript",
-    sha256 = "1626ee2cc9770af6950bfc77dffa027f9aedf330fe2ea2ee7e504428927bd95d",
-    strip_prefix = "rules_typescript-0.17.0",
-    url = "https://github.com/bazelbuild/rules_typescript/archive/0.17.0.zip",
+load(
+    "//packages/bazel:package.bzl", 
+    "rules_angular_dependencies",
+    "rules_angular_dev_dependencies",
 )
 
-load("@build_bazel_rules_typescript//:package.bzl", "rules_typescript_dependencies")
-
-rules_typescript_dependencies()
-
-http_archive(
-    name = "bazel_toolchains",
-    sha256 = "c3b08805602cd1d2b67ebe96407c1e8c6ed3d4ce55236ae2efe2f1948f38168d",
-    strip_prefix = "bazel-toolchains-5124557861ebf4c0b67f98180bff1f8551e0b421",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/5124557861ebf4c0b67f98180bff1f8551e0b421.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/archive/5124557861ebf4c0b67f98180bff1f8551e0b421.tar.gz",
-    ],
-)
-
-http_archive(
-    name = "io_bazel_rules_sass",
-    sha256 = "dbe9fb97d5a7833b2a733eebc78c9c1e3880f676ac8af16e58ccf2139cbcad03",
-    strip_prefix = "rules_sass-1.11.0",
-    url = "https://github.com/bazelbuild/rules_sass/archive/1.11.0.zip",
-)
-
-# This commit matches the version of buildifier in angular/ngcontainer
-# If you change this, also check if it matches the version in the angular/ngcontainer
-# version in /.circleci/config.yml
-BAZEL_BUILDTOOLS_VERSION = "49a6c199e3fbf5d94534b2771868677d3f9c6de9"
-
-http_archive(
-    name = "com_github_bazelbuild_buildtools",
-    sha256 = "edf39af5fc257521e4af4c40829fffe8fba6d0ebff9f4dd69a6f8f1223ae047b",
-    strip_prefix = "buildtools-%s" % BAZEL_BUILDTOOLS_VERSION,
-    url = "https://github.com/bazelbuild/buildtools/archive/%s.zip" % BAZEL_BUILDTOOLS_VERSION,
-)
-
-# Fetching the Bazel source code allows us to compile the Skylark linter
-http_archive(
-    name = "io_bazel",
-    sha256 = "ace8cced3b21e64a8fdad68508e9b0644201ec848ad583651719841d567fc66d",
-    strip_prefix = "bazel-0.17.1",
-    url = "https://github.com/bazelbuild/bazel/archive/0.17.1.zip",
-)
-
-http_archive(
-    name = "io_bazel_skydoc",
-    sha256 = "7bfb5545f59792a2745f2523b9eef363f9c3e7274791c030885e7069f8116016",
-    strip_prefix = "skydoc-fe2e9f888d28e567fef62ec9d4a93c425526d701",
-    # TODO: switch to upstream when https://github.com/bazelbuild/skydoc/pull/103 is merged
-    url = "https://github.com/alexeagle/skydoc/archive/fe2e9f888d28e567fef62ec9d4a93c425526d701.zip",
-)
-
-# We have a source dependency on the Devkit repository, because it's built with
-# Bazel.
-# This allows us to edit sources and have the effect appear immediately without
-# re-packaging or "npm link"ing.
-# Even better, things like aspects will visit the entire graph including
-# ts_library rules in the devkit repository.
-http_archive(
-    name = "angular_cli",
-    sha256 = "8cf320ea58c321e103f39087376feea502f20eaf79c61a4fdb05c7286c8684fd",
-    strip_prefix = "angular-cli-6.1.0-rc.0",
-    url = "https://github.com/angular/angular-cli/archive/v6.1.0-rc.0.zip",
-)
-
-http_archive(
-    name = "org_brotli",
-    sha256 = "774b893a0700b0692a76e2e5b7e7610dbbe330ffbe3fe864b4b52ca718061d5a",
-    strip_prefix = "brotli-1.0.5",
-    url = "https://github.com/google/brotli/archive/v1.0.5.zip",
-)
+# Angular Bazel users will call this function
+rules_angular_dependencies()
+# These are the dependencies only for us
+rules_angular_dev_dependencies()
 
 #
 # Point Bazel to WORKSPACEs that live in subdirectories
 #
-
 local_repository(
     name = "rxjs",
     path = "node_modules/rxjs/src",
@@ -93,6 +24,17 @@ local_repository(
 local_repository(
     name = "bazel_integration_test",
     path = "integration/bazel",
+)
+
+# Prevent Bazel from trying to build rxjs under angular devkit
+# TODO(alexeagle): remove after Bazel 0.18 upgrade
+local_repository(
+    name = "rxjs_ignore_nested_1",
+    path = "node_modules/@angular-devkit/core/node_modules/rxjs/src",
+)
+local_repository(
+    name = "rxjs_ignore_nested_2",
+    path = "node_modules/@angular-devkit/schematics/node_modules/rxjs/src",
 )
 
 #
@@ -147,14 +89,3 @@ sass_repositories()
 load("@io_bazel_skydoc//skylark:skylark.bzl", "skydoc_repositories")
 
 skydoc_repositories()
-
-##################################
-# Prevent Bazel from trying to build rxjs under angular devkit
-local_repository(
-    name = "rxjs_ignore_nested_1",
-    path = "node_modules/@angular-devkit/core/node_modules/rxjs/src",
-)
-local_repository(
-    name = "rxjs_ignore_nested_2",
-    path = "node_modules/@angular-devkit/schematics/node_modules/rxjs/src",
-)

--- a/packages/bazel/BUILD.bazel
+++ b/packages/bazel/BUILD.bazel
@@ -8,9 +8,8 @@ genrule(
 
 npm_package(
     name = "npm_package",
-    srcs = [
+    srcs = glob(["*.bzl"]) + [
         "BUILD.bazel",
-        "index.bzl",
         "package.json",
         "//packages/bazel/src:package_assets",
     ],

--- a/packages/bazel/package.bzl
+++ b/packages/bazel/package.bzl
@@ -1,0 +1,116 @@
+# Copyright Google Inc. All Rights Reserved.
+#
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file at https://angular.io/license
+
+"""Package file which defines dependencies of Angular rules in skylark
+"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load(":rules_nodejs_package.bzl", "rules_nodejs_dependencies")
+load(":rules_typescript_package.bzl", "rules_typescript_dependencies")
+
+def rules_angular_dependencies():
+    """
+    Fetch our transitive dependencies.
+
+    If the user wants to get a different version of these, they can just fetch it
+    from their WORKSPACE before calling this function, or not call this function at all.
+    """
+
+    #
+    # Download Bazel toolchain dependencies as needed by build actions
+    #
+    _maybe(
+        http_archive,
+        name = "build_bazel_rules_typescript",
+        strip_prefix = "rules_typescript-0.17.0",
+        url = "https://github.com/bazelbuild/rules_typescript/archive/0.17.0.zip",
+    )
+
+    # Needed for Remote Execution
+    _maybe(
+        http_archive,
+        name = "bazel_toolchains",
+        sha256 = "c3b08805602cd1d2b67ebe96407c1e8c6ed3d4ce55236ae2efe2f1948f38168d",
+        strip_prefix = "bazel-toolchains-5124557861ebf4c0b67f98180bff1f8551e0b421",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/5124557861ebf4c0b67f98180bff1f8551e0b421.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/archive/5124557861ebf4c0b67f98180bff1f8551e0b421.tar.gz",
+        ],
+    )
+
+    # Angular apps don't necessarily depend on Sass, but it's common enough
+    _maybe(
+        http_archive,
+        name = "io_bazel_rules_sass",
+        sha256 = "dbe9fb97d5a7833b2a733eebc78c9c1e3880f676ac8af16e58ccf2139cbcad03",
+        strip_prefix = "rules_sass-1.11.0",
+        url = "https://github.com/bazelbuild/rules_sass/archive/1.11.0.zip",
+    )
+
+    rules_typescript_dependencies()
+    rules_nodejs_dependencies()
+
+def rules_angular_dev_dependencies():
+    """
+    Fetch dependencies needed for local development, but not needed by users.
+
+    These are in this file to keep version information in one place, and make the WORKSPACE
+    shorter.
+    """
+
+    # We have a source dependency on the Devkit repository, because it's built with
+    # Bazel.
+    # This allows us to edit sources and have the effect appear immediately without
+    # re-packaging or "npm link"ing.
+    # Even better, things like aspects will visit the entire graph including
+    # ts_library rules in the devkit repository.
+    http_archive(
+        name = "angular_cli",
+        sha256 = "8cf320ea58c321e103f39087376feea502f20eaf79c61a4fdb05c7286c8684fd",
+        strip_prefix = "angular-cli-6.1.0-rc.0",
+        url = "https://github.com/angular/angular-cli/archive/v6.1.0-rc.0.zip",
+    )
+
+    http_archive(
+        name = "org_brotli",
+        sha256 = "774b893a0700b0692a76e2e5b7e7610dbbe330ffbe3fe864b4b52ca718061d5a",
+        strip_prefix = "brotli-1.0.5",
+        url = "https://github.com/google/brotli/archive/v1.0.5.zip",
+    )
+
+    # Fetching the Bazel source code allows us to compile the Skylark linter
+    http_archive(
+        name = "io_bazel",
+        sha256 = "ace8cced3b21e64a8fdad68508e9b0644201ec848ad583651719841d567fc66d",
+        strip_prefix = "bazel-0.17.1",
+        url = "https://github.com/bazelbuild/bazel/archive/0.17.1.zip",
+    )
+
+    # This commit matches the version of buildifier in angular/ngcontainer
+    # If you change this, also check if it matches the version in the angular/ngcontainer
+    # version in /.circleci/config.yml
+    BAZEL_BUILDTOOLS_VERSION = "49a6c199e3fbf5d94534b2771868677d3f9c6de9"
+
+    http_archive(
+        name = "com_github_bazelbuild_buildtools",
+        sha256 = "edf39af5fc257521e4af4c40829fffe8fba6d0ebff9f4dd69a6f8f1223ae047b",
+        strip_prefix = "buildtools-%s" % BAZEL_BUILDTOOLS_VERSION,
+        url = "https://github.com/bazelbuild/buildtools/archive/%s.zip" % BAZEL_BUILDTOOLS_VERSION,
+    )
+
+    #############################################
+    # Dependencies for generating documentation #
+    #############################################
+    http_archive(
+        name = "io_bazel_skydoc",
+        sha256 = "7bfb5545f59792a2745f2523b9eef363f9c3e7274791c030885e7069f8116016",
+        strip_prefix = "skydoc-fe2e9f888d28e567fef62ec9d4a93c425526d701",
+        # TODO: switch to upstream when https://github.com/bazelbuild/skydoc/pull/103 is merged
+        url = "https://github.com/alexeagle/skydoc/archive/fe2e9f888d28e567fef62ec9d4a93c425526d701.zip",
+    )
+
+def _maybe(repo_rule, name, **kwargs):
+    if name not in native.existing_rules():
+        repo_rule(name = name, **kwargs)

--- a/packages/bazel/rules_nodejs_package.bzl
+++ b/packages/bazel/rules_nodejs_package.bzl
@@ -1,0 +1,56 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dependency-related rules defining our version and dependency versions.
+
+Fulfills similar role as the package.json file.
+"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# This file mirrored from https://raw.githubusercontent.com/bazelbuild/rules_nodejs/0.13.4/package.bzl
+VERSION = "0.13.4"
+
+def rules_nodejs_dependencies():
+    """
+    Fetch our transitive dependencies.
+
+    If the user wants to get a different version of these, they can just fetch it
+    from their WORKSPACE before calling this function, or not call this function at all.
+    """
+    _maybe(
+        http_archive,
+        name = "bazel_skylib",
+        url = "https://github.com/bazelbuild/bazel-skylib/archive/0.3.1.zip",
+        strip_prefix = "bazel-skylib-0.3.1",
+        sha256 = "95518adafc9a2b656667bbf517a952e54ce7f350779d0dd95133db4eb5c27fb1",
+    )
+
+    # Needed for Remote Build Execution
+    # See https://releases.bazel.build/bazel-toolchains.html
+    # Not strictly a dependency for all users, but it is convenient for them to have this repository
+    # defined to reduce the effort required to on-board to remote execution.
+    http_archive(
+        name = "bazel_toolchains",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/cdea5b8675914d0a354d89f108de5d28e54e0edc.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/archive/cdea5b8675914d0a354d89f108de5d28e54e0edc.tar.gz",
+        ],
+        strip_prefix = "bazel-toolchains-cdea5b8675914d0a354d89f108de5d28e54e0edc",
+        sha256 = "cefb6ccf86ca592baaa029bcef04148593c0efe8f734542f10293ea58f170715",
+    )
+
+def _maybe(repo_rule, name, **kwargs):
+    if name not in native.existing_rules():
+        repo_rule(name = name, **kwargs)

--- a/packages/bazel/rules_typescript_package.bzl
+++ b/packages/bazel/rules_typescript_package.bzl
@@ -1,0 +1,71 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Package file which defines build_bazel_rules_typescript version in skylark
+
+check_rules_typescript_version can be used in downstream WORKSPACES to check
+against a minimum dependent build_bazel_rules_typescript version.
+"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# This file mirrored from https://raw.githubusercontent.com/bazelbuild/rules_typescript/0.17.0/package.bzl
+VERSION = "0.17.0"
+
+def rules_typescript_dependencies():
+    """
+    Fetch our transitive dependencies.
+
+    If the user wants to get a different version of these, they can just fetch it
+    from their WORKSPACE before calling this function, or not call this function at all.
+    """
+
+    # TypeScript compiler runs on node.js runtime
+    _maybe(
+        http_archive,
+        name = "build_bazel_rules_nodejs",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/archive/0.13.4.zip"],
+        strip_prefix = "rules_nodejs-0.13.4",
+        sha256 = "a612bfd80b980bf7aa1ef9b24ef3c86a7e82bcd3f8aa92c5ef492472657cc7c8",
+    )
+
+    # ts_web_test depends on the web testing rules to provision browsers.
+    _maybe(
+        http_archive,
+        name = "io_bazel_rules_webtesting",
+        urls = ["https://github.com/bazelbuild/rules_webtesting/archive/0.2.1.zip"],
+        strip_prefix = "rules_webtesting-0.2.1",
+        sha256 = "7d490aadff9b5262e5251fa69427ab2ffd1548422467cb9f9e1d110e2c36f0fa",
+    )
+
+    # ts_devserver depends on the Go rules.
+    # See https://github.com/bazelbuild/rules_go#setup for the latest version.
+    _maybe(
+        http_archive,
+        name = "io_bazel_rules_go",
+        urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.13.0/rules_go-0.13.0.tar.gz"],
+        sha256 = "ba79c532ac400cefd1859cbc8a9829346aa69e3b99482cd5a54432092cbc3933",
+    )
+
+    # go_repository is defined in bazel_gazelle
+    _maybe(
+        http_archive,
+        name = "bazel_gazelle",
+        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.13.0/bazel-gazelle-0.13.0.tar.gz"],
+        sha256 = "bc653d3e058964a5a26dcad02b6c72d7d63e6bb88d94704990b908a1445b8758",
+    )
+
+def _maybe(repo_rule, name, **kwargs):
+    if name not in native.existing_rules():
+        repo_rule(name = name, **kwargs)


### PR DESCRIPTION
This lets Angular Bazel users install our transitive deps, rather than have to list them in their WORKSPACE file.
If they want a different version of one of these deps, they just need to install it before calling rules_angular_dependencies.