### PR TITLE
refactor(ivy): replace LNode.dynamicLContainerNode with flat LContainers

### DIFF
--- a/packages/core/src/render3/context_discovery.ts
+++ b/packages/core/src/render3/context_discovery.ts
@@ -8,8 +8,10 @@
 import './ng_dev_mode';
 
 import {assertEqual} from './assert';
+import {ACTIVE_INDEX, HOST_NATIVE, LContainer} from './interfaces/container';
 import {LElementNode, TNode, TNodeFlags} from './interfaces/node';
 import {RElement} from './interfaces/renderer';
+import {StylingContext, StylingIndex} from './interfaces/styling';
 import {CONTEXT, HEADER_OFFSET, LViewData, TVIEW} from './interfaces/view';
 
 /**
@@ -390,6 +392,24 @@ function getDirectiveEndIndex(tNode: TNode, startIndex: number): number {
   return count ? (startIndex + count) : -1;
 }
 
-export function readElementValue(value: LElementNode | any[]): LElementNode {
-  return (Array.isArray(value) ? (value as any as any[])[0] : value) as LElementNode;
+/**
+ * Takes the value of a slot in `LViewData` and returns the element node.
+ *
+ * Normally, element nodes are stored flat, but if the node has styles/classes on it,
+ * it might be wrapped in a styling context. Or if that node has a directive that injects
+ * ViewContainerRef, it may be wrapped in an LContainer.
+ *
+ * @param value The initial value in `LViewData`
+ */
+export function readElementValue(value: LElementNode | StylingContext | LContainer): LElementNode {
+  if (!Array.isArray(value)) return value;  // Regular LNode is stored here
+
+  if (typeof value[ACTIVE_INDEX] === 'number') {
+    // This is an LContainer. It may also have a styling context.
+    value = value[HOST_NATIVE] as LElementNode | StylingContext;
+    return Array.isArray(value) ? value[StylingIndex.ElementPosition] ! : value;
+  } else {
+    // This is a StylingContext, which stores the element node at 0.
+    return value[StylingIndex.ElementPosition] as LElementNode;
+  }
 }

