### PR TITLE
fix(docs-infra): highlight current CLI command in navigation menu

### DIFF
--- a/aio/src/app/navigation/navigation.service.ts
+++ b/aio/src/app/navigation/navigation.service.ts
@@ -95,7 +95,7 @@ export class NavigationService {
       this.location.currentPath,
 
       (navMap, url) => {
-        const matchSpecialUrls = /^api|^cli/.exec(url);
+        const matchSpecialUrls = /^api/.exec(url);
         if (matchSpecialUrls) {
           url = matchSpecialUrls[0];
         }


### PR DESCRIPTION
Previously CLI was being treated like the API page, where the top level item
had to be highlighted for any command page. But now the CLI commands all
have their own navigation item, which can be selected, so there is no need
to special case CLI paths any more.

Closes #26373

