### PR TITLE
fix(ivy): display the name of the module not found

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/selector_scope.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/selector_scope.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Expression, ExternalExpr, ExternalReference, WrappedNodeExpr} from '@angular/compiler';
+import {Expression, WrappedNodeExpr} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {ReflectionHost} from '../../host';
@@ -198,7 +198,7 @@ export class SelectorScopeRegistry {
       SelectorScopes {
     const result = this.lookupScopes(node, ngModuleImportedFrom);
     if (result === null) {
-      throw new Error(`Module not found: ${reflectIdentifierOfDeclaration(node)}`);
+      throw new Error(`Module not found: ${reflectIdentifierOfDeclaration(node) !.escapedText}`);
     }
     return result;
   }


### PR DESCRIPTION
Currently `lookupScopesOrDie` fails if `lookupScopes` returns null.
But it displays the `ts.Identifier` returned in a string which logs as:

    Error: Module not found: [Object object]

This commit fixes it to display the name of the module:

    Error: Module not found: HttpClientModule

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently `lookupScopesOrDie` fails if `lookupScopes` returns null.
But it displays the `ts.Identifier` returned in a string which logs as:

    Error: Module not found: [Object object]

## What is the new behavior?

This commit fixes it to display the name of the module:

    Error: Module not found: HttpClientModule

It also removes two unused imports in the file.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
``
