### PR TITLE
refactor(ivy): remove LNode

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -18,10 +18,10 @@ import {getComponentDef} from './definition';
 import {queueInitHooks, queueLifecycleHooks} from './hooks';
 import {CLEAN_PROMISE, baseDirectiveCreate, createLViewData, createNodeAtIndex, createTView, detectChangesInternal, enterView, executeInitAndContentHooks, getOrCreateTView, leaveView, locateHostElement, prefillHostVars, resetComponentState, setHostBindings} from './instructions';
 import {ComponentDef, ComponentType} from './interfaces/definition';
-import {TNodeFlags, TNodeType} from './interfaces/node';
+import {TElementNode, TNodeFlags, TNodeType} from './interfaces/node';
 import {PlayerHandler} from './interfaces/player';
 import {RElement, RNode, Renderer3, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
-import {CONTEXT, HEADER_OFFSET, HOST, INJECTOR, LViewData, LViewFlags, RootContext, RootContextFlags, TVIEW} from './interfaces/view';
+import {CONTEXT, HEADER_OFFSET, HOST, HOST_NODE, INJECTOR, LViewData, LViewFlags, RootContext, RootContextFlags, TVIEW} from './interfaces/view';
 import {getRootView, readElementValue, readPatchedLViewData, stringify} from './util';
 
 
@@ -166,7 +166,7 @@ export function createRootComponentView(
       getOrCreateTView(
           def.template, def.consts, def.vars, def.directiveDefs, def.pipeDefs, def.viewQuery),
       null, def.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways, sanitizer);
-  const tNode = createNodeAtIndex(0, TNodeType.Element, rNode, null, null, componentView);
+  const tNode = createNodeAtIndex(0, TNodeType.Element, rNode, null, null);
 
   if (tView.firstTemplatePass) {
     tView.expandoInstructions = ROOT_EXPANDO_INSTRUCTIONS.slice();
@@ -177,9 +177,9 @@ export function createRootComponentView(
 
   // Store component view at node index, with node as the HOST
   componentView[HOST] = rootView[HEADER_OFFSET];
+  componentView[HOST_NODE] = tNode as TElementNode;
   return rootView[HEADER_OFFSET] = componentView;
 }
-
 
 /**
  * Creates a root component and sets it up with features and host bindings. Shared by
@@ -255,7 +255,7 @@ function getRootContext(component: any): RootContext {
  * @param component Component for which the host element should be retrieved.
  */
 export function getHostElement<T>(component: T): HTMLElement {
-  return readElementValue(getComponentViewByInstance(component)).native as HTMLElement;
+  return readElementValue(getComponentViewByInstance(component)) as HTMLElement;
 }
 
 /**

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -19,7 +19,7 @@ import {Type} from '../type';
 import {assertComponentType, assertDefined} from './assert';
 import {LifecycleHooksFeature, createRootComponent, createRootComponentView, createRootContext} from './component';
 import {getComponentDef} from './definition';
-import {adjustBlueprintForNewNode, createLViewData, createNodeAtIndex, createTView, elementCreate, enterView, locateHostElement, renderEmbeddedTemplate} from './instructions';
+import {adjustBlueprintForNewNode, createLViewData, createNodeAtIndex, createTView, createViewNode, elementCreate, enterView, locateHostElement, renderEmbeddedTemplate} from './instructions';
 import {ComponentDef, RenderFlags} from './interfaces/definition';
 import {TElementNode, TNode, TNodeType, TViewNode} from './interfaces/node';
 import {RElement, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
@@ -141,7 +141,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
           createRootComponentView(hostRNode, this.componentDef, rootView, renderer);
       tElementNode = getTNode(0, rootView) as TElementNode;
 
-      // Transform the arrays of native nodes into a LNode structure that can be consumed by the
+      // Transform the arrays of native nodes into a structure that can be consumed by the
       // projection instruction. This is needed to support the reprojection of these nodes.
       if (projectableNodes) {
         let index = 0;
@@ -223,7 +223,7 @@ export class ComponentRef<T> extends viewEngine_ComponentRef<T> {
     super();
     this.instance = instance;
     this.hostView = this.changeDetectorRef = new RootViewRef<T>(rootView);
-    this.hostView._tViewNode = createNodeAtIndex(-1, TNodeType.View, null, null, null, rootView);
+    this.hostView._tViewNode = createViewNode(-1, rootView);
     this.injector = injector;
     this.componentType = componentType;
   }

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -11,18 +11,17 @@
 
 import {getInjectableDef, getInjectorDef} from '../di/defs';
 import {InjectionToken} from '../di/injection_token';
-import {InjectFlags, Injector, NullInjector, inject, setCurrentInjector} from '../di/injector';
-import {Renderer2} from '../render';
+import {InjectFlags, Injector, inject, setCurrentInjector} from '../di/injector';
 import {Type} from '../type';
 
 import {assertDefined} from './assert';
 import {getComponentDef, getDirectiveDef, getPipeDef} from './definition';
 import {NG_ELEMENT_ID} from './fields';
-import {_getViewData, assertPreviousIsParent, getPreviousOrParentTNode, resolveDirective, setEnvironment} from './instructions';
+import {_getViewData, getPreviousOrParentTNode, resolveDirective, setEnvironment} from './instructions';
 import {DirectiveDef} from './interfaces/definition';
 import {InjectorLocationFlags, PARENT_INJECTOR, TNODE,} from './interfaces/injector';
 import {AttributeMarker, TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeFlags, TNodeType} from './interfaces/node';
-import {DECLARATION_VIEW, HOST_NODE, INJECTOR, LViewData, PARENT, RENDERER, TData, TVIEW, TView} from './interfaces/view';
+import {DECLARATION_VIEW, HOST_NODE, INJECTOR, LViewData, TData, TVIEW, TView} from './interfaces/view';
 import {assertNodeOfPossibleTypes} from './node_assert';
 
 /**

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -7,13 +7,14 @@
  */
 
 import {assertEqual, assertLessThan} from './assert';
-import {NO_CHANGE, _getViewData, adjustBlueprintForNewNode, bindingUpdated, bindingUpdated2, bindingUpdated3, bindingUpdated4, createNodeAtIndex, getRenderer, load, loadElement, resetComponentState} from './instructions';
+import {NO_CHANGE, _getViewData, adjustBlueprintForNewNode, bindingUpdated, bindingUpdated2, bindingUpdated3, bindingUpdated4, createNodeAtIndex, getRenderer, load, resetComponentState} from './instructions';
 import {LContainer, NATIVE, RENDER_PARENT} from './interfaces/container';
-import {LContainerNode, LNode, TElementNode, TNode, TNodeType} from './interfaces/node';
+import {TElementNode, TNode, TNodeType} from './interfaces/node';
+import {RComment, RElement} from './interfaces/renderer';
 import {StylingContext} from './interfaces/styling';
 import {BINDING_INDEX, HEADER_OFFSET, HOST_NODE, TVIEW} from './interfaces/view';
 import {appendChild, createTextNode, removeChild} from './node_manipulation';
-import {getNative, getTNode, isLContainer, stringify} from './util';
+import {getNativeByIndex, getNativeByTNode, getTNode, isLContainer, stringify} from './util';
 
 
 
@@ -273,7 +274,7 @@ function appendI18nNode(tNode: TNode, parentTNode: TNode, previousTNode: TNode):
     }
   }
 
