### PR TITLE
docs: typo fix

### DIFF
--- a/aio/content/guide/forms-overview.md
+++ b/aio/content/guide/forms-overview.md
@@ -128,7 +128,7 @@ The steps below outline the view to model data flow.
 1. The control value accessor attached to the input triggers the `setValue()` method on the `FormControl` instance.
 1. The `FormControl` instance emits the new value through the `valueChanges` observable.
 1. Any subscribers to the `valueChanges` observable receive the new value.
-1. The control value accessor also calls the `NgModel.viewToModel()` method which emits an `ngModelChange` event.
+1. The control value accessor also calls the `NgModel.viewToModelUpdate()` method which emits an `ngModelChange` event.
 1. Because the component template uses two-way data binding for the `favoriteColor`, the `favoriteColor` property in the component 
 is updated to the value emitted  by the `ngModelChange` event ("Blue").
 


### PR DESCRIPTION
according to the source code and the doc https://angular.io/api/forms/NgModel#inherited-from-formsngcontrol-1, the method name should be "viewToModelUpdate" instead of "viewToModel"

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
