### PR TITLE
fix(router): make sure deactivation does not fail when router outlet …

### DIFF
--- a/packages/router/src/pre_activation.ts
+++ b/packages/router/src/pre_activation.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector} from '@angular/core';
-import {Observable, from, of } from 'rxjs';
-import {concatMap, every, first, last, map, mergeMap, reduce} from 'rxjs/operators';
+import { Injector } from '@angular/core';
+import { Observable, from, of } from 'rxjs';
+import { concatMap, every, first, last, map, mergeMap, reduce } from 'rxjs/operators';
 
-import {LoadedRouterConfig, ResolveData, RunGuardsAndResolvers} from './config';
-import {ActivationStart, ChildActivationStart, Event} from './events';
-import {ChildrenOutletContexts, OutletContext} from './router_outlet_context';
-import {ActivatedRouteSnapshot, RouterStateSnapshot, equalParamsAndUrlSegments, inheritedParamsDataResolve} from './router_state';
-import {andObservables, forEach, shallowEqual, wrapIntoObservable} from './utils/collection';
-import {TreeNode, nodeChildrenAsMap} from './utils/tree';
+import { LoadedRouterConfig, ResolveData, RunGuardsAndResolvers } from './config';
+import { ActivationStart, ChildActivationStart, Event } from './events';
+import { ChildrenOutletContexts, OutletContext } from './router_outlet_context';
+import { ActivatedRouteSnapshot, RouterStateSnapshot, equalParamsAndUrlSegments, inheritedParamsDataResolve } from './router_state';
+import { andObservables, forEach, shallowEqual, wrapIntoObservable } from './utils/collection';
+import { TreeNode, nodeChildrenAsMap } from './utils/tree';
 
 class CanActivate {
   readonly route: ActivatedRouteSnapshot;
@@ -25,7 +25,7 @@ class CanActivate {
 }
 
 class CanDeactivate {
-  constructor(public component: Object|null, public route: ActivatedRouteSnapshot) {}
+  constructor(public component: Object | null, public route: ActivatedRouteSnapshot) { }
 }
 
 /**
@@ -36,8 +36,8 @@ export class PreActivation {
   private canDeactivateChecks: CanDeactivate[] = [];
 
   constructor(
-      private future: RouterStateSnapshot, private curr: RouterStateSnapshot,
-      private moduleInjector: Injector, private forwardEvent?: (evt: Event) => void) {}
+    private future: RouterStateSnapshot, private curr: RouterStateSnapshot,
+    private moduleInjector: Injector, private forwardEvent?: (evt: Event) => void) { }
 
   initialize(parentContexts: ChildrenOutletContexts): void {
     const futureRoot = this.future._root;
@@ -47,20 +47,20 @@ export class PreActivation {
 
   checkGuards(): Observable<boolean> {
     if (!this.isDeactivating() && !this.isActivating()) {
-      return of (true);
+      return of(true);
     }
     const canDeactivate$ = this.runCanDeactivateChecks();
     return canDeactivate$.pipe(mergeMap(
-        (canDeactivate: boolean) => canDeactivate ? this.runCanActivateChecks() : of (false)));
+      (canDeactivate: boolean) => canDeactivate ? this.runCanActivateChecks() : of(false)));
   }
 
-  resolveData(paramsInheritanceStrategy: 'emptyOnly'|'always'): Observable<any> {
-    if (!this.isActivating()) return of (null);
+  resolveData(paramsInheritanceStrategy: 'emptyOnly' | 'always'): Observable<any> {
+    if (!this.isActivating()) return of(null);
     return from(this.canActivateChecks)
-        .pipe(
-            concatMap(
-                (check: CanActivate) => this.runResolve(check.route, paramsInheritanceStrategy)),
-            reduce((_: any, __: any) => _));
+      .pipe(
+        concatMap(
+          (check: CanActivate) => this.runResolve(check.route, paramsInheritanceStrategy)),
+        reduce((_: any, __: any) => _));
   }
 
   isDeactivating(): boolean { return this.canDeactivateChecks.length !== 0; }
@@ -73,21 +73,21 @@ export class PreActivation {
    * proper state to run `checkGuards()` method.
    */
   private setupChildRouteGuards(
-      futureNode: TreeNode<ActivatedRouteSnapshot>, currNode: TreeNode<ActivatedRouteSnapshot>|null,
-      contexts: ChildrenOutletContexts|null, futurePath: ActivatedRouteSnapshot[]): void {
+    futureNode: TreeNode<ActivatedRouteSnapshot>, currNode: TreeNode<ActivatedRouteSnapshot> | null,
+    contexts: ChildrenOutletContexts | null, futurePath: ActivatedRouteSnapshot[]): void {
     const prevChildren = nodeChildrenAsMap(currNode);
 
     // Process the children of the future route
     futureNode.children.forEach(c => {
       this.setupRouteGuards(
-          c, prevChildren[c.value.outlet], contexts, futurePath.concat([c.value]));
+        c, prevChildren[c.value.outlet], contexts, futurePath.concat([c.value]));
       delete prevChildren[c.value.outlet];
     });
 
     // Process any children left from the current route (not active for the future route)
     forEach(
-        prevChildren, (v: TreeNode<ActivatedRouteSnapshot>, k: string) =>
-                          this.deactivateRouteAndItsChildren(v, contexts !.getContext(k)));
+      prevChildren, (v: TreeNode<ActivatedRouteSnapshot>, k: string) =>
+        this.deactivateRouteAndItsChildren(v, contexts!.getContext(k)));
   }
 
   /**
@@ -95,8 +95,8 @@ export class PreActivation {
    * proper state to run `checkGuards()` method.
    */
   private setupRouteGuards(
-      futureNode: TreeNode<ActivatedRouteSnapshot>, currNode: TreeNode<ActivatedRouteSnapshot>,
-      parentContexts: ChildrenOutletContexts|null, futurePath: ActivatedRouteSnapshot[]): void {
+    futureNode: TreeNode<ActivatedRouteSnapshot>, currNode: TreeNode<ActivatedRouteSnapshot>,
+    parentContexts: ChildrenOutletContexts | null, futurePath: ActivatedRouteSnapshot[]): void {
     const future = futureNode.value;
     const curr = currNode ? currNode.value : null;
     const context = parentContexts ? parentContexts.getContext(futureNode.value.outlet) : null;
@@ -104,7 +104,7 @@ export class PreActivation {
     // reusing the node
     if (curr && future.routeConfig === curr.routeConfig) {
       const shouldRunGuardsAndResolvers = this.shouldRunGuardsAndResolvers(
-          curr, future, future.routeConfig !.runGuardsAndResolvers);
+        curr, future, future.routeConfig!.runGuardsAndResolvers);
       if (shouldRunGuardsAndResolvers) {
         this.canActivateChecks.push(new CanActivate(futurePath));
       } else {
@@ -116,7 +116,7 @@ export class PreActivation {
       // If we have a component, we need to go through an outlet.
       if (future.component) {
         this.setupChildRouteGuards(
-            futureNode, currNode, context ? context.children : null, futurePath);
+          futureNode, currNode, context ? context.children : null, futurePath);
 
         // if we have a componentless route, we recurse but keep the same outlet map.
       } else {
@@ -147,15 +147,15 @@ export class PreActivation {
   }
 
   private shouldRunGuardsAndResolvers(
-      curr: ActivatedRouteSnapshot, future: ActivatedRouteSnapshot,
-      mode: RunGuardsAndResolvers|undefined): boolean {
+    curr: ActivatedRouteSnapshot, future: ActivatedRouteSnapshot,
+    mode: RunGuardsAndResolvers | undefined): boolean {
     switch (mode) {
       case 'always':
         return true;
 
       case 'paramsOrQueryParamsChange':
         return !equalParamsAndUrlSegments(curr, future) ||
-            !shallowEqual(curr.queryParams, future.queryParams);
+          !shallowEqual(curr.queryParams, future.queryParams);
 
       case 'paramsChange':
       default:
@@ -164,7 +164,7 @@ export class PreActivation {
   }
 
   private deactivateRouteAndItsChildren(
-      route: TreeNode<ActivatedRouteSnapshot>, context: OutletContext|null): void {
+    route: TreeNode<ActivatedRouteSnapshot>, context: OutletContext | null): void {
     const children = nodeChildrenAsMap(route);
     const r = route.value;
 
@@ -189,20 +189,20 @@ export class PreActivation {
 
   private runCanDeactivateChecks(): Observable<boolean> {
     return from(this.canDeactivateChecks)
-        .pipe(
-            mergeMap((check: CanDeactivate) => this.runCanDeactivate(check.component, check.route)),
-            every((result: boolean) => result === true));
+      .pipe(
+        mergeMap((check: CanDeactivate) => this.runCanDeactivate(check.component, check.route)),
+        every((result: boolean) => result === true));
   }
 
   private runCanActivateChecks(): Observable<boolean> {
     return from(this.canActivateChecks)
-        .pipe(
-            concatMap((check: CanActivate) => andObservables(from([
-                        this.fireChildActivationStart(check.route.parent),
-                        this.fireActivationStart(check.route), this.runCanActivateChild(check.path),
-                        this.runCanActivate(check.route)
-                      ]))),
-            every((result: boolean) => result === true));
+      .pipe(
+        concatMap((check: CanActivate) => andObservables(from([
+          this.fireChildActivationStart(check.route.parent),
+          this.fireActivationStart(check.route), this.runCanActivateChild(check.path),
+          this.runCanActivate(check.route)
+        ]))),
+        every((result: boolean) => result === true));
     // this.fireChildActivationStart(check.path),
   }
 
@@ -214,11 +214,11 @@ export class PreActivation {
    * return
    * `true` so checks continue to run.
    */
-  private fireActivationStart(snapshot: ActivatedRouteSnapshot|null): Observable<boolean> {
+  private fireActivationStart(snapshot: ActivatedRouteSnapshot | null): Observable<boolean> {
     if (snapshot !== null && this.forwardEvent) {
       this.forwardEvent(new ActivationStart(snapshot));
     }
-    return of (true);
+    return of(true);
   }
 
   /**
@@ -229,16 +229,16 @@ export class PreActivation {
    * return
    * `true` so checks continue to run.
    */
-  private fireChildActivationStart(snapshot: ActivatedRouteSnapshot|null): Observable<boolean> {
+  private fireChildActivationStart(snapshot: ActivatedRouteSnapshot | null): Observable<boolean> {
     if (snapshot !== null && this.forwardEvent) {
       this.forwardEvent(new ChildActivationStart(snapshot));
     }
-    return of (true);
+    return of(true);
   }
 
   private runCanActivate(future: ActivatedRouteSnapshot): Observable<boolean> {
     const canActivate = future.routeConfig ? future.routeConfig.canActivate : null;
-    if (!canActivate || canActivate.length === 0) return of (true);
+    if (!canActivate || canActivate.length === 0) return of(true);
     const obs = from(canActivate).pipe(map((c: any) => {
       const guard = this.getToken(c, future);
       let observable: Observable<boolean>;
@@ -256,9 +256,9 @@ export class PreActivation {
     const future = path[path.length - 1];
 
     const canActivateChildGuards = path.slice(0, path.length - 1)
-                                       .reverse()
-                                       .map(p => this.extractCanActivateChild(p))
-                                       .filter(_ => _ !== null);
+      .reverse()
+      .map(p => this.extractCanActivateChild(p))
+      .filter(_ => _ !== null);
 
     return andObservables(from(canActivateChildGuards).pipe(map((d: any) => {
       const obs = from(d.guards).pipe(map((c: any) => {
@@ -275,23 +275,22 @@ export class PreActivation {
     })));
   }
 
-  private extractCanActivateChild(p: ActivatedRouteSnapshot):
-      {node: ActivatedRouteSnapshot, guards: any[]}|null {
+  private extractCanActivateChild(p: ActivatedRouteSnapshot): { node: ActivatedRouteSnapshot, guards: any[] } | null {
     const canActivateChild = p.routeConfig ? p.routeConfig.canActivateChild : null;
     if (!canActivateChild || canActivateChild.length === 0) return null;
-    return {node: p, guards: canActivateChild};
+    return { node: p, guards: canActivateChild };
   }
 
-  private runCanDeactivate(component: Object|null, curr: ActivatedRouteSnapshot):
-      Observable<boolean> {
+  private runCanDeactivate(component: Object | null, curr: ActivatedRouteSnapshot):
+    Observable<boolean> {
     const canDeactivate = curr && curr.routeConfig ? curr.routeConfig.canDeactivate : null;
-    if (!canDeactivate || canDeactivate.length === 0) return of (true);
+    if (!canDeactivate || canDeactivate.length === 0) return of(true);
     const canDeactivate$ = from(canDeactivate).pipe(mergeMap((c: any) => {
       const guard = this.getToken(c, curr);
       let observable: Observable<boolean>;
       if (guard.canDeactivate) {
         observable =
-            wrapIntoObservable(guard.canDeactivate(component, curr, this.curr, this.future));
+          wrapIntoObservable(guard.canDeactivate(component, curr, this.curr, this.future));
       } else {
         observable = wrapIntoObservable(guard(component, curr, this.curr, this.future));
       }
@@ -301,13 +300,15 @@ export class PreActivation {
   }
 
   private runResolve(
-      future: ActivatedRouteSnapshot,
-      paramsInheritanceStrategy: 'emptyOnly'|'always'): Observable<any> {
+    future: ActivatedRouteSnapshot,
+    paramsInheritanceStrategy: 'emptyOnly' | 'always'): Observable<any> {
     const resolve = future._resolve;
     return this.resolveNode(resolve, future).pipe(map((resolvedData: any): any => {
       future._resolvedData = resolvedData;
-      future.data = {...future.data,
-                     ...inheritedParamsDataResolve(future, paramsInheritanceStrategy).resolve};
+      future.data = {
+        ...future.data,
+        ...inheritedParamsDataResolve(future, paramsInheritanceStrategy).resolve
+      };
       return null;
     }));
   }
@@ -315,15 +316,15 @@ export class PreActivation {
   private resolveNode(resolve: ResolveData, future: ActivatedRouteSnapshot): Observable<any> {
     const keys = Object.keys(resolve);
     if (keys.length === 0) {
-      return of ({});
+      return of({});
     }
     if (keys.length === 1) {
       const key = keys[0];
       return this.getResolver(resolve[key], future).pipe(map((value: any) => {
-        return {[key]: value};
+        return { [key]: value };
       }));
     }
-    const data: {[k: string]: any} = {};
+    const data: { [k: string]: any } = {};
     const runningResolvers$ = from(keys).pipe(mergeMap((key: string) => {
       return this.getResolver(resolve[key], future).pipe(map((value: any) => {
         data[key] = value;
@@ -336,7 +337,7 @@ export class PreActivation {
   private getResolver(injectionToken: any, future: ActivatedRouteSnapshot): Observable<any> {
     const resolver = this.getToken(injectionToken, future);
     return resolver.resolve ? wrapIntoObservable(resolver.resolve(future, this.future)) :
-                              wrapIntoObservable(resolver(future, this.future));
+      wrapIntoObservable(resolver(future, this.future));
   }
 
   private getToken(token: any, snapshot: ActivatedRouteSnapshot): any {
@@ -347,7 +348,7 @@ export class PreActivation {
 }
 
 
-function closestLoadedConfig(snapshot: ActivatedRouteSnapshot): LoadedRouterConfig|null {
+function closestLoadedConfig(snapshot: ActivatedRouteSnapshot): LoadedRouterConfig | null {
   if (!snapshot) return null;
 
   for (let s = snapshot.parent; s; s = s.parent) {

--- a/packages/router/src/pre_activation.ts
+++ b/packages/router/src/pre_activation.ts
@@ -124,8 +124,10 @@ export class PreActivation {
       }
 
       if (shouldRunGuardsAndResolvers) {
-        const outlet = context !.outlet !;
-        this.canDeactivateChecks.push(new CanDeactivate(outlet.component, curr));
+        const outlet = context ? context.outlet : null;
+        if (outlet && outlet.component) {
+          this.canDeactivateChecks.push(new CanDeactivate(outlet.component, curr));
+        }
       }
     } else {
       if (curr) {

--- a/packages/router/src/pre_activation.ts
+++ b/packages/router/src/pre_activation.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { Injector } from '@angular/core';
-import { Observable, from, of } from 'rxjs';
-import { concatMap, every, first, last, map, mergeMap, reduce } from 'rxjs/operators';
+import {Injector} from '@angular/core';
+import {Observable, from, of } from 'rxjs';
+import {concatMap, every, first, last, map, mergeMap, reduce} from 'rxjs/operators';
 
-import { LoadedRouterConfig, ResolveData, RunGuardsAndResolvers } from './config';
-import { ActivationStart, ChildActivationStart, Event } from './events';
-import { ChildrenOutletContexts, OutletContext } from './router_outlet_context';
-import { ActivatedRouteSnapshot, RouterStateSnapshot, equalParamsAndUrlSegments, inheritedParamsDataResolve } from './router_state';
-import { andObservables, forEach, shallowEqual, wrapIntoObservable } from './utils/collection';
-import { TreeNode, nodeChildrenAsMap } from './utils/tree';
+import {LoadedRouterConfig, ResolveData, RunGuardsAndResolvers} from './config';
+import {ActivationStart, ChildActivationStart, Event} from './events';
+import {ChildrenOutletContexts, OutletContext} from './router_outlet_context';
+import {ActivatedRouteSnapshot, RouterStateSnapshot, equalParamsAndUrlSegments, inheritedParamsDataResolve} from './router_state';
+import {andObservables, forEach, shallowEqual, wrapIntoObservable} from './utils/collection';
+import {TreeNode, nodeChildrenAsMap} from './utils/tree';
 
 class CanActivate {
   readonly route: ActivatedRouteSnapshot;
@@ -25,7 +25,7 @@ class CanActivate {
 }
 
 class CanDeactivate {
-  constructor(public component: Object | null, public route: ActivatedRouteSnapshot) { }
+  constructor(public component: Object|null, public route: ActivatedRouteSnapshot) {}
 }
 
 /**
@@ -36,8 +36,8 @@ export class PreActivation {
   private canDeactivateChecks: CanDeactivate[] = [];
 
   constructor(
-    private future: RouterStateSnapshot, private curr: RouterStateSnapshot,
-    private moduleInjector: Injector, private forwardEvent?: (evt: Event) => void) { }
+      private future: RouterStateSnapshot, private curr: RouterStateSnapshot,
+      private moduleInjector: Injector, private forwardEvent?: (evt: Event) => void) {}
 
   initialize(parentContexts: ChildrenOutletContexts): void {
     const futureRoot = this.future._root;
@@ -47,20 +47,20 @@ export class PreActivation {
 
   checkGuards(): Observable<boolean> {
     if (!this.isDeactivating() && !this.isActivating()) {
-      return of(true);
+      return of (true);
     }
     const canDeactivate$ = this.runCanDeactivateChecks();
     return canDeactivate$.pipe(mergeMap(
-      (canDeactivate: boolean) => canDeactivate ? this.runCanActivateChecks() : of(false)));
+        (canDeactivate: boolean) => canDeactivate ? this.runCanActivateChecks() : of (false)));
   }
 
-  resolveData(paramsInheritanceStrategy: 'emptyOnly' | 'always'): Observable<any> {
-    if (!this.isActivating()) return of(null);
+  resolveData(paramsInheritanceStrategy: 'emptyOnly'|'always'): Observable<any> {
+    if (!this.isActivating()) return of (null);
     return from(this.canActivateChecks)
-      .pipe(
-        concatMap(
-          (check: CanActivate) => this.runResolve(check.route, paramsInheritanceStrategy)),
-        reduce((_: any, __: any) => _));
+        .pipe(
+            concatMap(
+                (check: CanActivate) => this.runResolve(check.route, paramsInheritanceStrategy)),
+            reduce((_: any, __: any) => _));
   }
 
   isDeactivating(): boolean { return this.canDeactivateChecks.length !== 0; }
@@ -73,21 +73,21 @@ export class PreActivation {
    * proper state to run `checkGuards()` method.
    */
   private setupChildRouteGuards(
-    futureNode: TreeNode<ActivatedRouteSnapshot>, currNode: TreeNode<ActivatedRouteSnapshot> | null,
-    contexts: ChildrenOutletContexts | null, futurePath: ActivatedRouteSnapshot[]): void {
+      futureNode: TreeNode<ActivatedRouteSnapshot>, currNode: TreeNode<ActivatedRouteSnapshot>|null,
+      contexts: ChildrenOutletContexts|null, futurePath: ActivatedRouteSnapshot[]): void {
     const prevChildren = nodeChildrenAsMap(currNode);
 
     // Process the children of the future route
     futureNode.children.forEach(c => {
       this.setupRouteGuards(
-        c, prevChildren[c.value.outlet], contexts, futurePath.concat([c.value]));
+          c, prevChildren[c.value.outlet], contexts, futurePath.concat([c.value]));
       delete prevChildren[c.value.outlet];
     });
 
     // Process any children left from the current route (not active for the future route)
     forEach(
-      prevChildren, (v: TreeNode<ActivatedRouteSnapshot>, k: string) =>
-        this.deactivateRouteAndItsChildren(v, contexts!.getContext(k)));
+        prevChildren, (v: TreeNode<ActivatedRouteSnapshot>, k: string) =>
+                          this.deactivateRouteAndItsChildren(v, contexts !.getContext(k)));
   }
 
   /**
@@ -95,8 +95,8 @@ export class PreActivation {
    * proper state to run `checkGuards()` method.
    */
   private setupRouteGuards(
-    futureNode: TreeNode<ActivatedRouteSnapshot>, currNode: TreeNode<ActivatedRouteSnapshot>,
-    parentContexts: ChildrenOutletContexts | null, futurePath: ActivatedRouteSnapshot[]): void {
+      futureNode: TreeNode<ActivatedRouteSnapshot>, currNode: TreeNode<ActivatedRouteSnapshot>,
+      parentContexts: ChildrenOutletContexts|null, futurePath: ActivatedRouteSnapshot[]): void {
     const future = futureNode.value;
     const curr = currNode ? currNode.value : null;
     const context = parentContexts ? parentContexts.getContext(futureNode.value.outlet) : null;
@@ -104,7 +104,7 @@ export class PreActivation {
     // reusing the node
     if (curr && future.routeConfig === curr.routeConfig) {
       const shouldRunGuardsAndResolvers = this.shouldRunGuardsAndResolvers(
-        curr, future, future.routeConfig!.runGuardsAndResolvers);
+          curr, future, future.routeConfig !.runGuardsAndResolvers);
       if (shouldRunGuardsAndResolvers) {
         this.canActivateChecks.push(new CanActivate(futurePath));
       } else {
@@ -116,7 +116,7 @@ export class PreActivation {
       // If we have a component, we need to go through an outlet.
       if (future.component) {
         this.setupChildRouteGuards(
-          futureNode, currNode, context ? context.children : null, futurePath);
+            futureNode, currNode, context ? context.children : null, futurePath);
 
         // if we have a componentless route, we recurse but keep the same outlet map.
       } else {
@@ -147,15 +147,15 @@ export class PreActivation {
   }
 
   private shouldRunGuardsAndResolvers(
-    curr: ActivatedRouteSnapshot, future: ActivatedRouteSnapshot,
-    mode: RunGuardsAndResolvers | undefined): boolean {
+      curr: ActivatedRouteSnapshot, future: ActivatedRouteSnapshot,
+      mode: RunGuardsAndResolvers|undefined): boolean {
     switch (mode) {
       case 'always':
         return true;
 
       case 'paramsOrQueryParamsChange':
         return !equalParamsAndUrlSegments(curr, future) ||
-          !shallowEqual(curr.queryParams, future.queryParams);
+            !shallowEqual(curr.queryParams, future.queryParams);
 
       case 'paramsChange':
       default:
@@ -164,7 +164,7 @@ export class PreActivation {
   }
 
   private deactivateRouteAndItsChildren(
-    route: TreeNode<ActivatedRouteSnapshot>, context: OutletContext | null): void {
+      route: TreeNode<ActivatedRouteSnapshot>, context: OutletContext|null): void {
     const children = nodeChildrenAsMap(route);
     const r = route.value;
 
@@ -189,20 +189,20 @@ export class PreActivation {
 
   private runCanDeactivateChecks(): Observable<boolean> {
     return from(this.canDeactivateChecks)
-      .pipe(
-        mergeMap((check: CanDeactivate) => this.runCanDeactivate(check.component, check.route)),
-        every((result: boolean) => result === true));
+        .pipe(
+            mergeMap((check: CanDeactivate) => this.runCanDeactivate(check.component, check.route)),
+            every((result: boolean) => result === true));
   }
 
   private runCanActivateChecks(): Observable<boolean> {
     return from(this.canActivateChecks)
-      .pipe(
-        concatMap((check: CanActivate) => andObservables(from([
-          this.fireChildActivationStart(check.route.parent),
-          this.fireActivationStart(check.route), this.runCanActivateChild(check.path),
-          this.runCanActivate(check.route)
-        ]))),
-        every((result: boolean) => result === true));
+        .pipe(
+            concatMap((check: CanActivate) => andObservables(from([
+                        this.fireChildActivationStart(check.route.parent),
+                        this.fireActivationStart(check.route), this.runCanActivateChild(check.path),
+                        this.runCanActivate(check.route)
+                      ]))),
+            every((result: boolean) => result === true));
     // this.fireChildActivationStart(check.path),
   }
 
@@ -214,11 +214,11 @@ export class PreActivation {
    * return
    * `true` so checks continue to run.
    */
-  private fireActivationStart(snapshot: ActivatedRouteSnapshot | null): Observable<boolean> {
+  private fireActivationStart(snapshot: ActivatedRouteSnapshot|null): Observable<boolean> {
     if (snapshot !== null && this.forwardEvent) {
       this.forwardEvent(new ActivationStart(snapshot));
     }
-    return of(true);
+    return of (true);
   }
 
   /**
@@ -229,16 +229,16 @@ export class PreActivation {
    * return
    * `true` so checks continue to run.
    */
-  private fireChildActivationStart(snapshot: ActivatedRouteSnapshot | null): Observable<boolean> {
+  private fireChildActivationStart(snapshot: ActivatedRouteSnapshot|null): Observable<boolean> {
     if (snapshot !== null && this.forwardEvent) {
       this.forwardEvent(new ChildActivationStart(snapshot));
     }
-    return of(true);
+    return of (true);
   }
 
   private runCanActivate(future: ActivatedRouteSnapshot): Observable<boolean> {
     const canActivate = future.routeConfig ? future.routeConfig.canActivate : null;
-    if (!canActivate || canActivate.length === 0) return of(true);
+    if (!canActivate || canActivate.length === 0) return of (true);
     const obs = from(canActivate).pipe(map((c: any) => {
       const guard = this.getToken(c, future);
       let observable: Observable<boolean>;
@@ -256,9 +256,9 @@ export class PreActivation {
     const future = path[path.length - 1];
 
     const canActivateChildGuards = path.slice(0, path.length - 1)
-      .reverse()
-      .map(p => this.extractCanActivateChild(p))
-      .filter(_ => _ !== null);
+                                       .reverse()
+                                       .map(p => this.extractCanActivateChild(p))
+                                       .filter(_ => _ !== null);
 
     return andObservables(from(canActivateChildGuards).pipe(map((d: any) => {
       const obs = from(d.guards).pipe(map((c: any) => {
@@ -275,22 +275,23 @@ export class PreActivation {
     })));
   }
 
-  private extractCanActivateChild(p: ActivatedRouteSnapshot): { node: ActivatedRouteSnapshot, guards: any[] } | null {
+  private extractCanActivateChild(p: ActivatedRouteSnapshot):
+      {node: ActivatedRouteSnapshot, guards: any[]}|null {
     const canActivateChild = p.routeConfig ? p.routeConfig.canActivateChild : null;
     if (!canActivateChild || canActivateChild.length === 0) return null;
-    return { node: p, guards: canActivateChild };
+    return {node: p, guards: canActivateChild};
   }
 
-  private runCanDeactivate(component: Object | null, curr: ActivatedRouteSnapshot):
-    Observable<boolean> {
+  private runCanDeactivate(component: Object|null, curr: ActivatedRouteSnapshot):
+      Observable<boolean> {
     const canDeactivate = curr && curr.routeConfig ? curr.routeConfig.canDeactivate : null;
-    if (!canDeactivate || canDeactivate.length === 0) return of(true);
+    if (!canDeactivate || canDeactivate.length === 0) return of (true);
     const canDeactivate$ = from(canDeactivate).pipe(mergeMap((c: any) => {
       const guard = this.getToken(c, curr);
       let observable: Observable<boolean>;
       if (guard.canDeactivate) {
         observable =
-          wrapIntoObservable(guard.canDeactivate(component, curr, this.curr, this.future));
+            wrapIntoObservable(guard.canDeactivate(component, curr, this.curr, this.future));
       } else {
         observable = wrapIntoObservable(guard(component, curr, this.curr, this.future));
       }
@@ -300,15 +301,13 @@ export class PreActivation {
   }
 
   private runResolve(
-    future: ActivatedRouteSnapshot,
-    paramsInheritanceStrategy: 'emptyOnly' | 'always'): Observable<any> {
+      future: ActivatedRouteSnapshot,
+      paramsInheritanceStrategy: 'emptyOnly'|'always'): Observable<any> {
     const resolve = future._resolve;
     return this.resolveNode(resolve, future).pipe(map((resolvedData: any): any => {
       future._resolvedData = resolvedData;
-      future.data = {
-        ...future.data,
-        ...inheritedParamsDataResolve(future, paramsInheritanceStrategy).resolve
-      };
+      future.data = {...future.data,
+                     ...inheritedParamsDataResolve(future, paramsInheritanceStrategy).resolve};
       return null;
     }));
   }
@@ -316,15 +315,15 @@ export class PreActivation {
   private resolveNode(resolve: ResolveData, future: ActivatedRouteSnapshot): Observable<any> {
     const keys = Object.keys(resolve);
     if (keys.length === 0) {
-      return of({});
+      return of ({});
     }
     if (keys.length === 1) {
       const key = keys[0];
       return this.getResolver(resolve[key], future).pipe(map((value: any) => {
-        return { [key]: value };
+        return {[key]: value};
       }));
     }
-    const data: { [k: string]: any } = {};
+    const data: {[k: string]: any} = {};
     const runningResolvers$ = from(keys).pipe(mergeMap((key: string) => {
       return this.getResolver(resolve[key], future).pipe(map((value: any) => {
         data[key] = value;
@@ -337,7 +336,7 @@ export class PreActivation {
   private getResolver(injectionToken: any, future: ActivatedRouteSnapshot): Observable<any> {
     const resolver = this.getToken(injectionToken, future);
     return resolver.resolve ? wrapIntoObservable(resolver.resolve(future, this.future)) :
-      wrapIntoObservable(resolver(future, this.future));
+                              wrapIntoObservable(resolver(future, this.future));
   }
 
   private getToken(token: any, snapshot: ActivatedRouteSnapshot): any {
@@ -348,7 +347,7 @@ export class PreActivation {
 }
 
 
-function closestLoadedConfig(snapshot: ActivatedRouteSnapshot): LoadedRouterConfig | null {
+function closestLoadedConfig(snapshot: ActivatedRouteSnapshot): LoadedRouterConfig|null {
   if (!snapshot) return null;
 
   for (let s = snapshot.parent; s; s = s.parent) {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -9,11 +9,11 @@
 import {CommonModule, Location} from '@angular/common';
 import {SpyLocation} from '@angular/common/testing';
 import {ChangeDetectionStrategy, Component, Injectable, NgModule, NgModuleFactoryLoader, NgModuleRef, NgZone, OnDestroy, ɵConsole as Console, ɵNoopNgZone as NoopNgZone} from '@angular/core';
-import {ComponentFixture, TestBed, fakeAsync, inject, tick} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, PRIMARY_OUTLET, ParamMap, Params, PreloadAllModules, PreloadingStrategy, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouteReuseStrategy, Router, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
-import {Observable, Observer, Subscription, of } from 'rxjs';
+import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ParamMap, Params, PreloadAllModules, PreloadingStrategy, PRIMARY_OUTLET, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, Router, RouteReuseStrategy, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
+import {Observable, Observer, of, Subscription} from 'rxjs';
 import {filter, map} from 'rxjs/operators';
 
 import {forEach} from '../src/utils/collection';
@@ -94,8 +94,8 @@ describe('Integration', () => {
          router.navigateByUrl('/simple');
          tick();
 
-         expect(event !.navigationTrigger).toEqual('imperative');
-         expect(event !.restoredState).toEqual(null);
+         expect(event!.navigationTrigger).toEqual('imperative');
+         expect(event!.restoredState).toEqual(null);
        })));
 
     it('should not pollute browser history when replaceUrl is set to true',
@@ -161,7 +161,9 @@ describe('Integration', () => {
     let warnings: string[] = [];
 
     class MockConsole {
-      warn(message: string) { warnings.push(message); }
+      warn(message: string) {
+        warnings.push(message);
+      }
     }
 
     beforeEach(() => {
@@ -172,7 +174,9 @@ describe('Integration', () => {
     describe('with NgZone enabled', () => {
       it('should warn when triggered outside Angular zone',
          fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-           ngZone.runOutsideAngular(() => { router.navigateByUrl('/simple'); });
+           ngZone.runOutsideAngular(() => {
+             router.navigateByUrl('/simple');
+           });
 
            expect(warnings.length).toBe(1);
            expect(warnings[0])
@@ -182,19 +186,24 @@ describe('Integration', () => {
 
       it('should not warn when triggered inside Angular zone',
          fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-           ngZone.run(() => { router.navigateByUrl('/simple'); });
+           ngZone.run(() => {
+             router.navigateByUrl('/simple');
+           });
 
            expect(warnings.length).toBe(0);
          })));
     });
 
     describe('with NgZone disabled', () => {
-      beforeEach(() => { TestBed.overrideProvider(NgZone, {useValue: new NoopNgZone()}); });
+      beforeEach(() => {
+        TestBed.overrideProvider(NgZone, {useValue: new NoopNgZone()});
+      });
 
       it('should not warn when triggered outside Angular zone',
          fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-
-           ngZone.runOutsideAngular(() => { router.navigateByUrl('/simple'); });
+           ngZone.runOutsideAngular(() => {
+             router.navigateByUrl('/simple');
+           });
 
            expect(warnings.length).toBe(0);
          })));
@@ -237,18 +246,24 @@ describe('Integration', () => {
       @Component({template: '<router-outlet></router-outlet>'})
       class Parent {
         constructor(route: ActivatedRoute) {
-          route.params.subscribe((s: any) => { log.push(s); });
+          route.params.subscribe((s: any) => {
+            log.push(s);
+          });
         }
       }
 
       @Component({template: 'child1'})
       class Child1 {
-        ngOnDestroy() { log.push('child1 destroy'); }
+        ngOnDestroy() {
+          log.push('child1 destroy');
+        }
       }
 
       @Component({template: 'child2'})
       class Child2 {
-        constructor() { log.push('child2 constructor'); }
+        constructor() {
+          log.push('child2 constructor');
+        }
       }
 
       @NgModule({
@@ -288,7 +303,6 @@ describe('Integration', () => {
              'child2 constructor',
            ]);
          })));
-
     });
 
     it('should execute navigations serialy',
@@ -376,11 +390,9 @@ describe('Integration', () => {
      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
        const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{
-         path: 'team/:id',
-         component: TeamCmp,
-         children: [{path: 'simple', component: SimpleCmp}]
-       }]);
+       router.resetConfig([
+         {path: 'team/:id', component: TeamCmp, children: [{path: 'simple', component: SimpleCmp}]}
+       ]);
 
        router.navigateByUrl('/team/33/simple');
        advance(fixture);
@@ -447,7 +459,9 @@ describe('Integration', () => {
        @Component({template: `record`})
        class RecordLocationCmp {
          private storedPath: string;
-         constructor(loc: Location) { this.storedPath = loc.path(); }
+         constructor(loc: Location) {
+           this.storedPath = loc.path();
+         }
        }
 
        @NgModule({declarations: [RecordLocationCmp], entryComponents: [RecordLocationCmp]})
@@ -533,7 +547,7 @@ describe('Integration', () => {
        (router as any).hooks.beforePreactivation = () => {
          expect(location.path()).toEqual('/team/33');
          expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
-         return of (null);
+         return of(null);
        };
        router.navigateByUrl('/team/33');
 
@@ -562,24 +576,24 @@ describe('Integration', () => {
        router.navigateByUrl('/team/33/simple');
        advance(fixture);
        expect(location.path()).toEqual('/team/33/simple');
-       const simpleNavStart = event !;
+       const simpleNavStart = event!;
 
        router.navigateByUrl('/team/22/user/victor');
        advance(fixture);
-       const userVictorNavStart = event !;
+       const userVictorNavStart = event!;
 
 
        location.back();
        advance(fixture);
        expect(location.path()).toEqual('/team/33/simple');
-       expect(event !.navigationTrigger).toEqual('hashchange');
-       expect(event !.restoredState !.navigationId).toEqual(simpleNavStart.id);
+       expect(event!.navigationTrigger).toEqual('hashchange');
+       expect(event!.restoredState!.navigationId).toEqual(simpleNavStart.id);
 
        location.forward();
        advance(fixture);
        expect(location.path()).toEqual('/team/22/user/victor');
-       expect(event !.navigationTrigger).toEqual('hashchange');
-       expect(event !.restoredState !.navigationId).toEqual(userVictorNavStart.id);
+       expect(event!.navigationTrigger).toEqual('hashchange');
+       expect(event!.restoredState!.navigationId).toEqual(userVictorNavStart.id);
      })));
 
   it('should navigate to the same url when config changes',
@@ -871,8 +885,8 @@ describe('Integration', () => {
        const user = fixture.debugElement.children[1].componentInstance;
 
        let r1: any, r2: any;
-       router.navigateByUrl('/user/victor') !.then(_ => r1 = _);
-       router.navigateByUrl('/user/fedor') !.then(_ => r2 = _);
+       router.navigateByUrl('/user/victor')!.then(_ => r1 = _);
+       router.navigateByUrl('/user/fedor')!.then(_ => r2 = _);
        advance(fixture);
 
        expect(r1).toEqual(false);  // returns false because it was canceled
@@ -920,7 +934,7 @@ describe('Integration', () => {
        router.events.forEach(e => recordedEvents.push(e));
 
        let e: any;
-       router.navigateByUrl('/invalid') !.catch(_ => e = _);
+       router.navigateByUrl('/invalid')!.catch(_ => e = _);
        advance(fixture);
        expect(e.message).toContain('Cannot match any routes');
 
@@ -990,7 +1004,7 @@ describe('Integration', () => {
 
          router.navigateByUrl('/simple1');
          advance(fixture);
-         const simple1NavStart = event !;
+         const simple1NavStart = event!;
 
          router.navigateByUrl('/throwing').catch(() => null);
          advance(fixture);
@@ -1001,7 +1015,7 @@ describe('Integration', () => {
          location.back();
          tick();
 
-         expect(event !.restoredState !.navigationId).toEqual(simple1NavStart.id);
+         expect(event!.restoredState!.navigationId).toEqual(simple1NavStart.id);
        }));
 
     it('should not trigger another navigation when resetting the url back due to a NavigationError',
@@ -1031,7 +1045,6 @@ describe('Integration', () => {
          // we do not trigger another navigation to /simple
          expect(events).toEqual(['/simple', '/throwing']);
        }));
-
   });
 
   it('should dispatch NavigationCancel after the url has been reset back', fakeAsync(() => {
@@ -1077,7 +1090,7 @@ describe('Integration', () => {
        router.events.forEach(e => recordedEvents.push(e));
 
        let e: any;
-       router.navigateByUrl('/invalid') !.then(_ => e = _);
+       router.navigateByUrl('/invalid')!.then(_ => e = _);
        advance(fixture);
        expect(e).toEqual('resolvedValue');
 
@@ -1096,8 +1109,9 @@ describe('Integration', () => {
   it('should support custom malformed uri error handler',
      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
        const customMalformedUriErrorHandler =
-           (e: URIError, urlSerializer: UrlSerializer, url: string):
-               UrlTree => { return urlSerializer.parse('/?error=The-URL-you-went-to-is-invalid'); };
+           (e: URIError, urlSerializer: UrlSerializer, url: string): UrlTree => {
+             return urlSerializer.parse('/?error=The-URL-you-went-to-is-invalid');
+           };
        router.malformedUriErrorHandler = customMalformedUriErrorHandler;
 
        router.resetConfig([{path: 'simple', component: SimpleCmp}]);
@@ -1218,9 +1232,13 @@ describe('Integration', () => {
          activations: any[] = [];
          deactivations: any[] = [];
 
-         recordActivate(component: any): void { this.activations.push(component); }
+         recordActivate(component: any): void {
+           this.activations.push(component);
+         }
 
-         recordDeactivate(component: any): void { this.deactivations.push(component); }
+         recordDeactivate(component: any): void {
+           this.deactivations.push(component);
+         }
        }
 
        TestBed.configureTestingModule({declarations: [Container]});
@@ -1253,7 +1271,6 @@ describe('Integration', () => {
 
   it('should update url and router state before activating components',
      fakeAsync(inject([Router], (router: Router) => {
-
        const fixture = createRoot(router, RootCmp);
 
        router.resetConfig([{path: 'cmp', component: ComponentRecordingRoutePathAndUrl}]);
@@ -1271,7 +1288,9 @@ describe('Integration', () => {
 
   describe('data', () => {
     class ResolveSix implements Resolve<number> {
-      resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): number { return 6; }
+      resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): number {
+        return 6;
+      }
     }
 
     beforeEach(() => {
@@ -1337,7 +1356,7 @@ describe('Integration', () => {
          router.events.subscribe(e => e instanceof RouterEvent && recordedEvents.push(e));
 
          let e: any = null;
-         router.navigateByUrl('/simple') !.catch(error => e = error);
+         router.navigateByUrl('/simple')!.catch(error => e = error);
          advance(fixture);
 
          expectEvents(recordedEvents, [
@@ -1431,7 +1450,7 @@ describe('Integration', () => {
             {
               provide: 'resolver2',
               useValue: () => {
-                return of (null).pipe(map(() => {
+                return of(null).pipe(map(() => {
                   log.push('resolver2');
                   observer.next(null);
                   observer.complete();
@@ -1500,9 +1519,8 @@ describe('Integration', () => {
          router.resetConfig([{
            path: 'team/:id',
            component: TeamCmp,
-           children: [
-             {path: 'link', component: StringLinkCmp}, {path: 'simple', component: SimpleCmp}
-           ]
+           children:
+               [{path: 'link', component: StringLinkCmp}, {path: 'simple', component: SimpleCmp}]
          }]);
 
          router.navigateByUrl('/team/22/link');
@@ -1561,7 +1579,6 @@ describe('Integration', () => {
        }));
 
     it('should update hrefs when query params or fragment change', fakeAsync(() => {
-
          @Component({
            selector: 'someRoot',
            template:
@@ -1591,7 +1608,6 @@ describe('Integration', () => {
        }));
 
     it('should correctly use the preserve strategy', fakeAsync(() => {
-
          @Component({
            selector: 'someRoot',
            template:
@@ -1613,7 +1629,6 @@ describe('Integration', () => {
        }));
 
     it('should correctly use the merge strategy', fakeAsync(() => {
-
          @Component({
            selector: 'someRoot',
            template:
@@ -1641,8 +1656,7 @@ describe('Integration', () => {
            path: 'team/:id',
            component: TeamCmp,
            children: [
-             {path: 'link', component: StringLinkButtonCmp},
-             {path: 'simple', component: SimpleCmp}
+             {path: 'link', component: StringLinkButtonCmp}, {path: 'simple', component: SimpleCmp}
            ]
          }]);
 
@@ -1664,9 +1678,8 @@ describe('Integration', () => {
          router.resetConfig([{
            path: 'team/:id',
            component: TeamCmp,
-           children: [
-             {path: 'link', component: AbsoluteLinkCmp}, {path: 'simple', component: SimpleCmp}
-           ]
+           children:
+               [{path: 'link', component: AbsoluteLinkCmp}, {path: 'simple', component: SimpleCmp}]
          }]);
 
          router.navigateByUrl('/team/22/link');
@@ -1687,9 +1700,8 @@ describe('Integration', () => {
          router.resetConfig([{
            path: 'team/:id',
            component: TeamCmp,
-           children: [
-             {path: 'link', component: RelativeLinkCmp}, {path: 'simple', component: SimpleCmp}
-           ]
+           children:
+               [{path: 'link', component: RelativeLinkCmp}, {path: 'simple', component: SimpleCmp}]
          }]);
 
          router.navigateByUrl('/team/22/link');
@@ -1865,25 +1877,19 @@ describe('Integration', () => {
 
       describe('should activate a child wildcard route router outlet has yet to be mounted', () => {
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
-            router.resetConfig([{
-                path: 'teams',
-                component: BlankCmp,
-                children: [{
-                    path: ':team-id',
-                    children: [{
-                        path: '**',
-                        component: BlankCmp
-                    }]
-                }]
-            }]);
-            router.navigateByUrl('/teams/22/members');
-            advance(fixture);
-            expect(location.path()).toEqual('/teams/22/members');
-            router.navigateByUrl('/teams/22/manage');
-            advance(fixture);
-            expect(location.path()).toEqual('/teams/22/manage');
-        })));
+             const fixture = createRoot(router, RootCmp);
+             router.resetConfig([{
+               path: 'teams',
+               component: BlankCmp,
+               children: [{path: ':team-id', children: [{path: '**', component: BlankCmp}]}]
+             }]);
+             router.navigateByUrl('/teams/22/members');
+             advance(fixture);
+             expect(location.path()).toEqual('/teams/22/members');
+             router.navigateByUrl('/teams/22/manage');
+             advance(fixture);
+             expect(location.path()).toEqual('/teams/22/manage');
+           })));
       });
 
       describe('should activate a route when CanActivate returns true', () => {
@@ -1916,7 +1922,9 @@ describe('Integration', () => {
           }
         }
 
-        beforeEach(() => { TestBed.configureTestingModule({providers: [AlwaysTrue]}); });
+        beforeEach(() => {
+          TestBed.configureTestingModule({providers: [AlwaysTrue]});
+        });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
              const fixture = createRoot(router, RootCmp);
@@ -1937,7 +1945,9 @@ describe('Integration', () => {
             providers: [{
               provide: 'CanActivate',
               useValue: (a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-                return Observable.create((observer: any) => { observer.next(false); });
+                return Observable.create((observer: any) => {
+                  observer.next(false);
+                });
               }
             }]
           });
@@ -1994,7 +2004,9 @@ describe('Integration', () => {
           TestBed.configureTestingModule({
             providers: [{
               provide: 'alwaysFalse',
-              useValue: (a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => { return false; }
+              useValue: (a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
+                return false;
+              }
             }]
           });
         });
@@ -2014,7 +2026,6 @@ describe('Integration', () => {
              location.go('/two');
              advance(fixture);
              expect(location.path()).toEqual('/one');
-
            })));
       });
 
@@ -2264,14 +2275,15 @@ describe('Integration', () => {
             {
               provide: 'RecordingDeactivate',
               useValue: (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-                log.push({path: a.routeConfig !.path, component: c});
+                log.push({path: a.routeConfig!.path, component: c});
                 return true;
               }
             },
             {
               provide: 'alwaysFalse',
-              useValue:
-                  (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => { return false; }
+              useValue: (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
+                return false;
+              }
             },
             {
               provide: 'alwaysFalseAndLogging',
@@ -2313,13 +2325,13 @@ describe('Integration', () => {
              expect(location.path()).toEqual('/team/22');
 
              let successStatus: boolean = false;
-             router.navigateByUrl('/team/33') !.then(res => successStatus = res);
+             router.navigateByUrl('/team/33')!.then(res => successStatus = res);
              advance(fixture);
              expect(location.path()).toEqual('/team/33');
              expect(successStatus).toEqual(true);
 
              let canceledStatus: boolean = false;
-             router.navigateByUrl('/team/44') !.then(res => canceledStatus = res);
+             router.navigateByUrl('/team/44')!.then(res => canceledStatus = res);
              advance(fixture);
              expect(location.path()).toEqual('/team/33');
              expect(canceledStatus).toEqual(false);
@@ -2521,11 +2533,12 @@ describe('Integration', () => {
             providers: [
               ClassWithNextState, {
                 provide: 'FunctionWithNextState',
-                useValue: (cmp: any, currentRoute: ActivatedRouteSnapshot,
-                           currentState: RouterStateSnapshot, nextState: RouterStateSnapshot) => {
-                  log.push(currentState.url, nextState.url);
-                  return true;
-                }
+                useValue:
+                    (cmp: any, currentRoute: ActivatedRouteSnapshot,
+                     currentState: RouterStateSnapshot, nextState: RouterStateSnapshot) => {
+                      log.push(currentState.url, nextState.url);
+                      return true;
+                    }
               }
             ]
           });
@@ -2576,7 +2589,9 @@ describe('Integration', () => {
           }
         }
 
-        beforeEach(() => { TestBed.configureTestingModule({providers: [AlwaysTrue]}); });
+        beforeEach(() => {
+          TestBed.configureTestingModule({providers: [AlwaysTrue]});
+        });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
              const fixture = createRoot(router, RootCmp);
@@ -2601,7 +2616,9 @@ describe('Integration', () => {
             providers: [{
               provide: 'CanDeactivate',
               useValue: (c: TeamCmp, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-                return Observable.create((observer: any) => { observer.next(false); });
+                return Observable.create((observer: any) => {
+                  observer.next(false);
+                });
               }
             }]
           });
@@ -2649,7 +2666,7 @@ describe('Integration', () => {
 
              expect(location.path()).toEqual('/team/22');
 
-             router.navigateByUrl('/team/33') !.catch(() => {});
+             router.navigateByUrl('/team/33')!.catch(() => {});
              advance(fixture);
 
              expect(location.path()).toEqual('/team/22');
@@ -2660,7 +2677,6 @@ describe('Integration', () => {
          fakeAsync(inject(
              [Router, Location, NgModuleFactoryLoader],
              (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-
                @Component({selector: 'admin', template: '<router-outlet></router-outlet>'})
                class AdminComponent {
                }
@@ -2728,7 +2744,6 @@ describe('Integration', () => {
          fakeAsync(inject(
              [Router, Location, NgModuleFactoryLoader],
              (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-
                @Component({selector: 'lazy', template: 'lazy-loaded'})
                class LazyLoadedComponent {
                }
@@ -2796,7 +2811,6 @@ describe('Integration', () => {
 
       it('should support navigating from within the guard',
          fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-
            const fixture = createRoot(router, RootCmp);
 
            router.resetConfig([
@@ -2830,7 +2844,6 @@ describe('Integration', () => {
          fakeAsync(inject(
              [Router, Location, NgModuleFactoryLoader],
              (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-
                @Component({selector: 'lazy', template: 'lazy-loaded'})
                class LazyLoadedComponent {
                }
@@ -2865,10 +2878,11 @@ describe('Integration', () => {
     });
 
     describe('order', () => {
-
       class Logger {
         logs: string[] = [];
-        add(thing: string) { this.logs.push(thing); }
+        add(thing: string) {
+          this.logs.push(thing);
+        }
       }
 
       beforeEach(() => {
@@ -2999,8 +3013,7 @@ describe('Integration', () => {
            children: [{
              path: 'link',
              component: DummyLinkCmp,
-             children:
-                 [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
+             children: [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
            }]
          }]);
 
@@ -3056,8 +3069,7 @@ describe('Integration', () => {
            children: [{
              path: 'link',
              component: DummyLinkWithParentCmp,
-             children:
-                 [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
+             children: [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
            }]
          }]);
 
@@ -3085,8 +3097,7 @@ describe('Integration', () => {
            children: [{
              path: 'link',
              component: DummyLinkCmp,
-             children:
-                 [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
+             children: [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
            }]
          }]);
 
@@ -3143,7 +3154,6 @@ describe('Integration', () => {
          advance(fixture);
          expect(paragraph.textContent).toEqual('false');
        }));
-
   });
 
   describe('lazy loading', () => {
@@ -3246,8 +3256,8 @@ describe('Integration', () => {
              expect(location.path()).toEqual('/lazy/parent/child');
              expect(fixture.nativeElement).toHaveText('parent[child]');
 
-             const pInj = fixture.debugElement.query(By.directive(Parent)).injector !;
-             const cInj = fixture.debugElement.query(By.directive(Child)).injector !;
+             const pInj = fixture.debugElement.query(By.directive(Parent)).injector!;
+             const cInj = fixture.debugElement.query(By.directive(Child)).injector!;
 
              expect(pInj.get('moduleName')).toEqual('parent');
              expect(pInj.get('fromParent')).toEqual('from parent');
@@ -3301,7 +3311,9 @@ describe('Integration', () => {
              })
              class LoadedModule {
                static instances = 0;
-               constructor() { LoadedModule.instances++; }
+               constructor() {
+                 LoadedModule.instances++;
+               }
              }
 
              loader.stubbedModules = {expected: LoadedModule};
@@ -3433,7 +3445,7 @@ describe('Integration', () => {
              router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
 
              let recordedError: any = null;
-             router.navigateByUrl('/lazy/loaded') !.catch(err => recordedError = err);
+             router.navigateByUrl('/lazy/loaded')!.catch(err => recordedError = err);
              advance(fixture);
              expect(recordedError.message)
                  .toEqual(
@@ -3490,7 +3502,6 @@ describe('Integration', () => {
     it('should allow lazy loaded module in named outlet',
        fakeAsync(inject(
            [Router, NgModuleFactoryLoader], (router: Router, loader: SpyNgModuleFactoryLoader) => {
-
              @Component({selector: 'lazy', template: 'lazy-loaded'})
              class LazyComponent {
              }
@@ -3530,7 +3541,6 @@ describe('Integration', () => {
     it('should allow componentless named outlet to render children',
        fakeAsync(inject(
            [Router, NgModuleFactoryLoader], (router: Router, loader: SpyNgModuleFactoryLoader) => {
-
              const fixture = createRoot(router, RootCmp);
 
              router.resetConfig([{
@@ -3581,7 +3591,7 @@ describe('Integration', () => {
             lazyService: LazyLoadedServiceDefinedInModule,  // should be able to inject lazy service
             eager:
                 EagerParentComponent  // should use the injector of the location to create a parent
-            ) {}
+        ) {}
       }
 
       @NgModule({
@@ -3672,7 +3682,7 @@ describe('Integration', () => {
              const recordedEvents: any[] = [];
              router.events.forEach(e => recordedEvents.push(e));
 
-             router.navigateByUrl('/lazy/loaded') !.catch(s => {});
+             router.navigateByUrl('/lazy/loaded')!.catch(s => {});
              advance(fixture);
 
              expect(location.path()).toEqual('/');
@@ -3781,16 +3791,15 @@ describe('Integration', () => {
                advance(fixture);
 
                const config = router.config as any;
-               const firstConfig = config[1]._loadedConfig !;
+               const firstConfig = config[1]._loadedConfig!;
 
                expect(firstConfig).toBeDefined();
                expect(firstConfig.routes[0].path).toEqual('LoadedModule1');
 
-               const secondConfig = firstConfig.routes[0]._loadedConfig !;
+               const secondConfig = firstConfig.routes[0]._loadedConfig!;
                expect(secondConfig).toBeDefined();
                expect(secondConfig.routes[0].path).toEqual('LoadedModule2');
              })));
-
     });
 
     describe('custom url handling strategies', () => {
@@ -3840,9 +3849,8 @@ describe('Integration', () => {
            router.resetConfig([{
              path: 'include',
              component: TeamCmp,
-             children: [
-               {path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}
-             ]
+             children:
+                 [{path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}]
            }]);
 
            const events: any[] = [];
@@ -3904,9 +3912,8 @@ describe('Integration', () => {
            router.resetConfig([{
              path: 'include',
              component: TeamCmp,
-             children: [
-               {path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}
-             ]
+             children:
+                 [{path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}]
            }]);
 
            const events: any[] = [];
@@ -3947,19 +3954,19 @@ describe('Integration', () => {
       stored: {[k: string]: DetachedRouteHandle} = {};
 
       shouldDetach(route: ActivatedRouteSnapshot): boolean {
-        return route.routeConfig !.path === 'a';
+        return route.routeConfig!.path === 'a';
       }
 
       store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void {
-        this.stored[route.routeConfig !.path !] = detachedTree;
+        this.stored[route.routeConfig!.path!] = detachedTree;
       }
 
       shouldAttach(route: ActivatedRouteSnapshot): boolean {
-        return !!this.stored[route.routeConfig !.path !];
+        return !!this.stored[route.routeConfig!.path!];
       }
 
       retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle {
-        return this.stored[route.routeConfig !.path !];
+        return this.stored[route.routeConfig!.path!];
       }
 
       shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
@@ -3968,10 +3975,16 @@ describe('Integration', () => {
     }
 
     class ShortLifecycle implements RouteReuseStrategy {
-      shouldDetach(route: ActivatedRouteSnapshot): boolean { return false; }
+      shouldDetach(route: ActivatedRouteSnapshot): boolean {
+        return false;
+      }
       store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void {}
-      shouldAttach(route: ActivatedRouteSnapshot): boolean { return false; }
-      retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle|null { return null; }
+      shouldAttach(route: ActivatedRouteSnapshot): boolean {
+        return false;
+      }
+      retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle|null {
+        return null;
+      }
       shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
         if (future.routeConfig !== curr.routeConfig) {
           return false;
@@ -4065,7 +4078,9 @@ describe('Integration', () => {
                              !!router.parseUrl(router.url).root.children['toolpanel']);
            }
 
-           public ngOnDestroy(): void { this.subscription.unsubscribe(); }
+           public ngOnDestroy(): void {
+             this.subscription.unsubscribe();
+           }
          }
 
          @Component({selector: 'tool-1-cmp', template: 'Tool 1 showing'})
@@ -4137,7 +4152,6 @@ describe('Testing router options', () => {
   });
 
   describe('malformedUriErrorHandler', () => {
-
     function malformedUriErrorHandler(e: URIError, urlSerializer: UrlSerializer, url: string) {
       return urlSerializer.parse('/error');
     }
@@ -4328,7 +4342,9 @@ class OutletInNgIf {
 })
 class DummyLinkWithParentCmp {
   private exact: boolean;
-  constructor(route: ActivatedRoute) { this.exact = (<any>route.snapshot.params).exact === 'true'; }
+  constructor(route: ActivatedRoute) {
+    this.exact = (<any>route.snapshot.params).exact === 'true';
+  }
 }
 
 @Component({selector: 'cmp', template: ''})
@@ -4350,7 +4366,9 @@ class RootCmp {
 class RootCmpWithOnInit {
   constructor(private router: Router) {}
 
-  ngOnInit(): void { this.router.navigate(['one']); }
+  ngOnInit(): void {
+    this.router.navigate(['one']);
+  }
 }
 
 @Component({
@@ -4363,7 +4381,9 @@ class RootCmpWithTwoOutlets {
 
 @Component({selector: 'throwing-cmp', template: ''})
 class ThrowingCmp {
-  constructor() { throw new Error('Throwing Cmp'); }
+  constructor() {
+    throw new Error('Throwing Cmp');
+  }
 }
 
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -6,155 +6,155 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CommonModule, Location} from '@angular/common';
-import {SpyLocation} from '@angular/common/testing';
-import {ChangeDetectionStrategy, Component, Injectable, NgModule, NgModuleFactoryLoader, NgModuleRef, NgZone, OnDestroy, ɵConsole as Console, ɵNoopNgZone as NoopNgZone} from '@angular/core';
-import {ComponentFixture, TestBed, fakeAsync, inject, tick} from '@angular/core/testing';
-import {By} from '@angular/platform-browser/src/dom/debug/by';
-import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, PRIMARY_OUTLET, ParamMap, Params, PreloadAllModules, PreloadingStrategy, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouteReuseStrategy, Router, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
-import {Observable, Observer, Subscription, of } from 'rxjs';
-import {filter, map} from 'rxjs/operators';
+import { CommonModule, Location } from '@angular/common';
+import { SpyLocation } from '@angular/common/testing';
+import { ChangeDetectionStrategy, Component, Injectable, NgModule, NgModuleFactoryLoader, NgModuleRef, NgZone, OnDestroy, ɵConsole as Console, ɵNoopNgZone as NoopNgZone } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, inject, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser/src/dom/debug/by';
+import { expect } from '@angular/platform-browser/testing/src/matchers';
+import { ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, PRIMARY_OUTLET, ParamMap, Params, PreloadAllModules, PreloadingStrategy, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouteReuseStrategy, Router, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree } from '@angular/router';
+import { Observable, Observer, Subscription, of } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
 
-import {forEach} from '../src/utils/collection';
-import {RouterTestingModule, SpyNgModuleFactoryLoader} from '../testing';
+import { forEach } from '../src/utils/collection';
+import { RouterTestingModule, SpyNgModuleFactoryLoader } from '../testing';
 
 describe('Integration', () => {
-  const noopConsole: Console = {log() {}, warn() {}};
+  const noopConsole: Console = { log() { }, warn() { } };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports:
-          [RouterTestingModule.withRoutes([{path: 'simple', component: SimpleCmp}]), TestModule],
-      providers: [{provide: Console, useValue: noopConsole}]
+        [RouterTestingModule.withRoutes([{ path: 'simple', component: SimpleCmp }]), TestModule],
+      providers: [{ provide: Console, useValue: noopConsole }]
     });
   });
 
   it('should navigate with a provided config',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       const fixture = createRoot(router, RootCmp);
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      const fixture = createRoot(router, RootCmp);
 
-       router.navigateByUrl('/simple');
-       advance(fixture);
+      router.navigateByUrl('/simple');
+      advance(fixture);
 
-       expect(location.path()).toEqual('/simple');
-     })));
+      expect(location.path()).toEqual('/simple');
+    })));
 
   it('should navigate from ngOnInit hook',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       router.resetConfig([
-         {path: '', component: SimpleCmp},
-         {path: 'one', component: RouteCmp},
-       ]);
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      router.resetConfig([
+        { path: '', component: SimpleCmp },
+        { path: 'one', component: RouteCmp },
+      ]);
 
-       const fixture = createRoot(router, RootCmpWithOnInit);
-       expect(location.path()).toEqual('/one');
-       expect(fixture.nativeElement).toHaveText('route');
-     })));
+      const fixture = createRoot(router, RootCmpWithOnInit);
+      expect(location.path()).toEqual('/one');
+      expect(fixture.nativeElement).toHaveText('route');
+    })));
 
-  describe('navigation', function() {
+  describe('navigation', function () {
     it('should navigate to the current URL', fakeAsync(inject([Router], (router: Router) => {
-         router.onSameUrlNavigation = 'reload';
-         router.resetConfig([
-           {path: '', component: SimpleCmp},
-           {path: 'simple', component: SimpleCmp},
-         ]);
+      router.onSameUrlNavigation = 'reload';
+      router.resetConfig([
+        { path: '', component: SimpleCmp },
+        { path: 'simple', component: SimpleCmp },
+      ]);
 
-         const fixture = createRoot(router, RootCmp);
-         const events: Event[] = [];
-         router.events.subscribe(e => onlyNavigationStartAndEnd(e) && events.push(e));
+      const fixture = createRoot(router, RootCmp);
+      const events: Event[] = [];
+      router.events.subscribe(e => onlyNavigationStartAndEnd(e) && events.push(e));
 
-         router.navigateByUrl('/simple');
-         tick();
+      router.navigateByUrl('/simple');
+      tick();
 
-         router.navigateByUrl('/simple');
-         tick();
+      router.navigateByUrl('/simple');
+      tick();
 
-         expectEvents(events, [
-           [NavigationStart, '/simple'], [NavigationEnd, '/simple'], [NavigationStart, '/simple'],
-           [NavigationEnd, '/simple']
-         ]);
-       })));
+      expectEvents(events, [
+        [NavigationStart, '/simple'], [NavigationEnd, '/simple'], [NavigationStart, '/simple'],
+        [NavigationEnd, '/simple']
+      ]);
+    })));
 
     it('should set the restoredState to null when executing imperative navigations',
-       fakeAsync(inject([Router], (router: Router) => {
-         router.resetConfig([
-           {path: '', component: SimpleCmp},
-           {path: 'simple', component: SimpleCmp},
-         ]);
+      fakeAsync(inject([Router], (router: Router) => {
+        router.resetConfig([
+          { path: '', component: SimpleCmp },
+          { path: 'simple', component: SimpleCmp },
+        ]);
 
-         const fixture = createRoot(router, RootCmp);
-         let event: NavigationStart;
-         router.events.subscribe(e => {
-           if (e instanceof NavigationStart) {
-             event = e;
-           }
-         });
+        const fixture = createRoot(router, RootCmp);
+        let event: NavigationStart;
+        router.events.subscribe(e => {
+          if (e instanceof NavigationStart) {
+            event = e;
+          }
+        });
 
-         router.navigateByUrl('/simple');
-         tick();
+        router.navigateByUrl('/simple');
+        tick();
 
-         expect(event !.navigationTrigger).toEqual('imperative');
-         expect(event !.restoredState).toEqual(null);
-       })));
+        expect(event!.navigationTrigger).toEqual('imperative');
+        expect(event!.restoredState).toEqual(null);
+      })));
 
     it('should not pollute browser history when replaceUrl is set to true',
-       fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
-         router.resetConfig([
-           {path: '', component: SimpleCmp}, {path: 'a', component: SimpleCmp},
-           {path: 'b', component: SimpleCmp}
-         ]);
+      fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
+        router.resetConfig([
+          { path: '', component: SimpleCmp }, { path: 'a', component: SimpleCmp },
+          { path: 'b', component: SimpleCmp }
+        ]);
 
-         const fixture = createRoot(router, RootCmp);
+        const fixture = createRoot(router, RootCmp);
 
-         router.navigateByUrl('/a', {replaceUrl: true});
-         router.navigateByUrl('/b', {replaceUrl: true});
-         tick();
+        router.navigateByUrl('/a', { replaceUrl: true });
+        router.navigateByUrl('/b', { replaceUrl: true });
+        tick();
 
-         expect(location.urlChanges).toEqual(['replace: /', 'replace: /b']);
-       })));
+        expect(location.urlChanges).toEqual(['replace: /', 'replace: /b']);
+      })));
 
     it('should skip navigation if another navigation is already scheduled',
-       fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
-         router.resetConfig([
-           {path: '', component: SimpleCmp}, {path: 'a', component: SimpleCmp},
-           {path: 'b', component: SimpleCmp}
-         ]);
+      fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
+        router.resetConfig([
+          { path: '', component: SimpleCmp }, { path: 'a', component: SimpleCmp },
+          { path: 'b', component: SimpleCmp }
+        ]);
 
-         const fixture = createRoot(router, RootCmp);
+        const fixture = createRoot(router, RootCmp);
 
-         router.navigate(
-             ['/a'], {queryParams: {a: true}, queryParamsHandling: 'merge', replaceUrl: true});
-         router.navigate(
-             ['/b'], {queryParams: {b: true}, queryParamsHandling: 'merge', replaceUrl: true});
-         tick();
+        router.navigate(
+          ['/a'], { queryParams: { a: true }, queryParamsHandling: 'merge', replaceUrl: true });
+        router.navigate(
+          ['/b'], { queryParams: { b: true }, queryParamsHandling: 'merge', replaceUrl: true });
+        tick();
 
-         /**
-          * Why do we have '/b?b=true' and not '/b?a=true&b=true'?
-          *
-          * This is because the router has the right to stop a navigation mid-flight if another
-          * navigation has been already scheduled. This is why we can use a top-level guard
-          * to perform redirects. Calling `navigate` in such a guard will stop the navigation, and
-          * the components won't be instantiated.
-          *
-          * This is a fundamental property of the router: it only cares about its latest state.
-          *
-          * This means that components should only map params to something else, not reduce them.
-          * In other words, the following component is asking for trouble:
-          *
-          * ```
-          * class MyComponent {
-          *  constructor(a: ActivatedRoute) {
-          *    a.params.scan(...)
-          *  }
-          * }
-          * ```
-          *
-          * This also means "queryParamsHandling: 'merge'" should only be used to merge with
-          * long-living query parameters (e.g., debug).
-          */
-         expect(router.url).toEqual('/b?b=true');
-       })));
+        /**
+         * Why do we have '/b?b=true' and not '/b?a=true&b=true'?
+         *
+         * This is because the router has the right to stop a navigation mid-flight if another
+         * navigation has been already scheduled. This is why we can use a top-level guard
+         * to perform redirects. Calling `navigate` in such a guard will stop the navigation, and
+         * the components won't be instantiated.
+         *
+         * This is a fundamental property of the router: it only cares about its latest state.
+         *
+         * This means that components should only map params to something else, not reduce them.
+         * In other words, the following component is asking for trouble:
+         *
+         * ```
+         * class MyComponent {
+         *  constructor(a: ActivatedRoute) {
+         *    a.params.scan(...)
+         *  }
+         * }
+         * ```
+         *
+         * This also means "queryParamsHandling: 'merge'" should only be used to merge with
+         * long-living query parameters (e.g., debug).
+         */
+        expect(router.url).toEqual('/b?b=true');
+      })));
   });
 
   describe('navigation warning', () => {
@@ -166,38 +166,38 @@ describe('Integration', () => {
 
     beforeEach(() => {
       warnings = [];
-      TestBed.overrideProvider(Console, {useValue: new MockConsole()});
+      TestBed.overrideProvider(Console, { useValue: new MockConsole() });
     });
 
     describe('with NgZone enabled', () => {
       it('should warn when triggered outside Angular zone',
-         fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-           ngZone.runOutsideAngular(() => { router.navigateByUrl('/simple'); });
+        fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
+          ngZone.runOutsideAngular(() => { router.navigateByUrl('/simple'); });
 
-           expect(warnings.length).toBe(1);
-           expect(warnings[0])
-               .toBe(
-                   `Navigation triggered outside Angular zone, did you forget to call 'ngZone.run()'?`);
-         })));
+          expect(warnings.length).toBe(1);
+          expect(warnings[0])
+            .toBe(
+              `Navigation triggered outside Angular zone, did you forget to call 'ngZone.run()'?`);
+        })));
 
       it('should not warn when triggered inside Angular zone',
-         fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-           ngZone.run(() => { router.navigateByUrl('/simple'); });
+        fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
+          ngZone.run(() => { router.navigateByUrl('/simple'); });
 
-           expect(warnings.length).toBe(0);
-         })));
+          expect(warnings.length).toBe(0);
+        })));
     });
 
     describe('with NgZone disabled', () => {
-      beforeEach(() => { TestBed.overrideProvider(NgZone, {useValue: new NoopNgZone()}); });
+      beforeEach(() => { TestBed.overrideProvider(NgZone, { useValue: new NoopNgZone() }); });
 
       it('should not warn when triggered outside Angular zone',
-         fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
+        fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
 
-           ngZone.runOutsideAngular(() => { router.navigateByUrl('/simple'); });
+          ngZone.runOutsideAngular(() => { router.navigateByUrl('/simple'); });
 
-           expect(warnings.length).toBe(0);
-         })));
+          expect(warnings.length).toBe(0);
+        })));
     });
   });
 
@@ -234,19 +234,19 @@ describe('Integration', () => {
     });
 
     describe('should advance the parent route after deactivating its children', () => {
-      @Component({template: '<router-outlet></router-outlet>'})
+      @Component({ template: '<router-outlet></router-outlet>' })
       class Parent {
         constructor(route: ActivatedRoute) {
           route.params.subscribe((s: any) => { log.push(s); });
         }
       }
 
-      @Component({template: 'child1'})
+      @Component({ template: 'child1' })
       class Child1 {
         ngOnDestroy() { log.push('child1 destroy'); }
       }
 
-      @Component({template: 'child2'})
+      @Component({ template: 'child2' })
       class Child2 {
         constructor() { log.push('child2 constructor'); }
       }
@@ -259,398 +259,398 @@ describe('Integration', () => {
       class TestModule {
       }
 
-      beforeEach(() => TestBed.configureTestingModule({imports: [TestModule]}));
+      beforeEach(() => TestBed.configureTestingModule({ imports: [TestModule] }));
 
       it('should work',
-         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-           const fixture = createRoot(router, RootCmp);
+        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+          const fixture = createRoot(router, RootCmp);
 
-           router.resetConfig([{
-             path: 'parent/:id',
-             component: Parent,
-             children: [
-               {path: 'child1', component: Child1},
-               {path: 'child2', component: Child2},
-             ]
-           }]);
+          router.resetConfig([{
+            path: 'parent/:id',
+            component: Parent,
+            children: [
+              { path: 'child1', component: Child1 },
+              { path: 'child2', component: Child2 },
+            ]
+          }]);
 
-           router.navigateByUrl('/parent/1/child1');
-           advance(fixture);
+          router.navigateByUrl('/parent/1/child1');
+          advance(fixture);
 
-           router.navigateByUrl('/parent/2/child2');
-           advance(fixture);
+          router.navigateByUrl('/parent/2/child2');
+          advance(fixture);
 
-           expect(location.path()).toEqual('/parent/2/child2');
-           expect(log).toEqual([
-             {id: '1'},
-             'child1 destroy',
-             {id: '2'},
-             'child2 constructor',
-           ]);
-         })));
+          expect(location.path()).toEqual('/parent/2/child2');
+          expect(log).toEqual([
+            { id: '1' },
+            'child1 destroy',
+            { id: '2' },
+            'child2 constructor',
+          ]);
+        })));
 
     });
 
     it('should execute navigations serialy',
-       fakeAsync(inject([Router, Location], (router: Router) => {
-         const fixture = createRoot(router, RootCmp);
+      fakeAsync(inject([Router, Location], (router: Router) => {
+        const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig([
-           {path: 'a', component: SimpleCmp, canActivate: ['trueRightAway', 'trueIn2Seconds']},
-           {path: 'b', component: SimpleCmp, canActivate: ['trueRightAway', 'trueIn2Seconds']}
-         ]);
+        router.resetConfig([
+          { path: 'a', component: SimpleCmp, canActivate: ['trueRightAway', 'trueIn2Seconds'] },
+          { path: 'b', component: SimpleCmp, canActivate: ['trueRightAway', 'trueIn2Seconds'] }
+        ]);
 
-         router.navigateByUrl('/a');
-         tick(100);
-         fixture.detectChanges();
+        router.navigateByUrl('/a');
+        tick(100);
+        fixture.detectChanges();
 
-         router.navigateByUrl('/b');
-         tick(100);  // 200
-         fixture.detectChanges();
+        router.navigateByUrl('/b');
+        tick(100);  // 200
+        fixture.detectChanges();
 
-         expect(log).toEqual(['trueRightAway', 'trueIn2Seconds-start']);
+        expect(log).toEqual(['trueRightAway', 'trueIn2Seconds-start']);
 
-         tick(2000);  // 2200
-         fixture.detectChanges();
+        tick(2000);  // 2200
+        fixture.detectChanges();
 
-         expect(log).toEqual([
-           'trueRightAway', 'trueIn2Seconds-start', 'trueIn2Seconds-end', 'trueRightAway',
-           'trueIn2Seconds-start'
-         ]);
+        expect(log).toEqual([
+          'trueRightAway', 'trueIn2Seconds-start', 'trueIn2Seconds-end', 'trueRightAway',
+          'trueIn2Seconds-start'
+        ]);
 
-         tick(2000);  // 4200
-         fixture.detectChanges();
+        tick(2000);  // 4200
+        fixture.detectChanges();
 
-         expect(log).toEqual([
-           'trueRightAway', 'trueIn2Seconds-start', 'trueIn2Seconds-end', 'trueRightAway',
-           'trueIn2Seconds-start', 'trueIn2Seconds-end'
-         ]);
-       })));
+        expect(log).toEqual([
+          'trueRightAway', 'trueIn2Seconds-start', 'trueIn2Seconds-end', 'trueRightAway',
+          'trueIn2Seconds-start', 'trueIn2Seconds-end'
+        ]);
+      })));
   });
 
   it('Should work inside ChangeDetectionStrategy.OnPush components', fakeAsync(() => {
-       @Component({
-         selector: 'root-cmp',
-         template: `<router-outlet></router-outlet>`,
-         changeDetection: ChangeDetectionStrategy.OnPush,
-       })
-       class OnPushOutlet {
-       }
+    @Component({
+      selector: 'root-cmp',
+      template: `<router-outlet></router-outlet>`,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class OnPushOutlet {
+    }
 
-       @Component({selector: 'need-cd', template: `{{'it works!'}}`})
-       class NeedCdCmp {
-       }
+    @Component({ selector: 'need-cd', template: `{{'it works!'}}` })
+    class NeedCdCmp {
+    }
 
-       @NgModule({
-         declarations: [OnPushOutlet, NeedCdCmp],
-         entryComponents: [OnPushOutlet, NeedCdCmp],
-         imports: [RouterModule],
-       })
-       class TestModule {
-       }
+    @NgModule({
+      declarations: [OnPushOutlet, NeedCdCmp],
+      entryComponents: [OnPushOutlet, NeedCdCmp],
+      imports: [RouterModule],
+    })
+    class TestModule {
+    }
 
-       TestBed.configureTestingModule({imports: [TestModule]});
+    TestBed.configureTestingModule({ imports: [TestModule] });
 
-       const router: Router = TestBed.get(Router);
-       const fixture = createRoot(router, RootCmp);
+    const router: Router = TestBed.get(Router);
+    const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{
-         path: 'on',
-         component: OnPushOutlet,
-         children: [{
-           path: 'push',
-           component: NeedCdCmp,
-         }],
-       }]);
+    router.resetConfig([{
+      path: 'on',
+      component: OnPushOutlet,
+      children: [{
+        path: 'push',
+        component: NeedCdCmp,
+      }],
+    }]);
 
-       advance(fixture);
-       router.navigateByUrl('on');
-       advance(fixture);
-       router.navigateByUrl('on/push');
-       advance(fixture);
+    advance(fixture);
+    router.navigateByUrl('on');
+    advance(fixture);
+    router.navigateByUrl('on/push');
+    advance(fixture);
 
-       expect(fixture.nativeElement).toHaveText('it works!');
-     }));
+    expect(fixture.nativeElement).toHaveText('it works!');
+  }));
 
   it('should not error when no url left and no children are matching',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       const fixture = createRoot(router, RootCmp);
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{
-         path: 'team/:id',
-         component: TeamCmp,
-         children: [{path: 'simple', component: SimpleCmp}]
-       }]);
+      router.resetConfig([{
+        path: 'team/:id',
+        component: TeamCmp,
+        children: [{ path: 'simple', component: SimpleCmp }]
+      }]);
 
-       router.navigateByUrl('/team/33/simple');
-       advance(fixture);
+      router.navigateByUrl('/team/33/simple');
+      advance(fixture);
 
-       expect(location.path()).toEqual('/team/33/simple');
-       expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
+      expect(location.path()).toEqual('/team/33/simple');
+      expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
 
-       router.navigateByUrl('/team/33');
-       advance(fixture);
+      router.navigateByUrl('/team/33');
+      advance(fixture);
 
-       expect(location.path()).toEqual('/team/33');
-       expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-     })));
+      expect(location.path()).toEqual('/team/33');
+      expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
+    })));
 
   it('should work when an outlet is in an ngIf',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       const fixture = createRoot(router, RootCmp);
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{
-         path: 'child',
-         component: OutletInNgIf,
-         children: [{path: 'simple', component: SimpleCmp}]
-       }]);
+      router.resetConfig([{
+        path: 'child',
+        component: OutletInNgIf,
+        children: [{ path: 'simple', component: SimpleCmp }]
+      }]);
 
-       router.navigateByUrl('/child/simple');
-       advance(fixture);
+      router.navigateByUrl('/child/simple');
+      advance(fixture);
 
-       expect(location.path()).toEqual('/child/simple');
-     })));
+      expect(location.path()).toEqual('/child/simple');
+    })));
 
   it('should work when an outlet is added/removed', fakeAsync(() => {
-       @Component({
-         selector: 'someRoot',
-         template: `[<div *ngIf="cond"><router-outlet></router-outlet></div>]`
-       })
-       class RootCmpWithLink {
-         cond: boolean = true;
-       }
-       TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
+    @Component({
+      selector: 'someRoot',
+      template: `[<div *ngIf="cond"><router-outlet></router-outlet></div>]`
+    })
+    class RootCmpWithLink {
+      cond: boolean = true;
+    }
+    TestBed.configureTestingModule({ declarations: [RootCmpWithLink] });
 
-       const router: Router = TestBed.get(Router);
+    const router: Router = TestBed.get(Router);
 
-       const fixture = createRoot(router, RootCmpWithLink);
+    const fixture = createRoot(router, RootCmpWithLink);
 
-       router.resetConfig([
-         {path: 'simple', component: SimpleCmp},
-         {path: 'blank', component: BlankCmp},
-       ]);
+    router.resetConfig([
+      { path: 'simple', component: SimpleCmp },
+      { path: 'blank', component: BlankCmp },
+    ]);
 
-       router.navigateByUrl('/simple');
-       advance(fixture);
-       expect(fixture.nativeElement).toHaveText('[simple]');
+    router.navigateByUrl('/simple');
+    advance(fixture);
+    expect(fixture.nativeElement).toHaveText('[simple]');
 
-       fixture.componentInstance.cond = false;
-       advance(fixture);
-       expect(fixture.nativeElement).toHaveText('[]');
+    fixture.componentInstance.cond = false;
+    advance(fixture);
+    expect(fixture.nativeElement).toHaveText('[]');
 
-       fixture.componentInstance.cond = true;
-       advance(fixture);
-       expect(fixture.nativeElement).toHaveText('[simple]');
-     }));
+    fixture.componentInstance.cond = true;
+    advance(fixture);
+    expect(fixture.nativeElement).toHaveText('[simple]');
+  }));
 
   it('should update location when navigating', fakeAsync(() => {
-       @Component({template: `record`})
-       class RecordLocationCmp {
-         private storedPath: string;
-         constructor(loc: Location) { this.storedPath = loc.path(); }
-       }
+    @Component({ template: `record` })
+    class RecordLocationCmp {
+      private storedPath: string;
+      constructor(loc: Location) { this.storedPath = loc.path(); }
+    }
 
-       @NgModule({declarations: [RecordLocationCmp], entryComponents: [RecordLocationCmp]})
-       class TestModule {
-       }
+    @NgModule({ declarations: [RecordLocationCmp], entryComponents: [RecordLocationCmp] })
+    class TestModule {
+    }
 
-       TestBed.configureTestingModule({imports: [TestModule]});
+    TestBed.configureTestingModule({ imports: [TestModule] });
 
-       const router = TestBed.get(Router);
-       const location = TestBed.get(Location);
-       const fixture = createRoot(router, RootCmp);
+    const router = TestBed.get(Router);
+    const location = TestBed.get(Location);
+    const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{path: 'record/:id', component: RecordLocationCmp}]);
+    router.resetConfig([{ path: 'record/:id', component: RecordLocationCmp }]);
 
-       router.navigateByUrl('/record/22');
-       advance(fixture);
+    router.navigateByUrl('/record/22');
+    advance(fixture);
 
-       const c = fixture.debugElement.children[1].componentInstance;
-       expect(location.path()).toEqual('/record/22');
-       expect(c.storedPath).toEqual('/record/22');
+    const c = fixture.debugElement.children[1].componentInstance;
+    expect(location.path()).toEqual('/record/22');
+    expect(c.storedPath).toEqual('/record/22');
 
-       router.navigateByUrl('/record/33');
-       advance(fixture);
-       expect(location.path()).toEqual('/record/33');
-     }));
+    router.navigateByUrl('/record/33');
+    advance(fixture);
+    expect(location.path()).toEqual('/record/33');
+  }));
 
   it('should skip location update when using NavigationExtras.skipLocationChange with navigateByUrl',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       const fixture = TestBed.createComponent(RootCmp);
-       advance(fixture);
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      const fixture = TestBed.createComponent(RootCmp);
+      advance(fixture);
 
-       router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
+      router.resetConfig([{ path: 'team/:id', component: TeamCmp }]);
 
-       router.navigateByUrl('/team/22');
-       advance(fixture);
-       expect(location.path()).toEqual('/team/22');
+      router.navigateByUrl('/team/22');
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22');
 
-       expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+      expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
-       router.navigateByUrl('/team/33', {skipLocationChange: true});
-       advance(fixture);
+      router.navigateByUrl('/team/33', { skipLocationChange: true });
+      advance(fixture);
 
-       expect(location.path()).toEqual('/team/22');
+      expect(location.path()).toEqual('/team/22');
 
-       expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-     })));
+      expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
+    })));
 
   it('should skip location update when using NavigationExtras.skipLocationChange with navigate',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       const fixture = TestBed.createComponent(RootCmp);
-       advance(fixture);
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      const fixture = TestBed.createComponent(RootCmp);
+      advance(fixture);
 
-       router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
+      router.resetConfig([{ path: 'team/:id', component: TeamCmp }]);
 
-       router.navigate(['/team/22']);
-       advance(fixture);
-       expect(location.path()).toEqual('/team/22');
+      router.navigate(['/team/22']);
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22');
 
-       expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+      expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
-       router.navigate(['/team/33'], {skipLocationChange: true});
-       advance(fixture);
+      router.navigate(['/team/33'], { skipLocationChange: true });
+      advance(fixture);
 
-       expect(location.path()).toEqual('/team/22');
+      expect(location.path()).toEqual('/team/22');
 
-       expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-     })));
+      expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
+    })));
 
   it('should eagerly update the URL with urlUpdateStrategy="eagar"',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       const fixture = TestBed.createComponent(RootCmp);
-       advance(fixture);
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      const fixture = TestBed.createComponent(RootCmp);
+      advance(fixture);
 
-       router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
+      router.resetConfig([{ path: 'team/:id', component: TeamCmp }]);
 
-       router.navigateByUrl('/team/22');
-       advance(fixture);
-       expect(location.path()).toEqual('/team/22');
+      router.navigateByUrl('/team/22');
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22');
 
-       expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+      expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
-       router.urlUpdateStrategy = 'eager';
-       (router as any).hooks.beforePreactivation = () => {
-         expect(location.path()).toEqual('/team/33');
-         expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
-         return of (null);
-       };
-       router.navigateByUrl('/team/33');
+      router.urlUpdateStrategy = 'eager';
+      (router as any).hooks.beforePreactivation = () => {
+        expect(location.path()).toEqual('/team/33');
+        expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+        return of(null);
+      };
+      router.navigateByUrl('/team/33');
 
-       advance(fixture);
-       expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-     })));
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
+    })));
 
   it('should navigate back and forward',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       const fixture = createRoot(router, RootCmp);
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{
-         path: 'team/:id',
-         component: TeamCmp,
-         children:
-             [{path: 'simple', component: SimpleCmp}, {path: 'user/:name', component: UserCmp}]
-       }]);
+      router.resetConfig([{
+        path: 'team/:id',
+        component: TeamCmp,
+        children:
+          [{ path: 'simple', component: SimpleCmp }, { path: 'user/:name', component: UserCmp }]
+      }]);
 
-       let event: NavigationStart;
-       router.events.subscribe(e => {
-         if (e instanceof NavigationStart) {
-           event = e;
-         }
-       });
+      let event: NavigationStart;
+      router.events.subscribe(e => {
+        if (e instanceof NavigationStart) {
+          event = e;
+        }
+      });
 
-       router.navigateByUrl('/team/33/simple');
-       advance(fixture);
-       expect(location.path()).toEqual('/team/33/simple');
-       const simpleNavStart = event !;
+      router.navigateByUrl('/team/33/simple');
+      advance(fixture);
+      expect(location.path()).toEqual('/team/33/simple');
+      const simpleNavStart = event!;
 
-       router.navigateByUrl('/team/22/user/victor');
-       advance(fixture);
-       const userVictorNavStart = event !;
+      router.navigateByUrl('/team/22/user/victor');
+      advance(fixture);
+      const userVictorNavStart = event!;
 
 
-       location.back();
-       advance(fixture);
-       expect(location.path()).toEqual('/team/33/simple');
-       expect(event !.navigationTrigger).toEqual('hashchange');
-       expect(event !.restoredState !.navigationId).toEqual(simpleNavStart.id);
+      location.back();
+      advance(fixture);
+      expect(location.path()).toEqual('/team/33/simple');
+      expect(event!.navigationTrigger).toEqual('hashchange');
+      expect(event!.restoredState!.navigationId).toEqual(simpleNavStart.id);
 
-       location.forward();
-       advance(fixture);
-       expect(location.path()).toEqual('/team/22/user/victor');
-       expect(event !.navigationTrigger).toEqual('hashchange');
-       expect(event !.restoredState !.navigationId).toEqual(userVictorNavStart.id);
-     })));
+      location.forward();
+      advance(fixture);
+      expect(location.path()).toEqual('/team/22/user/victor');
+      expect(event!.navigationTrigger).toEqual('hashchange');
+      expect(event!.restoredState!.navigationId).toEqual(userVictorNavStart.id);
+    })));
 
   it('should navigate to the same url when config changes',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       const fixture = createRoot(router, RootCmp);
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{path: 'a', component: SimpleCmp}]);
+      router.resetConfig([{ path: 'a', component: SimpleCmp }]);
 
-       router.navigate(['/a']);
-       advance(fixture);
-       expect(location.path()).toEqual('/a');
-       expect(fixture.nativeElement).toHaveText('simple');
+      router.navigate(['/a']);
+      advance(fixture);
+      expect(location.path()).toEqual('/a');
+      expect(fixture.nativeElement).toHaveText('simple');
 
-       router.resetConfig([{path: 'a', component: RouteCmp}]);
+      router.resetConfig([{ path: 'a', component: RouteCmp }]);
 
-       router.navigate(['/a']);
-       advance(fixture);
-       expect(location.path()).toEqual('/a');
-       expect(fixture.nativeElement).toHaveText('route');
-     })));
+      router.navigate(['/a']);
+      advance(fixture);
+      expect(location.path()).toEqual('/a');
+      expect(fixture.nativeElement).toHaveText('route');
+    })));
 
   it('should navigate when locations changes',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       const fixture = createRoot(router, RootCmp);
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{
-         path: 'team/:id',
-         component: TeamCmp,
-         children: [{path: 'user/:name', component: UserCmp}]
-       }]);
+      router.resetConfig([{
+        path: 'team/:id',
+        component: TeamCmp,
+        children: [{ path: 'user/:name', component: UserCmp }]
+      }]);
 
-       const recordedEvents: any[] = [];
-       router.events.forEach(e => onlyNavigationStartAndEnd(e) && recordedEvents.push(e));
+      const recordedEvents: any[] = [];
+      router.events.forEach(e => onlyNavigationStartAndEnd(e) && recordedEvents.push(e));
 
-       router.navigateByUrl('/team/22/user/victor');
-       advance(fixture);
+      router.navigateByUrl('/team/22/user/victor');
+      advance(fixture);
 
-       (<any>location).simulateHashChange('/team/22/user/fedor');
-       advance(fixture);
+      (<any>location).simulateHashChange('/team/22/user/fedor');
+      advance(fixture);
 
-       (<any>location).simulateUrlPop('/team/22/user/fedor');
-       advance(fixture);
+      (<any>location).simulateUrlPop('/team/22/user/fedor');
+      advance(fixture);
 
-       expect(fixture.nativeElement).toHaveText('team 22 [ user fedor, right:  ]');
+      expect(fixture.nativeElement).toHaveText('team 22 [ user fedor, right:  ]');
 
-       expectEvents(recordedEvents, [
-         [NavigationStart, '/team/22/user/victor'], [NavigationEnd, '/team/22/user/victor'],
-         [NavigationStart, '/team/22/user/fedor'], [NavigationEnd, '/team/22/user/fedor']
-       ]);
-     })));
+      expectEvents(recordedEvents, [
+        [NavigationStart, '/team/22/user/victor'], [NavigationEnd, '/team/22/user/victor'],
+        [NavigationStart, '/team/22/user/fedor'], [NavigationEnd, '/team/22/user/fedor']
+      ]);
+    })));
 
   it('should update the location when the matched route does not change',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       const fixture = createRoot(router, RootCmp);
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{path: '**', component: CollectParamsCmp}]);
+      router.resetConfig([{ path: '**', component: CollectParamsCmp }]);
 
-       router.navigateByUrl('/one/two');
-       advance(fixture);
-       const cmp = fixture.debugElement.children[1].componentInstance;
-       expect(location.path()).toEqual('/one/two');
-       expect(fixture.nativeElement).toHaveText('collect-params');
+      router.navigateByUrl('/one/two');
+      advance(fixture);
+      const cmp = fixture.debugElement.children[1].componentInstance;
+      expect(location.path()).toEqual('/one/two');
+      expect(fixture.nativeElement).toHaveText('collect-params');
 
-       expect(cmp.recordedUrls()).toEqual(['one/two']);
+      expect(cmp.recordedUrls()).toEqual(['one/two']);
 
-       router.navigateByUrl('/three/four');
-       advance(fixture);
-       expect(location.path()).toEqual('/three/four');
-       expect(fixture.nativeElement).toHaveText('collect-params');
-       expect(cmp.recordedUrls()).toEqual(['one/two', 'three/four']);
-     })));
+      router.navigateByUrl('/three/four');
+      advance(fixture);
+      expect(location.path()).toEqual('/three/four');
+      expect(fixture.nativeElement).toHaveText('collect-params');
+      expect(cmp.recordedUrls()).toEqual(['one/two', 'three/four']);
+    })));
 
   describe('should reset location if a navigation by location is successful', () => {
     beforeEach(() => {
@@ -668,604 +668,604 @@ describe('Integration', () => {
     });
 
     it('work', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-         const fixture = createRoot(router, RootCmp);
+      const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig([{path: 'simple', component: SimpleCmp, canActivate: ['in1Second']}]);
+      router.resetConfig([{ path: 'simple', component: SimpleCmp, canActivate: ['in1Second'] }]);
 
-         // Trigger two location changes to the same URL.
-         // Because of the guard the order will look as follows:
-         // - location change 'simple'
-         // - start processing the change, start a guard
-         // - location change 'simple'
-         // - the first location change gets canceled, the URL gets reset to '/'
-         // - the second location change gets finished, the URL should be reset to '/simple'
-         (<any>location).simulateUrlPop('/simple');
-         (<any>location).simulateUrlPop('/simple');
+      // Trigger two location changes to the same URL.
+      // Because of the guard the order will look as follows:
+      // - location change 'simple'
+      // - start processing the change, start a guard
+      // - location change 'simple'
+      // - the first location change gets canceled, the URL gets reset to '/'
+      // - the second location change gets finished, the URL should be reset to '/simple'
+      (<any>location).simulateUrlPop('/simple');
+      (<any>location).simulateUrlPop('/simple');
 
-         tick(2000);
-         advance(fixture);
+      tick(2000);
+      advance(fixture);
 
-         expect(location.path()).toEqual('/simple');
-       })));
+      expect(location.path()).toEqual('/simple');
+    })));
   });
 
   it('should support secondary routes', fakeAsync(inject([Router], (router: Router) => {
-       const fixture = createRoot(router, RootCmp);
+    const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{
-         path: 'team/:id',
-         component: TeamCmp,
-         children: [
-           {path: 'user/:name', component: UserCmp},
-           {path: 'simple', component: SimpleCmp, outlet: 'right'}
-         ]
-       }]);
+    router.resetConfig([{
+      path: 'team/:id',
+      component: TeamCmp,
+      children: [
+        { path: 'user/:name', component: UserCmp },
+        { path: 'simple', component: SimpleCmp, outlet: 'right' }
+      ]
+    }]);
 
-       router.navigateByUrl('/team/22/(user/victor//right:simple)');
-       advance(fixture);
+    router.navigateByUrl('/team/22/(user/victor//right:simple)');
+    advance(fixture);
 
-       expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right: simple ]');
-     })));
+    expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right: simple ]');
+  })));
 
   it('should support secondary routes in separate commands',
-     fakeAsync(inject([Router], (router: Router) => {
-       const fixture = createRoot(router, RootCmp);
+    fakeAsync(inject([Router], (router: Router) => {
+      const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{
-         path: 'team/:id',
-         component: TeamCmp,
-         children: [
-           {path: 'user/:name', component: UserCmp},
-           {path: 'simple', component: SimpleCmp, outlet: 'right'}
-         ]
-       }]);
+      router.resetConfig([{
+        path: 'team/:id',
+        component: TeamCmp,
+        children: [
+          { path: 'user/:name', component: UserCmp },
+          { path: 'simple', component: SimpleCmp, outlet: 'right' }
+        ]
+      }]);
 
-       router.navigateByUrl('/team/22/user/victor');
-       advance(fixture);
-       router.navigate(['team/22', {outlets: {right: 'simple'}}]);
-       advance(fixture);
+      router.navigateByUrl('/team/22/user/victor');
+      advance(fixture);
+      router.navigate(['team/22', { outlets: { right: 'simple' } }]);
+      advance(fixture);
 
-       expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right: simple ]');
-     })));
+      expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right: simple ]');
+    })));
 
   it('should deactivate outlets', fakeAsync(inject([Router], (router: Router) => {
-       const fixture = createRoot(router, RootCmp);
+    const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{
-         path: 'team/:id',
-         component: TeamCmp,
-         children: [
-           {path: 'user/:name', component: UserCmp},
-           {path: 'simple', component: SimpleCmp, outlet: 'right'}
-         ]
-       }]);
+    router.resetConfig([{
+      path: 'team/:id',
+      component: TeamCmp,
+      children: [
+        { path: 'user/:name', component: UserCmp },
+        { path: 'simple', component: SimpleCmp, outlet: 'right' }
+      ]
+    }]);
 
-       router.navigateByUrl('/team/22/(user/victor//right:simple)');
-       advance(fixture);
+    router.navigateByUrl('/team/22/(user/victor//right:simple)');
+    advance(fixture);
 
-       router.navigateByUrl('/team/22/user/victor');
-       advance(fixture);
+    router.navigateByUrl('/team/22/user/victor');
+    advance(fixture);
 
-       expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right:  ]');
-     })));
+    expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right:  ]');
+  })));
 
   it('should deactivate nested outlets', fakeAsync(inject([Router], (router: Router) => {
-       const fixture = createRoot(router, RootCmp);
+    const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([
-         {
-           path: 'team/:id',
-           component: TeamCmp,
-           children: [
-             {path: 'user/:name', component: UserCmp},
-             {path: 'simple', component: SimpleCmp, outlet: 'right'}
-           ]
-         },
-         {path: '', component: BlankCmp}
-       ]);
+    router.resetConfig([
+      {
+        path: 'team/:id',
+        component: TeamCmp,
+        children: [
+          { path: 'user/:name', component: UserCmp },
+          { path: 'simple', component: SimpleCmp, outlet: 'right' }
+        ]
+      },
+      { path: '', component: BlankCmp }
+    ]);
 
-       router.navigateByUrl('/team/22/(user/victor//right:simple)');
-       advance(fixture);
+    router.navigateByUrl('/team/22/(user/victor//right:simple)');
+    advance(fixture);
 
-       router.navigateByUrl('/');
-       advance(fixture);
+    router.navigateByUrl('/');
+    advance(fixture);
 
-       expect(fixture.nativeElement).toHaveText('');
-     })));
+    expect(fixture.nativeElement).toHaveText('');
+  })));
 
   it('should set query params and fragment', fakeAsync(inject([Router], (router: Router) => {
-       const fixture = createRoot(router, RootCmp);
+    const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{path: 'query', component: QueryParamsAndFragmentCmp}]);
+    router.resetConfig([{ path: 'query', component: QueryParamsAndFragmentCmp }]);
 
-       router.navigateByUrl('/query?name=1#fragment1');
-       advance(fixture);
-       expect(fixture.nativeElement).toHaveText('query: 1 fragment: fragment1');
+    router.navigateByUrl('/query?name=1#fragment1');
+    advance(fixture);
+    expect(fixture.nativeElement).toHaveText('query: 1 fragment: fragment1');
 
-       router.navigateByUrl('/query?name=2#fragment2');
-       advance(fixture);
-       expect(fixture.nativeElement).toHaveText('query: 2 fragment: fragment2');
-     })));
+    router.navigateByUrl('/query?name=2#fragment2');
+    advance(fixture);
+    expect(fixture.nativeElement).toHaveText('query: 2 fragment: fragment2');
+  })));
 
   it('should ignore null and undefined query params',
-     fakeAsync(inject([Router], (router: Router) => {
-       const fixture = createRoot(router, RootCmp);
+    fakeAsync(inject([Router], (router: Router) => {
+      const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{path: 'query', component: EmptyQueryParamsCmp}]);
+      router.resetConfig([{ path: 'query', component: EmptyQueryParamsCmp }]);
 
-       router.navigate(['query'], {queryParams: {name: 1, age: null, page: undefined}});
-       advance(fixture);
-       const cmp = fixture.debugElement.children[1].componentInstance;
-       expect(cmp.recordedParams).toEqual([{name: '1'}]);
-     })));
+      router.navigate(['query'], { queryParams: { name: 1, age: null, page: undefined } });
+      advance(fixture);
+      const cmp = fixture.debugElement.children[1].componentInstance;
+      expect(cmp.recordedParams).toEqual([{ name: '1' }]);
+    })));
 
   it('should throw an error when one of the commands is null/undefined',
-     fakeAsync(inject([Router], (router: Router) => {
-       createRoot(router, RootCmp);
+    fakeAsync(inject([Router], (router: Router) => {
+      createRoot(router, RootCmp);
 
-       router.resetConfig([{path: 'query', component: EmptyQueryParamsCmp}]);
+      router.resetConfig([{ path: 'query', component: EmptyQueryParamsCmp }]);
 
-       expect(() => router.navigate([
-         undefined, 'query'
-       ])).toThrowError(`The requested path contains undefined segment at index 0`);
-     })));
+      expect(() => router.navigate([
+        undefined, 'query'
+      ])).toThrowError(`The requested path contains undefined segment at index 0`);
+    })));
 
   it('should push params only when they change', fakeAsync(inject([Router], (router: Router) => {
-       const fixture = createRoot(router, RootCmp);
+    const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{
-         path: 'team/:id',
-         component: TeamCmp,
-         children: [{path: 'user/:name', component: UserCmp}]
-       }]);
+    router.resetConfig([{
+      path: 'team/:id',
+      component: TeamCmp,
+      children: [{ path: 'user/:name', component: UserCmp }]
+    }]);
 
-       router.navigateByUrl('/team/22/user/victor');
-       advance(fixture);
-       const team = fixture.debugElement.children[1].componentInstance;
-       const user = fixture.debugElement.children[1].children[1].componentInstance;
+    router.navigateByUrl('/team/22/user/victor');
+    advance(fixture);
+    const team = fixture.debugElement.children[1].componentInstance;
+    const user = fixture.debugElement.children[1].children[1].componentInstance;
 
-       expect(team.recordedParams).toEqual([{id: '22'}]);
-       expect(team.snapshotParams).toEqual([{id: '22'}]);
-       expect(user.recordedParams).toEqual([{name: 'victor'}]);
-       expect(user.snapshotParams).toEqual([{name: 'victor'}]);
+    expect(team.recordedParams).toEqual([{ id: '22' }]);
+    expect(team.snapshotParams).toEqual([{ id: '22' }]);
+    expect(user.recordedParams).toEqual([{ name: 'victor' }]);
+    expect(user.snapshotParams).toEqual([{ name: 'victor' }]);
 
-       router.navigateByUrl('/team/22/user/fedor');
-       advance(fixture);
+    router.navigateByUrl('/team/22/user/fedor');
+    advance(fixture);
 
-       expect(team.recordedParams).toEqual([{id: '22'}]);
-       expect(team.snapshotParams).toEqual([{id: '22'}]);
-       expect(user.recordedParams).toEqual([{name: 'victor'}, {name: 'fedor'}]);
-       expect(user.snapshotParams).toEqual([{name: 'victor'}, {name: 'fedor'}]);
-     })));
+    expect(team.recordedParams).toEqual([{ id: '22' }]);
+    expect(team.snapshotParams).toEqual([{ id: '22' }]);
+    expect(user.recordedParams).toEqual([{ name: 'victor' }, { name: 'fedor' }]);
+    expect(user.snapshotParams).toEqual([{ name: 'victor' }, { name: 'fedor' }]);
+  })));
 
   it('should work when navigating to /', fakeAsync(inject([Router], (router: Router) => {
-       const fixture = createRoot(router, RootCmp);
+    const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([
-         {path: '', pathMatch: 'full', component: SimpleCmp},
-         {path: 'user/:name', component: UserCmp}
-       ]);
+    router.resetConfig([
+      { path: '', pathMatch: 'full', component: SimpleCmp },
+      { path: 'user/:name', component: UserCmp }
+    ]);
 
-       router.navigateByUrl('/user/victor');
-       advance(fixture);
+    router.navigateByUrl('/user/victor');
+    advance(fixture);
 
-       expect(fixture.nativeElement).toHaveText('user victor');
+    expect(fixture.nativeElement).toHaveText('user victor');
 
-       router.navigateByUrl('/');
-       advance(fixture);
+    router.navigateByUrl('/');
+    advance(fixture);
 
-       expect(fixture.nativeElement).toHaveText('simple');
-     })));
+    expect(fixture.nativeElement).toHaveText('simple');
+  })));
 
   it('should cancel in-flight navigations', fakeAsync(inject([Router], (router: Router) => {
-       const fixture = createRoot(router, RootCmp);
+    const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{path: 'user/:name', component: UserCmp}]);
+    router.resetConfig([{ path: 'user/:name', component: UserCmp }]);
 
-       const recordedEvents: any[] = [];
-       router.events.forEach(e => recordedEvents.push(e));
+    const recordedEvents: any[] = [];
+    router.events.forEach(e => recordedEvents.push(e));
 
-       router.navigateByUrl('/user/init');
-       advance(fixture);
+    router.navigateByUrl('/user/init');
+    advance(fixture);
 
-       const user = fixture.debugElement.children[1].componentInstance;
+    const user = fixture.debugElement.children[1].componentInstance;
 
-       let r1: any, r2: any;
-       router.navigateByUrl('/user/victor') !.then(_ => r1 = _);
-       router.navigateByUrl('/user/fedor') !.then(_ => r2 = _);
-       advance(fixture);
+    let r1: any, r2: any;
+    router.navigateByUrl('/user/victor')!.then(_ => r1 = _);
+    router.navigateByUrl('/user/fedor')!.then(_ => r2 = _);
+    advance(fixture);
 
-       expect(r1).toEqual(false);  // returns false because it was canceled
-       expect(r2).toEqual(true);   // returns true because it was successful
+    expect(r1).toEqual(false);  // returns false because it was canceled
+    expect(r2).toEqual(true);   // returns true because it was successful
 
-       expect(fixture.nativeElement).toHaveText('user fedor');
-       expect(user.recordedParams).toEqual([{name: 'init'}, {name: 'fedor'}]);
+    expect(fixture.nativeElement).toHaveText('user fedor');
+    expect(user.recordedParams).toEqual([{ name: 'init' }, { name: 'fedor' }]);
 
-       expectEvents(recordedEvents, [
-         [NavigationStart, '/user/init'],
-         [RoutesRecognized, '/user/init'],
-         [GuardsCheckStart, '/user/init'],
-         [ChildActivationStart],
-         [ActivationStart],
-         [GuardsCheckEnd, '/user/init'],
-         [ResolveStart, '/user/init'],
-         [ResolveEnd, '/user/init'],
-         [ActivationEnd],
-         [ChildActivationEnd],
-         [NavigationEnd, '/user/init'],
+    expectEvents(recordedEvents, [
+      [NavigationStart, '/user/init'],
+      [RoutesRecognized, '/user/init'],
+      [GuardsCheckStart, '/user/init'],
+      [ChildActivationStart],
+      [ActivationStart],
+      [GuardsCheckEnd, '/user/init'],
+      [ResolveStart, '/user/init'],
+      [ResolveEnd, '/user/init'],
+      [ActivationEnd],
+      [ChildActivationEnd],
+      [NavigationEnd, '/user/init'],
 
-         [NavigationStart, '/user/victor'],
-         [NavigationCancel, '/user/victor'],
+      [NavigationStart, '/user/victor'],
+      [NavigationCancel, '/user/victor'],
 
-         [NavigationStart, '/user/fedor'],
-         [RoutesRecognized, '/user/fedor'],
-         [GuardsCheckStart, '/user/fedor'],
-         [ChildActivationStart],
-         [ActivationStart],
-         [GuardsCheckEnd, '/user/fedor'],
-         [ResolveStart, '/user/fedor'],
-         [ResolveEnd, '/user/fedor'],
-         [ActivationEnd],
-         [ChildActivationEnd],
-         [NavigationEnd, '/user/fedor']
-       ]);
-     })));
+      [NavigationStart, '/user/fedor'],
+      [RoutesRecognized, '/user/fedor'],
+      [GuardsCheckStart, '/user/fedor'],
+      [ChildActivationStart],
+      [ActivationStart],
+      [GuardsCheckEnd, '/user/fedor'],
+      [ResolveStart, '/user/fedor'],
+      [ResolveEnd, '/user/fedor'],
+      [ActivationEnd],
+      [ChildActivationEnd],
+      [NavigationEnd, '/user/fedor']
+    ]);
+  })));
 
   it('should handle failed navigations gracefully', fakeAsync(inject([Router], (router: Router) => {
-       const fixture = createRoot(router, RootCmp);
+    const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{path: 'user/:name', component: UserCmp}]);
+    router.resetConfig([{ path: 'user/:name', component: UserCmp }]);
 
-       const recordedEvents: any[] = [];
-       router.events.forEach(e => recordedEvents.push(e));
+    const recordedEvents: any[] = [];
+    router.events.forEach(e => recordedEvents.push(e));
 
-       let e: any;
-       router.navigateByUrl('/invalid') !.catch(_ => e = _);
-       advance(fixture);
-       expect(e.message).toContain('Cannot match any routes');
+    let e: any;
+    router.navigateByUrl('/invalid')!.catch(_ => e = _);
+    advance(fixture);
+    expect(e.message).toContain('Cannot match any routes');
 
-       router.navigateByUrl('/user/fedor');
-       advance(fixture);
+    router.navigateByUrl('/user/fedor');
+    advance(fixture);
 
-       expect(fixture.nativeElement).toHaveText('user fedor');
+    expect(fixture.nativeElement).toHaveText('user fedor');
 
-       expectEvents(recordedEvents, [
-         [NavigationStart, '/invalid'], [NavigationError, '/invalid'],
+    expectEvents(recordedEvents, [
+      [NavigationStart, '/invalid'], [NavigationError, '/invalid'],
 
-         [NavigationStart, '/user/fedor'], [RoutesRecognized, '/user/fedor'],
-         [GuardsCheckStart, '/user/fedor'], [ChildActivationStart], [ActivationStart],
-         [GuardsCheckEnd, '/user/fedor'], [ResolveStart, '/user/fedor'],
-         [ResolveEnd, '/user/fedor'], [ActivationEnd], [ChildActivationEnd],
-         [NavigationEnd, '/user/fedor']
-       ]);
-     })));
+      [NavigationStart, '/user/fedor'], [RoutesRecognized, '/user/fedor'],
+      [GuardsCheckStart, '/user/fedor'], [ChildActivationStart], [ActivationStart],
+      [GuardsCheckEnd, '/user/fedor'], [ResolveStart, '/user/fedor'],
+      [ResolveEnd, '/user/fedor'], [ActivationEnd], [ChildActivationEnd],
+      [NavigationEnd, '/user/fedor']
+    ]);
+  })));
 
   // Errors should behave the same for both deferred and eager URL update strategies
   ['deferred', 'eager'].forEach((strat: any) => {
     it('should dispatch NavigationError after the url has been reset back', fakeAsync(() => {
-         const router: Router = TestBed.get(Router);
-         const location: SpyLocation = TestBed.get(Location);
-         const fixture = createRoot(router, RootCmp);
+      const router: Router = TestBed.get(Router);
+      const location: SpyLocation = TestBed.get(Location);
+      const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig(
-             [{path: 'simple', component: SimpleCmp}, {path: 'throwing', component: ThrowingCmp}]);
-         router.urlUpdateStrategy = strat;
+      router.resetConfig(
+        [{ path: 'simple', component: SimpleCmp }, { path: 'throwing', component: ThrowingCmp }]);
+      router.urlUpdateStrategy = strat;
 
-         router.navigateByUrl('/simple');
-         advance(fixture);
+      router.navigateByUrl('/simple');
+      advance(fixture);
 
-         let routerUrlBeforeEmittingError = '';
-         let locationUrlBeforeEmittingError = '';
-         router.events.forEach(e => {
-           if (e instanceof NavigationError) {
-             routerUrlBeforeEmittingError = router.url;
-             locationUrlBeforeEmittingError = location.path();
-           }
-         });
+      let routerUrlBeforeEmittingError = '';
+      let locationUrlBeforeEmittingError = '';
+      router.events.forEach(e => {
+        if (e instanceof NavigationError) {
+          routerUrlBeforeEmittingError = router.url;
+          locationUrlBeforeEmittingError = location.path();
+        }
+      });
 
-         router.navigateByUrl('/throwing').catch(() => null);
-         advance(fixture);
+      router.navigateByUrl('/throwing').catch(() => null);
+      advance(fixture);
 
-         expect(routerUrlBeforeEmittingError).toEqual('/simple');
-         expect(locationUrlBeforeEmittingError).toEqual('/simple');
-       }));
+      expect(routerUrlBeforeEmittingError).toEqual('/simple');
+      expect(locationUrlBeforeEmittingError).toEqual('/simple');
+    }));
 
     it('should reset the url with the right state when navigation errors', fakeAsync(() => {
-         const router: Router = TestBed.get(Router);
-         const location: SpyLocation = TestBed.get(Location);
-         const fixture = createRoot(router, RootCmp);
+      const router: Router = TestBed.get(Router);
+      const location: SpyLocation = TestBed.get(Location);
+      const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig([
-           {path: 'simple1', component: SimpleCmp}, {path: 'simple2', component: SimpleCmp},
-           {path: 'throwing', component: ThrowingCmp}
-         ]);
-         router.urlUpdateStrategy = strat;
+      router.resetConfig([
+        { path: 'simple1', component: SimpleCmp }, { path: 'simple2', component: SimpleCmp },
+        { path: 'throwing', component: ThrowingCmp }
+      ]);
+      router.urlUpdateStrategy = strat;
 
-         let event: NavigationStart;
-         router.events.subscribe(e => {
-           if (e instanceof NavigationStart) {
-             event = e;
-           }
-         });
+      let event: NavigationStart;
+      router.events.subscribe(e => {
+        if (e instanceof NavigationStart) {
+          event = e;
+        }
+      });
 
-         router.navigateByUrl('/simple1');
-         advance(fixture);
-         const simple1NavStart = event !;
+      router.navigateByUrl('/simple1');
+      advance(fixture);
+      const simple1NavStart = event!;
 
-         router.navigateByUrl('/throwing').catch(() => null);
-         advance(fixture);
+      router.navigateByUrl('/throwing').catch(() => null);
+      advance(fixture);
 
-         router.navigateByUrl('/simple2');
-         advance(fixture);
+      router.navigateByUrl('/simple2');
+      advance(fixture);
 
-         location.back();
-         tick();
+      location.back();
+      tick();
 
-         expect(event !.restoredState !.navigationId).toEqual(simple1NavStart.id);
-       }));
+      expect(event!.restoredState!.navigationId).toEqual(simple1NavStart.id);
+    }));
 
     it('should not trigger another navigation when resetting the url back due to a NavigationError',
-       fakeAsync(() => {
-         const router = TestBed.get(Router);
-         router.onSameUrlNavigation = 'reload';
+      fakeAsync(() => {
+        const router = TestBed.get(Router);
+        router.onSameUrlNavigation = 'reload';
 
-         const fixture = createRoot(router, RootCmp);
+        const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig(
-             [{path: 'simple', component: SimpleCmp}, {path: 'throwing', component: ThrowingCmp}]);
-         router.urlUpdateStrategy = strat;
+        router.resetConfig(
+          [{ path: 'simple', component: SimpleCmp }, { path: 'throwing', component: ThrowingCmp }]);
+        router.urlUpdateStrategy = strat;
 
-         const events: any[] = [];
-         router.events.forEach((e: any) => {
-           if (e instanceof NavigationStart) {
-             events.push(e.url);
-           }
-         });
+        const events: any[] = [];
+        router.events.forEach((e: any) => {
+          if (e instanceof NavigationStart) {
+            events.push(e.url);
+          }
+        });
 
-         router.navigateByUrl('/simple');
-         advance(fixture);
+        router.navigateByUrl('/simple');
+        advance(fixture);
 
-         router.navigateByUrl('/throwing').catch(() => null);
-         advance(fixture);
+        router.navigateByUrl('/throwing').catch(() => null);
+        advance(fixture);
 
-         // we do not trigger another navigation to /simple
-         expect(events).toEqual(['/simple', '/throwing']);
-       }));
+        // we do not trigger another navigation to /simple
+        expect(events).toEqual(['/simple', '/throwing']);
+      }));
 
   });
 
   it('should dispatch NavigationCancel after the url has been reset back', fakeAsync(() => {
-       TestBed.configureTestingModule(
-           {providers: [{provide: 'returnsFalse', useValue: () => false}]});
+    TestBed.configureTestingModule(
+      { providers: [{ provide: 'returnsFalse', useValue: () => false }] });
 
-       const router: Router = TestBed.get(Router);
-       const location: SpyLocation = TestBed.get(Location);
+    const router: Router = TestBed.get(Router);
+    const location: SpyLocation = TestBed.get(Location);
 
-       const fixture = createRoot(router, RootCmp);
+    const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([
-         {path: 'simple', component: SimpleCmp},
-         {path: 'throwing', loadChildren: 'doesnotmatter', canLoad: ['returnsFalse']}
-       ]);
+    router.resetConfig([
+      { path: 'simple', component: SimpleCmp },
+      { path: 'throwing', loadChildren: 'doesnotmatter', canLoad: ['returnsFalse'] }
+    ]);
 
-       router.navigateByUrl('/simple');
-       advance(fixture);
+    router.navigateByUrl('/simple');
+    advance(fixture);
 
-       let routerUrlBeforeEmittingError = '';
-       let locationUrlBeforeEmittingError = '';
-       router.events.forEach(e => {
-         if (e instanceof NavigationCancel) {
-           routerUrlBeforeEmittingError = router.url;
-           locationUrlBeforeEmittingError = location.path();
-         }
-       });
+    let routerUrlBeforeEmittingError = '';
+    let locationUrlBeforeEmittingError = '';
+    router.events.forEach(e => {
+      if (e instanceof NavigationCancel) {
+        routerUrlBeforeEmittingError = router.url;
+        locationUrlBeforeEmittingError = location.path();
+      }
+    });
 
-       location.simulateHashChange('/throwing');
-       advance(fixture);
+    location.simulateHashChange('/throwing');
+    advance(fixture);
 
-       expect(routerUrlBeforeEmittingError).toEqual('/simple');
-       expect(locationUrlBeforeEmittingError).toEqual('/simple');
-     }));
+    expect(routerUrlBeforeEmittingError).toEqual('/simple');
+    expect(locationUrlBeforeEmittingError).toEqual('/simple');
+  }));
 
   it('should support custom error handlers', fakeAsync(inject([Router], (router: Router) => {
-       router.errorHandler = (error) => 'resolvedValue';
-       const fixture = createRoot(router, RootCmp);
+    router.errorHandler = (error) => 'resolvedValue';
+    const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{path: 'user/:name', component: UserCmp}]);
+    router.resetConfig([{ path: 'user/:name', component: UserCmp }]);
 
-       const recordedEvents: any[] = [];
-       router.events.forEach(e => recordedEvents.push(e));
+    const recordedEvents: any[] = [];
+    router.events.forEach(e => recordedEvents.push(e));
 
-       let e: any;
-       router.navigateByUrl('/invalid') !.then(_ => e = _);
-       advance(fixture);
-       expect(e).toEqual('resolvedValue');
+    let e: any;
+    router.navigateByUrl('/invalid')!.then(_ => e = _);
+    advance(fixture);
+    expect(e).toEqual('resolvedValue');
 
-       expectEvents(recordedEvents, [[NavigationStart, '/invalid'], [NavigationError, '/invalid']]);
-     })));
+    expectEvents(recordedEvents, [[NavigationStart, '/invalid'], [NavigationError, '/invalid']]);
+  })));
 
   it('should recover from malformed uri errors',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       router.resetConfig([{path: 'simple', component: SimpleCmp}]);
-       const fixture = createRoot(router, RootCmp);
-       router.navigateByUrl('/invalid/url%with%percent');
-       advance(fixture);
-       expect(location.path()).toEqual('/');
-     })));
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      router.resetConfig([{ path: 'simple', component: SimpleCmp }]);
+      const fixture = createRoot(router, RootCmp);
+      router.navigateByUrl('/invalid/url%with%percent');
+      advance(fixture);
+      expect(location.path()).toEqual('/');
+    })));
 
   it('should support custom malformed uri error handler',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       const customMalformedUriErrorHandler =
-           (e: URIError, urlSerializer: UrlSerializer, url: string):
-               UrlTree => { return urlSerializer.parse('/?error=The-URL-you-went-to-is-invalid'); };
-       router.malformedUriErrorHandler = customMalformedUriErrorHandler;
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      const customMalformedUriErrorHandler =
+        (e: URIError, urlSerializer: UrlSerializer, url: string):
+          UrlTree => { return urlSerializer.parse('/?error=The-URL-you-went-to-is-invalid'); };
+      router.malformedUriErrorHandler = customMalformedUriErrorHandler;
 
-       router.resetConfig([{path: 'simple', component: SimpleCmp}]);
+      router.resetConfig([{ path: 'simple', component: SimpleCmp }]);
 
-       const fixture = createRoot(router, RootCmp);
-       router.navigateByUrl('/invalid/url%with%percent');
-       advance(fixture);
-       expect(location.path()).toEqual('/?error=The-URL-you-went-to-is-invalid');
-     })));
+      const fixture = createRoot(router, RootCmp);
+      router.navigateByUrl('/invalid/url%with%percent');
+      advance(fixture);
+      expect(location.path()).toEqual('/?error=The-URL-you-went-to-is-invalid');
+    })));
 
   it('should not swallow errors', fakeAsync(inject([Router], (router: Router) => {
-       const fixture = createRoot(router, RootCmp);
+    const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{path: 'simple', component: SimpleCmp}]);
+    router.resetConfig([{ path: 'simple', component: SimpleCmp }]);
 
-       router.navigateByUrl('/invalid');
-       expect(() => advance(fixture)).toThrow();
+    router.navigateByUrl('/invalid');
+    expect(() => advance(fixture)).toThrow();
 
-       router.navigateByUrl('/invalid2');
-       expect(() => advance(fixture)).toThrow();
-     })));
+    router.navigateByUrl('/invalid2');
+    expect(() => advance(fixture)).toThrow();
+  })));
 
 
   it('should replace state when path is equal to current path',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       const fixture = createRoot(router, RootCmp);
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{
-         path: 'team/:id',
-         component: TeamCmp,
-         children:
-             [{path: 'simple', component: SimpleCmp}, {path: 'user/:name', component: UserCmp}]
-       }]);
+      router.resetConfig([{
+        path: 'team/:id',
+        component: TeamCmp,
+        children:
+          [{ path: 'simple', component: SimpleCmp }, { path: 'user/:name', component: UserCmp }]
+      }]);
 
-       router.navigateByUrl('/team/33/simple');
-       advance(fixture);
+      router.navigateByUrl('/team/33/simple');
+      advance(fixture);
 
-       router.navigateByUrl('/team/22/user/victor');
-       advance(fixture);
+      router.navigateByUrl('/team/22/user/victor');
+      advance(fixture);
 
-       router.navigateByUrl('/team/22/user/victor');
-       advance(fixture);
+      router.navigateByUrl('/team/22/user/victor');
+      advance(fixture);
 
-       location.back();
-       advance(fixture);
-       expect(location.path()).toEqual('/team/33/simple');
-     })));
+      location.back();
+      advance(fixture);
+      expect(location.path()).toEqual('/team/33/simple');
+    })));
 
   it('should handle componentless paths',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       const fixture = createRoot(router, RootCmpWithTwoOutlets);
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      const fixture = createRoot(router, RootCmpWithTwoOutlets);
 
-       router.resetConfig([
-         {
-           path: 'parent/:id',
-           children: [
-             {path: 'simple', component: SimpleCmp},
-             {path: 'user/:name', component: UserCmp, outlet: 'right'}
-           ]
-         },
-         {path: 'user/:name', component: UserCmp}
-       ]);
+      router.resetConfig([
+        {
+          path: 'parent/:id',
+          children: [
+            { path: 'simple', component: SimpleCmp },
+            { path: 'user/:name', component: UserCmp, outlet: 'right' }
+          ]
+        },
+        { path: 'user/:name', component: UserCmp }
+      ]);
 
 
-       // navigate to a componentless route
-       router.navigateByUrl('/parent/11/(simple//right:user/victor)');
-       advance(fixture);
-       expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
-       expect(fixture.nativeElement).toHaveText('primary [simple] right [user victor]');
+      // navigate to a componentless route
+      router.navigateByUrl('/parent/11/(simple//right:user/victor)');
+      advance(fixture);
+      expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
+      expect(fixture.nativeElement).toHaveText('primary [simple] right [user victor]');
 
-       // navigate to the same route with different params (reuse)
-       router.navigateByUrl('/parent/22/(simple//right:user/fedor)');
-       advance(fixture);
-       expect(location.path()).toEqual('/parent/22/(simple//right:user/fedor)');
-       expect(fixture.nativeElement).toHaveText('primary [simple] right [user fedor]');
+      // navigate to the same route with different params (reuse)
+      router.navigateByUrl('/parent/22/(simple//right:user/fedor)');
+      advance(fixture);
+      expect(location.path()).toEqual('/parent/22/(simple//right:user/fedor)');
+      expect(fixture.nativeElement).toHaveText('primary [simple] right [user fedor]');
 
-       // navigate to a normal route (check deactivation)
-       router.navigateByUrl('/user/victor');
-       advance(fixture);
-       expect(location.path()).toEqual('/user/victor');
-       expect(fixture.nativeElement).toHaveText('primary [user victor] right []');
+      // navigate to a normal route (check deactivation)
+      router.navigateByUrl('/user/victor');
+      advance(fixture);
+      expect(location.path()).toEqual('/user/victor');
+      expect(fixture.nativeElement).toHaveText('primary [user victor] right []');
 
-       // navigate back to a componentless route
-       router.navigateByUrl('/parent/11/(simple//right:user/victor)');
-       advance(fixture);
-       expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
-       expect(fixture.nativeElement).toHaveText('primary [simple] right [user victor]');
-     })));
+      // navigate back to a componentless route
+      router.navigateByUrl('/parent/11/(simple//right:user/victor)');
+      advance(fixture);
+      expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
+      expect(fixture.nativeElement).toHaveText('primary [simple] right [user victor]');
+    })));
 
   it('should not deactivate aux routes when navigating from a componentless routes',
-     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-       const fixture = createRoot(router, TwoOutletsCmp);
+    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+      const fixture = createRoot(router, TwoOutletsCmp);
 
-       router.resetConfig([
-         {path: 'simple', component: SimpleCmp},
-         {path: 'componentless', children: [{path: 'simple', component: SimpleCmp}]},
-         {path: 'user/:name', outlet: 'aux', component: UserCmp}
-       ]);
+      router.resetConfig([
+        { path: 'simple', component: SimpleCmp },
+        { path: 'componentless', children: [{ path: 'simple', component: SimpleCmp }] },
+        { path: 'user/:name', outlet: 'aux', component: UserCmp }
+      ]);
 
-       router.navigateByUrl('/componentless/simple(aux:user/victor)');
-       advance(fixture);
-       expect(location.path()).toEqual('/componentless/simple(aux:user/victor)');
-       expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
+      router.navigateByUrl('/componentless/simple(aux:user/victor)');
+      advance(fixture);
+      expect(location.path()).toEqual('/componentless/simple(aux:user/victor)');
+      expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
 
-       router.navigateByUrl('/simple(aux:user/victor)');
-       advance(fixture);
-       expect(location.path()).toEqual('/simple(aux:user/victor)');
-       expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
-     })));
+      router.navigateByUrl('/simple(aux:user/victor)');
+      advance(fixture);
+      expect(location.path()).toEqual('/simple(aux:user/victor)');
+      expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
+    })));
 
   it('should emit an event when an outlet gets activated', fakeAsync(() => {
-       @Component({
-         selector: 'container',
-         template:
-             `<router-outlet (activate)="recordActivate($event)" (deactivate)="recordDeactivate($event)"></router-outlet>`
-       })
-       class Container {
-         activations: any[] = [];
-         deactivations: any[] = [];
+    @Component({
+      selector: 'container',
+      template:
+        `<router-outlet (activate)="recordActivate($event)" (deactivate)="recordDeactivate($event)"></router-outlet>`
+    })
+    class Container {
+      activations: any[] = [];
+      deactivations: any[] = [];
 
-         recordActivate(component: any): void { this.activations.push(component); }
+      recordActivate(component: any): void { this.activations.push(component); }
 
-         recordDeactivate(component: any): void { this.deactivations.push(component); }
-       }
+      recordDeactivate(component: any): void { this.deactivations.push(component); }
+    }
 
-       TestBed.configureTestingModule({declarations: [Container]});
+    TestBed.configureTestingModule({ declarations: [Container] });
 
-       const router: Router = TestBed.get(Router);
+    const router: Router = TestBed.get(Router);
 
-       const fixture = createRoot(router, Container);
-       const cmp = fixture.componentInstance;
+    const fixture = createRoot(router, Container);
+    const cmp = fixture.componentInstance;
 
-       router.resetConfig(
-           [{path: 'blank', component: BlankCmp}, {path: 'simple', component: SimpleCmp}]);
+    router.resetConfig(
+      [{ path: 'blank', component: BlankCmp }, { path: 'simple', component: SimpleCmp }]);
 
-       cmp.activations = [];
-       cmp.deactivations = [];
+    cmp.activations = [];
+    cmp.deactivations = [];
 
-       router.navigateByUrl('/blank');
-       advance(fixture);
+    router.navigateByUrl('/blank');
+    advance(fixture);
 
-       expect(cmp.activations.length).toEqual(1);
-       expect(cmp.activations[0] instanceof BlankCmp).toBe(true);
+    expect(cmp.activations.length).toEqual(1);
+    expect(cmp.activations[0] instanceof BlankCmp).toBe(true);
 
-       router.navigateByUrl('/simple');
-       advance(fixture);
+    router.navigateByUrl('/simple');
+    advance(fixture);
 
-       expect(cmp.activations.length).toEqual(2);
-       expect(cmp.activations[1] instanceof SimpleCmp).toBe(true);
-       expect(cmp.deactivations.length).toEqual(1);
-       expect(cmp.deactivations[0] instanceof BlankCmp).toBe(true);
-     }));
+    expect(cmp.activations.length).toEqual(2);
+    expect(cmp.activations[1] instanceof SimpleCmp).toBe(true);
+    expect(cmp.deactivations.length).toEqual(1);
+    expect(cmp.deactivations[0] instanceof BlankCmp).toBe(true);
+  }));
 
   it('should update url and router state before activating components',
-     fakeAsync(inject([Router], (router: Router) => {
+    fakeAsync(inject([Router], (router: Router) => {
 
-       const fixture = createRoot(router, RootCmp);
+      const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{path: 'cmp', component: ComponentRecordingRoutePathAndUrl}]);
+      router.resetConfig([{ path: 'cmp', component: ComponentRecordingRoutePathAndUrl }]);
 
-       router.navigateByUrl('/cmp');
-       advance(fixture);
+      router.navigateByUrl('/cmp');
+      advance(fixture);
 
-       const cmp = fixture.debugElement.children[1].componentInstance;
+      const cmp = fixture.debugElement.children[1].componentInstance;
 
-       expect(cmp.url).toBe('/cmp');
-       expect(cmp.path.length).toEqual(2);
-     })));
+      expect(cmp.url).toBe('/cmp');
+      expect(cmp.path.length).toEqual(2);
+    })));
 
 
 
@@ -1277,138 +1277,138 @@ describe('Integration', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         providers: [
-          {provide: 'resolveTwo', useValue: (a: any, b: any) => 2},
-          {provide: 'resolveFour', useValue: (a: any, b: any) => 4},
-          {provide: 'resolveSix', useClass: ResolveSix},
-          {provide: 'resolveError', useValue: (a: any, b: any) => Promise.reject('error')},
-          {provide: 'resolveNullError', useValue: (a: any, b: any) => Promise.reject(null)},
-          {provide: 'numberOfUrlSegments', useValue: (a: any, b: any) => a.url.length},
+          { provide: 'resolveTwo', useValue: (a: any, b: any) => 2 },
+          { provide: 'resolveFour', useValue: (a: any, b: any) => 4 },
+          { provide: 'resolveSix', useClass: ResolveSix },
+          { provide: 'resolveError', useValue: (a: any, b: any) => Promise.reject('error') },
+          { provide: 'resolveNullError', useValue: (a: any, b: any) => Promise.reject(null) },
+          { provide: 'numberOfUrlSegments', useValue: (a: any, b: any) => a.url.length },
         ]
       });
     });
 
     it('should provide resolved data', fakeAsync(inject([Router], (router: Router) => {
-         const fixture = createRoot(router, RootCmpWithTwoOutlets);
+      const fixture = createRoot(router, RootCmpWithTwoOutlets);
 
-         router.resetConfig([{
-           path: 'parent/:id',
-           data: {one: 1},
-           resolve: {two: 'resolveTwo'},
-           children: [
-             {path: '', data: {three: 3}, resolve: {four: 'resolveFour'}, component: RouteCmp}, {
-               path: '',
-               data: {five: 5},
-               resolve: {six: 'resolveSix'},
-               component: RouteCmp,
-               outlet: 'right'
-             }
-           ]
-         }]);
+      router.resetConfig([{
+        path: 'parent/:id',
+        data: { one: 1 },
+        resolve: { two: 'resolveTwo' },
+        children: [
+          { path: '', data: { three: 3 }, resolve: { four: 'resolveFour' }, component: RouteCmp }, {
+            path: '',
+            data: { five: 5 },
+            resolve: { six: 'resolveSix' },
+            component: RouteCmp,
+            outlet: 'right'
+          }
+        ]
+      }]);
 
-         router.navigateByUrl('/parent/1');
-         advance(fixture);
+      router.navigateByUrl('/parent/1');
+      advance(fixture);
 
-         const primaryCmp = fixture.debugElement.children[1].componentInstance;
-         const rightCmp = fixture.debugElement.children[3].componentInstance;
+      const primaryCmp = fixture.debugElement.children[1].componentInstance;
+      const rightCmp = fixture.debugElement.children[3].componentInstance;
 
-         expect(primaryCmp.route.snapshot.data).toEqual({one: 1, two: 2, three: 3, four: 4});
-         expect(rightCmp.route.snapshot.data).toEqual({one: 1, two: 2, five: 5, six: 6});
+      expect(primaryCmp.route.snapshot.data).toEqual({ one: 1, two: 2, three: 3, four: 4 });
+      expect(rightCmp.route.snapshot.data).toEqual({ one: 1, two: 2, five: 5, six: 6 });
 
-         const primaryRecorded: any[] = [];
-         primaryCmp.route.data.forEach((rec: any) => primaryRecorded.push(rec));
+      const primaryRecorded: any[] = [];
+      primaryCmp.route.data.forEach((rec: any) => primaryRecorded.push(rec));
 
-         const rightRecorded: any[] = [];
-         rightCmp.route.data.forEach((rec: any) => rightRecorded.push(rec));
+      const rightRecorded: any[] = [];
+      rightCmp.route.data.forEach((rec: any) => rightRecorded.push(rec));
 
-         router.navigateByUrl('/parent/2');
-         advance(fixture);
+      router.navigateByUrl('/parent/2');
+      advance(fixture);
 
-         expect(primaryRecorded).toEqual([{one: 1, three: 3, two: 2, four: 4}]);
-         expect(rightRecorded).toEqual([{one: 1, five: 5, two: 2, six: 6}]);
-       })));
+      expect(primaryRecorded).toEqual([{ one: 1, three: 3, two: 2, four: 4 }]);
+      expect(rightRecorded).toEqual([{ one: 1, five: 5, two: 2, six: 6 }]);
+    })));
 
     it('should handle errors', fakeAsync(inject([Router], (router: Router) => {
-         const fixture = createRoot(router, RootCmp);
+      const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig(
-             [{path: 'simple', component: SimpleCmp, resolve: {error: 'resolveError'}}]);
+      router.resetConfig(
+        [{ path: 'simple', component: SimpleCmp, resolve: { error: 'resolveError' } }]);
 
-         const recordedEvents: any[] = [];
-         router.events.subscribe(e => e instanceof RouterEvent && recordedEvents.push(e));
+      const recordedEvents: any[] = [];
+      router.events.subscribe(e => e instanceof RouterEvent && recordedEvents.push(e));
 
-         let e: any = null;
-         router.navigateByUrl('/simple') !.catch(error => e = error);
-         advance(fixture);
+      let e: any = null;
+      router.navigateByUrl('/simple')!.catch(error => e = error);
+      advance(fixture);
 
-         expectEvents(recordedEvents, [
-           [NavigationStart, '/simple'], [RoutesRecognized, '/simple'],
-           [GuardsCheckStart, '/simple'], [GuardsCheckEnd, '/simple'], [ResolveStart, '/simple'],
-           [NavigationError, '/simple']
-         ]);
+      expectEvents(recordedEvents, [
+        [NavigationStart, '/simple'], [RoutesRecognized, '/simple'],
+        [GuardsCheckStart, '/simple'], [GuardsCheckEnd, '/simple'], [ResolveStart, '/simple'],
+        [NavigationError, '/simple']
+      ]);
 
-         expect(e).toEqual('error');
-       })));
+      expect(e).toEqual('error');
+    })));
 
     it('should handle empty errors', fakeAsync(inject([Router], (router: Router) => {
-         const fixture = createRoot(router, RootCmp);
+      const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig(
-             [{path: 'simple', component: SimpleCmp, resolve: {error: 'resolveNullError'}}]);
+      router.resetConfig(
+        [{ path: 'simple', component: SimpleCmp, resolve: { error: 'resolveNullError' } }]);
 
-         const recordedEvents: any[] = [];
-         router.events.subscribe(e => e instanceof RouterEvent && recordedEvents.push(e));
+      const recordedEvents: any[] = [];
+      router.events.subscribe(e => e instanceof RouterEvent && recordedEvents.push(e));
 
-         let e: any = 'some value';
-         router.navigateByUrl('/simple').catch(error => e = error);
-         advance(fixture);
+      let e: any = 'some value';
+      router.navigateByUrl('/simple').catch(error => e = error);
+      advance(fixture);
 
-         expect(e).toEqual(null);
-       })));
+      expect(e).toEqual(null);
+    })));
 
     it('should preserve resolved data', fakeAsync(inject([Router], (router: Router) => {
-         const fixture = createRoot(router, RootCmp);
+      const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig([{
-           path: 'parent',
-           resolve: {two: 'resolveTwo'},
-           children: [
-             {path: 'child1', component: CollectParamsCmp},
-             {path: 'child2', component: CollectParamsCmp}
-           ]
-         }]);
+      router.resetConfig([{
+        path: 'parent',
+        resolve: { two: 'resolveTwo' },
+        children: [
+          { path: 'child1', component: CollectParamsCmp },
+          { path: 'child2', component: CollectParamsCmp }
+        ]
+      }]);
 
-         const e: any = null;
-         router.navigateByUrl('/parent/child1');
-         advance(fixture);
+      const e: any = null;
+      router.navigateByUrl('/parent/child1');
+      advance(fixture);
 
-         router.navigateByUrl('/parent/child2');
-         advance(fixture);
+      router.navigateByUrl('/parent/child2');
+      advance(fixture);
 
-         const cmp = fixture.debugElement.children[1].componentInstance;
-         expect(cmp.route.snapshot.data).toEqual({two: 2});
-       })));
+      const cmp = fixture.debugElement.children[1].componentInstance;
+      expect(cmp.route.snapshot.data).toEqual({ two: 2 });
+    })));
 
     it('should rerun resolvers when the urls segments of a wildcard route change',
-       fakeAsync(inject([Router, Location], (router: Router) => {
-         const fixture = createRoot(router, RootCmp);
+      fakeAsync(inject([Router, Location], (router: Router) => {
+        const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig([{
-           path: '**',
-           component: CollectParamsCmp,
-           resolve: {numberOfUrlSegments: 'numberOfUrlSegments'}
-         }]);
+        router.resetConfig([{
+          path: '**',
+          component: CollectParamsCmp,
+          resolve: { numberOfUrlSegments: 'numberOfUrlSegments' }
+        }]);
 
-         router.navigateByUrl('/one/two');
-         advance(fixture);
-         const cmp = fixture.debugElement.children[1].componentInstance;
+        router.navigateByUrl('/one/two');
+        advance(fixture);
+        const cmp = fixture.debugElement.children[1].componentInstance;
 
-         expect(cmp.route.snapshot.data).toEqual({numberOfUrlSegments: 2});
+        expect(cmp.route.snapshot.data).toEqual({ numberOfUrlSegments: 2 });
 
-         router.navigateByUrl('/one/two/three');
-         advance(fixture);
+        router.navigateByUrl('/one/two/three');
+        advance(fixture);
 
-         expect(cmp.route.snapshot.data).toEqual({numberOfUrlSegments: 3});
-       })));
+        expect(cmp.route.snapshot.data).toEqual({ numberOfUrlSegments: 3 });
+      })));
 
     describe('should run resolvers for the same route concurrently', () => {
       let log: string[];
@@ -1423,7 +1423,7 @@ describe('Integration', () => {
               useValue: () => {
                 const obs$ = new Observable((obs: Observer<any>) => {
                   observer = obs;
-                  return () => {};
+                  return () => { };
                 });
                 return obs$.pipe(map(() => log.push('resolver1')));
               }
@@ -1431,7 +1431,7 @@ describe('Integration', () => {
             {
               provide: 'resolver2',
               useValue: () => {
-                return of (null).pipe(map(() => {
+                return of(null).pipe(map(() => {
                   log.push('resolver2');
                   observer.next(null);
                   observer.complete();
@@ -1443,365 +1443,365 @@ describe('Integration', () => {
       });
 
       it('works', fakeAsync(inject([Router], (router: Router) => {
-           const fixture = createRoot(router, RootCmp);
+        const fixture = createRoot(router, RootCmp);
 
-           router.resetConfig([{
-             path: 'a',
-             resolve: {
-               one: 'resolver1',
-               two: 'resolver2',
-             },
-             component: SimpleCmp
-           }]);
+        router.resetConfig([{
+          path: 'a',
+          resolve: {
+            one: 'resolver1',
+            two: 'resolver2',
+          },
+          component: SimpleCmp
+        }]);
 
-           router.navigateByUrl('/a');
-           advance(fixture);
+        router.navigateByUrl('/a');
+        advance(fixture);
 
-           expect(log).toEqual(['resolver2', 'resolver1']);
-         })));
+        expect(log).toEqual(['resolver2', 'resolver1']);
+      })));
     });
   });
 
   describe('router links', () => {
     it('should support skipping location update for anchor router links',
-       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-         const fixture = TestBed.createComponent(RootCmp);
-         advance(fixture);
+      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+        const fixture = TestBed.createComponent(RootCmp);
+        advance(fixture);
 
-         router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
+        router.resetConfig([{ path: 'team/:id', component: TeamCmp }]);
 
-         router.navigateByUrl('/team/22');
-         advance(fixture);
-         expect(location.path()).toEqual('/team/22');
-         expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+        router.navigateByUrl('/team/22');
+        advance(fixture);
+        expect(location.path()).toEqual('/team/22');
+        expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
-         const teamCmp = fixture.debugElement.childNodes[1].componentInstance;
+        const teamCmp = fixture.debugElement.childNodes[1].componentInstance;
 
-         teamCmp.routerLink = ['/team/0'];
-         advance(fixture);
-         const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
-         anchor.click();
-         advance(fixture);
-         expect(fixture.nativeElement).toHaveText('team 0 [ , right:  ]');
-         expect(location.path()).toEqual('/team/22');
+        teamCmp.routerLink = ['/team/0'];
+        advance(fixture);
+        const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
+        anchor.click();
+        advance(fixture);
+        expect(fixture.nativeElement).toHaveText('team 0 [ , right:  ]');
+        expect(location.path()).toEqual('/team/22');
 
-         teamCmp.routerLink = ['/team/1'];
-         advance(fixture);
-         const button = fixture.debugElement.query(By.css('button')).nativeElement;
-         button.click();
-         advance(fixture);
-         expect(fixture.nativeElement).toHaveText('team 1 [ , right:  ]');
-         expect(location.path()).toEqual('/team/22');
-       })));
+        teamCmp.routerLink = ['/team/1'];
+        advance(fixture);
+        const button = fixture.debugElement.query(By.css('button')).nativeElement;
+        button.click();
+        advance(fixture);
+        expect(fixture.nativeElement).toHaveText('team 1 [ , right:  ]');
+        expect(location.path()).toEqual('/team/22');
+      })));
 
     it('should support string router links', fakeAsync(inject([Router], (router: Router) => {
-         const fixture = createRoot(router, RootCmp);
+      const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig([{
-           path: 'team/:id',
-           component: TeamCmp,
-           children: [
-             {path: 'link', component: StringLinkCmp}, {path: 'simple', component: SimpleCmp}
-           ]
-         }]);
+      router.resetConfig([{
+        path: 'team/:id',
+        component: TeamCmp,
+        children: [
+          { path: 'link', component: StringLinkCmp }, { path: 'simple', component: SimpleCmp }
+        ]
+      }]);
 
-         router.navigateByUrl('/team/22/link');
-         advance(fixture);
-         expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
+      router.navigateByUrl('/team/22/link');
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
-         const native = fixture.nativeElement.querySelector('a');
-         expect(native.getAttribute('href')).toEqual('/team/33/simple');
-         expect(native.getAttribute('target')).toEqual('_self');
-         native.click();
-         advance(fixture);
+      const native = fixture.nativeElement.querySelector('a');
+      expect(native.getAttribute('href')).toEqual('/team/33/simple');
+      expect(native.getAttribute('target')).toEqual('_self');
+      native.click();
+      advance(fixture);
 
-         expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
-       })));
+      expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
+    })));
 
     it('should not preserve query params and fragment by default', fakeAsync(() => {
-         @Component({
-           selector: 'someRoot',
-           template: `<router-outlet></router-outlet><a routerLink="/home">Link</a>`
-         })
-         class RootCmpWithLink {
-         }
+      @Component({
+        selector: 'someRoot',
+        template: `<router-outlet></router-outlet><a routerLink="/home">Link</a>`
+      })
+      class RootCmpWithLink {
+      }
 
-         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
-         const router: Router = TestBed.get(Router);
+      TestBed.configureTestingModule({ declarations: [RootCmpWithLink] });
+      const router: Router = TestBed.get(Router);
 
-         const fixture = createRoot(router, RootCmpWithLink);
+      const fixture = createRoot(router, RootCmpWithLink);
 
-         router.resetConfig([{path: 'home', component: SimpleCmp}]);
+      router.resetConfig([{ path: 'home', component: SimpleCmp }]);
 
-         const native = fixture.nativeElement.querySelector('a');
+      const native = fixture.nativeElement.querySelector('a');
 
-         router.navigateByUrl('/home?q=123#fragment');
-         advance(fixture);
-         expect(native.getAttribute('href')).toEqual('/home');
-       }));
+      router.navigateByUrl('/home?q=123#fragment');
+      advance(fixture);
+      expect(native.getAttribute('href')).toEqual('/home');
+    }));
 
     it('should not throw when commands is null', fakeAsync(() => {
-         @Component({
-           selector: 'someCmp',
-           template:
-               `<router-outlet></router-outlet><a [routerLink]="null">Link</a><button [routerLink]="null">Button</button>`
-         })
-         class CmpWithLink {
-         }
+      @Component({
+        selector: 'someCmp',
+        template:
+          `<router-outlet></router-outlet><a [routerLink]="null">Link</a><button [routerLink]="null">Button</button>`
+      })
+      class CmpWithLink {
+      }
 
-         TestBed.configureTestingModule({declarations: [CmpWithLink]});
-         const router: Router = TestBed.get(Router);
+      TestBed.configureTestingModule({ declarations: [CmpWithLink] });
+      const router: Router = TestBed.get(Router);
 
-         let fixture: ComponentFixture<CmpWithLink> = createRoot(router, CmpWithLink);
-         router.resetConfig([{path: 'home', component: SimpleCmp}]);
-         const anchor = fixture.nativeElement.querySelector('a');
-         const button = fixture.nativeElement.querySelector('button');
-         expect(() => anchor.click()).not.toThrow();
-         expect(() => button.click()).not.toThrow();
-       }));
+      let fixture: ComponentFixture<CmpWithLink> = createRoot(router, CmpWithLink);
+      router.resetConfig([{ path: 'home', component: SimpleCmp }]);
+      const anchor = fixture.nativeElement.querySelector('a');
+      const button = fixture.nativeElement.querySelector('button');
+      expect(() => anchor.click()).not.toThrow();
+      expect(() => button.click()).not.toThrow();
+    }));
 
     it('should update hrefs when query params or fragment change', fakeAsync(() => {
 
-         @Component({
-           selector: 'someRoot',
-           template:
-               `<router-outlet></router-outlet><a routerLink="/home" preserveQueryParams preserveFragment>Link</a>`
-         })
-         class RootCmpWithLink {
-         }
-         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
-         const router: Router = TestBed.get(Router);
-         const fixture = createRoot(router, RootCmpWithLink);
+      @Component({
+        selector: 'someRoot',
+        template:
+          `<router-outlet></router-outlet><a routerLink="/home" preserveQueryParams preserveFragment>Link</a>`
+      })
+      class RootCmpWithLink {
+      }
+      TestBed.configureTestingModule({ declarations: [RootCmpWithLink] });
+      const router: Router = TestBed.get(Router);
+      const fixture = createRoot(router, RootCmpWithLink);
 
-         router.resetConfig([{path: 'home', component: SimpleCmp}]);
+      router.resetConfig([{ path: 'home', component: SimpleCmp }]);
 
-         const native = fixture.nativeElement.querySelector('a');
+      const native = fixture.nativeElement.querySelector('a');
 
-         router.navigateByUrl('/home?q=123');
-         advance(fixture);
-         expect(native.getAttribute('href')).toEqual('/home?q=123');
+      router.navigateByUrl('/home?q=123');
+      advance(fixture);
+      expect(native.getAttribute('href')).toEqual('/home?q=123');
 
-         router.navigateByUrl('/home?q=456');
-         advance(fixture);
-         expect(native.getAttribute('href')).toEqual('/home?q=456');
+      router.navigateByUrl('/home?q=456');
+      advance(fixture);
+      expect(native.getAttribute('href')).toEqual('/home?q=456');
 
-         router.navigateByUrl('/home?q=456#1');
-         advance(fixture);
-         expect(native.getAttribute('href')).toEqual('/home?q=456#1');
-       }));
+      router.navigateByUrl('/home?q=456#1');
+      advance(fixture);
+      expect(native.getAttribute('href')).toEqual('/home?q=456#1');
+    }));
 
     it('should correctly use the preserve strategy', fakeAsync(() => {
 
-         @Component({
-           selector: 'someRoot',
-           template:
-               `<router-outlet></router-outlet><a routerLink="/home" [queryParams]="{q: 456}" queryParamsHandling="preserve">Link</a>`
-         })
-         class RootCmpWithLink {
-         }
-         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
-         const router: Router = TestBed.get(Router);
-         const fixture = createRoot(router, RootCmpWithLink);
+      @Component({
+        selector: 'someRoot',
+        template:
+          `<router-outlet></router-outlet><a routerLink="/home" [queryParams]="{q: 456}" queryParamsHandling="preserve">Link</a>`
+      })
+      class RootCmpWithLink {
+      }
+      TestBed.configureTestingModule({ declarations: [RootCmpWithLink] });
+      const router: Router = TestBed.get(Router);
+      const fixture = createRoot(router, RootCmpWithLink);
 
-         router.resetConfig([{path: 'home', component: SimpleCmp}]);
+      router.resetConfig([{ path: 'home', component: SimpleCmp }]);
 
-         const native = fixture.nativeElement.querySelector('a');
+      const native = fixture.nativeElement.querySelector('a');
 
-         router.navigateByUrl('/home?a=123');
-         advance(fixture);
-         expect(native.getAttribute('href')).toEqual('/home?a=123');
-       }));
+      router.navigateByUrl('/home?a=123');
+      advance(fixture);
+      expect(native.getAttribute('href')).toEqual('/home?a=123');
+    }));
 
     it('should correctly use the merge strategy', fakeAsync(() => {
 
-         @Component({
-           selector: 'someRoot',
-           template:
-               `<router-outlet></router-outlet><a routerLink="/home" [queryParams]="{removeMe: null, q: 456}" queryParamsHandling="merge">Link</a>`
-         })
-         class RootCmpWithLink {
-         }
-         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
-         const router: Router = TestBed.get(Router);
-         const fixture = createRoot(router, RootCmpWithLink);
+      @Component({
+        selector: 'someRoot',
+        template:
+          `<router-outlet></router-outlet><a routerLink="/home" [queryParams]="{removeMe: null, q: 456}" queryParamsHandling="merge">Link</a>`
+      })
+      class RootCmpWithLink {
+      }
+      TestBed.configureTestingModule({ declarations: [RootCmpWithLink] });
+      const router: Router = TestBed.get(Router);
+      const fixture = createRoot(router, RootCmpWithLink);
 
-         router.resetConfig([{path: 'home', component: SimpleCmp}]);
+      router.resetConfig([{ path: 'home', component: SimpleCmp }]);
 
-         const native = fixture.nativeElement.querySelector('a');
+      const native = fixture.nativeElement.querySelector('a');
 
-         router.navigateByUrl('/home?a=123&removeMe=123');
-         advance(fixture);
-         expect(native.getAttribute('href')).toEqual('/home?a=123&q=456');
-       }));
+      router.navigateByUrl('/home?a=123&removeMe=123');
+      advance(fixture);
+      expect(native.getAttribute('href')).toEqual('/home?a=123&q=456');
+    }));
 
     it('should support using links on non-a tags', fakeAsync(inject([Router], (router: Router) => {
-         const fixture = createRoot(router, RootCmp);
+      const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig([{
-           path: 'team/:id',
-           component: TeamCmp,
-           children: [
-             {path: 'link', component: StringLinkButtonCmp},
-             {path: 'simple', component: SimpleCmp}
-           ]
-         }]);
+      router.resetConfig([{
+        path: 'team/:id',
+        component: TeamCmp,
+        children: [
+          { path: 'link', component: StringLinkButtonCmp },
+          { path: 'simple', component: SimpleCmp }
+        ]
+      }]);
 
-         router.navigateByUrl('/team/22/link');
-         advance(fixture);
-         expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
+      router.navigateByUrl('/team/22/link');
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
-         const button = fixture.nativeElement.querySelector('button');
-         expect(button.getAttribute('tabindex')).toEqual('0');
-         button.click();
-         advance(fixture);
+      const button = fixture.nativeElement.querySelector('button');
+      expect(button.getAttribute('tabindex')).toEqual('0');
+      button.click();
+      advance(fixture);
 
-         expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
-       })));
+      expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
+    })));
 
     it('should support absolute router links', fakeAsync(inject([Router], (router: Router) => {
-         const fixture = createRoot(router, RootCmp);
+      const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig([{
-           path: 'team/:id',
-           component: TeamCmp,
-           children: [
-             {path: 'link', component: AbsoluteLinkCmp}, {path: 'simple', component: SimpleCmp}
-           ]
-         }]);
+      router.resetConfig([{
+        path: 'team/:id',
+        component: TeamCmp,
+        children: [
+          { path: 'link', component: AbsoluteLinkCmp }, { path: 'simple', component: SimpleCmp }
+        ]
+      }]);
 
-         router.navigateByUrl('/team/22/link');
-         advance(fixture);
-         expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
+      router.navigateByUrl('/team/22/link');
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
-         const native = fixture.nativeElement.querySelector('a');
-         expect(native.getAttribute('href')).toEqual('/team/33/simple');
-         native.click();
-         advance(fixture);
+      const native = fixture.nativeElement.querySelector('a');
+      expect(native.getAttribute('href')).toEqual('/team/33/simple');
+      native.click();
+      advance(fixture);
 
-         expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
-       })));
+      expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
+    })));
 
     it('should support relative router links', fakeAsync(inject([Router], (router: Router) => {
-         const fixture = createRoot(router, RootCmp);
+      const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig([{
-           path: 'team/:id',
-           component: TeamCmp,
-           children: [
-             {path: 'link', component: RelativeLinkCmp}, {path: 'simple', component: SimpleCmp}
-           ]
-         }]);
+      router.resetConfig([{
+        path: 'team/:id',
+        component: TeamCmp,
+        children: [
+          { path: 'link', component: RelativeLinkCmp }, { path: 'simple', component: SimpleCmp }
+        ]
+      }]);
 
-         router.navigateByUrl('/team/22/link');
-         advance(fixture);
-         expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
+      router.navigateByUrl('/team/22/link');
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
-         const native = fixture.nativeElement.querySelector('a');
-         expect(native.getAttribute('href')).toEqual('/team/22/simple');
-         native.click();
-         advance(fixture);
+      const native = fixture.nativeElement.querySelector('a');
+      expect(native.getAttribute('href')).toEqual('/team/22/simple');
+      native.click();
+      advance(fixture);
 
-         expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
-       })));
+      expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
+    })));
 
     it('should support top-level link', fakeAsync(inject([Router], (router: Router) => {
-         const fixture = createRoot(router, RelativeLinkInIfCmp);
-         advance(fixture);
+      const fixture = createRoot(router, RelativeLinkInIfCmp);
+      advance(fixture);
 
-         router.resetConfig(
-             [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]);
+      router.resetConfig(
+        [{ path: 'simple', component: SimpleCmp }, { path: '', component: BlankCmp }]);
 
-         router.navigateByUrl('/');
-         advance(fixture);
-         expect(fixture.nativeElement).toHaveText('');
-         const cmp = fixture.componentInstance;
+      router.navigateByUrl('/');
+      advance(fixture);
+      expect(fixture.nativeElement).toHaveText('');
+      const cmp = fixture.componentInstance;
 
-         cmp.show = true;
-         advance(fixture);
+      cmp.show = true;
+      advance(fixture);
 
-         expect(fixture.nativeElement).toHaveText('link');
-         const native = fixture.nativeElement.querySelector('a');
+      expect(fixture.nativeElement).toHaveText('link');
+      const native = fixture.nativeElement.querySelector('a');
 
-         expect(native.getAttribute('href')).toEqual('/simple');
-         native.click();
-         advance(fixture);
+      expect(native.getAttribute('href')).toEqual('/simple');
+      native.click();
+      advance(fixture);
 
-         expect(fixture.nativeElement).toHaveText('linksimple');
-       })));
+      expect(fixture.nativeElement).toHaveText('linksimple');
+    })));
 
     it('should support query params and fragments',
-       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-         const fixture = createRoot(router, RootCmp);
+      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+        const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig([{
-           path: 'team/:id',
-           component: TeamCmp,
-           children: [
-             {path: 'link', component: LinkWithQueryParamsAndFragment},
-             {path: 'simple', component: SimpleCmp}
-           ]
-         }]);
+        router.resetConfig([{
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [
+            { path: 'link', component: LinkWithQueryParamsAndFragment },
+            { path: 'simple', component: SimpleCmp }
+          ]
+        }]);
 
-         router.navigateByUrl('/team/22/link');
-         advance(fixture);
+        router.navigateByUrl('/team/22/link');
+        advance(fixture);
 
-         const native = fixture.nativeElement.querySelector('a');
-         expect(native.getAttribute('href')).toEqual('/team/22/simple?q=1#f');
-         native.click();
-         advance(fixture);
+        const native = fixture.nativeElement.querySelector('a');
+        expect(native.getAttribute('href')).toEqual('/team/22/simple?q=1#f');
+        native.click();
+        advance(fixture);
 
-         expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
+        expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
 
-         expect(location.path()).toEqual('/team/22/simple?q=1#f');
-       })));
+        expect(location.path()).toEqual('/team/22/simple?q=1#f');
+      })));
   });
 
   describe('redirects', () => {
     it('should work', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-         const fixture = createRoot(router, RootCmp);
+      const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig([
-           {path: 'old/team/:id', redirectTo: 'team/:id'}, {path: 'team/:id', component: TeamCmp}
-         ]);
+      router.resetConfig([
+        { path: 'old/team/:id', redirectTo: 'team/:id' }, { path: 'team/:id', component: TeamCmp }
+      ]);
 
-         router.navigateByUrl('old/team/22');
-         advance(fixture);
+      router.navigateByUrl('old/team/22');
+      advance(fixture);
 
-         expect(location.path()).toEqual('/team/22');
-       })));
+      expect(location.path()).toEqual('/team/22');
+    })));
 
     it('should not break the back button when trigger by location change',
-       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-         const fixture = TestBed.createComponent(RootCmp);
-         advance(fixture);
-         router.resetConfig([
-           {path: 'initial', component: BlankCmp}, {path: 'old/team/:id', redirectTo: 'team/:id'},
-           {path: 'team/:id', component: TeamCmp}
-         ]);
+      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+        const fixture = TestBed.createComponent(RootCmp);
+        advance(fixture);
+        router.resetConfig([
+          { path: 'initial', component: BlankCmp }, { path: 'old/team/:id', redirectTo: 'team/:id' },
+          { path: 'team/:id', component: TeamCmp }
+        ]);
 
-         location.go('initial');
-         location.go('old/team/22');
+        location.go('initial');
+        location.go('old/team/22');
 
-         // initial navigation
-         router.initialNavigation();
-         advance(fixture);
-         expect(location.path()).toEqual('/team/22');
+        // initial navigation
+        router.initialNavigation();
+        advance(fixture);
+        expect(location.path()).toEqual('/team/22');
 
-         location.back();
-         advance(fixture);
-         expect(location.path()).toEqual('/initial');
+        location.back();
+        advance(fixture);
+        expect(location.path()).toEqual('/initial');
 
-         // location change
-         (<any>location).go('/old/team/33');
+        // location change
+        (<any>location).go('/old/team/33');
 
 
-         advance(fixture);
-         expect(location.path()).toEqual('/team/33');
+        advance(fixture);
+        expect(location.path()).toEqual('/team/33');
 
-         location.back();
-         advance(fixture);
-         expect(location.path()).toEqual('/initial');
-       })));
+        location.back();
+        advance(fixture);
+        expect(location.path()).toEqual('/initial');
+      })));
   });
 
   describe('guards', () => {
@@ -1809,75 +1809,75 @@ describe('Integration', () => {
       describe('should not activate a route when CanActivate returns false', () => {
         beforeEach(() => {
           TestBed.configureTestingModule(
-              {providers: [{provide: 'alwaysFalse', useValue: (a: any, b: any) => false}]});
+            { providers: [{ provide: 'alwaysFalse', useValue: (a: any, b: any) => false }] });
         });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             const recordedEvents: any[] = [];
-             router.events.forEach(e => recordedEvents.push(e));
+          const recordedEvents: any[] = [];
+          router.events.forEach(e => recordedEvents.push(e));
 
-             router.resetConfig(
-                 [{path: 'team/:id', component: TeamCmp, canActivate: ['alwaysFalse']}]);
+          router.resetConfig(
+            [{ path: 'team/:id', component: TeamCmp, canActivate: ['alwaysFalse'] }]);
 
-             router.navigateByUrl('/team/22');
-             advance(fixture);
+          router.navigateByUrl('/team/22');
+          advance(fixture);
 
-             expect(location.path()).toEqual('/');
-             expectEvents(recordedEvents, [
-               [NavigationStart, '/team/22'],
-               [RoutesRecognized, '/team/22'],
-               [GuardsCheckStart, '/team/22'],
-               [ChildActivationStart],
-               [ActivationStart],
-               [GuardsCheckEnd, '/team/22'],
-               [NavigationCancel, '/team/22'],
-             ]);
-             expect((recordedEvents[5] as GuardsCheckEnd).shouldActivate).toBe(false);
-           })));
+          expect(location.path()).toEqual('/');
+          expectEvents(recordedEvents, [
+            [NavigationStart, '/team/22'],
+            [RoutesRecognized, '/team/22'],
+            [GuardsCheckStart, '/team/22'],
+            [ChildActivationStart],
+            [ActivationStart],
+            [GuardsCheckEnd, '/team/22'],
+            [NavigationCancel, '/team/22'],
+          ]);
+          expect((recordedEvents[5] as GuardsCheckEnd).shouldActivate).toBe(false);
+        })));
       });
 
       describe(
-          'should not activate a route when CanActivate returns false (componentless route)',
-          () => {
-            beforeEach(() => {
-              TestBed.configureTestingModule(
-                  {providers: [{provide: 'alwaysFalse', useValue: (a: any, b: any) => false}]});
-            });
-
-            it('works',
-               fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-                 const fixture = createRoot(router, RootCmp);
-
-                 router.resetConfig([{
-                   path: 'parent',
-                   canActivate: ['alwaysFalse'],
-                   children: [{path: 'team/:id', component: TeamCmp}]
-                 }]);
-
-                 router.navigateByUrl('parent/team/22');
-                 advance(fixture);
-
-                 expect(location.path()).toEqual('/');
-               })));
+        'should not activate a route when CanActivate returns false (componentless route)',
+        () => {
+          beforeEach(() => {
+            TestBed.configureTestingModule(
+              { providers: [{ provide: 'alwaysFalse', useValue: (a: any, b: any) => false }] });
           });
+
+          it('works',
+            fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+              const fixture = createRoot(router, RootCmp);
+
+              router.resetConfig([{
+                path: 'parent',
+                canActivate: ['alwaysFalse'],
+                children: [{ path: 'team/:id', component: TeamCmp }]
+              }]);
+
+              router.navigateByUrl('parent/team/22');
+              advance(fixture);
+
+              expect(location.path()).toEqual('/');
+            })));
+        });
 
       describe('should activate a child wildcard route router outlet has yet to be mounted', () => {
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-              const fixture = createRoot(router, RootCmp);
-              router.resetConfig([{
-                path: 'teams',
-                component: BlankCmp,
-                children: [{path: ':team-id', children: [{path: '**', component: BlankCmp}]}]
-              }]);
-              router.navigateByUrl('/teams/22/members');
-              advance(fixture);
-              expect(location.path()).toEqual('/teams/22/members');
-              router.navigateByUrl('/teams/22/manage');
-              advance(fixture);
-              expect(location.path()).toEqual('/teams/22/manage');
-            })));
+          const fixture = createRoot(router, RootCmp);
+          router.resetConfig([{
+            path: 'teams',
+            component: BlankCmp,
+            children: [{ path: ':team-id', children: [{ path: '**', component: BlankCmp }] }]
+          }]);
+          router.navigateByUrl('/teams/22/members');
+          advance(fixture);
+          expect(location.path()).toEqual('/teams/22/members');
+          router.navigateByUrl('/teams/22/manage');
+          advance(fixture);
+          expect(location.path()).toEqual('/teams/22/manage');
+        })));
       });
 
       describe('should activate a route when CanActivate returns true', () => {
@@ -1891,16 +1891,16 @@ describe('Integration', () => {
         });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig(
-                 [{path: 'team/:id', component: TeamCmp, canActivate: ['alwaysTrue']}]);
+          router.resetConfig(
+            [{ path: 'team/:id', component: TeamCmp, canActivate: ['alwaysTrue'] }]);
 
-             router.navigateByUrl('/team/22');
-             advance(fixture);
+          router.navigateByUrl('/team/22');
+          advance(fixture);
 
-             expect(location.path()).toEqual('/team/22');
-           })));
+          expect(location.path()).toEqual('/team/22');
+        })));
       });
 
       describe('should work when given a class', () => {
@@ -1910,19 +1910,19 @@ describe('Integration', () => {
           }
         }
 
-        beforeEach(() => { TestBed.configureTestingModule({providers: [AlwaysTrue]}); });
+        beforeEach(() => { TestBed.configureTestingModule({ providers: [AlwaysTrue] }); });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig(
-                 [{path: 'team/:id', component: TeamCmp, canActivate: [AlwaysTrue]}]);
+          router.resetConfig(
+            [{ path: 'team/:id', component: TeamCmp, canActivate: [AlwaysTrue] }]);
 
-             router.navigateByUrl('/team/22');
-             advance(fixture);
+          router.navigateByUrl('/team/22');
+          advance(fixture);
 
-             expect(location.path()).toEqual('/team/22');
-           })));
+          expect(location.path()).toEqual('/team/22');
+        })));
       });
 
       describe('should work when returns an observable', () => {
@@ -1939,15 +1939,15 @@ describe('Integration', () => {
 
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig(
-                 [{path: 'team/:id', component: TeamCmp, canActivate: ['CanActivate']}]);
+          router.resetConfig(
+            [{ path: 'team/:id', component: TeamCmp, canActivate: ['CanActivate'] }]);
 
-             router.navigateByUrl('/team/22');
-             advance(fixture);
-             expect(location.path()).toEqual('/');
-           })));
+          router.navigateByUrl('/team/22');
+          advance(fixture);
+          expect(location.path()).toEqual('/');
+        })));
       });
 
       describe('should work when returns a promise', () => {
@@ -1968,19 +1968,19 @@ describe('Integration', () => {
 
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig(
-                 [{path: 'team/:id', component: TeamCmp, canActivate: ['CanActivate']}]);
+          router.resetConfig(
+            [{ path: 'team/:id', component: TeamCmp, canActivate: ['CanActivate'] }]);
 
-             router.navigateByUrl('/team/22');
-             advance(fixture);
-             expect(location.path()).toEqual('/team/22');
+          router.navigateByUrl('/team/22');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/22');
 
-             router.navigateByUrl('/team/33');
-             advance(fixture);
-             expect(location.path()).toEqual('/team/22');
-           })));
+          router.navigateByUrl('/team/33');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/22');
+        })));
       });
 
       describe('should reset the location when cancleling a navigation', () => {
@@ -1994,22 +1994,22 @@ describe('Integration', () => {
         });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([
-               {path: 'one', component: SimpleCmp},
-               {path: 'two', component: SimpleCmp, canActivate: ['alwaysFalse']}
-             ]);
+          router.resetConfig([
+            { path: 'one', component: SimpleCmp },
+            { path: 'two', component: SimpleCmp, canActivate: ['alwaysFalse'] }
+          ]);
 
-             router.navigateByUrl('/one');
-             advance(fixture);
-             expect(location.path()).toEqual('/one');
+          router.navigateByUrl('/one');
+          advance(fixture);
+          expect(location.path()).toEqual('/one');
 
-             location.go('/two');
-             advance(fixture);
-             expect(location.path()).toEqual('/one');
+          location.go('/two');
+          advance(fixture);
+          expect(location.path()).toEqual('/one');
 
-           })));
+        })));
       });
 
       describe('should redirect to / when guard returns false', () => {
@@ -2025,20 +2025,20 @@ describe('Integration', () => {
         }));
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             router.resetConfig([
-               {
-                 path: '',
-                 component: SimpleCmp,
-               },
-               {path: 'one', component: RouteCmp, canActivate: ['returnFalseAndNavigate']}
-             ]);
+          router.resetConfig([
+            {
+              path: '',
+              component: SimpleCmp,
+            },
+            { path: 'one', component: RouteCmp, canActivate: ['returnFalseAndNavigate'] }
+          ]);
 
-             const fixture = TestBed.createComponent(RootCmp);
-             router.navigateByUrl('/one');
-             advance(fixture);
-             expect(location.path()).toEqual('/');
-             expect(fixture.nativeElement).toHaveText('simple');
-           })));
+          const fixture = TestBed.createComponent(RootCmp);
+          router.navigateByUrl('/one');
+          advance(fixture);
+          expect(location.path()).toEqual('/');
+          expect(fixture.nativeElement).toHaveText('simple');
+        })));
       });
 
       describe('runGuardsAndResolvers', () => {
@@ -2057,13 +2057,13 @@ describe('Integration', () => {
                   return true;
                 }
               },
-              {provide: 'resolver', useValue: () => resolverRunCount++}
+              { provide: 'resolver', useValue: () => resolverRunCount++ }
             ]
           });
         });
 
         function configureRouter(router: Router, runGuardsAndResolvers: RunGuardsAndResolvers):
-            ComponentFixture<RootCmpWithTwoOutlets> {
+          ComponentFixture<RootCmpWithTwoOutlets> {
           const fixture = createRoot(router, RootCmpWithTwoOutlets);
 
           router.resetConfig([
@@ -2072,9 +2072,9 @@ describe('Integration', () => {
               runGuardsAndResolvers,
               component: RouteCmp,
               canActivate: ['guard'],
-              resolve: {data: 'resolver'}
+              resolve: { data: 'resolver' }
             },
-            {path: 'b', component: SimpleCmp, outlet: 'right'}
+            { path: 'b', component: SimpleCmp, outlet: 'right' }
           ]);
 
           router.navigateByUrl('/a');
@@ -2083,95 +2083,95 @@ describe('Integration', () => {
         }
 
         it('should rerun guards and resolvers when params change',
-           fakeAsync(inject([Router], (router: Router) => {
-             const fixture = configureRouter(router, 'paramsChange');
+          fakeAsync(inject([Router], (router: Router) => {
+            const fixture = configureRouter(router, 'paramsChange');
 
-             const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
-             const recordedData: any[] = [];
-             cmp.route.data.subscribe((data: any) => recordedData.push(data));
+            const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
+            const recordedData: any[] = [];
+            cmp.route.data.subscribe((data: any) => recordedData.push(data));
 
-             expect(guardRunCount).toEqual(1);
-             expect(recordedData).toEqual([{data: 0}]);
+            expect(guardRunCount).toEqual(1);
+            expect(recordedData).toEqual([{ data: 0 }]);
 
-             router.navigateByUrl('/a;p=1');
-             advance(fixture);
-             expect(guardRunCount).toEqual(2);
-             expect(recordedData).toEqual([{data: 0}, {data: 1}]);
+            router.navigateByUrl('/a;p=1');
+            advance(fixture);
+            expect(guardRunCount).toEqual(2);
+            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }]);
 
-             router.navigateByUrl('/a;p=2');
-             advance(fixture);
-             expect(guardRunCount).toEqual(3);
-             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
+            router.navigateByUrl('/a;p=2');
+            advance(fixture);
+            expect(guardRunCount).toEqual(3);
+            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }]);
 
-             router.navigateByUrl('/a;p=2?q=1');
-             advance(fixture);
-             expect(guardRunCount).toEqual(3);
-             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
-           })));
+            router.navigateByUrl('/a;p=2?q=1');
+            advance(fixture);
+            expect(guardRunCount).toEqual(3);
+            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }]);
+          })));
 
         it('should rerun guards and resolvers when query params change',
-           fakeAsync(inject([Router], (router: Router) => {
-             const fixture = configureRouter(router, 'paramsOrQueryParamsChange');
+          fakeAsync(inject([Router], (router: Router) => {
+            const fixture = configureRouter(router, 'paramsOrQueryParamsChange');
 
-             const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
-             const recordedData: any[] = [];
-             cmp.route.data.subscribe((data: any) => recordedData.push(data));
+            const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
+            const recordedData: any[] = [];
+            cmp.route.data.subscribe((data: any) => recordedData.push(data));
 
-             expect(guardRunCount).toEqual(1);
-             expect(recordedData).toEqual([{data: 0}]);
+            expect(guardRunCount).toEqual(1);
+            expect(recordedData).toEqual([{ data: 0 }]);
 
-             router.navigateByUrl('/a;p=1');
-             advance(fixture);
-             expect(guardRunCount).toEqual(2);
-             expect(recordedData).toEqual([{data: 0}, {data: 1}]);
+            router.navigateByUrl('/a;p=1');
+            advance(fixture);
+            expect(guardRunCount).toEqual(2);
+            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }]);
 
-             router.navigateByUrl('/a;p=2');
-             advance(fixture);
-             expect(guardRunCount).toEqual(3);
-             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
+            router.navigateByUrl('/a;p=2');
+            advance(fixture);
+            expect(guardRunCount).toEqual(3);
+            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }]);
 
-             router.navigateByUrl('/a;p=2?q=1');
-             advance(fixture);
-             expect(guardRunCount).toEqual(4);
-             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}]);
+            router.navigateByUrl('/a;p=2?q=1');
+            advance(fixture);
+            expect(guardRunCount).toEqual(4);
+            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }, { data: 3 }]);
 
-             router.navigateByUrl('/a;p=2(right:b)?q=1');
-             advance(fixture);
-             expect(guardRunCount).toEqual(4);
-             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}]);
-           })));
+            router.navigateByUrl('/a;p=2(right:b)?q=1');
+            advance(fixture);
+            expect(guardRunCount).toEqual(4);
+            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }, { data: 3 }]);
+          })));
 
         it('should always rerun guards and resolvers',
-           fakeAsync(inject([Router], (router: Router) => {
-             const fixture = configureRouter(router, 'always');
+          fakeAsync(inject([Router], (router: Router) => {
+            const fixture = configureRouter(router, 'always');
 
-             const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
-             const recordedData: any[] = [];
-             cmp.route.data.subscribe((data: any) => recordedData.push(data));
+            const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
+            const recordedData: any[] = [];
+            cmp.route.data.subscribe((data: any) => recordedData.push(data));
 
-             expect(guardRunCount).toEqual(1);
-             expect(recordedData).toEqual([{data: 0}]);
+            expect(guardRunCount).toEqual(1);
+            expect(recordedData).toEqual([{ data: 0 }]);
 
-             router.navigateByUrl('/a;p=1');
-             advance(fixture);
-             expect(guardRunCount).toEqual(2);
-             expect(recordedData).toEqual([{data: 0}, {data: 1}]);
+            router.navigateByUrl('/a;p=1');
+            advance(fixture);
+            expect(guardRunCount).toEqual(2);
+            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }]);
 
-             router.navigateByUrl('/a;p=2');
-             advance(fixture);
-             expect(guardRunCount).toEqual(3);
-             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
+            router.navigateByUrl('/a;p=2');
+            advance(fixture);
+            expect(guardRunCount).toEqual(3);
+            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }]);
 
-             router.navigateByUrl('/a;p=2?q=1');
-             advance(fixture);
-             expect(guardRunCount).toEqual(4);
-             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}]);
+            router.navigateByUrl('/a;p=2?q=1');
+            advance(fixture);
+            expect(guardRunCount).toEqual(4);
+            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }, { data: 3 }]);
 
-             router.navigateByUrl('/a;p=2(right:b)?q=1');
-             advance(fixture);
-             expect(guardRunCount).toEqual(5);
-             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}, {data: 4}]);
-           })));
+            router.navigateByUrl('/a;p=2(right:b)?q=1');
+            advance(fixture);
+            expect(guardRunCount).toEqual(5);
+            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }, { data: 3 }, { data: 4 }]);
+          })));
       });
 
       describe('should wait for parent to complete', () => {
@@ -2211,21 +2211,21 @@ describe('Integration', () => {
         }
 
         it('works', fakeAsync(inject([Router], (router: Router) => {
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([{
-               path: 'parent',
-               canActivate: ['parentGuard'],
-               children: [
-                 {path: 'child', component: SimpleCmp, canActivate: ['childGuard']},
-               ]
-             }]);
+          router.resetConfig([{
+            path: 'parent',
+            canActivate: ['parentGuard'],
+            children: [
+              { path: 'child', component: SimpleCmp, canActivate: ['childGuard'] },
+            ]
+          }]);
 
-             router.navigateByUrl('/parent/child');
-             advance(fixture);
-             tick(15);
-             expect(log).toEqual(['parent', 'child']);
-           })));
+          router.navigateByUrl('/parent/child');
+          advance(fixture);
+          tick(15);
+          expect(log).toEqual(['parent', 'child']);
+        })));
       });
     });
 
@@ -2258,14 +2258,14 @@ describe('Integration', () => {
             {
               provide: 'RecordingDeactivate',
               useValue: (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-                log.push({path: a.routeConfig !.path, component: c});
+                log.push({ path: a.routeConfig!.path, component: c });
                 return true;
               }
             },
             {
               provide: 'alwaysFalse',
               useValue:
-                  (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => { return false; }
+                (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => { return false; }
             },
             {
               provide: 'alwaysFalseAndLogging',
@@ -2297,213 +2297,213 @@ describe('Integration', () => {
 
       describe('should not deactivate a route when CanDeactivate returns false', () => {
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig(
-                 [{path: 'team/:id', component: TeamCmp, canDeactivate: ['CanDeactivateTeam']}]);
+          router.resetConfig(
+            [{ path: 'team/:id', component: TeamCmp, canDeactivate: ['CanDeactivateTeam'] }]);
 
-             router.navigateByUrl('/team/22');
-             advance(fixture);
-             expect(location.path()).toEqual('/team/22');
+          router.navigateByUrl('/team/22');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/22');
 
-             let successStatus: boolean = false;
-             router.navigateByUrl('/team/33') !.then(res => successStatus = res);
-             advance(fixture);
-             expect(location.path()).toEqual('/team/33');
-             expect(successStatus).toEqual(true);
+          let successStatus: boolean = false;
+          router.navigateByUrl('/team/33')!.then(res => successStatus = res);
+          advance(fixture);
+          expect(location.path()).toEqual('/team/33');
+          expect(successStatus).toEqual(true);
 
-             let canceledStatus: boolean = false;
-             router.navigateByUrl('/team/44') !.then(res => canceledStatus = res);
-             advance(fixture);
-             expect(location.path()).toEqual('/team/33');
-             expect(canceledStatus).toEqual(false);
-           })));
+          let canceledStatus: boolean = false;
+          router.navigateByUrl('/team/44')!.then(res => canceledStatus = res);
+          advance(fixture);
+          expect(location.path()).toEqual('/team/33');
+          expect(canceledStatus).toEqual(false);
+        })));
 
         it('works with componentless routes',
-           fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, RootCmp);
+          fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+            const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([
-               {
-                 path: 'grandparent',
-                 canDeactivate: ['RecordingDeactivate'],
-                 children: [{
-                   path: 'parent',
-                   canDeactivate: ['RecordingDeactivate'],
-                   children: [{
-                     path: 'child',
-                     canDeactivate: ['RecordingDeactivate'],
-                     children: [{
-                       path: 'simple',
-                       component: SimpleCmp,
-                       canDeactivate: ['RecordingDeactivate']
-                     }]
-                   }]
-                 }]
-               },
-               {path: 'simple', component: SimpleCmp}
-             ]);
+            router.resetConfig([
+              {
+                path: 'grandparent',
+                canDeactivate: ['RecordingDeactivate'],
+                children: [{
+                  path: 'parent',
+                  canDeactivate: ['RecordingDeactivate'],
+                  children: [{
+                    path: 'child',
+                    canDeactivate: ['RecordingDeactivate'],
+                    children: [{
+                      path: 'simple',
+                      component: SimpleCmp,
+                      canDeactivate: ['RecordingDeactivate']
+                    }]
+                  }]
+                }]
+              },
+              { path: 'simple', component: SimpleCmp }
+            ]);
 
-             router.navigateByUrl('/grandparent/parent/child/simple');
-             advance(fixture);
-             expect(location.path()).toEqual('/grandparent/parent/child/simple');
+            router.navigateByUrl('/grandparent/parent/child/simple');
+            advance(fixture);
+            expect(location.path()).toEqual('/grandparent/parent/child/simple');
 
-             router.navigateByUrl('/simple');
-             advance(fixture);
+            router.navigateByUrl('/simple');
+            advance(fixture);
 
-             const child = fixture.debugElement.children[1].componentInstance;
+            const child = fixture.debugElement.children[1].componentInstance;
 
-             expect(log.map((a: any) => a.path)).toEqual([
-               'simple', 'child', 'parent', 'grandparent'
-             ]);
-             expect(log.map((a: any) => a.component)).toEqual([child, null, null, null]);
-           })));
+            expect(log.map((a: any) => a.path)).toEqual([
+              'simple', 'child', 'parent', 'grandparent'
+            ]);
+            expect(log.map((a: any) => a.component)).toEqual([child, null, null, null]);
+          })));
 
         it('works with aux routes',
-           fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, RootCmp);
+          fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+            const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([{
-               path: 'two-outlets',
-               component: TwoOutletsCmp,
-               children: [
-                 {path: 'a', component: BlankCmp}, {
-                   path: 'b',
-                   canDeactivate: ['RecordingDeactivate'],
-                   component: SimpleCmp,
-                   outlet: 'aux'
-                 }
-               ]
-             }]);
+            router.resetConfig([{
+              path: 'two-outlets',
+              component: TwoOutletsCmp,
+              children: [
+                { path: 'a', component: BlankCmp }, {
+                  path: 'b',
+                  canDeactivate: ['RecordingDeactivate'],
+                  component: SimpleCmp,
+                  outlet: 'aux'
+                }
+              ]
+            }]);
 
-             router.navigateByUrl('/two-outlets/(a//aux:b)');
-             advance(fixture);
-             expect(location.path()).toEqual('/two-outlets/(a//aux:b)');
+            router.navigateByUrl('/two-outlets/(a//aux:b)');
+            advance(fixture);
+            expect(location.path()).toEqual('/two-outlets/(a//aux:b)');
 
-             router.navigate(['two-outlets', {outlets: {aux: null}}]);
-             advance(fixture);
+            router.navigate(['two-outlets', { outlets: { aux: null } }]);
+            advance(fixture);
 
-             expect(log.map((a: any) => a.path)).toEqual(['b']);
-             expect(location.path()).toEqual('/two-outlets/(a)');
-           })));
+            expect(log.map((a: any) => a.path)).toEqual(['b']);
+            expect(location.path()).toEqual('/two-outlets/(a)');
+          })));
 
         it('works with a nested route',
-           fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, RootCmp);
+          fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+            const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([{
-               path: 'team/:id',
-               component: TeamCmp,
-               children: [
-                 {path: '', pathMatch: 'full', component: SimpleCmp},
-                 {path: 'user/:name', component: UserCmp, canDeactivate: ['CanDeactivateUser']}
-               ]
-             }]);
+            router.resetConfig([{
+              path: 'team/:id',
+              component: TeamCmp,
+              children: [
+                { path: '', pathMatch: 'full', component: SimpleCmp },
+                { path: 'user/:name', component: UserCmp, canDeactivate: ['CanDeactivateUser'] }
+              ]
+            }]);
 
-             router.navigateByUrl('/team/22/user/victor');
-             advance(fixture);
+            router.navigateByUrl('/team/22/user/victor');
+            advance(fixture);
 
-             // this works because we can deactivate victor
-             router.navigateByUrl('/team/33');
-             advance(fixture);
-             expect(location.path()).toEqual('/team/33');
+            // this works because we can deactivate victor
+            router.navigateByUrl('/team/33');
+            advance(fixture);
+            expect(location.path()).toEqual('/team/33');
 
-             router.navigateByUrl('/team/33/user/fedor');
-             advance(fixture);
+            router.navigateByUrl('/team/33/user/fedor');
+            advance(fixture);
 
-             // this doesn't work cause we cannot deactivate fedor
-             router.navigateByUrl('/team/44');
-             advance(fixture);
-             expect(location.path()).toEqual('/team/33/user/fedor');
-           })));
+            // this doesn't work cause we cannot deactivate fedor
+            router.navigateByUrl('/team/44');
+            advance(fixture);
+            expect(location.path()).toEqual('/team/33/user/fedor');
+          })));
       });
 
       it('should not create a route state if navigation is canceled',
-         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-           const fixture = createRoot(router, RootCmp);
+        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+          const fixture = createRoot(router, RootCmp);
 
-           router.resetConfig([{
-             path: 'main',
-             component: TeamCmp,
-             children: [
-               {path: 'component1', component: SimpleCmp, canDeactivate: ['alwaysFalse']},
-               {path: 'component2', component: SimpleCmp}
-             ]
-           }]);
+          router.resetConfig([{
+            path: 'main',
+            component: TeamCmp,
+            children: [
+              { path: 'component1', component: SimpleCmp, canDeactivate: ['alwaysFalse'] },
+              { path: 'component2', component: SimpleCmp }
+            ]
+          }]);
 
-           router.navigateByUrl('/main/component1');
-           advance(fixture);
+          router.navigateByUrl('/main/component1');
+          advance(fixture);
 
-           router.navigateByUrl('/main/component2');
-           advance(fixture);
+          router.navigateByUrl('/main/component2');
+          advance(fixture);
 
-           const teamCmp = fixture.debugElement.children[1].componentInstance;
-           expect(teamCmp.route.firstChild.url.value[0].path).toEqual('component1');
-           expect(location.path()).toEqual('/main/component1');
-         })));
+          const teamCmp = fixture.debugElement.children[1].componentInstance;
+          expect(teamCmp.route.firstChild.url.value[0].path).toEqual('component1');
+          expect(location.path()).toEqual('/main/component1');
+        })));
 
       it('should not run CanActivate when CanDeactivate returns false',
-         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-           const fixture = createRoot(router, RootCmp);
+        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+          const fixture = createRoot(router, RootCmp);
 
-           router.resetConfig([{
-             path: 'main',
-             component: TeamCmp,
-             children: [
-               {
-                 path: 'component1',
-                 component: SimpleCmp,
-                 canDeactivate: ['alwaysFalseWithDelayAndLogging']
-               },
-               {
-                 path: 'component2',
-                 component: SimpleCmp,
-                 canActivate: ['canActivate_alwaysTrueAndLogging']
-               },
-             ]
-           }]);
+          router.resetConfig([{
+            path: 'main',
+            component: TeamCmp,
+            children: [
+              {
+                path: 'component1',
+                component: SimpleCmp,
+                canDeactivate: ['alwaysFalseWithDelayAndLogging']
+              },
+              {
+                path: 'component2',
+                component: SimpleCmp,
+                canActivate: ['canActivate_alwaysTrueAndLogging']
+              },
+            ]
+          }]);
 
-           router.navigateByUrl('/main/component1');
-           advance(fixture);
-           expect(location.path()).toEqual('/main/component1');
+          router.navigateByUrl('/main/component1');
+          advance(fixture);
+          expect(location.path()).toEqual('/main/component1');
 
-           router.navigateByUrl('/main/component2');
-           advance(fixture);
-           expect(location.path()).toEqual('/main/component1');
-           expect(log).toEqual(['called']);
-         })));
+          router.navigateByUrl('/main/component2');
+          advance(fixture);
+          expect(location.path()).toEqual('/main/component1');
+          expect(log).toEqual(['called']);
+        })));
 
       it('should call guards every time when navigating to the same url over and over again',
-         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-           const fixture = createRoot(router, RootCmp);
+        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+          const fixture = createRoot(router, RootCmp);
 
-           router.resetConfig([
-             {path: 'simple', component: SimpleCmp, canDeactivate: ['alwaysFalseAndLogging']},
-             {path: 'blank', component: BlankCmp}
+          router.resetConfig([
+            { path: 'simple', component: SimpleCmp, canDeactivate: ['alwaysFalseAndLogging'] },
+            { path: 'blank', component: BlankCmp }
 
-           ]);
+          ]);
 
-           router.navigateByUrl('/simple');
-           advance(fixture);
+          router.navigateByUrl('/simple');
+          advance(fixture);
 
-           router.navigateByUrl('/blank');
-           advance(fixture);
-           expect(log).toEqual(['called']);
-           expect(location.path()).toEqual('/simple');
+          router.navigateByUrl('/blank');
+          advance(fixture);
+          expect(log).toEqual(['called']);
+          expect(location.path()).toEqual('/simple');
 
-           router.navigateByUrl('/blank');
-           advance(fixture);
-           expect(log).toEqual(['called', 'called']);
-           expect(location.path()).toEqual('/simple');
-         })));
+          router.navigateByUrl('/blank');
+          advance(fixture);
+          expect(log).toEqual(['called', 'called']);
+          expect(location.path()).toEqual('/simple');
+        })));
 
       describe('next state', () => {
         let log: string[];
 
         class ClassWithNextState implements CanDeactivate<TeamCmp> {
           canDeactivate(
-              component: TeamCmp, currentRoute: ActivatedRouteSnapshot,
-              currentState: RouterStateSnapshot, nextState: RouterStateSnapshot): boolean {
+            component: TeamCmp, currentRoute: ActivatedRouteSnapshot,
+            currentState: RouterStateSnapshot, nextState: RouterStateSnapshot): boolean {
             log.push(currentState.url, nextState.url);
             return true;
           }
@@ -2516,7 +2516,7 @@ describe('Integration', () => {
               ClassWithNextState, {
                 provide: 'FunctionWithNextState',
                 useValue: (cmp: any, currentRoute: ActivatedRouteSnapshot,
-                           currentState: RouterStateSnapshot, nextState: RouterStateSnapshot) => {
+                  currentState: RouterStateSnapshot, nextState: RouterStateSnapshot) => {
                   log.push(currentState.url, nextState.url);
                   return true;
                 }
@@ -2526,66 +2526,66 @@ describe('Integration', () => {
         });
 
         it('should pass next state as the 4 argument when guard is a class',
-           fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, RootCmp);
+          fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+            const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig(
-                 [{path: 'team/:id', component: TeamCmp, canDeactivate: [ClassWithNextState]}]);
+            router.resetConfig(
+              [{ path: 'team/:id', component: TeamCmp, canDeactivate: [ClassWithNextState] }]);
 
-             router.navigateByUrl('/team/22');
-             advance(fixture);
-             expect(location.path()).toEqual('/team/22');
+            router.navigateByUrl('/team/22');
+            advance(fixture);
+            expect(location.path()).toEqual('/team/22');
 
-             router.navigateByUrl('/team/33');
-             advance(fixture);
-             expect(location.path()).toEqual('/team/33');
-             expect(log).toEqual(['/team/22', '/team/33']);
-           })));
+            router.navigateByUrl('/team/33');
+            advance(fixture);
+            expect(location.path()).toEqual('/team/33');
+            expect(log).toEqual(['/team/22', '/team/33']);
+          })));
 
         it('should pass next state as the 4 argument when guard is a function',
-           fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, RootCmp);
+          fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+            const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([
-               {path: 'team/:id', component: TeamCmp, canDeactivate: ['FunctionWithNextState']}
-             ]);
+            router.resetConfig([
+              { path: 'team/:id', component: TeamCmp, canDeactivate: ['FunctionWithNextState'] }
+            ]);
 
-             router.navigateByUrl('/team/22');
-             advance(fixture);
-             expect(location.path()).toEqual('/team/22');
+            router.navigateByUrl('/team/22');
+            advance(fixture);
+            expect(location.path()).toEqual('/team/22');
 
-             router.navigateByUrl('/team/33');
-             advance(fixture);
-             expect(location.path()).toEqual('/team/33');
-             expect(log).toEqual(['/team/22', '/team/33']);
-           })));
+            router.navigateByUrl('/team/33');
+            advance(fixture);
+            expect(location.path()).toEqual('/team/33');
+            expect(log).toEqual(['/team/22', '/team/33']);
+          })));
       });
 
       describe('should work when given a class', () => {
         class AlwaysTrue implements CanDeactivate<TeamCmp> {
           canDeactivate(
-              component: TeamCmp, route: ActivatedRouteSnapshot,
-              state: RouterStateSnapshot): boolean {
+            component: TeamCmp, route: ActivatedRouteSnapshot,
+            state: RouterStateSnapshot): boolean {
             return true;
           }
         }
 
-        beforeEach(() => { TestBed.configureTestingModule({providers: [AlwaysTrue]}); });
+        beforeEach(() => { TestBed.configureTestingModule({ providers: [AlwaysTrue] }); });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig(
-                 [{path: 'team/:id', component: TeamCmp, canDeactivate: [AlwaysTrue]}]);
+          router.resetConfig(
+            [{ path: 'team/:id', component: TeamCmp, canDeactivate: [AlwaysTrue] }]);
 
-             router.navigateByUrl('/team/22');
-             advance(fixture);
-             expect(location.path()).toEqual('/team/22');
+          router.navigateByUrl('/team/22');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/22');
 
-             router.navigateByUrl('/team/33');
-             advance(fixture);
-             expect(location.path()).toEqual('/team/33');
-           })));
+          router.navigateByUrl('/team/33');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/33');
+        })));
       });
 
 
@@ -2602,19 +2602,19 @@ describe('Integration', () => {
         });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig(
-                 [{path: 'team/:id', component: TeamCmp, canDeactivate: ['CanDeactivate']}]);
+          router.resetConfig(
+            [{ path: 'team/:id', component: TeamCmp, canDeactivate: ['CanDeactivate'] }]);
 
-             router.navigateByUrl('/team/22');
-             advance(fixture);
-             expect(location.path()).toEqual('/team/22');
+          router.navigateByUrl('/team/22');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/22');
 
-             router.navigateByUrl('/team/33');
-             advance(fixture);
-             expect(location.path()).toEqual('/team/22');
-           })));
+          router.navigateByUrl('/team/33');
+          advance(fixture);
+          expect(location.path()).toEqual('/team/22');
+        })));
       });
     });
 
@@ -2630,66 +2630,66 @@ describe('Integration', () => {
         });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([{
-               path: '',
-               canActivateChild: ['alwaysFalse'],
-               children: [{path: 'team/:id', component: TeamCmp}]
-             }]);
+          router.resetConfig([{
+            path: '',
+            canActivateChild: ['alwaysFalse'],
+            children: [{ path: 'team/:id', component: TeamCmp }]
+          }]);
 
-             router.navigateByUrl('/team/22');
-             advance(fixture);
+          router.navigateByUrl('/team/22');
+          advance(fixture);
 
-             expect(location.path()).toEqual('/team/22');
+          expect(location.path()).toEqual('/team/22');
 
-             router.navigateByUrl('/team/33') !.catch(() => {});
-             advance(fixture);
+          router.navigateByUrl('/team/33')!.catch(() => { });
+          advance(fixture);
 
-             expect(location.path()).toEqual('/team/22');
-           })));
+          expect(location.path()).toEqual('/team/22');
+        })));
       });
 
       it('should find the guard provided in lazy loaded module',
-         fakeAsync(inject(
-             [Router, Location, NgModuleFactoryLoader],
-             (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+        fakeAsync(inject(
+          [Router, Location, NgModuleFactoryLoader],
+          (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
 
-               @Component({selector: 'admin', template: '<router-outlet></router-outlet>'})
-               class AdminComponent {
-               }
+            @Component({ selector: 'admin', template: '<router-outlet></router-outlet>' })
+            class AdminComponent {
+            }
 
-               @Component({selector: 'lazy', template: 'lazy-loaded'})
-               class LazyLoadedComponent {
-               }
+            @Component({ selector: 'lazy', template: 'lazy-loaded' })
+            class LazyLoadedComponent {
+            }
 
-               @NgModule({
-                 declarations: [AdminComponent, LazyLoadedComponent],
-                 imports: [RouterModule.forChild([{
-                   path: '',
-                   component: AdminComponent,
-                   children: [{
-                     path: '',
-                     canActivateChild: ['alwaysTrue'],
-                     children: [{path: '', component: LazyLoadedComponent}]
-                   }]
-                 }])],
-                 providers: [{provide: 'alwaysTrue', useValue: () => true}],
-               })
-               class LazyLoadedModule {
-               }
+            @NgModule({
+              declarations: [AdminComponent, LazyLoadedComponent],
+              imports: [RouterModule.forChild([{
+                path: '',
+                component: AdminComponent,
+                children: [{
+                  path: '',
+                  canActivateChild: ['alwaysTrue'],
+                  children: [{ path: '', component: LazyLoadedComponent }]
+                }]
+              }])],
+              providers: [{ provide: 'alwaysTrue', useValue: () => true }],
+            })
+            class LazyLoadedModule {
+            }
 
-               loader.stubbedModules = {lazy: LazyLoadedModule};
-               const fixture = createRoot(router, RootCmp);
+            loader.stubbedModules = { lazy: LazyLoadedModule };
+            const fixture = createRoot(router, RootCmp);
 
-               router.resetConfig([{path: 'admin', loadChildren: 'lazy'}]);
+            router.resetConfig([{ path: 'admin', loadChildren: 'lazy' }]);
 
-               router.navigateByUrl('/admin');
-               advance(fixture);
+            router.navigateByUrl('/admin');
+            advance(fixture);
 
-               expect(location.path()).toEqual('/admin');
-               expect(fixture.nativeElement).toHaveText('lazy-loaded');
-             })));
+            expect(location.path()).toEqual('/admin');
+            expect(fixture.nativeElement).toHaveText('lazy-loaded');
+          })));
     });
 
     describe('CanLoad', () => {
@@ -2698,7 +2698,7 @@ describe('Integration', () => {
         canLoadRunCount = 0;
         TestBed.configureTestingModule({
           providers: [
-            {provide: 'alwaysFalse', useValue: (a: any) => false},
+            { provide: 'alwaysFalse', useValue: (a: any) => false },
             {
               provide: 'returnFalseAndNavigate',
               useFactory: (router: any) => (a: any) => {
@@ -2719,143 +2719,143 @@ describe('Integration', () => {
       });
 
       it('should not load children when CanLoad returns false',
-         fakeAsync(inject(
-             [Router, Location, NgModuleFactoryLoader],
-             (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+        fakeAsync(inject(
+          [Router, Location, NgModuleFactoryLoader],
+          (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
 
-               @Component({selector: 'lazy', template: 'lazy-loaded'})
-               class LazyLoadedComponent {
-               }
+            @Component({ selector: 'lazy', template: 'lazy-loaded' })
+            class LazyLoadedComponent {
+            }
 
-               @NgModule({
-                 declarations: [LazyLoadedComponent],
-                 imports:
-                     [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])]
-               })
-               class LoadedModule {
-               }
+            @NgModule({
+              declarations: [LazyLoadedComponent],
+              imports:
+                [RouterModule.forChild([{ path: 'loaded', component: LazyLoadedComponent }])]
+            })
+            class LoadedModule {
+            }
 
-               loader.stubbedModules = {lazyFalse: LoadedModule, lazyTrue: LoadedModule};
-               const fixture = createRoot(router, RootCmp);
+            loader.stubbedModules = { lazyFalse: LoadedModule, lazyTrue: LoadedModule };
+            const fixture = createRoot(router, RootCmp);
 
-               router.resetConfig([
-                 {path: 'lazyFalse', canLoad: ['alwaysFalse'], loadChildren: 'lazyFalse'},
-                 {path: 'lazyTrue', canLoad: ['alwaysTrue'], loadChildren: 'lazyTrue'}
-               ]);
+            router.resetConfig([
+              { path: 'lazyFalse', canLoad: ['alwaysFalse'], loadChildren: 'lazyFalse' },
+              { path: 'lazyTrue', canLoad: ['alwaysTrue'], loadChildren: 'lazyTrue' }
+            ]);
 
-               const recordedEvents: any[] = [];
-               router.events.forEach(e => recordedEvents.push(e));
+            const recordedEvents: any[] = [];
+            router.events.forEach(e => recordedEvents.push(e));
 
 
-               // failed navigation
-               router.navigateByUrl('/lazyFalse/loaded');
-               advance(fixture);
+            // failed navigation
+            router.navigateByUrl('/lazyFalse/loaded');
+            advance(fixture);
 
-               expect(location.path()).toEqual('/');
+            expect(location.path()).toEqual('/');
 
-               expectEvents(recordedEvents, [
-                 [NavigationStart, '/lazyFalse/loaded'],
-                 //  [GuardsCheckStart, '/lazyFalse/loaded'],
-                 [NavigationCancel, '/lazyFalse/loaded'],
-               ]);
+            expectEvents(recordedEvents, [
+              [NavigationStart, '/lazyFalse/loaded'],
+              //  [GuardsCheckStart, '/lazyFalse/loaded'],
+              [NavigationCancel, '/lazyFalse/loaded'],
+            ]);
 
-               recordedEvents.splice(0);
+            recordedEvents.splice(0);
 
-               // successful navigation
-               router.navigateByUrl('/lazyTrue/loaded');
-               advance(fixture);
+            // successful navigation
+            router.navigateByUrl('/lazyTrue/loaded');
+            advance(fixture);
 
-               expect(location.path()).toEqual('/lazyTrue/loaded');
+            expect(location.path()).toEqual('/lazyTrue/loaded');
 
-               expectEvents(recordedEvents, [
-                 [NavigationStart, '/lazyTrue/loaded'],
-                 [RouteConfigLoadStart],
-                 [RouteConfigLoadEnd],
-                 [RoutesRecognized, '/lazyTrue/loaded'],
-                 [GuardsCheckStart, '/lazyTrue/loaded'],
-                 [ChildActivationStart],
-                 [ActivationStart],
-                 [ChildActivationStart],
-                 [ActivationStart],
-                 [GuardsCheckEnd, '/lazyTrue/loaded'],
-                 [ResolveStart, '/lazyTrue/loaded'],
-                 [ResolveEnd, '/lazyTrue/loaded'],
-                 [ActivationEnd],
-                 [ChildActivationEnd],
-                 [ActivationEnd],
-                 [ChildActivationEnd],
-                 [NavigationEnd, '/lazyTrue/loaded'],
-               ]);
-             })));
+            expectEvents(recordedEvents, [
+              [NavigationStart, '/lazyTrue/loaded'],
+              [RouteConfigLoadStart],
+              [RouteConfigLoadEnd],
+              [RoutesRecognized, '/lazyTrue/loaded'],
+              [GuardsCheckStart, '/lazyTrue/loaded'],
+              [ChildActivationStart],
+              [ActivationStart],
+              [ChildActivationStart],
+              [ActivationStart],
+              [GuardsCheckEnd, '/lazyTrue/loaded'],
+              [ResolveStart, '/lazyTrue/loaded'],
+              [ResolveEnd, '/lazyTrue/loaded'],
+              [ActivationEnd],
+              [ChildActivationEnd],
+              [ActivationEnd],
+              [ChildActivationEnd],
+              [NavigationEnd, '/lazyTrue/loaded'],
+            ]);
+          })));
 
       it('should support navigating from within the guard',
-         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
 
-           const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-           router.resetConfig([
-             {path: 'lazyFalse', canLoad: ['returnFalseAndNavigate'], loadChildren: 'lazyFalse'},
-             {path: 'blank', component: BlankCmp}
-           ]);
+          router.resetConfig([
+            { path: 'lazyFalse', canLoad: ['returnFalseAndNavigate'], loadChildren: 'lazyFalse' },
+            { path: 'blank', component: BlankCmp }
+          ]);
 
-           const recordedEvents: any[] = [];
-           router.events.forEach(e => recordedEvents.push(e));
+          const recordedEvents: any[] = [];
+          router.events.forEach(e => recordedEvents.push(e));
 
 
-           router.navigateByUrl('/lazyFalse/loaded');
-           advance(fixture);
+          router.navigateByUrl('/lazyFalse/loaded');
+          advance(fixture);
 
-           expect(location.path()).toEqual('/blank');
+          expect(location.path()).toEqual('/blank');
 
-           expectEvents(recordedEvents, [
-             [NavigationStart, '/lazyFalse/loaded'],
-             // No GuardCheck events as `canLoad` is a special guard that's not actually part of the
-             // guard lifecycle.
-             [NavigationCancel, '/lazyFalse/loaded'],
+          expectEvents(recordedEvents, [
+            [NavigationStart, '/lazyFalse/loaded'],
+            // No GuardCheck events as `canLoad` is a special guard that's not actually part of the
+            // guard lifecycle.
+            [NavigationCancel, '/lazyFalse/loaded'],
 
-             [NavigationStart, '/blank'], [RoutesRecognized, '/blank'],
-             [GuardsCheckStart, '/blank'], [ChildActivationStart], [ActivationStart],
-             [GuardsCheckEnd, '/blank'], [ResolveStart, '/blank'], [ResolveEnd, '/blank'],
-             [ActivationEnd], [ChildActivationEnd], [NavigationEnd, '/blank']
-           ]);
-         })));
+            [NavigationStart, '/blank'], [RoutesRecognized, '/blank'],
+            [GuardsCheckStart, '/blank'], [ChildActivationStart], [ActivationStart],
+            [GuardsCheckEnd, '/blank'], [ResolveStart, '/blank'], [ResolveEnd, '/blank'],
+            [ActivationEnd], [ChildActivationEnd], [NavigationEnd, '/blank']
+          ]);
+        })));
 
       it('should execute CanLoad only once',
-         fakeAsync(inject(
-             [Router, Location, NgModuleFactoryLoader],
-             (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+        fakeAsync(inject(
+          [Router, Location, NgModuleFactoryLoader],
+          (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
 
-               @Component({selector: 'lazy', template: 'lazy-loaded'})
-               class LazyLoadedComponent {
-               }
+            @Component({ selector: 'lazy', template: 'lazy-loaded' })
+            class LazyLoadedComponent {
+            }
 
-               @NgModule({
-                 declarations: [LazyLoadedComponent],
-                 imports:
-                     [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])]
-               })
-               class LazyLoadedModule {
-               }
+            @NgModule({
+              declarations: [LazyLoadedComponent],
+              imports:
+                [RouterModule.forChild([{ path: 'loaded', component: LazyLoadedComponent }])]
+            })
+            class LazyLoadedModule {
+            }
 
-               loader.stubbedModules = {lazy: LazyLoadedModule};
-               const fixture = createRoot(router, RootCmp);
+            loader.stubbedModules = { lazy: LazyLoadedModule };
+            const fixture = createRoot(router, RootCmp);
 
-               router.resetConfig([{path: 'lazy', canLoad: ['alwaysTrue'], loadChildren: 'lazy'}]);
+            router.resetConfig([{ path: 'lazy', canLoad: ['alwaysTrue'], loadChildren: 'lazy' }]);
 
-               router.navigateByUrl('/lazy/loaded');
-               advance(fixture);
-               expect(location.path()).toEqual('/lazy/loaded');
-               expect(canLoadRunCount).toEqual(1);
+            router.navigateByUrl('/lazy/loaded');
+            advance(fixture);
+            expect(location.path()).toEqual('/lazy/loaded');
+            expect(canLoadRunCount).toEqual(1);
 
-               router.navigateByUrl('/');
-               advance(fixture);
-               expect(location.path()).toEqual('/');
+            router.navigateByUrl('/');
+            advance(fixture);
+            expect(location.path()).toEqual('/');
 
-               router.navigateByUrl('/lazy/loaded');
-               advance(fixture);
-               expect(location.path()).toEqual('/lazy/loaded');
-               expect(canLoadRunCount).toEqual(1);
-             })));
+            router.navigateByUrl('/lazy/loaded');
+            advance(fixture);
+            expect(location.path()).toEqual('/lazy/loaded');
+            expect(canLoadRunCount).toEqual(1);
+          })));
     });
 
     describe('order', () => {
@@ -2893,663 +2893,663 @@ describe('Integration', () => {
       });
 
       it('should call guards in the right order',
-         fakeAsync(inject(
-             [Router, Location, Logger], (router: Router, location: Location, logger: Logger) => {
-               const fixture = createRoot(router, RootCmp);
+        fakeAsync(inject(
+          [Router, Location, Logger], (router: Router, location: Location, logger: Logger) => {
+            const fixture = createRoot(router, RootCmp);
 
-               router.resetConfig([{
-                 path: '',
-                 canActivateChild: ['canActivateChild_parent'],
-                 children: [{
-                   path: 'team/:id',
-                   canActivate: ['canActivate_team'],
-                   canDeactivate: ['canDeactivate_team'],
-                   component: TeamCmp
-                 }]
-               }]);
+            router.resetConfig([{
+              path: '',
+              canActivateChild: ['canActivateChild_parent'],
+              children: [{
+                path: 'team/:id',
+                canActivate: ['canActivate_team'],
+                canDeactivate: ['canDeactivate_team'],
+                component: TeamCmp
+              }]
+            }]);
 
-               router.navigateByUrl('/team/22');
-               advance(fixture);
+            router.navigateByUrl('/team/22');
+            advance(fixture);
 
-               router.navigateByUrl('/team/33');
-               advance(fixture);
+            router.navigateByUrl('/team/33');
+            advance(fixture);
 
-               expect(logger.logs).toEqual([
-                 'canActivateChild_parent', 'canActivate_team',
+            expect(logger.logs).toEqual([
+              'canActivateChild_parent', 'canActivate_team',
 
-                 'canDeactivate_team', 'canActivateChild_parent', 'canActivate_team'
-               ]);
-             })));
+              'canDeactivate_team', 'canActivateChild_parent', 'canActivate_team'
+            ]);
+          })));
 
       it('should call deactivate guards from bottom to top',
-         fakeAsync(inject(
-             [Router, Location, Logger], (router: Router, location: Location, logger: Logger) => {
-               const fixture = createRoot(router, RootCmp);
+        fakeAsync(inject(
+          [Router, Location, Logger], (router: Router, location: Location, logger: Logger) => {
+            const fixture = createRoot(router, RootCmp);
 
-               router.resetConfig([{
-                 path: '',
-                 children: [{
-                   path: 'team/:id',
-                   canDeactivate: ['canDeactivate_team'],
-                   children:
-                       [{path: '', component: SimpleCmp, canDeactivate: ['canDeactivate_simple']}],
-                   component: TeamCmp
-                 }]
-               }]);
+            router.resetConfig([{
+              path: '',
+              children: [{
+                path: 'team/:id',
+                canDeactivate: ['canDeactivate_team'],
+                children:
+                  [{ path: '', component: SimpleCmp, canDeactivate: ['canDeactivate_simple'] }],
+                component: TeamCmp
+              }]
+            }]);
 
-               router.navigateByUrl('/team/22');
-               advance(fixture);
+            router.navigateByUrl('/team/22');
+            advance(fixture);
 
-               router.navigateByUrl('/team/33');
-               advance(fixture);
+            router.navigateByUrl('/team/33');
+            advance(fixture);
 
-               expect(logger.logs).toEqual(['canDeactivate_simple', 'canDeactivate_team']);
-             })));
+            expect(logger.logs).toEqual(['canDeactivate_simple', 'canDeactivate_team']);
+          })));
     });
   });
 
   describe('route events', () => {
     it('should fire matching (Child)ActivationStart/End events',
-       fakeAsync(inject([Router], (router: Router) => {
-         const fixture = createRoot(router, RootCmp);
+      fakeAsync(inject([Router], (router: Router) => {
+        const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig([{path: 'user/:name', component: UserCmp}]);
+        router.resetConfig([{ path: 'user/:name', component: UserCmp }]);
 
-         const recordedEvents: any[] = [];
-         router.events.forEach(e => recordedEvents.push(e));
+        const recordedEvents: any[] = [];
+        router.events.forEach(e => recordedEvents.push(e));
 
-         router.navigateByUrl('/user/fedor');
-         advance(fixture);
+        router.navigateByUrl('/user/fedor');
+        advance(fixture);
 
-         expect(fixture.nativeElement).toHaveText('user fedor');
-         expect(recordedEvents[3] instanceof ChildActivationStart).toBe(true);
-         expect(recordedEvents[3].snapshot).toBe(recordedEvents[9].snapshot.root);
-         expect(recordedEvents[9] instanceof ChildActivationEnd).toBe(true);
-         expect(recordedEvents[9].snapshot).toBe(recordedEvents[9].snapshot.root);
+        expect(fixture.nativeElement).toHaveText('user fedor');
+        expect(recordedEvents[3] instanceof ChildActivationStart).toBe(true);
+        expect(recordedEvents[3].snapshot).toBe(recordedEvents[9].snapshot.root);
+        expect(recordedEvents[9] instanceof ChildActivationEnd).toBe(true);
+        expect(recordedEvents[9].snapshot).toBe(recordedEvents[9].snapshot.root);
 
-         expect(recordedEvents[4] instanceof ActivationStart).toBe(true);
-         expect(recordedEvents[4].snapshot.routeConfig.path).toBe('user/:name');
-         expect(recordedEvents[8] instanceof ActivationEnd).toBe(true);
-         expect(recordedEvents[8].snapshot.routeConfig.path).toBe('user/:name');
+        expect(recordedEvents[4] instanceof ActivationStart).toBe(true);
+        expect(recordedEvents[4].snapshot.routeConfig.path).toBe('user/:name');
+        expect(recordedEvents[8] instanceof ActivationEnd).toBe(true);
+        expect(recordedEvents[8].snapshot.routeConfig.path).toBe('user/:name');
 
-         expectEvents(recordedEvents, [
-           [NavigationStart, '/user/fedor'], [RoutesRecognized, '/user/fedor'],
-           [GuardsCheckStart, '/user/fedor'], [ChildActivationStart], [ActivationStart],
-           [GuardsCheckEnd, '/user/fedor'], [ResolveStart, '/user/fedor'],
-           [ResolveEnd, '/user/fedor'], [ActivationEnd], [ChildActivationEnd],
-           [NavigationEnd, '/user/fedor']
-         ]);
-       })));
+        expectEvents(recordedEvents, [
+          [NavigationStart, '/user/fedor'], [RoutesRecognized, '/user/fedor'],
+          [GuardsCheckStart, '/user/fedor'], [ChildActivationStart], [ActivationStart],
+          [GuardsCheckEnd, '/user/fedor'], [ResolveStart, '/user/fedor'],
+          [ResolveEnd, '/user/fedor'], [ActivationEnd], [ChildActivationEnd],
+          [NavigationEnd, '/user/fedor']
+        ]);
+      })));
   });
 
   describe('routerActiveLink', () => {
     it('should set the class when the link is active (a tag)',
-       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-         const fixture = createRoot(router, RootCmp);
+      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+        const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig([{
-           path: 'team/:id',
-           component: TeamCmp,
-           children: [{
-             path: 'link',
-             component: DummyLinkCmp,
-             children:
-                 [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
-           }]
-         }]);
+        router.resetConfig([{
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [{
+            path: 'link',
+            component: DummyLinkCmp,
+            children:
+              [{ path: 'simple', component: SimpleCmp }, { path: '', component: BlankCmp }]
+          }]
+        }]);
 
-         router.navigateByUrl('/team/22/link;exact=true');
-         advance(fixture);
-         advance(fixture);
-         expect(location.path()).toEqual('/team/22/link;exact=true');
+        router.navigateByUrl('/team/22/link;exact=true');
+        advance(fixture);
+        advance(fixture);
+        expect(location.path()).toEqual('/team/22/link;exact=true');
 
-         const nativeLink = fixture.nativeElement.querySelector('a');
-         const nativeButton = fixture.nativeElement.querySelector('button');
-         expect(nativeLink.className).toEqual('active');
-         expect(nativeButton.className).toEqual('active');
+        const nativeLink = fixture.nativeElement.querySelector('a');
+        const nativeButton = fixture.nativeElement.querySelector('button');
+        expect(nativeLink.className).toEqual('active');
+        expect(nativeButton.className).toEqual('active');
 
-         router.navigateByUrl('/team/22/link/simple');
-         advance(fixture);
-         expect(location.path()).toEqual('/team/22/link/simple');
-         expect(nativeLink.className).toEqual('');
-         expect(nativeButton.className).toEqual('');
-       })));
+        router.navigateByUrl('/team/22/link/simple');
+        advance(fixture);
+        expect(location.path()).toEqual('/team/22/link/simple');
+        expect(nativeLink.className).toEqual('');
+        expect(nativeButton.className).toEqual('');
+      })));
 
     it('should not set the class until the first navigation succeeds', fakeAsync(() => {
-         @Component({
-           template:
-               '<router-outlet></router-outlet><a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" ></a>'
-         })
-         class RootCmpWithLink {
-         }
+      @Component({
+        template:
+          '<router-outlet></router-outlet><a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" ></a>'
+      })
+      class RootCmpWithLink {
+      }
 
-         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
-         const router: Router = TestBed.get(Router);
-         const loc: any = TestBed.get(Location);
+      TestBed.configureTestingModule({ declarations: [RootCmpWithLink] });
+      const router: Router = TestBed.get(Router);
+      const loc: any = TestBed.get(Location);
 
-         const f = TestBed.createComponent(RootCmpWithLink);
-         advance(f);
+      const f = TestBed.createComponent(RootCmpWithLink);
+      advance(f);
 
-         const link = f.nativeElement.querySelector('a');
-         expect(link.className).toEqual('');
+      const link = f.nativeElement.querySelector('a');
+      expect(link.className).toEqual('');
 
-         router.initialNavigation();
-         advance(f);
+      router.initialNavigation();
+      advance(f);
 
-         expect(link.className).toEqual('active');
-       }));
+      expect(link.className).toEqual('active');
+    }));
 
 
     it('should set the class on a parent element when the link is active',
-       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-         const fixture = createRoot(router, RootCmp);
+      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+        const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig([{
-           path: 'team/:id',
-           component: TeamCmp,
-           children: [{
-             path: 'link',
-             component: DummyLinkWithParentCmp,
-             children:
-                 [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
-           }]
-         }]);
+        router.resetConfig([{
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [{
+            path: 'link',
+            component: DummyLinkWithParentCmp,
+            children:
+              [{ path: 'simple', component: SimpleCmp }, { path: '', component: BlankCmp }]
+          }]
+        }]);
 
-         router.navigateByUrl('/team/22/link;exact=true');
-         advance(fixture);
-         advance(fixture);
-         expect(location.path()).toEqual('/team/22/link;exact=true');
+        router.navigateByUrl('/team/22/link;exact=true');
+        advance(fixture);
+        advance(fixture);
+        expect(location.path()).toEqual('/team/22/link;exact=true');
 
-         const native = fixture.nativeElement.querySelector('#link-parent');
-         expect(native.className).toEqual('active');
+        const native = fixture.nativeElement.querySelector('#link-parent');
+        expect(native.className).toEqual('active');
 
-         router.navigateByUrl('/team/22/link/simple');
-         advance(fixture);
-         expect(location.path()).toEqual('/team/22/link/simple');
-         expect(native.className).toEqual('');
-       })));
+        router.navigateByUrl('/team/22/link/simple');
+        advance(fixture);
+        expect(location.path()).toEqual('/team/22/link/simple');
+        expect(native.className).toEqual('');
+      })));
 
     it('should set the class when the link is active',
-       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-         const fixture = createRoot(router, RootCmp);
+      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+        const fixture = createRoot(router, RootCmp);
 
-         router.resetConfig([{
-           path: 'team/:id',
-           component: TeamCmp,
-           children: [{
-             path: 'link',
-             component: DummyLinkCmp,
-             children:
-                 [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
-           }]
-         }]);
+        router.resetConfig([{
+          path: 'team/:id',
+          component: TeamCmp,
+          children: [{
+            path: 'link',
+            component: DummyLinkCmp,
+            children:
+              [{ path: 'simple', component: SimpleCmp }, { path: '', component: BlankCmp }]
+          }]
+        }]);
 
-         router.navigateByUrl('/team/22/link');
-         advance(fixture);
-         advance(fixture);
-         expect(location.path()).toEqual('/team/22/link');
+        router.navigateByUrl('/team/22/link');
+        advance(fixture);
+        advance(fixture);
+        expect(location.path()).toEqual('/team/22/link');
 
-         const native = fixture.nativeElement.querySelector('a');
-         expect(native.className).toEqual('active');
+        const native = fixture.nativeElement.querySelector('a');
+        expect(native.className).toEqual('active');
 
-         router.navigateByUrl('/team/22/link/simple');
-         advance(fixture);
-         expect(location.path()).toEqual('/team/22/link/simple');
-         expect(native.className).toEqual('active');
-       })));
+        router.navigateByUrl('/team/22/link/simple');
+        advance(fixture);
+        expect(location.path()).toEqual('/team/22/link/simple');
+        expect(native.className).toEqual('active');
+      })));
 
 
     it('should expose an isActive property', fakeAsync(() => {
-         @Component({
-           template: `<a routerLink="/team" routerLinkActive #rla="routerLinkActive"></a>
+      @Component({
+        template: `<a routerLink="/team" routerLinkActive #rla="routerLinkActive"></a>
               <p>{{rla.isActive}}</p>
               <span *ngIf="rla.isActive"></span>
               <span [ngClass]="{'highlight': rla.isActive}"></span>
               <router-outlet></router-outlet>`
-         })
-         class ComponentWithRouterLink {
-         }
+      })
+      class ComponentWithRouterLink {
+      }
 
-         TestBed.configureTestingModule({declarations: [ComponentWithRouterLink]});
-         const router: Router = TestBed.get(Router);
+      TestBed.configureTestingModule({ declarations: [ComponentWithRouterLink] });
+      const router: Router = TestBed.get(Router);
 
-         router.resetConfig([
-           {
-             path: 'team',
-             component: TeamCmp,
-           },
-           {
-             path: 'otherteam',
-             component: TeamCmp,
-           }
-         ]);
+      router.resetConfig([
+        {
+          path: 'team',
+          component: TeamCmp,
+        },
+        {
+          path: 'otherteam',
+          component: TeamCmp,
+        }
+      ]);
 
-         const fixture = TestBed.createComponent(ComponentWithRouterLink);
-         router.navigateByUrl('/team');
-         expect(() => advance(fixture)).not.toThrow();
-         advance(fixture);
+      const fixture = TestBed.createComponent(ComponentWithRouterLink);
+      router.navigateByUrl('/team');
+      expect(() => advance(fixture)).not.toThrow();
+      advance(fixture);
 
-         const paragraph = fixture.nativeElement.querySelector('p');
-         expect(paragraph.textContent).toEqual('true');
+      const paragraph = fixture.nativeElement.querySelector('p');
+      expect(paragraph.textContent).toEqual('true');
 
-         router.navigateByUrl('/otherteam');
-         advance(fixture);
-         advance(fixture);
-         expect(paragraph.textContent).toEqual('false');
-       }));
+      router.navigateByUrl('/otherteam');
+      advance(fixture);
+      advance(fixture);
+      expect(paragraph.textContent).toEqual('false');
+    }));
 
   });
 
   describe('lazy loading', () => {
     it('works',
-       fakeAsync(inject(
-           [Router, Location, NgModuleFactoryLoader],
-           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-             @Component({
-               selector: 'lazy',
-               template: 'lazy-loaded-parent [<router-outlet></router-outlet>]'
-             })
-             class ParentLazyLoadedComponent {
-             }
+      fakeAsync(inject(
+        [Router, Location, NgModuleFactoryLoader],
+        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+          @Component({
+            selector: 'lazy',
+            template: 'lazy-loaded-parent [<router-outlet></router-outlet>]'
+          })
+          class ParentLazyLoadedComponent {
+          }
 
-             @Component({selector: 'lazy', template: 'lazy-loaded-child'})
-             class ChildLazyLoadedComponent {
-             }
+          @Component({ selector: 'lazy', template: 'lazy-loaded-child' })
+          class ChildLazyLoadedComponent {
+          }
 
-             @NgModule({
-               declarations: [ParentLazyLoadedComponent, ChildLazyLoadedComponent],
-               imports: [RouterModule.forChild([{
-                 path: 'loaded',
-                 component: ParentLazyLoadedComponent,
-                 children: [{path: 'child', component: ChildLazyLoadedComponent}]
-               }])]
-             })
-             class LoadedModule {
-             }
+          @NgModule({
+            declarations: [ParentLazyLoadedComponent, ChildLazyLoadedComponent],
+            imports: [RouterModule.forChild([{
+              path: 'loaded',
+              component: ParentLazyLoadedComponent,
+              children: [{ path: 'child', component: ChildLazyLoadedComponent }]
+            }])]
+          })
+          class LoadedModule {
+          }
 
 
-             loader.stubbedModules = {expected: LoadedModule};
+          loader.stubbedModules = { expected: LoadedModule };
 
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
+          router.resetConfig([{ path: 'lazy', loadChildren: 'expected' }]);
 
-             router.navigateByUrl('/lazy/loaded/child');
-             advance(fixture);
+          router.navigateByUrl('/lazy/loaded/child');
+          advance(fixture);
 
-             expect(location.path()).toEqual('/lazy/loaded/child');
-             expect(fixture.nativeElement).toHaveText('lazy-loaded-parent [lazy-loaded-child]');
-           })));
+          expect(location.path()).toEqual('/lazy/loaded/child');
+          expect(fixture.nativeElement).toHaveText('lazy-loaded-parent [lazy-loaded-child]');
+        })));
 
     it('should have 2 injector trees: module and element',
-       fakeAsync(inject(
-           [Router, Location, NgModuleFactoryLoader],
-           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-             @Component({
-               selector: 'lazy',
-               template: 'parent[<router-outlet></router-outlet>]',
-               viewProviders: [
-                 {provide: 'shadow', useValue: 'from parent component'},
-               ],
-             })
-             class Parent {
-             }
+      fakeAsync(inject(
+        [Router, Location, NgModuleFactoryLoader],
+        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+          @Component({
+            selector: 'lazy',
+            template: 'parent[<router-outlet></router-outlet>]',
+            viewProviders: [
+              { provide: 'shadow', useValue: 'from parent component' },
+            ],
+          })
+          class Parent {
+          }
 
-             @Component({selector: 'lazy', template: 'child'})
-             class Child {
-             }
+          @Component({ selector: 'lazy', template: 'child' })
+          class Child {
+          }
 
-             @NgModule({
-               declarations: [Parent],
-               imports: [RouterModule.forChild([{
-                 path: 'parent',
-                 component: Parent,
-                 children: [
-                   {path: 'child', loadChildren: 'child'},
-                 ]
-               }])],
-               providers: [
-                 {provide: 'moduleName', useValue: 'parent'},
-                 {provide: 'fromParent', useValue: 'from parent'},
-               ],
-             })
-             class ParentModule {
-             }
+          @NgModule({
+            declarations: [Parent],
+            imports: [RouterModule.forChild([{
+              path: 'parent',
+              component: Parent,
+              children: [
+                { path: 'child', loadChildren: 'child' },
+              ]
+            }])],
+            providers: [
+              { provide: 'moduleName', useValue: 'parent' },
+              { provide: 'fromParent', useValue: 'from parent' },
+            ],
+          })
+          class ParentModule {
+          }
 
-             @NgModule({
-               declarations: [Child],
-               imports: [RouterModule.forChild([{path: '', component: Child}])],
-               providers: [
-                 {provide: 'moduleName', useValue: 'child'},
-                 {provide: 'fromChild', useValue: 'from child'},
-                 {provide: 'shadow', useValue: 'from child module'},
-               ],
-             })
-             class ChildModule {
-             }
+          @NgModule({
+            declarations: [Child],
+            imports: [RouterModule.forChild([{ path: '', component: Child }])],
+            providers: [
+              { provide: 'moduleName', useValue: 'child' },
+              { provide: 'fromChild', useValue: 'from child' },
+              { provide: 'shadow', useValue: 'from child module' },
+            ],
+          })
+          class ChildModule {
+          }
 
-             loader.stubbedModules = {
-               parent: ParentModule,
-               child: ChildModule,
-             };
+          loader.stubbedModules = {
+            parent: ParentModule,
+            child: ChildModule,
+          };
 
-             const fixture = createRoot(router, RootCmp);
-             router.resetConfig([{path: 'lazy', loadChildren: 'parent'}]);
-             router.navigateByUrl('/lazy/parent/child');
-             advance(fixture);
-             expect(location.path()).toEqual('/lazy/parent/child');
-             expect(fixture.nativeElement).toHaveText('parent[child]');
+          const fixture = createRoot(router, RootCmp);
+          router.resetConfig([{ path: 'lazy', loadChildren: 'parent' }]);
+          router.navigateByUrl('/lazy/parent/child');
+          advance(fixture);
+          expect(location.path()).toEqual('/lazy/parent/child');
+          expect(fixture.nativeElement).toHaveText('parent[child]');
 
-             const pInj = fixture.debugElement.query(By.directive(Parent)).injector !;
-             const cInj = fixture.debugElement.query(By.directive(Child)).injector !;
+          const pInj = fixture.debugElement.query(By.directive(Parent)).injector!;
+          const cInj = fixture.debugElement.query(By.directive(Child)).injector!;
 
-             expect(pInj.get('moduleName')).toEqual('parent');
-             expect(pInj.get('fromParent')).toEqual('from parent');
-             expect(pInj.get(Parent)).toBeAnInstanceOf(Parent);
-             expect(pInj.get('fromChild', null)).toEqual(null);
-             expect(pInj.get(Child, null)).toEqual(null);
+          expect(pInj.get('moduleName')).toEqual('parent');
+          expect(pInj.get('fromParent')).toEqual('from parent');
+          expect(pInj.get(Parent)).toBeAnInstanceOf(Parent);
+          expect(pInj.get('fromChild', null)).toEqual(null);
+          expect(pInj.get(Child, null)).toEqual(null);
 
-             expect(cInj.get('moduleName')).toEqual('child');
-             expect(cInj.get('fromParent')).toEqual('from parent');
-             expect(cInj.get('fromChild')).toEqual('from child');
-             expect(cInj.get(Parent)).toBeAnInstanceOf(Parent);
-             expect(cInj.get(Child)).toBeAnInstanceOf(Child);
-             // The child module can not shadow the parent component
-             expect(cInj.get('shadow')).toEqual('from parent component');
+          expect(cInj.get('moduleName')).toEqual('child');
+          expect(cInj.get('fromParent')).toEqual('from parent');
+          expect(cInj.get('fromChild')).toEqual('from child');
+          expect(cInj.get(Parent)).toBeAnInstanceOf(Parent);
+          expect(cInj.get(Child)).toBeAnInstanceOf(Child);
+          // The child module can not shadow the parent component
+          expect(cInj.get('shadow')).toEqual('from parent component');
 
-             const pmInj = pInj.get(NgModuleRef).injector;
-             const cmInj = cInj.get(NgModuleRef).injector;
+          const pmInj = pInj.get(NgModuleRef).injector;
+          const cmInj = cInj.get(NgModuleRef).injector;
 
-             expect(pmInj.get('moduleName')).toEqual('parent');
-             expect(cmInj.get('moduleName')).toEqual('child');
+          expect(pmInj.get('moduleName')).toEqual('parent');
+          expect(cmInj.get('moduleName')).toEqual('child');
 
-             expect(pmInj.get(Parent, '-')).toEqual('-');
-             expect(cmInj.get(Parent, '-')).toEqual('-');
-             expect(pmInj.get(Child, '-')).toEqual('-');
-             expect(cmInj.get(Child, '-')).toEqual('-');
-           })));
+          expect(pmInj.get(Parent, '-')).toEqual('-');
+          expect(cmInj.get(Parent, '-')).toEqual('-');
+          expect(pmInj.get(Child, '-')).toEqual('-');
+          expect(cmInj.get(Child, '-')).toEqual('-');
+        })));
 
     // https://github.com/angular/angular/issues/12889
     it('should create a single instance of lazy-loaded modules',
-       fakeAsync(inject(
-           [Router, Location, NgModuleFactoryLoader],
-           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-             @Component({
-               selector: 'lazy',
-               template: 'lazy-loaded-parent [<router-outlet></router-outlet>]'
-             })
-             class ParentLazyLoadedComponent {
-             }
+      fakeAsync(inject(
+        [Router, Location, NgModuleFactoryLoader],
+        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+          @Component({
+            selector: 'lazy',
+            template: 'lazy-loaded-parent [<router-outlet></router-outlet>]'
+          })
+          class ParentLazyLoadedComponent {
+          }
 
-             @Component({selector: 'lazy', template: 'lazy-loaded-child'})
-             class ChildLazyLoadedComponent {
-             }
+          @Component({ selector: 'lazy', template: 'lazy-loaded-child' })
+          class ChildLazyLoadedComponent {
+          }
 
-             @NgModule({
-               declarations: [ParentLazyLoadedComponent, ChildLazyLoadedComponent],
-               imports: [RouterModule.forChild([{
-                 path: 'loaded',
-                 component: ParentLazyLoadedComponent,
-                 children: [{path: 'child', component: ChildLazyLoadedComponent}]
-               }])]
-             })
-             class LoadedModule {
-               static instances = 0;
-               constructor() { LoadedModule.instances++; }
-             }
+          @NgModule({
+            declarations: [ParentLazyLoadedComponent, ChildLazyLoadedComponent],
+            imports: [RouterModule.forChild([{
+              path: 'loaded',
+              component: ParentLazyLoadedComponent,
+              children: [{ path: 'child', component: ChildLazyLoadedComponent }]
+            }])]
+          })
+          class LoadedModule {
+            static instances = 0;
+            constructor() { LoadedModule.instances++; }
+          }
 
-             loader.stubbedModules = {expected: LoadedModule};
-             const fixture = createRoot(router, RootCmp);
-             router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
-             router.navigateByUrl('/lazy/loaded/child');
-             advance(fixture);
-             expect(fixture.nativeElement).toHaveText('lazy-loaded-parent [lazy-loaded-child]');
-             expect(LoadedModule.instances).toEqual(1);
-           })));
+          loader.stubbedModules = { expected: LoadedModule };
+          const fixture = createRoot(router, RootCmp);
+          router.resetConfig([{ path: 'lazy', loadChildren: 'expected' }]);
+          router.navigateByUrl('/lazy/loaded/child');
+          advance(fixture);
+          expect(fixture.nativeElement).toHaveText('lazy-loaded-parent [lazy-loaded-child]');
+          expect(LoadedModule.instances).toEqual(1);
+        })));
 
     // https://github.com/angular/angular/issues/13870
     it('should create a single instance of guards for lazy-loaded modules',
-       fakeAsync(inject(
-           [Router, Location, NgModuleFactoryLoader],
-           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-             @Injectable()
-             class Service {
-             }
+      fakeAsync(inject(
+        [Router, Location, NgModuleFactoryLoader],
+        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+          @Injectable()
+          class Service {
+          }
 
-             @Injectable()
-             class Resolver implements Resolve<Service> {
-               constructor(public service: Service) {}
-               resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-                 return this.service;
-               }
-             }
+          @Injectable()
+          class Resolver implements Resolve<Service> {
+            constructor(public service: Service) { }
+            resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+              return this.service;
+            }
+          }
 
-             @Component({selector: 'lazy', template: 'lazy'})
-             class LazyLoadedComponent {
-               resolvedService: Service;
-               constructor(public injectedService: Service, route: ActivatedRoute) {
-                 this.resolvedService = route.snapshot.data['service'];
-               }
-             }
+          @Component({ selector: 'lazy', template: 'lazy' })
+          class LazyLoadedComponent {
+            resolvedService: Service;
+            constructor(public injectedService: Service, route: ActivatedRoute) {
+              this.resolvedService = route.snapshot.data['service'];
+            }
+          }
 
-             @NgModule({
-               declarations: [LazyLoadedComponent],
-               providers: [Service, Resolver],
-               imports: [
-                 RouterModule.forChild([{
-                   path: 'loaded',
-                   component: LazyLoadedComponent,
-                   resolve: {'service': Resolver},
-                 }]),
-               ]
-             })
-             class LoadedModule {
-             }
+          @NgModule({
+            declarations: [LazyLoadedComponent],
+            providers: [Service, Resolver],
+            imports: [
+              RouterModule.forChild([{
+                path: 'loaded',
+                component: LazyLoadedComponent,
+                resolve: { 'service': Resolver },
+              }]),
+            ]
+          })
+          class LoadedModule {
+          }
 
-             loader.stubbedModules = {expected: LoadedModule};
-             const fixture = createRoot(router, RootCmp);
-             router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
-             router.navigateByUrl('/lazy/loaded');
-             advance(fixture);
+          loader.stubbedModules = { expected: LoadedModule };
+          const fixture = createRoot(router, RootCmp);
+          router.resetConfig([{ path: 'lazy', loadChildren: 'expected' }]);
+          router.navigateByUrl('/lazy/loaded');
+          advance(fixture);
 
-             expect(fixture.nativeElement).toHaveText('lazy');
-             const lzc =
-                 fixture.debugElement.query(By.directive(LazyLoadedComponent)).componentInstance;
-             expect(lzc.injectedService).toBe(lzc.resolvedService);
-           })));
+          expect(fixture.nativeElement).toHaveText('lazy');
+          const lzc =
+            fixture.debugElement.query(By.directive(LazyLoadedComponent)).componentInstance;
+          expect(lzc.injectedService).toBe(lzc.resolvedService);
+        })));
 
 
     it('should emit RouteConfigLoadStart and RouteConfigLoadEnd event when route is lazy loaded',
-       fakeAsync(inject(
-           [Router, Location, NgModuleFactoryLoader],
-           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-             @Component({
-               selector: 'lazy',
-               template: 'lazy-loaded-parent [<router-outlet></router-outlet>]',
-             })
-             class ParentLazyLoadedComponent {
-             }
+      fakeAsync(inject(
+        [Router, Location, NgModuleFactoryLoader],
+        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+          @Component({
+            selector: 'lazy',
+            template: 'lazy-loaded-parent [<router-outlet></router-outlet>]',
+          })
+          class ParentLazyLoadedComponent {
+          }
 
-             @Component({selector: 'lazy', template: 'lazy-loaded-child'})
-             class ChildLazyLoadedComponent {
-             }
+          @Component({ selector: 'lazy', template: 'lazy-loaded-child' })
+          class ChildLazyLoadedComponent {
+          }
 
-             @NgModule({
-               declarations: [ParentLazyLoadedComponent, ChildLazyLoadedComponent],
-               imports: [RouterModule.forChild([{
-                 path: 'loaded',
-                 component: ParentLazyLoadedComponent,
-                 children: [{path: 'child', component: ChildLazyLoadedComponent}],
-               }])]
-             })
-             class LoadedModule {
-             }
+          @NgModule({
+            declarations: [ParentLazyLoadedComponent, ChildLazyLoadedComponent],
+            imports: [RouterModule.forChild([{
+              path: 'loaded',
+              component: ParentLazyLoadedComponent,
+              children: [{ path: 'child', component: ChildLazyLoadedComponent }],
+            }])]
+          })
+          class LoadedModule {
+          }
 
-             const events: Array<RouteConfigLoadStart|RouteConfigLoadEnd> = [];
+          const events: Array<RouteConfigLoadStart | RouteConfigLoadEnd> = [];
 
-             router.events.subscribe(e => {
-               if (e instanceof RouteConfigLoadStart || e instanceof RouteConfigLoadEnd) {
-                 events.push(e);
-               }
-             });
+          router.events.subscribe(e => {
+            if (e instanceof RouteConfigLoadStart || e instanceof RouteConfigLoadEnd) {
+              events.push(e);
+            }
+          });
 
-             loader.stubbedModules = {expected: LoadedModule};
-             const fixture = createRoot(router, RootCmp);
-             router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
+          loader.stubbedModules = { expected: LoadedModule };
+          const fixture = createRoot(router, RootCmp);
+          router.resetConfig([{ path: 'lazy', loadChildren: 'expected' }]);
 
-             router.navigateByUrl('/lazy/loaded/child');
-             advance(fixture);
+          router.navigateByUrl('/lazy/loaded/child');
+          advance(fixture);
 
-             expect(events.length).toEqual(2);
-             expect(events[0].toString()).toEqual('RouteConfigLoadStart(path: lazy)');
-             expect(events[1].toString()).toEqual('RouteConfigLoadEnd(path: lazy)');
-           })));
+          expect(events.length).toEqual(2);
+          expect(events[0].toString()).toEqual('RouteConfigLoadStart(path: lazy)');
+          expect(events[1].toString()).toEqual('RouteConfigLoadEnd(path: lazy)');
+        })));
 
     it('throws an error when forRoot() is used in a lazy context',
-       fakeAsync(inject(
-           [Router, Location, NgModuleFactoryLoader],
-           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-             @Component({selector: 'lazy', template: 'should not show'})
-             class LazyLoadedComponent {
-             }
+      fakeAsync(inject(
+        [Router, Location, NgModuleFactoryLoader],
+        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+          @Component({ selector: 'lazy', template: 'should not show' })
+          class LazyLoadedComponent {
+          }
 
-             @NgModule({
-               declarations: [LazyLoadedComponent],
-               imports: [RouterModule.forRoot([{path: 'loaded', component: LazyLoadedComponent}])]
-             })
-             class LoadedModule {
-             }
+          @NgModule({
+            declarations: [LazyLoadedComponent],
+            imports: [RouterModule.forRoot([{ path: 'loaded', component: LazyLoadedComponent }])]
+          })
+          class LoadedModule {
+          }
 
-             loader.stubbedModules = {expected: LoadedModule};
+          loader.stubbedModules = { expected: LoadedModule };
 
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
+          router.resetConfig([{ path: 'lazy', loadChildren: 'expected' }]);
 
-             let recordedError: any = null;
-             router.navigateByUrl('/lazy/loaded') !.catch(err => recordedError = err);
-             advance(fixture);
-             expect(recordedError.message)
-                 .toEqual(
-                     `RouterModule.forRoot() called twice. Lazy loaded modules should use RouterModule.forChild() instead.`);
-           })));
+          let recordedError: any = null;
+          router.navigateByUrl('/lazy/loaded')!.catch(err => recordedError = err);
+          advance(fixture);
+          expect(recordedError.message)
+            .toEqual(
+              `RouterModule.forRoot() called twice. Lazy loaded modules should use RouterModule.forChild() instead.`);
+        })));
 
     it('should combine routes from multiple modules into a single configuration',
-       fakeAsync(inject(
-           [Router, Location, NgModuleFactoryLoader],
-           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-             @Component({selector: 'lazy', template: 'lazy-loaded-2'})
-             class LazyComponent2 {
-             }
+      fakeAsync(inject(
+        [Router, Location, NgModuleFactoryLoader],
+        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+          @Component({ selector: 'lazy', template: 'lazy-loaded-2' })
+          class LazyComponent2 {
+          }
 
-             @NgModule({
-               declarations: [LazyComponent2],
-               imports: [RouterModule.forChild([{path: 'loaded', component: LazyComponent2}])]
-             })
-             class SiblingOfLoadedModule {
-             }
+          @NgModule({
+            declarations: [LazyComponent2],
+            imports: [RouterModule.forChild([{ path: 'loaded', component: LazyComponent2 }])]
+          })
+          class SiblingOfLoadedModule {
+          }
 
-             @Component({selector: 'lazy', template: 'lazy-loaded-1'})
-             class LazyComponent1 {
-             }
+          @Component({ selector: 'lazy', template: 'lazy-loaded-1' })
+          class LazyComponent1 {
+          }
 
-             @NgModule({
-               declarations: [LazyComponent1],
-               imports: [
-                 RouterModule.forChild([{path: 'loaded', component: LazyComponent1}]),
-                 SiblingOfLoadedModule
-               ]
-             })
-             class LoadedModule {
-             }
+          @NgModule({
+            declarations: [LazyComponent1],
+            imports: [
+              RouterModule.forChild([{ path: 'loaded', component: LazyComponent1 }]),
+              SiblingOfLoadedModule
+            ]
+          })
+          class LoadedModule {
+          }
 
-             loader.stubbedModules = {expected1: LoadedModule, expected2: SiblingOfLoadedModule};
+          loader.stubbedModules = { expected1: LoadedModule, expected2: SiblingOfLoadedModule };
 
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([
-               {path: 'lazy1', loadChildren: 'expected1'},
-               {path: 'lazy2', loadChildren: 'expected2'}
-             ]);
+          router.resetConfig([
+            { path: 'lazy1', loadChildren: 'expected1' },
+            { path: 'lazy2', loadChildren: 'expected2' }
+          ]);
 
-             router.navigateByUrl('/lazy1/loaded');
-             advance(fixture);
-             expect(location.path()).toEqual('/lazy1/loaded');
+          router.navigateByUrl('/lazy1/loaded');
+          advance(fixture);
+          expect(location.path()).toEqual('/lazy1/loaded');
 
-             router.navigateByUrl('/lazy2/loaded');
-             advance(fixture);
-             expect(location.path()).toEqual('/lazy2/loaded');
-           })));
+          router.navigateByUrl('/lazy2/loaded');
+          advance(fixture);
+          expect(location.path()).toEqual('/lazy2/loaded');
+        })));
 
     it('should allow lazy loaded module in named outlet',
-       fakeAsync(inject(
-           [Router, NgModuleFactoryLoader], (router: Router, loader: SpyNgModuleFactoryLoader) => {
+      fakeAsync(inject(
+        [Router, NgModuleFactoryLoader], (router: Router, loader: SpyNgModuleFactoryLoader) => {
 
-             @Component({selector: 'lazy', template: 'lazy-loaded'})
-             class LazyComponent {
-             }
+          @Component({ selector: 'lazy', template: 'lazy-loaded' })
+          class LazyComponent {
+          }
 
-             @NgModule({
-               declarations: [LazyComponent],
-               imports: [RouterModule.forChild([{path: '', component: LazyComponent}])]
-             })
-             class LazyLoadedModule {
-             }
+          @NgModule({
+            declarations: [LazyComponent],
+            imports: [RouterModule.forChild([{ path: '', component: LazyComponent }])]
+          })
+          class LazyLoadedModule {
+          }
 
-             loader.stubbedModules = {lazyModule: LazyLoadedModule};
+          loader.stubbedModules = { lazyModule: LazyLoadedModule };
 
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([{
-               path: 'team/:id',
-               component: TeamCmp,
-               children: [
-                 {path: 'user/:name', component: UserCmp},
-                 {path: 'lazy', loadChildren: 'lazyModule', outlet: 'right'},
-               ]
-             }]);
+          router.resetConfig([{
+            path: 'team/:id',
+            component: TeamCmp,
+            children: [
+              { path: 'user/:name', component: UserCmp },
+              { path: 'lazy', loadChildren: 'lazyModule', outlet: 'right' },
+            ]
+          }]);
 
 
-             router.navigateByUrl('/team/22/user/john');
-             advance(fixture);
+          router.navigateByUrl('/team/22/user/john');
+          advance(fixture);
 
-             expect(fixture.nativeElement).toHaveText('team 22 [ user john, right:  ]');
+          expect(fixture.nativeElement).toHaveText('team 22 [ user john, right:  ]');
 
-             router.navigateByUrl('/team/22/(user/john//right:lazy)');
-             advance(fixture);
+          router.navigateByUrl('/team/22/(user/john//right:lazy)');
+          advance(fixture);
 
-             expect(fixture.nativeElement).toHaveText('team 22 [ user john, right: lazy-loaded ]');
-           })));
+          expect(fixture.nativeElement).toHaveText('team 22 [ user john, right: lazy-loaded ]');
+        })));
 
     it('should allow componentless named outlet to render children',
-       fakeAsync(inject(
-           [Router, NgModuleFactoryLoader], (router: Router, loader: SpyNgModuleFactoryLoader) => {
+      fakeAsync(inject(
+        [Router, NgModuleFactoryLoader], (router: Router, loader: SpyNgModuleFactoryLoader) => {
 
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([{
-               path: 'team/:id',
-               component: TeamCmp,
-               children: [
-                 {path: 'user/:name', component: UserCmp},
-                 {path: 'simple', outlet: 'right', children: [{path: '', component: SimpleCmp}]},
-               ]
-             }]);
+          router.resetConfig([{
+            path: 'team/:id',
+            component: TeamCmp,
+            children: [
+              { path: 'user/:name', component: UserCmp },
+              { path: 'simple', outlet: 'right', children: [{ path: '', component: SimpleCmp }] },
+            ]
+          }]);
 
 
-             router.navigateByUrl('/team/22/user/john');
-             advance(fixture);
+          router.navigateByUrl('/team/22/user/john');
+          advance(fixture);
 
-             expect(fixture.nativeElement).toHaveText('team 22 [ user john, right:  ]');
+          expect(fixture.nativeElement).toHaveText('team 22 [ user john, right:  ]');
 
-             router.navigateByUrl('/team/22/(user/john//right:simple)');
-             advance(fixture);
+          router.navigateByUrl('/team/22/(user/john//right:simple)');
+          advance(fixture);
 
-             expect(fixture.nativeElement).toHaveText('team 22 [ user john, right: simple ]');
-           })));
+          expect(fixture.nativeElement).toHaveText('team 22 [ user john, right: simple ]');
+        })));
 
     describe('should use the injector of the lazily-loaded configuration', () => {
-      class LazyLoadedServiceDefinedInModule {}
+      class LazyLoadedServiceDefinedInModule { }
 
       @Component({
         selector: 'eager-parent',
@@ -3571,11 +3571,11 @@ describe('Integration', () => {
       })
       class LazyChildComponent {
         constructor(
-            lazy: LazyParentComponent,  // should be able to inject lazy/direct parent
-            lazyService: LazyLoadedServiceDefinedInModule,  // should be able to inject lazy service
-            eager:
-                EagerParentComponent  // should use the injector of the location to create a parent
-            ) {}
+          lazy: LazyParentComponent,  // should be able to inject lazy/direct parent
+          lazyService: LazyLoadedServiceDefinedInModule,  // should be able to inject lazy service
+          eager:
+            EagerParentComponent  // should use the injector of the location to create a parent
+        ) { }
       }
 
       @NgModule({
@@ -3585,7 +3585,7 @@ describe('Integration', () => {
           children: [{
             path: 'lazy-parent',
             component: LazyParentComponent,
-            children: [{path: 'lazy-child', component: LazyChildComponent}]
+            children: [{ path: 'lazy-child', component: LazyChildComponent }]
           }]
         }])],
         providers: [LazyLoadedServiceDefinedInModule]
@@ -3608,182 +3608,182 @@ describe('Integration', () => {
       });
 
       it('should use the injector of the lazily-loaded configuration',
-         fakeAsync(inject(
-             [Router, Location, NgModuleFactoryLoader],
-             (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-               loader.stubbedModules = {expected: LoadedModule};
+        fakeAsync(inject(
+          [Router, Location, NgModuleFactoryLoader],
+          (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+            loader.stubbedModules = { expected: LoadedModule };
 
-               const fixture = createRoot(router, RootCmp);
+            const fixture = createRoot(router, RootCmp);
 
-               router.resetConfig([{
-                 path: 'eager-parent',
-                 component: EagerParentComponent,
-                 children: [{path: 'lazy', loadChildren: 'expected'}]
-               }]);
+            router.resetConfig([{
+              path: 'eager-parent',
+              component: EagerParentComponent,
+              children: [{ path: 'lazy', loadChildren: 'expected' }]
+            }]);
 
-               router.navigateByUrl('/eager-parent/lazy/lazy-parent/lazy-child');
-               advance(fixture);
+            router.navigateByUrl('/eager-parent/lazy/lazy-parent/lazy-child');
+            advance(fixture);
 
-               expect(location.path()).toEqual('/eager-parent/lazy/lazy-parent/lazy-child');
-               expect(fixture.nativeElement).toHaveText('eager-parent lazy-parent lazy-child');
-             })));
+            expect(location.path()).toEqual('/eager-parent/lazy/lazy-parent/lazy-child');
+            expect(fixture.nativeElement).toHaveText('eager-parent lazy-parent lazy-child');
+          })));
     });
 
     it('works when given a callback',
-       fakeAsync(inject(
-           [Router, Location, NgModuleFactoryLoader], (router: Router, location: Location) => {
-             @Component({selector: 'lazy', template: 'lazy-loaded'})
-             class LazyLoadedComponent {
-             }
+      fakeAsync(inject(
+        [Router, Location, NgModuleFactoryLoader], (router: Router, location: Location) => {
+          @Component({ selector: 'lazy', template: 'lazy-loaded' })
+          class LazyLoadedComponent {
+          }
 
-             @NgModule({
-               declarations: [LazyLoadedComponent],
-               imports: [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])],
-             })
-             class LoadedModule {
-             }
+          @NgModule({
+            declarations: [LazyLoadedComponent],
+            imports: [RouterModule.forChild([{ path: 'loaded', component: LazyLoadedComponent }])],
+          })
+          class LoadedModule {
+          }
 
-             const fixture = createRoot(router, RootCmp);
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([{path: 'lazy', loadChildren: () => LoadedModule}]);
+          router.resetConfig([{ path: 'lazy', loadChildren: () => LoadedModule }]);
 
-             router.navigateByUrl('/lazy/loaded');
-             advance(fixture);
+          router.navigateByUrl('/lazy/loaded');
+          advance(fixture);
 
-             expect(location.path()).toEqual('/lazy/loaded');
-             expect(fixture.nativeElement).toHaveText('lazy-loaded');
-           })));
+          expect(location.path()).toEqual('/lazy/loaded');
+          expect(fixture.nativeElement).toHaveText('lazy-loaded');
+        })));
 
     it('error emit an error when cannot load a config',
-       fakeAsync(inject(
-           [Router, Location, NgModuleFactoryLoader],
-           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-             loader.stubbedModules = {};
-             const fixture = createRoot(router, RootCmp);
+      fakeAsync(inject(
+        [Router, Location, NgModuleFactoryLoader],
+        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+          loader.stubbedModules = {};
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([{path: 'lazy', loadChildren: 'invalid'}]);
+          router.resetConfig([{ path: 'lazy', loadChildren: 'invalid' }]);
 
-             const recordedEvents: any[] = [];
-             router.events.forEach(e => recordedEvents.push(e));
+          const recordedEvents: any[] = [];
+          router.events.forEach(e => recordedEvents.push(e));
 
-             router.navigateByUrl('/lazy/loaded') !.catch(s => {});
-             advance(fixture);
+          router.navigateByUrl('/lazy/loaded')!.catch(s => { });
+          advance(fixture);
 
-             expect(location.path()).toEqual('/');
+          expect(location.path()).toEqual('/');
 
-             expectEvents(recordedEvents, [
-               [NavigationStart, '/lazy/loaded'],
-               [RouteConfigLoadStart],
-               [NavigationError, '/lazy/loaded'],
-             ]);
-           })));
+          expectEvents(recordedEvents, [
+            [NavigationStart, '/lazy/loaded'],
+            [RouteConfigLoadStart],
+            [NavigationError, '/lazy/loaded'],
+          ]);
+        })));
 
     it('should work with complex redirect rules',
-       fakeAsync(inject(
-           [Router, Location, NgModuleFactoryLoader],
-           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-             @Component({selector: 'lazy', template: 'lazy-loaded'})
-             class LazyLoadedComponent {
-             }
+      fakeAsync(inject(
+        [Router, Location, NgModuleFactoryLoader],
+        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+          @Component({ selector: 'lazy', template: 'lazy-loaded' })
+          class LazyLoadedComponent {
+          }
 
-             @NgModule({
-               declarations: [LazyLoadedComponent],
-               imports: [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])],
-             })
-             class LoadedModule {
-             }
+          @NgModule({
+            declarations: [LazyLoadedComponent],
+            imports: [RouterModule.forChild([{ path: 'loaded', component: LazyLoadedComponent }])],
+          })
+          class LoadedModule {
+          }
 
-             loader.stubbedModules = {lazy: LoadedModule};
-             const fixture = createRoot(router, RootCmp);
+          loader.stubbedModules = { lazy: LoadedModule };
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig(
-                 [{path: 'lazy', loadChildren: 'lazy'}, {path: '**', redirectTo: 'lazy'}]);
+          router.resetConfig(
+            [{ path: 'lazy', loadChildren: 'lazy' }, { path: '**', redirectTo: 'lazy' }]);
 
-             router.navigateByUrl('/lazy/loaded');
-             advance(fixture);
+          router.navigateByUrl('/lazy/loaded');
+          advance(fixture);
 
-             expect(location.path()).toEqual('/lazy/loaded');
-           })));
+          expect(location.path()).toEqual('/lazy/loaded');
+        })));
 
     it('should work with wildcard route',
-       fakeAsync(inject(
-           [Router, Location, NgModuleFactoryLoader],
-           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-             @Component({selector: 'lazy', template: 'lazy-loaded'})
-             class LazyLoadedComponent {
-             }
+      fakeAsync(inject(
+        [Router, Location, NgModuleFactoryLoader],
+        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+          @Component({ selector: 'lazy', template: 'lazy-loaded' })
+          class LazyLoadedComponent {
+          }
 
-             @NgModule({
-               declarations: [LazyLoadedComponent],
-               imports: [RouterModule.forChild([{path: '', component: LazyLoadedComponent}])],
-             })
-             class LazyLoadedModule {
-             }
+          @NgModule({
+            declarations: [LazyLoadedComponent],
+            imports: [RouterModule.forChild([{ path: '', component: LazyLoadedComponent }])],
+          })
+          class LazyLoadedModule {
+          }
 
-             loader.stubbedModules = {lazy: LazyLoadedModule};
-             const fixture = createRoot(router, RootCmp);
+          loader.stubbedModules = { lazy: LazyLoadedModule };
+          const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([{path: '**', loadChildren: 'lazy'}]);
+          router.resetConfig([{ path: '**', loadChildren: 'lazy' }]);
 
-             router.navigateByUrl('/lazy');
-             advance(fixture);
+          router.navigateByUrl('/lazy');
+          advance(fixture);
 
-             expect(location.path()).toEqual('/lazy');
-             expect(fixture.nativeElement).toHaveText('lazy-loaded');
-           })));
+          expect(location.path()).toEqual('/lazy');
+          expect(fixture.nativeElement).toHaveText('lazy-loaded');
+        })));
 
     describe('preloading', () => {
       beforeEach(() => {
         TestBed.configureTestingModule(
-            {providers: [{provide: PreloadingStrategy, useExisting: PreloadAllModules}]});
+          { providers: [{ provide: PreloadingStrategy, useExisting: PreloadAllModules }] });
         const preloader = TestBed.get(RouterPreloader);
         preloader.setUpPreloading();
       });
 
       it('should work',
-         fakeAsync(inject(
-             [Router, Location, NgModuleFactoryLoader],
-             (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-               @Component({selector: 'lazy', template: 'should not show'})
-               class LazyLoadedComponent {
-               }
+        fakeAsync(inject(
+          [Router, Location, NgModuleFactoryLoader],
+          (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+            @Component({ selector: 'lazy', template: 'should not show' })
+            class LazyLoadedComponent {
+            }
 
-               @NgModule({
-                 declarations: [LazyLoadedComponent],
-                 imports: [RouterModule.forChild(
-                     [{path: 'LoadedModule2', component: LazyLoadedComponent}])]
-               })
-               class LoadedModule2 {
-               }
+            @NgModule({
+              declarations: [LazyLoadedComponent],
+              imports: [RouterModule.forChild(
+                [{ path: 'LoadedModule2', component: LazyLoadedComponent }])]
+            })
+            class LoadedModule2 {
+            }
 
-               @NgModule({
-                 imports:
-                     [RouterModule.forChild([{path: 'LoadedModule1', loadChildren: 'expected2'}])]
-               })
-               class LoadedModule1 {
-               }
+            @NgModule({
+              imports:
+                [RouterModule.forChild([{ path: 'LoadedModule1', loadChildren: 'expected2' }])]
+            })
+            class LoadedModule1 {
+            }
 
-               loader.stubbedModules = {expected: LoadedModule1, expected2: LoadedModule2};
+            loader.stubbedModules = { expected: LoadedModule1, expected2: LoadedModule2 };
 
-               const fixture = createRoot(router, RootCmp);
+            const fixture = createRoot(router, RootCmp);
 
-               router.resetConfig([
-                 {path: 'blank', component: BlankCmp}, {path: 'lazy', loadChildren: 'expected'}
-               ]);
+            router.resetConfig([
+              { path: 'blank', component: BlankCmp }, { path: 'lazy', loadChildren: 'expected' }
+            ]);
 
-               router.navigateByUrl('/blank');
-               advance(fixture);
+            router.navigateByUrl('/blank');
+            advance(fixture);
 
-               const config = router.config as any;
-               const firstConfig = config[1]._loadedConfig !;
+            const config = router.config as any;
+            const firstConfig = config[1]._loadedConfig!;
 
-               expect(firstConfig).toBeDefined();
-               expect(firstConfig.routes[0].path).toEqual('LoadedModule1');
+            expect(firstConfig).toBeDefined();
+            expect(firstConfig.routes[0].path).toEqual('LoadedModule1');
 
-               const secondConfig = firstConfig.routes[0]._loadedConfig !;
-               expect(secondConfig).toBeDefined();
-               expect(secondConfig.routes[0].path).toEqual('LoadedModule2');
-             })));
+            const secondConfig = firstConfig.routes[0]._loadedConfig!;
+            expect(secondConfig).toBeDefined();
+            expect(secondConfig.routes[0].path).toEqual('LoadedModule2');
+          })));
 
     });
 
@@ -3824,136 +3824,136 @@ describe('Integration', () => {
 
       beforeEach(() => {
         TestBed.configureTestingModule(
-            {providers: [{provide: UrlHandlingStrategy, useClass: CustomUrlHandlingStrategy}]});
+          { providers: [{ provide: UrlHandlingStrategy, useClass: CustomUrlHandlingStrategy }] });
       });
 
       it('should work',
-         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-           const fixture = createRoot(router, RootCmp);
+        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+          const fixture = createRoot(router, RootCmp);
 
-           router.resetConfig([{
-             path: 'include',
-             component: TeamCmp,
-             children: [
-               {path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}
-             ]
-           }]);
+          router.resetConfig([{
+            path: 'include',
+            component: TeamCmp,
+            children: [
+              { path: 'user/:name', component: UserCmp }, { path: 'simple', component: SimpleCmp }
+            ]
+          }]);
 
-           const events: any[] = [];
-           router.events.subscribe(e => e instanceof RouterEvent && events.push(e));
+          const events: any[] = [];
+          router.events.subscribe(e => e instanceof RouterEvent && events.push(e));
 
-           // supported URL
-           router.navigateByUrl('/include/user/kate');
-           advance(fixture);
+          // supported URL
+          router.navigateByUrl('/include/user/kate');
+          advance(fixture);
 
-           expect(location.path()).toEqual('/include/user/kate');
-           expectEvents(events, [
-             [NavigationStart, '/include/user/kate'], [RoutesRecognized, '/include/user/kate'],
-             [GuardsCheckStart, '/include/user/kate'], [GuardsCheckEnd, '/include/user/kate'],
-             [ResolveStart, '/include/user/kate'], [ResolveEnd, '/include/user/kate'],
-             [NavigationEnd, '/include/user/kate']
-           ]);
-           expect(fixture.nativeElement).toHaveText('team  [ user kate, right:  ]');
-           events.splice(0);
+          expect(location.path()).toEqual('/include/user/kate');
+          expectEvents(events, [
+            [NavigationStart, '/include/user/kate'], [RoutesRecognized, '/include/user/kate'],
+            [GuardsCheckStart, '/include/user/kate'], [GuardsCheckEnd, '/include/user/kate'],
+            [ResolveStart, '/include/user/kate'], [ResolveEnd, '/include/user/kate'],
+            [NavigationEnd, '/include/user/kate']
+          ]);
+          expect(fixture.nativeElement).toHaveText('team  [ user kate, right:  ]');
+          events.splice(0);
 
-           // unsupported URL
-           router.navigateByUrl('/exclude/one');
-           advance(fixture);
+          // unsupported URL
+          router.navigateByUrl('/exclude/one');
+          advance(fixture);
 
-           expect(location.path()).toEqual('/exclude/one');
-           expect(Object.keys(router.routerState.root.children).length).toEqual(0);
-           expect(fixture.nativeElement).toHaveText('');
-           expectEvents(events, [
-             [NavigationStart, '/exclude/one'], [GuardsCheckStart, '/exclude/one'],
-             [GuardsCheckEnd, '/exclude/one'], [NavigationEnd, '/exclude/one']
-           ]);
-           events.splice(0);
+          expect(location.path()).toEqual('/exclude/one');
+          expect(Object.keys(router.routerState.root.children).length).toEqual(0);
+          expect(fixture.nativeElement).toHaveText('');
+          expectEvents(events, [
+            [NavigationStart, '/exclude/one'], [GuardsCheckStart, '/exclude/one'],
+            [GuardsCheckEnd, '/exclude/one'], [NavigationEnd, '/exclude/one']
+          ]);
+          events.splice(0);
 
-           // another unsupported URL
-           location.go('/exclude/two');
-           advance(fixture);
+          // another unsupported URL
+          location.go('/exclude/two');
+          advance(fixture);
 
-           expect(location.path()).toEqual('/exclude/two');
-           expectEvents(events, []);
+          expect(location.path()).toEqual('/exclude/two');
+          expectEvents(events, []);
 
-           // back to a supported URL
-           location.go('/include/simple');
-           advance(fixture);
+          // back to a supported URL
+          location.go('/include/simple');
+          advance(fixture);
 
-           expect(location.path()).toEqual('/include/simple');
-           expect(fixture.nativeElement).toHaveText('team  [ simple, right:  ]');
+          expect(location.path()).toEqual('/include/simple');
+          expect(fixture.nativeElement).toHaveText('team  [ simple, right:  ]');
 
-           expectEvents(events, [
-             [NavigationStart, '/include/simple'], [RoutesRecognized, '/include/simple'],
-             [GuardsCheckStart, '/include/simple'], [GuardsCheckEnd, '/include/simple'],
-             [ResolveStart, '/include/simple'], [ResolveEnd, '/include/simple'],
-             [NavigationEnd, '/include/simple']
-           ]);
-         })));
+          expectEvents(events, [
+            [NavigationStart, '/include/simple'], [RoutesRecognized, '/include/simple'],
+            [GuardsCheckStart, '/include/simple'], [GuardsCheckEnd, '/include/simple'],
+            [ResolveStart, '/include/simple'], [ResolveEnd, '/include/simple'],
+            [NavigationEnd, '/include/simple']
+          ]);
+        })));
 
       it('should handle the case when the router takes only the primary url',
-         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-           const fixture = createRoot(router, RootCmp);
+        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+          const fixture = createRoot(router, RootCmp);
 
-           router.resetConfig([{
-             path: 'include',
-             component: TeamCmp,
-             children: [
-               {path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}
-             ]
-           }]);
+          router.resetConfig([{
+            path: 'include',
+            component: TeamCmp,
+            children: [
+              { path: 'user/:name', component: UserCmp }, { path: 'simple', component: SimpleCmp }
+            ]
+          }]);
 
-           const events: any[] = [];
-           router.events.subscribe(e => e instanceof RouterEvent && events.push(e));
+          const events: any[] = [];
+          router.events.subscribe(e => e instanceof RouterEvent && events.push(e));
 
-           location.go('/include/user/kate(aux:excluded)');
-           advance(fixture);
+          location.go('/include/user/kate(aux:excluded)');
+          advance(fixture);
 
-           expect(location.path()).toEqual('/include/user/kate(aux:excluded)');
-           expectEvents(events, [
-             [NavigationStart, '/include/user/kate'], [RoutesRecognized, '/include/user/kate'],
-             [GuardsCheckStart, '/include/user/kate'], [GuardsCheckEnd, '/include/user/kate'],
-             [ResolveStart, '/include/user/kate'], [ResolveEnd, '/include/user/kate'],
-             [NavigationEnd, '/include/user/kate']
-           ]);
-           events.splice(0);
+          expect(location.path()).toEqual('/include/user/kate(aux:excluded)');
+          expectEvents(events, [
+            [NavigationStart, '/include/user/kate'], [RoutesRecognized, '/include/user/kate'],
+            [GuardsCheckStart, '/include/user/kate'], [GuardsCheckEnd, '/include/user/kate'],
+            [ResolveStart, '/include/user/kate'], [ResolveEnd, '/include/user/kate'],
+            [NavigationEnd, '/include/user/kate']
+          ]);
+          events.splice(0);
 
-           location.go('/include/user/kate(aux:excluded2)');
-           advance(fixture);
-           expectEvents(events, []);
+          location.go('/include/user/kate(aux:excluded2)');
+          advance(fixture);
+          expectEvents(events, []);
 
-           router.navigateByUrl('/include/simple');
-           advance(fixture);
+          router.navigateByUrl('/include/simple');
+          advance(fixture);
 
-           expect(location.path()).toEqual('/include/simple(aux:excluded2)');
-           expectEvents(events, [
-             [NavigationStart, '/include/simple'], [RoutesRecognized, '/include/simple'],
-             [GuardsCheckStart, '/include/simple'], [GuardsCheckEnd, '/include/simple'],
-             [ResolveStart, '/include/simple'], [ResolveEnd, '/include/simple'],
-             [NavigationEnd, '/include/simple']
-           ]);
-         })));
+          expect(location.path()).toEqual('/include/simple(aux:excluded2)');
+          expectEvents(events, [
+            [NavigationStart, '/include/simple'], [RoutesRecognized, '/include/simple'],
+            [GuardsCheckStart, '/include/simple'], [GuardsCheckEnd, '/include/simple'],
+            [ResolveStart, '/include/simple'], [ResolveEnd, '/include/simple'],
+            [NavigationEnd, '/include/simple']
+          ]);
+        })));
     });
   });
 
   describe('Custom Route Reuse Strategy', () => {
     class AttachDetachReuseStrategy implements RouteReuseStrategy {
-      stored: {[k: string]: DetachedRouteHandle} = {};
+      stored: { [k: string]: DetachedRouteHandle } = {};
 
       shouldDetach(route: ActivatedRouteSnapshot): boolean {
-        return route.routeConfig !.path === 'a';
+        return route.routeConfig!.path === 'a';
       }
 
       store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void {
-        this.stored[route.routeConfig !.path !] = detachedTree;
+        this.stored[route.routeConfig!.path!] = detachedTree;
       }
 
       shouldAttach(route: ActivatedRouteSnapshot): boolean {
-        return !!this.stored[route.routeConfig !.path !];
+        return !!this.stored[route.routeConfig!.path!];
       }
 
       retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle {
-        return this.stored[route.routeConfig !.path !];
+        return this.stored[route.routeConfig!.path!];
       }
 
       shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
@@ -3963,9 +3963,9 @@ describe('Integration', () => {
 
     class ShortLifecycle implements RouteReuseStrategy {
       shouldDetach(route: ActivatedRouteSnapshot): boolean { return false; }
-      store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void {}
+      store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void { }
       shouldAttach(route: ActivatedRouteSnapshot): boolean { return false; }
-      retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle|null { return null; }
+      retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle | null { return null; }
       shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
         if (future.routeConfig !== curr.routeConfig) {
           return false;
@@ -3980,141 +3980,141 @@ describe('Integration', () => {
     }
 
     it('should support attaching & detaching fragments',
-       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-         const fixture = createRoot(router, RootCmp);
+      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+        const fixture = createRoot(router, RootCmp);
 
-         router.routeReuseStrategy = new AttachDetachReuseStrategy();
+        router.routeReuseStrategy = new AttachDetachReuseStrategy();
 
-         router.resetConfig([
-           {
-             path: 'a',
-             component: TeamCmp,
-             children: [{path: 'b', component: SimpleCmp}],
-           },
-           {path: 'c', component: UserCmp},
-         ]);
+        router.resetConfig([
+          {
+            path: 'a',
+            component: TeamCmp,
+            children: [{ path: 'b', component: SimpleCmp }],
+          },
+          { path: 'c', component: UserCmp },
+        ]);
 
-         router.navigateByUrl('/a/b');
-         advance(fixture);
-         const teamCmp = fixture.debugElement.children[1].componentInstance;
-         const simpleCmp = fixture.debugElement.children[1].children[1].componentInstance;
-         expect(location.path()).toEqual('/a/b');
-         expect(teamCmp).toBeDefined();
-         expect(simpleCmp).toBeDefined();
+        router.navigateByUrl('/a/b');
+        advance(fixture);
+        const teamCmp = fixture.debugElement.children[1].componentInstance;
+        const simpleCmp = fixture.debugElement.children[1].children[1].componentInstance;
+        expect(location.path()).toEqual('/a/b');
+        expect(teamCmp).toBeDefined();
+        expect(simpleCmp).toBeDefined();
 
-         router.navigateByUrl('/c');
-         advance(fixture);
-         expect(location.path()).toEqual('/c');
-         expect(fixture.debugElement.children[1].componentInstance).toBeAnInstanceOf(UserCmp);
+        router.navigateByUrl('/c');
+        advance(fixture);
+        expect(location.path()).toEqual('/c');
+        expect(fixture.debugElement.children[1].componentInstance).toBeAnInstanceOf(UserCmp);
 
-         router.navigateByUrl('/a;p=1/b;p=2');
-         advance(fixture);
-         const teamCmp2 = fixture.debugElement.children[1].componentInstance;
-         const simpleCmp2 = fixture.debugElement.children[1].children[1].componentInstance;
-         expect(location.path()).toEqual('/a;p=1/b;p=2');
-         expect(teamCmp2).toBe(teamCmp);
-         expect(simpleCmp2).toBe(simpleCmp);
+        router.navigateByUrl('/a;p=1/b;p=2');
+        advance(fixture);
+        const teamCmp2 = fixture.debugElement.children[1].componentInstance;
+        const simpleCmp2 = fixture.debugElement.children[1].children[1].componentInstance;
+        expect(location.path()).toEqual('/a;p=1/b;p=2');
+        expect(teamCmp2).toBe(teamCmp);
+        expect(simpleCmp2).toBe(simpleCmp);
 
-         expect(teamCmp.route).toBe(router.routerState.root.firstChild);
-         expect(teamCmp.route.snapshot).toBe(router.routerState.snapshot.root.firstChild);
-         expect(teamCmp.route.snapshot.params).toEqual({p: '1'});
-         expect(teamCmp.route.firstChild.snapshot.params).toEqual({p: '2'});
-       })));
+        expect(teamCmp.route).toBe(router.routerState.root.firstChild);
+        expect(teamCmp.route.snapshot).toBe(router.routerState.snapshot.root.firstChild);
+        expect(teamCmp.route.snapshot.params).toEqual({ p: '1' });
+        expect(teamCmp.route.firstChild.snapshot.params).toEqual({ p: '2' });
+      })));
 
     it('should support shorter lifecycles',
-       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-         const fixture = createRoot(router, RootCmp);
-         router.routeReuseStrategy = new ShortLifecycle();
+      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+        const fixture = createRoot(router, RootCmp);
+        router.routeReuseStrategy = new ShortLifecycle();
 
-         router.resetConfig([{path: 'a', component: SimpleCmp}]);
+        router.resetConfig([{ path: 'a', component: SimpleCmp }]);
 
-         router.navigateByUrl('/a');
-         advance(fixture);
-         const simpleCmp1 = fixture.debugElement.children[1].componentInstance;
-         expect(location.path()).toEqual('/a');
+        router.navigateByUrl('/a');
+        advance(fixture);
+        const simpleCmp1 = fixture.debugElement.children[1].componentInstance;
+        expect(location.path()).toEqual('/a');
 
-         router.navigateByUrl('/a;p=1');
-         advance(fixture);
-         expect(location.path()).toEqual('/a;p=1');
-         const simpleCmp2 = fixture.debugElement.children[1].componentInstance;
-         expect(simpleCmp1).not.toBe(simpleCmp2);
-       })));
+        router.navigateByUrl('/a;p=1');
+        advance(fixture);
+        expect(location.path()).toEqual('/a;p=1');
+        const simpleCmp2 = fixture.debugElement.children[1].componentInstance;
+        expect(simpleCmp1).not.toBe(simpleCmp2);
+      })));
 
     it('should not mount the component of the previously reused route when the outlet was not instantiated at the time of route activation',
-       fakeAsync(() => {
-         @Component({
-           selector: 'root-cmp',
-           template:
-               '<div *ngIf="isToolpanelShowing"><router-outlet name="toolpanel"></router-outlet></div>'
-         })
-         class RootCmpWithCondOutlet implements OnDestroy {
-           private subscription: Subscription;
-           public isToolpanelShowing: boolean = false;
+      fakeAsync(() => {
+        @Component({
+          selector: 'root-cmp',
+          template:
+            '<div *ngIf="isToolpanelShowing"><router-outlet name="toolpanel"></router-outlet></div>'
+        })
+        class RootCmpWithCondOutlet implements OnDestroy {
+          private subscription: Subscription;
+          public isToolpanelShowing: boolean = false;
 
-           constructor(router: Router) {
-             this.subscription =
-                 router.events.pipe(filter(event => event instanceof NavigationEnd))
-                     .subscribe(
-                         () => this.isToolpanelShowing =
-                             !!router.parseUrl(router.url).root.children['toolpanel']);
-           }
+          constructor(router: Router) {
+            this.subscription =
+              router.events.pipe(filter(event => event instanceof NavigationEnd))
+                .subscribe(
+                  () => this.isToolpanelShowing =
+                    !!router.parseUrl(router.url).root.children['toolpanel']);
+          }
 
-           public ngOnDestroy(): void { this.subscription.unsubscribe(); }
-         }
+          public ngOnDestroy(): void { this.subscription.unsubscribe(); }
+        }
 
-         @Component({selector: 'tool-1-cmp', template: 'Tool 1 showing'})
-         class Tool1Component {
-         }
+        @Component({ selector: 'tool-1-cmp', template: 'Tool 1 showing' })
+        class Tool1Component {
+        }
 
-         @Component({selector: 'tool-2-cmp', template: 'Tool 2 showing'})
-         class Tool2Component {
-         }
+        @Component({ selector: 'tool-2-cmp', template: 'Tool 2 showing' })
+        class Tool2Component {
+        }
 
-         @NgModule({
-           declarations: [RootCmpWithCondOutlet, Tool1Component, Tool2Component],
-           imports: [
-             CommonModule,
-             RouterTestingModule.withRoutes([
-               {path: 'a', outlet: 'toolpanel', component: Tool1Component},
-               {path: 'b', outlet: 'toolpanel', component: Tool2Component},
-             ]),
-           ],
-         })
-         class TestModule {
-         }
+        @NgModule({
+          declarations: [RootCmpWithCondOutlet, Tool1Component, Tool2Component],
+          imports: [
+            CommonModule,
+            RouterTestingModule.withRoutes([
+              { path: 'a', outlet: 'toolpanel', component: Tool1Component },
+              { path: 'b', outlet: 'toolpanel', component: Tool2Component },
+            ]),
+          ],
+        })
+        class TestModule {
+        }
 
-         TestBed.configureTestingModule({imports: [TestModule]});
+        TestBed.configureTestingModule({ imports: [TestModule] });
 
-         const router: Router = TestBed.get(Router);
-         router.routeReuseStrategy = new AttachDetachReuseStrategy();
+        const router: Router = TestBed.get(Router);
+        router.routeReuseStrategy = new AttachDetachReuseStrategy();
 
-         const fixture = createRoot(router, RootCmpWithCondOutlet);
+        const fixture = createRoot(router, RootCmpWithCondOutlet);
 
-         // Activate 'tool-1'
-         router.navigate([{outlets: {toolpanel: 'a'}}]);
-         advance(fixture);
-         expect(fixture).toContainComponent(Tool1Component, '(a)');
+        // Activate 'tool-1'
+        router.navigate([{ outlets: { toolpanel: 'a' } }]);
+        advance(fixture);
+        expect(fixture).toContainComponent(Tool1Component, '(a)');
 
-         // Deactivate 'tool-1'
-         router.navigate([{outlets: {toolpanel: null}}]);
-         advance(fixture);
-         expect(fixture).not.toContainComponent(Tool1Component, '(b)');
+        // Deactivate 'tool-1'
+        router.navigate([{ outlets: { toolpanel: null } }]);
+        advance(fixture);
+        expect(fixture).not.toContainComponent(Tool1Component, '(b)');
 
-         // Activate 'tool-1'
-         router.navigate([{outlets: {toolpanel: 'a'}}]);
-         advance(fixture);
-         expect(fixture).toContainComponent(Tool1Component, '(c)');
+        // Activate 'tool-1'
+        router.navigate([{ outlets: { toolpanel: 'a' } }]);
+        advance(fixture);
+        expect(fixture).toContainComponent(Tool1Component, '(c)');
 
-         // Deactivate 'tool-1'
-         router.navigate([{outlets: {toolpanel: null}}]);
-         advance(fixture);
-         expect(fixture).not.toContainComponent(Tool1Component, '(d)');
+        // Deactivate 'tool-1'
+        router.navigate([{ outlets: { toolpanel: null } }]);
+        advance(fixture);
+        expect(fixture).not.toContainComponent(Tool1Component, '(d)');
 
-         // Activate 'tool-2'
-         router.navigate([{outlets: {toolpanel: 'b'}}]);
-         advance(fixture);
-         expect(fixture).toContainComponent(Tool2Component, '(e)');
-       }));
+        // Activate 'tool-2'
+        router.navigate([{ outlets: { toolpanel: 'b' } }]);
+        advance(fixture);
+        expect(fixture).toContainComponent(Tool2Component, '(e)');
+      }));
   });
 });
 
@@ -4122,12 +4122,12 @@ describe('Testing router options', () => {
   describe('paramsInheritanceStrategy', () => {
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [RouterTestingModule.withRoutes([], {paramsInheritanceStrategy: 'always'})]});
+        { imports: [RouterTestingModule.withRoutes([], { paramsInheritanceStrategy: 'always' })] });
     });
 
     it('should configure the router', fakeAsync(inject([Router], (router: Router) => {
-         expect(router.paramsInheritanceStrategy).toEqual('always');
-       })));
+      expect(router.paramsInheritanceStrategy).toEqual('always');
+    })));
   });
 
   describe('malformedUriErrorHandler', () => {
@@ -4138,12 +4138,12 @@ describe('Testing router options', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [RouterTestingModule.withRoutes([], {malformedUriErrorHandler})]});
+        { imports: [RouterTestingModule.withRoutes([], { malformedUriErrorHandler })] });
     });
 
     it('should configure the router', fakeAsync(inject([Router], (router: Router) => {
-         expect(router.malformedUriErrorHandler).toBe(malformedUriErrorHandler);
-       })));
+      expect(router.malformedUriErrorHandler).toBe(malformedUriErrorHandler);
+    })));
   });
 });
 
@@ -4160,11 +4160,11 @@ function onlyNavigationStartAndEnd(e: Event): boolean {
 }
 
 @Component(
-    {selector: 'link-cmp', template: `<a routerLink="/team/33/simple" [target]="'_self'">link</a>`})
+  { selector: 'link-cmp', template: `<a routerLink="/team/33/simple" [target]="'_self'">link</a>` })
 class StringLinkCmp {
 }
 
-@Component({selector: 'link-cmp', template: `<button routerLink="/team/33/simple">link</button>`})
+@Component({ selector: 'link-cmp', template: `<button routerLink="/team/33/simple">link</button>` })
 class StringLinkButtonCmp {
 }
 
@@ -4178,7 +4178,7 @@ class AbsoluteLinkCmp {
 @Component({
   selector: 'link-cmp',
   template:
-      `<router-outlet></router-outlet><a routerLinkActive="active" [routerLinkActiveOptions]="{exact: exact}" [routerLink]="['./']">link</a>
+    `<router-outlet></router-outlet><a routerLinkActive="active" [routerLinkActiveOptions]="{exact: exact}" [routerLink]="['./']">link</a>
 <button routerLinkActive="active" [routerLinkActiveOptions]="{exact: exact}" [routerLink]="['./']">button</button>
 `
 })
@@ -4189,7 +4189,7 @@ class DummyLinkCmp {
   }
 }
 
-@Component({selector: 'link-cmp', template: `<a [routerLink]="['../simple']">link</a>`})
+@Component({ selector: 'link-cmp', template: `<a [routerLink]="['../simple']">link</a>` })
 class RelativeLinkCmp {
 }
 
@@ -4200,11 +4200,11 @@ class RelativeLinkCmp {
 class LinkWithQueryParamsAndFragment {
 }
 
-@Component({selector: 'simple-cmp', template: `simple`})
+@Component({ selector: 'simple-cmp', template: `simple` })
 class SimpleCmp {
 }
 
-@Component({selector: 'collect-params-cmp', template: `collect-params`})
+@Component({ selector: 'collect-params-cmp', template: `collect-params` })
 class CollectParamsCmp {
   private params: any = [];
   private urls: any = [];
@@ -4219,16 +4219,16 @@ class CollectParamsCmp {
   }
 }
 
-@Component({selector: 'blank-cmp', template: ``})
+@Component({ selector: 'blank-cmp', template: `` })
 class BlankCmp {
 }
 
 @Component({
   selector: 'team-cmp',
   template: `team {{id | async}} ` +
-      `[ <router-outlet></router-outlet>, right: <router-outlet name="right"></router-outlet> ]` +
-      `<a [routerLink]="routerLink" skipLocationChange></a>` +
-      `<button [routerLink]="routerLink" skipLocationChange></button>`
+    `[ <router-outlet></router-outlet>, right: <router-outlet name="right"></router-outlet> ]` +
+    `<a [routerLink]="routerLink" skipLocationChange></a>` +
+    `<button [routerLink]="routerLink" skipLocationChange></button>`
 })
 class TeamCmp {
   id: Observable<string>;
@@ -4253,7 +4253,7 @@ class TwoOutletsCmp {
 }
 
 
-@Component({selector: 'user-cmp', template: `user {{name | async}}`})
+@Component({ selector: 'user-cmp', template: `user {{name | async}}` })
 class UserCmp {
   name: Observable<string>;
   recordedParams: Params[] = [];
@@ -4268,14 +4268,14 @@ class UserCmp {
   }
 }
 
-@Component({selector: 'wrapper', template: `<router-outlet></router-outlet>`})
+@Component({ selector: 'wrapper', template: `<router-outlet></router-outlet>` })
 class WrapperCmp {
 }
 
 @Component(
-    {selector: 'query-cmp', template: `query: {{name | async}} fragment: {{fragment | async}}`})
+  { selector: 'query-cmp', template: `query: {{name | async}} fragment: {{fragment | async}}` })
 class QueryParamsAndFragmentCmp {
-  name: Observable<string|null>;
+  name: Observable<string | null>;
   fragment: Observable<string>;
 
   constructor(route: ActivatedRoute) {
@@ -4284,7 +4284,7 @@ class QueryParamsAndFragmentCmp {
   }
 }
 
-@Component({selector: 'empty-query-cmp', template: ``})
+@Component({ selector: 'empty-query-cmp', template: `` })
 class EmptyQueryParamsCmp {
   recordedParams: Params[] = [];
 
@@ -4293,22 +4293,22 @@ class EmptyQueryParamsCmp {
   }
 }
 
-@Component({selector: 'route-cmp', template: `route`})
+@Component({ selector: 'route-cmp', template: `route` })
 class RouteCmp {
-  constructor(public route: ActivatedRoute) {}
+  constructor(public route: ActivatedRoute) { }
 }
 
 @Component({
   selector: 'link-cmp',
   template:
-      `<div *ngIf="show"><a [routerLink]="['./simple']">link</a></div> <router-outlet></router-outlet>`
+    `<div *ngIf="show"><a [routerLink]="['./simple']">link</a></div> <router-outlet></router-outlet>`
 })
 class RelativeLinkInIfCmp {
   show: boolean = false;
 }
 
 @Component(
-    {selector: 'child', template: '<div *ngIf="alwaysTrue"><router-outlet></router-outlet></div>'})
+  { selector: 'child', template: '<div *ngIf="alwaysTrue"><router-outlet></router-outlet></div>' })
 class OutletInNgIf {
   alwaysTrue = true;
 }
@@ -4325,7 +4325,7 @@ class DummyLinkWithParentCmp {
   constructor(route: ActivatedRoute) { this.exact = (<any>route.snapshot.params).exact === 'true'; }
 }
 
-@Component({selector: 'cmp', template: ''})
+@Component({ selector: 'cmp', template: '' })
 class ComponentRecordingRoutePathAndUrl {
   private path: any;
   private url: any;
@@ -4336,13 +4336,13 @@ class ComponentRecordingRoutePathAndUrl {
   }
 }
 
-@Component({selector: 'root-cmp', template: `<router-outlet></router-outlet>`})
+@Component({ selector: 'root-cmp', template: `<router-outlet></router-outlet>` })
 class RootCmp {
 }
 
-@Component({selector: 'root-cmp-on-init', template: `<router-outlet></router-outlet>`})
+@Component({ selector: 'root-cmp-on-init', template: `<router-outlet></router-outlet>` })
 class RootCmpWithOnInit {
-  constructor(private router: Router) {}
+  constructor(private router: Router) { }
 
   ngOnInit(): void { this.router.navigate(['one']); }
 }
@@ -4350,12 +4350,12 @@ class RootCmpWithOnInit {
 @Component({
   selector: 'root-cmp',
   template:
-      `primary [<router-outlet></router-outlet>] right [<router-outlet name="right"></router-outlet>]`
+    `primary [<router-outlet></router-outlet>] right [<router-outlet name="right"></router-outlet>]`
 })
 class RootCmpWithTwoOutlets {
 }
 
-@Component({selector: 'throwing-cmp', template: ''})
+@Component({ selector: 'throwing-cmp', template: '' })
 class ThrowingCmp {
   constructor() { throw new Error('Throwing Cmp'); }
 }
@@ -4375,7 +4375,7 @@ function createRoot(router: Router, type: any): ComponentFixture<any> {
   return f;
 }
 
-@Component({selector: 'lazy', template: 'lazy-loaded'})
+@Component({ selector: 'lazy', template: 'lazy-loaded' })
 class LazyComponent {
 }
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -9,11 +9,11 @@
 import {CommonModule, Location} from '@angular/common';
 import {SpyLocation} from '@angular/common/testing';
 import {ChangeDetectionStrategy, Component, Injectable, NgModule, NgModuleFactoryLoader, NgModuleRef, NgZone, OnDestroy, ɵConsole as Console, ɵNoopNgZone as NoopNgZone} from '@angular/core';
-import {ComponentFixture, TestBed, fakeAsync, inject, tick} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, PRIMARY_OUTLET, ParamMap, Params, PreloadAllModules, PreloadingStrategy, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouteReuseStrategy, Router, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
-import {Observable, Observer, Subscription, of } from 'rxjs';
+import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ParamMap, Params, PreloadAllModules, PreloadingStrategy, PRIMARY_OUTLET, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, Router, RouteReuseStrategy, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
+import {Observable, Observer, of, Subscription} from 'rxjs';
 import {filter, map} from 'rxjs/operators';
 
 import {forEach} from '../src/utils/collection';
@@ -94,8 +94,8 @@ describe('Integration', () => {
          router.navigateByUrl('/simple');
          tick();
 
-         expect(event !.navigationTrigger).toEqual('imperative');
-         expect(event !.restoredState).toEqual(null);
+         expect(event!.navigationTrigger).toEqual('imperative');
+         expect(event!.restoredState).toEqual(null);
        })));
 
     it('should not pollute browser history when replaceUrl is set to true',
@@ -161,7 +161,9 @@ describe('Integration', () => {
     let warnings: string[] = [];
 
     class MockConsole {
-      warn(message: string) { warnings.push(message); }
+      warn(message: string) {
+        warnings.push(message);
+      }
     }
 
     beforeEach(() => {
@@ -172,7 +174,9 @@ describe('Integration', () => {
     describe('with NgZone enabled', () => {
       it('should warn when triggered outside Angular zone',
          fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-           ngZone.runOutsideAngular(() => { router.navigateByUrl('/simple'); });
+           ngZone.runOutsideAngular(() => {
+             router.navigateByUrl('/simple');
+           });
 
            expect(warnings.length).toBe(1);
            expect(warnings[0])
@@ -182,19 +186,24 @@ describe('Integration', () => {
 
       it('should not warn when triggered inside Angular zone',
          fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-           ngZone.run(() => { router.navigateByUrl('/simple'); });
+           ngZone.run(() => {
+             router.navigateByUrl('/simple');
+           });
 
            expect(warnings.length).toBe(0);
          })));
     });
 
     describe('with NgZone disabled', () => {
-      beforeEach(() => { TestBed.overrideProvider(NgZone, {useValue: new NoopNgZone()}); });
+      beforeEach(() => {
+        TestBed.overrideProvider(NgZone, {useValue: new NoopNgZone()});
+      });
 
       it('should not warn when triggered outside Angular zone',
          fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-
-           ngZone.runOutsideAngular(() => { router.navigateByUrl('/simple'); });
+           ngZone.runOutsideAngular(() => {
+             router.navigateByUrl('/simple');
+           });
 
            expect(warnings.length).toBe(0);
          })));
@@ -237,18 +246,24 @@ describe('Integration', () => {
       @Component({template: '<router-outlet></router-outlet>'})
       class Parent {
         constructor(route: ActivatedRoute) {
-          route.params.subscribe((s: any) => { log.push(s); });
+          route.params.subscribe((s: any) => {
+            log.push(s);
+          });
         }
       }
 
       @Component({template: 'child1'})
       class Child1 {
-        ngOnDestroy() { log.push('child1 destroy'); }
+        ngOnDestroy() {
+          log.push('child1 destroy');
+        }
       }
 
       @Component({template: 'child2'})
       class Child2 {
-        constructor() { log.push('child2 constructor'); }
+        constructor() {
+          log.push('child2 constructor');
+        }
       }
 
       @NgModule({
@@ -288,7 +303,6 @@ describe('Integration', () => {
              'child2 constructor',
            ]);
          })));
-
     });
 
     it('should execute navigations serialy',
@@ -376,11 +390,9 @@ describe('Integration', () => {
      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
        const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([{
-         path: 'team/:id',
-         component: TeamCmp,
-         children: [{path: 'simple', component: SimpleCmp}]
-       }]);
+       router.resetConfig([
+         {path: 'team/:id', component: TeamCmp, children: [{path: 'simple', component: SimpleCmp}]}
+       ]);
 
        router.navigateByUrl('/team/33/simple');
        advance(fixture);
@@ -447,7 +459,9 @@ describe('Integration', () => {
        @Component({template: `record`})
        class RecordLocationCmp {
          private storedPath: string;
-         constructor(loc: Location) { this.storedPath = loc.path(); }
+         constructor(loc: Location) {
+           this.storedPath = loc.path();
+         }
        }
 
        @NgModule({declarations: [RecordLocationCmp], entryComponents: [RecordLocationCmp]})
@@ -533,7 +547,7 @@ describe('Integration', () => {
        (router as any).hooks.beforePreactivation = () => {
          expect(location.path()).toEqual('/team/33');
          expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
-         return of (null);
+         return of(null);
        };
        router.navigateByUrl('/team/33');
 
@@ -562,24 +576,24 @@ describe('Integration', () => {
        router.navigateByUrl('/team/33/simple');
        advance(fixture);
        expect(location.path()).toEqual('/team/33/simple');
-       const simpleNavStart = event !;
+       const simpleNavStart = event!;
 
        router.navigateByUrl('/team/22/user/victor');
        advance(fixture);
-       const userVictorNavStart = event !;
+       const userVictorNavStart = event!;
 
 
        location.back();
        advance(fixture);
        expect(location.path()).toEqual('/team/33/simple');
-       expect(event !.navigationTrigger).toEqual('hashchange');
-       expect(event !.restoredState !.navigationId).toEqual(simpleNavStart.id);
+       expect(event!.navigationTrigger).toEqual('hashchange');
+       expect(event!.restoredState!.navigationId).toEqual(simpleNavStart.id);
 
        location.forward();
        advance(fixture);
        expect(location.path()).toEqual('/team/22/user/victor');
-       expect(event !.navigationTrigger).toEqual('hashchange');
-       expect(event !.restoredState !.navigationId).toEqual(userVictorNavStart.id);
+       expect(event!.navigationTrigger).toEqual('hashchange');
+       expect(event!.restoredState!.navigationId).toEqual(userVictorNavStart.id);
      })));
 
   it('should navigate to the same url when config changes',
@@ -871,8 +885,8 @@ describe('Integration', () => {
        const user = fixture.debugElement.children[1].componentInstance;
 
        let r1: any, r2: any;
-       router.navigateByUrl('/user/victor') !.then(_ => r1 = _);
-       router.navigateByUrl('/user/fedor') !.then(_ => r2 = _);
+       router.navigateByUrl('/user/victor')!.then(_ => r1 = _);
+       router.navigateByUrl('/user/fedor')!.then(_ => r2 = _);
        advance(fixture);
 
        expect(r1).toEqual(false);  // returns false because it was canceled
@@ -920,7 +934,7 @@ describe('Integration', () => {
        router.events.forEach(e => recordedEvents.push(e));
 
        let e: any;
-       router.navigateByUrl('/invalid') !.catch(_ => e = _);
+       router.navigateByUrl('/invalid')!.catch(_ => e = _);
        advance(fixture);
        expect(e.message).toContain('Cannot match any routes');
 
@@ -990,7 +1004,7 @@ describe('Integration', () => {
 
          router.navigateByUrl('/simple1');
          advance(fixture);
-         const simple1NavStart = event !;
+         const simple1NavStart = event!;
 
          router.navigateByUrl('/throwing').catch(() => null);
          advance(fixture);
@@ -1001,7 +1015,7 @@ describe('Integration', () => {
          location.back();
          tick();
 
-         expect(event !.restoredState !.navigationId).toEqual(simple1NavStart.id);
+         expect(event!.restoredState!.navigationId).toEqual(simple1NavStart.id);
        }));
 
     it('should not trigger another navigation when resetting the url back due to a NavigationError',
@@ -1031,7 +1045,6 @@ describe('Integration', () => {
          // we do not trigger another navigation to /simple
          expect(events).toEqual(['/simple', '/throwing']);
        }));
-
   });
 
   it('should dispatch NavigationCancel after the url has been reset back', fakeAsync(() => {
@@ -1077,7 +1090,7 @@ describe('Integration', () => {
        router.events.forEach(e => recordedEvents.push(e));
 
        let e: any;
-       router.navigateByUrl('/invalid') !.then(_ => e = _);
+       router.navigateByUrl('/invalid')!.then(_ => e = _);
        advance(fixture);
        expect(e).toEqual('resolvedValue');
 
@@ -1096,8 +1109,9 @@ describe('Integration', () => {
   it('should support custom malformed uri error handler',
      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
        const customMalformedUriErrorHandler =
-           (e: URIError, urlSerializer: UrlSerializer, url: string):
-               UrlTree => { return urlSerializer.parse('/?error=The-URL-you-went-to-is-invalid'); };
+           (e: URIError, urlSerializer: UrlSerializer, url: string): UrlTree => {
+             return urlSerializer.parse('/?error=The-URL-you-went-to-is-invalid');
+           };
        router.malformedUriErrorHandler = customMalformedUriErrorHandler;
 
        router.resetConfig([{path: 'simple', component: SimpleCmp}]);
@@ -1218,9 +1232,13 @@ describe('Integration', () => {
          activations: any[] = [];
          deactivations: any[] = [];
 
-         recordActivate(component: any): void { this.activations.push(component); }
+         recordActivate(component: any): void {
+           this.activations.push(component);
+         }
 
-         recordDeactivate(component: any): void { this.deactivations.push(component); }
+         recordDeactivate(component: any): void {
+           this.deactivations.push(component);
+         }
        }
 
        TestBed.configureTestingModule({declarations: [Container]});
@@ -1253,7 +1271,6 @@ describe('Integration', () => {
 
   it('should update url and router state before activating components',
      fakeAsync(inject([Router], (router: Router) => {
-
        const fixture = createRoot(router, RootCmp);
 
        router.resetConfig([{path: 'cmp', component: ComponentRecordingRoutePathAndUrl}]);
@@ -1271,7 +1288,9 @@ describe('Integration', () => {
 
   describe('data', () => {
     class ResolveSix implements Resolve<number> {
-      resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): number { return 6; }
+      resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): number {
+        return 6;
+      }
     }
 
     beforeEach(() => {
@@ -1337,7 +1356,7 @@ describe('Integration', () => {
          router.events.subscribe(e => e instanceof RouterEvent && recordedEvents.push(e));
 
          let e: any = null;
-         router.navigateByUrl('/simple') !.catch(error => e = error);
+         router.navigateByUrl('/simple')!.catch(error => e = error);
          advance(fixture);
 
          expectEvents(recordedEvents, [
@@ -1431,7 +1450,7 @@ describe('Integration', () => {
             {
               provide: 'resolver2',
               useValue: () => {
-                return of (null).pipe(map(() => {
+                return of(null).pipe(map(() => {
                   log.push('resolver2');
                   observer.next(null);
                   observer.complete();
@@ -1500,9 +1519,8 @@ describe('Integration', () => {
          router.resetConfig([{
            path: 'team/:id',
            component: TeamCmp,
-           children: [
-             {path: 'link', component: StringLinkCmp}, {path: 'simple', component: SimpleCmp}
-           ]
+           children:
+               [{path: 'link', component: StringLinkCmp}, {path: 'simple', component: SimpleCmp}]
          }]);
 
          router.navigateByUrl('/team/22/link');
@@ -1561,7 +1579,6 @@ describe('Integration', () => {
        }));
 
     it('should update hrefs when query params or fragment change', fakeAsync(() => {
-
          @Component({
            selector: 'someRoot',
            template:
@@ -1591,7 +1608,6 @@ describe('Integration', () => {
        }));
 
     it('should correctly use the preserve strategy', fakeAsync(() => {
-
          @Component({
            selector: 'someRoot',
            template:
@@ -1613,7 +1629,6 @@ describe('Integration', () => {
        }));
 
     it('should correctly use the merge strategy', fakeAsync(() => {
-
          @Component({
            selector: 'someRoot',
            template:
@@ -1641,8 +1656,7 @@ describe('Integration', () => {
            path: 'team/:id',
            component: TeamCmp,
            children: [
-             {path: 'link', component: StringLinkButtonCmp},
-             {path: 'simple', component: SimpleCmp}
+             {path: 'link', component: StringLinkButtonCmp}, {path: 'simple', component: SimpleCmp}
            ]
          }]);
 
@@ -1664,9 +1678,8 @@ describe('Integration', () => {
          router.resetConfig([{
            path: 'team/:id',
            component: TeamCmp,
-           children: [
-             {path: 'link', component: AbsoluteLinkCmp}, {path: 'simple', component: SimpleCmp}
-           ]
+           children:
+               [{path: 'link', component: AbsoluteLinkCmp}, {path: 'simple', component: SimpleCmp}]
          }]);
 
          router.navigateByUrl('/team/22/link');
@@ -1687,9 +1700,8 @@ describe('Integration', () => {
          router.resetConfig([{
            path: 'team/:id',
            component: TeamCmp,
-           children: [
-             {path: 'link', component: RelativeLinkCmp}, {path: 'simple', component: SimpleCmp}
-           ]
+           children:
+               [{path: 'link', component: RelativeLinkCmp}, {path: 'simple', component: SimpleCmp}]
          }]);
 
          router.navigateByUrl('/team/22/link');
@@ -1863,6 +1875,23 @@ describe('Integration', () => {
                })));
           });
 
+      describe('should activate a child wildcard route router outlet has yet to be mounted', () => {
+        it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+             const fixture = createRoot(router, RootCmp);
+             router.resetConfig([{
+               path: 'teams',
+               component: BlankCmp,
+               children: [{path: ':team-id', children: [{path: '**', component: BlankCmp}]}]
+             }]);
+             router.navigateByUrl('/teams/22/members');
+             advance(fixture);
+             expect(location.path()).toEqual('/teams/22/members');
+             router.navigateByUrl('/teams/22/manage');
+             advance(fixture);
+             expect(location.path()).toEqual('/teams/22/manage');
+           })));
+      });
+
       describe('should activate a route when CanActivate returns true', () => {
         beforeEach(() => {
           TestBed.configureTestingModule({
@@ -1893,7 +1922,9 @@ describe('Integration', () => {
           }
         }
 
-        beforeEach(() => { TestBed.configureTestingModule({providers: [AlwaysTrue]}); });
+        beforeEach(() => {
+          TestBed.configureTestingModule({providers: [AlwaysTrue]});
+        });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
              const fixture = createRoot(router, RootCmp);
@@ -1914,7 +1945,9 @@ describe('Integration', () => {
             providers: [{
               provide: 'CanActivate',
               useValue: (a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-                return Observable.create((observer: any) => { observer.next(false); });
+                return Observable.create((observer: any) => {
+                  observer.next(false);
+                });
               }
             }]
           });
@@ -1971,7 +2004,9 @@ describe('Integration', () => {
           TestBed.configureTestingModule({
             providers: [{
               provide: 'alwaysFalse',
-              useValue: (a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => { return false; }
+              useValue: (a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
+                return false;
+              }
             }]
           });
         });
@@ -1991,7 +2026,6 @@ describe('Integration', () => {
              location.go('/two');
              advance(fixture);
              expect(location.path()).toEqual('/one');
-
            })));
       });
 
@@ -2241,14 +2275,15 @@ describe('Integration', () => {
             {
               provide: 'RecordingDeactivate',
               useValue: (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-                log.push({path: a.routeConfig !.path, component: c});
+                log.push({path: a.routeConfig!.path, component: c});
                 return true;
               }
             },
             {
               provide: 'alwaysFalse',
-              useValue:
-                  (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => { return false; }
+              useValue: (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
+                return false;
+              }
             },
             {
               provide: 'alwaysFalseAndLogging',
@@ -2290,13 +2325,13 @@ describe('Integration', () => {
              expect(location.path()).toEqual('/team/22');
 
              let successStatus: boolean = false;
-             router.navigateByUrl('/team/33') !.then(res => successStatus = res);
+             router.navigateByUrl('/team/33')!.then(res => successStatus = res);
              advance(fixture);
              expect(location.path()).toEqual('/team/33');
              expect(successStatus).toEqual(true);
 
              let canceledStatus: boolean = false;
-             router.navigateByUrl('/team/44') !.then(res => canceledStatus = res);
+             router.navigateByUrl('/team/44')!.then(res => canceledStatus = res);
              advance(fixture);
              expect(location.path()).toEqual('/team/33');
              expect(canceledStatus).toEqual(false);
@@ -2498,11 +2533,12 @@ describe('Integration', () => {
             providers: [
               ClassWithNextState, {
                 provide: 'FunctionWithNextState',
-                useValue: (cmp: any, currentRoute: ActivatedRouteSnapshot,
-                           currentState: RouterStateSnapshot, nextState: RouterStateSnapshot) => {
-                  log.push(currentState.url, nextState.url);
-                  return true;
-                }
+                useValue:
+                    (cmp: any, currentRoute: ActivatedRouteSnapshot,
+                     currentState: RouterStateSnapshot, nextState: RouterStateSnapshot) => {
+                      log.push(currentState.url, nextState.url);
+                      return true;
+                    }
               }
             ]
           });
@@ -2553,7 +2589,9 @@ describe('Integration', () => {
           }
         }
 
-        beforeEach(() => { TestBed.configureTestingModule({providers: [AlwaysTrue]}); });
+        beforeEach(() => {
+          TestBed.configureTestingModule({providers: [AlwaysTrue]});
+        });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
              const fixture = createRoot(router, RootCmp);
@@ -2578,7 +2616,9 @@ describe('Integration', () => {
             providers: [{
               provide: 'CanDeactivate',
               useValue: (c: TeamCmp, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-                return Observable.create((observer: any) => { observer.next(false); });
+                return Observable.create((observer: any) => {
+                  observer.next(false);
+                });
               }
             }]
           });
@@ -2626,7 +2666,7 @@ describe('Integration', () => {
 
              expect(location.path()).toEqual('/team/22');
 
-             router.navigateByUrl('/team/33') !.catch(() => {});
+             router.navigateByUrl('/team/33')!.catch(() => {});
              advance(fixture);
 
              expect(location.path()).toEqual('/team/22');
@@ -2637,7 +2677,6 @@ describe('Integration', () => {
          fakeAsync(inject(
              [Router, Location, NgModuleFactoryLoader],
              (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-
                @Component({selector: 'admin', template: '<router-outlet></router-outlet>'})
                class AdminComponent {
                }
@@ -2705,7 +2744,6 @@ describe('Integration', () => {
          fakeAsync(inject(
              [Router, Location, NgModuleFactoryLoader],
              (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-
                @Component({selector: 'lazy', template: 'lazy-loaded'})
                class LazyLoadedComponent {
                }
@@ -2773,7 +2811,6 @@ describe('Integration', () => {
 
       it('should support navigating from within the guard',
          fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-
            const fixture = createRoot(router, RootCmp);
 
            router.resetConfig([
@@ -2807,7 +2844,6 @@ describe('Integration', () => {
          fakeAsync(inject(
              [Router, Location, NgModuleFactoryLoader],
              (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-
                @Component({selector: 'lazy', template: 'lazy-loaded'})
                class LazyLoadedComponent {
                }
@@ -2842,10 +2878,11 @@ describe('Integration', () => {
     });
 
     describe('order', () => {
-
       class Logger {
         logs: string[] = [];
-        add(thing: string) { this.logs.push(thing); }
+        add(thing: string) {
+          this.logs.push(thing);
+        }
       }
 
       beforeEach(() => {
@@ -2976,8 +3013,7 @@ describe('Integration', () => {
            children: [{
              path: 'link',
              component: DummyLinkCmp,
-             children:
-                 [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
+             children: [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
            }]
          }]);
 
@@ -3033,8 +3069,7 @@ describe('Integration', () => {
            children: [{
              path: 'link',
              component: DummyLinkWithParentCmp,
-             children:
-                 [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
+             children: [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
            }]
          }]);
 
@@ -3062,8 +3097,7 @@ describe('Integration', () => {
            children: [{
              path: 'link',
              component: DummyLinkCmp,
-             children:
-                 [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
+             children: [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
            }]
          }]);
 
@@ -3120,7 +3154,6 @@ describe('Integration', () => {
          advance(fixture);
          expect(paragraph.textContent).toEqual('false');
        }));
-
   });
 
   describe('lazy loading', () => {
@@ -3223,8 +3256,8 @@ describe('Integration', () => {
              expect(location.path()).toEqual('/lazy/parent/child');
              expect(fixture.nativeElement).toHaveText('parent[child]');
 
-             const pInj = fixture.debugElement.query(By.directive(Parent)).injector !;
-             const cInj = fixture.debugElement.query(By.directive(Child)).injector !;
+             const pInj = fixture.debugElement.query(By.directive(Parent)).injector!;
+             const cInj = fixture.debugElement.query(By.directive(Child)).injector!;
 
              expect(pInj.get('moduleName')).toEqual('parent');
              expect(pInj.get('fromParent')).toEqual('from parent');
@@ -3278,7 +3311,9 @@ describe('Integration', () => {
              })
              class LoadedModule {
                static instances = 0;
-               constructor() { LoadedModule.instances++; }
+               constructor() {
+                 LoadedModule.instances++;
+               }
              }
 
              loader.stubbedModules = {expected: LoadedModule};
@@ -3410,7 +3445,7 @@ describe('Integration', () => {
              router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
 
              let recordedError: any = null;
-             router.navigateByUrl('/lazy/loaded') !.catch(err => recordedError = err);
+             router.navigateByUrl('/lazy/loaded')!.catch(err => recordedError = err);
              advance(fixture);
              expect(recordedError.message)
                  .toEqual(
@@ -3467,7 +3502,6 @@ describe('Integration', () => {
     it('should allow lazy loaded module in named outlet',
        fakeAsync(inject(
            [Router, NgModuleFactoryLoader], (router: Router, loader: SpyNgModuleFactoryLoader) => {
-
              @Component({selector: 'lazy', template: 'lazy-loaded'})
              class LazyComponent {
              }
@@ -3507,7 +3541,6 @@ describe('Integration', () => {
     it('should allow componentless named outlet to render children',
        fakeAsync(inject(
            [Router, NgModuleFactoryLoader], (router: Router, loader: SpyNgModuleFactoryLoader) => {
-
              const fixture = createRoot(router, RootCmp);
 
              router.resetConfig([{
@@ -3558,7 +3591,7 @@ describe('Integration', () => {
             lazyService: LazyLoadedServiceDefinedInModule,  // should be able to inject lazy service
             eager:
                 EagerParentComponent  // should use the injector of the location to create a parent
-            ) {}
+        ) {}
       }
 
       @NgModule({
@@ -3649,7 +3682,7 @@ describe('Integration', () => {
              const recordedEvents: any[] = [];
              router.events.forEach(e => recordedEvents.push(e));
 
-             router.navigateByUrl('/lazy/loaded') !.catch(s => {});
+             router.navigateByUrl('/lazy/loaded')!.catch(s => {});
              advance(fixture);
 
              expect(location.path()).toEqual('/');
@@ -3758,16 +3791,15 @@ describe('Integration', () => {
                advance(fixture);
 
                const config = router.config as any;
-               const firstConfig = config[1]._loadedConfig !;
+               const firstConfig = config[1]._loadedConfig!;
 
                expect(firstConfig).toBeDefined();
                expect(firstConfig.routes[0].path).toEqual('LoadedModule1');
 
-               const secondConfig = firstConfig.routes[0]._loadedConfig !;
+               const secondConfig = firstConfig.routes[0]._loadedConfig!;
                expect(secondConfig).toBeDefined();
                expect(secondConfig.routes[0].path).toEqual('LoadedModule2');
              })));
-
     });
 
     describe('custom url handling strategies', () => {
@@ -3817,9 +3849,8 @@ describe('Integration', () => {
            router.resetConfig([{
              path: 'include',
              component: TeamCmp,
-             children: [
-               {path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}
-             ]
+             children:
+                 [{path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}]
            }]);
 
            const events: any[] = [];
@@ -3881,9 +3912,8 @@ describe('Integration', () => {
            router.resetConfig([{
              path: 'include',
              component: TeamCmp,
-             children: [
-               {path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}
-             ]
+             children:
+                 [{path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}]
            }]);
 
            const events: any[] = [];
@@ -3924,19 +3954,19 @@ describe('Integration', () => {
       stored: {[k: string]: DetachedRouteHandle} = {};
 
       shouldDetach(route: ActivatedRouteSnapshot): boolean {
-        return route.routeConfig !.path === 'a';
+        return route.routeConfig!.path === 'a';
       }
 
       store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void {
-        this.stored[route.routeConfig !.path !] = detachedTree;
+        this.stored[route.routeConfig!.path!] = detachedTree;
       }
 
       shouldAttach(route: ActivatedRouteSnapshot): boolean {
-        return !!this.stored[route.routeConfig !.path !];
+        return !!this.stored[route.routeConfig!.path!];
       }
 
       retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle {
-        return this.stored[route.routeConfig !.path !];
+        return this.stored[route.routeConfig!.path!];
       }
 
       shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
@@ -3945,10 +3975,16 @@ describe('Integration', () => {
     }
 
     class ShortLifecycle implements RouteReuseStrategy {
-      shouldDetach(route: ActivatedRouteSnapshot): boolean { return false; }
+      shouldDetach(route: ActivatedRouteSnapshot): boolean {
+        return false;
+      }
       store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void {}
-      shouldAttach(route: ActivatedRouteSnapshot): boolean { return false; }
-      retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle|null { return null; }
+      shouldAttach(route: ActivatedRouteSnapshot): boolean {
+        return false;
+      }
+      retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle|null {
+        return null;
+      }
       shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
         if (future.routeConfig !== curr.routeConfig) {
           return false;
@@ -4042,7 +4078,9 @@ describe('Integration', () => {
                              !!router.parseUrl(router.url).root.children['toolpanel']);
            }
 
-           public ngOnDestroy(): void { this.subscription.unsubscribe(); }
+           public ngOnDestroy(): void {
+             this.subscription.unsubscribe();
+           }
          }
 
          @Component({selector: 'tool-1-cmp', template: 'Tool 1 showing'})
@@ -4114,7 +4152,6 @@ describe('Testing router options', () => {
   });
 
   describe('malformedUriErrorHandler', () => {
-
     function malformedUriErrorHandler(e: URIError, urlSerializer: UrlSerializer, url: string) {
       return urlSerializer.parse('/error');
     }
@@ -4305,7 +4342,9 @@ class OutletInNgIf {
 })
 class DummyLinkWithParentCmp {
   private exact: boolean;
-  constructor(route: ActivatedRoute) { this.exact = (<any>route.snapshot.params).exact === 'true'; }
+  constructor(route: ActivatedRoute) {
+    this.exact = (<any>route.snapshot.params).exact === 'true';
+  }
 }
 
 @Component({selector: 'cmp', template: ''})
@@ -4327,7 +4366,9 @@ class RootCmp {
 class RootCmpWithOnInit {
   constructor(private router: Router) {}
 
-  ngOnInit(): void { this.router.navigate(['one']); }
+  ngOnInit(): void {
+    this.router.navigate(['one']);
+  }
 }
 
 @Component({
@@ -4340,7 +4381,9 @@ class RootCmpWithTwoOutlets {
 
 @Component({selector: 'throwing-cmp', template: ''})
 class ThrowingCmp {
-  constructor() { throw new Error('Throwing Cmp'); }
+  constructor() {
+    throw new Error('Throwing Cmp');
+  }
 }
 
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1863,6 +1863,23 @@ describe('Integration', () => {
                })));
           });
 
+      describe('should activate a child wildcard route router outlet has yet to be mounted', () => {
+        it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+              const fixture = createRoot(router, RootCmp);
+              router.resetConfig([{
+                path: 'teams',
+                component: BlankCmp,
+                children: [{path: ':team-id', children: [{path: '**', component: BlankCmp}]}]
+              }]);
+              router.navigateByUrl('/teams/22/members');
+              advance(fixture);
+              expect(location.path()).toEqual('/teams/22/members');
+              router.navigateByUrl('/teams/22/manage');
+              advance(fixture);
+              expect(location.path()).toEqual('/teams/22/manage');
+            })));
+      });
+
       describe('should activate a route when CanActivate returns true', () => {
         beforeEach(() => {
           TestBed.configureTestingModule({

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -9,11 +9,11 @@
 import {CommonModule, Location} from '@angular/common';
 import {SpyLocation} from '@angular/common/testing';
 import {ChangeDetectionStrategy, Component, Injectable, NgModule, NgModuleFactoryLoader, NgModuleRef, NgZone, OnDestroy, ɵConsole as Console, ɵNoopNgZone as NoopNgZone} from '@angular/core';
-import {ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, TestBed, fakeAsync, inject, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ParamMap, Params, PreloadAllModules, PreloadingStrategy, PRIMARY_OUTLET, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, Router, RouteReuseStrategy, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
-import {Observable, Observer, of, Subscription} from 'rxjs';
+import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, PRIMARY_OUTLET, ParamMap, Params, PreloadAllModules, PreloadingStrategy, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouteReuseStrategy, Router, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
+import {Observable, Observer, Subscription, of } from 'rxjs';
 import {filter, map} from 'rxjs/operators';
 
 import {forEach} from '../src/utils/collection';
@@ -94,8 +94,8 @@ describe('Integration', () => {
          router.navigateByUrl('/simple');
          tick();
 
-         expect(event!.navigationTrigger).toEqual('imperative');
-         expect(event!.restoredState).toEqual(null);
+         expect(event !.navigationTrigger).toEqual('imperative');
+         expect(event !.restoredState).toEqual(null);
        })));
 
     it('should not pollute browser history when replaceUrl is set to true',
@@ -161,9 +161,7 @@ describe('Integration', () => {
     let warnings: string[] = [];
 
     class MockConsole {
-      warn(message: string) {
-        warnings.push(message);
-      }
+      warn(message: string) { warnings.push(message); }
     }
 
     beforeEach(() => {
@@ -174,9 +172,7 @@ describe('Integration', () => {
     describe('with NgZone enabled', () => {
       it('should warn when triggered outside Angular zone',
          fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-           ngZone.runOutsideAngular(() => {
-             router.navigateByUrl('/simple');
-           });
+           ngZone.runOutsideAngular(() => { router.navigateByUrl('/simple'); });
 
            expect(warnings.length).toBe(1);
            expect(warnings[0])
@@ -186,24 +182,18 @@ describe('Integration', () => {
 
       it('should not warn when triggered inside Angular zone',
          fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-           ngZone.run(() => {
-             router.navigateByUrl('/simple');
-           });
+           ngZone.run(() => { router.navigateByUrl('/simple'); });
 
            expect(warnings.length).toBe(0);
          })));
     });
 
     describe('with NgZone disabled', () => {
-      beforeEach(() => {
-        TestBed.overrideProvider(NgZone, {useValue: new NoopNgZone()});
-      });
+      beforeEach(() => { TestBed.overrideProvider(NgZone, {useValue: new NoopNgZone()}); });
 
       it('should not warn when triggered outside Angular zone',
          fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-           ngZone.runOutsideAngular(() => {
-             router.navigateByUrl('/simple');
-           });
+           ngZone.runOutsideAngular(() => { router.navigateByUrl('/simple'); });
 
            expect(warnings.length).toBe(0);
          })));
@@ -246,24 +236,18 @@ describe('Integration', () => {
       @Component({template: '<router-outlet></router-outlet>'})
       class Parent {
         constructor(route: ActivatedRoute) {
-          route.params.subscribe((s: any) => {
-            log.push(s);
-          });
+          route.params.subscribe((s: any) => { log.push(s); });
         }
       }
 
       @Component({template: 'child1'})
       class Child1 {
-        ngOnDestroy() {
-          log.push('child1 destroy');
-        }
+        ngOnDestroy() { log.push('child1 destroy'); }
       }
 
       @Component({template: 'child2'})
       class Child2 {
-        constructor() {
-          log.push('child2 constructor');
-        }
+        constructor() { log.push('child2 constructor'); }
       }
 
       @NgModule({
@@ -390,9 +374,11 @@ describe('Integration', () => {
      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
        const fixture = createRoot(router, RootCmp);
 
-       router.resetConfig([
-         {path: 'team/:id', component: TeamCmp, children: [{path: 'simple', component: SimpleCmp}]}
-       ]);
+       router.resetConfig([{
+         path: 'team/:id',
+         component: TeamCmp,
+         children: [{path: 'simple', component: SimpleCmp}]
+       }]);
 
        router.navigateByUrl('/team/33/simple');
        advance(fixture);
@@ -459,9 +445,7 @@ describe('Integration', () => {
        @Component({template: `record`})
        class RecordLocationCmp {
          private storedPath: string;
-         constructor(loc: Location) {
-           this.storedPath = loc.path();
-         }
+         constructor(loc: Location) { this.storedPath = loc.path(); }
        }
 
        @NgModule({declarations: [RecordLocationCmp], entryComponents: [RecordLocationCmp]})
@@ -547,7 +531,7 @@ describe('Integration', () => {
        (router as any).hooks.beforePreactivation = () => {
          expect(location.path()).toEqual('/team/33');
          expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
-         return of(null);
+         return of (null);
        };
        router.navigateByUrl('/team/33');
 
@@ -576,24 +560,24 @@ describe('Integration', () => {
        router.navigateByUrl('/team/33/simple');
        advance(fixture);
        expect(location.path()).toEqual('/team/33/simple');
-       const simpleNavStart = event!;
+       const simpleNavStart = event !;
 
        router.navigateByUrl('/team/22/user/victor');
        advance(fixture);
-       const userVictorNavStart = event!;
+       const userVictorNavStart = event !;
 
 
        location.back();
        advance(fixture);
        expect(location.path()).toEqual('/team/33/simple');
-       expect(event!.navigationTrigger).toEqual('hashchange');
-       expect(event!.restoredState!.navigationId).toEqual(simpleNavStart.id);
+       expect(event !.navigationTrigger).toEqual('hashchange');
+       expect(event !.restoredState !.navigationId).toEqual(simpleNavStart.id);
 
        location.forward();
        advance(fixture);
        expect(location.path()).toEqual('/team/22/user/victor');
-       expect(event!.navigationTrigger).toEqual('hashchange');
-       expect(event!.restoredState!.navigationId).toEqual(userVictorNavStart.id);
+       expect(event !.navigationTrigger).toEqual('hashchange');
+       expect(event !.restoredState !.navigationId).toEqual(userVictorNavStart.id);
      })));
 
   it('should navigate to the same url when config changes',
@@ -885,8 +869,8 @@ describe('Integration', () => {
        const user = fixture.debugElement.children[1].componentInstance;
 
        let r1: any, r2: any;
-       router.navigateByUrl('/user/victor')!.then(_ => r1 = _);
-       router.navigateByUrl('/user/fedor')!.then(_ => r2 = _);
+       router.navigateByUrl('/user/victor') !.then(_ => r1 = _);
+       router.navigateByUrl('/user/fedor') !.then(_ => r2 = _);
        advance(fixture);
 
        expect(r1).toEqual(false);  // returns false because it was canceled
@@ -934,7 +918,7 @@ describe('Integration', () => {
        router.events.forEach(e => recordedEvents.push(e));
 
        let e: any;
-       router.navigateByUrl('/invalid')!.catch(_ => e = _);
+       router.navigateByUrl('/invalid') !.catch(_ => e = _);
        advance(fixture);
        expect(e.message).toContain('Cannot match any routes');
 
@@ -1004,7 +988,7 @@ describe('Integration', () => {
 
          router.navigateByUrl('/simple1');
          advance(fixture);
-         const simple1NavStart = event!;
+         const simple1NavStart = event !;
 
          router.navigateByUrl('/throwing').catch(() => null);
          advance(fixture);
@@ -1015,7 +999,7 @@ describe('Integration', () => {
          location.back();
          tick();
 
-         expect(event!.restoredState!.navigationId).toEqual(simple1NavStart.id);
+         expect(event !.restoredState !.navigationId).toEqual(simple1NavStart.id);
        }));
 
     it('should not trigger another navigation when resetting the url back due to a NavigationError',
@@ -1090,7 +1074,7 @@ describe('Integration', () => {
        router.events.forEach(e => recordedEvents.push(e));
 
        let e: any;
-       router.navigateByUrl('/invalid')!.then(_ => e = _);
+       router.navigateByUrl('/invalid') !.then(_ => e = _);
        advance(fixture);
        expect(e).toEqual('resolvedValue');
 
@@ -1109,9 +1093,8 @@ describe('Integration', () => {
   it('should support custom malformed uri error handler',
      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
        const customMalformedUriErrorHandler =
-           (e: URIError, urlSerializer: UrlSerializer, url: string): UrlTree => {
-             return urlSerializer.parse('/?error=The-URL-you-went-to-is-invalid');
-           };
+           (e: URIError, urlSerializer: UrlSerializer, url: string):
+               UrlTree => { return urlSerializer.parse('/?error=The-URL-you-went-to-is-invalid'); };
        router.malformedUriErrorHandler = customMalformedUriErrorHandler;
 
        router.resetConfig([{path: 'simple', component: SimpleCmp}]);
@@ -1232,13 +1215,9 @@ describe('Integration', () => {
          activations: any[] = [];
          deactivations: any[] = [];
 
-         recordActivate(component: any): void {
-           this.activations.push(component);
-         }
+         recordActivate(component: any): void { this.activations.push(component); }
 
-         recordDeactivate(component: any): void {
-           this.deactivations.push(component);
-         }
+         recordDeactivate(component: any): void { this.deactivations.push(component); }
        }
 
        TestBed.configureTestingModule({declarations: [Container]});
@@ -1288,9 +1267,7 @@ describe('Integration', () => {
 
   describe('data', () => {
     class ResolveSix implements Resolve<number> {
-      resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): number {
-        return 6;
-      }
+      resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): number { return 6; }
     }
 
     beforeEach(() => {
@@ -1356,7 +1333,7 @@ describe('Integration', () => {
          router.events.subscribe(e => e instanceof RouterEvent && recordedEvents.push(e));
 
          let e: any = null;
-         router.navigateByUrl('/simple')!.catch(error => e = error);
+         router.navigateByUrl('/simple') !.catch(error => e = error);
          advance(fixture);
 
          expectEvents(recordedEvents, [
@@ -1450,7 +1427,7 @@ describe('Integration', () => {
             {
               provide: 'resolver2',
               useValue: () => {
-                return of(null).pipe(map(() => {
+                return of (null).pipe(map(() => {
                   log.push('resolver2');
                   observer.next(null);
                   observer.complete();
@@ -1519,8 +1496,9 @@ describe('Integration', () => {
          router.resetConfig([{
            path: 'team/:id',
            component: TeamCmp,
-           children:
-               [{path: 'link', component: StringLinkCmp}, {path: 'simple', component: SimpleCmp}]
+           children: [
+             {path: 'link', component: StringLinkCmp}, {path: 'simple', component: SimpleCmp}
+           ]
          }]);
 
          router.navigateByUrl('/team/22/link');
@@ -1656,7 +1634,8 @@ describe('Integration', () => {
            path: 'team/:id',
            component: TeamCmp,
            children: [
-             {path: 'link', component: StringLinkButtonCmp}, {path: 'simple', component: SimpleCmp}
+             {path: 'link', component: StringLinkButtonCmp},
+             {path: 'simple', component: SimpleCmp}
            ]
          }]);
 
@@ -1678,8 +1657,9 @@ describe('Integration', () => {
          router.resetConfig([{
            path: 'team/:id',
            component: TeamCmp,
-           children:
-               [{path: 'link', component: AbsoluteLinkCmp}, {path: 'simple', component: SimpleCmp}]
+           children: [
+             {path: 'link', component: AbsoluteLinkCmp}, {path: 'simple', component: SimpleCmp}
+           ]
          }]);
 
          router.navigateByUrl('/team/22/link');
@@ -1700,8 +1680,9 @@ describe('Integration', () => {
          router.resetConfig([{
            path: 'team/:id',
            component: TeamCmp,
-           children:
-               [{path: 'link', component: RelativeLinkCmp}, {path: 'simple', component: SimpleCmp}]
+           children: [
+             {path: 'link', component: RelativeLinkCmp}, {path: 'simple', component: SimpleCmp}
+           ]
          }]);
 
          router.navigateByUrl('/team/22/link');
@@ -1922,9 +1903,7 @@ describe('Integration', () => {
           }
         }
 
-        beforeEach(() => {
-          TestBed.configureTestingModule({providers: [AlwaysTrue]});
-        });
+        beforeEach(() => { TestBed.configureTestingModule({providers: [AlwaysTrue]}); });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
              const fixture = createRoot(router, RootCmp);
@@ -1945,9 +1924,7 @@ describe('Integration', () => {
             providers: [{
               provide: 'CanActivate',
               useValue: (a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-                return Observable.create((observer: any) => {
-                  observer.next(false);
-                });
+                return Observable.create((observer: any) => { observer.next(false); });
               }
             }]
           });
@@ -2004,9 +1981,7 @@ describe('Integration', () => {
           TestBed.configureTestingModule({
             providers: [{
               provide: 'alwaysFalse',
-              useValue: (a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-                return false;
-              }
+              useValue: (a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => { return false; }
             }]
           });
         });
@@ -2275,15 +2250,14 @@ describe('Integration', () => {
             {
               provide: 'RecordingDeactivate',
               useValue: (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-                log.push({path: a.routeConfig!.path, component: c});
+                log.push({path: a.routeConfig !.path, component: c});
                 return true;
               }
             },
             {
               provide: 'alwaysFalse',
-              useValue: (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-                return false;
-              }
+              useValue:
+                  (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => { return false; }
             },
             {
               provide: 'alwaysFalseAndLogging',
@@ -2325,13 +2299,13 @@ describe('Integration', () => {
              expect(location.path()).toEqual('/team/22');
 
              let successStatus: boolean = false;
-             router.navigateByUrl('/team/33')!.then(res => successStatus = res);
+             router.navigateByUrl('/team/33') !.then(res => successStatus = res);
              advance(fixture);
              expect(location.path()).toEqual('/team/33');
              expect(successStatus).toEqual(true);
 
              let canceledStatus: boolean = false;
-             router.navigateByUrl('/team/44')!.then(res => canceledStatus = res);
+             router.navigateByUrl('/team/44') !.then(res => canceledStatus = res);
              advance(fixture);
              expect(location.path()).toEqual('/team/33');
              expect(canceledStatus).toEqual(false);
@@ -2533,12 +2507,11 @@ describe('Integration', () => {
             providers: [
               ClassWithNextState, {
                 provide: 'FunctionWithNextState',
-                useValue:
-                    (cmp: any, currentRoute: ActivatedRouteSnapshot,
-                     currentState: RouterStateSnapshot, nextState: RouterStateSnapshot) => {
-                      log.push(currentState.url, nextState.url);
-                      return true;
-                    }
+                useValue: (cmp: any, currentRoute: ActivatedRouteSnapshot,
+                           currentState: RouterStateSnapshot, nextState: RouterStateSnapshot) => {
+                  log.push(currentState.url, nextState.url);
+                  return true;
+                }
               }
             ]
           });
@@ -2589,9 +2562,7 @@ describe('Integration', () => {
           }
         }
 
-        beforeEach(() => {
-          TestBed.configureTestingModule({providers: [AlwaysTrue]});
-        });
+        beforeEach(() => { TestBed.configureTestingModule({providers: [AlwaysTrue]}); });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
              const fixture = createRoot(router, RootCmp);
@@ -2616,9 +2587,7 @@ describe('Integration', () => {
             providers: [{
               provide: 'CanDeactivate',
               useValue: (c: TeamCmp, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-                return Observable.create((observer: any) => {
-                  observer.next(false);
-                });
+                return Observable.create((observer: any) => { observer.next(false); });
               }
             }]
           });
@@ -2666,7 +2635,7 @@ describe('Integration', () => {
 
              expect(location.path()).toEqual('/team/22');
 
-             router.navigateByUrl('/team/33')!.catch(() => {});
+             router.navigateByUrl('/team/33') !.catch(() => {});
              advance(fixture);
 
              expect(location.path()).toEqual('/team/22');
@@ -2880,9 +2849,7 @@ describe('Integration', () => {
     describe('order', () => {
       class Logger {
         logs: string[] = [];
-        add(thing: string) {
-          this.logs.push(thing);
-        }
+        add(thing: string) { this.logs.push(thing); }
       }
 
       beforeEach(() => {
@@ -3013,7 +2980,8 @@ describe('Integration', () => {
            children: [{
              path: 'link',
              component: DummyLinkCmp,
-             children: [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
+             children:
+                 [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
            }]
          }]);
 
@@ -3069,7 +3037,8 @@ describe('Integration', () => {
            children: [{
              path: 'link',
              component: DummyLinkWithParentCmp,
-             children: [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
+             children:
+                 [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
            }]
          }]);
 
@@ -3097,7 +3066,8 @@ describe('Integration', () => {
            children: [{
              path: 'link',
              component: DummyLinkCmp,
-             children: [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
+             children:
+                 [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
            }]
          }]);
 
@@ -3256,8 +3226,8 @@ describe('Integration', () => {
              expect(location.path()).toEqual('/lazy/parent/child');
              expect(fixture.nativeElement).toHaveText('parent[child]');
 
-             const pInj = fixture.debugElement.query(By.directive(Parent)).injector!;
-             const cInj = fixture.debugElement.query(By.directive(Child)).injector!;
+             const pInj = fixture.debugElement.query(By.directive(Parent)).injector !;
+             const cInj = fixture.debugElement.query(By.directive(Child)).injector !;
 
              expect(pInj.get('moduleName')).toEqual('parent');
              expect(pInj.get('fromParent')).toEqual('from parent');
@@ -3311,9 +3281,7 @@ describe('Integration', () => {
              })
              class LoadedModule {
                static instances = 0;
-               constructor() {
-                 LoadedModule.instances++;
-               }
+               constructor() { LoadedModule.instances++; }
              }
 
              loader.stubbedModules = {expected: LoadedModule};
@@ -3445,7 +3413,7 @@ describe('Integration', () => {
              router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
 
              let recordedError: any = null;
-             router.navigateByUrl('/lazy/loaded')!.catch(err => recordedError = err);
+             router.navigateByUrl('/lazy/loaded') !.catch(err => recordedError = err);
              advance(fixture);
              expect(recordedError.message)
                  .toEqual(
@@ -3591,7 +3559,7 @@ describe('Integration', () => {
             lazyService: LazyLoadedServiceDefinedInModule,  // should be able to inject lazy service
             eager:
                 EagerParentComponent  // should use the injector of the location to create a parent
-        ) {}
+            ) {}
       }
 
       @NgModule({
@@ -3682,7 +3650,7 @@ describe('Integration', () => {
              const recordedEvents: any[] = [];
              router.events.forEach(e => recordedEvents.push(e));
 
-             router.navigateByUrl('/lazy/loaded')!.catch(s => {});
+             router.navigateByUrl('/lazy/loaded') !.catch(s => {});
              advance(fixture);
 
              expect(location.path()).toEqual('/');
@@ -3791,12 +3759,12 @@ describe('Integration', () => {
                advance(fixture);
 
                const config = router.config as any;
-               const firstConfig = config[1]._loadedConfig!;
+               const firstConfig = config[1]._loadedConfig !;
 
                expect(firstConfig).toBeDefined();
                expect(firstConfig.routes[0].path).toEqual('LoadedModule1');
 
-               const secondConfig = firstConfig.routes[0]._loadedConfig!;
+               const secondConfig = firstConfig.routes[0]._loadedConfig !;
                expect(secondConfig).toBeDefined();
                expect(secondConfig.routes[0].path).toEqual('LoadedModule2');
              })));
@@ -3849,8 +3817,9 @@ describe('Integration', () => {
            router.resetConfig([{
              path: 'include',
              component: TeamCmp,
-             children:
-                 [{path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}]
+             children: [
+               {path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}
+             ]
            }]);
 
            const events: any[] = [];
@@ -3912,8 +3881,9 @@ describe('Integration', () => {
            router.resetConfig([{
              path: 'include',
              component: TeamCmp,
-             children:
-                 [{path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}]
+             children: [
+               {path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}
+             ]
            }]);
 
            const events: any[] = [];
@@ -3954,19 +3924,19 @@ describe('Integration', () => {
       stored: {[k: string]: DetachedRouteHandle} = {};
 
       shouldDetach(route: ActivatedRouteSnapshot): boolean {
-        return route.routeConfig!.path === 'a';
+        return route.routeConfig !.path === 'a';
       }
 
       store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void {
-        this.stored[route.routeConfig!.path!] = detachedTree;
+        this.stored[route.routeConfig !.path !] = detachedTree;
       }
 
       shouldAttach(route: ActivatedRouteSnapshot): boolean {
-        return !!this.stored[route.routeConfig!.path!];
+        return !!this.stored[route.routeConfig !.path !];
       }
 
       retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle {
-        return this.stored[route.routeConfig!.path!];
+        return this.stored[route.routeConfig !.path !];
       }
 
       shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
@@ -3975,16 +3945,10 @@ describe('Integration', () => {
     }
 
     class ShortLifecycle implements RouteReuseStrategy {
-      shouldDetach(route: ActivatedRouteSnapshot): boolean {
-        return false;
-      }
+      shouldDetach(route: ActivatedRouteSnapshot): boolean { return false; }
       store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void {}
-      shouldAttach(route: ActivatedRouteSnapshot): boolean {
-        return false;
-      }
-      retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle|null {
-        return null;
-      }
+      shouldAttach(route: ActivatedRouteSnapshot): boolean { return false; }
+      retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle|null { return null; }
       shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
         if (future.routeConfig !== curr.routeConfig) {
           return false;
@@ -4078,9 +4042,7 @@ describe('Integration', () => {
                              !!router.parseUrl(router.url).root.children['toolpanel']);
            }
 
-           public ngOnDestroy(): void {
-             this.subscription.unsubscribe();
-           }
+           public ngOnDestroy(): void { this.subscription.unsubscribe(); }
          }
 
          @Component({selector: 'tool-1-cmp', template: 'Tool 1 showing'})
@@ -4342,9 +4304,7 @@ class OutletInNgIf {
 })
 class DummyLinkWithParentCmp {
   private exact: boolean;
-  constructor(route: ActivatedRoute) {
-    this.exact = (<any>route.snapshot.params).exact === 'true';
-  }
+  constructor(route: ActivatedRoute) { this.exact = (<any>route.snapshot.params).exact === 'true'; }
 }
 
 @Component({selector: 'cmp', template: ''})
@@ -4366,9 +4326,7 @@ class RootCmp {
 class RootCmpWithOnInit {
   constructor(private router: Router) {}
 
-  ngOnInit(): void {
-    this.router.navigate(['one']);
-  }
+  ngOnInit(): void { this.router.navigate(['one']); }
 }
 
 @Component({
@@ -4381,9 +4339,7 @@ class RootCmpWithTwoOutlets {
 
 @Component({selector: 'throwing-cmp', template: ''})
 class ThrowingCmp {
-  constructor() {
-    throw new Error('Throwing Cmp');
-  }
+  constructor() { throw new Error('Throwing Cmp'); }
 }
 
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -6,155 +6,155 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { CommonModule, Location } from '@angular/common';
-import { SpyLocation } from '@angular/common/testing';
-import { ChangeDetectionStrategy, Component, Injectable, NgModule, NgModuleFactoryLoader, NgModuleRef, NgZone, OnDestroy, ɵConsole as Console, ɵNoopNgZone as NoopNgZone } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, inject, tick } from '@angular/core/testing';
-import { By } from '@angular/platform-browser/src/dom/debug/by';
-import { expect } from '@angular/platform-browser/testing/src/matchers';
-import { ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, PRIMARY_OUTLET, ParamMap, Params, PreloadAllModules, PreloadingStrategy, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouteReuseStrategy, Router, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree } from '@angular/router';
-import { Observable, Observer, Subscription, of } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
+import {CommonModule, Location} from '@angular/common';
+import {SpyLocation} from '@angular/common/testing';
+import {ChangeDetectionStrategy, Component, Injectable, NgModule, NgModuleFactoryLoader, NgModuleRef, NgZone, OnDestroy, ɵConsole as Console, ɵNoopNgZone as NoopNgZone} from '@angular/core';
+import {ComponentFixture, TestBed, fakeAsync, inject, tick} from '@angular/core/testing';
+import {By} from '@angular/platform-browser/src/dom/debug/by';
+import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, PRIMARY_OUTLET, ParamMap, Params, PreloadAllModules, PreloadingStrategy, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouteReuseStrategy, Router, RouterEvent, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
+import {Observable, Observer, Subscription, of } from 'rxjs';
+import {filter, map} from 'rxjs/operators';
 
-import { forEach } from '../src/utils/collection';
-import { RouterTestingModule, SpyNgModuleFactoryLoader } from '../testing';
+import {forEach} from '../src/utils/collection';
+import {RouterTestingModule, SpyNgModuleFactoryLoader} from '../testing';
 
 describe('Integration', () => {
-  const noopConsole: Console = { log() { }, warn() { } };
+  const noopConsole: Console = {log() {}, warn() {}};
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports:
-        [RouterTestingModule.withRoutes([{ path: 'simple', component: SimpleCmp }]), TestModule],
-      providers: [{ provide: Console, useValue: noopConsole }]
+          [RouterTestingModule.withRoutes([{path: 'simple', component: SimpleCmp}]), TestModule],
+      providers: [{provide: Console, useValue: noopConsole}]
     });
   });
 
   it('should navigate with a provided config',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const fixture = createRoot(router, RootCmp);
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       const fixture = createRoot(router, RootCmp);
 
-      router.navigateByUrl('/simple');
-      advance(fixture);
+       router.navigateByUrl('/simple');
+       advance(fixture);
 
-      expect(location.path()).toEqual('/simple');
-    })));
+       expect(location.path()).toEqual('/simple');
+     })));
 
   it('should navigate from ngOnInit hook',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      router.resetConfig([
-        { path: '', component: SimpleCmp },
-        { path: 'one', component: RouteCmp },
-      ]);
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       router.resetConfig([
+         {path: '', component: SimpleCmp},
+         {path: 'one', component: RouteCmp},
+       ]);
 
-      const fixture = createRoot(router, RootCmpWithOnInit);
-      expect(location.path()).toEqual('/one');
-      expect(fixture.nativeElement).toHaveText('route');
-    })));
+       const fixture = createRoot(router, RootCmpWithOnInit);
+       expect(location.path()).toEqual('/one');
+       expect(fixture.nativeElement).toHaveText('route');
+     })));
 
-  describe('navigation', function () {
+  describe('navigation', function() {
     it('should navigate to the current URL', fakeAsync(inject([Router], (router: Router) => {
-      router.onSameUrlNavigation = 'reload';
-      router.resetConfig([
-        { path: '', component: SimpleCmp },
-        { path: 'simple', component: SimpleCmp },
-      ]);
+         router.onSameUrlNavigation = 'reload';
+         router.resetConfig([
+           {path: '', component: SimpleCmp},
+           {path: 'simple', component: SimpleCmp},
+         ]);
 
-      const fixture = createRoot(router, RootCmp);
-      const events: Event[] = [];
-      router.events.subscribe(e => onlyNavigationStartAndEnd(e) && events.push(e));
+         const fixture = createRoot(router, RootCmp);
+         const events: Event[] = [];
+         router.events.subscribe(e => onlyNavigationStartAndEnd(e) && events.push(e));
 
-      router.navigateByUrl('/simple');
-      tick();
+         router.navigateByUrl('/simple');
+         tick();
 
-      router.navigateByUrl('/simple');
-      tick();
+         router.navigateByUrl('/simple');
+         tick();
 
-      expectEvents(events, [
-        [NavigationStart, '/simple'], [NavigationEnd, '/simple'], [NavigationStart, '/simple'],
-        [NavigationEnd, '/simple']
-      ]);
-    })));
+         expectEvents(events, [
+           [NavigationStart, '/simple'], [NavigationEnd, '/simple'], [NavigationStart, '/simple'],
+           [NavigationEnd, '/simple']
+         ]);
+       })));
 
     it('should set the restoredState to null when executing imperative navigations',
-      fakeAsync(inject([Router], (router: Router) => {
-        router.resetConfig([
-          { path: '', component: SimpleCmp },
-          { path: 'simple', component: SimpleCmp },
-        ]);
+       fakeAsync(inject([Router], (router: Router) => {
+         router.resetConfig([
+           {path: '', component: SimpleCmp},
+           {path: 'simple', component: SimpleCmp},
+         ]);
 
-        const fixture = createRoot(router, RootCmp);
-        let event: NavigationStart;
-        router.events.subscribe(e => {
-          if (e instanceof NavigationStart) {
-            event = e;
-          }
-        });
+         const fixture = createRoot(router, RootCmp);
+         let event: NavigationStart;
+         router.events.subscribe(e => {
+           if (e instanceof NavigationStart) {
+             event = e;
+           }
+         });
 
-        router.navigateByUrl('/simple');
-        tick();
+         router.navigateByUrl('/simple');
+         tick();
 
-        expect(event!.navigationTrigger).toEqual('imperative');
-        expect(event!.restoredState).toEqual(null);
-      })));
+         expect(event !.navigationTrigger).toEqual('imperative');
+         expect(event !.restoredState).toEqual(null);
+       })));
 
     it('should not pollute browser history when replaceUrl is set to true',
-      fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
-        router.resetConfig([
-          { path: '', component: SimpleCmp }, { path: 'a', component: SimpleCmp },
-          { path: 'b', component: SimpleCmp }
-        ]);
+       fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
+         router.resetConfig([
+           {path: '', component: SimpleCmp}, {path: 'a', component: SimpleCmp},
+           {path: 'b', component: SimpleCmp}
+         ]);
 
-        const fixture = createRoot(router, RootCmp);
+         const fixture = createRoot(router, RootCmp);
 
-        router.navigateByUrl('/a', { replaceUrl: true });
-        router.navigateByUrl('/b', { replaceUrl: true });
-        tick();
+         router.navigateByUrl('/a', {replaceUrl: true});
+         router.navigateByUrl('/b', {replaceUrl: true});
+         tick();
 
-        expect(location.urlChanges).toEqual(['replace: /', 'replace: /b']);
-      })));
+         expect(location.urlChanges).toEqual(['replace: /', 'replace: /b']);
+       })));
 
     it('should skip navigation if another navigation is already scheduled',
-      fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
-        router.resetConfig([
-          { path: '', component: SimpleCmp }, { path: 'a', component: SimpleCmp },
-          { path: 'b', component: SimpleCmp }
-        ]);
+       fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
+         router.resetConfig([
+           {path: '', component: SimpleCmp}, {path: 'a', component: SimpleCmp},
+           {path: 'b', component: SimpleCmp}
+         ]);
 
-        const fixture = createRoot(router, RootCmp);
+         const fixture = createRoot(router, RootCmp);
 
-        router.navigate(
-          ['/a'], { queryParams: { a: true }, queryParamsHandling: 'merge', replaceUrl: true });
-        router.navigate(
-          ['/b'], { queryParams: { b: true }, queryParamsHandling: 'merge', replaceUrl: true });
-        tick();
+         router.navigate(
+             ['/a'], {queryParams: {a: true}, queryParamsHandling: 'merge', replaceUrl: true});
+         router.navigate(
+             ['/b'], {queryParams: {b: true}, queryParamsHandling: 'merge', replaceUrl: true});
+         tick();
 
-        /**
-         * Why do we have '/b?b=true' and not '/b?a=true&b=true'?
-         *
-         * This is because the router has the right to stop a navigation mid-flight if another
-         * navigation has been already scheduled. This is why we can use a top-level guard
-         * to perform redirects. Calling `navigate` in such a guard will stop the navigation, and
-         * the components won't be instantiated.
-         *
-         * This is a fundamental property of the router: it only cares about its latest state.
-         *
-         * This means that components should only map params to something else, not reduce them.
-         * In other words, the following component is asking for trouble:
-         *
-         * ```
-         * class MyComponent {
-         *  constructor(a: ActivatedRoute) {
-         *    a.params.scan(...)
-         *  }
-         * }
-         * ```
-         *
-         * This also means "queryParamsHandling: 'merge'" should only be used to merge with
-         * long-living query parameters (e.g., debug).
-         */
-        expect(router.url).toEqual('/b?b=true');
-      })));
+         /**
+          * Why do we have '/b?b=true' and not '/b?a=true&b=true'?
+          *
+          * This is because the router has the right to stop a navigation mid-flight if another
+          * navigation has been already scheduled. This is why we can use a top-level guard
+          * to perform redirects. Calling `navigate` in such a guard will stop the navigation, and
+          * the components won't be instantiated.
+          *
+          * This is a fundamental property of the router: it only cares about its latest state.
+          *
+          * This means that components should only map params to something else, not reduce them.
+          * In other words, the following component is asking for trouble:
+          *
+          * ```
+          * class MyComponent {
+          *  constructor(a: ActivatedRoute) {
+          *    a.params.scan(...)
+          *  }
+          * }
+          * ```
+          *
+          * This also means "queryParamsHandling: 'merge'" should only be used to merge with
+          * long-living query parameters (e.g., debug).
+          */
+         expect(router.url).toEqual('/b?b=true');
+       })));
   });
 
   describe('navigation warning', () => {
@@ -166,38 +166,38 @@ describe('Integration', () => {
 
     beforeEach(() => {
       warnings = [];
-      TestBed.overrideProvider(Console, { useValue: new MockConsole() });
+      TestBed.overrideProvider(Console, {useValue: new MockConsole()});
     });
 
     describe('with NgZone enabled', () => {
       it('should warn when triggered outside Angular zone',
-        fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-          ngZone.runOutsideAngular(() => { router.navigateByUrl('/simple'); });
+         fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
+           ngZone.runOutsideAngular(() => { router.navigateByUrl('/simple'); });
 
-          expect(warnings.length).toBe(1);
-          expect(warnings[0])
-            .toBe(
-              `Navigation triggered outside Angular zone, did you forget to call 'ngZone.run()'?`);
-        })));
+           expect(warnings.length).toBe(1);
+           expect(warnings[0])
+               .toBe(
+                   `Navigation triggered outside Angular zone, did you forget to call 'ngZone.run()'?`);
+         })));
 
       it('should not warn when triggered inside Angular zone',
-        fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
-          ngZone.run(() => { router.navigateByUrl('/simple'); });
+         fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
+           ngZone.run(() => { router.navigateByUrl('/simple'); });
 
-          expect(warnings.length).toBe(0);
-        })));
+           expect(warnings.length).toBe(0);
+         })));
     });
 
     describe('with NgZone disabled', () => {
-      beforeEach(() => { TestBed.overrideProvider(NgZone, { useValue: new NoopNgZone() }); });
+      beforeEach(() => { TestBed.overrideProvider(NgZone, {useValue: new NoopNgZone()}); });
 
       it('should not warn when triggered outside Angular zone',
-        fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
+         fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
 
-          ngZone.runOutsideAngular(() => { router.navigateByUrl('/simple'); });
+           ngZone.runOutsideAngular(() => { router.navigateByUrl('/simple'); });
 
-          expect(warnings.length).toBe(0);
-        })));
+           expect(warnings.length).toBe(0);
+         })));
     });
   });
 
@@ -234,19 +234,19 @@ describe('Integration', () => {
     });
 
     describe('should advance the parent route after deactivating its children', () => {
-      @Component({ template: '<router-outlet></router-outlet>' })
+      @Component({template: '<router-outlet></router-outlet>'})
       class Parent {
         constructor(route: ActivatedRoute) {
           route.params.subscribe((s: any) => { log.push(s); });
         }
       }
 
-      @Component({ template: 'child1' })
+      @Component({template: 'child1'})
       class Child1 {
         ngOnDestroy() { log.push('child1 destroy'); }
       }
 
-      @Component({ template: 'child2' })
+      @Component({template: 'child2'})
       class Child2 {
         constructor() { log.push('child2 constructor'); }
       }
@@ -259,398 +259,398 @@ describe('Integration', () => {
       class TestModule {
       }
 
-      beforeEach(() => TestBed.configureTestingModule({ imports: [TestModule] }));
+      beforeEach(() => TestBed.configureTestingModule({imports: [TestModule]}));
 
       it('should work',
-        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+           const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([{
-            path: 'parent/:id',
-            component: Parent,
-            children: [
-              { path: 'child1', component: Child1 },
-              { path: 'child2', component: Child2 },
-            ]
-          }]);
+           router.resetConfig([{
+             path: 'parent/:id',
+             component: Parent,
+             children: [
+               {path: 'child1', component: Child1},
+               {path: 'child2', component: Child2},
+             ]
+           }]);
 
-          router.navigateByUrl('/parent/1/child1');
-          advance(fixture);
+           router.navigateByUrl('/parent/1/child1');
+           advance(fixture);
 
-          router.navigateByUrl('/parent/2/child2');
-          advance(fixture);
+           router.navigateByUrl('/parent/2/child2');
+           advance(fixture);
 
-          expect(location.path()).toEqual('/parent/2/child2');
-          expect(log).toEqual([
-            { id: '1' },
-            'child1 destroy',
-            { id: '2' },
-            'child2 constructor',
-          ]);
-        })));
+           expect(location.path()).toEqual('/parent/2/child2');
+           expect(log).toEqual([
+             {id: '1'},
+             'child1 destroy',
+             {id: '2'},
+             'child2 constructor',
+           ]);
+         })));
 
     });
 
     it('should execute navigations serialy',
-      fakeAsync(inject([Router, Location], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+       fakeAsync(inject([Router, Location], (router: Router) => {
+         const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([
-          { path: 'a', component: SimpleCmp, canActivate: ['trueRightAway', 'trueIn2Seconds'] },
-          { path: 'b', component: SimpleCmp, canActivate: ['trueRightAway', 'trueIn2Seconds'] }
-        ]);
+         router.resetConfig([
+           {path: 'a', component: SimpleCmp, canActivate: ['trueRightAway', 'trueIn2Seconds']},
+           {path: 'b', component: SimpleCmp, canActivate: ['trueRightAway', 'trueIn2Seconds']}
+         ]);
 
-        router.navigateByUrl('/a');
-        tick(100);
-        fixture.detectChanges();
+         router.navigateByUrl('/a');
+         tick(100);
+         fixture.detectChanges();
 
-        router.navigateByUrl('/b');
-        tick(100);  // 200
-        fixture.detectChanges();
+         router.navigateByUrl('/b');
+         tick(100);  // 200
+         fixture.detectChanges();
 
-        expect(log).toEqual(['trueRightAway', 'trueIn2Seconds-start']);
+         expect(log).toEqual(['trueRightAway', 'trueIn2Seconds-start']);
 
-        tick(2000);  // 2200
-        fixture.detectChanges();
+         tick(2000);  // 2200
+         fixture.detectChanges();
 
-        expect(log).toEqual([
-          'trueRightAway', 'trueIn2Seconds-start', 'trueIn2Seconds-end', 'trueRightAway',
-          'trueIn2Seconds-start'
-        ]);
+         expect(log).toEqual([
+           'trueRightAway', 'trueIn2Seconds-start', 'trueIn2Seconds-end', 'trueRightAway',
+           'trueIn2Seconds-start'
+         ]);
 
-        tick(2000);  // 4200
-        fixture.detectChanges();
+         tick(2000);  // 4200
+         fixture.detectChanges();
 
-        expect(log).toEqual([
-          'trueRightAway', 'trueIn2Seconds-start', 'trueIn2Seconds-end', 'trueRightAway',
-          'trueIn2Seconds-start', 'trueIn2Seconds-end'
-        ]);
-      })));
+         expect(log).toEqual([
+           'trueRightAway', 'trueIn2Seconds-start', 'trueIn2Seconds-end', 'trueRightAway',
+           'trueIn2Seconds-start', 'trueIn2Seconds-end'
+         ]);
+       })));
   });
 
   it('Should work inside ChangeDetectionStrategy.OnPush components', fakeAsync(() => {
-    @Component({
-      selector: 'root-cmp',
-      template: `<router-outlet></router-outlet>`,
-      changeDetection: ChangeDetectionStrategy.OnPush,
-    })
-    class OnPushOutlet {
-    }
+       @Component({
+         selector: 'root-cmp',
+         template: `<router-outlet></router-outlet>`,
+         changeDetection: ChangeDetectionStrategy.OnPush,
+       })
+       class OnPushOutlet {
+       }
 
-    @Component({ selector: 'need-cd', template: `{{'it works!'}}` })
-    class NeedCdCmp {
-    }
+       @Component({selector: 'need-cd', template: `{{'it works!'}}`})
+       class NeedCdCmp {
+       }
 
-    @NgModule({
-      declarations: [OnPushOutlet, NeedCdCmp],
-      entryComponents: [OnPushOutlet, NeedCdCmp],
-      imports: [RouterModule],
-    })
-    class TestModule {
-    }
+       @NgModule({
+         declarations: [OnPushOutlet, NeedCdCmp],
+         entryComponents: [OnPushOutlet, NeedCdCmp],
+         imports: [RouterModule],
+       })
+       class TestModule {
+       }
 
-    TestBed.configureTestingModule({ imports: [TestModule] });
+       TestBed.configureTestingModule({imports: [TestModule]});
 
-    const router: Router = TestBed.get(Router);
-    const fixture = createRoot(router, RootCmp);
+       const router: Router = TestBed.get(Router);
+       const fixture = createRoot(router, RootCmp);
 
-    router.resetConfig([{
-      path: 'on',
-      component: OnPushOutlet,
-      children: [{
-        path: 'push',
-        component: NeedCdCmp,
-      }],
-    }]);
+       router.resetConfig([{
+         path: 'on',
+         component: OnPushOutlet,
+         children: [{
+           path: 'push',
+           component: NeedCdCmp,
+         }],
+       }]);
 
-    advance(fixture);
-    router.navigateByUrl('on');
-    advance(fixture);
-    router.navigateByUrl('on/push');
-    advance(fixture);
+       advance(fixture);
+       router.navigateByUrl('on');
+       advance(fixture);
+       router.navigateByUrl('on/push');
+       advance(fixture);
 
-    expect(fixture.nativeElement).toHaveText('it works!');
-  }));
+       expect(fixture.nativeElement).toHaveText('it works!');
+     }));
 
   it('should not error when no url left and no children are matching',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const fixture = createRoot(router, RootCmp);
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{
-        path: 'team/:id',
-        component: TeamCmp,
-        children: [{ path: 'simple', component: SimpleCmp }]
-      }]);
+       router.resetConfig([{
+         path: 'team/:id',
+         component: TeamCmp,
+         children: [{path: 'simple', component: SimpleCmp}]
+       }]);
 
-      router.navigateByUrl('/team/33/simple');
-      advance(fixture);
+       router.navigateByUrl('/team/33/simple');
+       advance(fixture);
 
-      expect(location.path()).toEqual('/team/33/simple');
-      expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
+       expect(location.path()).toEqual('/team/33/simple');
+       expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
 
-      router.navigateByUrl('/team/33');
-      advance(fixture);
+       router.navigateByUrl('/team/33');
+       advance(fixture);
 
-      expect(location.path()).toEqual('/team/33');
-      expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-    })));
+       expect(location.path()).toEqual('/team/33');
+       expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
+     })));
 
   it('should work when an outlet is in an ngIf',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const fixture = createRoot(router, RootCmp);
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{
-        path: 'child',
-        component: OutletInNgIf,
-        children: [{ path: 'simple', component: SimpleCmp }]
-      }]);
+       router.resetConfig([{
+         path: 'child',
+         component: OutletInNgIf,
+         children: [{path: 'simple', component: SimpleCmp}]
+       }]);
 
-      router.navigateByUrl('/child/simple');
-      advance(fixture);
+       router.navigateByUrl('/child/simple');
+       advance(fixture);
 
-      expect(location.path()).toEqual('/child/simple');
-    })));
+       expect(location.path()).toEqual('/child/simple');
+     })));
 
   it('should work when an outlet is added/removed', fakeAsync(() => {
-    @Component({
-      selector: 'someRoot',
-      template: `[<div *ngIf="cond"><router-outlet></router-outlet></div>]`
-    })
-    class RootCmpWithLink {
-      cond: boolean = true;
-    }
-    TestBed.configureTestingModule({ declarations: [RootCmpWithLink] });
+       @Component({
+         selector: 'someRoot',
+         template: `[<div *ngIf="cond"><router-outlet></router-outlet></div>]`
+       })
+       class RootCmpWithLink {
+         cond: boolean = true;
+       }
+       TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
 
-    const router: Router = TestBed.get(Router);
+       const router: Router = TestBed.get(Router);
 
-    const fixture = createRoot(router, RootCmpWithLink);
+       const fixture = createRoot(router, RootCmpWithLink);
 
-    router.resetConfig([
-      { path: 'simple', component: SimpleCmp },
-      { path: 'blank', component: BlankCmp },
-    ]);
+       router.resetConfig([
+         {path: 'simple', component: SimpleCmp},
+         {path: 'blank', component: BlankCmp},
+       ]);
 
-    router.navigateByUrl('/simple');
-    advance(fixture);
-    expect(fixture.nativeElement).toHaveText('[simple]');
+       router.navigateByUrl('/simple');
+       advance(fixture);
+       expect(fixture.nativeElement).toHaveText('[simple]');
 
-    fixture.componentInstance.cond = false;
-    advance(fixture);
-    expect(fixture.nativeElement).toHaveText('[]');
+       fixture.componentInstance.cond = false;
+       advance(fixture);
+       expect(fixture.nativeElement).toHaveText('[]');
 
-    fixture.componentInstance.cond = true;
-    advance(fixture);
-    expect(fixture.nativeElement).toHaveText('[simple]');
-  }));
+       fixture.componentInstance.cond = true;
+       advance(fixture);
+       expect(fixture.nativeElement).toHaveText('[simple]');
+     }));
 
   it('should update location when navigating', fakeAsync(() => {
-    @Component({ template: `record` })
-    class RecordLocationCmp {
-      private storedPath: string;
-      constructor(loc: Location) { this.storedPath = loc.path(); }
-    }
+       @Component({template: `record`})
+       class RecordLocationCmp {
+         private storedPath: string;
+         constructor(loc: Location) { this.storedPath = loc.path(); }
+       }
 
-    @NgModule({ declarations: [RecordLocationCmp], entryComponents: [RecordLocationCmp] })
-    class TestModule {
-    }
+       @NgModule({declarations: [RecordLocationCmp], entryComponents: [RecordLocationCmp]})
+       class TestModule {
+       }
 
-    TestBed.configureTestingModule({ imports: [TestModule] });
+       TestBed.configureTestingModule({imports: [TestModule]});
 
-    const router = TestBed.get(Router);
-    const location = TestBed.get(Location);
-    const fixture = createRoot(router, RootCmp);
+       const router = TestBed.get(Router);
+       const location = TestBed.get(Location);
+       const fixture = createRoot(router, RootCmp);
 
-    router.resetConfig([{ path: 'record/:id', component: RecordLocationCmp }]);
+       router.resetConfig([{path: 'record/:id', component: RecordLocationCmp}]);
 
-    router.navigateByUrl('/record/22');
-    advance(fixture);
+       router.navigateByUrl('/record/22');
+       advance(fixture);
 
-    const c = fixture.debugElement.children[1].componentInstance;
-    expect(location.path()).toEqual('/record/22');
-    expect(c.storedPath).toEqual('/record/22');
+       const c = fixture.debugElement.children[1].componentInstance;
+       expect(location.path()).toEqual('/record/22');
+       expect(c.storedPath).toEqual('/record/22');
 
-    router.navigateByUrl('/record/33');
-    advance(fixture);
-    expect(location.path()).toEqual('/record/33');
-  }));
+       router.navigateByUrl('/record/33');
+       advance(fixture);
+       expect(location.path()).toEqual('/record/33');
+     }));
 
   it('should skip location update when using NavigationExtras.skipLocationChange with navigateByUrl',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const fixture = TestBed.createComponent(RootCmp);
-      advance(fixture);
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       const fixture = TestBed.createComponent(RootCmp);
+       advance(fixture);
 
-      router.resetConfig([{ path: 'team/:id', component: TeamCmp }]);
+       router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
 
-      router.navigateByUrl('/team/22');
-      advance(fixture);
-      expect(location.path()).toEqual('/team/22');
+       router.navigateByUrl('/team/22');
+       advance(fixture);
+       expect(location.path()).toEqual('/team/22');
 
-      expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+       expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
-      router.navigateByUrl('/team/33', { skipLocationChange: true });
-      advance(fixture);
+       router.navigateByUrl('/team/33', {skipLocationChange: true});
+       advance(fixture);
 
-      expect(location.path()).toEqual('/team/22');
+       expect(location.path()).toEqual('/team/22');
 
-      expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-    })));
+       expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
+     })));
 
   it('should skip location update when using NavigationExtras.skipLocationChange with navigate',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const fixture = TestBed.createComponent(RootCmp);
-      advance(fixture);
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       const fixture = TestBed.createComponent(RootCmp);
+       advance(fixture);
 
-      router.resetConfig([{ path: 'team/:id', component: TeamCmp }]);
+       router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
 
-      router.navigate(['/team/22']);
-      advance(fixture);
-      expect(location.path()).toEqual('/team/22');
+       router.navigate(['/team/22']);
+       advance(fixture);
+       expect(location.path()).toEqual('/team/22');
 
-      expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+       expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
-      router.navigate(['/team/33'], { skipLocationChange: true });
-      advance(fixture);
+       router.navigate(['/team/33'], {skipLocationChange: true});
+       advance(fixture);
 
-      expect(location.path()).toEqual('/team/22');
+       expect(location.path()).toEqual('/team/22');
 
-      expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-    })));
+       expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
+     })));
 
   it('should eagerly update the URL with urlUpdateStrategy="eagar"',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const fixture = TestBed.createComponent(RootCmp);
-      advance(fixture);
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       const fixture = TestBed.createComponent(RootCmp);
+       advance(fixture);
 
-      router.resetConfig([{ path: 'team/:id', component: TeamCmp }]);
+       router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
 
-      router.navigateByUrl('/team/22');
-      advance(fixture);
-      expect(location.path()).toEqual('/team/22');
+       router.navigateByUrl('/team/22');
+       advance(fixture);
+       expect(location.path()).toEqual('/team/22');
 
-      expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+       expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
-      router.urlUpdateStrategy = 'eager';
-      (router as any).hooks.beforePreactivation = () => {
-        expect(location.path()).toEqual('/team/33');
-        expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
-        return of(null);
-      };
-      router.navigateByUrl('/team/33');
+       router.urlUpdateStrategy = 'eager';
+       (router as any).hooks.beforePreactivation = () => {
+         expect(location.path()).toEqual('/team/33');
+         expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+         return of (null);
+       };
+       router.navigateByUrl('/team/33');
 
-      advance(fixture);
-      expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
-    })));
+       advance(fixture);
+       expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
+     })));
 
   it('should navigate back and forward',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const fixture = createRoot(router, RootCmp);
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{
-        path: 'team/:id',
-        component: TeamCmp,
-        children:
-          [{ path: 'simple', component: SimpleCmp }, { path: 'user/:name', component: UserCmp }]
-      }]);
+       router.resetConfig([{
+         path: 'team/:id',
+         component: TeamCmp,
+         children:
+             [{path: 'simple', component: SimpleCmp}, {path: 'user/:name', component: UserCmp}]
+       }]);
 
-      let event: NavigationStart;
-      router.events.subscribe(e => {
-        if (e instanceof NavigationStart) {
-          event = e;
-        }
-      });
+       let event: NavigationStart;
+       router.events.subscribe(e => {
+         if (e instanceof NavigationStart) {
+           event = e;
+         }
+       });
 
-      router.navigateByUrl('/team/33/simple');
-      advance(fixture);
-      expect(location.path()).toEqual('/team/33/simple');
-      const simpleNavStart = event!;
+       router.navigateByUrl('/team/33/simple');
+       advance(fixture);
+       expect(location.path()).toEqual('/team/33/simple');
+       const simpleNavStart = event !;
 
-      router.navigateByUrl('/team/22/user/victor');
-      advance(fixture);
-      const userVictorNavStart = event!;
+       router.navigateByUrl('/team/22/user/victor');
+       advance(fixture);
+       const userVictorNavStart = event !;
 
 
-      location.back();
-      advance(fixture);
-      expect(location.path()).toEqual('/team/33/simple');
-      expect(event!.navigationTrigger).toEqual('hashchange');
-      expect(event!.restoredState!.navigationId).toEqual(simpleNavStart.id);
+       location.back();
+       advance(fixture);
+       expect(location.path()).toEqual('/team/33/simple');
+       expect(event !.navigationTrigger).toEqual('hashchange');
+       expect(event !.restoredState !.navigationId).toEqual(simpleNavStart.id);
 
-      location.forward();
-      advance(fixture);
-      expect(location.path()).toEqual('/team/22/user/victor');
-      expect(event!.navigationTrigger).toEqual('hashchange');
-      expect(event!.restoredState!.navigationId).toEqual(userVictorNavStart.id);
-    })));
+       location.forward();
+       advance(fixture);
+       expect(location.path()).toEqual('/team/22/user/victor');
+       expect(event !.navigationTrigger).toEqual('hashchange');
+       expect(event !.restoredState !.navigationId).toEqual(userVictorNavStart.id);
+     })));
 
   it('should navigate to the same url when config changes',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const fixture = createRoot(router, RootCmp);
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{ path: 'a', component: SimpleCmp }]);
+       router.resetConfig([{path: 'a', component: SimpleCmp}]);
 
-      router.navigate(['/a']);
-      advance(fixture);
-      expect(location.path()).toEqual('/a');
-      expect(fixture.nativeElement).toHaveText('simple');
+       router.navigate(['/a']);
+       advance(fixture);
+       expect(location.path()).toEqual('/a');
+       expect(fixture.nativeElement).toHaveText('simple');
 
-      router.resetConfig([{ path: 'a', component: RouteCmp }]);
+       router.resetConfig([{path: 'a', component: RouteCmp}]);
 
-      router.navigate(['/a']);
-      advance(fixture);
-      expect(location.path()).toEqual('/a');
-      expect(fixture.nativeElement).toHaveText('route');
-    })));
+       router.navigate(['/a']);
+       advance(fixture);
+       expect(location.path()).toEqual('/a');
+       expect(fixture.nativeElement).toHaveText('route');
+     })));
 
   it('should navigate when locations changes',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const fixture = createRoot(router, RootCmp);
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{
-        path: 'team/:id',
-        component: TeamCmp,
-        children: [{ path: 'user/:name', component: UserCmp }]
-      }]);
+       router.resetConfig([{
+         path: 'team/:id',
+         component: TeamCmp,
+         children: [{path: 'user/:name', component: UserCmp}]
+       }]);
 
-      const recordedEvents: any[] = [];
-      router.events.forEach(e => onlyNavigationStartAndEnd(e) && recordedEvents.push(e));
+       const recordedEvents: any[] = [];
+       router.events.forEach(e => onlyNavigationStartAndEnd(e) && recordedEvents.push(e));
 
-      router.navigateByUrl('/team/22/user/victor');
-      advance(fixture);
+       router.navigateByUrl('/team/22/user/victor');
+       advance(fixture);
 
-      (<any>location).simulateHashChange('/team/22/user/fedor');
-      advance(fixture);
+       (<any>location).simulateHashChange('/team/22/user/fedor');
+       advance(fixture);
 
-      (<any>location).simulateUrlPop('/team/22/user/fedor');
-      advance(fixture);
+       (<any>location).simulateUrlPop('/team/22/user/fedor');
+       advance(fixture);
 
-      expect(fixture.nativeElement).toHaveText('team 22 [ user fedor, right:  ]');
+       expect(fixture.nativeElement).toHaveText('team 22 [ user fedor, right:  ]');
 
-      expectEvents(recordedEvents, [
-        [NavigationStart, '/team/22/user/victor'], [NavigationEnd, '/team/22/user/victor'],
-        [NavigationStart, '/team/22/user/fedor'], [NavigationEnd, '/team/22/user/fedor']
-      ]);
-    })));
+       expectEvents(recordedEvents, [
+         [NavigationStart, '/team/22/user/victor'], [NavigationEnd, '/team/22/user/victor'],
+         [NavigationStart, '/team/22/user/fedor'], [NavigationEnd, '/team/22/user/fedor']
+       ]);
+     })));
 
   it('should update the location when the matched route does not change',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const fixture = createRoot(router, RootCmp);
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{ path: '**', component: CollectParamsCmp }]);
+       router.resetConfig([{path: '**', component: CollectParamsCmp}]);
 
-      router.navigateByUrl('/one/two');
-      advance(fixture);
-      const cmp = fixture.debugElement.children[1].componentInstance;
-      expect(location.path()).toEqual('/one/two');
-      expect(fixture.nativeElement).toHaveText('collect-params');
+       router.navigateByUrl('/one/two');
+       advance(fixture);
+       const cmp = fixture.debugElement.children[1].componentInstance;
+       expect(location.path()).toEqual('/one/two');
+       expect(fixture.nativeElement).toHaveText('collect-params');
 
-      expect(cmp.recordedUrls()).toEqual(['one/two']);
+       expect(cmp.recordedUrls()).toEqual(['one/two']);
 
-      router.navigateByUrl('/three/four');
-      advance(fixture);
-      expect(location.path()).toEqual('/three/four');
-      expect(fixture.nativeElement).toHaveText('collect-params');
-      expect(cmp.recordedUrls()).toEqual(['one/two', 'three/four']);
-    })));
+       router.navigateByUrl('/three/four');
+       advance(fixture);
+       expect(location.path()).toEqual('/three/four');
+       expect(fixture.nativeElement).toHaveText('collect-params');
+       expect(cmp.recordedUrls()).toEqual(['one/two', 'three/four']);
+     })));
 
   describe('should reset location if a navigation by location is successful', () => {
     beforeEach(() => {
@@ -668,604 +668,604 @@ describe('Integration', () => {
     });
 
     it('work', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const fixture = createRoot(router, RootCmp);
+         const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{ path: 'simple', component: SimpleCmp, canActivate: ['in1Second'] }]);
+         router.resetConfig([{path: 'simple', component: SimpleCmp, canActivate: ['in1Second']}]);
 
-      // Trigger two location changes to the same URL.
-      // Because of the guard the order will look as follows:
-      // - location change 'simple'
-      // - start processing the change, start a guard
-      // - location change 'simple'
-      // - the first location change gets canceled, the URL gets reset to '/'
-      // - the second location change gets finished, the URL should be reset to '/simple'
-      (<any>location).simulateUrlPop('/simple');
-      (<any>location).simulateUrlPop('/simple');
+         // Trigger two location changes to the same URL.
+         // Because of the guard the order will look as follows:
+         // - location change 'simple'
+         // - start processing the change, start a guard
+         // - location change 'simple'
+         // - the first location change gets canceled, the URL gets reset to '/'
+         // - the second location change gets finished, the URL should be reset to '/simple'
+         (<any>location).simulateUrlPop('/simple');
+         (<any>location).simulateUrlPop('/simple');
 
-      tick(2000);
-      advance(fixture);
+         tick(2000);
+         advance(fixture);
 
-      expect(location.path()).toEqual('/simple');
-    })));
+         expect(location.path()).toEqual('/simple');
+       })));
   });
 
   it('should support secondary routes', fakeAsync(inject([Router], (router: Router) => {
-    const fixture = createRoot(router, RootCmp);
+       const fixture = createRoot(router, RootCmp);
 
-    router.resetConfig([{
-      path: 'team/:id',
-      component: TeamCmp,
-      children: [
-        { path: 'user/:name', component: UserCmp },
-        { path: 'simple', component: SimpleCmp, outlet: 'right' }
-      ]
-    }]);
+       router.resetConfig([{
+         path: 'team/:id',
+         component: TeamCmp,
+         children: [
+           {path: 'user/:name', component: UserCmp},
+           {path: 'simple', component: SimpleCmp, outlet: 'right'}
+         ]
+       }]);
 
-    router.navigateByUrl('/team/22/(user/victor//right:simple)');
-    advance(fixture);
+       router.navigateByUrl('/team/22/(user/victor//right:simple)');
+       advance(fixture);
 
-    expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right: simple ]');
-  })));
+       expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right: simple ]');
+     })));
 
   it('should support secondary routes in separate commands',
-    fakeAsync(inject([Router], (router: Router) => {
-      const fixture = createRoot(router, RootCmp);
+     fakeAsync(inject([Router], (router: Router) => {
+       const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{
-        path: 'team/:id',
-        component: TeamCmp,
-        children: [
-          { path: 'user/:name', component: UserCmp },
-          { path: 'simple', component: SimpleCmp, outlet: 'right' }
-        ]
-      }]);
+       router.resetConfig([{
+         path: 'team/:id',
+         component: TeamCmp,
+         children: [
+           {path: 'user/:name', component: UserCmp},
+           {path: 'simple', component: SimpleCmp, outlet: 'right'}
+         ]
+       }]);
 
-      router.navigateByUrl('/team/22/user/victor');
-      advance(fixture);
-      router.navigate(['team/22', { outlets: { right: 'simple' } }]);
-      advance(fixture);
+       router.navigateByUrl('/team/22/user/victor');
+       advance(fixture);
+       router.navigate(['team/22', {outlets: {right: 'simple'}}]);
+       advance(fixture);
 
-      expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right: simple ]');
-    })));
+       expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right: simple ]');
+     })));
 
   it('should deactivate outlets', fakeAsync(inject([Router], (router: Router) => {
-    const fixture = createRoot(router, RootCmp);
+       const fixture = createRoot(router, RootCmp);
 
-    router.resetConfig([{
-      path: 'team/:id',
-      component: TeamCmp,
-      children: [
-        { path: 'user/:name', component: UserCmp },
-        { path: 'simple', component: SimpleCmp, outlet: 'right' }
-      ]
-    }]);
+       router.resetConfig([{
+         path: 'team/:id',
+         component: TeamCmp,
+         children: [
+           {path: 'user/:name', component: UserCmp},
+           {path: 'simple', component: SimpleCmp, outlet: 'right'}
+         ]
+       }]);
 
-    router.navigateByUrl('/team/22/(user/victor//right:simple)');
-    advance(fixture);
+       router.navigateByUrl('/team/22/(user/victor//right:simple)');
+       advance(fixture);
 
-    router.navigateByUrl('/team/22/user/victor');
-    advance(fixture);
+       router.navigateByUrl('/team/22/user/victor');
+       advance(fixture);
 
-    expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right:  ]');
-  })));
+       expect(fixture.nativeElement).toHaveText('team 22 [ user victor, right:  ]');
+     })));
 
   it('should deactivate nested outlets', fakeAsync(inject([Router], (router: Router) => {
-    const fixture = createRoot(router, RootCmp);
+       const fixture = createRoot(router, RootCmp);
 
-    router.resetConfig([
-      {
-        path: 'team/:id',
-        component: TeamCmp,
-        children: [
-          { path: 'user/:name', component: UserCmp },
-          { path: 'simple', component: SimpleCmp, outlet: 'right' }
-        ]
-      },
-      { path: '', component: BlankCmp }
-    ]);
+       router.resetConfig([
+         {
+           path: 'team/:id',
+           component: TeamCmp,
+           children: [
+             {path: 'user/:name', component: UserCmp},
+             {path: 'simple', component: SimpleCmp, outlet: 'right'}
+           ]
+         },
+         {path: '', component: BlankCmp}
+       ]);
 
-    router.navigateByUrl('/team/22/(user/victor//right:simple)');
-    advance(fixture);
+       router.navigateByUrl('/team/22/(user/victor//right:simple)');
+       advance(fixture);
 
-    router.navigateByUrl('/');
-    advance(fixture);
+       router.navigateByUrl('/');
+       advance(fixture);
 
-    expect(fixture.nativeElement).toHaveText('');
-  })));
+       expect(fixture.nativeElement).toHaveText('');
+     })));
 
   it('should set query params and fragment', fakeAsync(inject([Router], (router: Router) => {
-    const fixture = createRoot(router, RootCmp);
+       const fixture = createRoot(router, RootCmp);
 
-    router.resetConfig([{ path: 'query', component: QueryParamsAndFragmentCmp }]);
+       router.resetConfig([{path: 'query', component: QueryParamsAndFragmentCmp}]);
 
-    router.navigateByUrl('/query?name=1#fragment1');
-    advance(fixture);
-    expect(fixture.nativeElement).toHaveText('query: 1 fragment: fragment1');
+       router.navigateByUrl('/query?name=1#fragment1');
+       advance(fixture);
+       expect(fixture.nativeElement).toHaveText('query: 1 fragment: fragment1');
 
-    router.navigateByUrl('/query?name=2#fragment2');
-    advance(fixture);
-    expect(fixture.nativeElement).toHaveText('query: 2 fragment: fragment2');
-  })));
+       router.navigateByUrl('/query?name=2#fragment2');
+       advance(fixture);
+       expect(fixture.nativeElement).toHaveText('query: 2 fragment: fragment2');
+     })));
 
   it('should ignore null and undefined query params',
-    fakeAsync(inject([Router], (router: Router) => {
-      const fixture = createRoot(router, RootCmp);
+     fakeAsync(inject([Router], (router: Router) => {
+       const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{ path: 'query', component: EmptyQueryParamsCmp }]);
+       router.resetConfig([{path: 'query', component: EmptyQueryParamsCmp}]);
 
-      router.navigate(['query'], { queryParams: { name: 1, age: null, page: undefined } });
-      advance(fixture);
-      const cmp = fixture.debugElement.children[1].componentInstance;
-      expect(cmp.recordedParams).toEqual([{ name: '1' }]);
-    })));
+       router.navigate(['query'], {queryParams: {name: 1, age: null, page: undefined}});
+       advance(fixture);
+       const cmp = fixture.debugElement.children[1].componentInstance;
+       expect(cmp.recordedParams).toEqual([{name: '1'}]);
+     })));
 
   it('should throw an error when one of the commands is null/undefined',
-    fakeAsync(inject([Router], (router: Router) => {
-      createRoot(router, RootCmp);
+     fakeAsync(inject([Router], (router: Router) => {
+       createRoot(router, RootCmp);
 
-      router.resetConfig([{ path: 'query', component: EmptyQueryParamsCmp }]);
+       router.resetConfig([{path: 'query', component: EmptyQueryParamsCmp}]);
 
-      expect(() => router.navigate([
-        undefined, 'query'
-      ])).toThrowError(`The requested path contains undefined segment at index 0`);
-    })));
+       expect(() => router.navigate([
+         undefined, 'query'
+       ])).toThrowError(`The requested path contains undefined segment at index 0`);
+     })));
 
   it('should push params only when they change', fakeAsync(inject([Router], (router: Router) => {
-    const fixture = createRoot(router, RootCmp);
+       const fixture = createRoot(router, RootCmp);
 
-    router.resetConfig([{
-      path: 'team/:id',
-      component: TeamCmp,
-      children: [{ path: 'user/:name', component: UserCmp }]
-    }]);
+       router.resetConfig([{
+         path: 'team/:id',
+         component: TeamCmp,
+         children: [{path: 'user/:name', component: UserCmp}]
+       }]);
 
-    router.navigateByUrl('/team/22/user/victor');
-    advance(fixture);
-    const team = fixture.debugElement.children[1].componentInstance;
-    const user = fixture.debugElement.children[1].children[1].componentInstance;
+       router.navigateByUrl('/team/22/user/victor');
+       advance(fixture);
+       const team = fixture.debugElement.children[1].componentInstance;
+       const user = fixture.debugElement.children[1].children[1].componentInstance;
 
-    expect(team.recordedParams).toEqual([{ id: '22' }]);
-    expect(team.snapshotParams).toEqual([{ id: '22' }]);
-    expect(user.recordedParams).toEqual([{ name: 'victor' }]);
-    expect(user.snapshotParams).toEqual([{ name: 'victor' }]);
+       expect(team.recordedParams).toEqual([{id: '22'}]);
+       expect(team.snapshotParams).toEqual([{id: '22'}]);
+       expect(user.recordedParams).toEqual([{name: 'victor'}]);
+       expect(user.snapshotParams).toEqual([{name: 'victor'}]);
 
-    router.navigateByUrl('/team/22/user/fedor');
-    advance(fixture);
+       router.navigateByUrl('/team/22/user/fedor');
+       advance(fixture);
 
-    expect(team.recordedParams).toEqual([{ id: '22' }]);
-    expect(team.snapshotParams).toEqual([{ id: '22' }]);
-    expect(user.recordedParams).toEqual([{ name: 'victor' }, { name: 'fedor' }]);
-    expect(user.snapshotParams).toEqual([{ name: 'victor' }, { name: 'fedor' }]);
-  })));
+       expect(team.recordedParams).toEqual([{id: '22'}]);
+       expect(team.snapshotParams).toEqual([{id: '22'}]);
+       expect(user.recordedParams).toEqual([{name: 'victor'}, {name: 'fedor'}]);
+       expect(user.snapshotParams).toEqual([{name: 'victor'}, {name: 'fedor'}]);
+     })));
 
   it('should work when navigating to /', fakeAsync(inject([Router], (router: Router) => {
-    const fixture = createRoot(router, RootCmp);
+       const fixture = createRoot(router, RootCmp);
 
-    router.resetConfig([
-      { path: '', pathMatch: 'full', component: SimpleCmp },
-      { path: 'user/:name', component: UserCmp }
-    ]);
+       router.resetConfig([
+         {path: '', pathMatch: 'full', component: SimpleCmp},
+         {path: 'user/:name', component: UserCmp}
+       ]);
 
-    router.navigateByUrl('/user/victor');
-    advance(fixture);
+       router.navigateByUrl('/user/victor');
+       advance(fixture);
 
-    expect(fixture.nativeElement).toHaveText('user victor');
+       expect(fixture.nativeElement).toHaveText('user victor');
 
-    router.navigateByUrl('/');
-    advance(fixture);
+       router.navigateByUrl('/');
+       advance(fixture);
 
-    expect(fixture.nativeElement).toHaveText('simple');
-  })));
+       expect(fixture.nativeElement).toHaveText('simple');
+     })));
 
   it('should cancel in-flight navigations', fakeAsync(inject([Router], (router: Router) => {
-    const fixture = createRoot(router, RootCmp);
+       const fixture = createRoot(router, RootCmp);
 
-    router.resetConfig([{ path: 'user/:name', component: UserCmp }]);
+       router.resetConfig([{path: 'user/:name', component: UserCmp}]);
 
-    const recordedEvents: any[] = [];
-    router.events.forEach(e => recordedEvents.push(e));
+       const recordedEvents: any[] = [];
+       router.events.forEach(e => recordedEvents.push(e));
 
-    router.navigateByUrl('/user/init');
-    advance(fixture);
+       router.navigateByUrl('/user/init');
+       advance(fixture);
 
-    const user = fixture.debugElement.children[1].componentInstance;
+       const user = fixture.debugElement.children[1].componentInstance;
 
-    let r1: any, r2: any;
-    router.navigateByUrl('/user/victor')!.then(_ => r1 = _);
-    router.navigateByUrl('/user/fedor')!.then(_ => r2 = _);
-    advance(fixture);
+       let r1: any, r2: any;
+       router.navigateByUrl('/user/victor') !.then(_ => r1 = _);
+       router.navigateByUrl('/user/fedor') !.then(_ => r2 = _);
+       advance(fixture);
 
-    expect(r1).toEqual(false);  // returns false because it was canceled
-    expect(r2).toEqual(true);   // returns true because it was successful
+       expect(r1).toEqual(false);  // returns false because it was canceled
+       expect(r2).toEqual(true);   // returns true because it was successful
 
-    expect(fixture.nativeElement).toHaveText('user fedor');
-    expect(user.recordedParams).toEqual([{ name: 'init' }, { name: 'fedor' }]);
+       expect(fixture.nativeElement).toHaveText('user fedor');
+       expect(user.recordedParams).toEqual([{name: 'init'}, {name: 'fedor'}]);
 
-    expectEvents(recordedEvents, [
-      [NavigationStart, '/user/init'],
-      [RoutesRecognized, '/user/init'],
-      [GuardsCheckStart, '/user/init'],
-      [ChildActivationStart],
-      [ActivationStart],
-      [GuardsCheckEnd, '/user/init'],
-      [ResolveStart, '/user/init'],
-      [ResolveEnd, '/user/init'],
-      [ActivationEnd],
-      [ChildActivationEnd],
-      [NavigationEnd, '/user/init'],
+       expectEvents(recordedEvents, [
+         [NavigationStart, '/user/init'],
+         [RoutesRecognized, '/user/init'],
+         [GuardsCheckStart, '/user/init'],
+         [ChildActivationStart],
+         [ActivationStart],
+         [GuardsCheckEnd, '/user/init'],
+         [ResolveStart, '/user/init'],
+         [ResolveEnd, '/user/init'],
+         [ActivationEnd],
+         [ChildActivationEnd],
+         [NavigationEnd, '/user/init'],
 
-      [NavigationStart, '/user/victor'],
-      [NavigationCancel, '/user/victor'],
+         [NavigationStart, '/user/victor'],
+         [NavigationCancel, '/user/victor'],
 
-      [NavigationStart, '/user/fedor'],
-      [RoutesRecognized, '/user/fedor'],
-      [GuardsCheckStart, '/user/fedor'],
-      [ChildActivationStart],
-      [ActivationStart],
-      [GuardsCheckEnd, '/user/fedor'],
-      [ResolveStart, '/user/fedor'],
-      [ResolveEnd, '/user/fedor'],
-      [ActivationEnd],
-      [ChildActivationEnd],
-      [NavigationEnd, '/user/fedor']
-    ]);
-  })));
+         [NavigationStart, '/user/fedor'],
+         [RoutesRecognized, '/user/fedor'],
+         [GuardsCheckStart, '/user/fedor'],
+         [ChildActivationStart],
+         [ActivationStart],
+         [GuardsCheckEnd, '/user/fedor'],
+         [ResolveStart, '/user/fedor'],
+         [ResolveEnd, '/user/fedor'],
+         [ActivationEnd],
+         [ChildActivationEnd],
+         [NavigationEnd, '/user/fedor']
+       ]);
+     })));
 
   it('should handle failed navigations gracefully', fakeAsync(inject([Router], (router: Router) => {
-    const fixture = createRoot(router, RootCmp);
+       const fixture = createRoot(router, RootCmp);
 
-    router.resetConfig([{ path: 'user/:name', component: UserCmp }]);
+       router.resetConfig([{path: 'user/:name', component: UserCmp}]);
 
-    const recordedEvents: any[] = [];
-    router.events.forEach(e => recordedEvents.push(e));
+       const recordedEvents: any[] = [];
+       router.events.forEach(e => recordedEvents.push(e));
 
-    let e: any;
-    router.navigateByUrl('/invalid')!.catch(_ => e = _);
-    advance(fixture);
-    expect(e.message).toContain('Cannot match any routes');
+       let e: any;
+       router.navigateByUrl('/invalid') !.catch(_ => e = _);
+       advance(fixture);
+       expect(e.message).toContain('Cannot match any routes');
 
-    router.navigateByUrl('/user/fedor');
-    advance(fixture);
+       router.navigateByUrl('/user/fedor');
+       advance(fixture);
 
-    expect(fixture.nativeElement).toHaveText('user fedor');
+       expect(fixture.nativeElement).toHaveText('user fedor');
 
-    expectEvents(recordedEvents, [
-      [NavigationStart, '/invalid'], [NavigationError, '/invalid'],
+       expectEvents(recordedEvents, [
+         [NavigationStart, '/invalid'], [NavigationError, '/invalid'],
 
-      [NavigationStart, '/user/fedor'], [RoutesRecognized, '/user/fedor'],
-      [GuardsCheckStart, '/user/fedor'], [ChildActivationStart], [ActivationStart],
-      [GuardsCheckEnd, '/user/fedor'], [ResolveStart, '/user/fedor'],
-      [ResolveEnd, '/user/fedor'], [ActivationEnd], [ChildActivationEnd],
-      [NavigationEnd, '/user/fedor']
-    ]);
-  })));
+         [NavigationStart, '/user/fedor'], [RoutesRecognized, '/user/fedor'],
+         [GuardsCheckStart, '/user/fedor'], [ChildActivationStart], [ActivationStart],
+         [GuardsCheckEnd, '/user/fedor'], [ResolveStart, '/user/fedor'],
+         [ResolveEnd, '/user/fedor'], [ActivationEnd], [ChildActivationEnd],
+         [NavigationEnd, '/user/fedor']
+       ]);
+     })));
 
   // Errors should behave the same for both deferred and eager URL update strategies
   ['deferred', 'eager'].forEach((strat: any) => {
     it('should dispatch NavigationError after the url has been reset back', fakeAsync(() => {
-      const router: Router = TestBed.get(Router);
-      const location: SpyLocation = TestBed.get(Location);
-      const fixture = createRoot(router, RootCmp);
+         const router: Router = TestBed.get(Router);
+         const location: SpyLocation = TestBed.get(Location);
+         const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig(
-        [{ path: 'simple', component: SimpleCmp }, { path: 'throwing', component: ThrowingCmp }]);
-      router.urlUpdateStrategy = strat;
+         router.resetConfig(
+             [{path: 'simple', component: SimpleCmp}, {path: 'throwing', component: ThrowingCmp}]);
+         router.urlUpdateStrategy = strat;
 
-      router.navigateByUrl('/simple');
-      advance(fixture);
+         router.navigateByUrl('/simple');
+         advance(fixture);
 
-      let routerUrlBeforeEmittingError = '';
-      let locationUrlBeforeEmittingError = '';
-      router.events.forEach(e => {
-        if (e instanceof NavigationError) {
-          routerUrlBeforeEmittingError = router.url;
-          locationUrlBeforeEmittingError = location.path();
-        }
-      });
+         let routerUrlBeforeEmittingError = '';
+         let locationUrlBeforeEmittingError = '';
+         router.events.forEach(e => {
+           if (e instanceof NavigationError) {
+             routerUrlBeforeEmittingError = router.url;
+             locationUrlBeforeEmittingError = location.path();
+           }
+         });
 
-      router.navigateByUrl('/throwing').catch(() => null);
-      advance(fixture);
+         router.navigateByUrl('/throwing').catch(() => null);
+         advance(fixture);
 
-      expect(routerUrlBeforeEmittingError).toEqual('/simple');
-      expect(locationUrlBeforeEmittingError).toEqual('/simple');
-    }));
+         expect(routerUrlBeforeEmittingError).toEqual('/simple');
+         expect(locationUrlBeforeEmittingError).toEqual('/simple');
+       }));
 
     it('should reset the url with the right state when navigation errors', fakeAsync(() => {
-      const router: Router = TestBed.get(Router);
-      const location: SpyLocation = TestBed.get(Location);
-      const fixture = createRoot(router, RootCmp);
+         const router: Router = TestBed.get(Router);
+         const location: SpyLocation = TestBed.get(Location);
+         const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([
-        { path: 'simple1', component: SimpleCmp }, { path: 'simple2', component: SimpleCmp },
-        { path: 'throwing', component: ThrowingCmp }
-      ]);
-      router.urlUpdateStrategy = strat;
+         router.resetConfig([
+           {path: 'simple1', component: SimpleCmp}, {path: 'simple2', component: SimpleCmp},
+           {path: 'throwing', component: ThrowingCmp}
+         ]);
+         router.urlUpdateStrategy = strat;
 
-      let event: NavigationStart;
-      router.events.subscribe(e => {
-        if (e instanceof NavigationStart) {
-          event = e;
-        }
-      });
+         let event: NavigationStart;
+         router.events.subscribe(e => {
+           if (e instanceof NavigationStart) {
+             event = e;
+           }
+         });
 
-      router.navigateByUrl('/simple1');
-      advance(fixture);
-      const simple1NavStart = event!;
+         router.navigateByUrl('/simple1');
+         advance(fixture);
+         const simple1NavStart = event !;
 
-      router.navigateByUrl('/throwing').catch(() => null);
-      advance(fixture);
+         router.navigateByUrl('/throwing').catch(() => null);
+         advance(fixture);
 
-      router.navigateByUrl('/simple2');
-      advance(fixture);
+         router.navigateByUrl('/simple2');
+         advance(fixture);
 
-      location.back();
-      tick();
+         location.back();
+         tick();
 
-      expect(event!.restoredState!.navigationId).toEqual(simple1NavStart.id);
-    }));
+         expect(event !.restoredState !.navigationId).toEqual(simple1NavStart.id);
+       }));
 
     it('should not trigger another navigation when resetting the url back due to a NavigationError',
-      fakeAsync(() => {
-        const router = TestBed.get(Router);
-        router.onSameUrlNavigation = 'reload';
+       fakeAsync(() => {
+         const router = TestBed.get(Router);
+         router.onSameUrlNavigation = 'reload';
 
-        const fixture = createRoot(router, RootCmp);
+         const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig(
-          [{ path: 'simple', component: SimpleCmp }, { path: 'throwing', component: ThrowingCmp }]);
-        router.urlUpdateStrategy = strat;
+         router.resetConfig(
+             [{path: 'simple', component: SimpleCmp}, {path: 'throwing', component: ThrowingCmp}]);
+         router.urlUpdateStrategy = strat;
 
-        const events: any[] = [];
-        router.events.forEach((e: any) => {
-          if (e instanceof NavigationStart) {
-            events.push(e.url);
-          }
-        });
+         const events: any[] = [];
+         router.events.forEach((e: any) => {
+           if (e instanceof NavigationStart) {
+             events.push(e.url);
+           }
+         });
 
-        router.navigateByUrl('/simple');
-        advance(fixture);
+         router.navigateByUrl('/simple');
+         advance(fixture);
 
-        router.navigateByUrl('/throwing').catch(() => null);
-        advance(fixture);
+         router.navigateByUrl('/throwing').catch(() => null);
+         advance(fixture);
 
-        // we do not trigger another navigation to /simple
-        expect(events).toEqual(['/simple', '/throwing']);
-      }));
+         // we do not trigger another navigation to /simple
+         expect(events).toEqual(['/simple', '/throwing']);
+       }));
 
   });
 
   it('should dispatch NavigationCancel after the url has been reset back', fakeAsync(() => {
-    TestBed.configureTestingModule(
-      { providers: [{ provide: 'returnsFalse', useValue: () => false }] });
+       TestBed.configureTestingModule(
+           {providers: [{provide: 'returnsFalse', useValue: () => false}]});
 
-    const router: Router = TestBed.get(Router);
-    const location: SpyLocation = TestBed.get(Location);
+       const router: Router = TestBed.get(Router);
+       const location: SpyLocation = TestBed.get(Location);
 
-    const fixture = createRoot(router, RootCmp);
+       const fixture = createRoot(router, RootCmp);
 
-    router.resetConfig([
-      { path: 'simple', component: SimpleCmp },
-      { path: 'throwing', loadChildren: 'doesnotmatter', canLoad: ['returnsFalse'] }
-    ]);
+       router.resetConfig([
+         {path: 'simple', component: SimpleCmp},
+         {path: 'throwing', loadChildren: 'doesnotmatter', canLoad: ['returnsFalse']}
+       ]);
 
-    router.navigateByUrl('/simple');
-    advance(fixture);
+       router.navigateByUrl('/simple');
+       advance(fixture);
 
-    let routerUrlBeforeEmittingError = '';
-    let locationUrlBeforeEmittingError = '';
-    router.events.forEach(e => {
-      if (e instanceof NavigationCancel) {
-        routerUrlBeforeEmittingError = router.url;
-        locationUrlBeforeEmittingError = location.path();
-      }
-    });
+       let routerUrlBeforeEmittingError = '';
+       let locationUrlBeforeEmittingError = '';
+       router.events.forEach(e => {
+         if (e instanceof NavigationCancel) {
+           routerUrlBeforeEmittingError = router.url;
+           locationUrlBeforeEmittingError = location.path();
+         }
+       });
 
-    location.simulateHashChange('/throwing');
-    advance(fixture);
+       location.simulateHashChange('/throwing');
+       advance(fixture);
 
-    expect(routerUrlBeforeEmittingError).toEqual('/simple');
-    expect(locationUrlBeforeEmittingError).toEqual('/simple');
-  }));
+       expect(routerUrlBeforeEmittingError).toEqual('/simple');
+       expect(locationUrlBeforeEmittingError).toEqual('/simple');
+     }));
 
   it('should support custom error handlers', fakeAsync(inject([Router], (router: Router) => {
-    router.errorHandler = (error) => 'resolvedValue';
-    const fixture = createRoot(router, RootCmp);
+       router.errorHandler = (error) => 'resolvedValue';
+       const fixture = createRoot(router, RootCmp);
 
-    router.resetConfig([{ path: 'user/:name', component: UserCmp }]);
+       router.resetConfig([{path: 'user/:name', component: UserCmp}]);
 
-    const recordedEvents: any[] = [];
-    router.events.forEach(e => recordedEvents.push(e));
+       const recordedEvents: any[] = [];
+       router.events.forEach(e => recordedEvents.push(e));
 
-    let e: any;
-    router.navigateByUrl('/invalid')!.then(_ => e = _);
-    advance(fixture);
-    expect(e).toEqual('resolvedValue');
+       let e: any;
+       router.navigateByUrl('/invalid') !.then(_ => e = _);
+       advance(fixture);
+       expect(e).toEqual('resolvedValue');
 
-    expectEvents(recordedEvents, [[NavigationStart, '/invalid'], [NavigationError, '/invalid']]);
-  })));
+       expectEvents(recordedEvents, [[NavigationStart, '/invalid'], [NavigationError, '/invalid']]);
+     })));
 
   it('should recover from malformed uri errors',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      router.resetConfig([{ path: 'simple', component: SimpleCmp }]);
-      const fixture = createRoot(router, RootCmp);
-      router.navigateByUrl('/invalid/url%with%percent');
-      advance(fixture);
-      expect(location.path()).toEqual('/');
-    })));
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       router.resetConfig([{path: 'simple', component: SimpleCmp}]);
+       const fixture = createRoot(router, RootCmp);
+       router.navigateByUrl('/invalid/url%with%percent');
+       advance(fixture);
+       expect(location.path()).toEqual('/');
+     })));
 
   it('should support custom malformed uri error handler',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const customMalformedUriErrorHandler =
-        (e: URIError, urlSerializer: UrlSerializer, url: string):
-          UrlTree => { return urlSerializer.parse('/?error=The-URL-you-went-to-is-invalid'); };
-      router.malformedUriErrorHandler = customMalformedUriErrorHandler;
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       const customMalformedUriErrorHandler =
+           (e: URIError, urlSerializer: UrlSerializer, url: string):
+               UrlTree => { return urlSerializer.parse('/?error=The-URL-you-went-to-is-invalid'); };
+       router.malformedUriErrorHandler = customMalformedUriErrorHandler;
 
-      router.resetConfig([{ path: 'simple', component: SimpleCmp }]);
+       router.resetConfig([{path: 'simple', component: SimpleCmp}]);
 
-      const fixture = createRoot(router, RootCmp);
-      router.navigateByUrl('/invalid/url%with%percent');
-      advance(fixture);
-      expect(location.path()).toEqual('/?error=The-URL-you-went-to-is-invalid');
-    })));
+       const fixture = createRoot(router, RootCmp);
+       router.navigateByUrl('/invalid/url%with%percent');
+       advance(fixture);
+       expect(location.path()).toEqual('/?error=The-URL-you-went-to-is-invalid');
+     })));
 
   it('should not swallow errors', fakeAsync(inject([Router], (router: Router) => {
-    const fixture = createRoot(router, RootCmp);
+       const fixture = createRoot(router, RootCmp);
 
-    router.resetConfig([{ path: 'simple', component: SimpleCmp }]);
+       router.resetConfig([{path: 'simple', component: SimpleCmp}]);
 
-    router.navigateByUrl('/invalid');
-    expect(() => advance(fixture)).toThrow();
+       router.navigateByUrl('/invalid');
+       expect(() => advance(fixture)).toThrow();
 
-    router.navigateByUrl('/invalid2');
-    expect(() => advance(fixture)).toThrow();
-  })));
+       router.navigateByUrl('/invalid2');
+       expect(() => advance(fixture)).toThrow();
+     })));
 
 
   it('should replace state when path is equal to current path',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const fixture = createRoot(router, RootCmp);
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{
-        path: 'team/:id',
-        component: TeamCmp,
-        children:
-          [{ path: 'simple', component: SimpleCmp }, { path: 'user/:name', component: UserCmp }]
-      }]);
+       router.resetConfig([{
+         path: 'team/:id',
+         component: TeamCmp,
+         children:
+             [{path: 'simple', component: SimpleCmp}, {path: 'user/:name', component: UserCmp}]
+       }]);
 
-      router.navigateByUrl('/team/33/simple');
-      advance(fixture);
+       router.navigateByUrl('/team/33/simple');
+       advance(fixture);
 
-      router.navigateByUrl('/team/22/user/victor');
-      advance(fixture);
+       router.navigateByUrl('/team/22/user/victor');
+       advance(fixture);
 
-      router.navigateByUrl('/team/22/user/victor');
-      advance(fixture);
+       router.navigateByUrl('/team/22/user/victor');
+       advance(fixture);
 
-      location.back();
-      advance(fixture);
-      expect(location.path()).toEqual('/team/33/simple');
-    })));
+       location.back();
+       advance(fixture);
+       expect(location.path()).toEqual('/team/33/simple');
+     })));
 
   it('should handle componentless paths',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const fixture = createRoot(router, RootCmpWithTwoOutlets);
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       const fixture = createRoot(router, RootCmpWithTwoOutlets);
 
-      router.resetConfig([
-        {
-          path: 'parent/:id',
-          children: [
-            { path: 'simple', component: SimpleCmp },
-            { path: 'user/:name', component: UserCmp, outlet: 'right' }
-          ]
-        },
-        { path: 'user/:name', component: UserCmp }
-      ]);
+       router.resetConfig([
+         {
+           path: 'parent/:id',
+           children: [
+             {path: 'simple', component: SimpleCmp},
+             {path: 'user/:name', component: UserCmp, outlet: 'right'}
+           ]
+         },
+         {path: 'user/:name', component: UserCmp}
+       ]);
 
 
-      // navigate to a componentless route
-      router.navigateByUrl('/parent/11/(simple//right:user/victor)');
-      advance(fixture);
-      expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
-      expect(fixture.nativeElement).toHaveText('primary [simple] right [user victor]');
+       // navigate to a componentless route
+       router.navigateByUrl('/parent/11/(simple//right:user/victor)');
+       advance(fixture);
+       expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
+       expect(fixture.nativeElement).toHaveText('primary [simple] right [user victor]');
 
-      // navigate to the same route with different params (reuse)
-      router.navigateByUrl('/parent/22/(simple//right:user/fedor)');
-      advance(fixture);
-      expect(location.path()).toEqual('/parent/22/(simple//right:user/fedor)');
-      expect(fixture.nativeElement).toHaveText('primary [simple] right [user fedor]');
+       // navigate to the same route with different params (reuse)
+       router.navigateByUrl('/parent/22/(simple//right:user/fedor)');
+       advance(fixture);
+       expect(location.path()).toEqual('/parent/22/(simple//right:user/fedor)');
+       expect(fixture.nativeElement).toHaveText('primary [simple] right [user fedor]');
 
-      // navigate to a normal route (check deactivation)
-      router.navigateByUrl('/user/victor');
-      advance(fixture);
-      expect(location.path()).toEqual('/user/victor');
-      expect(fixture.nativeElement).toHaveText('primary [user victor] right []');
+       // navigate to a normal route (check deactivation)
+       router.navigateByUrl('/user/victor');
+       advance(fixture);
+       expect(location.path()).toEqual('/user/victor');
+       expect(fixture.nativeElement).toHaveText('primary [user victor] right []');
 
-      // navigate back to a componentless route
-      router.navigateByUrl('/parent/11/(simple//right:user/victor)');
-      advance(fixture);
-      expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
-      expect(fixture.nativeElement).toHaveText('primary [simple] right [user victor]');
-    })));
+       // navigate back to a componentless route
+       router.navigateByUrl('/parent/11/(simple//right:user/victor)');
+       advance(fixture);
+       expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
+       expect(fixture.nativeElement).toHaveText('primary [simple] right [user victor]');
+     })));
 
   it('should not deactivate aux routes when navigating from a componentless routes',
-    fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const fixture = createRoot(router, TwoOutletsCmp);
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       const fixture = createRoot(router, TwoOutletsCmp);
 
-      router.resetConfig([
-        { path: 'simple', component: SimpleCmp },
-        { path: 'componentless', children: [{ path: 'simple', component: SimpleCmp }] },
-        { path: 'user/:name', outlet: 'aux', component: UserCmp }
-      ]);
+       router.resetConfig([
+         {path: 'simple', component: SimpleCmp},
+         {path: 'componentless', children: [{path: 'simple', component: SimpleCmp}]},
+         {path: 'user/:name', outlet: 'aux', component: UserCmp}
+       ]);
 
-      router.navigateByUrl('/componentless/simple(aux:user/victor)');
-      advance(fixture);
-      expect(location.path()).toEqual('/componentless/simple(aux:user/victor)');
-      expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
+       router.navigateByUrl('/componentless/simple(aux:user/victor)');
+       advance(fixture);
+       expect(location.path()).toEqual('/componentless/simple(aux:user/victor)');
+       expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
 
-      router.navigateByUrl('/simple(aux:user/victor)');
-      advance(fixture);
-      expect(location.path()).toEqual('/simple(aux:user/victor)');
-      expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
-    })));
+       router.navigateByUrl('/simple(aux:user/victor)');
+       advance(fixture);
+       expect(location.path()).toEqual('/simple(aux:user/victor)');
+       expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
+     })));
 
   it('should emit an event when an outlet gets activated', fakeAsync(() => {
-    @Component({
-      selector: 'container',
-      template:
-        `<router-outlet (activate)="recordActivate($event)" (deactivate)="recordDeactivate($event)"></router-outlet>`
-    })
-    class Container {
-      activations: any[] = [];
-      deactivations: any[] = [];
+       @Component({
+         selector: 'container',
+         template:
+             `<router-outlet (activate)="recordActivate($event)" (deactivate)="recordDeactivate($event)"></router-outlet>`
+       })
+       class Container {
+         activations: any[] = [];
+         deactivations: any[] = [];
 
-      recordActivate(component: any): void { this.activations.push(component); }
+         recordActivate(component: any): void { this.activations.push(component); }
 
-      recordDeactivate(component: any): void { this.deactivations.push(component); }
-    }
+         recordDeactivate(component: any): void { this.deactivations.push(component); }
+       }
 
-    TestBed.configureTestingModule({ declarations: [Container] });
+       TestBed.configureTestingModule({declarations: [Container]});
 
-    const router: Router = TestBed.get(Router);
+       const router: Router = TestBed.get(Router);
 
-    const fixture = createRoot(router, Container);
-    const cmp = fixture.componentInstance;
+       const fixture = createRoot(router, Container);
+       const cmp = fixture.componentInstance;
 
-    router.resetConfig(
-      [{ path: 'blank', component: BlankCmp }, { path: 'simple', component: SimpleCmp }]);
+       router.resetConfig(
+           [{path: 'blank', component: BlankCmp}, {path: 'simple', component: SimpleCmp}]);
 
-    cmp.activations = [];
-    cmp.deactivations = [];
+       cmp.activations = [];
+       cmp.deactivations = [];
 
-    router.navigateByUrl('/blank');
-    advance(fixture);
+       router.navigateByUrl('/blank');
+       advance(fixture);
 
-    expect(cmp.activations.length).toEqual(1);
-    expect(cmp.activations[0] instanceof BlankCmp).toBe(true);
+       expect(cmp.activations.length).toEqual(1);
+       expect(cmp.activations[0] instanceof BlankCmp).toBe(true);
 
-    router.navigateByUrl('/simple');
-    advance(fixture);
+       router.navigateByUrl('/simple');
+       advance(fixture);
 
-    expect(cmp.activations.length).toEqual(2);
-    expect(cmp.activations[1] instanceof SimpleCmp).toBe(true);
-    expect(cmp.deactivations.length).toEqual(1);
-    expect(cmp.deactivations[0] instanceof BlankCmp).toBe(true);
-  }));
+       expect(cmp.activations.length).toEqual(2);
+       expect(cmp.activations[1] instanceof SimpleCmp).toBe(true);
+       expect(cmp.deactivations.length).toEqual(1);
+       expect(cmp.deactivations[0] instanceof BlankCmp).toBe(true);
+     }));
 
   it('should update url and router state before activating components',
-    fakeAsync(inject([Router], (router: Router) => {
+     fakeAsync(inject([Router], (router: Router) => {
 
-      const fixture = createRoot(router, RootCmp);
+       const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{ path: 'cmp', component: ComponentRecordingRoutePathAndUrl }]);
+       router.resetConfig([{path: 'cmp', component: ComponentRecordingRoutePathAndUrl}]);
 
-      router.navigateByUrl('/cmp');
-      advance(fixture);
+       router.navigateByUrl('/cmp');
+       advance(fixture);
 
-      const cmp = fixture.debugElement.children[1].componentInstance;
+       const cmp = fixture.debugElement.children[1].componentInstance;
 
-      expect(cmp.url).toBe('/cmp');
-      expect(cmp.path.length).toEqual(2);
-    })));
+       expect(cmp.url).toBe('/cmp');
+       expect(cmp.path.length).toEqual(2);
+     })));
 
 
 
@@ -1277,138 +1277,138 @@ describe('Integration', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         providers: [
-          { provide: 'resolveTwo', useValue: (a: any, b: any) => 2 },
-          { provide: 'resolveFour', useValue: (a: any, b: any) => 4 },
-          { provide: 'resolveSix', useClass: ResolveSix },
-          { provide: 'resolveError', useValue: (a: any, b: any) => Promise.reject('error') },
-          { provide: 'resolveNullError', useValue: (a: any, b: any) => Promise.reject(null) },
-          { provide: 'numberOfUrlSegments', useValue: (a: any, b: any) => a.url.length },
+          {provide: 'resolveTwo', useValue: (a: any, b: any) => 2},
+          {provide: 'resolveFour', useValue: (a: any, b: any) => 4},
+          {provide: 'resolveSix', useClass: ResolveSix},
+          {provide: 'resolveError', useValue: (a: any, b: any) => Promise.reject('error')},
+          {provide: 'resolveNullError', useValue: (a: any, b: any) => Promise.reject(null)},
+          {provide: 'numberOfUrlSegments', useValue: (a: any, b: any) => a.url.length},
         ]
       });
     });
 
     it('should provide resolved data', fakeAsync(inject([Router], (router: Router) => {
-      const fixture = createRoot(router, RootCmpWithTwoOutlets);
+         const fixture = createRoot(router, RootCmpWithTwoOutlets);
 
-      router.resetConfig([{
-        path: 'parent/:id',
-        data: { one: 1 },
-        resolve: { two: 'resolveTwo' },
-        children: [
-          { path: '', data: { three: 3 }, resolve: { four: 'resolveFour' }, component: RouteCmp }, {
-            path: '',
-            data: { five: 5 },
-            resolve: { six: 'resolveSix' },
-            component: RouteCmp,
-            outlet: 'right'
-          }
-        ]
-      }]);
+         router.resetConfig([{
+           path: 'parent/:id',
+           data: {one: 1},
+           resolve: {two: 'resolveTwo'},
+           children: [
+             {path: '', data: {three: 3}, resolve: {four: 'resolveFour'}, component: RouteCmp}, {
+               path: '',
+               data: {five: 5},
+               resolve: {six: 'resolveSix'},
+               component: RouteCmp,
+               outlet: 'right'
+             }
+           ]
+         }]);
 
-      router.navigateByUrl('/parent/1');
-      advance(fixture);
+         router.navigateByUrl('/parent/1');
+         advance(fixture);
 
-      const primaryCmp = fixture.debugElement.children[1].componentInstance;
-      const rightCmp = fixture.debugElement.children[3].componentInstance;
+         const primaryCmp = fixture.debugElement.children[1].componentInstance;
+         const rightCmp = fixture.debugElement.children[3].componentInstance;
 
-      expect(primaryCmp.route.snapshot.data).toEqual({ one: 1, two: 2, three: 3, four: 4 });
-      expect(rightCmp.route.snapshot.data).toEqual({ one: 1, two: 2, five: 5, six: 6 });
+         expect(primaryCmp.route.snapshot.data).toEqual({one: 1, two: 2, three: 3, four: 4});
+         expect(rightCmp.route.snapshot.data).toEqual({one: 1, two: 2, five: 5, six: 6});
 
-      const primaryRecorded: any[] = [];
-      primaryCmp.route.data.forEach((rec: any) => primaryRecorded.push(rec));
+         const primaryRecorded: any[] = [];
+         primaryCmp.route.data.forEach((rec: any) => primaryRecorded.push(rec));
 
-      const rightRecorded: any[] = [];
-      rightCmp.route.data.forEach((rec: any) => rightRecorded.push(rec));
+         const rightRecorded: any[] = [];
+         rightCmp.route.data.forEach((rec: any) => rightRecorded.push(rec));
 
-      router.navigateByUrl('/parent/2');
-      advance(fixture);
+         router.navigateByUrl('/parent/2');
+         advance(fixture);
 
-      expect(primaryRecorded).toEqual([{ one: 1, three: 3, two: 2, four: 4 }]);
-      expect(rightRecorded).toEqual([{ one: 1, five: 5, two: 2, six: 6 }]);
-    })));
+         expect(primaryRecorded).toEqual([{one: 1, three: 3, two: 2, four: 4}]);
+         expect(rightRecorded).toEqual([{one: 1, five: 5, two: 2, six: 6}]);
+       })));
 
     it('should handle errors', fakeAsync(inject([Router], (router: Router) => {
-      const fixture = createRoot(router, RootCmp);
+         const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig(
-        [{ path: 'simple', component: SimpleCmp, resolve: { error: 'resolveError' } }]);
+         router.resetConfig(
+             [{path: 'simple', component: SimpleCmp, resolve: {error: 'resolveError'}}]);
 
-      const recordedEvents: any[] = [];
-      router.events.subscribe(e => e instanceof RouterEvent && recordedEvents.push(e));
+         const recordedEvents: any[] = [];
+         router.events.subscribe(e => e instanceof RouterEvent && recordedEvents.push(e));
 
-      let e: any = null;
-      router.navigateByUrl('/simple')!.catch(error => e = error);
-      advance(fixture);
+         let e: any = null;
+         router.navigateByUrl('/simple') !.catch(error => e = error);
+         advance(fixture);
 
-      expectEvents(recordedEvents, [
-        [NavigationStart, '/simple'], [RoutesRecognized, '/simple'],
-        [GuardsCheckStart, '/simple'], [GuardsCheckEnd, '/simple'], [ResolveStart, '/simple'],
-        [NavigationError, '/simple']
-      ]);
+         expectEvents(recordedEvents, [
+           [NavigationStart, '/simple'], [RoutesRecognized, '/simple'],
+           [GuardsCheckStart, '/simple'], [GuardsCheckEnd, '/simple'], [ResolveStart, '/simple'],
+           [NavigationError, '/simple']
+         ]);
 
-      expect(e).toEqual('error');
-    })));
+         expect(e).toEqual('error');
+       })));
 
     it('should handle empty errors', fakeAsync(inject([Router], (router: Router) => {
-      const fixture = createRoot(router, RootCmp);
+         const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig(
-        [{ path: 'simple', component: SimpleCmp, resolve: { error: 'resolveNullError' } }]);
+         router.resetConfig(
+             [{path: 'simple', component: SimpleCmp, resolve: {error: 'resolveNullError'}}]);
 
-      const recordedEvents: any[] = [];
-      router.events.subscribe(e => e instanceof RouterEvent && recordedEvents.push(e));
+         const recordedEvents: any[] = [];
+         router.events.subscribe(e => e instanceof RouterEvent && recordedEvents.push(e));
 
-      let e: any = 'some value';
-      router.navigateByUrl('/simple').catch(error => e = error);
-      advance(fixture);
+         let e: any = 'some value';
+         router.navigateByUrl('/simple').catch(error => e = error);
+         advance(fixture);
 
-      expect(e).toEqual(null);
-    })));
+         expect(e).toEqual(null);
+       })));
 
     it('should preserve resolved data', fakeAsync(inject([Router], (router: Router) => {
-      const fixture = createRoot(router, RootCmp);
+         const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{
-        path: 'parent',
-        resolve: { two: 'resolveTwo' },
-        children: [
-          { path: 'child1', component: CollectParamsCmp },
-          { path: 'child2', component: CollectParamsCmp }
-        ]
-      }]);
+         router.resetConfig([{
+           path: 'parent',
+           resolve: {two: 'resolveTwo'},
+           children: [
+             {path: 'child1', component: CollectParamsCmp},
+             {path: 'child2', component: CollectParamsCmp}
+           ]
+         }]);
 
-      const e: any = null;
-      router.navigateByUrl('/parent/child1');
-      advance(fixture);
+         const e: any = null;
+         router.navigateByUrl('/parent/child1');
+         advance(fixture);
 
-      router.navigateByUrl('/parent/child2');
-      advance(fixture);
+         router.navigateByUrl('/parent/child2');
+         advance(fixture);
 
-      const cmp = fixture.debugElement.children[1].componentInstance;
-      expect(cmp.route.snapshot.data).toEqual({ two: 2 });
-    })));
+         const cmp = fixture.debugElement.children[1].componentInstance;
+         expect(cmp.route.snapshot.data).toEqual({two: 2});
+       })));
 
     it('should rerun resolvers when the urls segments of a wildcard route change',
-      fakeAsync(inject([Router, Location], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+       fakeAsync(inject([Router, Location], (router: Router) => {
+         const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([{
-          path: '**',
-          component: CollectParamsCmp,
-          resolve: { numberOfUrlSegments: 'numberOfUrlSegments' }
-        }]);
+         router.resetConfig([{
+           path: '**',
+           component: CollectParamsCmp,
+           resolve: {numberOfUrlSegments: 'numberOfUrlSegments'}
+         }]);
 
-        router.navigateByUrl('/one/two');
-        advance(fixture);
-        const cmp = fixture.debugElement.children[1].componentInstance;
+         router.navigateByUrl('/one/two');
+         advance(fixture);
+         const cmp = fixture.debugElement.children[1].componentInstance;
 
-        expect(cmp.route.snapshot.data).toEqual({ numberOfUrlSegments: 2 });
+         expect(cmp.route.snapshot.data).toEqual({numberOfUrlSegments: 2});
 
-        router.navigateByUrl('/one/two/three');
-        advance(fixture);
+         router.navigateByUrl('/one/two/three');
+         advance(fixture);
 
-        expect(cmp.route.snapshot.data).toEqual({ numberOfUrlSegments: 3 });
-      })));
+         expect(cmp.route.snapshot.data).toEqual({numberOfUrlSegments: 3});
+       })));
 
     describe('should run resolvers for the same route concurrently', () => {
       let log: string[];
@@ -1423,7 +1423,7 @@ describe('Integration', () => {
               useValue: () => {
                 const obs$ = new Observable((obs: Observer<any>) => {
                   observer = obs;
-                  return () => { };
+                  return () => {};
                 });
                 return obs$.pipe(map(() => log.push('resolver1')));
               }
@@ -1431,7 +1431,7 @@ describe('Integration', () => {
             {
               provide: 'resolver2',
               useValue: () => {
-                return of(null).pipe(map(() => {
+                return of (null).pipe(map(() => {
                   log.push('resolver2');
                   observer.next(null);
                   observer.complete();
@@ -1443,365 +1443,365 @@ describe('Integration', () => {
       });
 
       it('works', fakeAsync(inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+           const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([{
-          path: 'a',
-          resolve: {
-            one: 'resolver1',
-            two: 'resolver2',
-          },
-          component: SimpleCmp
-        }]);
+           router.resetConfig([{
+             path: 'a',
+             resolve: {
+               one: 'resolver1',
+               two: 'resolver2',
+             },
+             component: SimpleCmp
+           }]);
 
-        router.navigateByUrl('/a');
-        advance(fixture);
+           router.navigateByUrl('/a');
+           advance(fixture);
 
-        expect(log).toEqual(['resolver2', 'resolver1']);
-      })));
+           expect(log).toEqual(['resolver2', 'resolver1']);
+         })));
     });
   });
 
   describe('router links', () => {
     it('should support skipping location update for anchor router links',
-      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = TestBed.createComponent(RootCmp);
-        advance(fixture);
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = TestBed.createComponent(RootCmp);
+         advance(fixture);
 
-        router.resetConfig([{ path: 'team/:id', component: TeamCmp }]);
+         router.resetConfig([{path: 'team/:id', component: TeamCmp}]);
 
-        router.navigateByUrl('/team/22');
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22');
-        expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
+         router.navigateByUrl('/team/22');
+         advance(fixture);
+         expect(location.path()).toEqual('/team/22');
+         expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
-        const teamCmp = fixture.debugElement.childNodes[1].componentInstance;
+         const teamCmp = fixture.debugElement.childNodes[1].componentInstance;
 
-        teamCmp.routerLink = ['/team/0'];
-        advance(fixture);
-        const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
-        anchor.click();
-        advance(fixture);
-        expect(fixture.nativeElement).toHaveText('team 0 [ , right:  ]');
-        expect(location.path()).toEqual('/team/22');
+         teamCmp.routerLink = ['/team/0'];
+         advance(fixture);
+         const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
+         anchor.click();
+         advance(fixture);
+         expect(fixture.nativeElement).toHaveText('team 0 [ , right:  ]');
+         expect(location.path()).toEqual('/team/22');
 
-        teamCmp.routerLink = ['/team/1'];
-        advance(fixture);
-        const button = fixture.debugElement.query(By.css('button')).nativeElement;
-        button.click();
-        advance(fixture);
-        expect(fixture.nativeElement).toHaveText('team 1 [ , right:  ]');
-        expect(location.path()).toEqual('/team/22');
-      })));
+         teamCmp.routerLink = ['/team/1'];
+         advance(fixture);
+         const button = fixture.debugElement.query(By.css('button')).nativeElement;
+         button.click();
+         advance(fixture);
+         expect(fixture.nativeElement).toHaveText('team 1 [ , right:  ]');
+         expect(location.path()).toEqual('/team/22');
+       })));
 
     it('should support string router links', fakeAsync(inject([Router], (router: Router) => {
-      const fixture = createRoot(router, RootCmp);
+         const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{
-        path: 'team/:id',
-        component: TeamCmp,
-        children: [
-          { path: 'link', component: StringLinkCmp }, { path: 'simple', component: SimpleCmp }
-        ]
-      }]);
+         router.resetConfig([{
+           path: 'team/:id',
+           component: TeamCmp,
+           children: [
+             {path: 'link', component: StringLinkCmp}, {path: 'simple', component: SimpleCmp}
+           ]
+         }]);
 
-      router.navigateByUrl('/team/22/link');
-      advance(fixture);
-      expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
+         router.navigateByUrl('/team/22/link');
+         advance(fixture);
+         expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
-      const native = fixture.nativeElement.querySelector('a');
-      expect(native.getAttribute('href')).toEqual('/team/33/simple');
-      expect(native.getAttribute('target')).toEqual('_self');
-      native.click();
-      advance(fixture);
+         const native = fixture.nativeElement.querySelector('a');
+         expect(native.getAttribute('href')).toEqual('/team/33/simple');
+         expect(native.getAttribute('target')).toEqual('_self');
+         native.click();
+         advance(fixture);
 
-      expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
-    })));
+         expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
+       })));
 
     it('should not preserve query params and fragment by default', fakeAsync(() => {
-      @Component({
-        selector: 'someRoot',
-        template: `<router-outlet></router-outlet><a routerLink="/home">Link</a>`
-      })
-      class RootCmpWithLink {
-      }
+         @Component({
+           selector: 'someRoot',
+           template: `<router-outlet></router-outlet><a routerLink="/home">Link</a>`
+         })
+         class RootCmpWithLink {
+         }
 
-      TestBed.configureTestingModule({ declarations: [RootCmpWithLink] });
-      const router: Router = TestBed.get(Router);
+         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
+         const router: Router = TestBed.get(Router);
 
-      const fixture = createRoot(router, RootCmpWithLink);
+         const fixture = createRoot(router, RootCmpWithLink);
 
-      router.resetConfig([{ path: 'home', component: SimpleCmp }]);
+         router.resetConfig([{path: 'home', component: SimpleCmp}]);
 
-      const native = fixture.nativeElement.querySelector('a');
+         const native = fixture.nativeElement.querySelector('a');
 
-      router.navigateByUrl('/home?q=123#fragment');
-      advance(fixture);
-      expect(native.getAttribute('href')).toEqual('/home');
-    }));
+         router.navigateByUrl('/home?q=123#fragment');
+         advance(fixture);
+         expect(native.getAttribute('href')).toEqual('/home');
+       }));
 
     it('should not throw when commands is null', fakeAsync(() => {
-      @Component({
-        selector: 'someCmp',
-        template:
-          `<router-outlet></router-outlet><a [routerLink]="null">Link</a><button [routerLink]="null">Button</button>`
-      })
-      class CmpWithLink {
-      }
+         @Component({
+           selector: 'someCmp',
+           template:
+               `<router-outlet></router-outlet><a [routerLink]="null">Link</a><button [routerLink]="null">Button</button>`
+         })
+         class CmpWithLink {
+         }
 
-      TestBed.configureTestingModule({ declarations: [CmpWithLink] });
-      const router: Router = TestBed.get(Router);
+         TestBed.configureTestingModule({declarations: [CmpWithLink]});
+         const router: Router = TestBed.get(Router);
 
-      let fixture: ComponentFixture<CmpWithLink> = createRoot(router, CmpWithLink);
-      router.resetConfig([{ path: 'home', component: SimpleCmp }]);
-      const anchor = fixture.nativeElement.querySelector('a');
-      const button = fixture.nativeElement.querySelector('button');
-      expect(() => anchor.click()).not.toThrow();
-      expect(() => button.click()).not.toThrow();
-    }));
+         let fixture: ComponentFixture<CmpWithLink> = createRoot(router, CmpWithLink);
+         router.resetConfig([{path: 'home', component: SimpleCmp}]);
+         const anchor = fixture.nativeElement.querySelector('a');
+         const button = fixture.nativeElement.querySelector('button');
+         expect(() => anchor.click()).not.toThrow();
+         expect(() => button.click()).not.toThrow();
+       }));
 
     it('should update hrefs when query params or fragment change', fakeAsync(() => {
 
-      @Component({
-        selector: 'someRoot',
-        template:
-          `<router-outlet></router-outlet><a routerLink="/home" preserveQueryParams preserveFragment>Link</a>`
-      })
-      class RootCmpWithLink {
-      }
-      TestBed.configureTestingModule({ declarations: [RootCmpWithLink] });
-      const router: Router = TestBed.get(Router);
-      const fixture = createRoot(router, RootCmpWithLink);
+         @Component({
+           selector: 'someRoot',
+           template:
+               `<router-outlet></router-outlet><a routerLink="/home" preserveQueryParams preserveFragment>Link</a>`
+         })
+         class RootCmpWithLink {
+         }
+         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
+         const router: Router = TestBed.get(Router);
+         const fixture = createRoot(router, RootCmpWithLink);
 
-      router.resetConfig([{ path: 'home', component: SimpleCmp }]);
+         router.resetConfig([{path: 'home', component: SimpleCmp}]);
 
-      const native = fixture.nativeElement.querySelector('a');
+         const native = fixture.nativeElement.querySelector('a');
 
-      router.navigateByUrl('/home?q=123');
-      advance(fixture);
-      expect(native.getAttribute('href')).toEqual('/home?q=123');
+         router.navigateByUrl('/home?q=123');
+         advance(fixture);
+         expect(native.getAttribute('href')).toEqual('/home?q=123');
 
-      router.navigateByUrl('/home?q=456');
-      advance(fixture);
-      expect(native.getAttribute('href')).toEqual('/home?q=456');
+         router.navigateByUrl('/home?q=456');
+         advance(fixture);
+         expect(native.getAttribute('href')).toEqual('/home?q=456');
 
-      router.navigateByUrl('/home?q=456#1');
-      advance(fixture);
-      expect(native.getAttribute('href')).toEqual('/home?q=456#1');
-    }));
+         router.navigateByUrl('/home?q=456#1');
+         advance(fixture);
+         expect(native.getAttribute('href')).toEqual('/home?q=456#1');
+       }));
 
     it('should correctly use the preserve strategy', fakeAsync(() => {
 
-      @Component({
-        selector: 'someRoot',
-        template:
-          `<router-outlet></router-outlet><a routerLink="/home" [queryParams]="{q: 456}" queryParamsHandling="preserve">Link</a>`
-      })
-      class RootCmpWithLink {
-      }
-      TestBed.configureTestingModule({ declarations: [RootCmpWithLink] });
-      const router: Router = TestBed.get(Router);
-      const fixture = createRoot(router, RootCmpWithLink);
+         @Component({
+           selector: 'someRoot',
+           template:
+               `<router-outlet></router-outlet><a routerLink="/home" [queryParams]="{q: 456}" queryParamsHandling="preserve">Link</a>`
+         })
+         class RootCmpWithLink {
+         }
+         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
+         const router: Router = TestBed.get(Router);
+         const fixture = createRoot(router, RootCmpWithLink);
 
-      router.resetConfig([{ path: 'home', component: SimpleCmp }]);
+         router.resetConfig([{path: 'home', component: SimpleCmp}]);
 
-      const native = fixture.nativeElement.querySelector('a');
+         const native = fixture.nativeElement.querySelector('a');
 
-      router.navigateByUrl('/home?a=123');
-      advance(fixture);
-      expect(native.getAttribute('href')).toEqual('/home?a=123');
-    }));
+         router.navigateByUrl('/home?a=123');
+         advance(fixture);
+         expect(native.getAttribute('href')).toEqual('/home?a=123');
+       }));
 
     it('should correctly use the merge strategy', fakeAsync(() => {
 
-      @Component({
-        selector: 'someRoot',
-        template:
-          `<router-outlet></router-outlet><a routerLink="/home" [queryParams]="{removeMe: null, q: 456}" queryParamsHandling="merge">Link</a>`
-      })
-      class RootCmpWithLink {
-      }
-      TestBed.configureTestingModule({ declarations: [RootCmpWithLink] });
-      const router: Router = TestBed.get(Router);
-      const fixture = createRoot(router, RootCmpWithLink);
+         @Component({
+           selector: 'someRoot',
+           template:
+               `<router-outlet></router-outlet><a routerLink="/home" [queryParams]="{removeMe: null, q: 456}" queryParamsHandling="merge">Link</a>`
+         })
+         class RootCmpWithLink {
+         }
+         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
+         const router: Router = TestBed.get(Router);
+         const fixture = createRoot(router, RootCmpWithLink);
 
-      router.resetConfig([{ path: 'home', component: SimpleCmp }]);
+         router.resetConfig([{path: 'home', component: SimpleCmp}]);
 
-      const native = fixture.nativeElement.querySelector('a');
+         const native = fixture.nativeElement.querySelector('a');
 
-      router.navigateByUrl('/home?a=123&removeMe=123');
-      advance(fixture);
-      expect(native.getAttribute('href')).toEqual('/home?a=123&q=456');
-    }));
+         router.navigateByUrl('/home?a=123&removeMe=123');
+         advance(fixture);
+         expect(native.getAttribute('href')).toEqual('/home?a=123&q=456');
+       }));
 
     it('should support using links on non-a tags', fakeAsync(inject([Router], (router: Router) => {
-      const fixture = createRoot(router, RootCmp);
+         const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{
-        path: 'team/:id',
-        component: TeamCmp,
-        children: [
-          { path: 'link', component: StringLinkButtonCmp },
-          { path: 'simple', component: SimpleCmp }
-        ]
-      }]);
+         router.resetConfig([{
+           path: 'team/:id',
+           component: TeamCmp,
+           children: [
+             {path: 'link', component: StringLinkButtonCmp},
+             {path: 'simple', component: SimpleCmp}
+           ]
+         }]);
 
-      router.navigateByUrl('/team/22/link');
-      advance(fixture);
-      expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
+         router.navigateByUrl('/team/22/link');
+         advance(fixture);
+         expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
-      const button = fixture.nativeElement.querySelector('button');
-      expect(button.getAttribute('tabindex')).toEqual('0');
-      button.click();
-      advance(fixture);
+         const button = fixture.nativeElement.querySelector('button');
+         expect(button.getAttribute('tabindex')).toEqual('0');
+         button.click();
+         advance(fixture);
 
-      expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
-    })));
+         expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
+       })));
 
     it('should support absolute router links', fakeAsync(inject([Router], (router: Router) => {
-      const fixture = createRoot(router, RootCmp);
+         const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{
-        path: 'team/:id',
-        component: TeamCmp,
-        children: [
-          { path: 'link', component: AbsoluteLinkCmp }, { path: 'simple', component: SimpleCmp }
-        ]
-      }]);
+         router.resetConfig([{
+           path: 'team/:id',
+           component: TeamCmp,
+           children: [
+             {path: 'link', component: AbsoluteLinkCmp}, {path: 'simple', component: SimpleCmp}
+           ]
+         }]);
 
-      router.navigateByUrl('/team/22/link');
-      advance(fixture);
-      expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
+         router.navigateByUrl('/team/22/link');
+         advance(fixture);
+         expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
-      const native = fixture.nativeElement.querySelector('a');
-      expect(native.getAttribute('href')).toEqual('/team/33/simple');
-      native.click();
-      advance(fixture);
+         const native = fixture.nativeElement.querySelector('a');
+         expect(native.getAttribute('href')).toEqual('/team/33/simple');
+         native.click();
+         advance(fixture);
 
-      expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
-    })));
+         expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
+       })));
 
     it('should support relative router links', fakeAsync(inject([Router], (router: Router) => {
-      const fixture = createRoot(router, RootCmp);
+         const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([{
-        path: 'team/:id',
-        component: TeamCmp,
-        children: [
-          { path: 'link', component: RelativeLinkCmp }, { path: 'simple', component: SimpleCmp }
-        ]
-      }]);
+         router.resetConfig([{
+           path: 'team/:id',
+           component: TeamCmp,
+           children: [
+             {path: 'link', component: RelativeLinkCmp}, {path: 'simple', component: SimpleCmp}
+           ]
+         }]);
 
-      router.navigateByUrl('/team/22/link');
-      advance(fixture);
-      expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
+         router.navigateByUrl('/team/22/link');
+         advance(fixture);
+         expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
-      const native = fixture.nativeElement.querySelector('a');
-      expect(native.getAttribute('href')).toEqual('/team/22/simple');
-      native.click();
-      advance(fixture);
+         const native = fixture.nativeElement.querySelector('a');
+         expect(native.getAttribute('href')).toEqual('/team/22/simple');
+         native.click();
+         advance(fixture);
 
-      expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
-    })));
+         expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
+       })));
 
     it('should support top-level link', fakeAsync(inject([Router], (router: Router) => {
-      const fixture = createRoot(router, RelativeLinkInIfCmp);
-      advance(fixture);
+         const fixture = createRoot(router, RelativeLinkInIfCmp);
+         advance(fixture);
 
-      router.resetConfig(
-        [{ path: 'simple', component: SimpleCmp }, { path: '', component: BlankCmp }]);
+         router.resetConfig(
+             [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]);
 
-      router.navigateByUrl('/');
-      advance(fixture);
-      expect(fixture.nativeElement).toHaveText('');
-      const cmp = fixture.componentInstance;
+         router.navigateByUrl('/');
+         advance(fixture);
+         expect(fixture.nativeElement).toHaveText('');
+         const cmp = fixture.componentInstance;
 
-      cmp.show = true;
-      advance(fixture);
+         cmp.show = true;
+         advance(fixture);
 
-      expect(fixture.nativeElement).toHaveText('link');
-      const native = fixture.nativeElement.querySelector('a');
+         expect(fixture.nativeElement).toHaveText('link');
+         const native = fixture.nativeElement.querySelector('a');
 
-      expect(native.getAttribute('href')).toEqual('/simple');
-      native.click();
-      advance(fixture);
+         expect(native.getAttribute('href')).toEqual('/simple');
+         native.click();
+         advance(fixture);
 
-      expect(fixture.nativeElement).toHaveText('linksimple');
-    })));
+         expect(fixture.nativeElement).toHaveText('linksimple');
+       })));
 
     it('should support query params and fragments',
-      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([{
-          path: 'team/:id',
-          component: TeamCmp,
-          children: [
-            { path: 'link', component: LinkWithQueryParamsAndFragment },
-            { path: 'simple', component: SimpleCmp }
-          ]
-        }]);
+         router.resetConfig([{
+           path: 'team/:id',
+           component: TeamCmp,
+           children: [
+             {path: 'link', component: LinkWithQueryParamsAndFragment},
+             {path: 'simple', component: SimpleCmp}
+           ]
+         }]);
 
-        router.navigateByUrl('/team/22/link');
-        advance(fixture);
+         router.navigateByUrl('/team/22/link');
+         advance(fixture);
 
-        const native = fixture.nativeElement.querySelector('a');
-        expect(native.getAttribute('href')).toEqual('/team/22/simple?q=1#f');
-        native.click();
-        advance(fixture);
+         const native = fixture.nativeElement.querySelector('a');
+         expect(native.getAttribute('href')).toEqual('/team/22/simple?q=1#f');
+         native.click();
+         advance(fixture);
 
-        expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
+         expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
 
-        expect(location.path()).toEqual('/team/22/simple?q=1#f');
-      })));
+         expect(location.path()).toEqual('/team/22/simple?q=1#f');
+       })));
   });
 
   describe('redirects', () => {
     it('should work', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-      const fixture = createRoot(router, RootCmp);
+         const fixture = createRoot(router, RootCmp);
 
-      router.resetConfig([
-        { path: 'old/team/:id', redirectTo: 'team/:id' }, { path: 'team/:id', component: TeamCmp }
-      ]);
+         router.resetConfig([
+           {path: 'old/team/:id', redirectTo: 'team/:id'}, {path: 'team/:id', component: TeamCmp}
+         ]);
 
-      router.navigateByUrl('old/team/22');
-      advance(fixture);
+         router.navigateByUrl('old/team/22');
+         advance(fixture);
 
-      expect(location.path()).toEqual('/team/22');
-    })));
+         expect(location.path()).toEqual('/team/22');
+       })));
 
     it('should not break the back button when trigger by location change',
-      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = TestBed.createComponent(RootCmp);
-        advance(fixture);
-        router.resetConfig([
-          { path: 'initial', component: BlankCmp }, { path: 'old/team/:id', redirectTo: 'team/:id' },
-          { path: 'team/:id', component: TeamCmp }
-        ]);
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = TestBed.createComponent(RootCmp);
+         advance(fixture);
+         router.resetConfig([
+           {path: 'initial', component: BlankCmp}, {path: 'old/team/:id', redirectTo: 'team/:id'},
+           {path: 'team/:id', component: TeamCmp}
+         ]);
 
-        location.go('initial');
-        location.go('old/team/22');
+         location.go('initial');
+         location.go('old/team/22');
 
-        // initial navigation
-        router.initialNavigation();
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22');
+         // initial navigation
+         router.initialNavigation();
+         advance(fixture);
+         expect(location.path()).toEqual('/team/22');
 
-        location.back();
-        advance(fixture);
-        expect(location.path()).toEqual('/initial');
+         location.back();
+         advance(fixture);
+         expect(location.path()).toEqual('/initial');
 
-        // location change
-        (<any>location).go('/old/team/33');
+         // location change
+         (<any>location).go('/old/team/33');
 
 
-        advance(fixture);
-        expect(location.path()).toEqual('/team/33');
+         advance(fixture);
+         expect(location.path()).toEqual('/team/33');
 
-        location.back();
-        advance(fixture);
-        expect(location.path()).toEqual('/initial');
-      })));
+         location.back();
+         advance(fixture);
+         expect(location.path()).toEqual('/initial');
+       })));
   });
 
   describe('guards', () => {
@@ -1809,74 +1809,80 @@ describe('Integration', () => {
       describe('should not activate a route when CanActivate returns false', () => {
         beforeEach(() => {
           TestBed.configureTestingModule(
-            { providers: [{ provide: 'alwaysFalse', useValue: (a: any, b: any) => false }] });
+              {providers: [{provide: 'alwaysFalse', useValue: (a: any, b: any) => false}]});
         });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          const recordedEvents: any[] = [];
-          router.events.forEach(e => recordedEvents.push(e));
+             const recordedEvents: any[] = [];
+             router.events.forEach(e => recordedEvents.push(e));
 
-          router.resetConfig(
-            [{ path: 'team/:id', component: TeamCmp, canActivate: ['alwaysFalse'] }]);
+             router.resetConfig(
+                 [{path: 'team/:id', component: TeamCmp, canActivate: ['alwaysFalse']}]);
 
-          router.navigateByUrl('/team/22');
-          advance(fixture);
+             router.navigateByUrl('/team/22');
+             advance(fixture);
 
-          expect(location.path()).toEqual('/');
-          expectEvents(recordedEvents, [
-            [NavigationStart, '/team/22'],
-            [RoutesRecognized, '/team/22'],
-            [GuardsCheckStart, '/team/22'],
-            [ChildActivationStart],
-            [ActivationStart],
-            [GuardsCheckEnd, '/team/22'],
-            [NavigationCancel, '/team/22'],
-          ]);
-          expect((recordedEvents[5] as GuardsCheckEnd).shouldActivate).toBe(false);
-        })));
+             expect(location.path()).toEqual('/');
+             expectEvents(recordedEvents, [
+               [NavigationStart, '/team/22'],
+               [RoutesRecognized, '/team/22'],
+               [GuardsCheckStart, '/team/22'],
+               [ChildActivationStart],
+               [ActivationStart],
+               [GuardsCheckEnd, '/team/22'],
+               [NavigationCancel, '/team/22'],
+             ]);
+             expect((recordedEvents[5] as GuardsCheckEnd).shouldActivate).toBe(false);
+           })));
       });
 
       describe(
-        'should not activate a route when CanActivate returns false (componentless route)',
-        () => {
-          beforeEach(() => {
-            TestBed.configureTestingModule(
-              { providers: [{ provide: 'alwaysFalse', useValue: (a: any, b: any) => false }] });
+          'should not activate a route when CanActivate returns false (componentless route)',
+          () => {
+            beforeEach(() => {
+              TestBed.configureTestingModule(
+                  {providers: [{provide: 'alwaysFalse', useValue: (a: any, b: any) => false}]});
+            });
+
+            it('works',
+               fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+                 const fixture = createRoot(router, RootCmp);
+
+                 router.resetConfig([{
+                   path: 'parent',
+                   canActivate: ['alwaysFalse'],
+                   children: [{path: 'team/:id', component: TeamCmp}]
+                 }]);
+
+                 router.navigateByUrl('parent/team/22');
+                 advance(fixture);
+
+                 expect(location.path()).toEqual('/');
+               })));
           });
-
-          it('works',
-            fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-              const fixture = createRoot(router, RootCmp);
-
-              router.resetConfig([{
-                path: 'parent',
-                canActivate: ['alwaysFalse'],
-                children: [{ path: 'team/:id', component: TeamCmp }]
-              }]);
-
-              router.navigateByUrl('parent/team/22');
-              advance(fixture);
-
-              expect(location.path()).toEqual('/');
-            })));
-        });
 
       describe('should activate a child wildcard route router outlet has yet to be mounted', () => {
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
-          router.resetConfig([{
-            path: 'teams',
-            component: BlankCmp,
-            children: [{ path: ':team-id', children: [{ path: '**', component: BlankCmp }] }]
-          }]);
-          router.navigateByUrl('/teams/22/members');
-          advance(fixture);
-          expect(location.path()).toEqual('/teams/22/members');
-          router.navigateByUrl('/teams/22/manage');
-          advance(fixture);
-          expect(location.path()).toEqual('/teams/22/manage');
+            const fixture = createRoot(router, RootCmp);
+            router.resetConfig([{
+                path: 'teams',
+                component: BlankCmp,
+                children: [{
+                    path: ':team-id',
+                    children: [{
+                        path: '**',
+                        component: BlankCmp
+                    }]
+                }]
+            }]);
+            router.navigateByUrl('/teams/22/members');
+            advance(fixture);
+            expect(location.path()).toEqual('/teams/22/members');
+            router.navigateByUrl('/teams/22/manage');
+            advance(fixture);
+            expect(location.path()).toEqual('/teams/22/manage');
         })));
       });
 
@@ -1891,16 +1897,16 @@ describe('Integration', () => {
         });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig(
-            [{ path: 'team/:id', component: TeamCmp, canActivate: ['alwaysTrue'] }]);
+             router.resetConfig(
+                 [{path: 'team/:id', component: TeamCmp, canActivate: ['alwaysTrue']}]);
 
-          router.navigateByUrl('/team/22');
-          advance(fixture);
+             router.navigateByUrl('/team/22');
+             advance(fixture);
 
-          expect(location.path()).toEqual('/team/22');
-        })));
+             expect(location.path()).toEqual('/team/22');
+           })));
       });
 
       describe('should work when given a class', () => {
@@ -1910,19 +1916,19 @@ describe('Integration', () => {
           }
         }
 
-        beforeEach(() => { TestBed.configureTestingModule({ providers: [AlwaysTrue] }); });
+        beforeEach(() => { TestBed.configureTestingModule({providers: [AlwaysTrue]}); });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig(
-            [{ path: 'team/:id', component: TeamCmp, canActivate: [AlwaysTrue] }]);
+             router.resetConfig(
+                 [{path: 'team/:id', component: TeamCmp, canActivate: [AlwaysTrue]}]);
 
-          router.navigateByUrl('/team/22');
-          advance(fixture);
+             router.navigateByUrl('/team/22');
+             advance(fixture);
 
-          expect(location.path()).toEqual('/team/22');
-        })));
+             expect(location.path()).toEqual('/team/22');
+           })));
       });
 
       describe('should work when returns an observable', () => {
@@ -1939,15 +1945,15 @@ describe('Integration', () => {
 
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig(
-            [{ path: 'team/:id', component: TeamCmp, canActivate: ['CanActivate'] }]);
+             router.resetConfig(
+                 [{path: 'team/:id', component: TeamCmp, canActivate: ['CanActivate']}]);
 
-          router.navigateByUrl('/team/22');
-          advance(fixture);
-          expect(location.path()).toEqual('/');
-        })));
+             router.navigateByUrl('/team/22');
+             advance(fixture);
+             expect(location.path()).toEqual('/');
+           })));
       });
 
       describe('should work when returns a promise', () => {
@@ -1968,19 +1974,19 @@ describe('Integration', () => {
 
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig(
-            [{ path: 'team/:id', component: TeamCmp, canActivate: ['CanActivate'] }]);
+             router.resetConfig(
+                 [{path: 'team/:id', component: TeamCmp, canActivate: ['CanActivate']}]);
 
-          router.navigateByUrl('/team/22');
-          advance(fixture);
-          expect(location.path()).toEqual('/team/22');
+             router.navigateByUrl('/team/22');
+             advance(fixture);
+             expect(location.path()).toEqual('/team/22');
 
-          router.navigateByUrl('/team/33');
-          advance(fixture);
-          expect(location.path()).toEqual('/team/22');
-        })));
+             router.navigateByUrl('/team/33');
+             advance(fixture);
+             expect(location.path()).toEqual('/team/22');
+           })));
       });
 
       describe('should reset the location when cancleling a navigation', () => {
@@ -1994,22 +2000,22 @@ describe('Integration', () => {
         });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([
-            { path: 'one', component: SimpleCmp },
-            { path: 'two', component: SimpleCmp, canActivate: ['alwaysFalse'] }
-          ]);
+             router.resetConfig([
+               {path: 'one', component: SimpleCmp},
+               {path: 'two', component: SimpleCmp, canActivate: ['alwaysFalse']}
+             ]);
 
-          router.navigateByUrl('/one');
-          advance(fixture);
-          expect(location.path()).toEqual('/one');
+             router.navigateByUrl('/one');
+             advance(fixture);
+             expect(location.path()).toEqual('/one');
 
-          location.go('/two');
-          advance(fixture);
-          expect(location.path()).toEqual('/one');
+             location.go('/two');
+             advance(fixture);
+             expect(location.path()).toEqual('/one');
 
-        })));
+           })));
       });
 
       describe('should redirect to / when guard returns false', () => {
@@ -2025,20 +2031,20 @@ describe('Integration', () => {
         }));
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          router.resetConfig([
-            {
-              path: '',
-              component: SimpleCmp,
-            },
-            { path: 'one', component: RouteCmp, canActivate: ['returnFalseAndNavigate'] }
-          ]);
+             router.resetConfig([
+               {
+                 path: '',
+                 component: SimpleCmp,
+               },
+               {path: 'one', component: RouteCmp, canActivate: ['returnFalseAndNavigate']}
+             ]);
 
-          const fixture = TestBed.createComponent(RootCmp);
-          router.navigateByUrl('/one');
-          advance(fixture);
-          expect(location.path()).toEqual('/');
-          expect(fixture.nativeElement).toHaveText('simple');
-        })));
+             const fixture = TestBed.createComponent(RootCmp);
+             router.navigateByUrl('/one');
+             advance(fixture);
+             expect(location.path()).toEqual('/');
+             expect(fixture.nativeElement).toHaveText('simple');
+           })));
       });
 
       describe('runGuardsAndResolvers', () => {
@@ -2057,13 +2063,13 @@ describe('Integration', () => {
                   return true;
                 }
               },
-              { provide: 'resolver', useValue: () => resolverRunCount++ }
+              {provide: 'resolver', useValue: () => resolverRunCount++}
             ]
           });
         });
 
         function configureRouter(router: Router, runGuardsAndResolvers: RunGuardsAndResolvers):
-          ComponentFixture<RootCmpWithTwoOutlets> {
+            ComponentFixture<RootCmpWithTwoOutlets> {
           const fixture = createRoot(router, RootCmpWithTwoOutlets);
 
           router.resetConfig([
@@ -2072,9 +2078,9 @@ describe('Integration', () => {
               runGuardsAndResolvers,
               component: RouteCmp,
               canActivate: ['guard'],
-              resolve: { data: 'resolver' }
+              resolve: {data: 'resolver'}
             },
-            { path: 'b', component: SimpleCmp, outlet: 'right' }
+            {path: 'b', component: SimpleCmp, outlet: 'right'}
           ]);
 
           router.navigateByUrl('/a');
@@ -2083,95 +2089,95 @@ describe('Integration', () => {
         }
 
         it('should rerun guards and resolvers when params change',
-          fakeAsync(inject([Router], (router: Router) => {
-            const fixture = configureRouter(router, 'paramsChange');
+           fakeAsync(inject([Router], (router: Router) => {
+             const fixture = configureRouter(router, 'paramsChange');
 
-            const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
-            const recordedData: any[] = [];
-            cmp.route.data.subscribe((data: any) => recordedData.push(data));
+             const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
+             const recordedData: any[] = [];
+             cmp.route.data.subscribe((data: any) => recordedData.push(data));
 
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{ data: 0 }]);
+             expect(guardRunCount).toEqual(1);
+             expect(recordedData).toEqual([{data: 0}]);
 
-            router.navigateByUrl('/a;p=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(2);
-            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }]);
+             router.navigateByUrl('/a;p=1');
+             advance(fixture);
+             expect(guardRunCount).toEqual(2);
+             expect(recordedData).toEqual([{data: 0}, {data: 1}]);
 
-            router.navigateByUrl('/a;p=2');
-            advance(fixture);
-            expect(guardRunCount).toEqual(3);
-            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }]);
+             router.navigateByUrl('/a;p=2');
+             advance(fixture);
+             expect(guardRunCount).toEqual(3);
+             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
 
-            router.navigateByUrl('/a;p=2?q=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(3);
-            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }]);
-          })));
+             router.navigateByUrl('/a;p=2?q=1');
+             advance(fixture);
+             expect(guardRunCount).toEqual(3);
+             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
+           })));
 
         it('should rerun guards and resolvers when query params change',
-          fakeAsync(inject([Router], (router: Router) => {
-            const fixture = configureRouter(router, 'paramsOrQueryParamsChange');
+           fakeAsync(inject([Router], (router: Router) => {
+             const fixture = configureRouter(router, 'paramsOrQueryParamsChange');
 
-            const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
-            const recordedData: any[] = [];
-            cmp.route.data.subscribe((data: any) => recordedData.push(data));
+             const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
+             const recordedData: any[] = [];
+             cmp.route.data.subscribe((data: any) => recordedData.push(data));
 
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{ data: 0 }]);
+             expect(guardRunCount).toEqual(1);
+             expect(recordedData).toEqual([{data: 0}]);
 
-            router.navigateByUrl('/a;p=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(2);
-            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }]);
+             router.navigateByUrl('/a;p=1');
+             advance(fixture);
+             expect(guardRunCount).toEqual(2);
+             expect(recordedData).toEqual([{data: 0}, {data: 1}]);
 
-            router.navigateByUrl('/a;p=2');
-            advance(fixture);
-            expect(guardRunCount).toEqual(3);
-            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }]);
+             router.navigateByUrl('/a;p=2');
+             advance(fixture);
+             expect(guardRunCount).toEqual(3);
+             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
 
-            router.navigateByUrl('/a;p=2?q=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(4);
-            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }, { data: 3 }]);
+             router.navigateByUrl('/a;p=2?q=1');
+             advance(fixture);
+             expect(guardRunCount).toEqual(4);
+             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}]);
 
-            router.navigateByUrl('/a;p=2(right:b)?q=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(4);
-            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }, { data: 3 }]);
-          })));
+             router.navigateByUrl('/a;p=2(right:b)?q=1');
+             advance(fixture);
+             expect(guardRunCount).toEqual(4);
+             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}]);
+           })));
 
         it('should always rerun guards and resolvers',
-          fakeAsync(inject([Router], (router: Router) => {
-            const fixture = configureRouter(router, 'always');
+           fakeAsync(inject([Router], (router: Router) => {
+             const fixture = configureRouter(router, 'always');
 
-            const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
-            const recordedData: any[] = [];
-            cmp.route.data.subscribe((data: any) => recordedData.push(data));
+             const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
+             const recordedData: any[] = [];
+             cmp.route.data.subscribe((data: any) => recordedData.push(data));
 
-            expect(guardRunCount).toEqual(1);
-            expect(recordedData).toEqual([{ data: 0 }]);
+             expect(guardRunCount).toEqual(1);
+             expect(recordedData).toEqual([{data: 0}]);
 
-            router.navigateByUrl('/a;p=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(2);
-            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }]);
+             router.navigateByUrl('/a;p=1');
+             advance(fixture);
+             expect(guardRunCount).toEqual(2);
+             expect(recordedData).toEqual([{data: 0}, {data: 1}]);
 
-            router.navigateByUrl('/a;p=2');
-            advance(fixture);
-            expect(guardRunCount).toEqual(3);
-            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }]);
+             router.navigateByUrl('/a;p=2');
+             advance(fixture);
+             expect(guardRunCount).toEqual(3);
+             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}]);
 
-            router.navigateByUrl('/a;p=2?q=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(4);
-            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }, { data: 3 }]);
+             router.navigateByUrl('/a;p=2?q=1');
+             advance(fixture);
+             expect(guardRunCount).toEqual(4);
+             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}]);
 
-            router.navigateByUrl('/a;p=2(right:b)?q=1');
-            advance(fixture);
-            expect(guardRunCount).toEqual(5);
-            expect(recordedData).toEqual([{ data: 0 }, { data: 1 }, { data: 2 }, { data: 3 }, { data: 4 }]);
-          })));
+             router.navigateByUrl('/a;p=2(right:b)?q=1');
+             advance(fixture);
+             expect(guardRunCount).toEqual(5);
+             expect(recordedData).toEqual([{data: 0}, {data: 1}, {data: 2}, {data: 3}, {data: 4}]);
+           })));
       });
 
       describe('should wait for parent to complete', () => {
@@ -2211,21 +2217,21 @@ describe('Integration', () => {
         }
 
         it('works', fakeAsync(inject([Router], (router: Router) => {
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([{
-            path: 'parent',
-            canActivate: ['parentGuard'],
-            children: [
-              { path: 'child', component: SimpleCmp, canActivate: ['childGuard'] },
-            ]
-          }]);
+             router.resetConfig([{
+               path: 'parent',
+               canActivate: ['parentGuard'],
+               children: [
+                 {path: 'child', component: SimpleCmp, canActivate: ['childGuard']},
+               ]
+             }]);
 
-          router.navigateByUrl('/parent/child');
-          advance(fixture);
-          tick(15);
-          expect(log).toEqual(['parent', 'child']);
-        })));
+             router.navigateByUrl('/parent/child');
+             advance(fixture);
+             tick(15);
+             expect(log).toEqual(['parent', 'child']);
+           })));
       });
     });
 
@@ -2258,14 +2264,14 @@ describe('Integration', () => {
             {
               provide: 'RecordingDeactivate',
               useValue: (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
-                log.push({ path: a.routeConfig!.path, component: c });
+                log.push({path: a.routeConfig !.path, component: c});
                 return true;
               }
             },
             {
               provide: 'alwaysFalse',
               useValue:
-                (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => { return false; }
+                  (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => { return false; }
             },
             {
               provide: 'alwaysFalseAndLogging',
@@ -2297,213 +2303,213 @@ describe('Integration', () => {
 
       describe('should not deactivate a route when CanDeactivate returns false', () => {
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig(
-            [{ path: 'team/:id', component: TeamCmp, canDeactivate: ['CanDeactivateTeam'] }]);
+             router.resetConfig(
+                 [{path: 'team/:id', component: TeamCmp, canDeactivate: ['CanDeactivateTeam']}]);
 
-          router.navigateByUrl('/team/22');
-          advance(fixture);
-          expect(location.path()).toEqual('/team/22');
+             router.navigateByUrl('/team/22');
+             advance(fixture);
+             expect(location.path()).toEqual('/team/22');
 
-          let successStatus: boolean = false;
-          router.navigateByUrl('/team/33')!.then(res => successStatus = res);
-          advance(fixture);
-          expect(location.path()).toEqual('/team/33');
-          expect(successStatus).toEqual(true);
+             let successStatus: boolean = false;
+             router.navigateByUrl('/team/33') !.then(res => successStatus = res);
+             advance(fixture);
+             expect(location.path()).toEqual('/team/33');
+             expect(successStatus).toEqual(true);
 
-          let canceledStatus: boolean = false;
-          router.navigateByUrl('/team/44')!.then(res => canceledStatus = res);
-          advance(fixture);
-          expect(location.path()).toEqual('/team/33');
-          expect(canceledStatus).toEqual(false);
-        })));
+             let canceledStatus: boolean = false;
+             router.navigateByUrl('/team/44') !.then(res => canceledStatus = res);
+             advance(fixture);
+             expect(location.path()).toEqual('/team/33');
+             expect(canceledStatus).toEqual(false);
+           })));
 
         it('works with componentless routes',
-          fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+           fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+             const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([
-              {
-                path: 'grandparent',
-                canDeactivate: ['RecordingDeactivate'],
-                children: [{
-                  path: 'parent',
-                  canDeactivate: ['RecordingDeactivate'],
-                  children: [{
-                    path: 'child',
-                    canDeactivate: ['RecordingDeactivate'],
-                    children: [{
-                      path: 'simple',
-                      component: SimpleCmp,
-                      canDeactivate: ['RecordingDeactivate']
-                    }]
-                  }]
-                }]
-              },
-              { path: 'simple', component: SimpleCmp }
-            ]);
+             router.resetConfig([
+               {
+                 path: 'grandparent',
+                 canDeactivate: ['RecordingDeactivate'],
+                 children: [{
+                   path: 'parent',
+                   canDeactivate: ['RecordingDeactivate'],
+                   children: [{
+                     path: 'child',
+                     canDeactivate: ['RecordingDeactivate'],
+                     children: [{
+                       path: 'simple',
+                       component: SimpleCmp,
+                       canDeactivate: ['RecordingDeactivate']
+                     }]
+                   }]
+                 }]
+               },
+               {path: 'simple', component: SimpleCmp}
+             ]);
 
-            router.navigateByUrl('/grandparent/parent/child/simple');
-            advance(fixture);
-            expect(location.path()).toEqual('/grandparent/parent/child/simple');
+             router.navigateByUrl('/grandparent/parent/child/simple');
+             advance(fixture);
+             expect(location.path()).toEqual('/grandparent/parent/child/simple');
 
-            router.navigateByUrl('/simple');
-            advance(fixture);
+             router.navigateByUrl('/simple');
+             advance(fixture);
 
-            const child = fixture.debugElement.children[1].componentInstance;
+             const child = fixture.debugElement.children[1].componentInstance;
 
-            expect(log.map((a: any) => a.path)).toEqual([
-              'simple', 'child', 'parent', 'grandparent'
-            ]);
-            expect(log.map((a: any) => a.component)).toEqual([child, null, null, null]);
-          })));
+             expect(log.map((a: any) => a.path)).toEqual([
+               'simple', 'child', 'parent', 'grandparent'
+             ]);
+             expect(log.map((a: any) => a.component)).toEqual([child, null, null, null]);
+           })));
 
         it('works with aux routes',
-          fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+           fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+             const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([{
-              path: 'two-outlets',
-              component: TwoOutletsCmp,
-              children: [
-                { path: 'a', component: BlankCmp }, {
-                  path: 'b',
-                  canDeactivate: ['RecordingDeactivate'],
-                  component: SimpleCmp,
-                  outlet: 'aux'
-                }
-              ]
-            }]);
+             router.resetConfig([{
+               path: 'two-outlets',
+               component: TwoOutletsCmp,
+               children: [
+                 {path: 'a', component: BlankCmp}, {
+                   path: 'b',
+                   canDeactivate: ['RecordingDeactivate'],
+                   component: SimpleCmp,
+                   outlet: 'aux'
+                 }
+               ]
+             }]);
 
-            router.navigateByUrl('/two-outlets/(a//aux:b)');
-            advance(fixture);
-            expect(location.path()).toEqual('/two-outlets/(a//aux:b)');
+             router.navigateByUrl('/two-outlets/(a//aux:b)');
+             advance(fixture);
+             expect(location.path()).toEqual('/two-outlets/(a//aux:b)');
 
-            router.navigate(['two-outlets', { outlets: { aux: null } }]);
-            advance(fixture);
+             router.navigate(['two-outlets', {outlets: {aux: null}}]);
+             advance(fixture);
 
-            expect(log.map((a: any) => a.path)).toEqual(['b']);
-            expect(location.path()).toEqual('/two-outlets/(a)');
-          })));
+             expect(log.map((a: any) => a.path)).toEqual(['b']);
+             expect(location.path()).toEqual('/two-outlets/(a)');
+           })));
 
         it('works with a nested route',
-          fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+           fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+             const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([{
-              path: 'team/:id',
-              component: TeamCmp,
-              children: [
-                { path: '', pathMatch: 'full', component: SimpleCmp },
-                { path: 'user/:name', component: UserCmp, canDeactivate: ['CanDeactivateUser'] }
-              ]
-            }]);
+             router.resetConfig([{
+               path: 'team/:id',
+               component: TeamCmp,
+               children: [
+                 {path: '', pathMatch: 'full', component: SimpleCmp},
+                 {path: 'user/:name', component: UserCmp, canDeactivate: ['CanDeactivateUser']}
+               ]
+             }]);
 
-            router.navigateByUrl('/team/22/user/victor');
-            advance(fixture);
+             router.navigateByUrl('/team/22/user/victor');
+             advance(fixture);
 
-            // this works because we can deactivate victor
-            router.navigateByUrl('/team/33');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/33');
+             // this works because we can deactivate victor
+             router.navigateByUrl('/team/33');
+             advance(fixture);
+             expect(location.path()).toEqual('/team/33');
 
-            router.navigateByUrl('/team/33/user/fedor');
-            advance(fixture);
+             router.navigateByUrl('/team/33/user/fedor');
+             advance(fixture);
 
-            // this doesn't work cause we cannot deactivate fedor
-            router.navigateByUrl('/team/44');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/33/user/fedor');
-          })));
+             // this doesn't work cause we cannot deactivate fedor
+             router.navigateByUrl('/team/44');
+             advance(fixture);
+             expect(location.path()).toEqual('/team/33/user/fedor');
+           })));
       });
 
       it('should not create a route state if navigation is canceled',
-        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+           const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([{
-            path: 'main',
-            component: TeamCmp,
-            children: [
-              { path: 'component1', component: SimpleCmp, canDeactivate: ['alwaysFalse'] },
-              { path: 'component2', component: SimpleCmp }
-            ]
-          }]);
+           router.resetConfig([{
+             path: 'main',
+             component: TeamCmp,
+             children: [
+               {path: 'component1', component: SimpleCmp, canDeactivate: ['alwaysFalse']},
+               {path: 'component2', component: SimpleCmp}
+             ]
+           }]);
 
-          router.navigateByUrl('/main/component1');
-          advance(fixture);
+           router.navigateByUrl('/main/component1');
+           advance(fixture);
 
-          router.navigateByUrl('/main/component2');
-          advance(fixture);
+           router.navigateByUrl('/main/component2');
+           advance(fixture);
 
-          const teamCmp = fixture.debugElement.children[1].componentInstance;
-          expect(teamCmp.route.firstChild.url.value[0].path).toEqual('component1');
-          expect(location.path()).toEqual('/main/component1');
-        })));
+           const teamCmp = fixture.debugElement.children[1].componentInstance;
+           expect(teamCmp.route.firstChild.url.value[0].path).toEqual('component1');
+           expect(location.path()).toEqual('/main/component1');
+         })));
 
       it('should not run CanActivate when CanDeactivate returns false',
-        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+           const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([{
-            path: 'main',
-            component: TeamCmp,
-            children: [
-              {
-                path: 'component1',
-                component: SimpleCmp,
-                canDeactivate: ['alwaysFalseWithDelayAndLogging']
-              },
-              {
-                path: 'component2',
-                component: SimpleCmp,
-                canActivate: ['canActivate_alwaysTrueAndLogging']
-              },
-            ]
-          }]);
+           router.resetConfig([{
+             path: 'main',
+             component: TeamCmp,
+             children: [
+               {
+                 path: 'component1',
+                 component: SimpleCmp,
+                 canDeactivate: ['alwaysFalseWithDelayAndLogging']
+               },
+               {
+                 path: 'component2',
+                 component: SimpleCmp,
+                 canActivate: ['canActivate_alwaysTrueAndLogging']
+               },
+             ]
+           }]);
 
-          router.navigateByUrl('/main/component1');
-          advance(fixture);
-          expect(location.path()).toEqual('/main/component1');
+           router.navigateByUrl('/main/component1');
+           advance(fixture);
+           expect(location.path()).toEqual('/main/component1');
 
-          router.navigateByUrl('/main/component2');
-          advance(fixture);
-          expect(location.path()).toEqual('/main/component1');
-          expect(log).toEqual(['called']);
-        })));
+           router.navigateByUrl('/main/component2');
+           advance(fixture);
+           expect(location.path()).toEqual('/main/component1');
+           expect(log).toEqual(['called']);
+         })));
 
       it('should call guards every time when navigating to the same url over and over again',
-        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+           const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([
-            { path: 'simple', component: SimpleCmp, canDeactivate: ['alwaysFalseAndLogging'] },
-            { path: 'blank', component: BlankCmp }
+           router.resetConfig([
+             {path: 'simple', component: SimpleCmp, canDeactivate: ['alwaysFalseAndLogging']},
+             {path: 'blank', component: BlankCmp}
 
-          ]);
+           ]);
 
-          router.navigateByUrl('/simple');
-          advance(fixture);
+           router.navigateByUrl('/simple');
+           advance(fixture);
 
-          router.navigateByUrl('/blank');
-          advance(fixture);
-          expect(log).toEqual(['called']);
-          expect(location.path()).toEqual('/simple');
+           router.navigateByUrl('/blank');
+           advance(fixture);
+           expect(log).toEqual(['called']);
+           expect(location.path()).toEqual('/simple');
 
-          router.navigateByUrl('/blank');
-          advance(fixture);
-          expect(log).toEqual(['called', 'called']);
-          expect(location.path()).toEqual('/simple');
-        })));
+           router.navigateByUrl('/blank');
+           advance(fixture);
+           expect(log).toEqual(['called', 'called']);
+           expect(location.path()).toEqual('/simple');
+         })));
 
       describe('next state', () => {
         let log: string[];
 
         class ClassWithNextState implements CanDeactivate<TeamCmp> {
           canDeactivate(
-            component: TeamCmp, currentRoute: ActivatedRouteSnapshot,
-            currentState: RouterStateSnapshot, nextState: RouterStateSnapshot): boolean {
+              component: TeamCmp, currentRoute: ActivatedRouteSnapshot,
+              currentState: RouterStateSnapshot, nextState: RouterStateSnapshot): boolean {
             log.push(currentState.url, nextState.url);
             return true;
           }
@@ -2516,7 +2522,7 @@ describe('Integration', () => {
               ClassWithNextState, {
                 provide: 'FunctionWithNextState',
                 useValue: (cmp: any, currentRoute: ActivatedRouteSnapshot,
-                  currentState: RouterStateSnapshot, nextState: RouterStateSnapshot) => {
+                           currentState: RouterStateSnapshot, nextState: RouterStateSnapshot) => {
                   log.push(currentState.url, nextState.url);
                   return true;
                 }
@@ -2526,66 +2532,66 @@ describe('Integration', () => {
         });
 
         it('should pass next state as the 4 argument when guard is a class',
-          fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+           fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+             const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig(
-              [{ path: 'team/:id', component: TeamCmp, canDeactivate: [ClassWithNextState] }]);
+             router.resetConfig(
+                 [{path: 'team/:id', component: TeamCmp, canDeactivate: [ClassWithNextState]}]);
 
-            router.navigateByUrl('/team/22');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/22');
+             router.navigateByUrl('/team/22');
+             advance(fixture);
+             expect(location.path()).toEqual('/team/22');
 
-            router.navigateByUrl('/team/33');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/33');
-            expect(log).toEqual(['/team/22', '/team/33']);
-          })));
+             router.navigateByUrl('/team/33');
+             advance(fixture);
+             expect(location.path()).toEqual('/team/33');
+             expect(log).toEqual(['/team/22', '/team/33']);
+           })));
 
         it('should pass next state as the 4 argument when guard is a function',
-          fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-            const fixture = createRoot(router, RootCmp);
+           fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+             const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([
-              { path: 'team/:id', component: TeamCmp, canDeactivate: ['FunctionWithNextState'] }
-            ]);
+             router.resetConfig([
+               {path: 'team/:id', component: TeamCmp, canDeactivate: ['FunctionWithNextState']}
+             ]);
 
-            router.navigateByUrl('/team/22');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/22');
+             router.navigateByUrl('/team/22');
+             advance(fixture);
+             expect(location.path()).toEqual('/team/22');
 
-            router.navigateByUrl('/team/33');
-            advance(fixture);
-            expect(location.path()).toEqual('/team/33');
-            expect(log).toEqual(['/team/22', '/team/33']);
-          })));
+             router.navigateByUrl('/team/33');
+             advance(fixture);
+             expect(location.path()).toEqual('/team/33');
+             expect(log).toEqual(['/team/22', '/team/33']);
+           })));
       });
 
       describe('should work when given a class', () => {
         class AlwaysTrue implements CanDeactivate<TeamCmp> {
           canDeactivate(
-            component: TeamCmp, route: ActivatedRouteSnapshot,
-            state: RouterStateSnapshot): boolean {
+              component: TeamCmp, route: ActivatedRouteSnapshot,
+              state: RouterStateSnapshot): boolean {
             return true;
           }
         }
 
-        beforeEach(() => { TestBed.configureTestingModule({ providers: [AlwaysTrue] }); });
+        beforeEach(() => { TestBed.configureTestingModule({providers: [AlwaysTrue]}); });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig(
-            [{ path: 'team/:id', component: TeamCmp, canDeactivate: [AlwaysTrue] }]);
+             router.resetConfig(
+                 [{path: 'team/:id', component: TeamCmp, canDeactivate: [AlwaysTrue]}]);
 
-          router.navigateByUrl('/team/22');
-          advance(fixture);
-          expect(location.path()).toEqual('/team/22');
+             router.navigateByUrl('/team/22');
+             advance(fixture);
+             expect(location.path()).toEqual('/team/22');
 
-          router.navigateByUrl('/team/33');
-          advance(fixture);
-          expect(location.path()).toEqual('/team/33');
-        })));
+             router.navigateByUrl('/team/33');
+             advance(fixture);
+             expect(location.path()).toEqual('/team/33');
+           })));
       });
 
 
@@ -2602,19 +2608,19 @@ describe('Integration', () => {
         });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig(
-            [{ path: 'team/:id', component: TeamCmp, canDeactivate: ['CanDeactivate'] }]);
+             router.resetConfig(
+                 [{path: 'team/:id', component: TeamCmp, canDeactivate: ['CanDeactivate']}]);
 
-          router.navigateByUrl('/team/22');
-          advance(fixture);
-          expect(location.path()).toEqual('/team/22');
+             router.navigateByUrl('/team/22');
+             advance(fixture);
+             expect(location.path()).toEqual('/team/22');
 
-          router.navigateByUrl('/team/33');
-          advance(fixture);
-          expect(location.path()).toEqual('/team/22');
-        })));
+             router.navigateByUrl('/team/33');
+             advance(fixture);
+             expect(location.path()).toEqual('/team/22');
+           })));
       });
     });
 
@@ -2630,66 +2636,66 @@ describe('Integration', () => {
         });
 
         it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([{
-            path: '',
-            canActivateChild: ['alwaysFalse'],
-            children: [{ path: 'team/:id', component: TeamCmp }]
-          }]);
+             router.resetConfig([{
+               path: '',
+               canActivateChild: ['alwaysFalse'],
+               children: [{path: 'team/:id', component: TeamCmp}]
+             }]);
 
-          router.navigateByUrl('/team/22');
-          advance(fixture);
+             router.navigateByUrl('/team/22');
+             advance(fixture);
 
-          expect(location.path()).toEqual('/team/22');
+             expect(location.path()).toEqual('/team/22');
 
-          router.navigateByUrl('/team/33')!.catch(() => { });
-          advance(fixture);
+             router.navigateByUrl('/team/33') !.catch(() => {});
+             advance(fixture);
 
-          expect(location.path()).toEqual('/team/22');
-        })));
+             expect(location.path()).toEqual('/team/22');
+           })));
       });
 
       it('should find the guard provided in lazy loaded module',
-        fakeAsync(inject(
-          [Router, Location, NgModuleFactoryLoader],
-          (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+         fakeAsync(inject(
+             [Router, Location, NgModuleFactoryLoader],
+             (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
 
-            @Component({ selector: 'admin', template: '<router-outlet></router-outlet>' })
-            class AdminComponent {
-            }
+               @Component({selector: 'admin', template: '<router-outlet></router-outlet>'})
+               class AdminComponent {
+               }
 
-            @Component({ selector: 'lazy', template: 'lazy-loaded' })
-            class LazyLoadedComponent {
-            }
+               @Component({selector: 'lazy', template: 'lazy-loaded'})
+               class LazyLoadedComponent {
+               }
 
-            @NgModule({
-              declarations: [AdminComponent, LazyLoadedComponent],
-              imports: [RouterModule.forChild([{
-                path: '',
-                component: AdminComponent,
-                children: [{
-                  path: '',
-                  canActivateChild: ['alwaysTrue'],
-                  children: [{ path: '', component: LazyLoadedComponent }]
-                }]
-              }])],
-              providers: [{ provide: 'alwaysTrue', useValue: () => true }],
-            })
-            class LazyLoadedModule {
-            }
+               @NgModule({
+                 declarations: [AdminComponent, LazyLoadedComponent],
+                 imports: [RouterModule.forChild([{
+                   path: '',
+                   component: AdminComponent,
+                   children: [{
+                     path: '',
+                     canActivateChild: ['alwaysTrue'],
+                     children: [{path: '', component: LazyLoadedComponent}]
+                   }]
+                 }])],
+                 providers: [{provide: 'alwaysTrue', useValue: () => true}],
+               })
+               class LazyLoadedModule {
+               }
 
-            loader.stubbedModules = { lazy: LazyLoadedModule };
-            const fixture = createRoot(router, RootCmp);
+               loader.stubbedModules = {lazy: LazyLoadedModule};
+               const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([{ path: 'admin', loadChildren: 'lazy' }]);
+               router.resetConfig([{path: 'admin', loadChildren: 'lazy'}]);
 
-            router.navigateByUrl('/admin');
-            advance(fixture);
+               router.navigateByUrl('/admin');
+               advance(fixture);
 
-            expect(location.path()).toEqual('/admin');
-            expect(fixture.nativeElement).toHaveText('lazy-loaded');
-          })));
+               expect(location.path()).toEqual('/admin');
+               expect(fixture.nativeElement).toHaveText('lazy-loaded');
+             })));
     });
 
     describe('CanLoad', () => {
@@ -2698,7 +2704,7 @@ describe('Integration', () => {
         canLoadRunCount = 0;
         TestBed.configureTestingModule({
           providers: [
-            { provide: 'alwaysFalse', useValue: (a: any) => false },
+            {provide: 'alwaysFalse', useValue: (a: any) => false},
             {
               provide: 'returnFalseAndNavigate',
               useFactory: (router: any) => (a: any) => {
@@ -2719,143 +2725,143 @@ describe('Integration', () => {
       });
 
       it('should not load children when CanLoad returns false',
-        fakeAsync(inject(
-          [Router, Location, NgModuleFactoryLoader],
-          (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+         fakeAsync(inject(
+             [Router, Location, NgModuleFactoryLoader],
+             (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
 
-            @Component({ selector: 'lazy', template: 'lazy-loaded' })
-            class LazyLoadedComponent {
-            }
+               @Component({selector: 'lazy', template: 'lazy-loaded'})
+               class LazyLoadedComponent {
+               }
 
-            @NgModule({
-              declarations: [LazyLoadedComponent],
-              imports:
-                [RouterModule.forChild([{ path: 'loaded', component: LazyLoadedComponent }])]
-            })
-            class LoadedModule {
-            }
+               @NgModule({
+                 declarations: [LazyLoadedComponent],
+                 imports:
+                     [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])]
+               })
+               class LoadedModule {
+               }
 
-            loader.stubbedModules = { lazyFalse: LoadedModule, lazyTrue: LoadedModule };
-            const fixture = createRoot(router, RootCmp);
+               loader.stubbedModules = {lazyFalse: LoadedModule, lazyTrue: LoadedModule};
+               const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([
-              { path: 'lazyFalse', canLoad: ['alwaysFalse'], loadChildren: 'lazyFalse' },
-              { path: 'lazyTrue', canLoad: ['alwaysTrue'], loadChildren: 'lazyTrue' }
-            ]);
+               router.resetConfig([
+                 {path: 'lazyFalse', canLoad: ['alwaysFalse'], loadChildren: 'lazyFalse'},
+                 {path: 'lazyTrue', canLoad: ['alwaysTrue'], loadChildren: 'lazyTrue'}
+               ]);
 
-            const recordedEvents: any[] = [];
-            router.events.forEach(e => recordedEvents.push(e));
+               const recordedEvents: any[] = [];
+               router.events.forEach(e => recordedEvents.push(e));
 
 
-            // failed navigation
-            router.navigateByUrl('/lazyFalse/loaded');
-            advance(fixture);
+               // failed navigation
+               router.navigateByUrl('/lazyFalse/loaded');
+               advance(fixture);
 
-            expect(location.path()).toEqual('/');
+               expect(location.path()).toEqual('/');
 
-            expectEvents(recordedEvents, [
-              [NavigationStart, '/lazyFalse/loaded'],
-              //  [GuardsCheckStart, '/lazyFalse/loaded'],
-              [NavigationCancel, '/lazyFalse/loaded'],
-            ]);
+               expectEvents(recordedEvents, [
+                 [NavigationStart, '/lazyFalse/loaded'],
+                 //  [GuardsCheckStart, '/lazyFalse/loaded'],
+                 [NavigationCancel, '/lazyFalse/loaded'],
+               ]);
 
-            recordedEvents.splice(0);
+               recordedEvents.splice(0);
 
-            // successful navigation
-            router.navigateByUrl('/lazyTrue/loaded');
-            advance(fixture);
+               // successful navigation
+               router.navigateByUrl('/lazyTrue/loaded');
+               advance(fixture);
 
-            expect(location.path()).toEqual('/lazyTrue/loaded');
+               expect(location.path()).toEqual('/lazyTrue/loaded');
 
-            expectEvents(recordedEvents, [
-              [NavigationStart, '/lazyTrue/loaded'],
-              [RouteConfigLoadStart],
-              [RouteConfigLoadEnd],
-              [RoutesRecognized, '/lazyTrue/loaded'],
-              [GuardsCheckStart, '/lazyTrue/loaded'],
-              [ChildActivationStart],
-              [ActivationStart],
-              [ChildActivationStart],
-              [ActivationStart],
-              [GuardsCheckEnd, '/lazyTrue/loaded'],
-              [ResolveStart, '/lazyTrue/loaded'],
-              [ResolveEnd, '/lazyTrue/loaded'],
-              [ActivationEnd],
-              [ChildActivationEnd],
-              [ActivationEnd],
-              [ChildActivationEnd],
-              [NavigationEnd, '/lazyTrue/loaded'],
-            ]);
-          })));
+               expectEvents(recordedEvents, [
+                 [NavigationStart, '/lazyTrue/loaded'],
+                 [RouteConfigLoadStart],
+                 [RouteConfigLoadEnd],
+                 [RoutesRecognized, '/lazyTrue/loaded'],
+                 [GuardsCheckStart, '/lazyTrue/loaded'],
+                 [ChildActivationStart],
+                 [ActivationStart],
+                 [ChildActivationStart],
+                 [ActivationStart],
+                 [GuardsCheckEnd, '/lazyTrue/loaded'],
+                 [ResolveStart, '/lazyTrue/loaded'],
+                 [ResolveEnd, '/lazyTrue/loaded'],
+                 [ActivationEnd],
+                 [ChildActivationEnd],
+                 [ActivationEnd],
+                 [ChildActivationEnd],
+                 [NavigationEnd, '/lazyTrue/loaded'],
+               ]);
+             })));
 
       it('should support navigating from within the guard',
-        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
 
-          const fixture = createRoot(router, RootCmp);
+           const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([
-            { path: 'lazyFalse', canLoad: ['returnFalseAndNavigate'], loadChildren: 'lazyFalse' },
-            { path: 'blank', component: BlankCmp }
-          ]);
+           router.resetConfig([
+             {path: 'lazyFalse', canLoad: ['returnFalseAndNavigate'], loadChildren: 'lazyFalse'},
+             {path: 'blank', component: BlankCmp}
+           ]);
 
-          const recordedEvents: any[] = [];
-          router.events.forEach(e => recordedEvents.push(e));
+           const recordedEvents: any[] = [];
+           router.events.forEach(e => recordedEvents.push(e));
 
 
-          router.navigateByUrl('/lazyFalse/loaded');
-          advance(fixture);
+           router.navigateByUrl('/lazyFalse/loaded');
+           advance(fixture);
 
-          expect(location.path()).toEqual('/blank');
+           expect(location.path()).toEqual('/blank');
 
-          expectEvents(recordedEvents, [
-            [NavigationStart, '/lazyFalse/loaded'],
-            // No GuardCheck events as `canLoad` is a special guard that's not actually part of the
-            // guard lifecycle.
-            [NavigationCancel, '/lazyFalse/loaded'],
+           expectEvents(recordedEvents, [
+             [NavigationStart, '/lazyFalse/loaded'],
+             // No GuardCheck events as `canLoad` is a special guard that's not actually part of the
+             // guard lifecycle.
+             [NavigationCancel, '/lazyFalse/loaded'],
 
-            [NavigationStart, '/blank'], [RoutesRecognized, '/blank'],
-            [GuardsCheckStart, '/blank'], [ChildActivationStart], [ActivationStart],
-            [GuardsCheckEnd, '/blank'], [ResolveStart, '/blank'], [ResolveEnd, '/blank'],
-            [ActivationEnd], [ChildActivationEnd], [NavigationEnd, '/blank']
-          ]);
-        })));
+             [NavigationStart, '/blank'], [RoutesRecognized, '/blank'],
+             [GuardsCheckStart, '/blank'], [ChildActivationStart], [ActivationStart],
+             [GuardsCheckEnd, '/blank'], [ResolveStart, '/blank'], [ResolveEnd, '/blank'],
+             [ActivationEnd], [ChildActivationEnd], [NavigationEnd, '/blank']
+           ]);
+         })));
 
       it('should execute CanLoad only once',
-        fakeAsync(inject(
-          [Router, Location, NgModuleFactoryLoader],
-          (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+         fakeAsync(inject(
+             [Router, Location, NgModuleFactoryLoader],
+             (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
 
-            @Component({ selector: 'lazy', template: 'lazy-loaded' })
-            class LazyLoadedComponent {
-            }
+               @Component({selector: 'lazy', template: 'lazy-loaded'})
+               class LazyLoadedComponent {
+               }
 
-            @NgModule({
-              declarations: [LazyLoadedComponent],
-              imports:
-                [RouterModule.forChild([{ path: 'loaded', component: LazyLoadedComponent }])]
-            })
-            class LazyLoadedModule {
-            }
+               @NgModule({
+                 declarations: [LazyLoadedComponent],
+                 imports:
+                     [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])]
+               })
+               class LazyLoadedModule {
+               }
 
-            loader.stubbedModules = { lazy: LazyLoadedModule };
-            const fixture = createRoot(router, RootCmp);
+               loader.stubbedModules = {lazy: LazyLoadedModule};
+               const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([{ path: 'lazy', canLoad: ['alwaysTrue'], loadChildren: 'lazy' }]);
+               router.resetConfig([{path: 'lazy', canLoad: ['alwaysTrue'], loadChildren: 'lazy'}]);
 
-            router.navigateByUrl('/lazy/loaded');
-            advance(fixture);
-            expect(location.path()).toEqual('/lazy/loaded');
-            expect(canLoadRunCount).toEqual(1);
+               router.navigateByUrl('/lazy/loaded');
+               advance(fixture);
+               expect(location.path()).toEqual('/lazy/loaded');
+               expect(canLoadRunCount).toEqual(1);
 
-            router.navigateByUrl('/');
-            advance(fixture);
-            expect(location.path()).toEqual('/');
+               router.navigateByUrl('/');
+               advance(fixture);
+               expect(location.path()).toEqual('/');
 
-            router.navigateByUrl('/lazy/loaded');
-            advance(fixture);
-            expect(location.path()).toEqual('/lazy/loaded');
-            expect(canLoadRunCount).toEqual(1);
-          })));
+               router.navigateByUrl('/lazy/loaded');
+               advance(fixture);
+               expect(location.path()).toEqual('/lazy/loaded');
+               expect(canLoadRunCount).toEqual(1);
+             })));
     });
 
     describe('order', () => {
@@ -2893,663 +2899,663 @@ describe('Integration', () => {
       });
 
       it('should call guards in the right order',
-        fakeAsync(inject(
-          [Router, Location, Logger], (router: Router, location: Location, logger: Logger) => {
-            const fixture = createRoot(router, RootCmp);
+         fakeAsync(inject(
+             [Router, Location, Logger], (router: Router, location: Location, logger: Logger) => {
+               const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([{
-              path: '',
-              canActivateChild: ['canActivateChild_parent'],
-              children: [{
-                path: 'team/:id',
-                canActivate: ['canActivate_team'],
-                canDeactivate: ['canDeactivate_team'],
-                component: TeamCmp
-              }]
-            }]);
+               router.resetConfig([{
+                 path: '',
+                 canActivateChild: ['canActivateChild_parent'],
+                 children: [{
+                   path: 'team/:id',
+                   canActivate: ['canActivate_team'],
+                   canDeactivate: ['canDeactivate_team'],
+                   component: TeamCmp
+                 }]
+               }]);
 
-            router.navigateByUrl('/team/22');
-            advance(fixture);
+               router.navigateByUrl('/team/22');
+               advance(fixture);
 
-            router.navigateByUrl('/team/33');
-            advance(fixture);
+               router.navigateByUrl('/team/33');
+               advance(fixture);
 
-            expect(logger.logs).toEqual([
-              'canActivateChild_parent', 'canActivate_team',
+               expect(logger.logs).toEqual([
+                 'canActivateChild_parent', 'canActivate_team',
 
-              'canDeactivate_team', 'canActivateChild_parent', 'canActivate_team'
-            ]);
-          })));
+                 'canDeactivate_team', 'canActivateChild_parent', 'canActivate_team'
+               ]);
+             })));
 
       it('should call deactivate guards from bottom to top',
-        fakeAsync(inject(
-          [Router, Location, Logger], (router: Router, location: Location, logger: Logger) => {
-            const fixture = createRoot(router, RootCmp);
+         fakeAsync(inject(
+             [Router, Location, Logger], (router: Router, location: Location, logger: Logger) => {
+               const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([{
-              path: '',
-              children: [{
-                path: 'team/:id',
-                canDeactivate: ['canDeactivate_team'],
-                children:
-                  [{ path: '', component: SimpleCmp, canDeactivate: ['canDeactivate_simple'] }],
-                component: TeamCmp
-              }]
-            }]);
+               router.resetConfig([{
+                 path: '',
+                 children: [{
+                   path: 'team/:id',
+                   canDeactivate: ['canDeactivate_team'],
+                   children:
+                       [{path: '', component: SimpleCmp, canDeactivate: ['canDeactivate_simple']}],
+                   component: TeamCmp
+                 }]
+               }]);
 
-            router.navigateByUrl('/team/22');
-            advance(fixture);
+               router.navigateByUrl('/team/22');
+               advance(fixture);
 
-            router.navigateByUrl('/team/33');
-            advance(fixture);
+               router.navigateByUrl('/team/33');
+               advance(fixture);
 
-            expect(logger.logs).toEqual(['canDeactivate_simple', 'canDeactivate_team']);
-          })));
+               expect(logger.logs).toEqual(['canDeactivate_simple', 'canDeactivate_team']);
+             })));
     });
   });
 
   describe('route events', () => {
     it('should fire matching (Child)ActivationStart/End events',
-      fakeAsync(inject([Router], (router: Router) => {
-        const fixture = createRoot(router, RootCmp);
+       fakeAsync(inject([Router], (router: Router) => {
+         const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([{ path: 'user/:name', component: UserCmp }]);
+         router.resetConfig([{path: 'user/:name', component: UserCmp}]);
 
-        const recordedEvents: any[] = [];
-        router.events.forEach(e => recordedEvents.push(e));
+         const recordedEvents: any[] = [];
+         router.events.forEach(e => recordedEvents.push(e));
 
-        router.navigateByUrl('/user/fedor');
-        advance(fixture);
+         router.navigateByUrl('/user/fedor');
+         advance(fixture);
 
-        expect(fixture.nativeElement).toHaveText('user fedor');
-        expect(recordedEvents[3] instanceof ChildActivationStart).toBe(true);
-        expect(recordedEvents[3].snapshot).toBe(recordedEvents[9].snapshot.root);
-        expect(recordedEvents[9] instanceof ChildActivationEnd).toBe(true);
-        expect(recordedEvents[9].snapshot).toBe(recordedEvents[9].snapshot.root);
+         expect(fixture.nativeElement).toHaveText('user fedor');
+         expect(recordedEvents[3] instanceof ChildActivationStart).toBe(true);
+         expect(recordedEvents[3].snapshot).toBe(recordedEvents[9].snapshot.root);
+         expect(recordedEvents[9] instanceof ChildActivationEnd).toBe(true);
+         expect(recordedEvents[9].snapshot).toBe(recordedEvents[9].snapshot.root);
 
-        expect(recordedEvents[4] instanceof ActivationStart).toBe(true);
-        expect(recordedEvents[4].snapshot.routeConfig.path).toBe('user/:name');
-        expect(recordedEvents[8] instanceof ActivationEnd).toBe(true);
-        expect(recordedEvents[8].snapshot.routeConfig.path).toBe('user/:name');
+         expect(recordedEvents[4] instanceof ActivationStart).toBe(true);
+         expect(recordedEvents[4].snapshot.routeConfig.path).toBe('user/:name');
+         expect(recordedEvents[8] instanceof ActivationEnd).toBe(true);
+         expect(recordedEvents[8].snapshot.routeConfig.path).toBe('user/:name');
 
-        expectEvents(recordedEvents, [
-          [NavigationStart, '/user/fedor'], [RoutesRecognized, '/user/fedor'],
-          [GuardsCheckStart, '/user/fedor'], [ChildActivationStart], [ActivationStart],
-          [GuardsCheckEnd, '/user/fedor'], [ResolveStart, '/user/fedor'],
-          [ResolveEnd, '/user/fedor'], [ActivationEnd], [ChildActivationEnd],
-          [NavigationEnd, '/user/fedor']
-        ]);
-      })));
+         expectEvents(recordedEvents, [
+           [NavigationStart, '/user/fedor'], [RoutesRecognized, '/user/fedor'],
+           [GuardsCheckStart, '/user/fedor'], [ChildActivationStart], [ActivationStart],
+           [GuardsCheckEnd, '/user/fedor'], [ResolveStart, '/user/fedor'],
+           [ResolveEnd, '/user/fedor'], [ActivationEnd], [ChildActivationEnd],
+           [NavigationEnd, '/user/fedor']
+         ]);
+       })));
   });
 
   describe('routerActiveLink', () => {
     it('should set the class when the link is active (a tag)',
-      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([{
-          path: 'team/:id',
-          component: TeamCmp,
-          children: [{
-            path: 'link',
-            component: DummyLinkCmp,
-            children:
-              [{ path: 'simple', component: SimpleCmp }, { path: '', component: BlankCmp }]
-          }]
-        }]);
+         router.resetConfig([{
+           path: 'team/:id',
+           component: TeamCmp,
+           children: [{
+             path: 'link',
+             component: DummyLinkCmp,
+             children:
+                 [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
+           }]
+         }]);
 
-        router.navigateByUrl('/team/22/link;exact=true');
-        advance(fixture);
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link;exact=true');
+         router.navigateByUrl('/team/22/link;exact=true');
+         advance(fixture);
+         advance(fixture);
+         expect(location.path()).toEqual('/team/22/link;exact=true');
 
-        const nativeLink = fixture.nativeElement.querySelector('a');
-        const nativeButton = fixture.nativeElement.querySelector('button');
-        expect(nativeLink.className).toEqual('active');
-        expect(nativeButton.className).toEqual('active');
+         const nativeLink = fixture.nativeElement.querySelector('a');
+         const nativeButton = fixture.nativeElement.querySelector('button');
+         expect(nativeLink.className).toEqual('active');
+         expect(nativeButton.className).toEqual('active');
 
-        router.navigateByUrl('/team/22/link/simple');
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link/simple');
-        expect(nativeLink.className).toEqual('');
-        expect(nativeButton.className).toEqual('');
-      })));
+         router.navigateByUrl('/team/22/link/simple');
+         advance(fixture);
+         expect(location.path()).toEqual('/team/22/link/simple');
+         expect(nativeLink.className).toEqual('');
+         expect(nativeButton.className).toEqual('');
+       })));
 
     it('should not set the class until the first navigation succeeds', fakeAsync(() => {
-      @Component({
-        template:
-          '<router-outlet></router-outlet><a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" ></a>'
-      })
-      class RootCmpWithLink {
-      }
+         @Component({
+           template:
+               '<router-outlet></router-outlet><a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" ></a>'
+         })
+         class RootCmpWithLink {
+         }
 
-      TestBed.configureTestingModule({ declarations: [RootCmpWithLink] });
-      const router: Router = TestBed.get(Router);
-      const loc: any = TestBed.get(Location);
+         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
+         const router: Router = TestBed.get(Router);
+         const loc: any = TestBed.get(Location);
 
-      const f = TestBed.createComponent(RootCmpWithLink);
-      advance(f);
+         const f = TestBed.createComponent(RootCmpWithLink);
+         advance(f);
 
-      const link = f.nativeElement.querySelector('a');
-      expect(link.className).toEqual('');
+         const link = f.nativeElement.querySelector('a');
+         expect(link.className).toEqual('');
 
-      router.initialNavigation();
-      advance(f);
+         router.initialNavigation();
+         advance(f);
 
-      expect(link.className).toEqual('active');
-    }));
+         expect(link.className).toEqual('active');
+       }));
 
 
     it('should set the class on a parent element when the link is active',
-      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([{
-          path: 'team/:id',
-          component: TeamCmp,
-          children: [{
-            path: 'link',
-            component: DummyLinkWithParentCmp,
-            children:
-              [{ path: 'simple', component: SimpleCmp }, { path: '', component: BlankCmp }]
-          }]
-        }]);
+         router.resetConfig([{
+           path: 'team/:id',
+           component: TeamCmp,
+           children: [{
+             path: 'link',
+             component: DummyLinkWithParentCmp,
+             children:
+                 [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
+           }]
+         }]);
 
-        router.navigateByUrl('/team/22/link;exact=true');
-        advance(fixture);
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link;exact=true');
+         router.navigateByUrl('/team/22/link;exact=true');
+         advance(fixture);
+         advance(fixture);
+         expect(location.path()).toEqual('/team/22/link;exact=true');
 
-        const native = fixture.nativeElement.querySelector('#link-parent');
-        expect(native.className).toEqual('active');
+         const native = fixture.nativeElement.querySelector('#link-parent');
+         expect(native.className).toEqual('active');
 
-        router.navigateByUrl('/team/22/link/simple');
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link/simple');
-        expect(native.className).toEqual('');
-      })));
+         router.navigateByUrl('/team/22/link/simple');
+         advance(fixture);
+         expect(location.path()).toEqual('/team/22/link/simple');
+         expect(native.className).toEqual('');
+       })));
 
     it('should set the class when the link is active',
-      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = createRoot(router, RootCmp);
 
-        router.resetConfig([{
-          path: 'team/:id',
-          component: TeamCmp,
-          children: [{
-            path: 'link',
-            component: DummyLinkCmp,
-            children:
-              [{ path: 'simple', component: SimpleCmp }, { path: '', component: BlankCmp }]
-          }]
-        }]);
+         router.resetConfig([{
+           path: 'team/:id',
+           component: TeamCmp,
+           children: [{
+             path: 'link',
+             component: DummyLinkCmp,
+             children:
+                 [{path: 'simple', component: SimpleCmp}, {path: '', component: BlankCmp}]
+           }]
+         }]);
 
-        router.navigateByUrl('/team/22/link');
-        advance(fixture);
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link');
+         router.navigateByUrl('/team/22/link');
+         advance(fixture);
+         advance(fixture);
+         expect(location.path()).toEqual('/team/22/link');
 
-        const native = fixture.nativeElement.querySelector('a');
-        expect(native.className).toEqual('active');
+         const native = fixture.nativeElement.querySelector('a');
+         expect(native.className).toEqual('active');
 
-        router.navigateByUrl('/team/22/link/simple');
-        advance(fixture);
-        expect(location.path()).toEqual('/team/22/link/simple');
-        expect(native.className).toEqual('active');
-      })));
+         router.navigateByUrl('/team/22/link/simple');
+         advance(fixture);
+         expect(location.path()).toEqual('/team/22/link/simple');
+         expect(native.className).toEqual('active');
+       })));
 
 
     it('should expose an isActive property', fakeAsync(() => {
-      @Component({
-        template: `<a routerLink="/team" routerLinkActive #rla="routerLinkActive"></a>
+         @Component({
+           template: `<a routerLink="/team" routerLinkActive #rla="routerLinkActive"></a>
               <p>{{rla.isActive}}</p>
               <span *ngIf="rla.isActive"></span>
               <span [ngClass]="{'highlight': rla.isActive}"></span>
               <router-outlet></router-outlet>`
-      })
-      class ComponentWithRouterLink {
-      }
+         })
+         class ComponentWithRouterLink {
+         }
 
-      TestBed.configureTestingModule({ declarations: [ComponentWithRouterLink] });
-      const router: Router = TestBed.get(Router);
+         TestBed.configureTestingModule({declarations: [ComponentWithRouterLink]});
+         const router: Router = TestBed.get(Router);
 
-      router.resetConfig([
-        {
-          path: 'team',
-          component: TeamCmp,
-        },
-        {
-          path: 'otherteam',
-          component: TeamCmp,
-        }
-      ]);
+         router.resetConfig([
+           {
+             path: 'team',
+             component: TeamCmp,
+           },
+           {
+             path: 'otherteam',
+             component: TeamCmp,
+           }
+         ]);
 
-      const fixture = TestBed.createComponent(ComponentWithRouterLink);
-      router.navigateByUrl('/team');
-      expect(() => advance(fixture)).not.toThrow();
-      advance(fixture);
+         const fixture = TestBed.createComponent(ComponentWithRouterLink);
+         router.navigateByUrl('/team');
+         expect(() => advance(fixture)).not.toThrow();
+         advance(fixture);
 
-      const paragraph = fixture.nativeElement.querySelector('p');
-      expect(paragraph.textContent).toEqual('true');
+         const paragraph = fixture.nativeElement.querySelector('p');
+         expect(paragraph.textContent).toEqual('true');
 
-      router.navigateByUrl('/otherteam');
-      advance(fixture);
-      advance(fixture);
-      expect(paragraph.textContent).toEqual('false');
-    }));
+         router.navigateByUrl('/otherteam');
+         advance(fixture);
+         advance(fixture);
+         expect(paragraph.textContent).toEqual('false');
+       }));
 
   });
 
   describe('lazy loading', () => {
     it('works',
-      fakeAsync(inject(
-        [Router, Location, NgModuleFactoryLoader],
-        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-          @Component({
-            selector: 'lazy',
-            template: 'lazy-loaded-parent [<router-outlet></router-outlet>]'
-          })
-          class ParentLazyLoadedComponent {
-          }
+       fakeAsync(inject(
+           [Router, Location, NgModuleFactoryLoader],
+           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+             @Component({
+               selector: 'lazy',
+               template: 'lazy-loaded-parent [<router-outlet></router-outlet>]'
+             })
+             class ParentLazyLoadedComponent {
+             }
 
-          @Component({ selector: 'lazy', template: 'lazy-loaded-child' })
-          class ChildLazyLoadedComponent {
-          }
+             @Component({selector: 'lazy', template: 'lazy-loaded-child'})
+             class ChildLazyLoadedComponent {
+             }
 
-          @NgModule({
-            declarations: [ParentLazyLoadedComponent, ChildLazyLoadedComponent],
-            imports: [RouterModule.forChild([{
-              path: 'loaded',
-              component: ParentLazyLoadedComponent,
-              children: [{ path: 'child', component: ChildLazyLoadedComponent }]
-            }])]
-          })
-          class LoadedModule {
-          }
+             @NgModule({
+               declarations: [ParentLazyLoadedComponent, ChildLazyLoadedComponent],
+               imports: [RouterModule.forChild([{
+                 path: 'loaded',
+                 component: ParentLazyLoadedComponent,
+                 children: [{path: 'child', component: ChildLazyLoadedComponent}]
+               }])]
+             })
+             class LoadedModule {
+             }
 
 
-          loader.stubbedModules = { expected: LoadedModule };
+             loader.stubbedModules = {expected: LoadedModule};
 
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([{ path: 'lazy', loadChildren: 'expected' }]);
+             router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
 
-          router.navigateByUrl('/lazy/loaded/child');
-          advance(fixture);
+             router.navigateByUrl('/lazy/loaded/child');
+             advance(fixture);
 
-          expect(location.path()).toEqual('/lazy/loaded/child');
-          expect(fixture.nativeElement).toHaveText('lazy-loaded-parent [lazy-loaded-child]');
-        })));
+             expect(location.path()).toEqual('/lazy/loaded/child');
+             expect(fixture.nativeElement).toHaveText('lazy-loaded-parent [lazy-loaded-child]');
+           })));
 
     it('should have 2 injector trees: module and element',
-      fakeAsync(inject(
-        [Router, Location, NgModuleFactoryLoader],
-        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-          @Component({
-            selector: 'lazy',
-            template: 'parent[<router-outlet></router-outlet>]',
-            viewProviders: [
-              { provide: 'shadow', useValue: 'from parent component' },
-            ],
-          })
-          class Parent {
-          }
+       fakeAsync(inject(
+           [Router, Location, NgModuleFactoryLoader],
+           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+             @Component({
+               selector: 'lazy',
+               template: 'parent[<router-outlet></router-outlet>]',
+               viewProviders: [
+                 {provide: 'shadow', useValue: 'from parent component'},
+               ],
+             })
+             class Parent {
+             }
 
-          @Component({ selector: 'lazy', template: 'child' })
-          class Child {
-          }
+             @Component({selector: 'lazy', template: 'child'})
+             class Child {
+             }
 
-          @NgModule({
-            declarations: [Parent],
-            imports: [RouterModule.forChild([{
-              path: 'parent',
-              component: Parent,
-              children: [
-                { path: 'child', loadChildren: 'child' },
-              ]
-            }])],
-            providers: [
-              { provide: 'moduleName', useValue: 'parent' },
-              { provide: 'fromParent', useValue: 'from parent' },
-            ],
-          })
-          class ParentModule {
-          }
+             @NgModule({
+               declarations: [Parent],
+               imports: [RouterModule.forChild([{
+                 path: 'parent',
+                 component: Parent,
+                 children: [
+                   {path: 'child', loadChildren: 'child'},
+                 ]
+               }])],
+               providers: [
+                 {provide: 'moduleName', useValue: 'parent'},
+                 {provide: 'fromParent', useValue: 'from parent'},
+               ],
+             })
+             class ParentModule {
+             }
 
-          @NgModule({
-            declarations: [Child],
-            imports: [RouterModule.forChild([{ path: '', component: Child }])],
-            providers: [
-              { provide: 'moduleName', useValue: 'child' },
-              { provide: 'fromChild', useValue: 'from child' },
-              { provide: 'shadow', useValue: 'from child module' },
-            ],
-          })
-          class ChildModule {
-          }
+             @NgModule({
+               declarations: [Child],
+               imports: [RouterModule.forChild([{path: '', component: Child}])],
+               providers: [
+                 {provide: 'moduleName', useValue: 'child'},
+                 {provide: 'fromChild', useValue: 'from child'},
+                 {provide: 'shadow', useValue: 'from child module'},
+               ],
+             })
+             class ChildModule {
+             }
 
-          loader.stubbedModules = {
-            parent: ParentModule,
-            child: ChildModule,
-          };
+             loader.stubbedModules = {
+               parent: ParentModule,
+               child: ChildModule,
+             };
 
-          const fixture = createRoot(router, RootCmp);
-          router.resetConfig([{ path: 'lazy', loadChildren: 'parent' }]);
-          router.navigateByUrl('/lazy/parent/child');
-          advance(fixture);
-          expect(location.path()).toEqual('/lazy/parent/child');
-          expect(fixture.nativeElement).toHaveText('parent[child]');
+             const fixture = createRoot(router, RootCmp);
+             router.resetConfig([{path: 'lazy', loadChildren: 'parent'}]);
+             router.navigateByUrl('/lazy/parent/child');
+             advance(fixture);
+             expect(location.path()).toEqual('/lazy/parent/child');
+             expect(fixture.nativeElement).toHaveText('parent[child]');
 
-          const pInj = fixture.debugElement.query(By.directive(Parent)).injector!;
-          const cInj = fixture.debugElement.query(By.directive(Child)).injector!;
+             const pInj = fixture.debugElement.query(By.directive(Parent)).injector !;
+             const cInj = fixture.debugElement.query(By.directive(Child)).injector !;
 
-          expect(pInj.get('moduleName')).toEqual('parent');
-          expect(pInj.get('fromParent')).toEqual('from parent');
-          expect(pInj.get(Parent)).toBeAnInstanceOf(Parent);
-          expect(pInj.get('fromChild', null)).toEqual(null);
-          expect(pInj.get(Child, null)).toEqual(null);
+             expect(pInj.get('moduleName')).toEqual('parent');
+             expect(pInj.get('fromParent')).toEqual('from parent');
+             expect(pInj.get(Parent)).toBeAnInstanceOf(Parent);
+             expect(pInj.get('fromChild', null)).toEqual(null);
+             expect(pInj.get(Child, null)).toEqual(null);
 
-          expect(cInj.get('moduleName')).toEqual('child');
-          expect(cInj.get('fromParent')).toEqual('from parent');
-          expect(cInj.get('fromChild')).toEqual('from child');
-          expect(cInj.get(Parent)).toBeAnInstanceOf(Parent);
-          expect(cInj.get(Child)).toBeAnInstanceOf(Child);
-          // The child module can not shadow the parent component
-          expect(cInj.get('shadow')).toEqual('from parent component');
+             expect(cInj.get('moduleName')).toEqual('child');
+             expect(cInj.get('fromParent')).toEqual('from parent');
+             expect(cInj.get('fromChild')).toEqual('from child');
+             expect(cInj.get(Parent)).toBeAnInstanceOf(Parent);
+             expect(cInj.get(Child)).toBeAnInstanceOf(Child);
+             // The child module can not shadow the parent component
+             expect(cInj.get('shadow')).toEqual('from parent component');
 
-          const pmInj = pInj.get(NgModuleRef).injector;
-          const cmInj = cInj.get(NgModuleRef).injector;
+             const pmInj = pInj.get(NgModuleRef).injector;
+             const cmInj = cInj.get(NgModuleRef).injector;
 
-          expect(pmInj.get('moduleName')).toEqual('parent');
-          expect(cmInj.get('moduleName')).toEqual('child');
+             expect(pmInj.get('moduleName')).toEqual('parent');
+             expect(cmInj.get('moduleName')).toEqual('child');
 
-          expect(pmInj.get(Parent, '-')).toEqual('-');
-          expect(cmInj.get(Parent, '-')).toEqual('-');
-          expect(pmInj.get(Child, '-')).toEqual('-');
-          expect(cmInj.get(Child, '-')).toEqual('-');
-        })));
+             expect(pmInj.get(Parent, '-')).toEqual('-');
+             expect(cmInj.get(Parent, '-')).toEqual('-');
+             expect(pmInj.get(Child, '-')).toEqual('-');
+             expect(cmInj.get(Child, '-')).toEqual('-');
+           })));
 
     // https://github.com/angular/angular/issues/12889
     it('should create a single instance of lazy-loaded modules',
-      fakeAsync(inject(
-        [Router, Location, NgModuleFactoryLoader],
-        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-          @Component({
-            selector: 'lazy',
-            template: 'lazy-loaded-parent [<router-outlet></router-outlet>]'
-          })
-          class ParentLazyLoadedComponent {
-          }
+       fakeAsync(inject(
+           [Router, Location, NgModuleFactoryLoader],
+           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+             @Component({
+               selector: 'lazy',
+               template: 'lazy-loaded-parent [<router-outlet></router-outlet>]'
+             })
+             class ParentLazyLoadedComponent {
+             }
 
-          @Component({ selector: 'lazy', template: 'lazy-loaded-child' })
-          class ChildLazyLoadedComponent {
-          }
+             @Component({selector: 'lazy', template: 'lazy-loaded-child'})
+             class ChildLazyLoadedComponent {
+             }
 
-          @NgModule({
-            declarations: [ParentLazyLoadedComponent, ChildLazyLoadedComponent],
-            imports: [RouterModule.forChild([{
-              path: 'loaded',
-              component: ParentLazyLoadedComponent,
-              children: [{ path: 'child', component: ChildLazyLoadedComponent }]
-            }])]
-          })
-          class LoadedModule {
-            static instances = 0;
-            constructor() { LoadedModule.instances++; }
-          }
+             @NgModule({
+               declarations: [ParentLazyLoadedComponent, ChildLazyLoadedComponent],
+               imports: [RouterModule.forChild([{
+                 path: 'loaded',
+                 component: ParentLazyLoadedComponent,
+                 children: [{path: 'child', component: ChildLazyLoadedComponent}]
+               }])]
+             })
+             class LoadedModule {
+               static instances = 0;
+               constructor() { LoadedModule.instances++; }
+             }
 
-          loader.stubbedModules = { expected: LoadedModule };
-          const fixture = createRoot(router, RootCmp);
-          router.resetConfig([{ path: 'lazy', loadChildren: 'expected' }]);
-          router.navigateByUrl('/lazy/loaded/child');
-          advance(fixture);
-          expect(fixture.nativeElement).toHaveText('lazy-loaded-parent [lazy-loaded-child]');
-          expect(LoadedModule.instances).toEqual(1);
-        })));
+             loader.stubbedModules = {expected: LoadedModule};
+             const fixture = createRoot(router, RootCmp);
+             router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
+             router.navigateByUrl('/lazy/loaded/child');
+             advance(fixture);
+             expect(fixture.nativeElement).toHaveText('lazy-loaded-parent [lazy-loaded-child]');
+             expect(LoadedModule.instances).toEqual(1);
+           })));
 
     // https://github.com/angular/angular/issues/13870
     it('should create a single instance of guards for lazy-loaded modules',
-      fakeAsync(inject(
-        [Router, Location, NgModuleFactoryLoader],
-        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-          @Injectable()
-          class Service {
-          }
+       fakeAsync(inject(
+           [Router, Location, NgModuleFactoryLoader],
+           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+             @Injectable()
+             class Service {
+             }
 
-          @Injectable()
-          class Resolver implements Resolve<Service> {
-            constructor(public service: Service) { }
-            resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-              return this.service;
-            }
-          }
+             @Injectable()
+             class Resolver implements Resolve<Service> {
+               constructor(public service: Service) {}
+               resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+                 return this.service;
+               }
+             }
 
-          @Component({ selector: 'lazy', template: 'lazy' })
-          class LazyLoadedComponent {
-            resolvedService: Service;
-            constructor(public injectedService: Service, route: ActivatedRoute) {
-              this.resolvedService = route.snapshot.data['service'];
-            }
-          }
+             @Component({selector: 'lazy', template: 'lazy'})
+             class LazyLoadedComponent {
+               resolvedService: Service;
+               constructor(public injectedService: Service, route: ActivatedRoute) {
+                 this.resolvedService = route.snapshot.data['service'];
+               }
+             }
 
-          @NgModule({
-            declarations: [LazyLoadedComponent],
-            providers: [Service, Resolver],
-            imports: [
-              RouterModule.forChild([{
-                path: 'loaded',
-                component: LazyLoadedComponent,
-                resolve: { 'service': Resolver },
-              }]),
-            ]
-          })
-          class LoadedModule {
-          }
+             @NgModule({
+               declarations: [LazyLoadedComponent],
+               providers: [Service, Resolver],
+               imports: [
+                 RouterModule.forChild([{
+                   path: 'loaded',
+                   component: LazyLoadedComponent,
+                   resolve: {'service': Resolver},
+                 }]),
+               ]
+             })
+             class LoadedModule {
+             }
 
-          loader.stubbedModules = { expected: LoadedModule };
-          const fixture = createRoot(router, RootCmp);
-          router.resetConfig([{ path: 'lazy', loadChildren: 'expected' }]);
-          router.navigateByUrl('/lazy/loaded');
-          advance(fixture);
+             loader.stubbedModules = {expected: LoadedModule};
+             const fixture = createRoot(router, RootCmp);
+             router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
+             router.navigateByUrl('/lazy/loaded');
+             advance(fixture);
 
-          expect(fixture.nativeElement).toHaveText('lazy');
-          const lzc =
-            fixture.debugElement.query(By.directive(LazyLoadedComponent)).componentInstance;
-          expect(lzc.injectedService).toBe(lzc.resolvedService);
-        })));
+             expect(fixture.nativeElement).toHaveText('lazy');
+             const lzc =
+                 fixture.debugElement.query(By.directive(LazyLoadedComponent)).componentInstance;
+             expect(lzc.injectedService).toBe(lzc.resolvedService);
+           })));
 
 
     it('should emit RouteConfigLoadStart and RouteConfigLoadEnd event when route is lazy loaded',
-      fakeAsync(inject(
-        [Router, Location, NgModuleFactoryLoader],
-        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-          @Component({
-            selector: 'lazy',
-            template: 'lazy-loaded-parent [<router-outlet></router-outlet>]',
-          })
-          class ParentLazyLoadedComponent {
-          }
+       fakeAsync(inject(
+           [Router, Location, NgModuleFactoryLoader],
+           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+             @Component({
+               selector: 'lazy',
+               template: 'lazy-loaded-parent [<router-outlet></router-outlet>]',
+             })
+             class ParentLazyLoadedComponent {
+             }
 
-          @Component({ selector: 'lazy', template: 'lazy-loaded-child' })
-          class ChildLazyLoadedComponent {
-          }
+             @Component({selector: 'lazy', template: 'lazy-loaded-child'})
+             class ChildLazyLoadedComponent {
+             }
 
-          @NgModule({
-            declarations: [ParentLazyLoadedComponent, ChildLazyLoadedComponent],
-            imports: [RouterModule.forChild([{
-              path: 'loaded',
-              component: ParentLazyLoadedComponent,
-              children: [{ path: 'child', component: ChildLazyLoadedComponent }],
-            }])]
-          })
-          class LoadedModule {
-          }
+             @NgModule({
+               declarations: [ParentLazyLoadedComponent, ChildLazyLoadedComponent],
+               imports: [RouterModule.forChild([{
+                 path: 'loaded',
+                 component: ParentLazyLoadedComponent,
+                 children: [{path: 'child', component: ChildLazyLoadedComponent}],
+               }])]
+             })
+             class LoadedModule {
+             }
 
-          const events: Array<RouteConfigLoadStart | RouteConfigLoadEnd> = [];
+             const events: Array<RouteConfigLoadStart|RouteConfigLoadEnd> = [];
 
-          router.events.subscribe(e => {
-            if (e instanceof RouteConfigLoadStart || e instanceof RouteConfigLoadEnd) {
-              events.push(e);
-            }
-          });
+             router.events.subscribe(e => {
+               if (e instanceof RouteConfigLoadStart || e instanceof RouteConfigLoadEnd) {
+                 events.push(e);
+               }
+             });
 
-          loader.stubbedModules = { expected: LoadedModule };
-          const fixture = createRoot(router, RootCmp);
-          router.resetConfig([{ path: 'lazy', loadChildren: 'expected' }]);
+             loader.stubbedModules = {expected: LoadedModule};
+             const fixture = createRoot(router, RootCmp);
+             router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
 
-          router.navigateByUrl('/lazy/loaded/child');
-          advance(fixture);
+             router.navigateByUrl('/lazy/loaded/child');
+             advance(fixture);
 
-          expect(events.length).toEqual(2);
-          expect(events[0].toString()).toEqual('RouteConfigLoadStart(path: lazy)');
-          expect(events[1].toString()).toEqual('RouteConfigLoadEnd(path: lazy)');
-        })));
+             expect(events.length).toEqual(2);
+             expect(events[0].toString()).toEqual('RouteConfigLoadStart(path: lazy)');
+             expect(events[1].toString()).toEqual('RouteConfigLoadEnd(path: lazy)');
+           })));
 
     it('throws an error when forRoot() is used in a lazy context',
-      fakeAsync(inject(
-        [Router, Location, NgModuleFactoryLoader],
-        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-          @Component({ selector: 'lazy', template: 'should not show' })
-          class LazyLoadedComponent {
-          }
+       fakeAsync(inject(
+           [Router, Location, NgModuleFactoryLoader],
+           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+             @Component({selector: 'lazy', template: 'should not show'})
+             class LazyLoadedComponent {
+             }
 
-          @NgModule({
-            declarations: [LazyLoadedComponent],
-            imports: [RouterModule.forRoot([{ path: 'loaded', component: LazyLoadedComponent }])]
-          })
-          class LoadedModule {
-          }
+             @NgModule({
+               declarations: [LazyLoadedComponent],
+               imports: [RouterModule.forRoot([{path: 'loaded', component: LazyLoadedComponent}])]
+             })
+             class LoadedModule {
+             }
 
-          loader.stubbedModules = { expected: LoadedModule };
+             loader.stubbedModules = {expected: LoadedModule};
 
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([{ path: 'lazy', loadChildren: 'expected' }]);
+             router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
 
-          let recordedError: any = null;
-          router.navigateByUrl('/lazy/loaded')!.catch(err => recordedError = err);
-          advance(fixture);
-          expect(recordedError.message)
-            .toEqual(
-              `RouterModule.forRoot() called twice. Lazy loaded modules should use RouterModule.forChild() instead.`);
-        })));
+             let recordedError: any = null;
+             router.navigateByUrl('/lazy/loaded') !.catch(err => recordedError = err);
+             advance(fixture);
+             expect(recordedError.message)
+                 .toEqual(
+                     `RouterModule.forRoot() called twice. Lazy loaded modules should use RouterModule.forChild() instead.`);
+           })));
 
     it('should combine routes from multiple modules into a single configuration',
-      fakeAsync(inject(
-        [Router, Location, NgModuleFactoryLoader],
-        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-          @Component({ selector: 'lazy', template: 'lazy-loaded-2' })
-          class LazyComponent2 {
-          }
+       fakeAsync(inject(
+           [Router, Location, NgModuleFactoryLoader],
+           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+             @Component({selector: 'lazy', template: 'lazy-loaded-2'})
+             class LazyComponent2 {
+             }
 
-          @NgModule({
-            declarations: [LazyComponent2],
-            imports: [RouterModule.forChild([{ path: 'loaded', component: LazyComponent2 }])]
-          })
-          class SiblingOfLoadedModule {
-          }
+             @NgModule({
+               declarations: [LazyComponent2],
+               imports: [RouterModule.forChild([{path: 'loaded', component: LazyComponent2}])]
+             })
+             class SiblingOfLoadedModule {
+             }
 
-          @Component({ selector: 'lazy', template: 'lazy-loaded-1' })
-          class LazyComponent1 {
-          }
+             @Component({selector: 'lazy', template: 'lazy-loaded-1'})
+             class LazyComponent1 {
+             }
 
-          @NgModule({
-            declarations: [LazyComponent1],
-            imports: [
-              RouterModule.forChild([{ path: 'loaded', component: LazyComponent1 }]),
-              SiblingOfLoadedModule
-            ]
-          })
-          class LoadedModule {
-          }
+             @NgModule({
+               declarations: [LazyComponent1],
+               imports: [
+                 RouterModule.forChild([{path: 'loaded', component: LazyComponent1}]),
+                 SiblingOfLoadedModule
+               ]
+             })
+             class LoadedModule {
+             }
 
-          loader.stubbedModules = { expected1: LoadedModule, expected2: SiblingOfLoadedModule };
+             loader.stubbedModules = {expected1: LoadedModule, expected2: SiblingOfLoadedModule};
 
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([
-            { path: 'lazy1', loadChildren: 'expected1' },
-            { path: 'lazy2', loadChildren: 'expected2' }
-          ]);
+             router.resetConfig([
+               {path: 'lazy1', loadChildren: 'expected1'},
+               {path: 'lazy2', loadChildren: 'expected2'}
+             ]);
 
-          router.navigateByUrl('/lazy1/loaded');
-          advance(fixture);
-          expect(location.path()).toEqual('/lazy1/loaded');
+             router.navigateByUrl('/lazy1/loaded');
+             advance(fixture);
+             expect(location.path()).toEqual('/lazy1/loaded');
 
-          router.navigateByUrl('/lazy2/loaded');
-          advance(fixture);
-          expect(location.path()).toEqual('/lazy2/loaded');
-        })));
+             router.navigateByUrl('/lazy2/loaded');
+             advance(fixture);
+             expect(location.path()).toEqual('/lazy2/loaded');
+           })));
 
     it('should allow lazy loaded module in named outlet',
-      fakeAsync(inject(
-        [Router, NgModuleFactoryLoader], (router: Router, loader: SpyNgModuleFactoryLoader) => {
+       fakeAsync(inject(
+           [Router, NgModuleFactoryLoader], (router: Router, loader: SpyNgModuleFactoryLoader) => {
 
-          @Component({ selector: 'lazy', template: 'lazy-loaded' })
-          class LazyComponent {
-          }
+             @Component({selector: 'lazy', template: 'lazy-loaded'})
+             class LazyComponent {
+             }
 
-          @NgModule({
-            declarations: [LazyComponent],
-            imports: [RouterModule.forChild([{ path: '', component: LazyComponent }])]
-          })
-          class LazyLoadedModule {
-          }
+             @NgModule({
+               declarations: [LazyComponent],
+               imports: [RouterModule.forChild([{path: '', component: LazyComponent}])]
+             })
+             class LazyLoadedModule {
+             }
 
-          loader.stubbedModules = { lazyModule: LazyLoadedModule };
+             loader.stubbedModules = {lazyModule: LazyLoadedModule};
 
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([{
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              { path: 'user/:name', component: UserCmp },
-              { path: 'lazy', loadChildren: 'lazyModule', outlet: 'right' },
-            ]
-          }]);
+             router.resetConfig([{
+               path: 'team/:id',
+               component: TeamCmp,
+               children: [
+                 {path: 'user/:name', component: UserCmp},
+                 {path: 'lazy', loadChildren: 'lazyModule', outlet: 'right'},
+               ]
+             }]);
 
 
-          router.navigateByUrl('/team/22/user/john');
-          advance(fixture);
+             router.navigateByUrl('/team/22/user/john');
+             advance(fixture);
 
-          expect(fixture.nativeElement).toHaveText('team 22 [ user john, right:  ]');
+             expect(fixture.nativeElement).toHaveText('team 22 [ user john, right:  ]');
 
-          router.navigateByUrl('/team/22/(user/john//right:lazy)');
-          advance(fixture);
+             router.navigateByUrl('/team/22/(user/john//right:lazy)');
+             advance(fixture);
 
-          expect(fixture.nativeElement).toHaveText('team 22 [ user john, right: lazy-loaded ]');
-        })));
+             expect(fixture.nativeElement).toHaveText('team 22 [ user john, right: lazy-loaded ]');
+           })));
 
     it('should allow componentless named outlet to render children',
-      fakeAsync(inject(
-        [Router, NgModuleFactoryLoader], (router: Router, loader: SpyNgModuleFactoryLoader) => {
+       fakeAsync(inject(
+           [Router, NgModuleFactoryLoader], (router: Router, loader: SpyNgModuleFactoryLoader) => {
 
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([{
-            path: 'team/:id',
-            component: TeamCmp,
-            children: [
-              { path: 'user/:name', component: UserCmp },
-              { path: 'simple', outlet: 'right', children: [{ path: '', component: SimpleCmp }] },
-            ]
-          }]);
+             router.resetConfig([{
+               path: 'team/:id',
+               component: TeamCmp,
+               children: [
+                 {path: 'user/:name', component: UserCmp},
+                 {path: 'simple', outlet: 'right', children: [{path: '', component: SimpleCmp}]},
+               ]
+             }]);
 
 
-          router.navigateByUrl('/team/22/user/john');
-          advance(fixture);
+             router.navigateByUrl('/team/22/user/john');
+             advance(fixture);
 
-          expect(fixture.nativeElement).toHaveText('team 22 [ user john, right:  ]');
+             expect(fixture.nativeElement).toHaveText('team 22 [ user john, right:  ]');
 
-          router.navigateByUrl('/team/22/(user/john//right:simple)');
-          advance(fixture);
+             router.navigateByUrl('/team/22/(user/john//right:simple)');
+             advance(fixture);
 
-          expect(fixture.nativeElement).toHaveText('team 22 [ user john, right: simple ]');
-        })));
+             expect(fixture.nativeElement).toHaveText('team 22 [ user john, right: simple ]');
+           })));
 
     describe('should use the injector of the lazily-loaded configuration', () => {
-      class LazyLoadedServiceDefinedInModule { }
+      class LazyLoadedServiceDefinedInModule {}
 
       @Component({
         selector: 'eager-parent',
@@ -3571,11 +3577,11 @@ describe('Integration', () => {
       })
       class LazyChildComponent {
         constructor(
-          lazy: LazyParentComponent,  // should be able to inject lazy/direct parent
-          lazyService: LazyLoadedServiceDefinedInModule,  // should be able to inject lazy service
-          eager:
-            EagerParentComponent  // should use the injector of the location to create a parent
-        ) { }
+            lazy: LazyParentComponent,  // should be able to inject lazy/direct parent
+            lazyService: LazyLoadedServiceDefinedInModule,  // should be able to inject lazy service
+            eager:
+                EagerParentComponent  // should use the injector of the location to create a parent
+            ) {}
       }
 
       @NgModule({
@@ -3585,7 +3591,7 @@ describe('Integration', () => {
           children: [{
             path: 'lazy-parent',
             component: LazyParentComponent,
-            children: [{ path: 'lazy-child', component: LazyChildComponent }]
+            children: [{path: 'lazy-child', component: LazyChildComponent}]
           }]
         }])],
         providers: [LazyLoadedServiceDefinedInModule]
@@ -3608,182 +3614,182 @@ describe('Integration', () => {
       });
 
       it('should use the injector of the lazily-loaded configuration',
-        fakeAsync(inject(
-          [Router, Location, NgModuleFactoryLoader],
-          (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-            loader.stubbedModules = { expected: LoadedModule };
+         fakeAsync(inject(
+             [Router, Location, NgModuleFactoryLoader],
+             (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+               loader.stubbedModules = {expected: LoadedModule};
 
-            const fixture = createRoot(router, RootCmp);
+               const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([{
-              path: 'eager-parent',
-              component: EagerParentComponent,
-              children: [{ path: 'lazy', loadChildren: 'expected' }]
-            }]);
+               router.resetConfig([{
+                 path: 'eager-parent',
+                 component: EagerParentComponent,
+                 children: [{path: 'lazy', loadChildren: 'expected'}]
+               }]);
 
-            router.navigateByUrl('/eager-parent/lazy/lazy-parent/lazy-child');
-            advance(fixture);
+               router.navigateByUrl('/eager-parent/lazy/lazy-parent/lazy-child');
+               advance(fixture);
 
-            expect(location.path()).toEqual('/eager-parent/lazy/lazy-parent/lazy-child');
-            expect(fixture.nativeElement).toHaveText('eager-parent lazy-parent lazy-child');
-          })));
+               expect(location.path()).toEqual('/eager-parent/lazy/lazy-parent/lazy-child');
+               expect(fixture.nativeElement).toHaveText('eager-parent lazy-parent lazy-child');
+             })));
     });
 
     it('works when given a callback',
-      fakeAsync(inject(
-        [Router, Location, NgModuleFactoryLoader], (router: Router, location: Location) => {
-          @Component({ selector: 'lazy', template: 'lazy-loaded' })
-          class LazyLoadedComponent {
-          }
+       fakeAsync(inject(
+           [Router, Location, NgModuleFactoryLoader], (router: Router, location: Location) => {
+             @Component({selector: 'lazy', template: 'lazy-loaded'})
+             class LazyLoadedComponent {
+             }
 
-          @NgModule({
-            declarations: [LazyLoadedComponent],
-            imports: [RouterModule.forChild([{ path: 'loaded', component: LazyLoadedComponent }])],
-          })
-          class LoadedModule {
-          }
+             @NgModule({
+               declarations: [LazyLoadedComponent],
+               imports: [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])],
+             })
+             class LoadedModule {
+             }
 
-          const fixture = createRoot(router, RootCmp);
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([{ path: 'lazy', loadChildren: () => LoadedModule }]);
+             router.resetConfig([{path: 'lazy', loadChildren: () => LoadedModule}]);
 
-          router.navigateByUrl('/lazy/loaded');
-          advance(fixture);
+             router.navigateByUrl('/lazy/loaded');
+             advance(fixture);
 
-          expect(location.path()).toEqual('/lazy/loaded');
-          expect(fixture.nativeElement).toHaveText('lazy-loaded');
-        })));
+             expect(location.path()).toEqual('/lazy/loaded');
+             expect(fixture.nativeElement).toHaveText('lazy-loaded');
+           })));
 
     it('error emit an error when cannot load a config',
-      fakeAsync(inject(
-        [Router, Location, NgModuleFactoryLoader],
-        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-          loader.stubbedModules = {};
-          const fixture = createRoot(router, RootCmp);
+       fakeAsync(inject(
+           [Router, Location, NgModuleFactoryLoader],
+           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+             loader.stubbedModules = {};
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([{ path: 'lazy', loadChildren: 'invalid' }]);
+             router.resetConfig([{path: 'lazy', loadChildren: 'invalid'}]);
 
-          const recordedEvents: any[] = [];
-          router.events.forEach(e => recordedEvents.push(e));
+             const recordedEvents: any[] = [];
+             router.events.forEach(e => recordedEvents.push(e));
 
-          router.navigateByUrl('/lazy/loaded')!.catch(s => { });
-          advance(fixture);
+             router.navigateByUrl('/lazy/loaded') !.catch(s => {});
+             advance(fixture);
 
-          expect(location.path()).toEqual('/');
+             expect(location.path()).toEqual('/');
 
-          expectEvents(recordedEvents, [
-            [NavigationStart, '/lazy/loaded'],
-            [RouteConfigLoadStart],
-            [NavigationError, '/lazy/loaded'],
-          ]);
-        })));
+             expectEvents(recordedEvents, [
+               [NavigationStart, '/lazy/loaded'],
+               [RouteConfigLoadStart],
+               [NavigationError, '/lazy/loaded'],
+             ]);
+           })));
 
     it('should work with complex redirect rules',
-      fakeAsync(inject(
-        [Router, Location, NgModuleFactoryLoader],
-        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-          @Component({ selector: 'lazy', template: 'lazy-loaded' })
-          class LazyLoadedComponent {
-          }
+       fakeAsync(inject(
+           [Router, Location, NgModuleFactoryLoader],
+           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+             @Component({selector: 'lazy', template: 'lazy-loaded'})
+             class LazyLoadedComponent {
+             }
 
-          @NgModule({
-            declarations: [LazyLoadedComponent],
-            imports: [RouterModule.forChild([{ path: 'loaded', component: LazyLoadedComponent }])],
-          })
-          class LoadedModule {
-          }
+             @NgModule({
+               declarations: [LazyLoadedComponent],
+               imports: [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])],
+             })
+             class LoadedModule {
+             }
 
-          loader.stubbedModules = { lazy: LoadedModule };
-          const fixture = createRoot(router, RootCmp);
+             loader.stubbedModules = {lazy: LoadedModule};
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig(
-            [{ path: 'lazy', loadChildren: 'lazy' }, { path: '**', redirectTo: 'lazy' }]);
+             router.resetConfig(
+                 [{path: 'lazy', loadChildren: 'lazy'}, {path: '**', redirectTo: 'lazy'}]);
 
-          router.navigateByUrl('/lazy/loaded');
-          advance(fixture);
+             router.navigateByUrl('/lazy/loaded');
+             advance(fixture);
 
-          expect(location.path()).toEqual('/lazy/loaded');
-        })));
+             expect(location.path()).toEqual('/lazy/loaded');
+           })));
 
     it('should work with wildcard route',
-      fakeAsync(inject(
-        [Router, Location, NgModuleFactoryLoader],
-        (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-          @Component({ selector: 'lazy', template: 'lazy-loaded' })
-          class LazyLoadedComponent {
-          }
+       fakeAsync(inject(
+           [Router, Location, NgModuleFactoryLoader],
+           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+             @Component({selector: 'lazy', template: 'lazy-loaded'})
+             class LazyLoadedComponent {
+             }
 
-          @NgModule({
-            declarations: [LazyLoadedComponent],
-            imports: [RouterModule.forChild([{ path: '', component: LazyLoadedComponent }])],
-          })
-          class LazyLoadedModule {
-          }
+             @NgModule({
+               declarations: [LazyLoadedComponent],
+               imports: [RouterModule.forChild([{path: '', component: LazyLoadedComponent}])],
+             })
+             class LazyLoadedModule {
+             }
 
-          loader.stubbedModules = { lazy: LazyLoadedModule };
-          const fixture = createRoot(router, RootCmp);
+             loader.stubbedModules = {lazy: LazyLoadedModule};
+             const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([{ path: '**', loadChildren: 'lazy' }]);
+             router.resetConfig([{path: '**', loadChildren: 'lazy'}]);
 
-          router.navigateByUrl('/lazy');
-          advance(fixture);
+             router.navigateByUrl('/lazy');
+             advance(fixture);
 
-          expect(location.path()).toEqual('/lazy');
-          expect(fixture.nativeElement).toHaveText('lazy-loaded');
-        })));
+             expect(location.path()).toEqual('/lazy');
+             expect(fixture.nativeElement).toHaveText('lazy-loaded');
+           })));
 
     describe('preloading', () => {
       beforeEach(() => {
         TestBed.configureTestingModule(
-          { providers: [{ provide: PreloadingStrategy, useExisting: PreloadAllModules }] });
+            {providers: [{provide: PreloadingStrategy, useExisting: PreloadAllModules}]});
         const preloader = TestBed.get(RouterPreloader);
         preloader.setUpPreloading();
       });
 
       it('should work',
-        fakeAsync(inject(
-          [Router, Location, NgModuleFactoryLoader],
-          (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-            @Component({ selector: 'lazy', template: 'should not show' })
-            class LazyLoadedComponent {
-            }
+         fakeAsync(inject(
+             [Router, Location, NgModuleFactoryLoader],
+             (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+               @Component({selector: 'lazy', template: 'should not show'})
+               class LazyLoadedComponent {
+               }
 
-            @NgModule({
-              declarations: [LazyLoadedComponent],
-              imports: [RouterModule.forChild(
-                [{ path: 'LoadedModule2', component: LazyLoadedComponent }])]
-            })
-            class LoadedModule2 {
-            }
+               @NgModule({
+                 declarations: [LazyLoadedComponent],
+                 imports: [RouterModule.forChild(
+                     [{path: 'LoadedModule2', component: LazyLoadedComponent}])]
+               })
+               class LoadedModule2 {
+               }
 
-            @NgModule({
-              imports:
-                [RouterModule.forChild([{ path: 'LoadedModule1', loadChildren: 'expected2' }])]
-            })
-            class LoadedModule1 {
-            }
+               @NgModule({
+                 imports:
+                     [RouterModule.forChild([{path: 'LoadedModule1', loadChildren: 'expected2'}])]
+               })
+               class LoadedModule1 {
+               }
 
-            loader.stubbedModules = { expected: LoadedModule1, expected2: LoadedModule2 };
+               loader.stubbedModules = {expected: LoadedModule1, expected2: LoadedModule2};
 
-            const fixture = createRoot(router, RootCmp);
+               const fixture = createRoot(router, RootCmp);
 
-            router.resetConfig([
-              { path: 'blank', component: BlankCmp }, { path: 'lazy', loadChildren: 'expected' }
-            ]);
+               router.resetConfig([
+                 {path: 'blank', component: BlankCmp}, {path: 'lazy', loadChildren: 'expected'}
+               ]);
 
-            router.navigateByUrl('/blank');
-            advance(fixture);
+               router.navigateByUrl('/blank');
+               advance(fixture);
 
-            const config = router.config as any;
-            const firstConfig = config[1]._loadedConfig!;
+               const config = router.config as any;
+               const firstConfig = config[1]._loadedConfig !;
 
-            expect(firstConfig).toBeDefined();
-            expect(firstConfig.routes[0].path).toEqual('LoadedModule1');
+               expect(firstConfig).toBeDefined();
+               expect(firstConfig.routes[0].path).toEqual('LoadedModule1');
 
-            const secondConfig = firstConfig.routes[0]._loadedConfig!;
-            expect(secondConfig).toBeDefined();
-            expect(secondConfig.routes[0].path).toEqual('LoadedModule2');
-          })));
+               const secondConfig = firstConfig.routes[0]._loadedConfig !;
+               expect(secondConfig).toBeDefined();
+               expect(secondConfig.routes[0].path).toEqual('LoadedModule2');
+             })));
 
     });
 
@@ -3824,136 +3830,136 @@ describe('Integration', () => {
 
       beforeEach(() => {
         TestBed.configureTestingModule(
-          { providers: [{ provide: UrlHandlingStrategy, useClass: CustomUrlHandlingStrategy }] });
+            {providers: [{provide: UrlHandlingStrategy, useClass: CustomUrlHandlingStrategy}]});
       });
 
       it('should work',
-        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+           const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([{
-            path: 'include',
-            component: TeamCmp,
-            children: [
-              { path: 'user/:name', component: UserCmp }, { path: 'simple', component: SimpleCmp }
-            ]
-          }]);
+           router.resetConfig([{
+             path: 'include',
+             component: TeamCmp,
+             children: [
+               {path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}
+             ]
+           }]);
 
-          const events: any[] = [];
-          router.events.subscribe(e => e instanceof RouterEvent && events.push(e));
+           const events: any[] = [];
+           router.events.subscribe(e => e instanceof RouterEvent && events.push(e));
 
-          // supported URL
-          router.navigateByUrl('/include/user/kate');
-          advance(fixture);
+           // supported URL
+           router.navigateByUrl('/include/user/kate');
+           advance(fixture);
 
-          expect(location.path()).toEqual('/include/user/kate');
-          expectEvents(events, [
-            [NavigationStart, '/include/user/kate'], [RoutesRecognized, '/include/user/kate'],
-            [GuardsCheckStart, '/include/user/kate'], [GuardsCheckEnd, '/include/user/kate'],
-            [ResolveStart, '/include/user/kate'], [ResolveEnd, '/include/user/kate'],
-            [NavigationEnd, '/include/user/kate']
-          ]);
-          expect(fixture.nativeElement).toHaveText('team  [ user kate, right:  ]');
-          events.splice(0);
+           expect(location.path()).toEqual('/include/user/kate');
+           expectEvents(events, [
+             [NavigationStart, '/include/user/kate'], [RoutesRecognized, '/include/user/kate'],
+             [GuardsCheckStart, '/include/user/kate'], [GuardsCheckEnd, '/include/user/kate'],
+             [ResolveStart, '/include/user/kate'], [ResolveEnd, '/include/user/kate'],
+             [NavigationEnd, '/include/user/kate']
+           ]);
+           expect(fixture.nativeElement).toHaveText('team  [ user kate, right:  ]');
+           events.splice(0);
 
-          // unsupported URL
-          router.navigateByUrl('/exclude/one');
-          advance(fixture);
+           // unsupported URL
+           router.navigateByUrl('/exclude/one');
+           advance(fixture);
 
-          expect(location.path()).toEqual('/exclude/one');
-          expect(Object.keys(router.routerState.root.children).length).toEqual(0);
-          expect(fixture.nativeElement).toHaveText('');
-          expectEvents(events, [
-            [NavigationStart, '/exclude/one'], [GuardsCheckStart, '/exclude/one'],
-            [GuardsCheckEnd, '/exclude/one'], [NavigationEnd, '/exclude/one']
-          ]);
-          events.splice(0);
+           expect(location.path()).toEqual('/exclude/one');
+           expect(Object.keys(router.routerState.root.children).length).toEqual(0);
+           expect(fixture.nativeElement).toHaveText('');
+           expectEvents(events, [
+             [NavigationStart, '/exclude/one'], [GuardsCheckStart, '/exclude/one'],
+             [GuardsCheckEnd, '/exclude/one'], [NavigationEnd, '/exclude/one']
+           ]);
+           events.splice(0);
 
-          // another unsupported URL
-          location.go('/exclude/two');
-          advance(fixture);
+           // another unsupported URL
+           location.go('/exclude/two');
+           advance(fixture);
 
-          expect(location.path()).toEqual('/exclude/two');
-          expectEvents(events, []);
+           expect(location.path()).toEqual('/exclude/two');
+           expectEvents(events, []);
 
-          // back to a supported URL
-          location.go('/include/simple');
-          advance(fixture);
+           // back to a supported URL
+           location.go('/include/simple');
+           advance(fixture);
 
-          expect(location.path()).toEqual('/include/simple');
-          expect(fixture.nativeElement).toHaveText('team  [ simple, right:  ]');
+           expect(location.path()).toEqual('/include/simple');
+           expect(fixture.nativeElement).toHaveText('team  [ simple, right:  ]');
 
-          expectEvents(events, [
-            [NavigationStart, '/include/simple'], [RoutesRecognized, '/include/simple'],
-            [GuardsCheckStart, '/include/simple'], [GuardsCheckEnd, '/include/simple'],
-            [ResolveStart, '/include/simple'], [ResolveEnd, '/include/simple'],
-            [NavigationEnd, '/include/simple']
-          ]);
-        })));
+           expectEvents(events, [
+             [NavigationStart, '/include/simple'], [RoutesRecognized, '/include/simple'],
+             [GuardsCheckStart, '/include/simple'], [GuardsCheckEnd, '/include/simple'],
+             [ResolveStart, '/include/simple'], [ResolveEnd, '/include/simple'],
+             [NavigationEnd, '/include/simple']
+           ]);
+         })));
 
       it('should handle the case when the router takes only the primary url',
-        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-          const fixture = createRoot(router, RootCmp);
+         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+           const fixture = createRoot(router, RootCmp);
 
-          router.resetConfig([{
-            path: 'include',
-            component: TeamCmp,
-            children: [
-              { path: 'user/:name', component: UserCmp }, { path: 'simple', component: SimpleCmp }
-            ]
-          }]);
+           router.resetConfig([{
+             path: 'include',
+             component: TeamCmp,
+             children: [
+               {path: 'user/:name', component: UserCmp}, {path: 'simple', component: SimpleCmp}
+             ]
+           }]);
 
-          const events: any[] = [];
-          router.events.subscribe(e => e instanceof RouterEvent && events.push(e));
+           const events: any[] = [];
+           router.events.subscribe(e => e instanceof RouterEvent && events.push(e));
 
-          location.go('/include/user/kate(aux:excluded)');
-          advance(fixture);
+           location.go('/include/user/kate(aux:excluded)');
+           advance(fixture);
 
-          expect(location.path()).toEqual('/include/user/kate(aux:excluded)');
-          expectEvents(events, [
-            [NavigationStart, '/include/user/kate'], [RoutesRecognized, '/include/user/kate'],
-            [GuardsCheckStart, '/include/user/kate'], [GuardsCheckEnd, '/include/user/kate'],
-            [ResolveStart, '/include/user/kate'], [ResolveEnd, '/include/user/kate'],
-            [NavigationEnd, '/include/user/kate']
-          ]);
-          events.splice(0);
+           expect(location.path()).toEqual('/include/user/kate(aux:excluded)');
+           expectEvents(events, [
+             [NavigationStart, '/include/user/kate'], [RoutesRecognized, '/include/user/kate'],
+             [GuardsCheckStart, '/include/user/kate'], [GuardsCheckEnd, '/include/user/kate'],
+             [ResolveStart, '/include/user/kate'], [ResolveEnd, '/include/user/kate'],
+             [NavigationEnd, '/include/user/kate']
+           ]);
+           events.splice(0);
 
-          location.go('/include/user/kate(aux:excluded2)');
-          advance(fixture);
-          expectEvents(events, []);
+           location.go('/include/user/kate(aux:excluded2)');
+           advance(fixture);
+           expectEvents(events, []);
 
-          router.navigateByUrl('/include/simple');
-          advance(fixture);
+           router.navigateByUrl('/include/simple');
+           advance(fixture);
 
-          expect(location.path()).toEqual('/include/simple(aux:excluded2)');
-          expectEvents(events, [
-            [NavigationStart, '/include/simple'], [RoutesRecognized, '/include/simple'],
-            [GuardsCheckStart, '/include/simple'], [GuardsCheckEnd, '/include/simple'],
-            [ResolveStart, '/include/simple'], [ResolveEnd, '/include/simple'],
-            [NavigationEnd, '/include/simple']
-          ]);
-        })));
+           expect(location.path()).toEqual('/include/simple(aux:excluded2)');
+           expectEvents(events, [
+             [NavigationStart, '/include/simple'], [RoutesRecognized, '/include/simple'],
+             [GuardsCheckStart, '/include/simple'], [GuardsCheckEnd, '/include/simple'],
+             [ResolveStart, '/include/simple'], [ResolveEnd, '/include/simple'],
+             [NavigationEnd, '/include/simple']
+           ]);
+         })));
     });
   });
 
   describe('Custom Route Reuse Strategy', () => {
     class AttachDetachReuseStrategy implements RouteReuseStrategy {
-      stored: { [k: string]: DetachedRouteHandle } = {};
+      stored: {[k: string]: DetachedRouteHandle} = {};
 
       shouldDetach(route: ActivatedRouteSnapshot): boolean {
-        return route.routeConfig!.path === 'a';
+        return route.routeConfig !.path === 'a';
       }
 
       store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void {
-        this.stored[route.routeConfig!.path!] = detachedTree;
+        this.stored[route.routeConfig !.path !] = detachedTree;
       }
 
       shouldAttach(route: ActivatedRouteSnapshot): boolean {
-        return !!this.stored[route.routeConfig!.path!];
+        return !!this.stored[route.routeConfig !.path !];
       }
 
       retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle {
-        return this.stored[route.routeConfig!.path!];
+        return this.stored[route.routeConfig !.path !];
       }
 
       shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
@@ -3963,9 +3969,9 @@ describe('Integration', () => {
 
     class ShortLifecycle implements RouteReuseStrategy {
       shouldDetach(route: ActivatedRouteSnapshot): boolean { return false; }
-      store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void { }
+      store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void {}
       shouldAttach(route: ActivatedRouteSnapshot): boolean { return false; }
-      retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle | null { return null; }
+      retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle|null { return null; }
       shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
         if (future.routeConfig !== curr.routeConfig) {
           return false;
@@ -3980,141 +3986,141 @@ describe('Integration', () => {
     }
 
     it('should support attaching & detaching fragments',
-      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = createRoot(router, RootCmp);
 
-        router.routeReuseStrategy = new AttachDetachReuseStrategy();
+         router.routeReuseStrategy = new AttachDetachReuseStrategy();
 
-        router.resetConfig([
-          {
-            path: 'a',
-            component: TeamCmp,
-            children: [{ path: 'b', component: SimpleCmp }],
-          },
-          { path: 'c', component: UserCmp },
-        ]);
+         router.resetConfig([
+           {
+             path: 'a',
+             component: TeamCmp,
+             children: [{path: 'b', component: SimpleCmp}],
+           },
+           {path: 'c', component: UserCmp},
+         ]);
 
-        router.navigateByUrl('/a/b');
-        advance(fixture);
-        const teamCmp = fixture.debugElement.children[1].componentInstance;
-        const simpleCmp = fixture.debugElement.children[1].children[1].componentInstance;
-        expect(location.path()).toEqual('/a/b');
-        expect(teamCmp).toBeDefined();
-        expect(simpleCmp).toBeDefined();
+         router.navigateByUrl('/a/b');
+         advance(fixture);
+         const teamCmp = fixture.debugElement.children[1].componentInstance;
+         const simpleCmp = fixture.debugElement.children[1].children[1].componentInstance;
+         expect(location.path()).toEqual('/a/b');
+         expect(teamCmp).toBeDefined();
+         expect(simpleCmp).toBeDefined();
 
-        router.navigateByUrl('/c');
-        advance(fixture);
-        expect(location.path()).toEqual('/c');
-        expect(fixture.debugElement.children[1].componentInstance).toBeAnInstanceOf(UserCmp);
+         router.navigateByUrl('/c');
+         advance(fixture);
+         expect(location.path()).toEqual('/c');
+         expect(fixture.debugElement.children[1].componentInstance).toBeAnInstanceOf(UserCmp);
 
-        router.navigateByUrl('/a;p=1/b;p=2');
-        advance(fixture);
-        const teamCmp2 = fixture.debugElement.children[1].componentInstance;
-        const simpleCmp2 = fixture.debugElement.children[1].children[1].componentInstance;
-        expect(location.path()).toEqual('/a;p=1/b;p=2');
-        expect(teamCmp2).toBe(teamCmp);
-        expect(simpleCmp2).toBe(simpleCmp);
+         router.navigateByUrl('/a;p=1/b;p=2');
+         advance(fixture);
+         const teamCmp2 = fixture.debugElement.children[1].componentInstance;
+         const simpleCmp2 = fixture.debugElement.children[1].children[1].componentInstance;
+         expect(location.path()).toEqual('/a;p=1/b;p=2');
+         expect(teamCmp2).toBe(teamCmp);
+         expect(simpleCmp2).toBe(simpleCmp);
 
-        expect(teamCmp.route).toBe(router.routerState.root.firstChild);
-        expect(teamCmp.route.snapshot).toBe(router.routerState.snapshot.root.firstChild);
-        expect(teamCmp.route.snapshot.params).toEqual({ p: '1' });
-        expect(teamCmp.route.firstChild.snapshot.params).toEqual({ p: '2' });
-      })));
+         expect(teamCmp.route).toBe(router.routerState.root.firstChild);
+         expect(teamCmp.route.snapshot).toBe(router.routerState.snapshot.root.firstChild);
+         expect(teamCmp.route.snapshot.params).toEqual({p: '1'});
+         expect(teamCmp.route.firstChild.snapshot.params).toEqual({p: '2'});
+       })));
 
     it('should support shorter lifecycles',
-      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-        const fixture = createRoot(router, RootCmp);
-        router.routeReuseStrategy = new ShortLifecycle();
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = createRoot(router, RootCmp);
+         router.routeReuseStrategy = new ShortLifecycle();
 
-        router.resetConfig([{ path: 'a', component: SimpleCmp }]);
+         router.resetConfig([{path: 'a', component: SimpleCmp}]);
 
-        router.navigateByUrl('/a');
-        advance(fixture);
-        const simpleCmp1 = fixture.debugElement.children[1].componentInstance;
-        expect(location.path()).toEqual('/a');
+         router.navigateByUrl('/a');
+         advance(fixture);
+         const simpleCmp1 = fixture.debugElement.children[1].componentInstance;
+         expect(location.path()).toEqual('/a');
 
-        router.navigateByUrl('/a;p=1');
-        advance(fixture);
-        expect(location.path()).toEqual('/a;p=1');
-        const simpleCmp2 = fixture.debugElement.children[1].componentInstance;
-        expect(simpleCmp1).not.toBe(simpleCmp2);
-      })));
+         router.navigateByUrl('/a;p=1');
+         advance(fixture);
+         expect(location.path()).toEqual('/a;p=1');
+         const simpleCmp2 = fixture.debugElement.children[1].componentInstance;
+         expect(simpleCmp1).not.toBe(simpleCmp2);
+       })));
 
     it('should not mount the component of the previously reused route when the outlet was not instantiated at the time of route activation',
-      fakeAsync(() => {
-        @Component({
-          selector: 'root-cmp',
-          template:
-            '<div *ngIf="isToolpanelShowing"><router-outlet name="toolpanel"></router-outlet></div>'
-        })
-        class RootCmpWithCondOutlet implements OnDestroy {
-          private subscription: Subscription;
-          public isToolpanelShowing: boolean = false;
+       fakeAsync(() => {
+         @Component({
+           selector: 'root-cmp',
+           template:
+               '<div *ngIf="isToolpanelShowing"><router-outlet name="toolpanel"></router-outlet></div>'
+         })
+         class RootCmpWithCondOutlet implements OnDestroy {
+           private subscription: Subscription;
+           public isToolpanelShowing: boolean = false;
 
-          constructor(router: Router) {
-            this.subscription =
-              router.events.pipe(filter(event => event instanceof NavigationEnd))
-                .subscribe(
-                  () => this.isToolpanelShowing =
-                    !!router.parseUrl(router.url).root.children['toolpanel']);
-          }
+           constructor(router: Router) {
+             this.subscription =
+                 router.events.pipe(filter(event => event instanceof NavigationEnd))
+                     .subscribe(
+                         () => this.isToolpanelShowing =
+                             !!router.parseUrl(router.url).root.children['toolpanel']);
+           }
 
-          public ngOnDestroy(): void { this.subscription.unsubscribe(); }
-        }
+           public ngOnDestroy(): void { this.subscription.unsubscribe(); }
+         }
 
-        @Component({ selector: 'tool-1-cmp', template: 'Tool 1 showing' })
-        class Tool1Component {
-        }
+         @Component({selector: 'tool-1-cmp', template: 'Tool 1 showing'})
+         class Tool1Component {
+         }
 
-        @Component({ selector: 'tool-2-cmp', template: 'Tool 2 showing' })
-        class Tool2Component {
-        }
+         @Component({selector: 'tool-2-cmp', template: 'Tool 2 showing'})
+         class Tool2Component {
+         }
 
-        @NgModule({
-          declarations: [RootCmpWithCondOutlet, Tool1Component, Tool2Component],
-          imports: [
-            CommonModule,
-            RouterTestingModule.withRoutes([
-              { path: 'a', outlet: 'toolpanel', component: Tool1Component },
-              { path: 'b', outlet: 'toolpanel', component: Tool2Component },
-            ]),
-          ],
-        })
-        class TestModule {
-        }
+         @NgModule({
+           declarations: [RootCmpWithCondOutlet, Tool1Component, Tool2Component],
+           imports: [
+             CommonModule,
+             RouterTestingModule.withRoutes([
+               {path: 'a', outlet: 'toolpanel', component: Tool1Component},
+               {path: 'b', outlet: 'toolpanel', component: Tool2Component},
+             ]),
+           ],
+         })
+         class TestModule {
+         }
 
-        TestBed.configureTestingModule({ imports: [TestModule] });
+         TestBed.configureTestingModule({imports: [TestModule]});
 
-        const router: Router = TestBed.get(Router);
-        router.routeReuseStrategy = new AttachDetachReuseStrategy();
+         const router: Router = TestBed.get(Router);
+         router.routeReuseStrategy = new AttachDetachReuseStrategy();
 
-        const fixture = createRoot(router, RootCmpWithCondOutlet);
+         const fixture = createRoot(router, RootCmpWithCondOutlet);
 
-        // Activate 'tool-1'
-        router.navigate([{ outlets: { toolpanel: 'a' } }]);
-        advance(fixture);
-        expect(fixture).toContainComponent(Tool1Component, '(a)');
+         // Activate 'tool-1'
+         router.navigate([{outlets: {toolpanel: 'a'}}]);
+         advance(fixture);
+         expect(fixture).toContainComponent(Tool1Component, '(a)');
 
-        // Deactivate 'tool-1'
-        router.navigate([{ outlets: { toolpanel: null } }]);
-        advance(fixture);
-        expect(fixture).not.toContainComponent(Tool1Component, '(b)');
+         // Deactivate 'tool-1'
+         router.navigate([{outlets: {toolpanel: null}}]);
+         advance(fixture);
+         expect(fixture).not.toContainComponent(Tool1Component, '(b)');
 
-        // Activate 'tool-1'
-        router.navigate([{ outlets: { toolpanel: 'a' } }]);
-        advance(fixture);
-        expect(fixture).toContainComponent(Tool1Component, '(c)');
+         // Activate 'tool-1'
+         router.navigate([{outlets: {toolpanel: 'a'}}]);
+         advance(fixture);
+         expect(fixture).toContainComponent(Tool1Component, '(c)');
 
-        // Deactivate 'tool-1'
-        router.navigate([{ outlets: { toolpanel: null } }]);
-        advance(fixture);
-        expect(fixture).not.toContainComponent(Tool1Component, '(d)');
+         // Deactivate 'tool-1'
+         router.navigate([{outlets: {toolpanel: null}}]);
+         advance(fixture);
+         expect(fixture).not.toContainComponent(Tool1Component, '(d)');
 
-        // Activate 'tool-2'
-        router.navigate([{ outlets: { toolpanel: 'b' } }]);
-        advance(fixture);
-        expect(fixture).toContainComponent(Tool2Component, '(e)');
-      }));
+         // Activate 'tool-2'
+         router.navigate([{outlets: {toolpanel: 'b'}}]);
+         advance(fixture);
+         expect(fixture).toContainComponent(Tool2Component, '(e)');
+       }));
   });
 });
 
@@ -4122,12 +4128,12 @@ describe('Testing router options', () => {
   describe('paramsInheritanceStrategy', () => {
     beforeEach(() => {
       TestBed.configureTestingModule(
-        { imports: [RouterTestingModule.withRoutes([], { paramsInheritanceStrategy: 'always' })] });
+          {imports: [RouterTestingModule.withRoutes([], {paramsInheritanceStrategy: 'always'})]});
     });
 
     it('should configure the router', fakeAsync(inject([Router], (router: Router) => {
-      expect(router.paramsInheritanceStrategy).toEqual('always');
-    })));
+         expect(router.paramsInheritanceStrategy).toEqual('always');
+       })));
   });
 
   describe('malformedUriErrorHandler', () => {
@@ -4138,12 +4144,12 @@ describe('Testing router options', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-        { imports: [RouterTestingModule.withRoutes([], { malformedUriErrorHandler })] });
+          {imports: [RouterTestingModule.withRoutes([], {malformedUriErrorHandler})]});
     });
 
     it('should configure the router', fakeAsync(inject([Router], (router: Router) => {
-      expect(router.malformedUriErrorHandler).toBe(malformedUriErrorHandler);
-    })));
+         expect(router.malformedUriErrorHandler).toBe(malformedUriErrorHandler);
+       })));
   });
 });
 
@@ -4160,11 +4166,11 @@ function onlyNavigationStartAndEnd(e: Event): boolean {
 }
 
 @Component(
-  { selector: 'link-cmp', template: `<a routerLink="/team/33/simple" [target]="'_self'">link</a>` })
+    {selector: 'link-cmp', template: `<a routerLink="/team/33/simple" [target]="'_self'">link</a>`})
 class StringLinkCmp {
 }
 
-@Component({ selector: 'link-cmp', template: `<button routerLink="/team/33/simple">link</button>` })
+@Component({selector: 'link-cmp', template: `<button routerLink="/team/33/simple">link</button>`})
 class StringLinkButtonCmp {
 }
 
@@ -4178,7 +4184,7 @@ class AbsoluteLinkCmp {
 @Component({
   selector: 'link-cmp',
   template:
-    `<router-outlet></router-outlet><a routerLinkActive="active" [routerLinkActiveOptions]="{exact: exact}" [routerLink]="['./']">link</a>
+      `<router-outlet></router-outlet><a routerLinkActive="active" [routerLinkActiveOptions]="{exact: exact}" [routerLink]="['./']">link</a>
 <button routerLinkActive="active" [routerLinkActiveOptions]="{exact: exact}" [routerLink]="['./']">button</button>
 `
 })
@@ -4189,7 +4195,7 @@ class DummyLinkCmp {
   }
 }
 
-@Component({ selector: 'link-cmp', template: `<a [routerLink]="['../simple']">link</a>` })
+@Component({selector: 'link-cmp', template: `<a [routerLink]="['../simple']">link</a>`})
 class RelativeLinkCmp {
 }
 
@@ -4200,11 +4206,11 @@ class RelativeLinkCmp {
 class LinkWithQueryParamsAndFragment {
 }
 
-@Component({ selector: 'simple-cmp', template: `simple` })
+@Component({selector: 'simple-cmp', template: `simple`})
 class SimpleCmp {
 }
 
-@Component({ selector: 'collect-params-cmp', template: `collect-params` })
+@Component({selector: 'collect-params-cmp', template: `collect-params`})
 class CollectParamsCmp {
   private params: any = [];
   private urls: any = [];
@@ -4219,16 +4225,16 @@ class CollectParamsCmp {
   }
 }
 
-@Component({ selector: 'blank-cmp', template: `` })
+@Component({selector: 'blank-cmp', template: ``})
 class BlankCmp {
 }
 
 @Component({
   selector: 'team-cmp',
   template: `team {{id | async}} ` +
-    `[ <router-outlet></router-outlet>, right: <router-outlet name="right"></router-outlet> ]` +
-    `<a [routerLink]="routerLink" skipLocationChange></a>` +
-    `<button [routerLink]="routerLink" skipLocationChange></button>`
+      `[ <router-outlet></router-outlet>, right: <router-outlet name="right"></router-outlet> ]` +
+      `<a [routerLink]="routerLink" skipLocationChange></a>` +
+      `<button [routerLink]="routerLink" skipLocationChange></button>`
 })
 class TeamCmp {
   id: Observable<string>;
@@ -4253,7 +4259,7 @@ class TwoOutletsCmp {
 }
 
 
-@Component({ selector: 'user-cmp', template: `user {{name | async}}` })
+@Component({selector: 'user-cmp', template: `user {{name | async}}`})
 class UserCmp {
   name: Observable<string>;
   recordedParams: Params[] = [];
@@ -4268,14 +4274,14 @@ class UserCmp {
   }
 }
 
-@Component({ selector: 'wrapper', template: `<router-outlet></router-outlet>` })
+@Component({selector: 'wrapper', template: `<router-outlet></router-outlet>`})
 class WrapperCmp {
 }
 
 @Component(
-  { selector: 'query-cmp', template: `query: {{name | async}} fragment: {{fragment | async}}` })
+    {selector: 'query-cmp', template: `query: {{name | async}} fragment: {{fragment | async}}`})
 class QueryParamsAndFragmentCmp {
-  name: Observable<string | null>;
+  name: Observable<string|null>;
   fragment: Observable<string>;
 
   constructor(route: ActivatedRoute) {
@@ -4284,7 +4290,7 @@ class QueryParamsAndFragmentCmp {
   }
 }
 
-@Component({ selector: 'empty-query-cmp', template: `` })
+@Component({selector: 'empty-query-cmp', template: ``})
 class EmptyQueryParamsCmp {
   recordedParams: Params[] = [];
 
@@ -4293,22 +4299,22 @@ class EmptyQueryParamsCmp {
   }
 }
 
-@Component({ selector: 'route-cmp', template: `route` })
+@Component({selector: 'route-cmp', template: `route`})
 class RouteCmp {
-  constructor(public route: ActivatedRoute) { }
+  constructor(public route: ActivatedRoute) {}
 }
 
 @Component({
   selector: 'link-cmp',
   template:
-    `<div *ngIf="show"><a [routerLink]="['./simple']">link</a></div> <router-outlet></router-outlet>`
+      `<div *ngIf="show"><a [routerLink]="['./simple']">link</a></div> <router-outlet></router-outlet>`
 })
 class RelativeLinkInIfCmp {
   show: boolean = false;
 }
 
 @Component(
-  { selector: 'child', template: '<div *ngIf="alwaysTrue"><router-outlet></router-outlet></div>' })
+    {selector: 'child', template: '<div *ngIf="alwaysTrue"><router-outlet></router-outlet></div>'})
 class OutletInNgIf {
   alwaysTrue = true;
 }
@@ -4325,7 +4331,7 @@ class DummyLinkWithParentCmp {
   constructor(route: ActivatedRoute) { this.exact = (<any>route.snapshot.params).exact === 'true'; }
 }
 
-@Component({ selector: 'cmp', template: '' })
+@Component({selector: 'cmp', template: ''})
 class ComponentRecordingRoutePathAndUrl {
   private path: any;
   private url: any;
@@ -4336,13 +4342,13 @@ class ComponentRecordingRoutePathAndUrl {
   }
 }
 
-@Component({ selector: 'root-cmp', template: `<router-outlet></router-outlet>` })
+@Component({selector: 'root-cmp', template: `<router-outlet></router-outlet>`})
 class RootCmp {
 }
 
-@Component({ selector: 'root-cmp-on-init', template: `<router-outlet></router-outlet>` })
+@Component({selector: 'root-cmp-on-init', template: `<router-outlet></router-outlet>`})
 class RootCmpWithOnInit {
-  constructor(private router: Router) { }
+  constructor(private router: Router) {}
 
   ngOnInit(): void { this.router.navigate(['one']); }
 }
@@ -4350,12 +4356,12 @@ class RootCmpWithOnInit {
 @Component({
   selector: 'root-cmp',
   template:
-    `primary [<router-outlet></router-outlet>] right [<router-outlet name="right"></router-outlet>]`
+      `primary [<router-outlet></router-outlet>] right [<router-outlet name="right"></router-outlet>]`
 })
 class RootCmpWithTwoOutlets {
 }
 
-@Component({ selector: 'throwing-cmp', template: '' })
+@Component({selector: 'throwing-cmp', template: ''})
 class ThrowingCmp {
   constructor() { throw new Error('Throwing Cmp'); }
 }
@@ -4375,7 +4381,7 @@ function createRoot(router: Router, type: any): ComponentFixture<any> {
   return f;
 }
 
-@Component({ selector: 'lazy', template: 'lazy-loaded' })
+@Component({selector: 'lazy', template: 'lazy-loaded'})
 class LazyComponent {
 }
 


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If no router-outlet is present (usually because of the router-outlet being inserted conditionally, ie with a ngIf for instance) and deactivation checks are set on the route, the routing will fail with an error:

```
ERROR Error: Uncaught (in promise): TypeError: Cannot read property 'component' of null
TypeError: Cannot read property 'component' of null
[..]
```

Issue Number: N/A


## What is the new behavior?
It checks whether there is an outlet. If not: Simply skip the deactivation checks (which are related to a component) instead of hard fail.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is heavily inspired from #19374  and #24850 , whose maintainer (@blaubaer) is currently inactive.