### PR TITLE
refactor(ivy): replace LNode.nodeInjector with TNode.injectorIndex

### DIFF
--- a/packages/core/src/render3/debug.ts
+++ b/packages/core/src/render3/debug.ts
@@ -14,7 +14,6 @@ import {DebugRenderer2, DebugRendererFactory2} from '../view/services';
 import {getLElementNode} from './context_discovery';
 import * as di from './di';
 import {_getViewData} from './instructions';
-import {LElementNode} from './interfaces/node';
 import {CONTEXT, DIRECTIVES, LViewData, TVIEW} from './interfaces/view';
 
 /**
@@ -47,9 +46,8 @@ class Render3DebugContext implements DebugContext {
 
   get injector(): Injector {
     if (this.nodeIndex !== null) {
-      const lElementNode: LElementNode = this.view[this.nodeIndex];
-      const nodeInjector = lElementNode.nodeInjector;
-
+      const tNode = this.view[TVIEW].data[this.nodeIndex];
+      const nodeInjector = di.getInjector(tNode, this.view);
       if (nodeInjector) {
         return new di.NodeInjector(nodeInjector);
       }

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -9,10 +9,9 @@
 import {assertEqual, assertLessThan} from './assert';
 import {NO_CHANGE, _getViewData, adjustBlueprintForNewNode, bindingUpdated, bindingUpdated2, bindingUpdated3, bindingUpdated4, createNodeAtIndex, getRenderer, getTNode, load, loadElement, resetComponentState} from './instructions';
 import {RENDER_PARENT} from './interfaces/container';
-import {LContainerNode, LElementNode, LNode, TElementNode, TNode, TNodeType, TViewNode} from './interfaces/node';
-import {RElement} from './interfaces/renderer';
+import {LContainerNode, LNode, TElementNode, TNode, TNodeType} from './interfaces/node';
 import {BINDING_INDEX, HEADER_OFFSET, HOST_NODE, TVIEW} from './interfaces/view';
-import {appendChild, createTextNode, getContainerRenderParent, getParentLNode, getParentOrContainerNode, removeChild} from './node_manipulation';
+import {appendChild, createTextNode, removeChild} from './node_manipulation';
 import {stringify} from './util';
 
 /**

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -25,7 +25,7 @@ import {LQueries} from './interfaces/query';
 import {ProceduralRenderer3, RComment, RElement, RNode, RText, Renderer3, RendererFactory3, isProceduralRenderer} from './interfaces/renderer';
 import {BINDING_INDEX, CLEANUP, CONTAINER_INDEX, CONTENT_QUERIES, CONTEXT, CurrentMatchesList, DECLARATION_VIEW, DIRECTIVES, FLAGS, HEADER_OFFSET, HOST_NODE, INJECTOR, LViewData, LViewFlags, NEXT, OpaqueViewState, PARENT, QUERIES, RENDERER, RootContext, RootContextFlags, SANITIZER, TAIL, TVIEW, TView} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
-import {appendChild, appendProjectedNode, createTextNode, findComponentView, getContainerNode, getHostElementNode, getLViewChild, getParentOrContainerNode, getRenderParent, insertView, removeView} from './node_manipulation';
+import {appendChild, appendProjectedNode, createTextNode, findComponentView, getHostElementNode, getLViewChild, getRenderParent, insertView, removeView} from './node_manipulation';
 import {isNodeMatchingSelectorList, matchingSelectorIndex} from './node_selector_matcher';
 import {StylingContext, allocStylingContext, createStylingContextTemplate, renderStyling as renderElementStyles, updateClassProp as updateElementClassProp, updateStyleProp as updateElementStyleProp, updateStylingMap} from './styling';
 import {assertDataInRangeInternal, getLNode, isContentQueryHost, isDifferent, loadElementInternal, loadInternal, stringify} from './util';
@@ -333,6 +333,8 @@ export function leaveView(newView: LViewData, creationOnly?: boolean): void {
  * Note: view hooks are triggered later when leaving the view.
  */
 function refreshDescendantViews() {
+  setHostBindings(tView.hostBindings);
+
   // This needs to be set before children are processed to support recursive components
   tView.firstTemplatePass = firstTemplatePass = false;
 
@@ -348,7 +350,6 @@ function refreshDescendantViews() {
     executeHooks(directives !, tView.contentHooks, tView.contentCheckHooks, creationMode);
   }
 
-  setHostBindings(tView.hostBindings);
   refreshChildComponents(tView.components);
 }
 
