### PR TITLE
With _factories cost static, Components can be shared between modules.

### DIFF
--- a/packages/core/src/linker/component_factory_resolver.ts
+++ b/packages/core/src/linker/component_factory_resolver.ts
@@ -39,7 +39,15 @@ export abstract class ComponentFactoryResolver {
 }
 
 export class CodegenComponentFactoryResolver implements ComponentFactoryResolver {
-  private _factories = new Map<any, ComponentFactory<any>>();
+  /**
+   * With _factories cost static, Components can be shared between modules.
+   */
+  private static _factories = new Map<any, ComponentFactory<any>>();
+  private _self = CodegenComponentFactoryResolver;
+  private get _factories() {
+    return this._self._factories;
+  }
+    
 
   constructor(
       factories: ComponentFactory<any>[], private _parent: ComponentFactoryResolver,


### PR DESCRIPTION
With _factories cost static, Components can be shared between modules.

When I want to create components in different modules, Angular always throws exceptions. I think this method has great limitations. Since components can only be included in unique modules, there is no need for modules to be isolated from each other. Static variables enable components to be shared and can create components of other modules. I hope it can be passed. This is very important.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
new feature

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Feature
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
ComponentFactoryResolver.resolveComponentFactory: Only components of this module can be created.
Issue Number: 1


## What is the new behavior?
ComponentFactoryResolver.resolveComponentFactory: Can cearte other module's components.

## Does this PR introduce a breaking change?
```
[x] Yes
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
