### PR TITLE
refactor(ivy): invert LNode.data into LViewData[HOST]

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -158,7 +158,6 @@ export {
 } from './sanitization/bypass';
 
 export {
-  LContext as ɵLContext,
   getContext as ɵgetContext
 } from './render3/context_discovery';
 
@@ -167,6 +166,10 @@ export {
   PlayState as ɵPlayState,
   PlayerHandler as ɵPlayerHandler,
 } from './render3/interfaces/player';
+
+export {
+  LContext as ɵLContext,
+} from './render3/interfaces/context';
 
 export {
   addPlayer as ɵaddPlayer,

--- a/packages/core/src/render3/discovery_utils.ts
+++ b/packages/core/src/render3/discovery_utils.ts
@@ -8,10 +8,13 @@
 import {Injector} from '../di/injector';
 
 import {assertDefined} from './assert';
-import {LContext, discoverDirectives, discoverLocalRefs, getContext, isComponentInstance, readPatchedLViewData} from './context_discovery';
+import {discoverDirectives, discoverLocalRefs, getContext, isComponentInstance} from './context_discovery';
 import {NodeInjector} from './di';
-import {LElementNode, TElementNode, TNode, TNodeFlags} from './interfaces/node';
+import {LContext} from './interfaces/context';
+import {TElementNode, TNode, TNodeFlags} from './interfaces/node';
 import {CONTEXT, FLAGS, LViewData, LViewFlags, PARENT, RootContext, TVIEW} from './interfaces/view';
+import {getComponentViewByIndex, readPatchedLViewData} from './util';
+
 
 /**
  * NOTE: The following functions might not be ideal for core usage in Angular...
@@ -61,8 +64,8 @@ export function getHostComponent<T = {}>(target: {}): T|null {
   const context = loadContext(target);
   const tNode = context.lViewData[TVIEW].data[context.nodeIndex] as TNode;
   if (tNode.flags & TNodeFlags.isComponent) {
-    const lNode = context.lViewData[context.nodeIndex] as LElementNode;
-    return lNode.data ![CONTEXT] as any as T;
+    const componentView = getComponentViewByIndex(context.nodeIndex, context.lViewData);
+    return componentView[CONTEXT] as any as T;
   }
   return null;
 }

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -7,13 +7,14 @@
  */
 
 import {assertEqual, assertLessThan} from './assert';
-import {NO_CHANGE, _getViewData, adjustBlueprintForNewNode, bindingUpdated, bindingUpdated2, bindingUpdated3, bindingUpdated4, createNodeAtIndex, getRenderer, getTNode, load, loadElement, resetComponentState} from './instructions';
+import {NO_CHANGE, _getViewData, adjustBlueprintForNewNode, bindingUpdated, bindingUpdated2, bindingUpdated3, bindingUpdated4, createNodeAtIndex, getRenderer, load, loadElement, resetComponentState} from './instructions';
 import {LContainer, NATIVE, RENDER_PARENT} from './interfaces/container';
 import {LContainerNode, LNode, TElementNode, TNode, TNodeType} from './interfaces/node';
 import {StylingContext} from './interfaces/styling';
 import {BINDING_INDEX, HEADER_OFFSET, HOST_NODE, TVIEW} from './interfaces/view';
 import {appendChild, createTextNode, removeChild} from './node_manipulation';
-import {getLNode, isLContainer, stringify} from './util';
+import {getNative, getTNode, isLContainer, stringify} from './util';
+
 
 
 /**
@@ -272,8 +273,7 @@ function appendI18nNode(tNode: TNode, parentTNode: TNode, previousTNode: TNode):
     }
   }
 
-  const native = getLNode(tNode, viewData).native;
-  appendChild(native, tNode, viewData);
+  appendChild(getNative(tNode, viewData), tNode, viewData);
 
   const slotValue = viewData[tNode.index];
   if (tNode.type !== TNodeType.Container && isLContainer(slotValue)) {
@@ -320,7 +320,7 @@ export function i18nApply(startIndex: number, instructions: I18nInstruction[]): 
   }
 
   const renderer = getRenderer();
-  const startTNode = getTNode(startIndex);
+  const startTNode = getTNode(startIndex, viewData);
   let localParentTNode: TNode = startTNode.parent || viewData[HOST_NODE] !;
   let localPreviousTNode: TNode = localParentTNode;
   resetComponentState();  // We don't want to add to the tree with the wrong previous node
@@ -329,7 +329,7 @@ export function i18nApply(startIndex: number, instructions: I18nInstruction[]): 
     const instruction = instructions[i] as number;
     switch (instruction & I18nInstructions.InstructionMask) {
       case I18nInstructions.Element:
-        const elementTNode = getTNode(instruction & I18nInstructions.IndexMask);
+        const elementTNode = getTNode(instruction & I18nInstructions.IndexMask, viewData);
         localPreviousTNode = appendI18nNode(elementTNode, localParentTNode, localPreviousTNode);
         localParentTNode = elementTNode;
         break;
@@ -338,7 +338,7 @@ export function i18nApply(startIndex: number, instructions: I18nInstruction[]): 
       case I18nInstructions.Any:
         const nodeIndex = instruction & I18nInstructions.IndexMask;
         localPreviousTNode =
-            appendI18nNode(getTNode(nodeIndex), localParentTNode, localPreviousTNode);
+            appendI18nNode(getTNode(nodeIndex, viewData), localParentTNode, localPreviousTNode);
         break;
       case I18nInstructions.Text:
         if (ngDevMode) {
@@ -365,7 +365,7 @@ export function i18nApply(startIndex: number, instructions: I18nInstruction[]): 
         }
         const removeIndex = instruction & I18nInstructions.IndexMask;
         const removedNode: LNode|LContainerNode = loadElement(removeIndex);
-        const removedTNode = getTNode(removeIndex);
+        const removedTNode = getTNode(removeIndex, viewData);
         removeChild(removedTNode, removedNode.native || null, viewData);
 
         const slotValue = load(removeIndex) as LNode | LContainer | StylingContext;

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -10,7 +10,8 @@ import {LContainerNode, LElementContainerNode, LElementNode} from './node';
 import {LQueries} from './query';
 import {RComment} from './renderer';
 import {StylingContext} from './styling';
-import {LViewData, NEXT, PARENT, QUERIES} from './view';
+import {HOST, LViewData, NEXT, PARENT, QUERIES} from './view';
+
 
 /**
  * Below are constants for LContainer indices to help us look up LContainer members
@@ -18,11 +19,10 @@ import {LViewData, NEXT, PARENT, QUERIES} from './view';
  * Uglify will inline these when minifying so there shouldn't be a cost.
  */
 export const ACTIVE_INDEX = 0;
-// PARENT, NEXT, and QUERIES are indices 1, 2, and 3.
+export const VIEWS = 1;
+// PARENT, NEXT, QUERIES, and HOST are indices 2, 3, 4, and 5.
 // As we already have these constants in LViewData, we don't need to re-create them.
-export const HOST_NATIVE = 4;
-export const NATIVE = 5;
-export const VIEWS = 6;
+export const NATIVE = 6;
 export const RENDER_PARENT = 7;
 
 /**
@@ -44,6 +44,15 @@ export interface LContainer extends Array<any> {
   [ACTIVE_INDEX]: number;
 
   /**
+   * A list of the container's currently active child views. Views will be inserted
+   * here as they are added and spliced from here when they are removed. We need
+   * to keep a record of current views so we know which views are already in the DOM
+   * (and don't need to be re-added) and so we can remove views from the DOM when they
+   * are no longer required.
+   */
+  [VIEWS]: LViewData[];
+
+  /**
    * Access to the parent view is necessary so we can propagate back
    * up from inside a container to parent[NEXT].
    */
@@ -63,19 +72,10 @@ export interface LContainer extends Array<any> {
 
   /** The host node of this LContainer. */
   // TODO: Should contain just the native element once LNode is removed.
-  [HOST_NATIVE]: LElementNode|LContainerNode|LElementContainerNode|StylingContext;
+  [HOST]: LElementNode|LContainerNode|LElementContainerNode|StylingContext|LViewData;
 
   /** The comment element that serves as an anchor for this LContainer. */
   [NATIVE]: RComment;
-
-  /**
-   * A list of the container's currently active child views. Views will be inserted
-   * here as they are added and spliced from here when they are removed. We need
-   * to keep a record of current views so we know which views are already in the DOM
-   * (and don't need to be re-added) and so we can remove views from the DOM when they
-   * are no longer required.
-   */
-  [VIEWS]: LViewData[];
 
   /**
    * Parent Element which will contain the location where all of the Views will be

--- a/packages/core/src/render3/interfaces/context.ts
+++ b/packages/core/src/render3/interfaces/context.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+
+import {RElement} from './renderer';
+import {LViewData} from './view';
+
+/**
+ * This property will be monkey-patched on elements, components and directives
+ */
+export const MONKEY_PATCH_KEY_NAME = '__ngContext__';
+
+/**
+ * The internal view context which is specific to a given DOM element, directive or
+ * component instance. Each value in here (besides the LViewData and element node details)
+ * can be present, null or undefined. If undefined then it implies the value has not been
+ * looked up yet, otherwise, if null, then a lookup was executed and nothing was found.
+ *
+ * Each value will get filled when the respective value is examined within the getContext
+ * function. The component, element and each directive instance will share the same instance
+ * of the context.
+ */
+export interface LContext {
+  /**
+   * The component's parent view data.
+   */
+  lViewData: LViewData;
+
+  /**
+   * The index instance of the node.
+   */
+  nodeIndex: number;
+
+  /**
+   * The instance of the DOM node that is attached to the lNode.
+   */
+  native: RElement;
+
+  /**
+   * The instance of the Component node.
+   */
+  component: {}|null|undefined;
+
+  /**
+   * The list of active directives that exist on this element.
+   */
+  directives: any[]|null|undefined;
+
+  /**
+   * The map of local references (local reference name => element or directive instance) that exist
+   * on this element.
+   */
+  localRefs: {[key: string]: any}|null|undefined;
+}

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -69,14 +69,6 @@ export interface LNode {
    *  - retrieve the sibling elements of text nodes whose creation / insertion has been delayed
    */
   readonly native: RComment|RElement|RText|null;
-
-  /**
-   * If regular LElementNode, LTextNode, LContainerNode, and LProjectionNode then `data` will be
-   * null.
-   * If LElementNode with component, then `data` contains LViewData.
-   * If LViewNode, then `data` contains the LViewData.
-   */
-  readonly data: LViewData|null;
 }
 
 
@@ -84,30 +76,22 @@ export interface LNode {
 export interface LElementNode extends LNode {
   /** The DOM element associated with this node. */
   readonly native: RElement;
-
-  /** If Component then data has LView (light DOM) */
-  readonly data: LViewData|null;
 }
 
 /** LNode representing <ng-container>. */
 export interface LElementContainerNode extends LNode {
   /** The DOM comment associated with this node. */
   readonly native: RComment;
-  readonly data: null;
 }
 
 /** LNode representing a #text node. */
 export interface LTextNode extends LNode {
   /** The text node associated with this node. */
   native: RText;
-  readonly data: null;
 }
 
 /** Abstract node which contains root nodes of a view. */
-export interface LViewNode extends LNode {
-  readonly native: null;
-  readonly data: LViewData;
-}
+export interface LViewNode extends LNode { readonly native: null; }
 
 /** Abstract node container which contains other views. */
 export interface LContainerNode extends LNode {
@@ -119,14 +103,10 @@ export interface LContainerNode extends LNode {
    * until the parent view is processed.
    */
   native: RComment;
-  readonly data: null;
 }
 
 
-export interface LProjectionNode extends LNode {
-  readonly native: null;
-  readonly data: null;
-}
+export interface LProjectionNode extends LNode { readonly native: null; }
 
 /**
  * A set of marker values to be used in the attributes arrays. Those markers indicate that some

--- a/packages/core/src/render3/interfaces/styling.ts
+++ b/packages/core/src/render3/interfaces/styling.ts
@@ -122,11 +122,6 @@ export interface StylingContext extends
     Array<InitialStyles|{[key: string]: any}|number|string|boolean|LElementNode|StyleSanitizeFn|
           PlayerContext|null> {
   /**
-   * Location of element that is used as a target for this context.
-   */
-  [StylingIndex.ElementPosition]: LElementNode|null;
-
-  /**
    * Location of animation context (which contains the active players) for this element styling
    * context.
    */
@@ -155,6 +150,11 @@ export interface StylingContext extends
    * need to take into account any style values that exist in the context.
    */
   [StylingIndex.ClassOffsetPosition]: number;
+
+  /**
+   * Location of element that is used as a target for this context.
+   */
+  [StylingIndex.ElementPosition]: LElementNode|null;
 
   /**
    * The last class value that was interpreted by elementStylingMap. This is cached
@@ -201,17 +201,18 @@ export const enum StylingFlags {
 /** Used as numeric pointer values to determine what cells to update in the `StylingContext` */
 export const enum StylingIndex {
   // Position of where the initial styles are stored in the styling context
-  ElementPosition = 0,
-  // Position of where the initial styles are stored in the styling context
-  PlayerContext = 1,
+  PlayerContext = 0,
   // Position of where the style sanitizer is stored within the styling context
-  StyleSanitizerPosition = 2,
+  StyleSanitizerPosition = 1,
   // Position of where the initial styles are stored in the styling context
-  InitialStylesPosition = 3,
+  InitialStylesPosition = 2,
   // Index of location where the start of single properties are stored. (`updateStyleProp`)
-  MasterFlagPosition = 4,
+  MasterFlagPosition = 3,
   // Index of location where the class index offset value is located
-  ClassOffsetPosition = 5,
+  ClassOffsetPosition = 4,
+  // Position of where the initial styles are stored in the styling context
+  // This index must align with HOST, see interfaces/view.ts
+  ElementPosition = 5,
   // Position of where the last string-based CSS class value was stored
   PreviousMultiClassValue = 6,
   // Position of where the last string-based CSS class value was stored

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -13,32 +13,34 @@ import {PlayerHandler} from '../interfaces/player';
 
 import {LContainer} from './container';
 import {ComponentDef, ComponentQuery, ComponentTemplate, DirectiveDef, DirectiveDefList, HostBindingsFunction, PipeDef, PipeDefList} from './definition';
-import {TElementNode, TNode, TViewNode} from './node';
+import {LContainerNode, LElementContainerNode, LElementNode, TElementNode, TNode, TViewNode} from './node';
 import {LQueries} from './query';
 import {Renderer3} from './renderer';
+import {StylingContext} from './styling';
 
 /** Size of LViewData's header. Necessary to adjust for it when setting slots.  */
-export const HEADER_OFFSET = 16;
+export const HEADER_OFFSET = 17;
 
 // Below are constants for LViewData indices to help us look up LViewData members
 // without having to remember the specific indices.
 // Uglify will inline these when minifying so there shouldn't be a cost.
 export const TVIEW = 0;
-export const PARENT = 1;
-export const NEXT = 2;
-export const QUERIES = 3;
-export const FLAGS = 4;
-export const HOST_NODE = 5;
-export const BINDING_INDEX = 6;
-export const CLEANUP = 7;
-export const CONTEXT = 8;
-export const INJECTOR = 9;
-export const RENDERER = 10;
-export const SANITIZER = 11;
-export const TAIL = 12;
-export const CONTAINER_INDEX = 13;
-export const CONTENT_QUERIES = 14;
-export const DECLARATION_VIEW = 15;
+export const FLAGS = 1;
+export const PARENT = 2;
+export const NEXT = 3;
+export const QUERIES = 4;
+export const HOST = 5;
+export const HOST_NODE = 6;
+export const BINDING_INDEX = 7;
+export const CLEANUP = 8;
+export const CONTEXT = 9;
+export const INJECTOR = 10;
+export const RENDERER = 11;
+export const SANITIZER = 12;
+export const TAIL = 13;
+export const CONTAINER_INDEX = 14;
+export const CONTENT_QUERIES = 15;
+export const DECLARATION_VIEW = 16;
 
 // This interface replaces the real LViewData interface if it is an arg or a
 // return value of a public instruction. This ensures we don't need to expose
@@ -66,6 +68,9 @@ export interface LViewData extends Array<any> {
    */
   [TVIEW]: TView;
 
+  /** Flags for this view. See LViewFlags for more info. */
+  [FLAGS]: LViewFlags;
+
   /**
    * The parent view is needed when we exit the view and must restore the previous
    * `LViewData`. Without this, the render method would have to keep a stack of
@@ -90,8 +95,13 @@ export interface LViewData extends Array<any> {
   /** Queries active for this view - nodes from a view are reported to those queries. */
   [QUERIES]: LQueries|null;
 
-  /** Flags for this view. See LViewFlags for more info. */
-  [FLAGS]: LViewFlags;
+  /**
+   * The host node for this LViewData instance, if this is a component view.
+   *
+   * If this is an embedded view, HOST will be null.
+   */
+  // TODO: should store native elements directly when we remove LNode
+  [HOST]: LElementNode|LContainerNode|LElementContainerNode|StylingContext|null;
 
   /**
    * Pointer to the `TViewNode` or `TElementNode` which represents the root of the view.

--- a/packages/core/src/render3/styling/class_and_style_bindings.ts
+++ b/packages/core/src/render3/styling/class_and_style_bindings.ts
@@ -14,21 +14,6 @@ import {InitialStyles, StylingContext, StylingFlags, StylingIndex} from '../inte
 
 import {EMPTY_ARR, EMPTY_OBJ, createEmptyStylingContext} from './util';
 
-
-/**
- * Used clone a copy of a pre-computed template of a styling context.
- *
- * A pre-computed template is designed to be computed once for a given element
- * (instructions.ts has logic for caching this).
- */
-export function allocStylingContext(
-    lElement: LElementNode | null, templateStyleContext: StylingContext): StylingContext {
-  // each instance gets a copy
-  const context = templateStyleContext.slice() as any as StylingContext;
-  context[StylingIndex.ElementPosition] = lElement;
-  return context;
-}
-
 /**
  * Creates a styling context template where styling information is stored.
  * Any styles that are later referenced using `updateStyleProp` must be

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -28,7 +28,7 @@ import {RComment, RElement, Renderer3, isProceduralRenderer} from './interfaces/
 import {CONTEXT, HOST_NODE, LViewData, QUERIES, RENDERER, TVIEW, TView} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
 import {addRemoveViewFromContainer, appendChild, detachView, findComponentView, getBeforeNodeForView, getRenderParent, insertView, removeView} from './node_manipulation';
-import {getLNode, isComponent, isLContainer} from './util';
+import {getComponentViewByIndex, getNative, isComponent, isLContainer} from './util';
 import {ViewRef} from './view_ref';
 
 
@@ -60,7 +60,7 @@ export function createElementRef(
     // TODO: Fix class name, should be ElementRef, but there appears to be a rollup bug
     R3ElementRef = class ElementRef_ extends ElementRefToken {};
   }
-  return new R3ElementRef(getLNode(tNode, view).native);
+  return new R3ElementRef(getNative(tNode, view));
 }
 
 let R3TemplateRef: {
@@ -325,7 +325,7 @@ export function createViewRef(
     hostTNode: TNode, hostView: LViewData, context: any): ViewEngine_ChangeDetectorRef {
   if (isComponent(hostTNode)) {
     const componentIndex = hostTNode.flags >> TNodeFlags.DirectiveStartingIndexShift;
-    const componentView = getLNode(hostTNode, hostView).data as LViewData;
+    const componentView = getComponentViewByIndex(hostTNode.index, hostView);
     return new ViewRef(componentView, context, componentIndex);
   } else if (hostTNode.type === TNodeType.Element) {
     const hostComponentView = findComponentView(hostView);

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -69,7 +69,7 @@
     "name": "HEADER_OFFSET"
   },
   {
-    "name": "HOST_NATIVE"
+    "name": "HOST"
   },
   {
     "name": "HOST_NODE"
@@ -375,9 +375,6 @@
     "name": "createLContext"
   },
   {
-    "name": "createLNodeObject"
-  },
-  {
     "name": "createLViewData"
   },
   {
@@ -388,6 +385,9 @@
   },
   {
     "name": "createRootComponent"
+  },
+  {
+    "name": "createRootComponentView"
   },
   {
     "name": "createRootContext"
@@ -552,6 +552,12 @@
     "name": "getComponentDef"
   },
   {
+    "name": "getComponentViewByIndex"
+  },
+  {
+    "name": "getComponentViewByInstance"
+  },
+  {
     "name": "getContainerRenderParent"
   },
   {
@@ -591,9 +597,6 @@
     "name": "getLContainer"
   },
   {
-    "name": "getLElementFromComponent"
-  },
-  {
     "name": "getLNode"
   },
   {
@@ -607,6 +610,9 @@
   },
   {
     "name": "getMultiStartIndex"
+  },
+  {
+    "name": "getNative"
   },
   {
     "name": "getOrCreateInjectable"
@@ -643,9 +649,6 @@
   },
   {
     "name": "getPreviousIndex"
-  },
-  {
-    "name": "getPreviousOrParentNode"
   },
   {
     "name": "getPreviousOrParentTNode"
@@ -699,9 +702,6 @@
     "name": "hasValueChanged"
   },
   {
-    "name": "hostElement"
-  },
-  {
     "name": "inject"
   },
   {
@@ -733,6 +733,9 @@
   },
   {
     "name": "isClassBased"
+  },
+  {
+    "name": "isComponent"
   },
   {
     "name": "isComponentInstance"
@@ -783,6 +786,9 @@
     "name": "isSanitizable"
   },
   {
+    "name": "isStylingContext"
+  },
+  {
     "name": "iterateListLike"
   },
   {
@@ -823,9 +829,6 @@
   },
   {
     "name": "nativeInsertBefore"
-  },
-  {
-    "name": "nativeNodeLocalRefExtractor"
   },
   {
     "name": "nextContext"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -39,7 +39,7 @@
     "name": "HEADER_OFFSET"
   },
   {
-    "name": "HOST_NATIVE"
+    "name": "HOST"
   },
   {
     "name": "HOST_NODE"
@@ -156,9 +156,6 @@
     "name": "componentRefresh"
   },
   {
-    "name": "createLNodeObject"
-  },
-  {
     "name": "createLViewData"
   },
   {
@@ -166,6 +163,9 @@
   },
   {
     "name": "createRootComponent"
+  },
+  {
+    "name": "createRootComponentView"
   },
   {
     "name": "createRootContext"
@@ -231,6 +231,9 @@
     "name": "getComponentDef"
   },
   {
+    "name": "getComponentViewByIndex"
+  },
+  {
     "name": "getContainerRenderParent"
   },
   {
@@ -253,6 +256,9 @@
   },
   {
     "name": "getLViewChild"
+  },
+  {
+    "name": "getNative"
   },
   {
     "name": "getOrCreateNodeInjector"
@@ -283,9 +289,6 @@
   },
   {
     "name": "getRenderParent"
-  },
-  {
-    "name": "hostElement"
   },
   {
     "name": "invertObject"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -54,7 +54,7 @@
     "name": "HEADER_OFFSET"
   },
   {
-    "name": "HOST_NATIVE"
+    "name": "HOST"
   },
   {
     "name": "HOST_NODE"
@@ -438,9 +438,6 @@
     "name": "createLContext"
   },
   {
-    "name": "createLNodeObject"
-  },
-  {
     "name": "createLViewData"
   },
   {
@@ -451,6 +448,9 @@
   },
   {
     "name": "createRootComponent"
+  },
+  {
+    "name": "createRootComponentView"
   },
   {
     "name": "createRootContext"
@@ -603,6 +603,12 @@
     "name": "getComponentDef"
   },
   {
+    "name": "getComponentViewByIndex"
+  },
+  {
+    "name": "getComponentViewByInstance"
+  },
+  {
     "name": "getContainerRenderParent"
   },
   {
@@ -636,9 +642,6 @@
     "name": "getLContainer"
   },
   {
-    "name": "getLElementFromComponent"
-  },
-  {
     "name": "getLNode"
   },
   {
@@ -649,6 +652,9 @@
   },
   {
     "name": "getMultiStartIndex"
+  },
+  {
+    "name": "getNative"
   },
   {
     "name": "getOrCreateInjectable"
@@ -682,9 +688,6 @@
   },
   {
     "name": "getPreviousIndex"
-  },
-  {
-    "name": "getPreviousOrParentNode"
   },
   {
     "name": "getPreviousOrParentTNode"
@@ -732,9 +735,6 @@
     "name": "hasValueChanged"
   },
   {
-    "name": "hostElement"
-  },
-  {
     "name": "inject"
   },
   {
@@ -760,6 +760,9 @@
   },
   {
     "name": "invertObject"
+  },
+  {
+    "name": "isComponent"
   },
   {
     "name": "isContentQueryHost"
@@ -799,6 +802,9 @@
   },
   {
     "name": "isProceduralRenderer"
+  },
+  {
+    "name": "isStylingContext"
   },
   {
     "name": "iterateListLike"
@@ -844,9 +850,6 @@
   },
   {
     "name": "nativeInsertBefore"
-  },
-  {
-    "name": "nativeNodeLocalRefExtractor"
   },
   {
     "name": "nextContext"

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -321,10 +321,10 @@
     "name": "HEADER_OFFSET"
   },
   {
-    "name": "HOST_ATTR$1"
+    "name": "HOST"
   },
   {
-    "name": "HOST_NATIVE"
+    "name": "HOST_ATTR$1"
   },
   {
     "name": "HOST_NODE"
@@ -1320,9 +1320,6 @@
     "name": "createLContext"
   },
   {
-    "name": "createLNodeObject"
-  },
-  {
     "name": "createLViewData"
   },
   {
@@ -1339,6 +1336,9 @@
   },
   {
     "name": "createRootComponent"
+  },
+  {
+    "name": "createRootComponentView"
   },
   {
     "name": "createRootContext"
@@ -1611,6 +1611,12 @@
     "name": "getComponentDef"
   },
   {
+    "name": "getComponentViewByIndex"
+  },
+  {
+    "name": "getComponentViewByInstance"
+  },
+  {
     "name": "getContainerRenderParent"
   },
   {
@@ -1674,9 +1680,6 @@
     "name": "getLContainer"
   },
   {
-    "name": "getLElementFromComponent"
-  },
-  {
     "name": "getLNode"
   },
   {
@@ -1737,6 +1740,9 @@
     "name": "getNamedFormat"
   },
   {
+    "name": "getNative"
+  },
+  {
     "name": "getNgModuleDef"
   },
   {
@@ -1792,9 +1798,6 @@
   },
   {
     "name": "getPreviousIndex"
-  },
-  {
-    "name": "getPreviousOrParentNode"
   },
   {
     "name": "getPreviousOrParentTNode"
@@ -1864,9 +1867,6 @@
   },
   {
     "name": "hasValueChanged"
-  },
-  {
-    "name": "hostElement"
   },
   {
     "name": "hostReportError"
@@ -2019,6 +2019,9 @@
     "name": "isScheduler"
   },
   {
+    "name": "isStylingContext"
+  },
+  {
     "name": "isTemplateElement"
   },
   {
@@ -2110,9 +2113,6 @@
   },
   {
     "name": "nativeInsertBefore"
-  },
-  {
-    "name": "nativeNodeLocalRefExtractor"
   },
   {
     "name": "nextContext"

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -81,7 +81,7 @@ describe('instructions', () => {
         element(0, 'div', ['id', 'test', 'title', 'Hello']);
       }, () => {}, 1);
 
-      const div = (t.hostNode.native as HTMLElement).querySelector('div') !;
+      const div = (t.hostElement as HTMLElement).querySelector('div') !;
       expect(div.id).toEqual('test');
       expect(div.title).toEqual('Hello');
       expect(ngDevMode).toHaveProperties({
@@ -109,7 +109,7 @@ describe('instructions', () => {
         ]);
       }, () => {}, 1);
 
-      const div = (t.hostNode.native as HTMLElement).querySelector('div') !;
+      const div = (t.hostElement as HTMLElement).querySelector('div') !;
       const attrs: any = div.attributes;
 
       expect(attrs['id'].name).toEqual('id');
@@ -179,7 +179,7 @@ describe('instructions', () => {
 
       t.update(() => elementProperty(0, 'hidden', false));
       // The hidden property would be true if `false` was stringified into `"false"`.
-      expect((t.hostNode.native as HTMLElement).querySelector('div') !.hidden).toEqual(false);
+      expect((t.hostElement as HTMLElement).querySelector('div') !.hidden).toEqual(false);
       expect(ngDevMode).toHaveProperties({
         firstTemplatePass: 1,
         tNode: 2,  // 1 for div, 1 for host element

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -25,7 +25,7 @@ import {DirectiveDefList, DirectiveTypesOrFactory, PipeDef, PipeDefList, PipeTyp
 import {LElementNode} from '../../src/render3/interfaces/node';
 import {PlayerHandler} from '../../src/render3/interfaces/player';
 import {RElement, RText, Renderer3, RendererFactory3, domRendererFactory3} from '../../src/render3/interfaces/renderer';
-import {HEADER_OFFSET} from '../../src/render3/interfaces/view';
+import {HEADER_OFFSET, LViewData} from '../../src/render3/interfaces/view';
 import {Sanitizer} from '../../src/sanitization/security';
 import {Type} from '../../src/type';
 
@@ -55,7 +55,7 @@ function noop() {}
  * - access to the render `html`.
  */
 export class TemplateFixture extends BaseFixture {
-  hostNode: LElementNode;
+  hostView: LViewData;
   private _directiveDefs: DirectiveDefList|null;
   private _pipeDefs: PipeDefList|null;
   private _sanitizer: Sanitizer|null;
@@ -78,7 +78,7 @@ export class TemplateFixture extends BaseFixture {
     this._pipeDefs = toDefs(pipes, extractPipeDef);
     this._sanitizer = sanitizer || null;
     this._rendererFactory = rendererFactory || domRendererFactory3;
-    this.hostNode = renderTemplate(
+    this.hostView = renderTemplate(
         this.hostElement,
         (rf: RenderFlags, ctx: any) => {
           if (rf & RenderFlags.Create) {
@@ -99,8 +99,8 @@ export class TemplateFixture extends BaseFixture {
    */
   update(updateBlock?: () => void): void {
     renderTemplate(
-        this.hostNode.native, updateBlock || this.updateBlock, 0, this.vars, null !,
-        this._rendererFactory, this.hostNode, this._directiveDefs, this._pipeDefs, this._sanitizer);
+        this.hostElement, updateBlock || this.updateBlock, 0, this.vars, null !,
+        this._rendererFactory, this.hostView, this._directiveDefs, this._pipeDefs, this._sanitizer);
   }
 }
 
@@ -152,7 +152,7 @@ export class ComponentFixture<T> extends BaseFixture {
 
 export const document = ((typeof global == 'object' && global || window) as any).document;
 export let containerEl: HTMLElement = null !;
-let host: LElementNode|null;
+let hostView: LViewData|null;
 const isRenderer2 =
     typeof process == 'object' && process.argv[3] && process.argv[3] === '--r=renderer2';
 // tslint:disable-next-line:no-console
@@ -181,7 +181,7 @@ export function resetDOM() {
   containerEl = document.createElement('div');
   containerEl.setAttribute('host', '');
   document.body.appendChild(containerEl);
-  host = null;
+  hostView = null;
   // TODO: assert that the global state is clean (e.g. ngData, previousOrParentNode, etc)
 }
 
@@ -192,9 +192,9 @@ export function renderToHtml(
     template: ComponentTemplate<any>, ctx: any, consts: number = 0, vars: number = 0,
     directives?: DirectiveTypesOrFactory | null, pipes?: PipeTypesOrFactory | null,
     providedRendererFactory?: RendererFactory3 | null) {
-  host = renderTemplate(
+  hostView = renderTemplate(
       containerEl, template, consts, vars, ctx, providedRendererFactory || testRendererFactory,
-      host, toDefs(directives, extractDirectiveDef), toDefs(pipes, extractPipeDef));
+      hostView, toDefs(directives, extractDirectiveDef), toDefs(pipes, extractPipeDef));
   return toHtml(containerEl);
 }
 

--- a/packages/core/test/render3/styling/styling_spec.ts
+++ b/packages/core/test/render3/styling/styling_spec.ts
@@ -10,10 +10,10 @@ import {InitialStylingFlags, RenderFlags} from '../../../src/render3/interfaces/
 import {LElementNode} from '../../../src/render3/interfaces/node';
 import {Renderer3} from '../../../src/render3/interfaces/renderer';
 import {StylingContext, StylingFlags, StylingIndex} from '../../../src/render3/interfaces/styling';
-import {allocStylingContext, createStylingContextTemplate, isContextDirty, renderStyling as _renderStyling, setContextDirty, updateClassProp, updateStyleProp, updateStylingMap} from '../../../src/render3/styling/class_and_style_bindings';
+import {createStylingContextTemplate, isContextDirty, renderStyling as _renderStyling, setContextDirty, updateClassProp, updateStyleProp, updateStylingMap} from '../../../src/render3/styling/class_and_style_bindings';
+import {allocStylingContext} from '../../../src/render3/styling/util';
 import {defaultStyleSanitizer} from '../../../src/sanitization/sanitization';
 import {StyleSanitizeFn} from '../../../src/sanitization/style_sanitizer';
-
 import {renderToHtml} from '../render_util';
 
 describe('styling', () => {
@@ -110,19 +110,19 @@ describe('styling', () => {
     describe('createStylingContextTemplate', () => {
       it('should initialize empty template', () => {
         const template = initContext();
-        expect(template).toEqual([element, null, null, [null], cleanStyle(0, 8), 0, null, null]);
+        expect(template).toEqual([null, null, [null], cleanStyle(0, 8), 0, element, null, null]);
       });
 
       it('should initialize static styles', () => {
         const template =
             initContext([InitialStylingFlags.VALUES_MODE, 'color', 'red', 'width', '10px']);
         expect(template).toEqual([
-          element,
           null,
           null,
           [null, 'red', '10px'],
           dirtyStyle(0, 14),  //
           0,
+          element,
           null,
           null,
 
@@ -321,12 +321,12 @@ describe('styling', () => {
         updateStyles(stylingContext, {width: '100px', height: '100px'});
 
         expect(stylingContext).toEqual([
-          element,
           null,
           null,
           [null],
           dirtyStyle(0, 14),  //
           2,
+          element,
           null,
           {width: '100px', height: '100px'},
 
@@ -355,12 +355,12 @@ describe('styling', () => {
         updateStyles(stylingContext, {width: '200px', opacity: '0'});
 
         expect(stylingContext).toEqual([
-          element,
           null,
           null,
           [null],
           dirtyStyle(0, 14),  //
           2,
+          element,
           null,
           {width: '200px', opacity: '0'},
 
@@ -392,12 +392,12 @@ describe('styling', () => {
 
         getStyles(stylingContext);
         expect(stylingContext).toEqual([
-          element,
           null,
           null,
           [null],
           cleanStyle(0, 14),  //
           2,
+          element,
           null,
           {width: '200px', opacity: '0'},
 
@@ -431,12 +431,12 @@ describe('styling', () => {
         updateStyleProp(stylingContext, 0, '300px');
 
         expect(stylingContext).toEqual([
-          element,
           null,
           null,
           [null],
           dirtyStyle(0, 14),  //
           2,
+          element,
           null,
           {width: null},
 
@@ -470,12 +470,12 @@ describe('styling', () => {
 
         updateStyleProp(stylingContext, 0, null);
         expect(stylingContext).toEqual([
-          element,
           null,
           null,
           [null],
           dirtyStyle(0, 14),  //
           2,
+          element,
           null,
           {width: null},
 
@@ -514,12 +514,12 @@ describe('styling', () => {
            updateStyles(stylingContext, {width: '100px', height: '100px', opacity: '0.5'});
 
            expect(stylingContext).toEqual([
-             element,
              null,
              null,
              [null],
              dirtyStyle(0, 11),  //
              1,
+             element,
              null,
              {width: '100px', height: '100px', opacity: '0.5'},
 
@@ -553,12 +553,12 @@ describe('styling', () => {
 
            updateStyles(stylingContext, {});
            expect(stylingContext).toEqual([
-             element,
              null,
              null,
              [null],
              dirtyStyle(0, 11),  //
              1,
+             element,
              null,
              {},
 
@@ -594,12 +594,12 @@ describe('styling', () => {
            });
 
            expect(stylingContext).toEqual([
-             element,
              null,
              null,
              [null],
              dirtyStyle(0, 11),  //
              1,
+             element,
              null,
              {borderWidth: '5px'},
 
@@ -637,12 +637,12 @@ describe('styling', () => {
            updateStyleProp(stylingContext, 0, '200px');
 
            expect(stylingContext).toEqual([
-             element,
              null,
              null,
              [null],
              dirtyStyle(0, 11),  //
              1,
+             element,
              null,
              {borderWidth: '5px'},
 
@@ -680,12 +680,12 @@ describe('styling', () => {
            updateStyles(stylingContext, {borderWidth: '15px', borderColor: 'red'});
 
            expect(stylingContext).toEqual([
-             element,
              null,
              null,
              [null],
              dirtyStyle(0, 11),  //
              1,
+             element,
              null,
              {borderWidth: '15px', borderColor: 'red'},
 
@@ -737,12 +737,12 @@ describe('styling', () => {
         updateStyleProp(stylingContext, 0, '200px');
 
         expect(stylingContext).toEqual([
-          element,
           null,
           null,
           [null],
           dirtyStyle(0, 11),  //
           1,
+          element,
           null,
           {width: '100px'},
 
@@ -765,12 +765,12 @@ describe('styling', () => {
         getStyles(stylingContext);
 
         expect(stylingContext).toEqual([
-          element,
           null,
           null,
           [null],
           cleanStyle(0, 11),  //
           1,
+          element,
           null,
           {width: '100px'},
 
@@ -802,12 +802,12 @@ describe('styling', () => {
            updateStyleProp(stylingContext, 1, '100px');
 
            expect(stylingContext).toEqual([
-             element,
              null,
              styleSanitizer,
              [null],
              dirtyStyle(0, 14),  //
              2,
+             element,
              null,
              null,
 
@@ -835,12 +835,12 @@ describe('styling', () => {
            updateStyles(stylingContext, {'background-image': 'unsafe'});
 
            expect(stylingContext).toEqual([
-             element,
              null,
              styleSanitizer,
              [null],
              dirtyStyle(0, 14),  //
              2,
+             element,
              null,
              {'background-image': 'unsafe'},
 
@@ -873,12 +873,12 @@ describe('styling', () => {
            getStyles(stylingContext);
 
            expect(stylingContext).toEqual([
-             element,
              null,
              styleSanitizer,
              [null],
              cleanStyle(0, 14),  //
              2,
+             element,
              null,
              {'background-image': 'unsafe'},
 
@@ -916,8 +916,8 @@ describe('styling', () => {
       const template =
           initContext(null, [InitialStylingFlags.VALUES_MODE, 'one', true, 'two', true]);
       expect(template).toEqual([
-        element, null, null, [null, true, true], dirtyStyle(0, 14),  //
-        0, null, null,
+        null, null, [null, true, true], dirtyStyle(0, 14),  //
+        0, element, null, null,
 
         // #8
         cleanClass(1, 14), 'one', null,
@@ -979,12 +979,12 @@ describe('styling', () => {
       const initialClasses = ['wide', 'tall', InitialStylingFlags.VALUES_MODE, 'wide', true];
       const stylingContext = initContext(initialStyles, initialClasses);
       expect(stylingContext).toEqual([
-        element,
         null,
         null,
         [null, '100px', true],
         dirtyStyle(0, 20),  //
         2,
+        element,
         null,
         null,
 
@@ -1033,12 +1033,12 @@ describe('styling', () => {
 
       updateStylingMap(stylingContext, 'tall round', {width: '200px', opacity: '0.5'});
       expect(stylingContext).toEqual([
-        element,
         null,
         null,
         [null, '100px', true],
         dirtyStyle(0, 20),  //
         2,
+        element,
         'tall round',
         {width: '200px', opacity: '0.5'},
 
@@ -1101,12 +1101,12 @@ describe('styling', () => {
       updateStyleProp(stylingContext, 0, '300px');
 
       expect(stylingContext).toEqual([
-        element,
         null,
         null,
         [null, '100px', true],
         dirtyStyle(0, 20),  //
         2,
+        element,
         {tall: true, wide: true},
         {width: '500px'},
 
@@ -1179,12 +1179,12 @@ describe('styling', () => {
     getStylesAndClasses(stylingContext);
 
     expect(stylingContext).toEqual([
-      element,
       null,
       null,
       [null],
       cleanStyle(0, 8),  //
       0,
+      element,
       {foo: true},
       {width: '200px'},
 
@@ -1208,12 +1208,12 @@ describe('styling', () => {
     getStylesAndClasses(stylingContext);
 
     expect(stylingContext).toEqual([
-      element,
       null,
       null,
       [null],
       cleanStyle(0, 8),  //
       0,
+      element,
       {foo: false},
       {width: '300px'},
 
@@ -1240,12 +1240,12 @@ describe('styling', () => {
     expect(getClasses(stylingContext)).toEqual({apple: true, orange: true, banana: true});
 
     expect(stylingContext).toEqual([
-      element,
       null,
       null,
       [null],
       cleanStyle(0, 8),  //
       0,
+      element,
       'apple orange banana',
       null,
 


### PR DESCRIPTION
This PR removes `LNode.data` by inverting the relationship between `LNode` and component view instances. Previously, we'd access component views through `LNode.data`, whereas now we can access component nodes through `LViewData[HOST]`.

Notes:
- This PR also contains some minor housekeeping:
   - `hostElement` has been renamed to `createRootComponentView` and moved to `component.ts`
   - `LContext` has moved to its own `interfaces/context `file
   - Utils like `readElementValue` and `getTNode` have been moved to `util.ts`


Still TODO:
- Remove `LNode.native`