@@ -361,6 +362,12 @@ export function setHostBindings(bindings: number[] | null): void {
     for (let i = 0; i < bindings.length; i += 2) {
       const dirIndex = bindings[i];
       const def = defs[dirIndex] as DirectiveDefInternal<any>;
+      if (firstTemplatePass) {
+        for (let i = 0; i < def.hostVars; i++) {
+          tView.blueprint.push(NO_CHANGE);
+          viewData.push(NO_CHANGE);
+        }
+      }
       def.hostBindings !(dirIndex, bindings[i + 1]);
       bindingRootIndex = viewData[BINDING_INDEX] = bindingRootIndex + def.hostVars;
     }
@@ -399,7 +406,7 @@ export function createLViewData<T>(
     renderer: Renderer3, tView: TView, context: T | null, flags: LViewFlags,
     sanitizer?: Sanitizer | null): LViewData {
   const instance = tView.blueprint.slice() as LViewData;
-  instance[PARENT] = viewData;
+  instance[PARENT] = instance[DECLARATION_VIEW] = viewData;
   instance[FLAGS] = flags | LViewFlags.CreationMode | LViewFlags.Attached | LViewFlags.RunInit;
   instance[CONTEXT] = context;
   instance[INJECTOR] = viewData ? viewData[INJECTOR] : null;
@@ -414,14 +421,9 @@ export function createLViewData<T>(
  * (same properties assigned in the same order).
  */
 export function createLNodeObject(
-    type: TNodeType, nodeInjector: LInjector | null, native: RText | RElement | RComment | null,
-    state: any): LElementNode&LTextNode&LViewNode&LContainerNode&LProjectionNode {
-  return {
-    native: native as any,
-    nodeInjector: nodeInjector,
-    data: state,
-    dynamicLContainerNode: null
-  };
+    type: TNodeType, native: RText | RElement | RComment | null, state: any): LElementNode&
+    LTextNode&LViewNode&LContainerNode&LProjectionNode {
+  return {native: native as any, data: state, dynamicLContainerNode: null};
 }
 
 /**
@@ -464,7 +466,7 @@ export function createNodeAtIndex(
   const tParent = parentInSameView ? parent as TElementNode | TContainerNode : null;
 
   const isState = state != null;
-  const node = createLNodeObject(type, null, native, isState ? state as any : null);
+  const node = createLNodeObject(type, native, isState ? state as any : null);
   let tNode: TNode;
 
   if (index === -1 || type === TNodeType.View) {
@@ -505,13 +507,6 @@ export function createNodeAtIndex(
         previousOrParentTNode.child = tNode;
       }
     }
-  }
-  // TODO: temporary, remove this when removing nodeInjector (bringing in fns to hello world)
-  if (index !== -1 && !(viewData[FLAGS] & LViewFlags.IsRoot)) {
-    const parentLNode: LNode|null = type === TNodeType.View ?
-        getContainerNode(tNode, state as LViewData) :
-        getParentOrContainerNode(tNode, viewData);
-    parentLNode && (node.nodeInjector = parentLNode.nodeInjector);
   }
 
   // View nodes and host elements need to set their host node (components do not save host TNodes)
@@ -607,7 +602,7 @@ export function renderTemplate<T>(
  */
 export function createEmbeddedViewAndNode<T>(
     tView: TView, context: T, declarationView: LViewData, renderer: Renderer3,
-    queries?: LQueries | null): LViewData {
+    queries: LQueries | null, injectorIndex: number): LViewData {
   const _isParent = isParent;
   const _previousOrParentTNode = previousOrParentTNode;
   isParent = true;
@@ -621,6 +616,10 @@ export function createEmbeddedViewAndNode<T>(
     lView[QUERIES] = queries.createView();
   }
   createNodeAtIndex(-1, TNodeType.View, null, null, null, lView);
+
+  if (tView.firstTemplatePass) {
+    tView.node !.injectorIndex = injectorIndex;
+  }
 
   isParent = _isParent;
   previousOrParentTNode = _previousOrParentTNode;
@@ -969,10 +968,6 @@ export function queueHostBindingForCheck(dirIndex: number, hostVars: number): vo
   // instructions that expect element indices that are NOT adjusted (e.g. elementProperty).
   ngDevMode &&
       assertEqual(firstTemplatePass, true, 'Should only be called in first template pass.');
-  for (let i = 0; i < hostVars; i++) {
-    tView.blueprint.push(NO_CHANGE);
-    viewData.push(NO_CHANGE);
-  }
   (tView.hostBindings || (tView.hostBindings = [
    ])).push(dirIndex, previousOrParentTNode.index - HEADER_OFFSET);
 }
@@ -1476,6 +1471,7 @@ export function createTNode(
   return {
     type: type,
     index: adjustedIndex,
+    injectorIndex: parent ? parent.injectorIndex : -1,
     flags: 0,
     tagName: tagName,
     attrs: attrs,

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -81,9 +81,6 @@ export interface LNode {
    */
   readonly data: LViewData|LContainer|null;
 
-  /** The injector associated with this node. Necessary for DI. */
-  nodeInjector: LInjector|null;
-
   /**
    * A pointer to an LContainerNode created by directives requesting ViewContainerRef
    */
@@ -195,6 +192,21 @@ export interface TNode {
    * If index is -1, this is a dynamically created container node or embedded view node.
    */
   index: number;
+
+  /**
+   * The index of the closest injector in this node's LViewData.
+   *
+   * If the index === -1, there is no injector on this node or any ancestor node in this view.
+   *
+   * If the index !== -1, it is the index of this node's injector OR the index of a parent injector
+   * in the same view. We pass the parent injector index down the node tree of a view so it's
+   * possible to find the parent injector without walking a potentially deep node tree. Injector
+   * indices are not set across view boundaries because there could be multiple component hosts.
+   *
+   * If tNode.injectorIndex === tNode.parent.injectorIndex, then the index belongs to a parent
+   * injector.
+   */
+  injectorIndex: number;
 
   /**
    * This number stores two values using its bits:

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -37,18 +37,6 @@ export function getHostElementNode(currentView: LViewData): LElementNode|null {
       null;
 }
 
-/**
- * Gets the parent LNode if it's not a view. If it's a view, it will instead return the view's
- * parent container node.
- */
-export function getParentOrContainerNode(tNode: TNode, currentView: LViewData): LElementNode|
-    LElementContainerNode|LContainerNode|null {
-  const parentTNode = tNode.parent || currentView[HOST_NODE];
-  return parentTNode && parentTNode.type === TNodeType.View ?
-      getContainerNode(parentTNode, currentView) :
-      getParentLNode(tNode, currentView);
-}
-
 export function getContainerNode(tNode: TNode, embeddedView: LViewData): LContainerNode|null {
   if (tNode.index === -1) {
     // This is a dynamically created view inside a dynamic container.

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -582,6 +582,9 @@
     "name": "getInjectableDef"
   },
   {
+    "name": "getInjector$1"
+  },
+  {
     "name": "getLElementFromComponent"
   },
   {
@@ -618,10 +621,10 @@
     "name": "getOrCreateTView"
   },
   {
-    "name": "getParentLNode"
+    "name": "getParentInjector"
   },
   {
-    "name": "getParentOrContainerNode"
+    "name": "getParentLNode"
   },
   {
     "name": "getParentState"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -21,6 +21,9 @@
     "name": "ChangeDetectionStrategy"
   },
   {
+    "name": "DECLARATION_VIEW"
+  },
+  {
     "name": "DIRECTIVES"
   },
   {
@@ -237,6 +240,9 @@
     "name": "getHostElementNode"
   },
   {
+    "name": "getInjector$1"
+  },
+  {
     "name": "getLNode"
   },
   {
@@ -252,16 +258,13 @@
     "name": "getOrCreateTView"
   },
   {
+    "name": "getParentInjector"
+  },
+  {
     "name": "getParentLNode"
   },
   {
-    "name": "getParentOrContainerNode"
-  },
-  {
     "name": "getPipeDef"
-  },
-  {
-    "name": "getPreviousOrParentNode"
   },
   {
     "name": "getPreviousOrParentTNode"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -624,6 +624,9 @@
     "name": "getInjectableDef"
   },
   {
+    "name": "getInjector$1"
+  },
+  {
     "name": "getLElementFromComponent"
   },
   {
@@ -654,10 +657,10 @@
     "name": "getOrCreateTView"
   },
   {
-    "name": "getParentLNode"
+    "name": "getParentInjector"
   },
   {
-    "name": "getParentOrContainerNode"
+    "name": "getParentLNode"
   },
   {
     "name": "getParentState"

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -1653,6 +1653,9 @@
     "name": "getInjectableDef"
   },
   {
+    "name": "getInjector$1"
+  },
+  {
     "name": "getInjectorDef"
   },
   {
@@ -1749,10 +1752,10 @@
     "name": "getOriginalError"
   },
   {
-    "name": "getParentLNode"
+    "name": "getParentInjector"
   },
   {
-    "name": "getParentOrContainerNode"
+    "name": "getParentLNode"
   },
   {
     "name": "getParentState"


### PR DESCRIPTION
This PR removes `LNode.nodeInjector`, as part of a larger effort to remove the `LNode` object entirely and reduce memory pressure.  Instead of saving the injector instance on the `LNode`, we store the instance in the next available slot in `LViewData` and save the injector index on the `TNode`.