### PR TITLE
fix(docs-infra): fix positioning of message for disabled JavaScript

### DIFF
--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -99,7 +99,7 @@
         <div class="hero-headline">One framework.<br>Mobile &amp; desktop.</div>
       </div>
     </section>
-    <h2 style="color: red; text-align: center; margin-top: -50px;">
+    <h2 style="color: red; text-align: center;">
       <b><i>This website requires JavaScript.</i></b>
     </h2>
   </noscript>

--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -91,7 +91,7 @@
 
   <noscript>
     <div class="background-sky hero"></div>
-    <section id="intro">
+    <section id="intro" style="text-shadow: 1px 1px #1976d2;">
       <div class="hero-logo">
         <img src="assets/images/logos/angular/angular.svg" width="250" height="250">
       </div>
@@ -99,7 +99,7 @@
         <div class="hero-headline">One framework.<br>Mobile &amp; desktop.</div>
       </div>
     </section>
-    <h2 style="color: red; text-align: center;">
+    <h2 style="color: red; margin-top: 40px; position: relative; text-align: center; text-shadow: 1px 1px #fafafa;">
       <b><i>This website requires JavaScript.</i></b>
     </h2>
   </noscript>


### PR DESCRIPTION
The old positioning didn't work well on certain screen sizes:

**Before**
![noscript-before](https://user-images.githubusercontent.com/8604205/46310886-474b0f80-c5c9-11e8-95d3-72844882f902.png)

**After**
![noscript-after](https://user-images.githubusercontent.com/8604205/46310891-4ade9680-c5c9-11e8-856e-5f5a01b7522c.png)
