### PR TITLE
refactor(ivy): remove unused directives field from TView

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1142,7 +1142,6 @@ export function createTView(
     childIndex: -1,           // Children set in addToViewTree(), if any
     bindingStartIndex: bindingStartIndex,
     expandoStartIndex: initialViewLength,
-    directives: null,
     expandoInstructions: null,
     firstTemplatePass: true,
     initHooks: null,

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -344,15 +344,6 @@ export interface TView {
   currentMatches: CurrentMatchesList|null;
 
   /**
-   * Directive and component defs that have already been matched to nodes on
-   * this view.
-   *
-   * Defs are stored at the same index in TView.directives[] as their instances
-   * are stored in LView.directives[]. This simplifies lookup in DI.
-   */
-  directives: DirectiveDefList|null;
-
-  /**
    * Set of instructions used to process host bindings efficiently.
    *
    * See VIEW_DATA.md for more information.


### PR DESCRIPTION
Tiny cleanup after #26316 got merged. cc @kara 
