### PR TITLE
feat(upgrade): support downgrading multiple modules

### DIFF
--- a/aio/content/guide/upgrade-performance.md
+++ b/aio/content/guide/upgrade-performance.md
@@ -281,22 +281,28 @@ The differences between `downgradeModule()` and `UpgradeModule` end here. The re
 `upgrade/static` APIs and concepts work in the exact same way for both types of hybrid apps.
 See [Upgrading from AngularJS](guide/upgrade) to learn about:
 
-- [Using Angular Components from AngularJS Code](guide/upgrade#using-angular-components-from-angularjs-code).
+- [Using Angular Components from AngularJS Code](guide/upgrade#using-angular-components-from-angularjs-code).<br />
+  _NOTE: If you are downgrading multiple modules, you need to specify the name of the downgraded
+  module each component belongs to, when calling `downgradeComponent()`._
 - [Using AngularJS Component Directives from Angular Code](guide/upgrade#using-angularjs-component-directives-from-angular-code).
 - [Projecting AngularJS Content into Angular Components](guide/upgrade#projecting-angularjs-content-into-angular-components).
 - [Transcluding Angular Content into AngularJS Component Directives](guide/upgrade#transcluding-angular-content-into-angularjs-component-directives).
 - [Making AngularJS Dependencies Injectable to Angular](guide/upgrade#making-angularjs-dependencies-injectable-to-angular).
-- [Making Angular Dependencies Injectable to AngularJS](guide/upgrade#making-angular-dependencies-injectable-to-angularjs).
+- [Making Angular Dependencies Injectable to AngularJS](guide/upgrade#making-angular-dependencies-injectable-to-angularjs).<br />
+  _NOTE: If you are downgrading multiple modules, you need to specify the name of the downgraded
+  module each injectable belongs to, when calling `downgradeInjectable()`._
 
 <div class="alert is-important">
 
   While it is possible to downgrade injectables, downgraded injectables will not be available until
-  the Angular module is instantiated. In order to be safe, you need to ensure that the downgraded
-  injectables are not used anywhere _outside_ the part of the app that is controlled by Angular.
+  the Angular module that provides them is instantiated. In order to be safe, you need to ensure
+  that the downgraded injectables are not used anywhere _outside_ the part of the app where it is
+  guaranteed that their module has been instantiated.
 
   For example, it is _OK_ to use a downgraded service in an upgraded component that is only used
-  from Angular components, but it is _not OK_ to use it in an AngularJS component that may be used
-  independently of Angular.
+  from a downgraded Angular component provided by the same Angular module as the injectable, but it
+  is _not OK_ to use it in an AngularJS component that may be used independently of Angular or use
+  it in a downgraded Angular component from a different module.
 
 </div>
 

--- a/packages/examples/upgrade/static/ts/lite-multi/e2e_test/static_lite_multi_spec.ts
+++ b/packages/examples/upgrade/static/ts/lite-multi/e2e_test/static_lite_multi_spec.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {browser, by, element} from 'protractor';
+
+import {verifyNoBrowserErrors} from '../../../../../_common/e2e_util';
+
+
+describe('upgrade/static (lite with multiple downgraded modules)', () => {
+  const navButtons = element.all(by.css('nav button'));
+  const mainContent = element(by.css('main'));
+
+  beforeEach(() => browser.get('/upgrade/static/ts/lite-multi/'));
+  afterEach(verifyNoBrowserErrors);
+
+  it('should correctly bootstrap multiple downgraded modules', () => {
+    navButtons.get(1).click();
+    expect(mainContent.getText()).toBe('Component B');
+
+    navButtons.get(0).click();
+    expect(mainContent.getText()).toBe('Component A | ng1(ng2)');
+  });
+});

--- a/packages/examples/upgrade/static/ts/lite-multi/module.ts
+++ b/packages/examples/upgrade/static/ts/lite-multi/module.ts
@@ -103,11 +103,15 @@ const appModule =
         })
         .directive('ng2A', downgradeComponent({
                      component: Ng2AComponent,
+                     // Since there are more than one downgraded Angular module,
+                     // specify which module this component belongs to.
                      downgradedModule: downgradedNg2AModule,
                      propagateDigest: false,
                    }))
         .directive('ng2B', downgradeComponent({
                      component: Ng2BComponent,
+                     // Since there are more than one downgraded Angular module,
+                     // specify which module this component belongs to.
                      downgradedModule: downgradedNg2BModule,
                      propagateDigest: false,
                    }))

--- a/packages/examples/upgrade/static/ts/lite-multi/module.ts
+++ b/packages/examples/upgrade/static/ts/lite-multi/module.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// #docplaster
+import {Component, Directive, ElementRef, Injectable, Injector, NgModule, StaticProvider, getPlatform} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+import {UpgradeComponent, downgradeComponent, downgradeInjectable, downgradeModule} from '@angular/upgrade/static';
+
+
+declare var angular: ng.IAngularStatic;
+
+// An Angular module that declares an Angular service and a component,
+// which in turn uses an upgraded AngularJS component.
+@Component({
+  selector: 'ng2A',
+  template: 'Component A | <ng1A></ng1A>',
+})
+export class Ng2AComponent {
+}
+
+@Directive({
+  selector: 'ng1A',
+})
+export class Ng1AComponentFacade extends UpgradeComponent {
+  constructor(elementRef: ElementRef, injector: Injector) { super('ng1A', elementRef, injector); }
+}
+
+@Injectable()
+export class Ng2AService {
+  getValue() { return 'ng2'; }
+}
+
+@NgModule({
+  imports: [BrowserModule],
+  providers: [Ng2AService],
+  declarations: [Ng1AComponentFacade, Ng2AComponent],
+  entryComponents: [Ng2AComponent],
+})
+export class Ng2AModule {
+  ngDoBootstrap() {}
+}
+
+
+// Another Angular module that declares an Angular component.
+@Component({
+  selector: 'ng2B',
+  template: 'Component B',
+})
+export class Ng2BComponent {
+}
+
+@NgModule({
+  imports: [BrowserModule],
+  declarations: [Ng2BComponent],
+  entryComponents: [Ng2BComponent],
+})
+export class Ng2BModule {
+  ngDoBootstrap() {}
+}
+
+
+// The downgraded Angular modules.
+const downgradedNg2AModule = downgradeModule(
+    (extraProviders: StaticProvider[]) =>
+        (getPlatform() || platformBrowserDynamic(extraProviders)).bootstrapModule(Ng2AModule));
+
+const downgradedNg2BModule = downgradeModule(
+    (extraProviders: StaticProvider[]) =>
+        (getPlatform() || platformBrowserDynamic(extraProviders)).bootstrapModule(Ng2BModule));
+
+
+// The AngularJS app including downgraded modules, components and injectables.
+const appModule =
+    angular.module('exampleAppModule', [downgradedNg2AModule, downgradedNg2BModule])
+        .component('exampleApp', {
+          template: `
+        <nav>
+          <button ng-click="$ctrl.page = page" ng-repeat="page in ['A', 'B']">
+            Page {{ page }}
+          </button>
+        </nav>
+        <hr />
+        <main ng-switch="$ctrl.page">
+          <ng2-a ng-switch-when="A"></ng2-a>
+          <ng2-b ng-switch-when="B"></ng2-b>
+        </main>
+      `,
+          controller: class ExampleAppController{page = 'A';},
+        })
+        .component('ng1A', {
+          template: 'ng1({{ $ctrl.value }})',
+          controller: [
+            'ng2AService', class Ng1AController{
+              value = this.ng2AService.getValue(); constructor(private ng2AService: Ng2AService) {}
+            }
+          ],
+        })
+        .directive('ng2A', downgradeComponent({
+                     component: Ng2AComponent,
+                     downgradedModule: downgradedNg2AModule,
+                     propagateDigest: false,
+                   }))
+        .directive('ng2B', downgradeComponent({
+                     component: Ng2BComponent,
+                     downgradedModule: downgradedNg2BModule,
+                     propagateDigest: false,
+                   }))
+        .factory('ng2AService', downgradeInjectable(Ng2AService, downgradedNg2AModule));
+
+
+// Bootstrap the AngularJS app.
+angular.bootstrap(document.body, [appModule.name]);

--- a/packages/examples/upgrade/static/ts/lite/module.ts
+++ b/packages/examples/upgrade/static/ts/lite/module.ts
@@ -17,7 +17,6 @@ import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 /* tslint:disable: no-duplicate-imports */
 import {UpgradeComponent} from '@angular/upgrade/static';
 import {downgradeComponent} from '@angular/upgrade/static';
-import {downgradeInjectable} from '@angular/upgrade/static';
 // #docregion basic-how-to
 import {downgradeModule} from '@angular/upgrade/static';
 // #enddocregion

--- a/packages/upgrade/src/common/constants.ts
+++ b/packages/upgrade/src/common/constants.ts
@@ -9,6 +9,7 @@
 export const $COMPILE = '$compile';
 export const $CONTROLLER = '$controller';
 export const $DELEGATE = '$delegate';
+export const $EXCEPTION_HANDLER = '$exceptionHandler';
 export const $HTTP_BACKEND = '$httpBackend';
 export const $INJECTOR = '$injector';
 export const $INTERVAL = '$interval';

--- a/packages/upgrade/src/common/constants.ts
+++ b/packages/upgrade/src/common/constants.ts
@@ -23,10 +23,12 @@ export const $TEMPLATE_REQUEST = '$templateRequest';
 export const $$TESTABILITY = '$$testability';
 
 export const COMPILER_KEY = '$$angularCompiler';
+export const DOWNGRADED_MODULE_COUNT_KEY = '$$angularDowngradedModuleCount';
 export const GROUP_PROJECTABLE_NODES_KEY = '$$angularGroupProjectableNodes';
 export const INJECTOR_KEY = '$$angularInjector';
 export const LAZY_MODULE_REF = '$$angularLazyModuleRef';
 export const NG_ZONE_KEY = '$$angularNgZone';
+export const UPGRADE_APP_TYPE_KEY = '$$angularUpgradeAppType';
 
 export const REQUIRE_INJECTOR = '?^^' + INJECTOR_KEY;
 export const REQUIRE_NG_MODEL = '?ngModel';

--- a/packages/upgrade/src/common/downgrade_component.ts
+++ b/packages/upgrade/src/common/downgrade_component.ts
@@ -11,7 +11,7 @@ import {ComponentFactory, ComponentFactoryResolver, Injector, NgZone, Type} from
 import * as angular from './angular1';
 import {$COMPILE, $INJECTOR, $PARSE, INJECTOR_KEY, LAZY_MODULE_REF, REQUIRE_INJECTOR, REQUIRE_NG_MODEL} from './constants';
 import {DowngradeComponentAdapter} from './downgrade_component_adapter';
-import {LazyModuleRef, controllerKey, getComponentName, isFunction} from './util';
+import {LazyModuleRef, controllerKey, getTypeName, isFunction, validateInjectionKey} from './util';
 
 
 interface Thenable<T> {
@@ -104,6 +104,10 @@ export function downgradeComponent(info: {
         if (!parentInjector) {
           const downgradedModule = info.downgradedModule || '';
           const lazyModuleRefKey = `${LAZY_MODULE_REF}${downgradedModule}`;
+          const attemptedAction = `instantiating component '${getTypeName(info.component)}'`;
+
+          validateInjectionKey($injector, downgradedModule, lazyModuleRefKey, attemptedAction);
+
           const lazyModuleRef = $injector.get(lazyModuleRefKey) as LazyModuleRef;
           needsNgZone = lazyModuleRef.needsNgZone;
           parentInjector = lazyModuleRef.injector || lazyModuleRef.promise as Promise<Injector>;
@@ -116,7 +120,7 @@ export function downgradeComponent(info: {
               componentFactoryResolver.resolveComponentFactory(info.component) !;
 
           if (!componentFactory) {
-            throw new Error('Expecting ComponentFactory for: ' + getComponentName(info.component));
+            throw new Error(`Expecting ComponentFactory for: ${getTypeName(info.component)}`);
           }
 
           const injectorPromise = new ParentInjectorPromise(element);

--- a/packages/upgrade/src/common/downgrade_component.ts
+++ b/packages/upgrade/src/common/downgrade_component.ts
@@ -46,8 +46,14 @@ interface Thenable<T> {
  *
  * @param info contains information about the Component that is being downgraded:
  *
- * * `component: Type<any>`: The type of the Component that will be downgraded
- * * `propagateDigest?: boolean`: Whether to perform {@link ChangeDetectorRef#detectChanges
+ * - `component: Type<any>`: The type of the Component that will be downgraded
+ * - `downgradedModule?: string`: The name of the downgraded module (if any) that the component
+ *   "belongs to", as returned by a call to `downgradeModule()`. It is the module, whose
+ *   corresponding Angular module will be bootstrapped, when the component needs to be instantiated.
+ *   <br />
+ *   (This option is only necessary when using `downgradeModule()` to downgrade more than one
+ *   Angular module.)
+ * - `propagateDigest?: boolean`: Whether to perform {@link ChangeDetectorRef#detectChanges
  *   change detection} on the component on every
  *   [$digest](https://docs.angularjs.org/api/ng/type/$rootScope.Scope#$digest). If set to `false`,
  *   change detection will still be performed when any of the component's inputs changes.
@@ -59,7 +65,7 @@ interface Thenable<T> {
  * @publicApi
  */
 export function downgradeComponent(info: {
-  component: Type<any>; propagateDigest?: boolean;
+  component: Type<any>; downgradedModule?: string; propagateDigest?: boolean;
   /** @deprecated since v4. This parameter is no longer used */
   inputs?: string[];
   /** @deprecated since v4. This parameter is no longer used */
@@ -96,7 +102,9 @@ export function downgradeComponent(info: {
         let ranAsync = false;
 
         if (!parentInjector) {
-          const lazyModuleRef = $injector.get(LAZY_MODULE_REF) as LazyModuleRef;
+          const downgradedModule = info.downgradedModule || '';
+          const lazyModuleRefKey = `${LAZY_MODULE_REF}${downgradedModule}`;
+          const lazyModuleRef = $injector.get(lazyModuleRefKey) as LazyModuleRef;
           needsNgZone = lazyModuleRef.needsNgZone;
           parentInjector = lazyModuleRef.injector || lazyModuleRef.promise as Promise<Injector>;
         }

--- a/packages/upgrade/src/common/downgrade_component_adapter.ts
+++ b/packages/upgrade/src/common/downgrade_component_adapter.ts
@@ -11,7 +11,7 @@ import {ApplicationRef, ChangeDetectorRef, ComponentFactory, ComponentRef, Event
 import * as angular from './angular1';
 import {PropertyBinding} from './component_info';
 import {$SCOPE} from './constants';
-import {getComponentName, hookupNgModel, strictEquals} from './util';
+import {getTypeName, hookupNgModel, strictEquals} from './util';
 
 const INITIAL_VALUE = {
   __UNINITIALIZED__: true
@@ -208,7 +208,7 @@ export class DowngradeComponentAdapter {
       });
     } else {
       throw new Error(
-          `Missing emitter '${output.prop}' on component '${getComponentName(this.componentFactory.componentType)}'!`);
+          `Missing emitter '${output.prop}' on component '${getTypeName(this.componentFactory.componentType)}'!`);
     }
   }
 

--- a/packages/upgrade/src/common/downgrade_injectable.ts
+++ b/packages/upgrade/src/common/downgrade_injectable.ts
@@ -43,16 +43,35 @@ import {INJECTOR_KEY} from './constants';
  *
  * {@example upgrade/static/ts/full/module.ts region="example-app"}
  *
+ * <div class="alert is-important">
+ *
+ *   When using `downgradeModule()`, downgraded injectables will not be available until the Angular
+ *   module that provides them is instantiated. In order to be safe, you need to ensure that the
+ *   downgraded injectables are not used anywhere _outside_ the part of the app where it is
+ *   guaranteed that their module has been instantiated.
+ *
+ *   For example, it is _OK_ to use a downgraded service in an upgraded component that is only used
+ *   from a downgraded Angular component provided by the same Angular module as the injectable, but
+ *   it is _not OK_ to use it in an AngularJS component that may be used independently of Angular or
+ *   use it in a downgraded Angular component from a different module.
+ *
+ * </div>
+ *
  * @param token an `InjectionToken` that identifies a service provided from Angular.
+ * @param downgradedModule the name of the downgraded module (if any) that the injectable
+ * "belongs to", as returned by a call to `downgradeModule()`. It is the module, whose injector will
+ * be used for instantiating the injectable.<br />
+ * (This option is only necessary when using `downgradeModule()` to downgrade more than one Angular
+ * module.)
  *
  * @returns a [factory function](https://docs.angularjs.org/guide/di) that can be
  * used to register the service on an AngularJS module.
  *
  * @publicApi
  */
-export function downgradeInjectable(token: any): Function {
+export function downgradeInjectable(token: any, downgradedModule: string = ''): Function {
   const factory = function(i: Injector) { return i.get(token); };
-  (factory as any)['$inject'] = [INJECTOR_KEY];
+  (factory as any)['$inject'] = [`${INJECTOR_KEY}${downgradedModule}`];
 
   return factory;
 }

--- a/packages/upgrade/src/common/downgrade_injectable.ts
+++ b/packages/upgrade/src/common/downgrade_injectable.ts
@@ -7,7 +7,9 @@
  */
 
 import {Injector} from '@angular/core';
-import {INJECTOR_KEY} from './constants';
+import * as angular from './angular1';
+import {$INJECTOR, INJECTOR_KEY} from './constants';
+import {getTypeName, isFunction, validateInjectionKey} from './util';
 
 /**
  * @description
@@ -70,8 +72,17 @@ import {INJECTOR_KEY} from './constants';
  * @publicApi
  */
 export function downgradeInjectable(token: any, downgradedModule: string = ''): Function {
-  const factory = function(i: Injector) { return i.get(token); };
-  (factory as any)['$inject'] = [`${INJECTOR_KEY}${downgradedModule}`];
+  const factory = function($injector: angular.IInjectorService) {
+    const injectorKey = `${INJECTOR_KEY}${downgradedModule}`;
+    const injectableName = isFunction(token) ? getTypeName(token) : String(token);
+    const attemptedAction = `instantiating injectable '${injectableName}'`;
+
+    validateInjectionKey($injector, downgradedModule, injectorKey, attemptedAction);
+
+    const injector: Injector = $injector.get(injectorKey);
+    return injector.get(token);
+  };
+  (factory as any)['$inject'] = [$INJECTOR];
 
   return factory;
 }

--- a/packages/upgrade/src/dynamic/upgrade_adapter.ts
+++ b/packages/upgrade/src/dynamic/upgrade_adapter.ts
@@ -10,10 +10,10 @@ import {Compiler, CompilerOptions, Directive, Injector, NgModule, NgModuleRef, N
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
 import * as angular from '../common/angular1';
-import {$$TESTABILITY, $COMPILE, $INJECTOR, $ROOT_SCOPE, COMPILER_KEY, INJECTOR_KEY, LAZY_MODULE_REF, NG_ZONE_KEY} from '../common/constants';
+import {$$TESTABILITY, $COMPILE, $INJECTOR, $ROOT_SCOPE, COMPILER_KEY, INJECTOR_KEY, LAZY_MODULE_REF, NG_ZONE_KEY, UPGRADE_APP_TYPE_KEY} from '../common/constants';
 import {downgradeComponent} from '../common/downgrade_component';
 import {downgradeInjectable} from '../common/downgrade_injectable';
-import {Deferred, LazyModuleRef, controllerKey, onError} from '../common/util';
+import {Deferred, LazyModuleRef, UpgradeAppType, controllerKey, onError} from '../common/util';
 
 import {UpgradeNg1ComponentAdapterBuilder} from './upgrade_ng1_adapter';
 
@@ -506,7 +506,8 @@ export class UpgradeAdapter {
 
     this.ngZone = new NgZone({enableLongStackTrace: Zone.hasOwnProperty('longStackTraceZoneSpec')});
     this.ng2BootstrapDeferred = new Deferred();
-    ng1Module.factory(INJECTOR_KEY, () => this.moduleRef !.injector.get(Injector))
+    ng1Module.constant(UPGRADE_APP_TYPE_KEY, UpgradeAppType.Dynamic)
+        .factory(INJECTOR_KEY, () => this.moduleRef !.injector.get(Injector))
         .factory(
             LAZY_MODULE_REF,
             [

--- a/packages/upgrade/src/static/upgrade_module.ts
+++ b/packages/upgrade/src/static/upgrade_module.ts
@@ -9,8 +9,8 @@
 import {Injector, NgModule, NgZone, Testability} from '@angular/core';
 
 import * as angular from '../common/angular1';
-import {$$TESTABILITY, $DELEGATE, $INJECTOR, $INTERVAL, $PROVIDE, INJECTOR_KEY, LAZY_MODULE_REF, UPGRADE_MODULE_NAME} from '../common/constants';
-import {LazyModuleRef, controllerKey} from '../common/util';
+import {$$TESTABILITY, $DELEGATE, $INJECTOR, $INTERVAL, $PROVIDE, INJECTOR_KEY, LAZY_MODULE_REF, UPGRADE_APP_TYPE_KEY, UPGRADE_MODULE_NAME} from '../common/constants';
+import {LazyModuleRef, UpgradeAppType, controllerKey} from '../common/util';
 
 import {angular1Providers, setTempInjectorRef} from './angular1_providers';
 import {NgAdapterInjector} from './util';
@@ -172,6 +172,8 @@ export class UpgradeModule {
     const initModule =
         angular
             .module(INIT_MODULE_NAME, [])
+
+            .constant(UPGRADE_APP_TYPE_KEY, UpgradeAppType.Static)
 
             .value(INJECTOR_KEY, this.injector)
 

--- a/packages/upgrade/test/common/downgrade_injectable_spec.ts
+++ b/packages/upgrade/test/common/downgrade_injectable_spec.ts
@@ -21,5 +21,16 @@ import {downgradeInjectable} from '@angular/upgrade/src/common/downgrade_injecta
       expect(injector.get).toHaveBeenCalledWith('someToken');
       expect(value).toEqual('service value');
     });
+
+    it('should inject the specified module\'s injector when specifying a module name', () => {
+      const factory = downgradeInjectable('someToken', 'someModule');
+      expect(factory).toEqual(jasmine.any(Function));
+      expect((factory as any).$inject).toEqual([`${INJECTOR_KEY}someModule`]);
+
+      const injector = {get: jasmine.createSpy('get').and.returnValue('service value')};
+      const value = factory(injector);
+      expect(injector.get).toHaveBeenCalledWith('someToken');
+      expect(value).toEqual('service value');
+    });
   });
 }

--- a/packages/upgrade/test/common/downgrade_injectable_spec.ts
+++ b/packages/upgrade/test/common/downgrade_injectable_spec.ts
@@ -6,31 +6,46 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {INJECTOR_KEY} from '@angular/upgrade/src/common/constants';
+import {Injector} from '@angular/core';
+import * as angular from '@angular/upgrade/src/common/angular1';
+import {$INJECTOR, INJECTOR_KEY, UPGRADE_APP_TYPE_KEY} from '@angular/upgrade/src/common/constants';
 import {downgradeInjectable} from '@angular/upgrade/src/common/downgrade_injectable';
+import {UpgradeAppType} from '@angular/upgrade/src/common/util';
 
-{
-  describe('downgradeInjectable', () => {
-    it('should return an AngularJS annotated factory for the token', () => {
-      const factory = downgradeInjectable('someToken');
-      expect(factory).toEqual(jasmine.any(Function));
-      expect((factory as any).$inject).toEqual([INJECTOR_KEY]);
+describe('downgradeInjectable', () => {
+  const setupMockInjectors = (downgradedModule = '') => {
+    const mockNg1Injector = jasmine.createSpyObj<angular.IInjectorService>(['get', 'has']);
+    mockNg1Injector.get.and.callFake((key: string) => mockDependencies[key]);
+    mockNg1Injector.has.and.callFake((key: string) => mockDependencies.hasOwnProperty(key));
 
-      const injector = {get: jasmine.createSpy('get').and.returnValue('service value')};
-      const value = factory(injector);
-      expect(injector.get).toHaveBeenCalledWith('someToken');
-      expect(value).toEqual('service value');
-    });
+    const mockNg2Injector = jasmine.createSpyObj<Injector>(['get']);
+    mockNg2Injector.get.and.returnValue('service value');
 
-    it('should inject the specified module\'s injector when specifying a module name', () => {
-      const factory = downgradeInjectable('someToken', 'someModule');
-      expect(factory).toEqual(jasmine.any(Function));
-      expect((factory as any).$inject).toEqual([`${INJECTOR_KEY}someModule`]);
+    const mockDependencies: {[key: string]: any} = {
+      [UPGRADE_APP_TYPE_KEY]: downgradedModule ? UpgradeAppType.Lite : UpgradeAppType.Static,
+      [`${INJECTOR_KEY}${downgradedModule}`]: mockNg2Injector,
+    };
 
-      const injector = {get: jasmine.createSpy('get').and.returnValue('service value')};
-      const value = factory(injector);
-      expect(injector.get).toHaveBeenCalledWith('someToken');
-      expect(value).toEqual('service value');
-    });
+    return {mockNg1Injector, mockNg2Injector};
+  };
+
+  it('should return an AngularJS annotated factory for the token', () => {
+    const factory = downgradeInjectable('someToken');
+    expect(factory).toEqual(jasmine.any(Function));
+    expect((factory as any).$inject).toEqual([$INJECTOR]);
+
+    const {mockNg1Injector, mockNg2Injector} = setupMockInjectors();
+    expect(factory(mockNg1Injector)).toEqual('service value');
+    expect(mockNg2Injector.get).toHaveBeenCalledWith('someToken');
   });
-}
+
+  it('should inject the specified module\'s injector when specifying a module name', () => {
+    const factory = downgradeInjectable('someToken', 'someModule');
+    expect(factory).toEqual(jasmine.any(Function));
+    expect((factory as any).$inject).toEqual([$INJECTOR]);
+
+    const {mockNg1Injector, mockNg2Injector} = setupMockInjectors('someModule');
+    expect(factory(mockNg1Injector)).toEqual('service value');
+    expect(mockNg2Injector.get).toHaveBeenCalledWith('someToken');
+  });
+});

--- a/packages/upgrade/test/dynamic/upgrade_spec.ts
+++ b/packages/upgrade/test/dynamic/upgrade_spec.ts
@@ -11,6 +11,7 @@ import {async, fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import * as angular from '@angular/upgrade/src/common/angular1';
+import {$EXCEPTION_HANDLER} from '@angular/upgrade/src/common/constants';
 import {UpgradeAdapter, UpgradeAdapterRef} from '@angular/upgrade/src/dynamic/upgrade_adapter';
 
 import {$apply, $digest, html, multiTrim, withEachNg1Version} from './test_helpers';
@@ -318,7 +319,7 @@ withEachNg1Version(() => {
       it('should bind properties, events', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
            const ng1Module =
-               angular.module('ng1', []).value('$exceptionHandler', (err: any) => { throw err; });
+               angular.module('ng1', []).value($EXCEPTION_HANDLER, (err: any) => { throw err; });
 
            ng1Module.run(($rootScope: any) => {
              $rootScope.name = 'world';
@@ -2904,7 +2905,7 @@ withEachNg1Version(() => {
              // Define `ng1Module`
              const ng1Module =
                  angular.module('ng1Module', [])
-                     .value('$exceptionHandler', (error: Error) => errorMessage = error.message)
+                     .value($EXCEPTION_HANDLER, (error: Error) => errorMessage = error.message)
                      .component('ng1', ng1Component)
                      .directive('ng2', adapter.downgradeNg2Component(Ng2Component));
 

--- a/packages/upgrade/test/static/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/test/static/integration/downgrade_component_spec.ts
@@ -784,5 +784,37 @@ withEachNg1Version(() => {
          });
 
        }));
+
+    it('should throw if `downgradedModule` is specified', async(() => {
+         @Component({selector: 'ng2', template: ''})
+         class Ng2Component {
+         }
+
+         @NgModule({
+           declarations: [Ng2Component],
+           entryComponents: [Ng2Component],
+           imports: [BrowserModule, UpgradeModule],
+         })
+         class Ng2Module {
+           ngDoBootstrap() {}
+         }
+
+
+         const ng1Module = angular.module('ng1', []).directive(
+             'ng2', downgradeComponent({component: Ng2Component, downgradedModule: 'foo'}));
+
+         const element = html('<ng2></ng2>');
+
+         bootstrap(platformBrowserDynamic(), Ng2Module, element, ng1Module)
+             .then(
+                 () => { throw new Error('Expected bootstraping to fail.'); },
+                 err =>
+                     expect(err.message)
+                         .toBe(
+                             'Error while instantiating component \'Ng2Component\': \'downgradedModule\' ' +
+                             'unexpectedly specified.\n' +
+                             'You should not specify a value for \'downgradedModule\', unless you are ' +
+                             'downgrading more than one Angular module (via \'downgradeModule()\').'));
+       }));
   });
 });

--- a/packages/upgrade/test/static/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/test/static/integration/downgrade_component_spec.ts
@@ -22,18 +22,15 @@ withEachNg1Version(() => {
     afterEach(() => destroyPlatform());
 
     it('should bind properties, events', async(() => {
-         const ng1Module =
-             angular.module('ng1', []).value('$exceptionHandler', (err: any) => {
-                                        throw err;
-                                      }).run(($rootScope: angular.IScope) => {
-               $rootScope['name'] = 'world';
-               $rootScope['dataA'] = 'A';
-               $rootScope['dataB'] = 'B';
-               $rootScope['modelA'] = 'initModelA';
-               $rootScope['modelB'] = 'initModelB';
-               $rootScope['eventA'] = '?';
-               $rootScope['eventB'] = '?';
-             });
+         const ng1Module = angular.module('ng1', []).run(($rootScope: angular.IScope) => {
+           $rootScope['name'] = 'world';
+           $rootScope['dataA'] = 'A';
+           $rootScope['dataB'] = 'B';
+           $rootScope['modelA'] = 'initModelA';
+           $rootScope['modelB'] = 'initModelB';
+           $rootScope['eventA'] = '?';
+           $rootScope['eventB'] = '?';
+         });
 
          @Component({
            selector: 'ng2',
@@ -149,12 +146,8 @@ withEachNg1Version(() => {
        }));
 
     it('should bind properties to onpush components', async(() => {
-         const ng1Module =
-             angular.module('ng1', []).value('$exceptionHandler', (err: any) => {
-                                        throw err;
-                                      }).run(($rootScope: angular.IScope) => {
-               $rootScope['dataB'] = 'B';
-             });
+         const ng1Module = angular.module('ng1', []).run(
+             ($rootScope: angular.IScope) => { $rootScope['dataB'] = 'B'; });
 
          @Component({
            selector: 'ng2',

--- a/packages/upgrade/test/static/integration/downgrade_module_spec.ts
+++ b/packages/upgrade/test/static/integration/downgrade_module_spec.ts
@@ -13,7 +13,7 @@ import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
 import {downgradeComponent, downgradeModule} from '@angular/upgrade/static';
 import * as angular from '@angular/upgrade/static/src/common/angular1';
-import {$ROOT_SCOPE, INJECTOR_KEY, LAZY_MODULE_REF} from '@angular/upgrade/static/src/common/constants';
+import {$EXCEPTION_HANDLER, $ROOT_SCOPE, INJECTOR_KEY, LAZY_MODULE_REF} from '@angular/upgrade/static/src/common/constants';
 import {LazyModuleRef} from '@angular/upgrade/static/src/common/util';
 
 import {html, multiTrim, withEachNg1Version} from '../test_helpers';
@@ -661,6 +661,138 @@ withEachNg1Version(() => {
            // Wait for the module to be bootstrapped.
            setTimeout(() => expect($injectorFromNg2).toBe($injectorFromNg1));
          }));
+
+      describe('(common error)', () => {
+        let Ng2CompA: Type<any>;
+        let Ng2CompB: Type<any>;
+        let downModA: string;
+        let downModB: string;
+        let errorSpy: jasmine.Spy;
+
+        const doDowngradeModule = (module: Type<any>) => {
+          const bootstrapFn = (extraProviders: StaticProvider[]) =>
+              (getPlatform() || platformBrowserDynamic(extraProviders)).bootstrapModule(module);
+          return downgradeModule(bootstrapFn);
+        };
+
+        beforeEach(() => {
+          @Component({selector: 'ng2A', template: 'a'})
+          class Ng2ComponentA {
+          }
+
+          @Component({selector: 'ng2B', template: 'b'})
+          class Ng2ComponentB {
+          }
+
+          @NgModule({
+            declarations: [Ng2ComponentA],
+            entryComponents: [Ng2ComponentA],
+            imports: [BrowserModule],
+          })
+          class Ng2ModuleA {
+            ngDoBootstrap() {}
+          }
+
+          @NgModule({
+            declarations: [Ng2ComponentB],
+            entryComponents: [Ng2ComponentB],
+            imports: [BrowserModule],
+          })
+          class Ng2ModuleB {
+            ngDoBootstrap() {}
+          }
+
+          Ng2CompA = Ng2ComponentA;
+          Ng2CompB = Ng2ComponentB;
+          downModA = doDowngradeModule(Ng2ModuleA);
+          downModB = doDowngradeModule(Ng2ModuleB);
+          errorSpy = jasmine.createSpy($EXCEPTION_HANDLER);
+        });
+
+        it('should throw if no downgraded module is included', async(() => {
+             const ng1Module = angular.module('ng1', [])
+                                   .value($EXCEPTION_HANDLER, errorSpy)
+                                   .directive('ng2A', downgradeComponent({
+                                                component: Ng2CompA,
+                                                downgradedModule: downModA, propagateDigest,
+                                              }))
+                                   .directive('ng2B', downgradeComponent({
+                                                component: Ng2CompB,
+                                                propagateDigest,
+                                              }));
+
+             const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
+             angular.bootstrap(element, [ng1Module.name]);
+
+             expect(errorSpy).toHaveBeenCalledTimes(2);
+             expect(errorSpy).toHaveBeenCalledWith(
+                 new Error(
+                     'Error while instantiating component \'Ng2ComponentA\': Not a valid ' +
+                     '\'@angular/upgrade\' application.\n' +
+                     'Did you forget to downgrade an Angular module or include it in the AngularJS ' +
+                     'application?'),
+                 '<ng2-a>');
+             expect(errorSpy).toHaveBeenCalledWith(
+                 new Error(
+                     'Error while instantiating component \'Ng2ComponentB\': Not a valid ' +
+                     '\'@angular/upgrade\' application.\n' +
+                     'Did you forget to downgrade an Angular module or include it in the AngularJS ' +
+                     'application?'),
+                 '<ng2-b>');
+           }));
+
+        it('should throw if the corresponding downgraded module is not included', async(() => {
+             const ng1Module = angular.module('ng1', [downModA])
+                                   .value($EXCEPTION_HANDLER, errorSpy)
+                                   .directive('ng2A', downgradeComponent({
+                                                component: Ng2CompA,
+                                                downgradedModule: downModA, propagateDigest,
+                                              }))
+                                   .directive('ng2B', downgradeComponent({
+                                                component: Ng2CompB,
+                                                downgradedModule: downModB, propagateDigest,
+                                              }));
+
+             const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
+             angular.bootstrap(element, [ng1Module.name]);
+
+             expect(errorSpy).toHaveBeenCalledTimes(1);
+             expect(errorSpy).toHaveBeenCalledWith(
+                 new Error(
+                     'Error while instantiating component \'Ng2ComponentB\': Unable to find the ' +
+                     'specified downgraded module.\n' +
+                     'Did you forget to downgrade an Angular module or include it in the AngularJS ' +
+                     'application?'),
+                 '<ng2-b>');
+           }));
+
+        it('should throw if `downgradedModule` is not specified and there are multiple downgraded modules',
+           async(() => {
+             const ng1Module = angular.module('ng1', [downModA, downModB])
+                                   .value($EXCEPTION_HANDLER, errorSpy)
+                                   .directive('ng2A', downgradeComponent({
+                                                component: Ng2CompA,
+                                                downgradedModule: downModA, propagateDigest,
+                                              }))
+                                   .directive('ng2B', downgradeComponent({
+                                                component: Ng2CompB,
+                                                propagateDigest,
+                                              }));
+
+             const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
+             angular.bootstrap(element, [ng1Module.name]);
+
+             expect(errorSpy).toHaveBeenCalledTimes(1);
+             expect(errorSpy).toHaveBeenCalledWith(
+                 new Error(
+                     'Error while instantiating component \'Ng2ComponentB\': \'downgradedModule\' not ' +
+                     'specified.\n' +
+                     'This application contains more than one downgraded Angular module, thus you need ' +
+                     'to always specify \'downgradedModule\' when downgrading components and ' +
+                     'injectables.'),
+                 '<ng2-b>');
+           }));
+      });
     });
   });
 });

--- a/packages/upgrade/test/static/integration/upgrade_component_spec.ts
+++ b/packages/upgrade/test/static/integration/upgrade_component_spec.ts
@@ -12,7 +12,7 @@ import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {UpgradeComponent, UpgradeModule, downgradeComponent} from '@angular/upgrade/static';
 import * as angular from '@angular/upgrade/static/src/common/angular1';
-import {$SCOPE} from '@angular/upgrade/static/src/common/constants';
+import {$EXCEPTION_HANDLER, $SCOPE} from '@angular/upgrade/static/src/common/constants';
 
 import {$digest, bootstrap, html, multiTrim, withEachNg1Version} from '../test_helpers';
 
@@ -1777,7 +1777,7 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const mockExceptionHandler = jasmine.createSpy('$exceptionHandler');
+             const mockExceptionHandler = jasmine.createSpy($EXCEPTION_HANDLER);
              const ng1Module =
                  angular.module('ng1Module', [])
                      .component('ng1A', ng1ComponentA)
@@ -1786,7 +1786,7 @@ withEachNg1Version(() => {
                      .directive('ng2A', downgradeComponent({component: Ng2ComponentA}))
                      .directive('ng2B', downgradeComponent({component: Ng2ComponentB}))
                      .directive('ng2C', downgradeComponent({component: Ng2ComponentC}))
-                     .value('$exceptionHandler', mockExceptionHandler);
+                     .value($EXCEPTION_HANDLER, mockExceptionHandler);
 
              // Define `Ng2Module`
              @NgModule({
@@ -1849,11 +1849,11 @@ withEachNg1Version(() => {
              }
 
              // Define `ng1Module`
-             const mockExceptionHandler = jasmine.createSpy('$exceptionHandler');
+             const mockExceptionHandler = jasmine.createSpy($EXCEPTION_HANDLER);
              const ng1Module = angular.module('ng1Module', [])
                                    .component('ng1', ng1Component)
                                    .directive('ng2', downgradeComponent({component: Ng2Component}))
-                                   .value('$exceptionHandler', mockExceptionHandler);
+                                   .value($EXCEPTION_HANDLER, mockExceptionHandler);
 
              // Define `Ng2Module`
              @NgModule({
@@ -2502,7 +2502,7 @@ withEachNg1Version(() => {
            // Define `ng1Module`
            const ng1Module =
                angular.module('ng1Module', [])
-                   .value('$exceptionHandler', (error: Error) => errorMessage = error.message)
+                   .value($EXCEPTION_HANDLER, (error: Error) => errorMessage = error.message)
                    .component('ng1', ng1Component)
                    .directive('ng2', downgradeComponent({component: Ng2Component}));
 

--- a/packages/upgrade/test/static/test_helpers.ts
+++ b/packages/upgrade/test/static/test_helpers.ts
@@ -9,7 +9,7 @@
 import {NgZone, PlatformRef, Type} from '@angular/core';
 import {UpgradeModule} from '@angular/upgrade/static';
 import * as angular from '@angular/upgrade/static/src/common/angular1';
-import {$ROOT_SCOPE} from '@angular/upgrade/static/src/common/constants';
+import {$EXCEPTION_HANDLER, $ROOT_SCOPE} from '@angular/upgrade/static/src/common/constants';
 
 import {createWithEachNg1VersionFn} from '../common/test_helpers';
 export * from '../common/test_helpers';
@@ -22,7 +22,7 @@ export function bootstrap(
     const ngZone = ref.injector.get<NgZone>(NgZone);
     const upgrade = ref.injector.get(UpgradeModule);
     const failHardModule: any = ($provide: angular.IProvideService) => {
-      $provide.value('$exceptionHandler', (err: any) => { throw err; });
+      $provide.value($EXCEPTION_HANDLER, (err: any) => { throw err; });
     };
 
     // The `bootstrap()` helper is used for convenience in tests, so that we don't have to inject

--- a/tools/public_api_guard/upgrade/static.d.ts
+++ b/tools/public_api_guard/upgrade/static.d.ts
@@ -1,12 +1,13 @@
 export declare function downgradeComponent(info: {
     component: Type<any>;
+    downgradedModule?: string;
     propagateDigest?: boolean;
     /** @deprecated */ inputs?: string[];
     /** @deprecated */ outputs?: string[];
     /** @deprecated */ selectors?: string[];
 }): any;
 
-export declare function downgradeInjectable(token: any): Function;
+export declare function downgradeInjectable(token: any, downgradedModule?: string): Function;
 
 export declare function downgradeModule<T>(moduleFactoryOrBootstrapFn: NgModuleFactory<T> | ((extraProviders: StaticProvider[]) => Promise<NgModuleRef<T>>)): string;
 


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
```
[x] Feature
[x] Refactoring (no functional changes, no api changes)
```

## What is the current behavior?
Currently, calling `downgradeModule()` more than once is not supported. If one wants to downgrade multiple Angular modules, they can create a
"super-module" that imports all the rest and downgrade that (but that doesn't work in all scenarios).

Issue Number: #26062


## What is the new behavior?
This PR adds support for downgrading multiple Angular modules. If multiple modules are downgraded, then one must explicitly specify the downgraded module that each downgraded component or injectable belongs to, when calling `downgradeComponent()` and `downgradeInjectable()` respectively.

No modification is needed (i.e. there is no need to specify a module for downgraded components and injectables), if an app is not using `downgradeModule()` or if there is only one downgraded Angular module.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
Fixes #26062.
This is an alternative to #26084.