### PR TITLE
Updated hero-search.component.html

### DIFF
--- a/aio/content/examples/toh-pt6/src/app/hero-search/hero-search.component.html
+++ b/aio/content/examples/toh-pt6/src/app/hero-search/hero-search.component.html
@@ -2,7 +2,7 @@
   <h4>Hero Search</h4>
 
   <!-- #docregion input -->
-  <input #searchBox id="search-box" (keyup)="search(searchBox.value)" />
+  <input #searchBox id="search-box" (input)="search(searchBox.value)" />
   <!-- #enddocregion input -->
 
   <ul class="search-result">

--- a/aio/content/examples/universal/src/app/hero-search/hero-search.component.html
+++ b/aio/content/examples/universal/src/app/hero-search/hero-search.component.html
@@ -1,7 +1,7 @@
 <div id="search-component">
   <h4>Hero Search</h4>
 
-  <input #searchBox id="search-box" (keyup)="search(searchBox.value)" />
+  <input #searchBox id="search-box" (input)="search(searchBox.value)" />
 
   <ul class="search-result">
     <li *ngFor="let hero of heroes | async" >

--- a/aio/content/tutorial/toh-pt6.md
+++ b/aio/content/tutorial/toh-pt6.md
@@ -461,7 +461,7 @@ Replace the generated `HeroSearchComponent` _template_ with a text box and a lis
 Add private CSS styles to `hero-search.component.css`
 as listed in the [final code review](#herosearchcomponent) below.
 
-As the user types in the search box, a *keyup* event binding calls the component's `search()`
+As the user types in the search box, an *input* event binding calls the component's `search()`
 method with the new search box value.
 
 {@a asyncpipe}
@@ -511,7 +511,7 @@ You can also push values into that `Observable` by calling its `next(value)` met
 as the `search()` method does.
 
 The `search()` method is called via an _event binding_ to the
-textbox's `keystroke` event.
+textbox's `input` event.
 
 <code-example path="toh-pt6/src/app/hero-search/hero-search.component.html" region="input"></code-example>
 


### PR DESCRIPTION
The initial event listener attached to the input tag with id search-box was keyup, which only listened to the keyboard event of pressing a key. But a non-keyboard event like copying and pasting through a mouse was not listened. Hence the (change) event was changed to (input) event

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The (keyup) event listener on the input tag with id="search-box", inside the hero-search.component.html doesn't listen to non-keyboard events such as a copy paste command. Hence no search for the hero is done in such a scenario.


Issue Number: 26440


## What is the new behavior?
The (keyup) event listener is changed to (input) event listener.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->



## Other information