-  appendChild(getNative(tNode, viewData), tNode, viewData);
+  appendChild(getNativeByTNode(tNode, viewData), tNode, viewData);
 
   const slotValue = viewData[tNode.index];
   if (tNode.type !== TNodeType.Container && isLContainer(slotValue)) {
@@ -364,11 +365,11 @@ export function i18nApply(startIndex: number, instructions: I18nInstruction[]): 
           ngDevMode.rendererRemoveNode++;
         }
         const removeIndex = instruction & I18nInstructions.IndexMask;
-        const removedNode: LNode|LContainerNode = loadElement(removeIndex);
+        const removedElement: RElement|RComment = getNativeByIndex(removeIndex, viewData);
         const removedTNode = getTNode(removeIndex, viewData);
-        removeChild(removedTNode, removedNode.native || null, viewData);
+        removeChild(removedTNode, removedElement || null, viewData);
 
-        const slotValue = load(removeIndex) as LNode | LContainer | StylingContext;
+        const slotValue = load(removeIndex) as RElement | RComment | LContainer | StylingContext;
         if (isLContainer(slotValue)) {
           const lContainer = slotValue as LContainer;
           if (removedTNode.type !== TNodeType.Container) {

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {LContainerNode, LElementContainerNode, LElementNode} from './node';
 import {LQueries} from './query';
-import {RComment} from './renderer';
+import {RComment, RElement} from './renderer';
 import {StylingContext} from './styling';
 import {HOST, LViewData, NEXT, PARENT, QUERIES} from './view';
 
@@ -26,7 +25,7 @@ export const NATIVE = 6;
 export const RENDER_PARENT = 7;
 
 /**
- * The state associated with an LContainerNode.
+ * The state associated with a container.
  *
  * This is an array so that its structure is closer to LViewData. This helps
  * when traversing the view tree (which is a mix of containers and component
@@ -70,34 +69,41 @@ export interface LContainer extends Array<any> {
    */
   [QUERIES]: LQueries|null;
 
-  /** The host node of this LContainer. */
-  // TODO: Should contain just the native element once LNode is removed.
-  [HOST]: LElementNode|LContainerNode|LElementContainerNode|StylingContext|LViewData;
+  /**
+   * The host element of this LContainer.
+   *
+   * The host could be an LViewData if this container is on a component node.
+   * In that case, the component LViewData is its HOST.
+   *
+   * It could also be a styling context if this is a node with a style/class
+   * binding.
+   */
+  [HOST]: RElement|RComment|StylingContext|LViewData;
 
   /** The comment element that serves as an anchor for this LContainer. */
   [NATIVE]: RComment;
 
   /**
-   * Parent Element which will contain the location where all of the Views will be
+   * Parent Element which will contain the location where all of the views will be
    * inserted into to.
    *
    * If `renderParent` is `null` it is headless. This means that it is contained
-   * in another `LViewNode` which in turn is contained in another `LContainerNode` and
+   * in another view which in turn is contained in another container and
    * therefore it does not yet have its own parent.
    *
    * If `renderParent` is not `null` then it may be:
-   * - same as `LContainerNode.parent` in which case it is just a normal container.
-   * - different from `LContainerNode.parent` in which case it has been re-projected.
-   *   In other words `LContainerNode.parent` is logical parent where as
-   *   `LContainer.projectedParent` is render parent.
+   * - same as `tContainerNode.parent` in which case it is just a normal container.
+   * - different from `tContainerNode.parent` in which case it has been re-projected.
+   *   In other words `tContainerNode.parent` is logical parent where as
+   *   `tContainerNode.projectedParent` is render parent.
    *
-   * When views are inserted into `LContainerNode` then `renderParent` is:
-   * - `null`, we are in `LViewNode` keep going up a hierarchy until actual
+   * When views are inserted into `LContainer` then `renderParent` is:
+   * - `null`, we are in a view, keep going up a hierarchy until actual
    *   `renderParent` is found.
    * - not `null`, then use the `projectedParent.native` as the `RElement` to insert
-   *   `LViewNode`s into.
+   * views into.
    */
-  [RENDER_PARENT]: LElementNode|null;
+  [RENDER_PARENT]: RElement|null;
 }
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency

--- a/packages/core/src/render3/interfaces/styling.ts
+++ b/packages/core/src/render3/interfaces/styling.ts
@@ -7,8 +7,8 @@
  */
 
 import {StyleSanitizeFn} from '../../sanitization/style_sanitizer';
+import {RElement} from '../interfaces/renderer';
 
-import {LElementNode} from './node';
 import {PlayerContext} from './player';
 
 
@@ -118,9 +118,8 @@ import {PlayerContext} from './player';
  * `updateStyleProp` or `updateClassProp` cannot be called with a new property (only
  * `updateStylingMap` can include new CSS properties that will be added to the context).
  */
-export interface StylingContext extends
-    Array<InitialStyles|{[key: string]: any}|number|string|boolean|LElementNode|StyleSanitizeFn|
-          PlayerContext|null> {
+export interface StylingContext extends Array<InitialStyles|{[key: string]: any}|number|string|
+                                              boolean|RElement|StyleSanitizeFn|PlayerContext|null> {
   /**
    * Location of animation context (which contains the active players) for this element styling
    * context.
@@ -154,7 +153,7 @@ export interface StylingContext extends
   /**
    * Location of element that is used as a target for this context.
    */
-  [StylingIndex.ElementPosition]: LElementNode|null;
+  [StylingIndex.ElementPosition]: RElement|null;
 
   /**
    * The last class value that was interpreted by elementStylingMap. This is cached

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -13,9 +13,9 @@ import {PlayerHandler} from '../interfaces/player';
 
 import {LContainer} from './container';
 import {ComponentDef, ComponentQuery, ComponentTemplate, DirectiveDef, DirectiveDefList, HostBindingsFunction, PipeDef, PipeDefList} from './definition';
-import {LContainerNode, LElementContainerNode, LElementNode, TElementNode, TNode, TViewNode} from './node';
+import {TElementNode, TNode, TViewNode} from './node';
 import {LQueries} from './query';
-import {Renderer3} from './renderer';
+import {RElement, Renderer3} from './renderer';
 import {StylingContext} from './styling';
 
 /** Size of LViewData's header. Necessary to adjust for it when setting slots.  */
@@ -100,8 +100,7 @@ export interface LViewData extends Array<any> {
    *
    * If this is an embedded view, HOST will be null.
    */
-  // TODO: should store native elements directly when we remove LNode
-  [HOST]: LElementNode|LContainerNode|LElementContainerNode|StylingContext|null;
+  [HOST]: RElement|StylingContext|null;
 
   /**
    * Pointer to the `TViewNode` or `TElementNode` which represents the root of the view.

--- a/packages/core/src/render3/node_assert.ts
+++ b/packages/core/src/render3/node_assert.ts
@@ -7,7 +7,7 @@
  */
 
 import {assertDefined, assertEqual} from './assert';
-import {LNode, TNode, TNodeType} from './interfaces/node';
+import {TNode, TNodeType} from './interfaces/node';
 
 export function assertNodeType(tNode: TNode, type: TNodeType) {
   assertDefined(tNode, 'should be called with a TNode');

--- a/packages/core/src/render3/styling/class_and_style_bindings.ts
+++ b/packages/core/src/render3/styling/class_and_style_bindings.ts
@@ -8,7 +8,6 @@
 
 import {StyleSanitizeFn} from '../../sanitization/style_sanitizer';
 import {InitialStylingFlags} from '../interfaces/definition';
-import {LElementNode} from '../interfaces/node';
 import {Renderer3, RendererStyleFlags3, isProceduralRenderer} from '../interfaces/renderer';
 import {InitialStyles, StylingContext, StylingFlags, StylingIndex} from '../interfaces/styling';
 
@@ -388,7 +387,7 @@ export function renderStyling(
     context: StylingContext, renderer: Renderer3, styleStore?: {[key: string]: any},
     classStore?: {[key: string]: boolean}) {
   if (isContextDirty(context)) {
-    const native = context[StylingIndex.ElementPosition] !.native;
+    const native = context[StylingIndex.ElementPosition] !;
     const multiStartIndex = getMultiStartIndex(context);
     const styleSanitizer = getStyleSanitizer(context);
     for (let i = StylingIndex.SingleStylesStartPosition; i < context.length;

--- a/packages/core/src/render3/styling/util.ts
+++ b/packages/core/src/render3/styling/util.ts
@@ -10,8 +10,8 @@ import {StyleSanitizeFn} from '../../sanitization/style_sanitizer';
 import {getContext} from '../context_discovery';
 import {ACTIVE_INDEX, LContainer} from '../interfaces/container';
 import {LContext} from '../interfaces/context';
-import {LElementNode} from '../interfaces/node';
 import {PlayerContext} from '../interfaces/player';
+import {RElement} from '../interfaces/renderer';
 import {InitialStyles, StylingContext, StylingIndex} from '../interfaces/styling';
 import {FLAGS, HEADER_OFFSET, HOST, LViewData} from '../interfaces/view';
 import {getTNode} from '../util';
@@ -20,7 +20,7 @@ export const EMPTY_ARR: any[] = [];
 export const EMPTY_OBJ: {[key: string]: any} = {};
 
 export function createEmptyStylingContext(
-    element?: LElementNode | null, sanitizer?: StyleSanitizeFn | null,
+    element?: RElement | null, sanitizer?: StyleSanitizeFn | null,
     initialStylingValues?: InitialStyles): StylingContext {
   return [
     null,                            // PlayerContext
@@ -41,10 +41,10 @@ export function createEmptyStylingContext(
  * (instructions.ts has logic for caching this).
  */
 export function allocStylingContext(
-    lElement: LElementNode | null, templateStyleContext: StylingContext): StylingContext {
+    element: RElement | null, templateStyleContext: StylingContext): StylingContext {
   // each instance gets a copy
   const context = templateStyleContext.slice() as any as StylingContext;
-  context[StylingIndex.ElementPosition] = lElement;
+  context[StylingIndex.ElementPosition] = element;
   return context;
 }
 
@@ -61,12 +61,12 @@ export function allocStylingContext(
  */
 export function getStylingContext(index: number, viewData: LViewData): StylingContext {
   let storageIndex = index + HEADER_OFFSET;
-  let slotValue: LContainer|LViewData|StylingContext|LElementNode = viewData[storageIndex];
+  let slotValue: LContainer|LViewData|StylingContext|RElement = viewData[storageIndex];
   let wrapper: LContainer|LViewData|StylingContext = viewData;
 
   while (Array.isArray(slotValue)) {
     wrapper = slotValue;
-    slotValue = slotValue[HOST] as LViewData | StylingContext | LElementNode;
+    slotValue = slotValue[HOST] as LViewData | StylingContext | RElement;
   }
 
   if (isStylingContext(wrapper)) {

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -28,7 +28,7 @@ import {RComment, RElement, Renderer3, isProceduralRenderer} from './interfaces/
 import {CONTEXT, HOST_NODE, LViewData, QUERIES, RENDERER, TVIEW, TView} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
 import {addRemoveViewFromContainer, appendChild, detachView, findComponentView, getBeforeNodeForView, getRenderParent, insertView, removeView} from './node_manipulation';
-import {getComponentViewByIndex, getNative, isComponent, isLContainer} from './util';
+import {getComponentViewByIndex, getNativeByTNode, isComponent, isLContainer} from './util';
 import {ViewRef} from './view_ref';
 
 
@@ -60,7 +60,7 @@ export function createElementRef(
     // TODO: Fix class name, should be ElementRef, but there appears to be a rollup bug
     R3ElementRef = class ElementRef_ extends ElementRefToken {};
   }
-  return new R3ElementRef(getNative(tNode, view));
+  return new R3ElementRef(getNativeByTNode(tNode, view));
 }
 
 let R3TemplateRef: {

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -411,6 +411,9 @@
     "name": "createViewBlueprint"
   },
   {
+    "name": "createViewNode"
+  },
+  {
     "name": "createViewQuery"
   },
   {
@@ -579,7 +582,7 @@
     "name": "getHighestElementContainer"
   },
   {
-    "name": "getHostElementNode"
+    "name": "getHostNative"
   },
   {
     "name": "getInitialIndex"
@@ -597,12 +600,6 @@
     "name": "getLContainer"
   },
   {
-    "name": "getLNode"
-  },
-  {
-    "name": "getLNodeFromViewData"
-  },
-  {
     "name": "getLViewChild"
   },
   {
@@ -612,7 +609,10 @@
     "name": "getMultiStartIndex"
   },
   {
-    "name": "getNative"
+    "name": "getNativeByIndex"
+  },
+  {
+    "name": "getNativeByTNode"
   },
   {
     "name": "getOrCreateInjectable"
@@ -636,7 +636,7 @@
     "name": "getParentInjectorView"
   },
   {
-    "name": "getParentLNode"
+    "name": "getParentNative"
   },
   {
     "name": "getParentState"
@@ -796,15 +796,6 @@
   },
   {
     "name": "listener"
-  },
-  {
-    "name": "loadElement"
-  },
-  {
-    "name": "loadElementInternal"
-  },
-  {
-    "name": "loadInternal"
   },
   {
     "name": "locateHostElement"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -243,7 +243,7 @@
     "name": "getHighestElementContainer"
   },
   {
-    "name": "getHostElementNode"
+    "name": "getHostNative"
   },
   {
     "name": "getInjectorIndex"
@@ -252,13 +252,10 @@
     "name": "getLContainer"
   },
   {
-    "name": "getLNode"
-  },
-  {
     "name": "getLViewChild"
   },
   {
-    "name": "getNative"
+    "name": "getNativeByTNode"
   },
   {
     "name": "getOrCreateNodeInjector"
@@ -276,7 +273,7 @@
     "name": "getParentInjectorView"
   },
   {
-    "name": "getParentLNode"
+    "name": "getParentNative"
   },
   {
     "name": "getPipeDef"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -474,6 +474,9 @@
     "name": "createViewBlueprint"
   },
   {
+    "name": "createViewNode"
+  },
+  {
     "name": "createViewQuery"
   },
   {
@@ -624,7 +627,7 @@
     "name": "getHighestElementContainer"
   },
   {
-    "name": "getHostElementNode"
+    "name": "getHostNative"
   },
   {
     "name": "getInitialIndex"
@@ -642,9 +645,6 @@
     "name": "getLContainer"
   },
   {
-    "name": "getLNode"
-  },
-  {
     "name": "getLViewChild"
   },
   {
@@ -654,7 +654,10 @@
     "name": "getMultiStartIndex"
   },
   {
-    "name": "getNative"
+    "name": "getNativeByIndex"
+  },
+  {
+    "name": "getNativeByTNode"
   },
   {
     "name": "getOrCreateInjectable"
@@ -675,7 +678,7 @@
     "name": "getParentInjectorView"
   },
   {
-    "name": "getParentLNode"
+    "name": "getParentNative"
   },
   {
     "name": "getParentState"
@@ -814,12 +817,6 @@
   },
   {
     "name": "listener"
-  },
-  {
-    "name": "loadElement"
-  },
-  {
-    "name": "loadElementInternal"
   },
   {
     "name": "loadInternal"

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -1365,6 +1365,9 @@
     "name": "createViewBlueprint"
   },
   {
+    "name": "createViewNode"
+  },
+  {
     "name": "createViewQuery"
   },
   {
@@ -1659,7 +1662,7 @@
     "name": "getHighestElementContainer"
   },
   {
-    "name": "getHostElementNode"
+    "name": "getHostNative"
   },
   {
     "name": "getInitialIndex"
@@ -1678,9 +1681,6 @@
   },
   {
     "name": "getLContainer"
-  },
-  {
-    "name": "getLNode"
   },
   {
     "name": "getLViewChild"
@@ -1740,7 +1740,10 @@
     "name": "getNamedFormat"
   },
   {
-    "name": "getNative"
+    "name": "getNativeByIndex"
+  },
+  {
+    "name": "getNativeByTNode"
   },
   {
     "name": "getNgModuleDef"
@@ -1779,7 +1782,7 @@
     "name": "getParentInjectorView"
   },
   {
-    "name": "getParentLNode"
+    "name": "getParentNative"
   },
   {
     "name": "getParentState"
@@ -2050,12 +2053,6 @@
   },
   {
     "name": "listener"
-  },
-  {
-    "name": "loadElement"
-  },
-  {
-    "name": "loadElementInternal"
   },
   {
     "name": "loadInternal"

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -13,10 +13,10 @@ import {defineComponent} from '../../src/render3/definition';
 import {bloomAdd, bloomHashBitOrFactory as bloomHash, getOrCreateNodeInjector, injectAttribute, injectorHasToken} from '../../src/render3/di';
 import {PublicFeature, defineDirective, directiveInject, elementProperty, load, templateRefExtractor} from '../../src/render3/index';
 
-import {bind, container, containerRefreshEnd, containerRefreshStart, createNodeAtIndex, createLViewData, createTView, element, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, enterView, interpolation2, leaveView, projection, projectionDef, reference, template, text, textBinding, elementContainerStart, elementContainerEnd, loadElement} from '../../src/render3/instructions';
-import {isProceduralRenderer} from '../../src/render3/interfaces/renderer';
-import {AttributeMarker, LContainerNode, LElementNode, TNodeType} from '../../src/render3/interfaces/node';
-
+import {bind, container, containerRefreshEnd, containerRefreshStart, createNodeAtIndex, createLViewData, createTView, element, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, enterView, interpolation2, leaveView, projection, projectionDef, reference, template, text, textBinding, elementContainerStart, elementContainerEnd, _getViewData} from '../../src/render3/instructions';
+import {isProceduralRenderer, RElement} from '../../src/render3/interfaces/renderer';
+import {AttributeMarker, TNodeType} from '../../src/render3/interfaces/node';
+import {getNativeByIndex} from '../../src/render3/util';
 import {LViewFlags} from '../../src/render3/interfaces/view';
 import {ViewRef} from '../../src/render3/view_ref';
 
@@ -1086,7 +1086,7 @@ describe('di', () => {
       it('should create directive with ElementRef dependencies', () => {
         let dir !: Directive;
         let dirSameInstance !: DirectiveSameInstance;
-        let divNode !: LElementNode;
+        let div !: RElement;
 
         class Directive {
           value: string;
@@ -1121,14 +1121,14 @@ describe('di', () => {
           if (rf & RenderFlags.Create) {
             elementStart(0, 'div', ['dir', '', 'dirSame', '']);
             elementEnd();
-            divNode = load(0);
+            div = getNativeByIndex(0, _getViewData());
           }
         }, 1, 0, [Directive, DirectiveSameInstance]);
 
         const fixture = new ComponentFixture(App);
         expect(dir.value).toContain('ElementRef');
-        expect(dir.elementRef.nativeElement).toEqual(divNode.native);
-        expect(dirSameInstance.elementRef.nativeElement).toEqual(divNode.native);
+        expect(dir.elementRef.nativeElement).toEqual(div);
+        expect(dirSameInstance.elementRef.nativeElement).toEqual(div);
 
         // Each ElementRef instance should be unique
         expect(dirSameInstance.isSameInstance).toBe(false);
@@ -1841,7 +1841,7 @@ describe('di', () => {
           null !, createTView(-1, null, 1, 0, null, null, null), null, LViewFlags.CheckAlways);
       const oldView = enterView(contentView, null);
       try {
-        const parentTNode = createNodeAtIndex(0, TNodeType.Element, null, null, null, null);
+        const parentTNode = createNodeAtIndex(0, TNodeType.Element, null, null, null);
         // Simulate the situation where the previous parent is not initialized.
         // This happens on first bootstrap because we don't init existing values
         // so that we have smaller HelloWorld.

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -8,12 +8,11 @@
 
 import {NgForOfContext} from '@angular/common';
 
-import {RenderFlags, directiveInject} from '../../src/render3';
+import {RenderFlags} from '../../src/render3';
 import {defineComponent} from '../../src/render3/definition';
 import {bind, element, elementAttribute, elementEnd, elementProperty, elementStart, elementStyleProp, elementStyling, elementStylingApply, elementStylingMap, interpolation1, renderTemplate, template, text, textBinding} from '../../src/render3/instructions';
 import {InitialStylingFlags} from '../../src/render3/interfaces/definition';
-import {AttributeMarker, LElementNode, LNode} from '../../src/render3/interfaces/node';
-import {RElement, domRendererFactory3} from '../../src/render3/interfaces/renderer';
+import {AttributeMarker} from '../../src/render3/interfaces/node';
 import {bypassSanitizationTrustHtml, bypassSanitizationTrustResourceUrl, bypassSanitizationTrustScript, bypassSanitizationTrustStyle, bypassSanitizationTrustUrl} from '../../src/sanitization/bypass';
 import {defaultStyleSanitizer, sanitizeHtml, sanitizeResourceUrl, sanitizeScript, sanitizeStyle, sanitizeUrl} from '../../src/sanitization/sanitization';
 import {Sanitizer, SecurityContext} from '../../src/sanitization/security';

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -1970,7 +1970,7 @@ describe('render3 integration test', () => {
 
          const elementResult = result1[HEADER_OFFSET];  // first element
          expect(Array.isArray(elementResult)).toBeTruthy();
-         expect(elementResult[StylingIndex.ElementPosition].native).toBe(section);
+         expect(elementResult[StylingIndex.ElementPosition]).toBe(section);
 
          const context = getContext(section) !;
          const result2 = section[MONKEY_PATCH_KEY_NAME];

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -13,13 +13,13 @@ import {getProjectAsAttrValue, isNodeMatchingSelectorList, isNodeMatchingSelecto
 import {createTNode} from '@angular/core/src/render3/instructions';
 
 function testLStaticData(tagName: string, attrs: TAttributes | null): TNode {
-  return createTNode(TNodeType.Element, 0, tagName, attrs, null, null);
+  return createTNode(TNodeType.Element, 0, tagName, attrs, null);
 }
 
 describe('css selector matching', () => {
   function isMatching(tagName: string, attrs: TAttributes | null, selector: CssSelector): boolean {
     return isNodeMatchingSelector(
-        createTNode(TNodeType.Element, 0, tagName, attrs, null, null), selector);
+        createTNode(TNodeType.Element, 0, tagName, attrs, null), selector);
   }
 
   describe('isNodeMatchingSimpleSelector', () => {
@@ -36,7 +36,7 @@ describe('css selector matching', () => {
       });
 
       /**
-       * We assume that compiler will lower-case tag names both in LNode
+       * We assume that compiler will lower-case tag names both in node
        * and in a selector.
        */
       it('should match element name case-sensitively', () => {

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -13,8 +13,8 @@ import {EventEmitter} from '../..';
 import {directiveInject} from '../../src/render3/di';
 
 import {AttributeMarker, QueryList, defineComponent, defineDirective, detectChanges} from '../../src/render3/index';
-
-import {bind, container, containerRefreshEnd, containerRefreshStart, element, elementContainerEnd, elementContainerStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, load, loadElement, loadQueryList, reference, registerContentQuery, template} from '../../src/render3/instructions';
+import {getNativeByIndex} from '../../src/render3/util';
+import {bind, container, containerRefreshEnd, containerRefreshStart, element, elementContainerEnd, elementContainerStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, load, loadQueryList, reference, registerContentQuery, template, _getViewData} from '../../src/render3/instructions';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {query, queryRefresh} from '../../src/render3/query';
 import {templateRefExtractor} from '../../src/render3/view_engine_compatibility_prebound';
@@ -115,7 +115,7 @@ describe('query', () => {
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
                 element(1, 'div', ['child', '']);
-                elToQuery = loadElement(1).native;
+                elToQuery = getNativeByIndex(1, _getViewData());
               }
             },
             2, 0, [Child], [],
@@ -222,7 +222,7 @@ describe('query', () => {
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
                 element(1, 'div', null, ['foo', '']);
-                elToQuery = loadElement(1).native;
+                elToQuery = getNativeByIndex(1, _getViewData());
                 element(3, 'div');
               }
             },
@@ -259,7 +259,7 @@ describe('query', () => {
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
                 element(2, 'div', null, ['foo', '', 'bar', '']);
-                elToQuery = loadElement(2).native;
+                elToQuery = getNativeByIndex(2, _getViewData());
                 element(5, 'div');
               }
             },
@@ -306,10 +306,10 @@ describe('query', () => {
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
                 element(1, 'div', null, ['foo', '']);
-                el1ToQuery = loadElement(1).native;
+                el1ToQuery = getNativeByIndex(1, _getViewData());
                 element(3, 'div');
                 element(4, 'div', null, ['bar', '']);
-                el2ToQuery = loadElement(4).native;
+                el2ToQuery = getNativeByIndex(4, _getViewData());
               }
             },
             6, 0, [], [],
@@ -345,7 +345,7 @@ describe('query', () => {
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
                 element(1, 'div', null, ['foo', '']);
-                elToQuery = loadElement(1).native;
+                elToQuery = getNativeByIndex(1, _getViewData());
                 element(3, 'div');
               }
             },
@@ -381,7 +381,7 @@ describe('query', () => {
                function(rf: RenderFlags, ctx: any) {
                  if (rf & RenderFlags.Create) {
                    elementContainerStart(1, null, ['foo', '']);
-                   elToQuery = loadElement(1).native;
+                   elToQuery = getNativeByIndex(1, _getViewData());
                    elementContainerEnd();
                  }
                },
@@ -417,7 +417,7 @@ describe('query', () => {
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
                 elementContainerStart(1, null, ['foo', '']);
-                elToQuery = loadElement(1).native;
+                elToQuery = getNativeByIndex(1, _getViewData());
                 elementContainerEnd();
               }
             },
@@ -480,7 +480,7 @@ describe('query', () => {
                 elementContainerStart(2);
                 {
                   element(3, 'div', null, ['foo', '']);
-                  elToQuery = loadElement(3).native;
+                  elToQuery = getNativeByIndex(3, _getViewData());
                 }
                 elementContainerEnd();
               }
@@ -890,7 +890,7 @@ describe('query', () => {
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
                 element(1, 'div', ['child', ''], ['foo', 'child']);
-                div = loadElement(1).native;
+                div = getNativeByIndex(1, _getViewData());
               }
             },
             3, 0, [Child], [],
@@ -925,7 +925,7 @@ describe('query', () => {
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
                 element(1, 'div', ['child', ''], ['foo', '', 'bar', 'child']);
-                div = loadElement(1).native;
+                div = getNativeByIndex(1, _getViewData());
               }
               if (rf & RenderFlags.Update) {
                 childInstance = getDirectiveOnNode(1);
@@ -1409,7 +1409,7 @@ describe('query', () => {
                     {
                       if (rf1 & RenderFlags.Create) {
                         element(0, 'div', null, ['foo', '']);
-                        firstEl = loadElement(0).native;
+                        firstEl = getNativeByIndex(0, _getViewData());
                       }
                     }
                     embeddedViewEnd();
@@ -1461,10 +1461,10 @@ describe('query', () => {
                function(rf: RenderFlags, ctx: any) {
                  if (rf & RenderFlags.Create) {
                    element(1, 'span', null, ['foo', '']);
-                   firstEl = loadElement(1).native;
+                   firstEl = getNativeByIndex(1, _getViewData());
                    container(3);
                    element(4, 'span', null, ['foo', '']);
-                   lastEl = loadElement(4).native;
+                   lastEl = getNativeByIndex(4, _getViewData());
                  }
                  if (rf & RenderFlags.Update) {
                    containerRefreshStart(3);
@@ -1474,7 +1474,7 @@ describe('query', () => {
                        {
                          if (rf1 & RenderFlags.Create) {
                            element(0, 'div', null, ['foo', '']);
-                           viewEl = loadElement(0).native;
+                           viewEl = getNativeByIndex(0, _getViewData());
                          }
                        }
                        embeddedViewEnd();
@@ -1541,7 +1541,7 @@ describe('query', () => {
                     {
                       if (rf0 & RenderFlags.Create) {
                         element(0, 'div', null, ['foo', '']);
-                        firstEl = loadElement(0).native;
+                        firstEl = getNativeByIndex(0, _getViewData());
                       }
                     }
                     embeddedViewEnd();
@@ -1551,7 +1551,7 @@ describe('query', () => {
                     {
                       if (rf1 & RenderFlags.Create) {
                         element(0, 'span', null, ['foo', '']);
-                        lastEl = loadElement(0).native;
+                        lastEl = getNativeByIndex(0, _getViewData());
                       }
                     }
                     embeddedViewEnd();
@@ -1614,7 +1614,7 @@ describe('query', () => {
                     {
                       if (rf0 & RenderFlags.Create) {
                         element(0, 'div', null, ['foo', '']);
-                        firstEl = loadElement(0).native;
+                        firstEl = getNativeByIndex(0, _getViewData());
                         container(2);
                       }
                       if (rf0 & RenderFlags.Update) {
@@ -1625,7 +1625,7 @@ describe('query', () => {
                             {
                               if (rf2) {
                                 element(0, 'span', null, ['foo', '']);
-                                lastEl = loadElement(0).native;
+                                lastEl = getNativeByIndex(0, _getViewData());
                               }
                             }
                             embeddedViewEnd();

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -22,7 +22,6 @@ import {NG_ELEMENT_ID} from '../../src/render3/fields';
 import {ComponentTemplate, ComponentType, DirectiveDef, DirectiveType, PublicFeature, RenderFlags, defineComponent, defineDirective, renderComponent as _renderComponent, tick} from '../../src/render3/index';
 import {_getViewData, renderTemplate} from '../../src/render3/instructions';
 import {DirectiveDefList, DirectiveTypesOrFactory, PipeDef, PipeDefList, PipeTypesOrFactory} from '../../src/render3/interfaces/definition';
-import {LElementNode} from '../../src/render3/interfaces/node';
 import {PlayerHandler} from '../../src/render3/interfaces/player';
 import {RElement, RText, Renderer3, RendererFactory3, domRendererFactory3} from '../../src/render3/interfaces/renderer';
 import {HEADER_OFFSET, LViewData} from '../../src/render3/interfaces/view';

--- a/packages/core/test/render3/styling/styling_spec.ts
+++ b/packages/core/test/render3/styling/styling_spec.ts
@@ -7,8 +7,7 @@
  */
 import {elementEnd, elementStart, elementStyleProp, elementStyling, elementStylingApply, elementStylingMap} from '../../../src/render3/instructions';
 import {InitialStylingFlags, RenderFlags} from '../../../src/render3/interfaces/definition';
-import {LElementNode} from '../../../src/render3/interfaces/node';
-import {Renderer3} from '../../../src/render3/interfaces/renderer';
+import {RElement, Renderer3} from '../../../src/render3/interfaces/renderer';
 import {StylingContext, StylingFlags, StylingIndex} from '../../../src/render3/interfaces/styling';
 import {createStylingContextTemplate, isContextDirty, renderStyling as _renderStyling, setContextDirty, updateClassProp, updateStyleProp, updateStylingMap} from '../../../src/render3/styling/class_and_style_bindings';
 import {allocStylingContext} from '../../../src/render3/styling/util';
@@ -17,7 +16,7 @@ import {StyleSanitizeFn} from '../../../src/sanitization/style_sanitizer';
 import {renderToHtml} from '../render_util';
 
 describe('styling', () => {
-  let element: LElementNode|null = null;
+  let element: RElement|null = null;
   beforeEach(() => { element = {} as any; });
 
   function initContext(


### PR DESCRIPTION
This PR removes the `LNode` object. We used to create an `LNode` object for every single DOM element.

So if you had an `ngFor` with 10,000 items like below, you'd get 10,000 `LNode` objects and 1 `TNode`

```html
<div *ngFor="let row of rows"></div>
```

With this PR, the same template will only produce 1 `TNode`  and 0 `LNodes`. 