### PR TITLE
build(docs-infra): pin git ref for cli command docs

### DIFF
--- a/aio/content/cli-src/.gitignore
+++ b/aio/content/cli-src/.gitignore
@@ -1,1 +1,3 @@
+/node_modules
+package.json
 yarn.lock

--- a/aio/content/cli-src/package.json
+++ b/aio/content/cli-src/package.json
@@ -1,5 +1,0 @@
-{
-  "dependencies": {
-    "@angular/cli": "https://github.com/angular/cli-builds#master"
-  }
-}

--- a/aio/package.json
+++ b/aio/package.json
@@ -18,7 +18,7 @@
     "build-for": "yarn ~~build --configuration",
     "prebuild-local": "yarn setup-local",
     "build-local": "yarn ~~build --configuration=stable",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 93bb6efee",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",

--- a/aio/tools/transforms/cli-docs-package/extract-cli-commands.js
+++ b/aio/tools/transforms/cli-docs-package/extract-cli-commands.js
@@ -1,7 +1,16 @@
-const shelljs = require('shelljs');
-const {resolve}  = require('canonical-path');
+const {resolve} = require('canonical-path');
+const sh = require('shelljs');
 const {CONTENTS_PATH} = require('../config');
 
-shelljs.cd(resolve(CONTENTS_PATH, 'cli-src'));
-shelljs.exec('git clean -Xfd');
-shelljs.exec('yarn install');
+const cliGitRef = process.argv[2] || 'master';  // Can be a branch, commit or tag.
+const pkgContent = JSON.stringify({
+  dependencies: {
+    '@angular/cli': `https://github.com/angular/cli-builds#${cliGitRef}`,
+  },
+}, null, 2);
+
+sh.set('-e');
+sh.cd(resolve(CONTENTS_PATH, 'cli-src'));
+sh.exec('git clean -Xfd');
+sh.echo(pkgContent).to('package.json');
+sh.exec('yarn install --no-lockfile --non-interactive');


### PR DESCRIPTION
The JSON files from which cli command docs for angular.io are generated is broken on master (e.g. angular/cli-builds@e0ec867), which cause foc generation (and CI) to fail.

Pinning the git ref where we pull cli sources from to a version that is known to be working (until we figure out what the best approach is)