### PR TITLE
fix(router): fix some empty path related navigation bugs

### DIFF
--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -147,14 +147,17 @@ function findStartingPosition(nav: Navigation, tree: UrlTree, route: ActivatedRo
     return new Position(tree.root, true, 0);
   }
 
+  const segmentGroup = route.snapshot._urlSegment;
+
   if (route.snapshot._lastPathIndex === -1) {
-    return new Position(route.snapshot._urlSegment, true, 0);
+    // Pathless ActivatedRoute has _lastPathIndex === -1 but should not process children
+    // see issue #26224
+    return new Position(segmentGroup, segmentGroup.segments.length === 0, 0);
   }
 
   const modifier = isMatrixParams(nav.commands[0]) ? 0 : 1;
   const index = route.snapshot._lastPathIndex + modifier;
-  return createPositionApplyingDoubleDots(
-      route.snapshot._urlSegment, index, nav.numberOfDoubleDots);
+  return createPositionApplyingDoubleDots(segmentGroup, index, nav.numberOfDoubleDots);
 }
 
 function createPositionApplyingDoubleDots(

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -70,6 +70,14 @@ class Recognizer {
   processSegmentGroup(config: Route[], segmentGroup: UrlSegmentGroup, outlet: string):
       TreeNode<ActivatedRouteSnapshot>[] {
     if (segmentGroup.segments.length === 0 && segmentGroup.hasChildren()) {
+      const empties = config.filter(r => emptyPathMatch(segmentGroup, segmentGroup.segments, r));
+      if (empties.length !== 0) {
+        try {
+          return this.processSegment(empties, segmentGroup, segmentGroup.segments, outlet);
+        } catch (e) {
+          if (!(e instanceof NoMatch)) throw e;
+        }
+      }
       return this.processChildren(config, segmentGroup);
     }
 

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -233,6 +233,12 @@ describe('createUrlTree', () => {
       const t = create(p.root.children[PRIMARY_OUTLET], 1, p, [{outlets: {right: ['c']}}]);
       expect(serializer.serialize(t)).toEqual('/a/b/(right:c)');
     });
+
+    it('should support pathless route', () => {
+      const p = serializer.parse('/a');
+      const t = create(p.root.children[PRIMARY_OUTLET], -1, p, ['b']);
+      expect(serializer.serialize(t)).toEqual('/b');
+    });
   });
 
   it('should set fragment', () => {
@@ -260,8 +266,8 @@ function create(
     expect(segment).toBeDefined();
   }
   const s = new (ActivatedRouteSnapshot as any)(
-      [], <any>{}, <any>{}, '', <any>{}, PRIMARY_OUTLET, 'someComponent', null, <any>segment,
-      startIndex, <any>null);
+      segment.segments, <any>{}, <any>{}, '', <any>{}, PRIMARY_OUTLET, 'someComponent', null,
+      <any>segment, startIndex, <any>null);
   const a = new (ActivatedRoute as any)(
       new BehaviorSubject(null !), new BehaviorSubject(null !), new BehaviorSubject(null !),
       new BehaviorSubject(null !), new BehaviorSubject(null !), PRIMARY_OUTLET, 'someComponent', s);

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -263,6 +263,20 @@ describe('recognize', () => {
         });
       });
 
+      it('should work with children outlets', () => {
+        checkRecognize(
+            [{
+              path: '',
+              component: ComponentA,
+              children: [{path: 'b', outlet: 'b', component: ComponentB}]
+            }],
+            '(b:b)', (s: RouterStateSnapshot) => {
+              checkActivatedRoute((s as any).firstChild(s.root) !, '', {}, ComponentA);
+              checkActivatedRoute(
+                  (s as any).firstChild((s as any).firstChild(s.root)) !, 'b', {}, ComponentB, 'b');
+            });
+      });
+
       it('should match when terminal', () => {
         checkRecognize(
             [{path: '', pathMatch: 'full', component: ComponentA}], '',


### PR DESCRIPTION
fix some empty path related navigation bugs

PR Close #26224, #10726

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #26224 , #10726


## What is the new behavior?

* The next path of a pathless activated route is no longer added to the url and the commands passed to the createUrlTree are no longer added as children of an undefined outlet of this path but as children of the actual url.
* The navigation to aux routes with empty-path parent route is now possible.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

