### PR TITLE
build: fix bad merge to patch branch

### DIFF
--- a/packages/bazel/src/modify_tsconfig.js
+++ b/packages/bazel/src/modify_tsconfig.js
@@ -23,6 +23,9 @@ function main(args) {
   const data = JSON.parse(fs.readFileSync(input, {encoding: 'utf-8'}));
   data['compilerOptions']['target'] = 'es5';
   data['bazelOptions']['es5Mode'] = true;
+  // Enable tsickle for decorator downleveling only
+  data['bazelOptions']['tsickle'] = true;
+  data['bazelOptions']['tsickleExternsPath'] = '';
   data['compilerOptions']['outDir'] = path.join(data['compilerOptions']['outDir'], newRoot);
   if (data['angularCompilerOptions']) {
     // Don't enable tsickle's closure conversions

--- a/packages/bazel/src/modify_tsconfig.js
+++ b/packages/bazel/src/modify_tsconfig.js
@@ -23,9 +23,14 @@ function main(args) {
   const data = JSON.parse(fs.readFileSync(input, {encoding: 'utf-8'}));
   data['compilerOptions']['target'] = 'es5';
   data['bazelOptions']['es5Mode'] = true;
-  // Enable tsickle for decorator downleveling only
-  data['bazelOptions']['tsickle'] = true;
-  data['bazelOptions']['tsickleExternsPath'] = '';
+  // TODO(gregmagolan): remove this temporary fix for @rxjs on 6.1.x branch
+  //   once we can switch to an named UMD rxjs bundle and we are not building
+  //   rxjs from source with Bazel
+  if (!data['bazelOptions']['target'].startsWith('@rxjs//')) {
+    // Enable tsickle for decorator downleveling only
+    data['bazelOptions']['tsickle'] = true;
+    data['bazelOptions']['tsickleExternsPath'] = '';
+  }
   data['compilerOptions']['outDir'] = path.join(data['compilerOptions']['outDir'], newRoot);
   if (data['angularCompilerOptions']) {
     // Don't enable tsickle's closure conversions

--- a/packages/bazel/src/modify_tsconfig.js
+++ b/packages/bazel/src/modify_tsconfig.js
@@ -23,16 +23,12 @@ function main(args) {
   const data = JSON.parse(fs.readFileSync(input, {encoding: 'utf-8'}));
   data['compilerOptions']['target'] = 'es5';
   data['bazelOptions']['es5Mode'] = true;
-  // TODO(gregmagolan): remove this temporary fix for @rxjs on 6.1.x branch
-  //   once we can switch to an named UMD rxjs bundle and we are not building
-  //   rxjs from source with Bazel
-  if (!data['bazelOptions']['target'].startsWith('@rxjs//')) {
+  data['compilerOptions']['outDir'] = path.join(data['compilerOptions']['outDir'], newRoot);
+  if (data['angularCompilerOptions']) {
     // Enable tsickle for decorator downleveling only
     data['bazelOptions']['tsickle'] = true;
     data['bazelOptions']['tsickleExternsPath'] = '';
-  }
-  data['compilerOptions']['outDir'] = path.join(data['compilerOptions']['outDir'], newRoot);
-  if (data['angularCompilerOptions']) {
+
     // Don't enable tsickle's closure conversions
     data['angularCompilerOptions']['annotateForClosureCompiler'] = false;
     data['angularCompilerOptions']['expectedOut'] =

--- a/packages/bazel/test/ng_package/core_package.spec.ts
+++ b/packages/bazel/test/ng_package/core_package.spec.ts
@@ -126,8 +126,8 @@ describe('@angular/core ng_package', () => {
         expect(shx.cat('fesm5/core.js')).not.toContain('@fileoverview added by tsickle');
       });
 
-      it('should have decorators',
-         () => { expect(shx.cat('fesm5/core.js')).toContain('__decorate'); });
+      it('should have annotations rather than decorators',
+         () => { expect(shx.cat('fesm5/core.js')).not.toContain('__decorate'); });
 
       it('should load tslib from external bundle', () => {
         expect(shx.cat('fesm5/core.js')).not.toContain('function __extends');

--- a/packages/compiler-cli/src/diagnostics/typescript_version.ts
+++ b/packages/compiler-cli/src/diagnostics/typescript_version.ts
@@ -23,7 +23,7 @@ export function toNumbers(value: string): number[] {
  *
  * @param a The 'left hand' array in the comparison test
  * @param b The 'right hand' in the comparison test
- * @returns {-1|0|1} The comparison result: 1 if a is greater, -1 if b is greater, 0 is the two
+ * @returns The comparison result: 1 if a is greater, -1 if b is greater, 0 is the two
  * arrays are equals
  */
 export function compareNumbers(a: number[], b: number[]): -1|0|1 {
@@ -77,7 +77,7 @@ export function isVersionBetween(version: string, low: string, high?: string): b
  *
  * @param v1 The 'left hand' version in the comparison test
  * @param v2 The 'right hand' version in the comparison test
- * @returns {-1|0|1} The comparison result: 1 if v1 is greater, -1 if v2 is greater, 0 is the two
+ * @returns The comparison result: 1 if v1 is greater, -1 if v2 is greater, 0 is the two
  * versions are equals
  */
 export function compareVersions(v1: string, v2: string): -1|0|1 {

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -225,7 +225,7 @@
     "name": "AttrAst"
   },
   {
-    "name": "Attribute$2"
+    "name": "Attribute$1"
   },
   {
     "name": "B64_DIGITS"
@@ -646,6 +646,9 @@
   },
   {
     "name": "EmitterVisitorContext"
+  },
+  {
+    "name": "EmptyErrorImpl"
   },
   {
     "name": "EmptyExpr"
@@ -1096,6 +1099,9 @@
   },
   {
     "name": "ObjectUnsubscribedError"
+  },
+  {
+    "name": "ObjectUnsubscribedErrorImpl"
   },
   {
     "name": "Observable"
@@ -1578,6 +1584,9 @@
     "name": "UnsubscriptionError"
   },
   {
+    "name": "UnsubscriptionErrorImpl"
+  },
+  {
     "name": "UrlResolver"
   },
   {
@@ -1920,22 +1929,16 @@
     "name": "__extends$5"
   },
   {
-    "name": "__extends$6"
+    "name": "__extends$l"
   },
   {
-    "name": "__extends$7"
+    "name": "__extends$m"
   },
   {
-    "name": "__extends$q"
+    "name": "__extends$n"
   },
   {
-    "name": "__extends$r"
-  },
-  {
-    "name": "__extends$s"
-  },
-  {
-    "name": "__extends$u"
+    "name": "__extends$p"
   },
   {
     "name": "__read"
@@ -2338,6 +2341,9 @@
   },
   {
     "name": "camelCaseToDashCase"
+  },
+  {
+    "name": "canReportError"
   },
   {
     "name": "checkAndUpdateBinding"
@@ -3129,6 +3135,9 @@
     "name": "isIdentifierStart"
   },
   {
+    "name": "isInteropObservable"
+  },
+  {
     "name": "isIterable"
   },
   {
@@ -3162,9 +3171,6 @@
     "name": "isObject"
   },
   {
-    "name": "isObservable"
-  },
-  {
     "name": "isPrefixEnd"
   },
   {
@@ -3187,9 +3193,6 @@
   },
   {
     "name": "isStyleUrlResolvable"
-  },
-  {
-    "name": "isTrustedSubscriber"
   },
   {
     "name": "isType"

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -183,9 +183,6 @@
     "name": "APP_BOOTSTRAP_LISTENER"
   },
   {
-    "name": "APP_INITIALIZER"
-  },
-  {
     "name": "APP_ROOT"
   },
   {
@@ -228,7 +225,7 @@
     "name": "AttrAst"
   },
   {
-    "name": "Attribute$1"
+    "name": "Attribute$2"
   },
   {
     "name": "B64_DIGITS"
@@ -1905,9 +1902,6 @@
     "name": "__assign"
   },
   {
-    "name": "__decorate"
-  },
-  {
     "name": "__extends"
   },
   {
@@ -1942,12 +1936,6 @@
   },
   {
     "name": "__extends$u"
-  },
-  {
-    "name": "__metadata"
-  },
-  {
-    "name": "__param"
   },
   {
     "name": "__read"

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -15,6 +15,9 @@
     "name": "INJECTOR"
   },
   {
+    "name": "INJECTOR$2"
+  },
+  {
     "name": "Inject"
   },
   {

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -9,13 +9,13 @@
     "name": "EMPTY_ARRAY$1"
   },
   {
+    "name": "EmptyErrorImpl"
+  },
+  {
     "name": "GET_PROPERTY_NAME"
   },
   {
     "name": "INJECTOR"
-  },
-  {
-    "name": "INJECTOR$2"
   },
   {
     "name": "Inject"
@@ -31,6 +31,9 @@
   },
   {
     "name": "NullInjector"
+  },
+  {
+    "name": "ObjectUnsubscribedErrorImpl"
   },
   {
     "name": "Optional"
@@ -55,6 +58,9 @@
   },
   {
     "name": "USE_VALUE"
+  },
+  {
+    "name": "UnsubscriptionErrorImpl"
   },
   {
     "name": "_THROW_IF_NOT_FOUND"


### PR DESCRIPTION
Fix bad merge in https://github.com/angular/angular/pull/25774.

Included temporary workaround to not turn on tsickle when building rxjs as this creates build failures:

```
RROR: /home/circleci/.cache/bazel/_bazel_circleci/9ce5c2144ecf75d11717c0aa41e45a8d/external/rxjs/BUILD.bazel:7:1: Compiling TypeScript (ES5 with ES Modules) @rxjs//:lib failed (Exit 1)
external/rxjs/internal/Subscription.ts:9:1 - warning TS0: @class annotations are redundant with TypeScript equivalents

  9 /**
    ~~~
 10  * Represents a disposable resource, such as the execution of an Observable. A
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
... 
 20  */
    ~~~
 21 export class Subscription implements SubscriptionLike {
...
```

Work-around to be removed once we can generate a named UMD rxjs bundle and no longer build rxjs from source with Bazel.