### PR TITLE
refactor(platform-browser): remove type assertion on console.profileEnd

### DIFF
--- a/packages/platform-browser/src/browser/tools/common_tools.ts
+++ b/packages/platform-browser/src/browser/tools/common_tools.ts
@@ -56,11 +56,7 @@ export class AngularProfiler {
     }
     const end = getDOM().performanceNow();
     if (record && isProfilerAvailable) {
-      // need to cast to <any> because type checker thinks there's no argument
-      // while in fact there is:
-      //
-      // https://developer.mozilla.org/en-US/docs/Web/API/Console/profileEnd
-      (<any>window.console.profileEnd)(profileName);
+      window.console.profileEnd(profileName);
     }
     const msPerTick = (end - start) / numTicks;
     window.console.log(`ran ${numTicks} change detection cycles`);


### PR DESCRIPTION
Since typescript v3.1 type definition for console.profileEnd is fixed and type assertion 'any' is
not needed any more



## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
N/A
Issue Number: N/A


## What is the new behavior?
N/A

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
-

