### PR TITLE
refactor(ivy): update context discovery to prep for dir merge

### DIFF
--- a/packages/core/src/render3/discovery_utils.ts
+++ b/packages/core/src/render3/discovery_utils.ts
@@ -8,7 +8,7 @@
 import {Injector} from '../di/injector';
 
 import {assertDefined} from './assert';
-import {LContext, discoverDirectiveIndices, discoverDirectives, discoverLocalRefs, getContext, isComponentInstance, readPatchedLViewData} from './context_discovery';
+import {LContext, discoverDirectives, discoverLocalRefs, getContext, isComponentInstance, readPatchedLViewData} from './context_discovery';
 import {NodeInjector} from './di';
 import {LElementNode, TElementNode, TNode, TNodeFlags} from './interfaces/node';
 import {CONTEXT, FLAGS, LViewData, LViewFlags, PARENT, RootContext, TVIEW} from './interfaces/view';
@@ -59,9 +59,9 @@ export function getComponent<T = {}>(target: {}): T|null {
  */
 export function getHostComponent<T = {}>(target: {}): T|null {
   const context = loadContext(target);
-  const tNode = context.lViewData[TVIEW].data[context.lNodeIndex] as TNode;
+  const tNode = context.lViewData[TVIEW].data[context.nodeIndex] as TNode;
   if (tNode.flags & TNodeFlags.isComponent) {
-    const lNode = context.lViewData[context.lNodeIndex] as LElementNode;
+    const lNode = context.lViewData[context.nodeIndex] as LElementNode;
     return lNode.data ![CONTEXT] as any as T;
   }
   return null;
@@ -91,7 +91,7 @@ export function getRootComponents(target: {}): any[] {
  */
 export function getInjector(target: {}): Injector {
   const context = loadContext(target);
-  const tNode = context.lViewData[TVIEW].data[context.lNodeIndex] as TElementNode;
+  const tNode = context.lViewData[TVIEW].data[context.nodeIndex] as TElementNode;
 
   return new NodeInjector(tNode, context.lViewData);
 }
@@ -104,10 +104,7 @@ export function getDirectives(target: {}): Array<{}> {
   const context = loadContext(target) !;
 
   if (context.directives === undefined) {
-    context.directiveIndices = discoverDirectiveIndices(context.lViewData, context.lNodeIndex);
-    context.directives = context.directiveIndices ?
-        discoverDirectives(context.lViewData, context.directiveIndices) :
-        null;
+    context.directives = discoverDirectives(context.nodeIndex, context.lViewData);
   }
 
   return context.directives || [];
@@ -151,7 +148,7 @@ export function getLocalRefs(target: {}): {[key: string]: any} {
   const context = loadContext(target) !;
 
   if (context.localRefs === undefined) {
-    context.localRefs = discoverLocalRefs(context.lViewData, context.lNodeIndex);
+    context.localRefs = discoverLocalRefs(context.lViewData, context.nodeIndex);
   }
 
   return context.localRefs || {};

--- a/packages/core/src/render3/styling/util.ts
+++ b/packages/core/src/render3/styling/util.ts
@@ -29,11 +29,11 @@ export function getOrCreatePlayerContext(target: {}, context?: LContext | null):
         'Only elements that exist in an Angular application can be used for player access');
   }
 
-  const {lViewData, lNodeIndex} = context;
-  const value = lViewData[lNodeIndex];
+  const {lViewData, nodeIndex} = context;
+  const value = lViewData[nodeIndex];
   let stylingContext = value as StylingContext;
   if (!Array.isArray(value)) {
-    stylingContext = lViewData[lNodeIndex] = createEmptyStylingContext(value as LElementNode);
+    stylingContext = lViewData[nodeIndex] = createEmptyStylingContext(value as LElementNode);
   }
   return stylingContext[StylingIndex.PlayerContext] || allocPlayerContext(stylingContext);
 }

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -447,9 +447,6 @@
     "name": "directiveInject"
   },
   {
-    "name": "discoverDirectiveIndices"
-  },
-  {
     "name": "discoverDirectives"
   },
   {

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -1765,14 +1765,14 @@ describe('render3 integration test', () => {
       const section = fixture.hostElement.querySelector('section') !;
       const sectionContext = getContext(section) !;
       const sectionLView = sectionContext.lViewData !;
-      expect(sectionContext.lNodeIndex).toEqual(HEADER_OFFSET);
+      expect(sectionContext.nodeIndex).toEqual(HEADER_OFFSET);
       expect(sectionLView.length).toBeGreaterThan(HEADER_OFFSET);
       expect(sectionContext.native).toBe(section);
 
       const div = fixture.hostElement.querySelector('div') !;
       const divContext = getContext(div) !;
       const divLView = divContext.lViewData !;
-      expect(divContext.lNodeIndex).toEqual(HEADER_OFFSET + 1);
+      expect(divContext.nodeIndex).toEqual(HEADER_OFFSET + 1);
       expect(divLView.length).toBeGreaterThan(HEADER_OFFSET);
       expect(divContext.native).toBe(div);
 
@@ -2110,7 +2110,7 @@ describe('render3 integration test', () => {
          const div1 = hostElm.querySelector('div:first-child') !as any;
          const div2 = hostElm.querySelector('div:last-child') !as any;
          const context = getContext(hostElm) !;
-         const elementNode = context.lViewData[context.lNodeIndex];
+         const elementNode = context.lViewData[context.nodeIndex];
          const elmData = elementNode.data !;
          const dirs = elmData[DIRECTIVES];
 
@@ -2134,15 +2134,15 @@ describe('render3 integration test', () => {
          expect((myDir2Instance as any)[MONKEY_PATCH_KEY_NAME]).toBe(d2Context);
          expect((myDir3Instance as any)[MONKEY_PATCH_KEY_NAME]).toBe(d3Context);
 
-         expect(d1Context.lNodeIndex).toEqual(HEADER_OFFSET);
+         expect(d1Context.nodeIndex).toEqual(HEADER_OFFSET);
          expect(d1Context.native).toBe(div1);
          expect(d1Context.directives as any[]).toEqual([myDir1Instance, myDir2Instance]);
 
-         expect(d2Context.lNodeIndex).toEqual(HEADER_OFFSET);
+         expect(d2Context.nodeIndex).toEqual(HEADER_OFFSET);
          expect(d2Context.native).toBe(div1);
          expect(d2Context.directives as any[]).toEqual([myDir1Instance, myDir2Instance]);
 
-         expect(d3Context.lNodeIndex).toEqual(HEADER_OFFSET + 1);
+         expect(d3Context.nodeIndex).toEqual(HEADER_OFFSET + 1);
          expect(d3Context.native).toBe(div2);
          expect(d3Context.directives as any[]).toEqual([myDir3Instance]);
        });
@@ -2292,14 +2292,14 @@ describe('render3 integration test', () => {
          const context = getContext(child) !;
          expect(child[MONKEY_PATCH_KEY_NAME]).toBeTruthy();
 
-         const componentData = context.lViewData[context.lNodeIndex].data;
+         const componentData = context.lViewData[context.nodeIndex].data;
          const component = componentData[CONTEXT];
          expect(component instanceof ChildComp).toBeTruthy();
          expect(component[MONKEY_PATCH_KEY_NAME]).toBe(context.lViewData);
 
          const componentContext = getContext(component) !;
          expect(component[MONKEY_PATCH_KEY_NAME]).toBe(componentContext);
-         expect(componentContext.lNodeIndex).toEqual(context.lNodeIndex);
+         expect(componentContext.nodeIndex).toEqual(context.nodeIndex);
          expect(componentContext.native).toEqual(context.native);
          expect(componentContext.lViewData).toEqual(context.lViewData);
        });


### PR DESCRIPTION
This is a small PR to prep for flattening directives into `LViewData`. In a few places, we are searching the `directives` array directly, but this strategy won't work well once the containing array for directives is `LViewData` (way too broad of a search). 