### PR TITLE
feat(ivy): expose node injector as part of debug context

### DIFF
--- a/packages/core/src/render3/discovery_utils.ts
+++ b/packages/core/src/render3/discovery_utils.ts
@@ -9,9 +9,9 @@ import {Injector} from '../di/injector';
 
 import {assertDefined} from './assert';
 import {LContext, discoverDirectiveIndices, discoverDirectives, discoverLocalRefs, getContext, isComponentInstance, readPatchedLViewData} from './context_discovery';
-import {LElementNode, TNode, TNodeFlags} from './interfaces/node';
-import {CONTEXT, FLAGS, INJECTOR, LViewData, LViewFlags, PARENT, RootContext, TVIEW} from './interfaces/view';
-
+import {NodeInjector} from './di';
+import {LElementNode, TElementNode, TNode, TNodeFlags} from './interfaces/node';
+import {CONTEXT, FLAGS, LViewData, LViewFlags, PARENT, RootContext, TVIEW} from './interfaces/view';
 
 /**
  * NOTE: The following functions might not be ideal for core usage in Angular...
@@ -89,9 +89,11 @@ export function getRootComponents(target: {}): any[] {
  * Returns the injector instance that is associated with
  * the element, component or directive.
  */
-export function getInjector(target: {}): Injector|null {
-  const context = loadContext(target) !;
-  return context.lViewData[INJECTOR] || null;
+export function getInjector(target: {}): Injector {
+  const context = loadContext(target);
+  const tNode = context.lViewData[TVIEW].data[context.lNodeIndex] as TElementNode;
+
+  return new NodeInjector(tNode, context.lViewData);
 }
 
 /**

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -14,7 +14,6 @@ import {StyleSanitizeFn} from '../sanitization/style_sanitizer';
 
 import {assertDefined, assertEqual, assertLessThan, assertNotEqual} from './assert';
 import {attachPatchData, getLElementFromComponent, readElementValue, readPatchedLViewData} from './context_discovery';
-import {getRootView} from './discovery_utils';
 import {throwCyclicDependencyError, throwErrorIfNoChangesMode, throwMultipleComponentError} from './errors';
 import {executeHooks, executeInitHooks, queueInitHooks, queueLifecycleHooks} from './hooks';
 import {ACTIVE_INDEX, LContainer, RENDER_PARENT, VIEWS} from './interfaces/container';
@@ -29,7 +28,7 @@ import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
 import {appendChild, appendProjectedNode, createTextNode, findComponentView, getHostElementNode, getLViewChild, getRenderParent, insertView, removeView} from './node_manipulation';
 import {isNodeMatchingSelectorList, matchingSelectorIndex} from './node_selector_matcher';
 import {allocStylingContext, createStylingContextTemplate, renderStyling as renderElementStyles, updateClassProp as updateElementClassProp, updateStyleProp as updateElementStyleProp, updateStylingMap} from './styling/class_and_style_bindings';
-import {assertDataInRangeInternal, getLNode, isContentQueryHost, isDifferent, loadElementInternal, loadInternal, stringify} from './util';
+import {assertDataInRangeInternal, getLNode, getRootView, isContentQueryHost, isDifferent, loadElementInternal, loadInternal, stringify} from './util';
 
 
 /**

--- a/packages/core/src/render3/util.ts
+++ b/packages/core/src/render3/util.ts
@@ -11,7 +11,7 @@ import {devModeEqual} from '../change_detection/change_detection_util';
 import {assertDefined, assertLessThan} from './assert';
 import {readElementValue, readPatchedLViewData} from './context_discovery';
 import {LContainerNode, LElementContainerNode, LElementNode, TNode, TNodeFlags} from './interfaces/node';
-import {CONTEXT, FLAGS, HEADER_OFFSET, LViewData, LViewFlags, PARENT, RootContext, TData} from './interfaces/view';
+import {CONTEXT, FLAGS, HEADER_OFFSET, LViewData, LViewFlags, PARENT, RootContext, TData, TVIEW} from './interfaces/view';
 
 
 

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -666,10 +666,10 @@
     "name": "getRendererFactory"
   },
   {
-    "name": "getRootContext$1"
+    "name": "getRootContext"
   },
   {
-    "name": "getRootView$1"
+    "name": "getRootView"
   },
   {
     "name": "getStyleSanitizer"


### PR DESCRIPTION
This PR exposes node injector as part as context discovery utils. 

Additionally it fixes a bug where tokens with `NG_ELEMENT_ID=0` wouldn't be injected correctly (as `0` is falsy and `(token as any)[NG_ELEMENT_ID] || null` would always return `null` for the very first token).

@matsko @kara I didn't do this in this PR but I would propose that we:
* remove the existing `getInjector()` util function;
* rename the  `getNodeInjector ` proposed here to `getInjector()`

I'm proposing this since I believe that the method proposed here is more useful as end users would probably get access to tokens regardless if those come from a node injector or module injector.