--- a/packages/core/src/render3/context_discovery.ts
+++ b/packages/core/src/render3/context_discovery.ts
@@ -402,14 +402,16 @@ function getDirectiveEndIndex(tNode: TNode, startIndex: number): number {
  * @param value The initial value in `LViewData`
  */
 export function readElementValue(value: LElementNode | StylingContext | LContainer): LElementNode {
-  if (!Array.isArray(value)) return value;  // Regular LNode is stored here
-
-  if (typeof value[ACTIVE_INDEX] === 'number') {
-    // This is an LContainer. It may also have a styling context.
-    value = value[HOST_NATIVE] as LElementNode | StylingContext;
-    return Array.isArray(value) ? value[StylingIndex.ElementPosition] ! : value;
+  if (Array.isArray(value)) {
+    if (typeof value[ACTIVE_INDEX] === 'number') {
+      // This is an LContainer. It may also have a styling context.
+      value = value[HOST_NATIVE] as LElementNode | StylingContext;
+      return Array.isArray(value) ? value[StylingIndex.ElementPosition] ! : value;
+    } else {
+      // This is a StylingContext, which stores the element node at 0.
+      return value[StylingIndex.ElementPosition] as LElementNode;
+    }
   } else {
-    // This is a StylingContext, which stores the element node at 0.
-    return value[StylingIndex.ElementPosition] as LElementNode;
+    return value;  // Regular LNode is stored here
   }
 }

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -277,7 +277,6 @@ function appendI18nNode(
   // Template containers also have a comment node for the `ViewContainerRef` that should be moved
   if (tNode.type === TNodeType.Container && node.dynamicLContainerNode) {
     appendChild(node.dynamicLContainerNode.native, tNode, viewData);
-    return tNode.dynamicContainerNode !;
   }
 
   return tNode;
@@ -376,7 +375,7 @@ export function i18nApply(startIndex: number, instructions: I18nInstruction[]): 
         // For template containers we also need to remove their `ViewContainerRef` from the DOM
         if (removedTNode.type === TNodeType.Container && removedNode.dynamicLContainerNode) {
           removeChild(removedTNode, removedNode.dynamicLContainerNode.native || null, viewData);
-          removedTNode.dynamicContainerNode !.detached = true;
+          removedTNode.detached = true;
           removedNode.dynamicLContainerNode.data[RENDER_PARENT] = null;
         }
         break;

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -496,8 +496,6 @@ export function createNodeAtIndex(
           createTNode(type, adjustedIndex, name, attrs, tParent, null);
       if (!isParent && previousOrParentTNode) {
         previousOrParentTNode.next = tNode;
-        if (previousOrParentTNode.dynamicContainerNode)
-          previousOrParentTNode.dynamicContainerNode.next = tNode;
       }
     }
 
@@ -1518,7 +1516,6 @@ export function createTNode(
     next: null,
     child: null,
     parent: parent,
-    dynamicContainerNode: null,
     detached: null,
     stylingTemplate: null,
     projection: null

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1434,17 +1434,15 @@ export function elementProperty<T>(
   if (inputData && (dataValue = inputData[propName])) {
     setInputsForProperty(dataValue, value);
     if (tNode.type === TNodeType.Element) markDirtyIfOnPush(node as LElementNode);
-  } else {
+  } else if (tNode.type === TNodeType.Element) {
     // It is assumed that the sanitizer is only added when the compiler determines that the property
     // is risky, so sanitization can be done without further checks.
     value = sanitizer != null ? (sanitizer(value) as any) : value;
-    if (tNode.type === TNodeType.Element) {
-      const native = node.native as RElement;
-      ngDevMode && ngDevMode.rendererSetProperty++;
-      isProceduralRenderer(renderer) ? renderer.setProperty(native, propName, value) :
-                                       (native.setProperty ? native.setProperty(propName, value) :
-                                                             (native as any)[propName] = value);
-    }
+    const native = node.native as RElement;
+    ngDevMode && ngDevMode.rendererSetProperty++;
+    isProceduralRenderer(renderer) ? renderer.setProperty(native, propName, value) :
+                                     (native.setProperty ? native.setProperty(propName, value) :
+                                                           (native as any)[propName] = value);
   }
 }
 

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -16,7 +16,7 @@ import {assertDefined, assertEqual, assertLessThan, assertNotEqual} from './asse
 import {attachPatchData, getLElementFromComponent, readElementValue, readPatchedLViewData} from './context_discovery';
 import {throwCyclicDependencyError, throwErrorIfNoChangesMode, throwMultipleComponentError} from './errors';
 import {executeHooks, executeInitHooks, queueInitHooks, queueLifecycleHooks} from './hooks';
-import {ACTIVE_INDEX, LContainer, RENDER_PARENT, VIEWS} from './interfaces/container';
+import {ACTIVE_INDEX, HOST_NATIVE, LContainer, RENDER_PARENT, VIEWS} from './interfaces/container';
 import {ComponentDef, ComponentQuery, ComponentTemplate, DirectiveDef, DirectiveDefListOrFactory, InitialStylingFlags, PipeDefListOrFactory, RenderFlags} from './interfaces/definition';
 import {INJECTOR_SIZE} from './interfaces/injector';
 import {AttributeMarker, InitialInputData, InitialInputs, LContainerNode, LElementContainerNode, LElementNode, LNode, LProjectionNode, LTextNode, LViewNode, LocalRefExtractor, PropertyAliasValue, PropertyAliases, TAttributes, TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeFlags, TNodeType, TProjectionNode, TViewNode} from './interfaces/node';
@@ -29,7 +29,7 @@ import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
 import {appendChild, appendProjectedNode, createTextNode, findComponentView, getHostElementNode, getLViewChild, getRenderParent, insertView, removeView} from './node_manipulation';
 import {isNodeMatchingSelectorList, matchingSelectorIndex} from './node_selector_matcher';
 import {allocStylingContext, createStylingContextTemplate, renderStyling as renderElementStyles, updateClassProp as updateElementClassProp, updateStyleProp as updateElementStyleProp, updateStylingMap} from './styling/class_and_style_bindings';
-import {assertDataInRangeInternal, getLNode, getRootView, isContentQueryHost, isDifferent, loadElementInternal, loadInternal, stringify} from './util';
+import {assertDataInRangeInternal, getLNode, getRootView, isContentQueryHost, isDifferent, isLContainer, loadElementInternal, loadInternal, stringify} from './util';
 
 
 /**
@@ -430,7 +430,7 @@ export function createLViewData<T>(
 export function createLNodeObject(
     type: TNodeType, native: RText | RElement | RComment | null, state: any): LElementNode&
     LTextNode&LViewNode&LContainerNode&LProjectionNode {
-  return {native: native as any, data: state, dynamicLContainerNode: null};
+  return {native: native as any, data: state};
 }
 
 /**
@@ -453,7 +453,7 @@ export function createNodeAtIndex(
     lViewData: LViewData): TViewNode;
 export function createNodeAtIndex(
     index: number, type: TNodeType.Container, native: RComment, name: string | null,
-    attrs: TAttributes | null, lContainer: LContainer): TContainerNode;
+    attrs: TAttributes | null, data: null): TContainerNode;
 export function createNodeAtIndex(
     index: number, type: TNodeType.Projection, native: null, name: null, attrs: TAttributes | null,
     lProjection: null): TProjectionNode;
@@ -935,8 +935,10 @@ function cacheMatchingDirectivesForNode(
 function generateExpandoBlock(tNode: TNode, matches: CurrentMatchesList | null): void {
   const directiveCount = matches ? matches.length / 2 : 0;
   const elementIndex = -(tNode.index - HEADER_OFFSET);
-  (tView.expandoInstructions || (tView.expandoInstructions = [
-   ])).push(elementIndex, directiveCount);
+  if (directiveCount > 0) {
+    (tView.expandoInstructions || (tView.expandoInstructions = [
+     ])).push(elementIndex, directiveCount);
+  }
 }
 
 /**
@@ -1418,7 +1420,7 @@ export function elementAttribute(
 export function elementProperty<T>(
     index: number, propName: string, value: T | NO_CHANGE, sanitizer?: SanitizerFn): void {
   if (value === NO_CHANGE) return;
-  const node = loadElement(index) as LElementNode;
+  const node = loadElement(index) as LElementNode | LContainerNode | LElementContainerNode;
   const tNode = getTNode(index);
   // if tNode.inputs is undefined, a listener has created outputs, but inputs haven't
   // yet been checked
@@ -1431,16 +1433,18 @@ export function elementProperty<T>(
   let dataValue: PropertyAliasValue|undefined;
   if (inputData && (dataValue = inputData[propName])) {
     setInputsForProperty(dataValue, value);
-    markDirtyIfOnPush(node);
+    if (tNode.type === TNodeType.Element) markDirtyIfOnPush(node as LElementNode);
   } else {
     // It is assumed that the sanitizer is only added when the compiler determines that the property
     // is risky, so sanitization can be done without further checks.
     value = sanitizer != null ? (sanitizer(value) as any) : value;
-    const native = node.native;
-    ngDevMode && ngDevMode.rendererSetProperty++;
-    isProceduralRenderer(renderer) ? renderer.setProperty(native, propName, value) :
-                                     (native.setProperty ? native.setProperty(propName, value) :
-                                                           (native as any)[propName] = value);
+    if (tNode.type === TNodeType.Element) {
+      const native = node.native as RElement;
+      ngDevMode && ngDevMode.rendererSetProperty++;
+      isProceduralRenderer(renderer) ? renderer.setProperty(native, propName, value) :
+                                       (native.setProperty ? native.setProperty(propName, value) :
+                                                             (native as any)[propName] = value);
+    }
   }
 }
 
@@ -1639,16 +1643,22 @@ export function elementStyling<T>(
  * @param index Index of the style allocation. See: `elementStyling`.
  */
 function getStylingContext(index: number): StylingContext {
-  let stylingContext = load<StylingContext>(index);
-  if (!Array.isArray(stylingContext)) {
-    const lElement = stylingContext as any as LElementNode;
-    const tNode = getTNode(index);
-    ngDevMode &&
-        assertDefined(tNode.stylingTemplate, 'getStylingContext() called before elementStyling()');
-    stylingContext = viewData[index + HEADER_OFFSET] =
-        allocStylingContext(lElement, tNode.stylingTemplate !);
+  let slotValue = viewData[index + HEADER_OFFSET];
+
+  if (isLContainer(slotValue)) {
+    const lContainer = slotValue;
+    slotValue = lContainer[HOST_NATIVE];
+    if (!Array.isArray(slotValue)) {
+      return lContainer[HOST_NATIVE] =
+                 allocStylingContext(slotValue, getTNode(index).stylingTemplate !);
+    }
+  } else if (!Array.isArray(slotValue)) {
+    // This is a regular ElementNode
+    return viewData[index + HEADER_OFFSET] =
+               allocStylingContext(slotValue, getTNode(index).stylingTemplate !);
   }
-  return stylingContext;
+
+  return slotValue as StylingContext;
 }
 
 /**
@@ -1971,19 +1981,26 @@ function generateInitialInputs(
 /**
  * Creates a LContainer, either from a container instruction, or for a ViewContainerRef.
  *
+ * @param hostLNode The host node for the LContainer
+ * @param hostTNode The host TNode for the LContainer
  * @param currentView The parent view of the LContainer
+ * @param native The native comment element
  * @param isForViewContainerRef Optional a flag indicating the ViewContainerRef case
  * @returns LContainer
  */
 export function createLContainer(
-    currentView: LViewData, isForViewContainerRef?: boolean): LContainer {
+    hostLNode: LElementNode | LContainerNode | LElementContainerNode,
+    hostTNode: TElementNode | TContainerNode | TElementContainerNode, currentView: LViewData,
+    native: RComment, isForViewContainerRef?: boolean): LContainer {
   return [
-    isForViewContainerRef ? null : 0,  // active index
-    currentView,                       // parent
-    null,                              // next
-    null,                              // queries
-    [],                                // views
-    null                               // renderParent, set after node creation
+    isForViewContainerRef ? -1 : 0,          // active index
+    currentView,                             // parent
+    null,                                    // next
+    null,                                    // queries
+    hostLNode,                               // host native
+    native,                                  // native
+    [],                                      // views
+    getRenderParent(hostTNode, currentView)  // renderParent
   ];
 }
 
@@ -2044,12 +2061,13 @@ function containerInternal(
                    viewData[BINDING_INDEX], tView.bindingStartIndex,
                    'container nodes should be created before any bindings');
 
-  const lContainer = createLContainer(viewData);
-  ngDevMode && ngDevMode.rendererCreateComment++;
+  const adjustedIndex = index + HEADER_OFFSET;
   const comment = renderer.createComment(ngDevMode ? 'container' : '');
-  const tNode = createNodeAtIndex(index, TNodeType.Container, comment, tagName, attrs, lContainer);
+  ngDevMode && ngDevMode.rendererCreateComment++;
+  const tNode = createNodeAtIndex(index, TNodeType.Container, comment, tagName, attrs, null);
+  const lContainer = viewData[adjustedIndex] =
+      createLContainer(viewData[adjustedIndex], tNode, viewData, comment);
 
-  lContainer[RENDER_PARENT] = getRenderParent(tNode, viewData);
   appendChild(comment, tNode, viewData);
 
   // Containers are added to the current view tree instead of their embedded views
@@ -2075,8 +2093,8 @@ export function containerRefreshStart(index: number): void {
 
   ngDevMode && assertNodeType(previousOrParentTNode, TNodeType.Container);
   isParent = true;
-  // Inline containers cannot have style bindings, so we can read the value directly
-  (viewData[previousOrParentTNode.index] as LContainerNode).data[ACTIVE_INDEX] = 0;
+
+  viewData[index + HEADER_OFFSET][ACTIVE_INDEX] = 0;
 
   if (!checkNoChangesMode) {
     // We need to execute init hooks here so ngOnInit hooks are called in top level views
@@ -2101,8 +2119,7 @@ export function containerRefreshEnd(): void {
 
   ngDevMode && assertNodeType(previousOrParentTNode, TNodeType.Container);
 
-  // Inline containers cannot have style bindings, so we can read the value directly
-  const lContainer = viewData[previousOrParentTNode.index].data;
+  const lContainer = viewData[previousOrParentTNode.index];
   const nextIndex = lContainer[ACTIVE_INDEX];
 
   // remove extra views at the end of the container
@@ -2120,7 +2137,7 @@ function refreshDynamicEmbeddedViews(lViewData: LViewData) {
     // Note: current can be an LViewData or an LContainer instance, but here we are only interested
     // in LContainer. We can tell it's an LContainer because its length is less than the LViewData
     // header.
-    if (current.length < HEADER_OFFSET && current[ACTIVE_INDEX] === null) {
+    if (current.length < HEADER_OFFSET && current[ACTIVE_INDEX] === -1) {
       const container = current as LContainer;
       for (let i = 0; i < container[VIEWS].length; i++) {
         const dynamicViewData = container[VIEWS][i];
@@ -2177,12 +2194,10 @@ export function embeddedViewStart(viewBlockId: number, consts: number, vars: num
   const containerTNode = previousOrParentTNode.type === TNodeType.View ?
       previousOrParentTNode.parent ! :
       previousOrParentTNode;
-  // Inline containers cannot have style bindings, so we can read the value directly
-  const container = viewData[containerTNode.index] as LContainerNode;
+  const lContainer = viewData[containerTNode.index] as LContainer;
   const currentView = viewData;
 
   ngDevMode && assertNodeType(containerTNode, TNodeType.Container);
-  const lContainer = container.data;
   let viewToRender = scanForView(
       lContainer, containerTNode as TContainerNode, lContainer[ACTIVE_INDEX] !, viewBlockId);
 
@@ -2203,7 +2218,7 @@ export function embeddedViewStart(viewBlockId: number, consts: number, vars: num
     createNodeAtIndex(viewBlockId, TNodeType.View, null, null, null, viewToRender);
     enterView(viewToRender, viewToRender[TVIEW].node);
   }
-  if (container) {
+  if (lContainer) {
     if (creationMode) {
       // it is a new view, insert it into collection of views for a given container
       insertView(viewToRender, lContainer, currentView, lContainer[ACTIVE_INDEX] !, -1);
@@ -2411,12 +2426,10 @@ export function projection(nodeIndex: number, selectorIndex: number = 0, attrs?:
         continue;
       }
     } else {
-      const lNode = projectedView[nodeToProject.index] as LTextNode | LElementNode | LContainerNode;
       // This flag must be set now or we won't know that this node is projected
       // if the nodes are inserted into a container later.
       nodeToProject.flags |= TNodeFlags.isProjected;
-
-      appendProjectedNode(lNode, nodeToProject, tProjectionNode, viewData, projectedView);
+      appendProjectedNode(nodeToProject, tProjectionNode, viewData, projectedView);
     }
 
     // If we are finished with a list of re-projected nodes, we need to get

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {LElementNode} from './node';
+import {LContainerNode, LElementContainerNode, LElementNode} from './node';
 import {LQueries} from './query';
+import {RComment} from './renderer';
+import {StylingContext} from './styling';
 import {LViewData, NEXT, PARENT, QUERIES} from './view';
 
 /**
@@ -18,8 +20,10 @@ import {LViewData, NEXT, PARENT, QUERIES} from './view';
 export const ACTIVE_INDEX = 0;
 // PARENT, NEXT, and QUERIES are indices 1, 2, and 3.
 // As we already have these constants in LViewData, we don't need to re-create them.
-export const VIEWS = 4;
-export const RENDER_PARENT = 5;
+export const HOST_NATIVE = 4;
+export const NATIVE = 5;
+export const VIEWS = 6;
+export const RENDER_PARENT = 7;
 
 /**
  * The state associated with an LContainerNode.
@@ -37,7 +41,7 @@ export interface LContainer extends Array<any> {
    * it is set to null to identify this scenario, as indices are "absolute" in that case,
    * i.e. provided directly by the user of the ViewContainerRef API.
    */
-  [ACTIVE_INDEX]: number|null;
+  [ACTIVE_INDEX]: number;
 
   /**
    * Access to the parent view is necessary so we can propagate back
@@ -56,6 +60,13 @@ export interface LContainer extends Array<any> {
    * this container are reported to queries referenced here.
    */
   [QUERIES]: LQueries|null;
+
+  /** The host node of this LContainer. */
+  // TODO: Should contain just the native element once LNode is removed.
+  [HOST_NATIVE]: LElementNode|LContainerNode|LElementContainerNode|StylingContext;
+
+  /** The comment element that serves as an anchor for this LContainer. */
+  [NATIVE]: RComment;
 
   /**
    * A list of the container's currently active child views. Views will be inserted

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -326,11 +326,6 @@ export interface TNode {
   parent: TElementNode|TContainerNode|null;
 
   /**
-   * A pointer to a TContainerNode created by directives requesting ViewContainerRef
-   */
-  dynamicContainerNode: TNode|null;
-
-  /**
    * If this node is part of an i18n block, it indicates whether this container is part of the DOM
    * If this node is not part of an i18n block, this field is null.
    */

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -71,18 +71,12 @@ export interface LNode {
   readonly native: RComment|RElement|RText|null;
 
   /**
-   * If regular LElementNode, LTextNode, and LProjectionNode then `data` will be null.
+   * If regular LElementNode, LTextNode, LContainerNode, and LProjectionNode then `data` will be
+   * null.
    * If LElementNode with component, then `data` contains LViewData.
    * If LViewNode, then `data` contains the LViewData.
-   * If LContainerNode, then `data` contains LContainer.
    */
-  readonly data: LViewData|LContainer|null;
-
-  /**
-   * A pointer to an LContainerNode created by directives requesting ViewContainerRef
-   */
-  // TODO(kara): Remove when removing LNodes
-  dynamicLContainerNode: LContainerNode|null;
+  readonly data: LViewData|null;
 }
 
 
@@ -107,14 +101,12 @@ export interface LTextNode extends LNode {
   /** The text node associated with this node. */
   native: RText;
   readonly data: null;
-  dynamicLContainerNode: null;
 }
 
 /** Abstract node which contains root nodes of a view. */
 export interface LViewNode extends LNode {
   readonly native: null;
   readonly data: LViewData;
-  dynamicLContainerNode: null;
 }
 
 /** Abstract node container which contains other views. */
@@ -127,14 +119,13 @@ export interface LContainerNode extends LNode {
    * until the parent view is processed.
    */
   native: RComment;
-  readonly data: LContainer;
+  readonly data: null;
 }
 
 
 export interface LProjectionNode extends LNode {
   readonly native: null;
   readonly data: null;
-  dynamicLContainerNode: null;
 }
 
 /**

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -10,7 +10,7 @@ import {assertDefined} from './assert';
 import {attachPatchData, readElementValue} from './context_discovery';
 import {callHooks} from './hooks';
 import {LContainer, RENDER_PARENT, VIEWS, unusedValueExportToPlacateAjd as unused1} from './interfaces/container';
-import {LContainerNode, LElementContainerNode, LElementNode, LTextNode, TContainerNode, TElementNode, TNode, TNodeFlags, TNodeType, TViewNode, unusedValueExportToPlacateAjd as unused2} from './interfaces/node';
+import {LContainerNode, LElementContainerNode, LElementNode, LTextNode, TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeFlags, TNodeType, TViewNode, unusedValueExportToPlacateAjd as unused2} from './interfaces/node';
 import {unusedValueExportToPlacateAjd as unused3} from './interfaces/projection';
 import {ProceduralRenderer3, RComment, RElement, RNode, RText, Renderer3, isProceduralRenderer, unusedValueExportToPlacateAjd as unused4} from './interfaces/renderer';
 import {CLEANUP, CONTAINER_INDEX, FLAGS, HEADER_OFFSET, HOST_NODE, HookData, LViewData, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, TVIEW, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
@@ -393,9 +393,10 @@ export function detachView(lContainer: LContainer, removeIndex: number, detached
  * @param removeIndex The index of the view to remove
  */
 export function removeView(
-    lContainer: LContainer, tContainer: TContainerNode, removeIndex: number) {
+    lContainer: LContainer, containerHost: TElementNode | TContainerNode | TElementContainerNode,
+    removeIndex: number) {
   const view = lContainer[VIEWS][removeIndex];
-  detachView(lContainer, removeIndex, !!tContainer.detached);
+  detachView(lContainer, removeIndex, !!containerHost.detached);
   destroyLView(view);
 }
 

--- a/packages/core/src/render3/util.ts
+++ b/packages/core/src/render3/util.ts
@@ -10,9 +10,10 @@ import {devModeEqual} from '../change_detection/change_detection_util';
 
 import {assertDefined, assertLessThan} from './assert';
 import {readElementValue, readPatchedLViewData} from './context_discovery';
-import {LContainerNode, LElementContainerNode, LElementNode, TNode, TNodeFlags} from './interfaces/node';
+import {ACTIVE_INDEX, LContainer} from './interfaces/container';
+import {LContainerNode, LElementContainerNode, LElementNode, LNode, TNode, TNodeFlags} from './interfaces/node';
+import {StylingContext} from './interfaces/styling';
 import {CONTEXT, FLAGS, HEADER_OFFSET, LViewData, LViewFlags, PARENT, RootContext, TData, TVIEW} from './interfaces/view';
-
 
 
 /**
@@ -103,6 +104,12 @@ export function isContentQueryHost(tNode: TNode): boolean {
 export function isComponent(tNode: TNode): boolean {
   return (tNode.flags & TNodeFlags.isComponent) === TNodeFlags.isComponent;
 }
+
+export function isLContainer(value: LNode | LContainer | StylingContext): boolean {
+  // Styling contexts are also arrays, but their first index contains an element node
+  return Array.isArray(value) && typeof value[ACTIVE_INDEX] === 'number';
+}
+
 /**
  * Retrieve the root view from any component by walking the parent `LViewData` until
  * reaching the root `LViewData`.

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -104,13 +104,14 @@ export function createTemplateRef<T>(
       }
 
       createEmbeddedView(
-          context: T, container?: LContainer, tContainerNode?: TContainerNode, hostView?: LViewData,
+          context: T, container?: LContainer,
+          hostTNode?: TElementNode|TContainerNode|TElementContainerNode, hostView?: LViewData,
           index?: number): viewEngine_EmbeddedViewRef<T> {
         const lView = createEmbeddedViewAndNode(
             this._tView, context, this._declarationParentView, this._renderer, this._queries,
             this._injectorIndex);
         if (container) {
-          insertView(lView, container, hostView !, index !, tContainerNode !.parent !.index);
+          insertView(lView, container, hostView !, index !, hostTNode !.index);
         }
         renderEmbeddedTemplate(lView, this._tView, context, RenderFlags.Create);
         const viewRef = new ViewRef(lView, context, -1);
@@ -131,9 +132,8 @@ export function createTemplateRef<T>(
 
 let R3ViewContainerRef: {
   new (
-      lContainer: LContainer, tContainerNode: TContainerNode,
-      hostTNode: TElementNode | TContainerNode | TElementContainerNode, hostView: LViewData):
-      ViewEngine_ViewContainerRef
+      lContainer: LContainer, hostTNode: TElementNode | TContainerNode | TElementContainerNode,
+      hostView: LViewData): ViewEngine_ViewContainerRef
 };
 
 /**
@@ -171,7 +171,7 @@ export function createContainerRef(
       private _viewRefs: viewEngine_ViewRef[] = [];
 
       constructor(
-          private _lContainer: LContainer, private _tContainerNode: TContainerNode,
+          private _lContainer: LContainer,
           private _hostTNode: TElementNode|TContainerNode|TElementContainerNode,
           private _hostView: LViewData) {
         super();
@@ -209,7 +209,7 @@ export function createContainerRef(
         const adjustedIdx = this._adjustIndex(index);
         const viewRef = (templateRef as any)
                             .createEmbeddedView(
-                                context || <any>{}, this._lContainer, this._tContainerNode,
+                                context || <any>{}, this._lContainer, this._hostTNode,
                                 this._hostView, adjustedIdx);
         (viewRef as ViewRef<any>).attachToViewContainerRef(this);
         this._viewRefs.splice(adjustedIdx, 0, viewRef);
@@ -238,9 +238,7 @@ export function createContainerRef(
         const lView = (viewRef as ViewRef<any>)._view !;
         const adjustedIdx = this._adjustIndex(index);
 
-        insertView(
-            lView, this._lContainer, this._hostView, adjustedIdx,
-            this._tContainerNode.parent !.index);
+        insertView(lView, this._lContainer, this._hostView, adjustedIdx, this._hostTNode.index);
 
         const container = this._getHostNode().dynamicLContainerNode !;
         const beforeNode = getBeforeNodeForView(adjustedIdx, this._lContainer[VIEWS], container);
@@ -263,13 +261,13 @@ export function createContainerRef(
 
       remove(index?: number): void {
         const adjustedIdx = this._adjustIndex(index, -1);
-        removeView(this._lContainer, this._tContainerNode as TContainerNode, adjustedIdx);
+        removeView(this._lContainer, this._hostTNode, adjustedIdx);
         this._viewRefs.splice(adjustedIdx, 1);
       }
 
       detach(index?: number): viewEngine_ViewRef|null {
         const adjustedIdx = this._adjustIndex(index, -1);
-        detachView(this._lContainer, adjustedIdx, !!this._tContainerNode.detached);
+        detachView(this._lContainer, adjustedIdx, !!this._hostTNode.detached);
         return this._viewRefs.splice(adjustedIdx, 1)[0] || null;
       }
 
@@ -301,17 +299,10 @@ export function createContainerRef(
   lContainer[RENDER_PARENT] = getRenderParent(hostTNode, hostView);
 
   appendChild(comment, hostTNode, hostView);
-
-  if (!hostTNode.dynamicContainerNode) {
-    hostTNode.dynamicContainerNode =
-        createTNode(TNodeType.Container, -1, null, null, hostTNode, null);
-  }
-
   hostLNode.dynamicLContainerNode = lContainerNode;
   addToViewTree(hostView, hostTNode.index as number, lContainer);
 
-  return new R3ViewContainerRef(
-      lContainer, hostTNode.dynamicContainerNode as TContainerNode, hostTNode, hostView);
+  return new R3ViewContainerRef(lContainer, hostTNode, hostView);
 }
 
 

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -17,17 +17,17 @@ import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, ViewRef as viewEngine_Vie
 
 import {assertDefined, assertGreaterThan, assertLessThan} from './assert';
 import {NodeInjector, getParentInjectorLocation, getParentInjectorView} from './di';
-import {_getViewData, addToViewTree, createEmbeddedViewAndNode, createLContainer, createLNodeObject, createTNode, getPreviousOrParentTNode, getRenderer, renderEmbeddedTemplate} from './instructions';
-import {LContainer, RENDER_PARENT, VIEWS} from './interfaces/container';
+import {_getViewData, addToViewTree, createEmbeddedViewAndNode, createLContainer, getPreviousOrParentTNode, getRenderer, renderEmbeddedTemplate} from './instructions';
+import {ACTIVE_INDEX, LContainer, NATIVE, RENDER_PARENT, VIEWS} from './interfaces/container';
 import {RenderFlags} from './interfaces/definition';
 import {InjectorLocationFlags} from './interfaces/injector';
-import {LContainerNode, TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeFlags, TNodeType, TViewNode} from './interfaces/node';
+import {TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeFlags, TNodeType, TViewNode} from './interfaces/node';
 import {LQueries} from './interfaces/query';
 import {RComment, RElement, Renderer3} from './interfaces/renderer';
 import {CONTEXT, HOST_NODE, LViewData, QUERIES, RENDERER, TVIEW, TView} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
 import {addRemoveViewFromContainer, appendChild, detachView, findComponentView, getBeforeNodeForView, getRenderParent, insertView, removeView} from './node_manipulation';
-import {getLNode, isComponent} from './util';
+import {getLNode, isComponent, isLContainer} from './util';
 import {ViewRef} from './view_ref';
 
 
@@ -121,13 +121,12 @@ export function createTemplateRef<T>(
     };
   }
 
-
-  const hostNode = getLNode(hostTNode, hostView);
+  const hostContainer: LContainer = hostView[hostTNode.index];
   ngDevMode && assertNodeType(hostTNode, TNodeType.Container);
   ngDevMode && assertDefined(hostTNode.tViews, 'TView must be allocated');
   return new R3TemplateRef(
       hostView, createElementRef(ElementRefToken, hostTNode, hostView), hostTNode.tViews as TView,
-      getRenderer(), hostNode.data ![QUERIES], hostTNode.injectorIndex);
+      getRenderer(), hostContainer[QUERIES], hostTNode.injectorIndex);
 }
 
 let R3ViewContainerRef: {
@@ -240,8 +239,8 @@ export function createContainerRef(
 
         insertView(lView, this._lContainer, this._hostView, adjustedIdx, this._hostTNode.index);
 
-        const container = this._getHostNode().dynamicLContainerNode !;
-        const beforeNode = getBeforeNodeForView(adjustedIdx, this._lContainer[VIEWS], container);
+        const beforeNode =
+            getBeforeNodeForView(adjustedIdx, this._lContainer[VIEWS], this._lContainer[NATIVE]);
         addRemoveViewFromContainer(lView, true, beforeNode);
 
         (viewRef as ViewRef<any>).attachToViewContainerRef(this);
@@ -282,25 +281,27 @@ export function createContainerRef(
         }
         return index;
       }
-
-      private _getHostNode() { return getLNode(this._hostTNode, this._hostView); }
     };
   }
 
-  const hostLNode = getLNode(hostTNode, hostView);
   ngDevMode && assertNodeOfPossibleTypes(
                    hostTNode, TNodeType.Container, TNodeType.Element, TNodeType.ElementContainer);
 
-  const lContainer = createLContainer(hostView, true);
-  const comment = hostView[RENDERER].createComment(ngDevMode ? 'container' : '');
-  const lContainerNode: LContainerNode =
-      createLNodeObject(TNodeType.Container, comment, lContainer);
+  let lContainer: LContainer;
+  const slotValue = hostView[hostTNode.index];
+  if (isLContainer(slotValue)) {
+    // If the host is a container, we don't need to create a new LContainer
+    lContainer = slotValue;
+    lContainer[ACTIVE_INDEX] = -1;
+  } else {
+    const comment = hostView[RENDERER].createComment(ngDevMode ? 'container' : '');
+    ngDevMode && ngDevMode.rendererCreateComment++;
+    hostView[hostTNode.index] = lContainer =
+        createLContainer(slotValue, hostTNode, hostView, comment, true);
 
-  lContainer[RENDER_PARENT] = getRenderParent(hostTNode, hostView);
-
-  appendChild(comment, hostTNode, hostView);
-  hostLNode.dynamicLContainerNode = lContainerNode;
-  addToViewTree(hostView, hostTNode.index as number, lContainer);
+    appendChild(comment, hostTNode, hostView);
+    addToViewTree(hostView, hostTNode.index as number, lContainer);
+  }
 
   return new R3ViewContainerRef(lContainer, hostTNode, hostView);
 }

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -69,6 +69,9 @@
     "name": "HEADER_OFFSET"
   },
   {
+    "name": "HOST_NATIVE"
+  },
+  {
     "name": "HOST_NODE"
   },
   {
@@ -85,6 +88,9 @@
   },
   {
     "name": "MONKEY_PATCH_KEY_NAME"
+  },
+  {
+    "name": "NATIVE"
   },
   {
     "name": "NEXT"
@@ -549,9 +555,6 @@
     "name": "getComponentDef"
   },
   {
-    "name": "getContainerNode"
-  },
-  {
     "name": "getContainerRenderParent"
   },
   {
@@ -586,6 +589,9 @@
   },
   {
     "name": "getInjectorIndex"
+  },
+  {
+    "name": "getLContainer"
   },
   {
     "name": "getLElementFromComponent"
@@ -762,6 +768,9 @@
     "name": "isJsObject"
   },
   {
+    "name": "isLContainer"
+  },
+  {
     "name": "isListLikeIterable"
   },
   {
@@ -787,9 +796,6 @@
   },
   {
     "name": "listener"
-  },
-  {
-    "name": "load"
   },
   {
     "name": "loadElement"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -39,6 +39,9 @@
     "name": "HEADER_OFFSET"
   },
   {
+    "name": "HOST_NATIVE"
+  },
+  {
     "name": "HOST_NODE"
   },
   {
@@ -49,6 +52,9 @@
   },
   {
     "name": "MONKEY_PATCH_KEY_NAME"
+  },
+  {
+    "name": "NATIVE"
   },
   {
     "name": "NEXT"
@@ -225,9 +231,6 @@
     "name": "getComponentDef"
   },
   {
-    "name": "getContainerNode"
-  },
-  {
     "name": "getContainerRenderParent"
   },
   {
@@ -241,6 +244,9 @@
   },
   {
     "name": "getInjectorIndex"
+  },
+  {
+    "name": "getLContainer"
   },
   {
     "name": "getLNode"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -54,6 +54,9 @@
     "name": "HEADER_OFFSET"
   },
   {
+    "name": "HOST_NATIVE"
+  },
+  {
     "name": "HOST_NODE"
   },
   {
@@ -70,6 +73,9 @@
   },
   {
     "name": "MONKEY_PATCH_KEY_NAME"
+  },
+  {
+    "name": "NATIVE"
   },
   {
     "name": "NEXT"
@@ -600,9 +606,6 @@
     "name": "getComponentDef"
   },
   {
-    "name": "getContainerNode"
-  },
-  {
     "name": "getContainerRenderParent"
   },
   {
@@ -631,6 +634,9 @@
   },
   {
     "name": "getInjectorIndex"
+  },
+  {
+    "name": "getLContainer"
   },
   {
     "name": "getLElementFromComponent"
@@ -783,6 +789,9 @@
     "name": "isJsObject"
   },
   {
+    "name": "isLContainer"
+  },
+  {
     "name": "isListLikeIterable"
   },
   {
@@ -805,9 +814,6 @@
   },
   {
     "name": "listener"
-  },
-  {
-    "name": "load"
   },
   {
     "name": "loadElement"

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -324,6 +324,9 @@
     "name": "HOST_ATTR$1"
   },
   {
+    "name": "HOST_NATIVE"
+  },
+  {
     "name": "HOST_NODE"
   },
   {
@@ -442,6 +445,9 @@
   },
   {
     "name": "NAMESPACE_URIS"
+  },
+  {
+    "name": "NATIVE"
   },
   {
     "name": "NATIVE_ADD_LISTENER"
@@ -1602,9 +1608,6 @@
     "name": "getComponentDef"
   },
   {
-    "name": "getContainerNode"
-  },
-  {
     "name": "getContainerRenderParent"
   },
   {
@@ -1663,6 +1666,9 @@
   },
   {
     "name": "getInjectorIndex"
+  },
+  {
+    "name": "getLContainer"
   },
   {
     "name": "getLElementFromComponent"
@@ -1974,6 +1980,9 @@
     "name": "isJsObject"
   },
   {
+    "name": "isLContainer"
+  },
+  {
     "name": "isListLikeIterable"
   },
   {
@@ -2035,9 +2044,6 @@
   },
   {
     "name": "listener"
-  },
-  {
-    "name": "load"
   },
   {
     "name": "loadElement"

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -13,7 +13,7 @@ import {defineComponent} from '../../src/render3/definition';
 import {bloomAdd, bloomHashBitOrFactory as bloomHash, getOrCreateNodeInjector, injectAttribute, injectorHasToken} from '../../src/render3/di';
 import {PublicFeature, defineDirective, directiveInject, elementProperty, injectRenderer2, load, templateRefExtractor} from '../../src/render3/index';
 
-import {bind, container, containerRefreshEnd, containerRefreshStart, createNodeAtIndex, createLViewData, createTView, element, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, enterView, interpolation2, leaveView, projection, projectionDef, reference, template, text, textBinding, elementContainerStart, elementContainerEnd} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, createNodeAtIndex, createLViewData, createTView, element, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, enterView, interpolation2, leaveView, projection, projectionDef, reference, template, text, textBinding, elementContainerStart, elementContainerEnd, loadElement} from '../../src/render3/instructions';
 import {isProceduralRenderer} from '../../src/render3/interfaces/renderer';
 import {AttributeMarker, LContainerNode, LElementNode, TNodeType} from '../../src/render3/interfaces/node';
 
@@ -24,6 +24,7 @@ import {getRendererFactory2} from './imported_renderer2';
 import {ComponentFixture, createComponent, createDirective, getDirectiveOnNode, renderComponent, toHtml} from './render_util';
 import {NgIf} from './common_with_def';
 import {TNODE} from '../../src/render3/interfaces/injector';
+import {LContainer, NATIVE} from '../../src/render3/interfaces/container';
 
 describe('di', () => {
   describe('no dependencies', () => {
@@ -1136,7 +1137,7 @@ describe('di', () => {
       it('should create ElementRef with comment if requesting directive is on <ng-template> node',
          () => {
            let dir !: Directive;
-           let commentNode !: LContainerNode;
+           let lContainer !: LContainer;
 
            class Directive {
              value: string;
@@ -1156,13 +1157,13 @@ describe('di', () => {
            const App = createComponent('app', function(rf: RenderFlags, ctx: any) {
              if (rf & RenderFlags.Create) {
                template(0, () => {}, 0, 0, null, ['dir', '']);
-               commentNode = load(0);
+               lContainer = load(0) as any;
              }
            }, 1, 0, [Directive]);
 
            const fixture = new ComponentFixture(App);
            expect(dir.value).toContain('ElementRef');
-           expect(dir.elementRef.nativeElement).toEqual(commentNode.native);
+           expect(dir.elementRef.nativeElement).toEqual(lContainer[NATIVE]);
          });
     });
 


### PR DESCRIPTION
Previously, nodes with containers were stored flat in `LViewData`, so it was necessary to read `LNode.data` to reach the `LContainer` instance. This PR inverts this relationship, so we are now storing `LContainer` instances flat in `LViewData`, with `LContainer[HOST_NATIVE]` storing the host nodes. This allows us to remove `LNode.dynamicLContainerNode` and `TNode.dynamicContainerNode`, and is the first step toward removing `LNode.data`.

Still TODO:
- Invert `LNode.data` for component and view nodes
- Remove `LNode.native`
