### PR TITLE
docs: update npm packages to be accurate for v7

### DIFF
--- a/aio/content/guide/npm-packages.md
+++ b/aio/content/guide/npm-packages.md
@@ -84,7 +84,7 @@ For information about choosing the best forms approach for your app, see [Introd
 the pieces that help render into the DOM.
 This package also includes the `bootstrapModuleFactory()` method for bootstrapping applications for production builds that pre-compile with [AOT](guide/aot-compiler).
 
-[**@angular/platform-browser-dynamic:**](api/platform-browser-dymanic) Includes [providers](api/core/Provider) and methods to compile and run the app on the client using the [JIT compiler](guide/aot-compiler).
+[**@angular/platform-browser-dynamic:**](api/platform-browser-dynamic) Includes [providers](api/core/Provider) and methods to compile and run the app on the client using the [JIT compiler](guide/aot-compiler).
 
 [**@angular/router:**](api/router) The router module navigates among your app pages when the browser URL changes.
 For more information, see [Routing and Navigation](guide/router).

--- a/aio/content/guide/npm-packages.md
+++ b/aio/content/guide/npm-packages.md
@@ -1,30 +1,20 @@
 # Npm Packages
 
- The [**Angular CLI**](https://cli.angular.io/), Angular applications, and Angular itself depend upon features and functionality provided by libraries that are available as [**npm**](https://docs.npmjs.com/) packages.
+ The [**Angular CLI**](cli), Angular applications, and Angular itself depend upon features and functionality provided by libraries that are available as [**npm**](https://docs.npmjs.com/) packages.
 
-You can download and install these npm packages with the [**npm client**](https://docs.npmjs.com/cli/install), which runs as a Node.js® application.
+You can download and install these npm packages by using the [**npm CLI client**](https://docs.npmjs.com/cli/install), which is installed with and runs as a Node.js® application. By default, the Angular CLI uses the npm client to install npm packages when you create a new project.
 
-The [**yarn client**](https://yarnpkg.com/en/) is a popular alternative for downloading and installing npm packages.
-The Angular CLI uses `yarn` by default to install npm packages when you create a new project.
 
 <div class="alert is-helpful">
 
-Node.js and npm are essential to Angular development.
+See [Getting Started](guide/quickstart#prerequisites) for information about the required versions and installation of Node.js and npm.
 
-[Get them now](https://docs.npmjs.com/getting-started/installing-node "Installing Node.js and updating npm")
-if they're not already installed on your machine.
-
-**Verify that you are running Node.js `v8.x` or higher and npm `5.x` or higher**
-by running the commands `node -v` and `npm -v` in a terminal/console window.
-Older versions produce errors.
-
-Consider using [nvm](https://github.com/creationix/nvm) for managing multiple
-versions of Node.js and npm. You may need [nvm](https://github.com/creationix/nvm) if
-you already have projects running on your machine that use other versions of Node.js and npm.
+If you already have projects running on your machine that use other versions of Node.js and npm, consider using [nvm](https://github.com/creationix/nvm) to manage the multiple versions of Node.js and npm. 
 
 </div>
 
-## _package.json_
+
+## `package.json`
 
 Both `npm` and `yarn` install packages that are identified in a [**package.json**](https://docs.npmjs.com/files/package.json) file.
 
@@ -37,17 +27,17 @@ You may even remove some.
 
 This guide focuses on the most important packages in the starter set.
 
-#### *dependencies* and *devDependencies*
+#### Dependencies and devDependencies
 
 The `package.json` includes two sets of packages,
 [dependencies](guide/npm-packages#dependencies) and [devDependencies](guide/npm-packages#dev-dependencies).
 
-The *dependencies* are essential to *running* the application.
-The *devDependencies* are only necessary to *develop* the application.
+* The *dependencies* are essential to *running* the application.
+* The *devDependencies* are only necessary to *develop* the application.
 
 {@a dependencies}
 
-## *Dependencies*
+## Dependencies
 The `dependencies` section of `package.json` contains:
 
 * **Angular packages**: Angular core and optional modules; their package names begin `@angular/`.
@@ -58,18 +48,20 @@ The `dependencies` section of `package.json` contains:
 
 ### Angular Packages
 
+For a complete list of Angular packages (and links to package overviews), see the [API reference](http://angular.io/api?type=package). The following packages are included as dependencies in the initial `package.json` file. 
+
 **@angular/animations**: Angular's animations library makes it easy to define and apply animation effects such as page and list transitions.
 Read about it in the [Animations guide](guide/animations).
 
 **@angular/common**: The commonly needed services, pipes, and directives provided by the Angular team.
 The [`HttpClientModule`](guide/http) is also here, in the '@angular/common/http' subfolder.
 
-**@angular/core**: Critical runtime parts of the framework needed by every application.
-Includes all metadata decorators, `Component`, `Directive`,  dependency injection, and the component lifecycle hooks.
-
 **@angular/compiler**: Angular's *Template Compiler*.
 It understands templates and can convert them to code that makes the application run and render.
 Typically you don’t interact with the compiler directly; rather, you use it indirectly via `platform-browser-dynamic` when [JIT compiling](guide/aot-compiler) in the browser.
+
+**@angular/core**: Critical runtime parts of the framework needed by every application.
+Includes all metadata decorators, `Component`, `Directive`,  dependency injection, and the component lifecycle hooks.
 
 **@angular/forms**: support for both [template-driven](guide/forms) and [reactive forms](guide/reactive-forms).
 
@@ -85,8 +77,6 @@ and methods to compile and run the app on the client
 using the [JIT compiler](guide/aot-compiler).
 
 **@angular/router**: The [router module](/guide/router) navigates among your app pages when the browser URL changes.
-
-**@angular/upgrade**: Set of utilities for upgrading AngularJS applications to Angular.
 
 {@a polyfills}
 
@@ -113,11 +103,13 @@ which polyfills missing features for several popular browser.
 
 {@a dev-dependencies}
 
-## *DevDependencies*
+## DevDependencies
 
 The packages listed in the *devDependencies* section of the `package.json` help you develop the application on your local machine.
 
-You don't deploy them with the production application although there is no harm in doing so.
+You don't deploy them with the production application, although there is no harm in doing so.
+
+**@angular-devkit/build-angular: The Angular build tools.
 
 **[@angular/cli](https://github.com/angular/angular-cli/)**: The Angular CLI tools.
 
@@ -155,19 +147,18 @@ Built on top of [WebDriverJS](https://github.com/SeleniumHQ/selenium/wiki/WebDri
 the TypeScript language server, including the *tsc* TypeScript compiler.
 
 
-## So many packages! So many files!
+## Managing packages and files
 
 The default `package.json` installs more packages than you'll need for your project.
 
 A given package may contain tens, hundreds, even thousands of files,
 all of them in your local machine's `node_modules` directory.
-The sheer volume of files is intimidating, 
 
-You can remove packages that you don't need but how can you be sure that you won't need it?
+You can remove any package that you don't need, but how can you be sure that you won't need it?
 As a practical matter, it's better to install a package you don't need than worry about it.
 Extra packages and package files on your local development machine are harmless.
 
-By default the Angular CLI build process bundles into a single file just the few "vendor" library files that your application actually needs.
+By default, the Angular CLI build process bundles into a single file just the few "vendor" library files that your application actually needs.
 The browser downloads this bundle, not the original package files.
 
-See the [Deployment](guide/deployment) to learn more.
+See [Deployment](guide/deployment) to learn more.

--- a/aio/content/guide/npm-packages.md
+++ b/aio/content/guide/npm-packages.md
@@ -1,8 +1,9 @@
 # Npm Packages
 
- The [**Angular CLI**](cli), Angular applications, and Angular itself depend upon features and functionality provided by libraries that are available as [**npm**](https://docs.npmjs.com/) packages.
+ The Angular Framework, Angular CLI, and components used by Angular applications are packaged as [**npm packages**](https://docs.npmjs.com/getting-started/what-is-npm "What is npm?") and distributed via the [npm registry](https://docs.npmjs.com/).
 
 You can download and install these npm packages by using the [**npm CLI client**](https://docs.npmjs.com/cli/install), which is installed with and runs as a Node.js® application. By default, the Angular CLI uses the npm client to install npm packages when you create a new project.
+
 
 
 <div class="alert is-helpful">
@@ -27,7 +28,6 @@ You may even remove some.
 
 This guide focuses on the most important packages in the starter set.
 
-#### Dependencies and devDependencies
 
 The `package.json` includes two sets of packages,
 [dependencies](guide/npm-packages#dependencies) and [devDependencies](guide/npm-packages#dev-dependencies).
@@ -45,6 +45,9 @@ The `dependencies` section of `package.json` contains:
 * **Support packages**: 3rd party libraries that must be present for Angular apps to run.
 
 * **Polyfill packages**: Polyfills plug gaps in a browser's JavaScript implementation.
+
+To add a new dependency, use the [`ng add`](cli/add) command.
+
 
 ### Angular Packages
 
@@ -93,8 +96,8 @@ which polyfills missing features for several popular browser.
 
 ### Support packages
 
-**[rxjs](https://github.com/benlesh/RxJS)**: Many Angular APIs return _observables_. RxJS is an implementation of the proposed [Observables specification](https://github.com/zenparsing/es-observable) currently before the
-[TC39](http://www.ecma-international.org/memento/TC39.htm) committee that determines standards for the JavaScript language.
+**[rxjs](https://github.com/ReactiveX/rxjs)**: Many Angular APIs return [_observables_](guide/glossary#observable). RxJS is an implementation of the proposed [Observables specification](https://github.com/zenparsing/es-observable) currently before the
+[TC39](http://www.ecma-international.org/memento/TC39.htm) committee, which determines standards for the JavaScript language.
 
 
 **[zone.js](https://github.com/angular/zone.js)**: Angular relies on zone.js to run Angular's change detection processes when native JavaScript operations raise events.  Zone.js is an implementation of a [specification](https://gist.github.com/mhevery/63fdcdf7c65886051d55) currently before the
@@ -105,9 +108,14 @@ which polyfills missing features for several popular browser.
 
 ## DevDependencies
 
-The packages listed in the *devDependencies* section of the `package.json` help you develop the application on your local machine.
+The packages listed in the `devDependencies` section of `package.json` help you develop the application on your local machine. You don't deploy them with the production application.
 
-You don't deploy them with the production application, although there is no harm in doing so.
+To add a new `devDependency`, use either one of the following commands, depending on which package manager you use:
+
+* `npm install --dev` 
+* `yarn add --dev` 
+
+The following `devDependencies` are provided in the initial `package.json` file.
 
 **@angular-devkit/build-angular: The Angular build tools.
 
@@ -146,17 +154,7 @@ Built on top of [WebDriverJS](https://github.com/SeleniumHQ/selenium/wiki/WebDri
 **[typescript](https://www.npmjs.com/package/typescript)**:
 the TypeScript language server, including the *tsc* TypeScript compiler.
 
-
-## Managing packages and files
-
-The default `package.json` installs more packages than you'll need for your project.
-
-A given package may contain tens, hundreds, even thousands of files,
-all of them in your local machine's `node_modules` directory.
-
-You can remove any package that you don't need, but how can you be sure that you won't need it?
-As a practical matter, it's better to install a package you don't need than worry about it.
-Extra packages and package files on your local development machine are harmless.
+## Related information
 
 By default, the Angular CLI build process bundles into a single file just the few "vendor" library files that your application actually needs.
 The browser downloads this bundle, not the original package files.

--- a/aio/content/guide/npm-packages.md
+++ b/aio/content/guide/npm-packages.md
@@ -1,8 +1,8 @@
-# Angular packages and dependencies
+# Workspace npm dependencies
 
  The Angular Framework, Angular CLI, and components used by Angular applications are packaged as [**npm packages**](https://docs.npmjs.com/getting-started/what-is-npm "What is npm?") and distributed via the [npm registry](https://docs.npmjs.com/).
 
-You can download and install these npm packages by using the [**npm CLI client**](https://docs.npmjs.com/cli/install), which is installed with and runs as a [Node.js®](https://nodejs.org "Nodejs.org") application. By default, the Angular CLI uses the npm client to install npm packages when you create a new project.
+You can download and install these npm packages by using the [**npm CLI client**](https://docs.npmjs.com/cli/install), which is installed with and runs as a [Node.js®](https://nodejs.org "Nodejs.org") application. By default, the Angular CLI uses the npm client.
 
 Alternatively, you can use the [yarn client](https://yarnpkg.com/) for downloading and installing npm packages. 
 
@@ -18,16 +18,17 @@ If you already have projects running on your machine that use other versions of 
 
 ## `package.json`
 
-Both `npm` and `yarn` install packages that are identified in a [`package.json`](https://docs.npmjs.com/files/package.json) file.
+Both `npm` and `yarn` install the packages that are identified in a [`package.json`](https://docs.npmjs.com/files/package.json) file.
 
-The CLI `ng new` command creates a default `package.json` file for your project.
-This `package.json` specifies _a starter set of packages_ that work well together and 
-jointly support many common application scenarios.
+The CLI `ng new` command creates a `package.json` file when it creates the new workspace. 
+This `package.json` is used by all projects in the workspace, including the initial CLI application.   
+
+By default, this `package.json` includes _a starter set of packages_, some of which are required by Angular and others that support common application scenarios.
 
 The `package.json` includes two sets of packages:
 
-* [Dependencies](guide/npm-packages#dependencies) are essential to *running* the application.
-* [DevDependencies](guide/npm-packages#dev-dependencies) are only necessary to *develop* the application.
+* [Dependencies](guide/npm-packages#dependencies) are essential to *running* applications.
+* [DevDependencies](guide/npm-packages#dev-dependencies) are only necessary to *develop* applications.
 
 You add packages to `package.json` as your application evolves. 
 You may even remove some. 
@@ -36,7 +37,7 @@ You may even remove some.
 {@a dependencies}
 ## Dependencies
 
-The packages listed in the `dependencies` section of `package.json` are essential to *running* the application. 
+The packages listed in the `dependencies` section of `package.json` are essential to *running* applications. 
 
 The `dependencies` section of `package.json` contains:
 

--- a/aio/content/guide/npm-packages.md
+++ b/aio/content/guide/npm-packages.md
@@ -1,8 +1,8 @@
 # Workspace npm dependencies
 
-The Angular Framework, Angular CLI, and components used by Angular applicatins are packaged as [**npm packages**](https://docs.npmjs.com/getting-started/what-is-npm "What is npm?") and distributed via the [npm registry](https://docs.npmjs.com/).
+The Angular Framework, Angular CLI, and components used by Angular applicatins are packaged as [npm packages](https://docs.npmjs.com/getting-started/what-is-npm "What is npm?") and distributed via the [npm registry](https://docs.npmjs.com/).
 
-You can download and install these npm packages by using the [**npm CLI client**](https://docs.npmjs.com/cli/install), which is installed with and runs as a [Node.js®](https://nodejs.org "Nodejs.org") application. By default, the Angular CLI uses the npm client.
+You can download and install these npm packages by using the [npm CLI client](https://docs.npmjs.com/cli/install), which is installed with and runs as a [Node.js®](https://nodejs.org "Nodejs.org") application. By default, the Angular CLI uses the npm client.
 
 Alternatively, you can use the [yarn client](https://yarnpkg.com/) for downloading and installing npm packages. 
 
@@ -20,7 +20,7 @@ If you already have projects running on your machine that use other versions of 
 
 Both `npm` and `yarn` install the packages that are identified in a [`package.json`](https://docs.npmjs.com/files/package.json) file.
 
-The CLI `ng new` command creates a `package.json` file when it creates the new workspace. 
+The CLI command `ng new` creates a `package.json` file when it creates the new workspace. 
 This `package.json` is used by all projects in the workspace, including the initial app project that is  created by the CLI when it creates the workspace.   
 
 Initially, this `package.json` includes _a starter set of packages_, some of which are required by Angular and others that support common application scenarios.
@@ -31,6 +31,12 @@ The `package.json` is organized into two groups of packages:
 
 * [Dependencies](guide/npm-packages#dependencies) are essential to *running* applications.
 * [DevDependencies](guide/npm-packages#dev-dependencies) are only necessary to *develop* applications.
+
+<div class="alert is-helpful">
+
+**Library developers:** By default, the CLI command [`ng generate library`](cli/generate) creates a `package.json` for the new library. That `package.json` is used when publishing the library to npm.
+For more information, see the CLI wiki page [Library Support](https://github.com/angular/angular-cli/wiki/stories-create-library). 
+</div>
 
 
 {@a dependencies}
@@ -54,77 +60,47 @@ To add a new dependency, use the [`ng add`](cli/add) command.
 The following Angular packages are included as dependencies in the default `package.json` file for a new Angular workspace.
 For a complete list of Angular packages, see the [API reference](http://angular.io/api?type=package). 
 
-[**@angular/animations**:](api/animations) Angular's animations library makes it easy to define and apply animation effects such as page and list transitions.
-Read about it in the [Animations guide](guide/animations).
+[**@angular/animations:**](api/animations) Angular's animations library makes it easy to define and apply animation effects such as page and list transitions.
+For more information, see the [Animations guide](guide/animations).
 
-[**@angular/common**:](api/common) The commonly-needed services, pipes, and directives provided by the Angular team.
+[**@angular/common:**](api/common) The commonly-needed services, pipes, and directives provided by the Angular team.
 The [`HttpClientModule`](api/common/http/HttpClientModule) is also here, in the [`@angular/common/http`](api/common/http) subfolder.
 For more information, see the [HttpClient guide](guide/http).
 
-**@angular/compiler**: Angular's *Template Compiler*.
+**@angular/compiler:** Angular's template compiler.
 It understands templates and can convert them to code that makes the application run and render.
 Typically you don’t interact with the compiler directly; rather, you use it indirectly via `platform-browser-dynamic` when JIT compiling in the browser.
 For more information, see the [Ahead-of-time Compilation guide](guide/aot-compiler).
 
-[**@angular/core**:](api/core) Critical runtime parts of the framework needed by every application.
+[**@angular/core:**](api/core) Critical runtime parts of the framework that are needed by every application.
 Includes all metadata decorators, `Component`, `Directive`,  dependency injection, and the component lifecycle hooks.
 
-[**@angular/forms**:](api/forms) Support for both [template-driven](guide/forms) and [reactive forms](guide/reactive-forms).
+[**@angular/forms:**](api/forms) Support for both [template-driven](guide/forms) and [reactive forms](guide/reactive-forms).
 For information about choosing the best forms approach for your app, see [Introduction to forms](guide/forms-overview).
 
-[**@angular/http**:](api/http) Angular's legacy HTTP client, which was deprecated in version 5.0 in favor of [@angular/common/http](api/common/http).
+[**@angular/http:**](api/http) Angular's legacy HTTP client, which was deprecated in version 5.0 in favor of [@angular/common/http](api/common/http).
 
-[**@angular/platform-browser**:](api/platform-browser) Everything DOM and browser related, especially
+[**@angular/platform-browser:**](api/platform-browser) Everything DOM and browser related, especially
 the pieces that help render into the DOM.
-This package also includes the `bootstrapModuleFactory()` method
-for bootstrapping applications for production builds that pre-compile with [AOT](guide/aot-compiler).
+This package also includes the `bootstrapModuleFactory()` method for bootstrapping applications for production builds that pre-compile with [AOT](guide/aot-compiler).
 
-[**@angular/platform-browser-dynamic**:](api/platform-browser-dymanic) Includes [Providers](api/core/Provider) and methods to compile and run the app on the client using the [JIT compiler](guide/aot-compiler).
+[**@angular/platform-browser-dynamic:**](api/platform-browser-dymanic) Includes [providers](api/core/Provider) and methods to compile and run the app on the client using the [JIT compiler](guide/aot-compiler).
 
-[**@angular/router**:](api/router) The router module navigates among your app pages when the browser URL changes.
-To include router functionality in the initial app created by `ng new`, choose `Y` when prompted for "Angular routing" by that command. 
-For more information about routing, see [Routing and Navigation](guide/routing).
-
-### Angular packages table
-
-The following Angular packages are included as dependencies in the default `package.json` file for a new Angular workspace.
-For a complete list of Angular packages, see the [API reference](http://angular.io/api?type=package). 
-
-Angular package | Description 
----------------------------------------------- | -------------------------------------------  
-[@angular/animations](api/animations)          | Angular's animations library makes it easy to define and apply animation effects such as page and list transitions. Read about it in the [Animations guide](guide/animations). 
-[@angular/common](api/common)         | The commonly-needed services, pipes, and directives provided by the Angular team. The [`HttpClientModule`](api/common/http/HttpClientModule) is also here, in the [`@angular/common/http`](api/common/http) subfolder. For more information, see the [HttpClient guide](guide/http).
-@angular/compiler                     |  Angular's *Template Compiler*. It understands templates and can convert them to code that makes the application run and render. Typically you don’t interact with the compiler directly; rather, you use it indirectly via `platform-browser-dynamic` when JIT compiling in the browser. For more information, see the [Ahead-of-time Compilation guide](guide/aot-compiler).
-[@angular/core](api/core)             | Critical runtime parts of the framework needed by every application. Includes all metadata decorators, `Component`, `Directive`,  dependency injection, and the component lifecycle hooks.
-[@angular/forms](api/forms)           | Support for both [template-driven](guide/forms) and [reactive forms](guide/reactive-forms). For information about choosing the best forms approach for your app, see [Introduction to forms](guide/forms-overview).
-[@angular/http](api/http)             | Angular's legacy HTTP client, which was deprecated in version 5.0 in favor of [@angular/common/http](api/common/http).
-[@angular/ platform-browser](api/platform-browser) | Everything DOM and browser related, especially the pieces that help render into the DOM. This package also includes the `bootstrapModuleFactory()` method for bootstrapping applications for production builds that pre-compile with [AOT](guide/aot-compiler).
-[@angular/ platform-browser-dynamic](api/platform-browser-dymanic) | Includes [Providers](api/core/Provider) and methods to compile and run the app on the client using the [JIT compiler](guide/aot-compiler).
-[@angular/router](api/router)                     | The router module navigates among your app pages when the browser URL changes. To include router functionality in the initial app created by `ng new`, choose `Y` when prompted for "Angular routing" by that command. For more information about routing, see [Routing and Navigation](guide/routing).
+[**@angular/router:**](api/router) The router module navigates among your app pages when the browser URL changes.
+For more information, see [Routing and Navigation](guide/router).
 
 
 {@a support-packages}
 ### Support packages
 
-The following support packages are included as dependencies in the  `package.json` file for a new Angular workspace. 
+The following support packages are included as dependencies in the default `package.json` file for a new Angular workspace. 
 
-**[rxjs](https://github.com/ReactiveX/rxjs)**: Many Angular APIs return [_observables_](guide/glossary#observable). RxJS is an implementation of the proposed [Observables specification](https://github.com/zenparsing/es-observable) currently before the
+[**rxjs:**](https://github.com/ReactiveX/rxjs) Many Angular APIs return [_observables_](guide/glossary#observable). RxJS is an implementation of the proposed [Observables specification](https://github.com/zenparsing/es-observable) currently before the
 [TC39](http://www.ecma-international.org/memento/TC39.htm) committee, which determines standards for the JavaScript language.
 
 
-**[zone.js](https://github.com/angular/zone.js)**: Angular relies on zone.js to run Angular's change detection processes when native JavaScript operations raise events.  Zone.js is an implementation of a [specification](https://gist.github.com/mhevery/63fdcdf7c65886051d55) currently before the
+[**zone.js:**](https://github.com/angular/zone.js) Angular relies on zone.js to run Angular's change detection processes when native JavaScript operations raise events.  Zone.js is an implementation of a [specification](https://gist.github.com/mhevery/63fdcdf7c65886051d55) currently before the
 [TC39](http://www.ecma-international.org/memento/TC39.htm) committee that determines standards for the JavaScript language.
-
-
-{@a support-packages}
-### Support packages table
-
-The following support packages are included as dependencies in the  `package.json` file for a new Angular workspace. 
-
- Package name | Description
- ------------ | -----------------------------------------------------------------------
-[rxjs](https://github.com/ReactiveX/rxjs)    | Many Angular APIs return [_observables_](guide/glossary#observable). RxJS is an implementation of the proposed [Observables specification](https://github.com/zenparsing/es-observable) currently before the [TC39](http://www.ecma-international.org/memento/TC39.htm) committee, which determines standards for the JavaScript language.
-[zone.js](https://github.com/angular/zone.js) | Angular relies on zone.js to run Angular's change detection processes when native JavaScript operations raise events.  Zone.js is an implementation of a [specification](https://gist.github.com/mhevery/63fdcdf7c65886051d55) currently before the [TC39](http://www.ecma-international.org/memento/TC39.htm) committee that determines standards for the JavaScript language.
 
 
 {@a polyfills}
@@ -132,7 +108,7 @@ The following support packages are included as dependencies in the  `package.jso
 
 Many browsers lack native support for some features in the latest HTML standards,
 features that Angular requires.
-[**Polyfills**](https://en.wikipedia.org/wiki/Polyfill) can emulate the missing features.
+[_Polyfills_](https://en.wikipedia.org/wiki/Polyfill) can emulate the missing features.
 The [Browser Support](guide/browser-support) guide explains which browsers need polyfills and 
 how you can add them.
 
@@ -148,45 +124,53 @@ The packages listed in the `devDependencies` section of `package.json` help you 
 
 To add a new `devDependency`, use either one of the following commands:
 
-* `npm install --dev <package-name>` 
-* `yarn add --dev <package-name>` 
+<code-example language="sh" class="code-shell">
+  npm install --dev &lt;package-name&gt;
+</code-example>
+
+<code-example language="sh" class="code-shell">
+  yarn add --dev &lt;package-name&gt;
+</code-example>
 
 The following `devDependencies` are provided in the default `package.json` file for a new Angular workspace. 
 
-**[@angular-devkit/build-angular](https://github.com/angular/angular-cli/)**: The Angular build tools.
+[**@angular-devkit/build-angular:**](https://github.com/angular/angular-cli/) The Angular build tools.
 
-**[@angular/cli](https://github.com/angular/angular-cli/)**: The Angular CLI tools.
 
-**[@angular/compiler-cli](https://github.com/angular/angular/blob/master/packages/compiler-cli/README.md)**: The Angular compiler, which is invoked by the Angular CLI's `ng build` and `ng serve` commands.
+[**@angular/cli:**](https://github.com/angular/angular-cli/) The Angular CLI tools.
 
-**[@angular/language-service](https://github.com/angular/angular-cli/)**: The Angular language service analyzes component templates and provides type and error information that TypeScript-aware editors can use to improve the developer's experience.
+
+**@angular/compiler-cli:** The Angular compiler, which is invoked by the Angular CLI's `ng build` and `ng serve` commands.
+
+
+**@angular/language-service:** The [Angular language service](guide/language-service) analyzes component templates and provides type and error information that TypeScript-aware editors can use to improve the developer's experience.
 For example, see the [Angular language service extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Angular.ng-template).
 
 
-**@types/... **: TypeScript definition files for 3rd party libraries such as Jasmine and Node.js.
+**@types/... :** TypeScript definition files for 3rd party libraries such as Jasmine and Node.js.
 
 
-**[codelyzer](https://www.npmjs.com/package/codelyzer)**: A linter for Angular apps whose rules conform to the Angular [style guide](guide/styleguide).
+[**codelyzer:**](https://www.npmjs.com/package/codelyzer) A linter for Angular apps whose rules conform to the Angular [style guide](guide/styleguide).
 
 
-**jasmine/... **: packages to support the [Jasmine](https://jasmine.github.io/) test library.
+**jasmine/... :** Packages to support the [Jasmine](https://jasmine.github.io/) test library.
 
 
-**karma/... **: packages to support the [karma](https://www.npmjs.com/package/karma) test runner.
+**karma/... :** Packages to support the [karma](https://www.npmjs.com/package/karma) test runner.
 
 
-**[protractor](https://www.npmjs.com/package/protractor)**: an end-to-end (e2e) framework for Angular apps. 
+[**protractor:**](https://www.npmjs.com/package/protractor) An end-to-end (e2e) framework for Angular apps.
 Built on top of [WebDriverJS](https://github.com/SeleniumHQ/selenium/wiki/WebDriverJs).
 
 
-**[ts-node](https://www.npmjs.com/package/ts-node)**: TypeScript execution environment and REPL for Node.js.
+[**ts-node:**](https://www.npmjs.com/package/ts-node) TypeScript execution environment and REPL for Node.js.
 
 
-**[tslint](https://www.npmjs.com/package/tslint)**: a static analysis tool that checks TypeScript code for readability, maintainability, and functionality errors.
+[**tslint:**](https://www.npmjs.com/package/tslint) A static analysis tool that checks TypeScript code for readability, maintainability, and functionality errors.
 
 
-**[typescript](https://www.npmjs.com/package/typescript)**:
-the TypeScript language server, including the *tsc* TypeScript compiler.
+[**typescript:**](https://www.npmjs.com/package/typescript) The TypeScript language server, including the *tsc* TypeScript compiler.
+
 
 ## Related information
 

--- a/aio/content/guide/npm-packages.md
+++ b/aio/content/guide/npm-packages.md
@@ -1,6 +1,6 @@
 # Workspace npm dependencies
 
- The Angular Framework, Angular CLI, and components used by Angular applications are packaged as [**npm packages**](https://docs.npmjs.com/getting-started/what-is-npm "What is npm?") and distributed via the [npm registry](https://docs.npmjs.com/).
+The Angular Framework, Angular CLI, and components used by Angular applicatins are packaged as [**npm packages**](https://docs.npmjs.com/getting-started/what-is-npm "What is npm?") and distributed via the [npm registry](https://docs.npmjs.com/).
 
 You can download and install these npm packages by using the [**npm CLI client**](https://docs.npmjs.com/cli/install), which is installed with and runs as a [Node.js®](https://nodejs.org "Nodejs.org") application. By default, the Angular CLI uses the npm client.
 
@@ -21,17 +21,16 @@ If you already have projects running on your machine that use other versions of 
 Both `npm` and `yarn` install the packages that are identified in a [`package.json`](https://docs.npmjs.com/files/package.json) file.
 
 The CLI `ng new` command creates a `package.json` file when it creates the new workspace. 
-This `package.json` is used by all projects in the workspace, including the initial CLI application.   
+This `package.json` is used by all projects in the workspace, including the initial app project that is  created by the CLI when it creates the workspace.   
 
-By default, this `package.json` includes _a starter set of packages_, some of which are required by Angular and others that support common application scenarios.
+Initially, this `package.json` includes _a starter set of packages_, some of which are required by Angular and others that support common application scenarios.
+You add packages to `package.json` as your application evolves. 
+You may even remove some. 
 
-The `package.json` includes two sets of packages:
+The `package.json` is organized into two groups of packages:
 
 * [Dependencies](guide/npm-packages#dependencies) are essential to *running* applications.
 * [DevDependencies](guide/npm-packages#dev-dependencies) are only necessary to *develop* applications.
-
-You add packages to `package.json` as your application evolves. 
-You may even remove some. 
 
 
 {@a dependencies}
@@ -52,40 +51,62 @@ To add a new dependency, use the [`ng add`](cli/add) command.
 {@a angular-packages}
 ### Angular packages
 
-For a complete list of Angular packages (and links to package overviews), see the [API reference](http://angular.io/api?type=package). The following Angular packages are included as dependencies in the  `package.json` file for a new Angular CLI application. 
+The following Angular packages are included as dependencies in the default `package.json` file for a new Angular workspace.
+For a complete list of Angular packages, see the [API reference](http://angular.io/api?type=package). 
 
-**@angular/animations**: Angular's animations library makes it easy to define and apply animation effects such as page and list transitions.
+[**@angular/animations**:](api/animations) Angular's animations library makes it easy to define and apply animation effects such as page and list transitions.
 Read about it in the [Animations guide](guide/animations).
 
-**@angular/common**: The commonly needed services, pipes, and directives provided by the Angular team.
-The [`HttpClientModule`](guide/http) is also here, in the '@angular/common/http' subfolder.
+[**@angular/common**:](api/common) The commonly-needed services, pipes, and directives provided by the Angular team.
+The [`HttpClientModule`](api/common/http/HttpClientModule) is also here, in the [`@angular/common/http`](api/common/http) subfolder.
+For more information, see the [HttpClient guide](guide/http).
 
 **@angular/compiler**: Angular's *Template Compiler*.
 It understands templates and can convert them to code that makes the application run and render.
-Typically you don’t interact with the compiler directly; rather, you use it indirectly via `platform-browser-dynamic` when [JIT compiling](guide/aot-compiler) in the browser.
+Typically you don’t interact with the compiler directly; rather, you use it indirectly via `platform-browser-dynamic` when JIT compiling in the browser.
+For more information, see the [Ahead-of-time Compilation guide](guide/aot-compiler).
 
-**@angular/core**: Critical runtime parts of the framework needed by every application.
+[**@angular/core**:](api/core) Critical runtime parts of the framework needed by every application.
 Includes all metadata decorators, `Component`, `Directive`,  dependency injection, and the component lifecycle hooks.
 
-**@angular/forms**: support for both [template-driven](guide/forms) and [reactive forms](guide/reactive-forms).
+[**@angular/forms**:](api/forms) Support for both [template-driven](guide/forms) and [reactive forms](guide/reactive-forms).
+For information about choosing the best forms approach for your app, see [Introduction to forms](guide/forms-overview).
 
-**@angular/http**: Angular's old, deprecated, HTTP client.
+[**@angular/http**:](api/http) Angular's legacy HTTP client, which was deprecated in version 5.0 in favor of [@angular/common/http](api/common/http).
 
-**@angular/platform-browser**: Everything DOM and browser related, especially
+[**@angular/platform-browser**:](api/platform-browser) Everything DOM and browser related, especially
 the pieces that help render into the DOM.
 This package also includes the `bootstrapModuleFactory()` method
 for bootstrapping applications for production builds that pre-compile with [AOT](guide/aot-compiler).
 
-**@angular/platform-browser-dynamic**: Includes [Providers](api/core/Provider)
-and methods to compile and run the app on the client 
-using the [JIT compiler](guide/aot-compiler).
+[**@angular/platform-browser-dynamic**:](api/platform-browser-dymanic) Includes [Providers](api/core/Provider) and methods to compile and run the app on the client using the [JIT compiler](guide/aot-compiler).
 
-**@angular/router**: The [router module](/guide/router) navigates among your app pages when the browser URL changes.
+[**@angular/router**:](api/router) The router module navigates among your app pages when the browser URL changes.
+To include router functionality in the initial app created by `ng new`, choose `Y` when prompted for "Angular routing" by that command. 
+For more information about routing, see [Routing and Navigation](guide/routing).
+
+### Angular packages table
+
+The following Angular packages are included as dependencies in the default `package.json` file for a new Angular workspace.
+For a complete list of Angular packages, see the [API reference](http://angular.io/api?type=package). 
+
+Angular package | Description 
+---------------------------------------------- | -------------------------------------------  
+[@angular/animations](api/animations)          | Angular's animations library makes it easy to define and apply animation effects such as page and list transitions. Read about it in the [Animations guide](guide/animations). 
+[@angular/common](api/common)         | The commonly-needed services, pipes, and directives provided by the Angular team. The [`HttpClientModule`](api/common/http/HttpClientModule) is also here, in the [`@angular/common/http`](api/common/http) subfolder. For more information, see the [HttpClient guide](guide/http).
+@angular/compiler                     |  Angular's *Template Compiler*. It understands templates and can convert them to code that makes the application run and render. Typically you don’t interact with the compiler directly; rather, you use it indirectly via `platform-browser-dynamic` when JIT compiling in the browser. For more information, see the [Ahead-of-time Compilation guide](guide/aot-compiler).
+[@angular/core](api/core)             | Critical runtime parts of the framework needed by every application. Includes all metadata decorators, `Component`, `Directive`,  dependency injection, and the component lifecycle hooks.
+[@angular/forms](api/forms)           | Support for both [template-driven](guide/forms) and [reactive forms](guide/reactive-forms). For information about choosing the best forms approach for your app, see [Introduction to forms](guide/forms-overview).
+[@angular/http](api/http)             | Angular's legacy HTTP client, which was deprecated in version 5.0 in favor of [@angular/common/http](api/common/http).
+[@angular/ platform-browser](api/platform-browser) | Everything DOM and browser related, especially the pieces that help render into the DOM. This package also includes the `bootstrapModuleFactory()` method for bootstrapping applications for production builds that pre-compile with [AOT](guide/aot-compiler).
+[@angular/ platform-browser-dynamic](api/platform-browser-dymanic) | Includes [Providers](api/core/Provider) and methods to compile and run the app on the client using the [JIT compiler](guide/aot-compiler).
+[@angular/router](api/router)                     | The router module navigates among your app pages when the browser URL changes. To include router functionality in the initial app created by `ng new`, choose `Y` when prompted for "Angular routing" by that command. For more information about routing, see [Routing and Navigation](guide/routing).
+
 
 {@a support-packages}
 ### Support packages
 
-The following support packages are included as dependencies in the  `package.json` file for a new Angular CLI application. 
+The following support packages are included as dependencies in the  `package.json` file for a new Angular workspace. 
 
 **[rxjs](https://github.com/ReactiveX/rxjs)**: Many Angular APIs return [_observables_](guide/glossary#observable). RxJS is an implementation of the proposed [Observables specification](https://github.com/zenparsing/es-observable) currently before the
 [TC39](http://www.ecma-international.org/memento/TC39.htm) committee, which determines standards for the JavaScript language.
@@ -93,6 +114,17 @@ The following support packages are included as dependencies in the  `package.jso
 
 **[zone.js](https://github.com/angular/zone.js)**: Angular relies on zone.js to run Angular's change detection processes when native JavaScript operations raise events.  Zone.js is an implementation of a [specification](https://gist.github.com/mhevery/63fdcdf7c65886051d55) currently before the
 [TC39](http://www.ecma-international.org/memento/TC39.htm) committee that determines standards for the JavaScript language.
+
+
+{@a support-packages}
+### Support packages table
+
+The following support packages are included as dependencies in the  `package.json` file for a new Angular workspace. 
+
+ Package name | Description
+ ------------ | -----------------------------------------------------------------------
+[rxjs](https://github.com/ReactiveX/rxjs)    | Many Angular APIs return [_observables_](guide/glossary#observable). RxJS is an implementation of the proposed [Observables specification](https://github.com/zenparsing/es-observable) currently before the [TC39](http://www.ecma-international.org/memento/TC39.htm) committee, which determines standards for the JavaScript language.
+[zone.js](https://github.com/angular/zone.js) | Angular relies on zone.js to run Angular's change detection processes when native JavaScript operations raise events.  Zone.js is an implementation of a [specification](https://gist.github.com/mhevery/63fdcdf7c65886051d55) currently before the [TC39](http://www.ecma-international.org/memento/TC39.htm) committee that determines standards for the JavaScript language.
 
 
 {@a polyfills}
@@ -104,7 +136,7 @@ features that Angular requires.
 The [Browser Support](guide/browser-support) guide explains which browsers need polyfills and 
 how you can add them.
 
-The default `package.json` for a new Angular CLI application installs the [core-js](https://github.com/zloirock/core-js) package, 
+The `package.json` for a new Angular workspace installs the [core-js](https://github.com/zloirock/core-js) package, 
 which polyfills missing features for several popular browser.
 
 
@@ -119,7 +151,7 @@ To add a new `devDependency`, use either one of the following commands:
 * `npm install --dev <package-name>` 
 * `yarn add --dev <package-name>` 
 
-The following `devDependencies` are provided in the default `package.json` file for a new Angular CLI application. 
+The following `devDependencies` are provided in the default `package.json` file for a new Angular workspace. 
 
 **[@angular-devkit/build-angular](https://github.com/angular/angular-cli/)**: The Angular build tools.
 

--- a/aio/content/guide/npm-packages.md
+++ b/aio/content/guide/npm-packages.md
@@ -1,9 +1,10 @@
-# Npm Packages
+# Angular packages and dependencies
 
  The Angular Framework, Angular CLI, and components used by Angular applications are packaged as [**npm packages**](https://docs.npmjs.com/getting-started/what-is-npm "What is npm?") and distributed via the [npm registry](https://docs.npmjs.com/).
 
-You can download and install these npm packages by using the [**npm CLI client**](https://docs.npmjs.com/cli/install), which is installed with and runs as a Node.js® application. By default, the Angular CLI uses the npm client to install npm packages when you create a new project.
+You can download and install these npm packages by using the [**npm CLI client**](https://docs.npmjs.com/cli/install), which is installed with and runs as a [Node.js®](https://nodejs.org "Nodejs.org") application. By default, the Angular CLI uses the npm client to install npm packages when you create a new project.
 
+Alternatively, you can use the [yarn client](https://yarnpkg.com/) for downloading and installing npm packages. 
 
 
 <div class="alert is-helpful">
@@ -17,41 +18,40 @@ If you already have projects running on your machine that use other versions of 
 
 ## `package.json`
 
-Both `npm` and `yarn` install packages that are identified in a [**package.json**](https://docs.npmjs.com/files/package.json) file.
+Both `npm` and `yarn` install packages that are identified in a [`package.json`](https://docs.npmjs.com/files/package.json) file.
 
 The CLI `ng new` command creates a default `package.json` file for your project.
 This `package.json` specifies _a starter set of packages_ that work well together and 
 jointly support many common application scenarios.
 
-You will add packages to `package.json` as your application evolves.
-You may even remove some.
+The `package.json` includes two sets of packages:
 
-This guide focuses on the most important packages in the starter set.
+* [Dependencies](guide/npm-packages#dependencies) are essential to *running* the application.
+* [DevDependencies](guide/npm-packages#dev-dependencies) are only necessary to *develop* the application.
 
+You add packages to `package.json` as your application evolves. 
+You may even remove some. 
 
-The `package.json` includes two sets of packages,
-[dependencies](guide/npm-packages#dependencies) and [devDependencies](guide/npm-packages#dev-dependencies).
-
-* The *dependencies* are essential to *running* the application.
-* The *devDependencies* are only necessary to *develop* the application.
 
 {@a dependencies}
-
 ## Dependencies
+
+The packages listed in the `dependencies` section of `package.json` are essential to *running* the application. 
+
 The `dependencies` section of `package.json` contains:
 
-* **Angular packages**: Angular core and optional modules; their package names begin `@angular/`.
+* [**Angular packages**](#angular-packages): Angular core and optional modules; their package names begin `@angular/`.
 
-* **Support packages**: 3rd party libraries that must be present for Angular apps to run.
+* [**Support packages**](#support-packages): 3rd party libraries that must be present for Angular apps to run.
 
-* **Polyfill packages**: Polyfills plug gaps in a browser's JavaScript implementation.
+* [**Polyfill packages**](#polyfills): Polyfills plug gaps in a browser's JavaScript implementation.
 
 To add a new dependency, use the [`ng add`](cli/add) command.
 
+{@a angular-packages}
+### Angular packages
 
-### Angular Packages
-
-For a complete list of Angular packages (and links to package overviews), see the [API reference](http://angular.io/api?type=package). The following packages are included as dependencies in the initial `package.json` file. 
+For a complete list of Angular packages (and links to package overviews), see the [API reference](http://angular.io/api?type=package). The following Angular packages are included as dependencies in the  `package.json` file for a new Angular CLI application. 
 
 **@angular/animations**: Angular's animations library makes it easy to define and apply animation effects such as page and list transitions.
 Read about it in the [Animations guide](guide/animations).
@@ -81,20 +81,10 @@ using the [JIT compiler](guide/aot-compiler).
 
 **@angular/router**: The [router module](/guide/router) navigates among your app pages when the browser URL changes.
 
-{@a polyfills}
-
-### Polyfill packages
-
-Many browsers lack native support for some features in the latest HTML standards,
-features that Angular requires.
-"[Polyfills](https://en.wikipedia.org/wiki/Polyfill)" can emulate the missing features.
-The [Browser Support](guide/browser-support) guide explains which browsers need polyfills and 
-how you can add them.
-
-The default `package.json` installs the **[core-js](https://github.com/zloirock/core-js)** package
-which polyfills missing features for several popular browser.
-
+{@a support-packages}
 ### Support packages
+
+The following support packages are included as dependencies in the  `package.json` file for a new Angular CLI application. 
 
 **[rxjs](https://github.com/ReactiveX/rxjs)**: Many Angular APIs return [_observables_](guide/glossary#observable). RxJS is an implementation of the proposed [Observables specification](https://github.com/zenparsing/es-observable) currently before the
 [TC39](http://www.ecma-international.org/memento/TC39.htm) committee, which determines standards for the JavaScript language.
@@ -104,29 +94,40 @@ which polyfills missing features for several popular browser.
 [TC39](http://www.ecma-international.org/memento/TC39.htm) committee that determines standards for the JavaScript language.
 
 
+{@a polyfills}
+### Polyfill packages
+
+Many browsers lack native support for some features in the latest HTML standards,
+features that Angular requires.
+[**Polyfills**](https://en.wikipedia.org/wiki/Polyfill) can emulate the missing features.
+The [Browser Support](guide/browser-support) guide explains which browsers need polyfills and 
+how you can add them.
+
+The default `package.json` for a new Angular CLI application installs the [core-js](https://github.com/zloirock/core-js) package, 
+which polyfills missing features for several popular browser.
+
+
 {@a dev-dependencies}
 
 ## DevDependencies
 
 The packages listed in the `devDependencies` section of `package.json` help you develop the application on your local machine. You don't deploy them with the production application.
 
-To add a new `devDependency`, use either one of the following commands, depending on which package manager you use:
+To add a new `devDependency`, use either one of the following commands:
 
-* `npm install --dev` 
-* `yarn add --dev` 
+* `npm install --dev <package-name>` 
+* `yarn add --dev <package-name>` 
 
-The following `devDependencies` are provided in the initial `package.json` file.
+The following `devDependencies` are provided in the default `package.json` file for a new Angular CLI application. 
 
-**@angular-devkit/build-angular: The Angular build tools.
+**[@angular-devkit/build-angular](https://github.com/angular/angular-cli/)**: The Angular build tools.
 
 **[@angular/cli](https://github.com/angular/angular-cli/)**: The Angular CLI tools.
 
-
-**[@angular/compiler-cli](https://github.com/angular/angular/blob/master/packages/compiler-cli/README.md)**: The Angular compiler, which is invoked by the Angular CLI's `build` and `serve` commands.
-
+**[@angular/compiler-cli](https://github.com/angular/angular/blob/master/packages/compiler-cli/README.md)**: The Angular compiler, which is invoked by the Angular CLI's `ng build` and `ng serve` commands.
 
 **[@angular/language-service](https://github.com/angular/angular-cli/)**: The Angular language service analyzes component templates and provides type and error information that TypeScript-aware editors can use to improve the developer's experience.
-For example, see the [Angular language service extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Angular.ng-template)
+For example, see the [Angular language service extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Angular.ng-template).
 
 
 **@types/... **: TypeScript definition files for 3rd party libraries such as Jasmine and Node.js.
@@ -156,7 +157,7 @@ the TypeScript language server, including the *tsc* TypeScript compiler.
 
 ## Related information
 
-By default, the Angular CLI build process bundles into a single file just the few "vendor" library files that your application actually needs.
-The browser downloads this bundle, not the original package files.
-
-See [Deployment](guide/deployment) to learn more.
+ For information about how the Angular CLI handles packages see the following guides: 
+ 
+ * [Building and serving](guide/build) describes how packages come together to create a development build.
+ * [Deployment](guide/deployment) describes how packages come together to create a production build.

--- a/aio/content/guide/npm-packages.md
+++ b/aio/content/guide/npm-packages.md
@@ -60,34 +60,17 @@ To add a new dependency, use the [`ng add`](cli/add) command.
 The following Angular packages are included as dependencies in the default `package.json` file for a new Angular workspace.
 For a complete list of Angular packages, see the [API reference](http://angular.io/api?type=package). 
 
-[**@angular/animations:**](api/animations) Angular's animations library makes it easy to define and apply animation effects such as page and list transitions.
-For more information, see the [Animations guide](guide/animations).
-
-[**@angular/common:**](api/common) The commonly-needed services, pipes, and directives provided by the Angular team.
-The [`HttpClientModule`](api/common/http/HttpClientModule) is also here, in the [`@angular/common/http`](api/common/http) subfolder.
-For more information, see the [HttpClient guide](guide/http).
-
-**@angular/compiler:** Angular's template compiler.
-It understands templates and can convert them to code that makes the application run and render.
-Typically you don’t interact with the compiler directly; rather, you use it indirectly via `platform-browser-dynamic` when JIT compiling in the browser.
-For more information, see the [Ahead-of-time Compilation guide](guide/aot-compiler).
-
-[**@angular/core:**](api/core) Critical runtime parts of the framework that are needed by every application.
-Includes all metadata decorators, `Component`, `Directive`,  dependency injection, and the component lifecycle hooks.
-
-[**@angular/forms:**](api/forms) Support for both [template-driven](guide/forms) and [reactive forms](guide/reactive-forms).
-For information about choosing the best forms approach for your app, see [Introduction to forms](guide/forms-overview).
-
-[**@angular/http:**](api/http) Angular's legacy HTTP client, which was deprecated in version 5.0 in favor of [@angular/common/http](api/common/http).
-
-[**@angular/platform-browser:**](api/platform-browser) Everything DOM and browser related, especially
-the pieces that help render into the DOM.
-This package also includes the `bootstrapModuleFactory()` method for bootstrapping applications for production builds that pre-compile with [AOT](guide/aot-compiler).
-
-[**@angular/platform-browser-dynamic:**](api/platform-browser-dynamic) Includes [providers](api/core/Provider) and methods to compile and run the app on the client using the [JIT compiler](guide/aot-compiler).
-
-[**@angular/router:**](api/router) The router module navigates among your app pages when the browser URL changes.
-For more information, see [Routing and Navigation](guide/router).
+Package name                               | Description
+----------------------------------------   | --------------------------------------------------
+[**@angular/animations**](api/animations) | Angular's animations library makes it easy to define and apply animation effects such as page and list transitions. For more information, see the [Animations guide](guide/animations).
+[**@angular/common**](api/common) | The commonly-needed services, pipes, and directives provided by the Angular team. The [`HttpClientModule`](api/common/http/HttpClientModule) is also here, in the [`@angular/common/http`](api/common/http) subfolder. For more information, see the [HttpClient guide](guide/http).
+**@angular/compiler** | Angular's template compiler. It understands templates and can convert them to code that makes the application run and render. Typically you don’t interact with the compiler directly; rather, you use it indirectly via `platform-browser-dynamic` when JIT compiling in the browser. For more information, see the [Ahead-of-time Compilation guide](guide/aot-compiler).
+[**@angular/core**](api/core) | Critical runtime parts of the framework that are needed by every application. Includes all metadata decorators, `Component`, `Directive`,  dependency injection, and the component lifecycle hooks.
+[**@angular/forms**](api/forms) | Support for both [template-driven](guide/forms) and [reactive forms](guide/reactive-forms). For information about choosing the best forms approach for your app, see [Introduction to forms](guide/forms-overview).
+[**@angular/http**](api/http) | Angular's legacy HTTP client, which was deprecated in version 5.0 in favor of [@angular/common/http](api/common/http).
+[**@angular/<br />platform&#8209;browser**](api/platform-browser) | Everything DOM and browser related, especially the pieces that help render into the DOM. This package also includes the `bootstrapModuleFactory()` method for bootstrapping applications for production builds that pre-compile with [AOT](guide/aot-compiler).
+[**@angular/<br />platform&#8209;browser&#8209;dynamic**](api/platform-browser-dynamic) | Includes [providers](api/core/Provider) and methods to compile and run the app on the client using the [JIT compiler](guide/aot-compiler).
+[**@angular/router**](api/router) | The router module navigates among your app pages when the browser URL changes. For more information, see [Routing and Navigation](guide/router).
 
 
 {@a support-packages}
@@ -95,12 +78,11 @@ For more information, see [Routing and Navigation](guide/router).
 
 The following support packages are included as dependencies in the default `package.json` file for a new Angular workspace. 
 
-[**rxjs:**](https://github.com/ReactiveX/rxjs) Many Angular APIs return [_observables_](guide/glossary#observable). RxJS is an implementation of the proposed [Observables specification](https://github.com/zenparsing/es-observable) currently before the
-[TC39](http://www.ecma-international.org/memento/TC39.htm) committee, which determines standards for the JavaScript language.
 
-
-[**zone.js:**](https://github.com/angular/zone.js) Angular relies on zone.js to run Angular's change detection processes when native JavaScript operations raise events.  Zone.js is an implementation of a [specification](https://gist.github.com/mhevery/63fdcdf7c65886051d55) currently before the
-[TC39](http://www.ecma-international.org/memento/TC39.htm) committee that determines standards for the JavaScript language.
+Package name                               | Description
+----------------------------------------   | --------------------------------------------------
+[**rxjs**](https://github.com/ReactiveX/rxjs) | Many Angular APIs return [_observables_](guide/glossary#observable). RxJS is an implementation of the proposed [Observables specification](https://github.com/zenparsing/es-observable) currently before the [TC39](http://www.ecma-international.org/memento/TC39.htm) committee, which determines standards for the JavaScript language.
+[**zone.js**](https://github.com/angular/zone.js) | Angular relies on zone.js to run Angular's change detection processes when native JavaScript operations raise events.  Zone.js is an implementation of a [specification](https://gist.github.com/mhevery/63fdcdf7c65886051d55) currently before the [TC39](http://www.ecma-international.org/memento/TC39.htm) committee that determines standards for the JavaScript language.
 
 
 {@a polyfills}
@@ -134,42 +116,21 @@ To add a new `devDependency`, use either one of the following commands:
 
 The following `devDependencies` are provided in the default `package.json` file for a new Angular workspace. 
 
-[**@angular-devkit/build-angular:**](https://github.com/angular/angular-cli/) The Angular build tools.
 
-
-[**@angular/cli:**](https://github.com/angular/angular-cli/) The Angular CLI tools.
-
-
-**@angular/compiler-cli:** The Angular compiler, which is invoked by the Angular CLI's `ng build` and `ng serve` commands.
-
-
-**@angular/language-service:** The [Angular language service](guide/language-service) analyzes component templates and provides type and error information that TypeScript-aware editors can use to improve the developer's experience.
-For example, see the [Angular language service extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Angular.ng-template).
-
-
-**@types/... :** TypeScript definition files for 3rd party libraries such as Jasmine and Node.js.
-
-
-[**codelyzer:**](https://www.npmjs.com/package/codelyzer) A linter for Angular apps whose rules conform to the Angular [style guide](guide/styleguide).
-
-
-**jasmine/... :** Packages to support the [Jasmine](https://jasmine.github.io/) test library.
-
-
-**karma/... :** Packages to support the [karma](https://www.npmjs.com/package/karma) test runner.
-
-
-[**protractor:**](https://www.npmjs.com/package/protractor) An end-to-end (e2e) framework for Angular apps.
-Built on top of [WebDriverJS](https://github.com/SeleniumHQ/selenium/wiki/WebDriverJs).
-
-
-[**ts-node:**](https://www.npmjs.com/package/ts-node) TypeScript execution environment and REPL for Node.js.
-
-
-[**tslint:**](https://www.npmjs.com/package/tslint) A static analysis tool that checks TypeScript code for readability, maintainability, and functionality errors.
-
-
-[**typescript:**](https://www.npmjs.com/package/typescript) The TypeScript language server, including the *tsc* TypeScript compiler.
+Package name                               | Description
+----------------------------------------   | -----------------------------------
+[**@angular&#8209;devkit/<br />build&#8209;angular**](https://github.com/angular/angular-cli/) | The Angular build tools.
+[**@angular/cli**](https://github.com/angular/angular-cli/) | The Angular CLI tools.
+**@angular/<br />compiler&#8209;cli** | The Angular compiler, which is invoked by the Angular CLI's `ng build` and `ng serve` commands.
+**@angular/<br />language&#8209;service** | The [Angular language service](guide/language-service) analyzes component templates and provides type and error information that TypeScript-aware editors can use to improve the developer's experience. For example, see the [Angular language service extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Angular.ng-template).
+**@types/... ** | TypeScript definition files for 3rd party libraries such as Jasmine and Node.js.
+[**codelyzer**](https://www.npmjs.com/package/codelyzer) | A linter for Angular apps whose rules conform to the Angular [style guide](guide/styleguide).
+**jasmine/... ** | Packages to support the [Jasmine](https://jasmine.github.io/) test library.
+**karma/... ** | Packages to support the [karma](https://www.npmjs.com/package/karma) test runner.
+[**protractor**](https://www.npmjs.com/package/protractor) | An end-to-end (e2e) framework for Angular apps. Built on top of [WebDriverJS](https://github.com/SeleniumHQ/selenium/wiki/WebDriverJs).
+[**ts-node**](https://www.npmjs.com/package/ts-node) | TypeScript execution environment and REPL for Node.js.
+[**tslint**](https://www.npmjs.com/package/tslint) | A static analysis tool that checks TypeScript code for readability, maintainability, and functionality errors.
+[**typescript**](https://www.npmjs.com/package/typescript) | The TypeScript language server, including the *tsc* TypeScript compiler.
 
 
 ## Related information

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -517,8 +517,8 @@
         },
         {
           "url": "guide/npm-packages",
-          "title": "Packages",
-          "tooltip": "Explanation of npm packages installed into a project by default."
+          "title": "npm Dependencies",
+          "tooltip": "Description of npm packages required at development time and at runtime."
         },
         {
           "url": "guide/typescript-configuration",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ X] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Npm packages doc was not current for v7.
* Referred to old version of node
* Described yarn as default for CLI, not npm
* package lists were not current


Issue Number: N/A


## What is the new behavior?

The doc needs a larger rewrite, but this PR is to make it accurate in the ways mentioned above. 

Also made some copy edits. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[X ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
