### PR TITLE
refactor(core) Sharing components between modules.

### DIFF
--- a/packages/core/src/linker/component_factory_resolver.ts
+++ b/packages/core/src/linker/component_factory_resolver.ts
@@ -39,7 +39,13 @@ export abstract class ComponentFactoryResolver {
 }
 
 export class CodegenComponentFactoryResolver implements ComponentFactoryResolver {
-  private _factories = new Map<any, ComponentFactory<any>>();
+  /**
+   * Make _factories to be static, components can be shared between modules.
+   */
+  private static _factories = new Map<any, ComponentFactory<any>>();
+  private get _factories() {
+    return CodegenComponentFactoryResolver._factories;
+  }
 
   constructor(
       factories: ComponentFactory<any>[], private _parent: ComponentFactoryResolver,


### PR DESCRIPTION
When I want to create components in different modules, Angular always throws exceptions. I think this method has great limitations. Since components can only be included in unique modules, there is no need for modules to be isolated from each other. Static variables enable components to be shared and can create components of other modules. I hope it can be passed. This is very important.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [v] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[v] Feature
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Component of B module cannot be created in A module.
Issue Number: 1


## What is the new behavior?
Components can be shared in all modules.

## Does this PR introduce a breaking change?
```
[v] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
This small change allows us to implement previously impossible functions, such as when we want to create components of module A without importing module A. 

Specific scenarios: I want to use guards to control whether a new page should replace the current page, or pop up as a modal box using MatDialog. It is impossible to implement this function until it changes, and it will always report that it is not added to entryComponents. 

This change will solve a big problem. It is very important to cancel unnecessary isolation before the module.

## Other information
Please try and think about the benefits it brings!