### PR TITLE
ci(docs-infra): allow `aio_local` builds to fail on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: "CI_MODE=aio_local"
     - env: "CI_MODE=saucelabs_optional"
     - env: "CI_MODE=browserstack_optional"
 


### PR DESCRIPTION
This job is flaky (up to 50%!) so let's allow it to fail while
we investigate the reason.
