### PR TITLE
docs-infra: aio CLI boolean options

### DIFF
--- a/aio/src/styles/2-modules/_cli-pages.scss
+++ b/aio/src/styles/2-modules/_cli-pages.scss
@@ -6,7 +6,3 @@
   white-space: pre;
 }
 
-.cli-default, .cli-aliases {
-  font-style: italic;
-  color: $blue;
-}

--- a/aio/src/styles/2-modules/_cli-pages.scss
+++ b/aio/src/styles/2-modules/_cli-pages.scss
@@ -1,7 +1,12 @@
-.cli-name, .cli-default {
+.cli-name {
   font-weight: bold;
 }
 
 .cli-option-syntax {
   white-space: pre;
+}
+
+.cli-default, .cli-aliases {
+  font-style: italic;
+  color: $blue;
 }

--- a/aio/tools/transforms/templates/cli/lib/cli.html
+++ b/aio/tools/transforms/templates/cli/lib/cli.html
@@ -72,7 +72,8 @@
 {%- endmacro %}
 
 {%- macro renderValues(values, default) -%}
-{$ values.join('|') $}
+{%- set valString = values.join('|') -%}
+{%- if valString.length > 15 %}<br>    {% endif %}{$ valString $}
 {%- endmacro -%}
 
 {%- macro renderOption(name, type, default, values) -%}
@@ -81,7 +82,7 @@
 {%- elif values.length -%}
 {$ prefix $}{$ name $}={$ renderValues(values, default) $}
 {%- elif type === 'string' -%}
-<var>{$ name $}</var>
+{$ prefix $}{$ name $}={% if name.length > 15 %}<br>    {% endif %}<var>{$ name $}</var>
 {%- else -%}
 {$ prefix $}{$ name $}
 {%- endif -%}

--- a/aio/tools/transforms/templates/cli/lib/cli.html
+++ b/aio/tools/transforms/templates/cli/lib/cli.html
@@ -20,7 +20,7 @@
   <tbody>
   {% for option in arguments %}
   <tr class="cli-option">
-    <td><code>{$ option.name $}</code></td>
+    <td><code>&lt;<var>{$ option.name $}</var>&gt;</code></td>
     <td>
       {$ option.description | marked $}
       {% if option.subcommands.length -%}

--- a/aio/tools/transforms/templates/cli/lib/cli.html
+++ b/aio/tools/transforms/templates/cli/lib/cli.html
@@ -53,16 +53,12 @@
   {% for option in options %}
     <tr class="cli-option">
       <td>
-        {% for type in option.types -%}
-        {% for alias in option.names -%}
-        <code class="cli-option-syntax">{$ renderOption(option.name, alias, type, option.default, option.enum) $}</code>
-        {% if not loop.last %}<br>{% endif %}
-        {% endfor -%}
-        {% if not loop.last %}<br>{% endif %}
-        {% endfor -%}
+        <code class="cli-option-syntax">{$ renderOption(option.name, option.type, option.default, option.enum) $}</code>
       </td>
       <td>
         {$ option.description | marked $}
+        {% if option.default !== undefined %}<p><span class="cli-default">Default:</span> <code>{$ option.default $}</code></p>{% endif %}
+        {% if option.aliases.length %}<p><span class="cli-aliases">Aliases:</span> {% for alias in option.aliases %}{$ renderOptionName(alias) $}{% if not loop.last %}, {% endif %}{% endfor %}</p>{% endif %}
       </td>
     </tr>
   {% endfor %}
@@ -71,26 +67,23 @@
 {% endif %}
 {% endmacro %}
 
-{% macro bold(isBold, contents) -%}
-<span {% if isBold %}class="cli-default"{% endif %}>{$ contents $}</span>
-{%- endmacro -%}
+{%- macro renderOptionName(name) -%}
+{% if name.length > 1 %}-{% endif %}-{$ name $}
+{%- endmacro %}
 
 {%- macro renderValues(values, default) -%}
-{% for value in values %}{$ bold(value==default, value) $}{% if not loop.last %}|{% endif %}{% endfor %}
+{$ values.join('|') $}
 {%- endmacro -%}
 
-{%- macro renderOption(name, alias, type, default, values) -%}
-{% set prefix = '--' if (name === alias and name.length > 1) else '-' %}
-{%- if type === 'boolean' -%}
-{%- if not values.length %}{$ prefix $}{$ alias $}={$ renderValues([true, false], default) $}
-{% endif -%}
-{$ prefix $}{$ bold(default, alias) $}|{$ prefix $}{$ bold(not default, alias | cliNegate) $}
+{%- macro renderOption(name, type, default, values) -%}
+{% set prefix = '--' if name.length > 1 else '-' %}
+{%- if type === 'boolean' and not values.length %}{$ prefix $}{$ name $}={$ renderValues([true, false], default) $}
 {%- elif values.length -%}
-{$ prefix $}{$ alias $}={$ renderValues(values, default) $}
+{$ prefix $}{$ name $}={$ renderValues(values, default) $}
 {%- elif type === 'string' -%}
-{$ prefix $}{$ alias $}=<var>{$ name $}</var>
+<var>{$ name $}</var>
 {%- else -%}
-{$ prefix $}{$ alias $}
+{$ prefix $}{$ name $}
 {%- endif -%}
 {%- endmacro -%}
 


### PR DESCRIPTION
These are the changes based on offline discussions from 4 Oct 18.

Notably, we only show the "canonical" syntax for each option:

* the primary name of the option
* the list of values (including true/false for boolean)
* no visual indication of the default value

Then the default value and any aliases are listed at the end of the description.

Additionally, if the value (or list of values) is over 15 character long, then we move that to a new (indented) line, to prevent the description column from being squashed.

Here are some examples:

<img width="837" alt="screen shot 2018-10-05 at 14 06 10" src="https://user-images.githubusercontent.com/15655/46536920-db59f700-c8a7-11e8-94ed-50df6dfb6380.png">

<img width="842" alt="screen shot 2018-10-05 at 14 07 57" src="https://user-images.githubusercontent.com/15655/46537005-19efb180-c8a8-11e8-9927-40a76c749f39.png">

<img width="842" alt="screen shot 2018-10-05 at 14 07 52" src="https://user-images.githubusercontent.com/15655/46537007-19efb180-c8a8-11e8-82bf-98db74683fcd.png">
