### PR TITLE
docs: move cli commands above api in nav

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -622,8 +622,8 @@
       "tooltip": "Angular CLI command reference.",
       "children": [
         {
-          "title": "Using the CLI",
-          "tooltip": "An overview of how to use the CLI tool.",
+          "title": "Overview",
+          "tooltip": "An introduction to the CLI tool, commands, and syntax.",
           "url": "cli"
         }
       ]

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -617,22 +617,21 @@
         }
       ]
     },
-
-    {
-      "title": "API",
-      "tooltip": "Details of the Angular packages, classes, interfaces, and other types.",
-      "url": "api"
-    },
     {
       "title": "CLI Commands",
       "tooltip": "Angular CLI command reference.",
       "children": [
         {
           "title": "Using the CLI",
-          "tooltip": "An overview of how to use the CLI tool",
+          "tooltip": "An overview of how to use the CLI tool.",
           "url": "cli"
         }
       ]
+    },
+    {
+      "title": "API",
+      "tooltip": "Details of the Angular packages, classes, interfaces, and other types.",
+      "url": "api"
     },
     {
       "url": "guide/change-log",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Left navigation...

Release Information >
Quick Reference >
API
CLI Commands >

Issue Number: N/A


## What is the new behavior?
Left navigation...

Release Information >
Quick Reference >
CLI Commands >
API

Given that 100% of users need the API reference at some point, given the ease of access at the bottom of the nav, and given that it doesn't have any children...this feels better. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[X ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
