### PR TITLE
feat(ivy): i18n compiler - i18nStart and i18nEnd support

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -26,7 +26,8 @@ describe('i18n support in the view compiler', () => {
             @Component({
               selector: 'my-component',
               template: \`
-                <div i18n-title="meaning|desc@@id" title="introduction">Hello world</div>
+                <div i18n="meaningA|descA@@idA">Hello world (in i18n section)!</div>
+                <div i18n-title="meaningB|descB@@idB" title="introduction">Hello world</div>
               \`
             })
             export class MyComponent {}
@@ -39,17 +40,26 @@ describe('i18n support in the view compiler', () => {
 
       const template = `
         /**
-         * @desc desc
-         * @meaning meaning
+         * @desc descA
+         * @meaning meaningA
          */
-        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("introduction");
-        const $_c1$ = ["title", $MSG_APP_SPEC_TS_0$, 0];
+        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("Hello world (in i18n section)!");
+        /**
+         * @desc descB
+         * @meaning meaningB
+         */
+        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("introduction");
+        const $_c2$ = ["title", $MSG_APP_SPEC_TS_1$, 0];
         …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵelementStart(0, "div");
-            $r3$.ɵi18nAttribute(1, $_c1$);
-            $r3$.ɵtext(2, "Hello world");
+            $r3$.ɵi18nStart(1, MSG_APP_SPEC_TS_0);
+            $r3$.ɵi18nEnd();
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementStart(2, "div");
+            $r3$.ɵi18nAttribute(3, _c2);
+            $r3$.ɵtext(4, "Hello world");
             $r3$.ɵelementEnd();
           }
         }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -379,6 +379,41 @@ describe('i18n support in the view compiler', () => {
   });
 
   describe('nested nodes', () => {
+    it('should not produce instructions for empty content', () => {
+      const files = {
+        app: {
+          'spec.ts': `
+            import {Component, NgModule} from '@angular/core';
+
+            @Component({
+              selector: 'my-component',
+              template: \`
+                <div i18n></div>
+                <div i18n>  </div>
+              \`
+            })
+            export class MyComponent {}
+
+            @NgModule({declarations: [MyComponent]})
+            export class MyModule {}
+          `
+        }
+      };
+
+      const template = String.raw `
+        template: function MyComponent_Template(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵelement(0, "div");
+            $r3$.ɵelement(1, "div");
+          }
+        }
+      `;
+
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect template');
+    });
+
+
     it('should handle i18n attributes with plain-text content', () => {
       const files = {
         app: {
@@ -404,9 +439,9 @@ describe('i18n support in the view compiler', () => {
       };
 
       const template = String.raw `
-        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("\uFFFD#0\uFFFDMy i18n block #1\uFFFD/#0\uFFFD");
-        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("\uFFFD#4\uFFFDMy i18n block #2\uFFFD/#4\uFFFD");
-        const $MSG_APP_SPEC_TS_2$ = goog.getMsg("\uFFFD#8\uFFFDMy i18n block #3\uFFFD/#8\uFFFD");
+        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("My i18n block #1");
+        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("My i18n block #2");
+        const $MSG_APP_SPEC_TS_2$ = goog.getMsg("My i18n block #3");
         …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
@@ -459,9 +494,9 @@ describe('i18n support in the view compiler', () => {
       };
 
       const template = String.raw `
-        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("\uFFFD#0\uFFFDMy i18n block #\uFFFD0\uFFFD\uFFFD/#0\uFFFD");
-        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("\uFFFD#2\uFFFDMy i18n block #\uFFFD0\uFFFD\uFFFD/#2\uFFFD");
-        const $MSG_APP_SPEC_TS_2$ = goog.getMsg("\uFFFD#5\uFFFDMy i18n block #\uFFFD0\uFFFD\uFFFD/#5\uFFFD");
+        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("My i18n block #\uFFFD0\uFFFD");
+        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("My i18n block #\uFFFD0\uFFFD");
+        const $MSG_APP_SPEC_TS_2$ = goog.getMsg("My i18n block #\uFFFD0\uFFFD");
         …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
@@ -528,8 +563,8 @@ describe('i18n support in the view compiler', () => {
       };
 
       const template = String.raw `
-        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("\uFFFD#0\uFFFD My i18n block #\uFFFD0\uFFFD \uFFFD#2\uFFFDPlain text in nested element\uFFFD/#2\uFFFD\uFFFD/#0\uFFFD");
-        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("\uFFFD#3\uFFFD My i18n block #\uFFFD0\uFFFD \uFFFD#6\uFFFD\uFFFD#7\uFFFD\uFFFD#8\uFFFD More bindings in more nested element: \uFFFD1\uFFFD \uFFFD/#8\uFFFD\uFFFD/#7\uFFFD\uFFFD/#6\uFFFD\uFFFD/#3\uFFFD");
+        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("My i18n block #\uFFFD0\uFFFD\uFFFD#2\uFFFDPlain text in nested element\uFFFD/#2\uFFFD");
+        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("My i18n block #\uFFFD0\uFFFD\uFFFD#6\uFFFD\uFFFD#7\uFFFD\uFFFD#8\uFFFDMore bindings in more nested element: \uFFFD1\uFFFD\uFFFD/#8\uFFFD\uFFFD/#7\uFFFD\uFFFD/#6\uFFFD");
         …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
@@ -597,10 +632,10 @@ describe('i18n support in the view compiler', () => {
       };
 
       const template = String.raw `
-        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("\uFFFD#0\uFFFD My i18n block #1 with value: \uFFFD0\uFFFD \uFFFD#2\uFFFD Plain text in nested element (block #1) \uFFFD/#2\uFFFD\uFFFD/#0\uFFFD");
+        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("My i18n block #1 with value: \uFFFD0\uFFFD\uFFFD#2\uFFFDPlain text in nested element (block #1)\uFFFD/#2\uFFFD");
         const $MSG_APP_SPEC_TS_1$ = goog.getMsg("Span title \uFFFD0\uFFFD and \uFFFD1\uFFFD");
         const $_c2$ = ["title", $MSG_APP_SPEC_TS_1$, 2];
-        const $MSG_APP_SPEC_TS_3$ = goog.getMsg("\uFFFD#4\uFFFD My i18n block #2 with value \uFFFD0\uFFFD \uFFFD#7\uFFFD Plain text in nested element (block #2) \uFFFD/#7\uFFFD\uFFFD/#4\uFFFD");
+        const $MSG_APP_SPEC_TS_3$ = goog.getMsg("My i18n block #2 with value \uFFFD0\uFFFD\uFFFD#7\uFFFDPlain text in nested element (block #2)\uFFFD/#7\uFFFD");
         const $MSG_APP_SPEC_TS_4$ = goog.getMsg("Span title \uFFFD0\uFFFD");
         const $_c5$ = ["title", $MSG_APP_SPEC_TS_4$, 1];
         …
@@ -672,7 +707,7 @@ describe('i18n support in the view compiler', () => {
 
       const template = String.raw `
         const $_c0$ = [1, "ngIf"];
-        const $MSG_APP_SPEC_TS__1$ = goog.getMsg("\uFFFD#1\uFFFD Some other content \uFFFD0\uFFFD \uFFFD#3\uFFFD More nested levels with bindings \uFFFD1\uFFFD \uFFFD/#3\uFFFD\uFFFD/#1\uFFFD");
+        const $MSG_APP_SPEC_TS__1$ = goog.getMsg("Some other content \uFFFD0\uFFFD\uFFFD#3\uFFFDMore nested levels with bindings \uFFFD1\uFFFD\uFFFD/#3\uFFFD");
         …
         function MyComponent_div_Template_2(rf, ctx) {
           if (rf & 1) {
@@ -752,7 +787,7 @@ describe('i18n support in the view compiler', () => {
       };
 
       const template = String.raw `
-        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("\uFFFD#0\uFFFD Some content \uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD Some other content \uFFFD0:1\uFFFD \uFFFD#2:1\uFFFD More nested levels with bindings \uFFFD1:1\uFFFD \uFFFD*4:2\uFFFD\uFFFD#1:2\uFFFD Content inside sub-template \uFFFD0:2\uFFFD \uFFFD#2:2\uFFFD Bottom level element \uFFFD1:2\uFFFD \uFFFD/#2:2\uFFFD\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD\uFFFD/#2:1\uFFFD\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD\uFFFD*3:3\uFFFD\uFFFD#1:3\uFFFD Some other content \uFFFD0:3\uFFFD \uFFFD#2:3\uFFFD More nested levels with bindings \uFFFD1:3\uFFFD \uFFFD/#2:3\uFFFD\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD\uFFFD/#0\uFFFD");
+        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("Some content\uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFDSome other content \uFFFD0:1\uFFFD\uFFFD#2:1\uFFFDMore nested levels with bindings \uFFFD1:1\uFFFD\uFFFD*4:2\uFFFD\uFFFD#1:2\uFFFDContent inside sub-template \uFFFD0:2\uFFFD\uFFFD#2:2\uFFFDBottom level element \uFFFD1:2\uFFFD\uFFFD/#2:2\uFFFD\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD\uFFFD/#2:1\uFFFD\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD\uFFFD*3:3\uFFFD\uFFFD#1:3\uFFFDSome other content \uFFFD0:3\uFFFD\uFFFD#2:3\uFFFDMore nested levels with bindings \uFFFD1:3\uFFFD\uFFFD/#2:3\uFFFD\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD");
         const $_c1$ = [1, "ngIf"];
         …
         function MyComponent_div_div_Template_4(rf, ctx) {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -580,8 +580,7 @@ describe('i18n support in the view compiler', () => {
           if (rf & 1) {
             $r3$.ɵelementStart(0, "div");
             $r3$.ɵi18nStart(1, $MSG_APP_SPEC_TS_0$);
-            $r3$.ɵelementStart(2, "span");
-            $r3$.ɵelementEnd();
+            $r3$.ɵelement(2, "span");
             $r3$.ɵi18nEnd();
             $r3$.ɵelementEnd();
             $r3$.ɵelementStart(3, "div");
@@ -589,8 +588,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵpipe(5, "uppercase");
             $r3$.ɵelementStart(6, "div");
             $r3$.ɵelementStart(7, "div");
-            $r3$.ɵelementStart(8, "span");
-            $r3$.ɵelementEnd();
+            $r3$.ɵelement(8, "span");
             $r3$.ɵelementEnd();
             $r3$.ɵelementEnd();
             $r3$.ɵi18nEnd();
@@ -724,9 +722,8 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementStart(0, "div");
             $r3$.ɵelementStart(1, "div");
             $r3$.ɵi18nStart(2, $MSG_APP_SPEC_TS__1$);
-            $r3$.ɵelementStart(3, "div");
+            $r3$.ɵelement(3, "div");
             $r3$.ɵpipe(4, "uppercase");
-            $r3$.ɵelementEnd();
             $r3$.ɵi18nEnd();
             $r3$.ɵelementEnd();
             $r3$.ɵelementEnd();
@@ -804,8 +801,7 @@ describe('i18n support in the view compiler', () => {
           if (rf & 1) {
             $r3$.ɵi18nStart(0, $MSG_APP_SPEC_TS_0$, 2);
             $r3$.ɵelementStart(1, "div");
-            $r3$.ɵelementStart(2, "div");
-            $r3$.ɵelementEnd();
+            $r3$.ɵelement(2, "div");
             $r3$.ɵelementEnd();
             $r3$.ɵi18nEnd();
           }
@@ -839,9 +835,8 @@ describe('i18n support in the view compiler', () => {
           if (rf & 1) {
             $r3$.ɵi18nStart(0, $MSG_APP_SPEC_TS_0$, 3);
             $r3$.ɵelementStart(1, "div");
-            $r3$.ɵelementStart(2, "div");
+            $r3$.ɵelement(2, "div");
             $r3$.ɵpipe(3, "uppercase");
-            $r3$.ɵelementEnd();
             $r3$.ɵelementEnd();
             $r3$.ɵi18nEnd();
           }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -327,49 +327,47 @@ describe('i18n support in the view compiler', () => {
       };
 
       const template = String.raw `
-        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("static text");
-        const $_c1$ = ["id", "dynamic-1", "aria-roledescription", $MSG_APP_SPEC_TS_0$];
+        const $_c0$ = ["id", "dynamic-1"];
         /**
          * @desc d
          * @meaning m
          */
-        const $MSG_APP_SPEC_TS_2$ = goog.getMsg("intro \uFFFD0\uFFFD");
+        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("intro \uFFFD0\uFFFD");
         /**
          * @desc d1
          * @meaning m1
          */
-        const $MSG_APP_SPEC_TS_3$ = goog.getMsg("\uFFFD0\uFFFD");
-        const $_c4$ = ["id", "dynamic-2"];
+        const $MSG_APP_SPEC_TS_2$ = goog.getMsg("\uFFFD0\uFFFD");
+        const $MSG_APP_SPEC_TS_3$ = goog.getMsg("static text");
+        const $_c4$ = ["title", $MSG_APP_SPEC_TS_1$, 1, "aria-label", $MSG_APP_SPEC_TS_2$, 1, "aria-roledescription", $MSG_APP_SPEC_TS_3$, 0];
+        const $_c5$ = ["id", "dynamic-2"];
         /**
          * @desc d2
          * @meaning m2
          */
-        const $MSG_APP_SPEC_TS_5$ = goog.getMsg("\uFFFD0\uFFFD and \uFFFD1\uFFFD and again \uFFFD2\uFFFD");
-        const $MSG_APP_SPEC_TS_6$ = goog.getMsg("\uFFFD0\uFFFD");
+        const $MSG_APP_SPEC_TS_6$ = goog.getMsg("\uFFFD0\uFFFD and \uFFFD1\uFFFD and again \uFFFD2\uFFFD");
+        const $MSG_APP_SPEC_TS_7$ = goog.getMsg("\uFFFD0\uFFFD");
+        const $_c8$ = ["title", $MSG_APP_SPEC_TS_6$, 3, "aria-roledescription", $MSG_APP_SPEC_TS_7$, 1];
         …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
-            $r3$.ɵelementStart(0, "div", $_c1$);
+            $r3$.ɵelementStart(0, "div", $_c0$);
             $r3$.ɵpipe(1, "uppercase");
-            $r3$.ɵi18nAttribute(2, "title", $MSG_APP_SPEC_TS_2$);
-            $r3$.ɵi18nAttribute(3, "aria-label", $MSG_APP_SPEC_TS_3$);
+            $r3$.ɵi18nAttribute(2, $_c4$);
             $r3$.ɵelementEnd();
-            $r3$.ɵelementStart(4, "div", $_c4$);
-            $r3$.ɵi18nAttribute(5, "title", $MSG_APP_SPEC_TS_5$);
-            $r3$.ɵi18nAttribute(6, "aria-roledescription", $MSG_APP_SPEC_TS_6$);
+            $r3$.ɵelementStart(3, "div", $_c5$);
+            $r3$.ɵi18nAttribute(4, $_c8$);
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(1, 0, ctx.valueA)));
-            $r3$.ɵi18nApply(2);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueB));
-            $r3$.ɵi18nApply(3);
+            $r3$.ɵi18nApply(2);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueA));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueB));
             $r3$.ɵi18nExp($r3$.ɵbind((ctx.valueA + ctx.valueB)));
-            $r3$.ɵi18nApply(5);
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueC));
-            $r3$.ɵi18nApply(6);
+            $r3$.ɵi18nApply(4);
           }
         }
       `;
@@ -396,7 +394,7 @@ describe('i18n support in the view compiler', () => {
 
             @NgModule({declarations: [MyComponent]})
             export class MyModule {}
-        `
+          `
         }
       };
 
@@ -407,12 +405,13 @@ describe('i18n support in the view compiler', () => {
          * @meaning m
          */
         const $MSG_APP_SPEC_TS__1$ = goog.getMsg("different scope \uFFFD0\uFFFD");
+        const $_c2$ = ["title", $MSG_APP_SPEC_TS__1$, 1];
         function MyComponent_div_Template_0(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵelementStart(0, "div");
             $r3$.ɵelementStart(1, "div");
             $r3$.ɵpipe(2, "uppercase");
-            $r3$.ɵi18nAttribute(3, "title", $MSG_APP_SPEC_TS__1$);
+            $r3$.ɵi18nAttribute(3, $_c2$);
             $r3$.ɵelementEnd();
             $r3$.ɵelementEnd();
           }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -123,6 +123,7 @@ describe('i18n support in the view compiler', () => {
         app: {
           'spec.ts': `
             import {Component, NgModule} from '@angular/core';
+
             @Component({
               selector: 'my-component',
               template: \`
@@ -130,6 +131,7 @@ describe('i18n support in the view compiler', () => {
               \`
             })
             export class MyComponent {}
+
             @NgModule({declarations: [MyComponent]})
             export class MyModule {}
           `
@@ -296,7 +298,7 @@ describe('i18n support in the view compiler', () => {
       expectEmit(result.source, template, 'Incorrect template');
     });
 
-    fit('should support interpolation', () => {
+    it('should support interpolation', () => {
       const files = {
         app: {
           'spec.ts': `
@@ -323,26 +325,27 @@ describe('i18n support in the view compiler', () => {
         `
         }
       };
-      const template = `
+
+      const template = String.raw`
         const $MSG_APP_SPEC_TS_0$ = goog.getMsg("static text");
         const $_c1$ = ["id", "dynamic-1", "aria-roledescription", $MSG_APP_SPEC_TS_0$];
         /**
          * @desc d
          * @meaning m
          */
-        const $MSG_APP_SPEC_TS_2$ = goog.getMsg("intro �0�");
+        const $MSG_APP_SPEC_TS_2$ = goog.getMsg("intro \uFFFD0\uFFFD");
         /**
          * @desc d1
          * @meaning m1
          */
-        const $MSG_APP_SPEC_TS_3$ = goog.getMsg("�0�");
+        const $MSG_APP_SPEC_TS_3$ = goog.getMsg("\uFFFD0\uFFFD");
         const $_c4$ = ["id", "dynamic-2"];
         /**
          * @desc d2
          * @meaning m2
          */
-        const $MSG_APP_SPEC_TS_5$ = goog.getMsg("�0� and �1� and again �2�");
-        const $MSG_APP_SPEC_TS_6$ = goog.getMsg("�0�");
+        const $MSG_APP_SPEC_TS_5$ = goog.getMsg("\uFFFD0\uFFFD and \uFFFD1\uFFFD and again \uFFFD2\uFFFD");
+        const $MSG_APP_SPEC_TS_6$ = goog.getMsg("\uFFFD0\uFFFD");
         …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
@@ -397,13 +400,13 @@ describe('i18n support in the view compiler', () => {
         }
       };
 
-      const template = `
+      const template = String.raw`
         const $_c0$ = ["ngFor", "", 1, "ngForOf"];
         /**
          * @desc d
          * @meaning m
          */
-        const $MSG_APP_SPEC_TS__1$ = goog.getMsg("different scope �0�");
+        const $MSG_APP_SPEC_TS__1$ = goog.getMsg("different scope \uFFFD0\uFFFD");
         function MyComponent_div_Template_0(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵelementStart(0, "div");

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -440,7 +440,7 @@ describe('i18n support in the view compiler', () => {
   describe('nested nodes', () => {
     // TODO: test with ng-template:
     // <ng-template i18n><span title="a">My Template Test</span></ng-template>
-    it('should handle top level i18n attributes', () => {
+    it('should handle i18n attributes with plain-text content', () => {
       const files = {
         app: {
           'spec.ts': `
@@ -497,7 +497,137 @@ describe('i18n support in the view compiler', () => {
       expectEmit(result.source, template, 'Incorrect template');
     });
 
-    fit('should generate i18nStart and i18nEnd instructions', () => {
+    it('should handle i18n attributes with bindings in content', () => {
+      const files = {
+        app: {
+          'spec.ts': `
+            import {Component, NgModule} from '@angular/core';
+
+            @Component({
+              selector: 'my-component',
+              template: \`
+                <div i18n>My i18n block #{{ one }}</div>
+                <div i18n>My i18n block #{{ two | uppercase }}</div>
+                <div i18n>My i18n block #{{ three + four + five }}</div>
+              \`
+            })
+            export class MyComponent {}
+
+            @NgModule({declarations: [MyComponent]})
+            export class MyModule {}
+          `
+        }
+      };
+
+      const template = String.raw `
+        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("\uFFFD#0\uFFFDMy i18n block #\uFFFD0\uFFFD\uFFFD/#0\uFFFD");
+        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("\uFFFD#2\uFFFDMy i18n block #\uFFFD0\uFFFD\uFFFD/#2\uFFFD");
+        const $MSG_APP_SPEC_TS_2$ = goog.getMsg("\uFFFD#5\uFFFDMy i18n block #\uFFFD0\uFFFD\uFFFD/#5\uFFFD");
+        …
+        template: function MyComponent_Template(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵelementStart(0, "div");
+            $r3$.ɵi18nStart(1, $MSG_APP_SPEC_TS_0$);
+            $r3$.ɵi18nEnd();
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementStart(2, "div");
+            $r3$.ɵi18nStart(3, $MSG_APP_SPEC_TS_1$);
+            $r3$.ɵpipe(4, "uppercase");
+            $r3$.ɵi18nEnd();
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementStart(5, "div");
+            $r3$.ɵi18nStart(6, $MSG_APP_SPEC_TS_2$);
+            $r3$.ɵi18nEnd();
+            $r3$.ɵelementEnd();
+          }
+          if (rf & 2) {
+            $r3$.ɵi18nExp($r3$.ɵbind(ctx.one));
+            $r3$.ɵi18nApply(1);
+            $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(4, 0, ctx.two)));
+            $r3$.ɵi18nApply(3);
+            $r3$.ɵi18nExp($r3$.ɵbind(((ctx.three + ctx.four) + ctx.five)));
+            $r3$.ɵi18nApply(6);
+          }
+        }
+      `;
+
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect template');
+    });
+
+    fit('should handle i18n attributes with bindings and nested elements in content', () => {
+      const files = {
+        app: {
+          'spec.ts': `
+            import {Component, NgModule} from '@angular/core';
+
+            @Component({
+              selector: 'my-component',
+              template: \`
+                <div i18n>
+                  My i18n block #{{ one }}
+                  <span>Plain text in nested element</span>
+                </div>
+                <div i18n>
+                  My i18n block #{{ two | uppercase }}
+                  <div>
+                    <div>
+                      <span>
+                        More bindings in more nested element: {{ nestedInBlockTwo }}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              \`
+            })
+            export class MyComponent {}
+
+            @NgModule({declarations: [MyComponent]})
+            export class MyModule {}
+          `
+        }
+      };
+
+      const template = String.raw `
+        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("\uFFFD#0\uFFFD My i18n block #\uFFFD0\uFFFD \uFFFD#2\uFFFDPlain text in nested element\uFFFD/#2\uFFFD\uFFFD/#0\uFFFD");
+        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("\uFFFD#3\uFFFD My i18n block #\uFFFD0\uFFFD \uFFFD#6\uFFFD\uFFFD#7\uFFFD\uFFFD#8\uFFFD More bindings in more nested element: \uFFFD0\uFFFD \uFFFD/#8\uFFFD\uFFFD/#7\uFFFD\uFFFD/#6\uFFFD\uFFFD/#3\uFFFD");
+        …
+        template: function MyComponent_Template(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵelementStart(0, "div");
+            $r3$.ɵi18nStart(1, $MSG_APP_SPEC_TS_0$);
+            $r3$.ɵelementStart(2, "span");
+            $r3$.ɵelementEnd();
+            $r3$.ɵi18nEnd();
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementStart(3, "div");
+            $r3$.ɵi18nStart(4, $MSG_APP_SPEC_TS_1$);
+            $r3$.ɵpipe(5, "uppercase");
+            $r3$.ɵelementStart(6, "div");
+            $r3$.ɵelementStart(7, "div");
+            $r3$.ɵelementStart(8, "span");
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementEnd();
+            $r3$.ɵi18nEnd();
+            $r3$.ɵelementEnd();
+          }
+          if (rf & 2) {
+            $r3$.ɵi18nExp($r3$.ɵbind(ctx.one));
+            $r3$.ɵi18nApply(1);
+            $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(5, 0, ctx.two)));
+            $r3$.ɵi18nExp($r3$.ɵbind(ctx.nestedInBlockTwo));
+            $r3$.ɵi18nApply(4);
+          }
+        }
+      `;
+
+      const result = compile(files, angularFiles);
+      console.log(result.source);
+      expectEmit(result.source, template, 'Incorrect template');
+    });
+
+    it('should generate i18nStart and i18nEnd instructions', () => {
       const files = {
         app: {
           'spec.ts': `

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -26,8 +26,12 @@ describe('i18n support in the view compiler', () => {
             @Component({
               selector: 'my-component',
               template: \`
-                <div i18n="meaningA|descA@@idA">Hello world (in i18n section)!</div>
-                <div i18n-title="meaningB|descB@@idB" title="introduction">Hello world</div>
+                <div i18n="meaningA|descA@@idA">Content A</div>
+                <div i18n-title="meaningB|descB@@idB" title="Title B">Content B</div>
+                <div i18n-title="meaningC" title="Title C">Content C</div>
+                <div i18n-title="meaningD|descD" title="Title D">Content D</div>
+                <div i18n-title="meaningE@@idE" title="Title E">Content E</div>
+                <div i18n-title="@@idF" title="Title F">Content F</div>
               \`
             })
             export class MyComponent {}
@@ -40,26 +44,63 @@ describe('i18n support in the view compiler', () => {
 
       const template = `
         /**
-         * @desc descA
+         * @desc [BACKUP_MESSAGE_ID:idA] descA
          * @meaning meaningA
          */
-        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("Hello world (in i18n section)!");
+        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("Content A");
         /**
-         * @desc descB
+         * @desc [BACKUP_MESSAGE_ID:idB] descB
          * @meaning meaningB
          */
-        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("introduction");
+        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("Title B");
         const $_c2$ = ["title", $MSG_APP_SPEC_TS_1$, 0];
+        /**
+         * @desc meaningC
+         */
+        const $MSG_APP_SPEC_TS_3$ = goog.getMsg("Title C");
+        const $_c4$ = ["title", $MSG_APP_SPEC_TS_3$, 0];
+        /**
+         * @desc descD
+         * @meaning meaningD
+         */
+        const $MSG_APP_SPEC_TS_5$ = goog.getMsg("Title D");
+        const $_c6$ = ["title", $MSG_APP_SPEC_TS_5$, 0];
+        /**
+         * @desc [BACKUP_MESSAGE_ID:idE] meaningE
+         */
+        const $MSG_APP_SPEC_TS_7$ = goog.getMsg("Title E");
+        const $_c8$ = ["title", $MSG_APP_SPEC_TS_7$, 0];
+        /**
+         * @desc [BACKUP_MESSAGE_ID:idF]
+         */
+        const $MSG_APP_SPEC_TS_9$ = goog.getMsg("Title F");
+        const $_c10$ = ["title", $MSG_APP_SPEC_TS_9$, 0];
         …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵelementStart(0, "div");
-            $r3$.ɵi18nStart(1, MSG_APP_SPEC_TS_0);
+            $r3$.ɵi18nStart(1, $MSG_APP_SPEC_TS_0$);
             $r3$.ɵi18nEnd();
             $r3$.ɵelementEnd();
             $r3$.ɵelementStart(2, "div");
-            $r3$.ɵi18nAttribute(3, _c2);
-            $r3$.ɵtext(4, "Hello world");
+            $r3$.ɵi18nAttribute(3, $_c2$);
+            $r3$.ɵtext(4, "Content B");
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementStart(5, "div");
+            $r3$.ɵi18nAttribute(6, $_c4$);
+            $r3$.ɵtext(7, "Content C");
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementStart(8, "div");
+            $r3$.ɵi18nAttribute(9, $_c6$);
+            $r3$.ɵtext(10, "Content D");
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementStart(11, "div");
+            $r3$.ɵi18nAttribute(12, $_c8$);
+            $r3$.ɵtext(13, "Content E");
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementStart(14, "div");
+            $r3$.ɵi18nAttribute(15, $_c10$);
+            $r3$.ɵtext(16, "Content F");
             $r3$.ɵelementEnd();
           }
         }

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -379,8 +379,6 @@ describe('i18n support in the view compiler', () => {
   });
 
   describe('nested nodes', () => {
-    // TODO: test with ng-template:
-    // <ng-template i18n><span title="a">My Template Test</span></ng-template>
     it('should handle i18n attributes with plain-text content', () => {
       const files = {
         app: {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -123,7 +123,6 @@ describe('i18n support in the view compiler', () => {
         app: {
           'spec.ts': `
             import {Component, NgModule} from '@angular/core';
-
             @Component({
               selector: 'my-component',
               template: \`
@@ -131,7 +130,6 @@ describe('i18n support in the view compiler', () => {
               \`
             })
             export class MyComponent {}
-
             @NgModule({declarations: [MyComponent]})
             export class MyModule {}
           `
@@ -295,6 +293,141 @@ describe('i18n support in the view compiler', () => {
       `;
 
       const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect template');
+    });
+
+    it('should support interpolation', () => {
+      const files = {
+        app: {
+          'spec.ts': `
+            import {Component, NgModule} from '@angular/core';
+
+            @Component({
+              selector: 'my-component',
+              template: \`
+                <div i18n id="dynamic-1"
+                  i18n-title="m|d" title="intro {{ valueA | uppercase }}"
+                  i18n-aria-label="m1|d1" aria-label="{{ valueB }}"
+                  i18n-aria-description aria-description="static text"
+                ></div>
+                <div i18n id="dynamic-2"
+                  i18n-title="m2|d2" title="{{ valueA }} and {{ valueB }} and again {{ valueA + valueB }}"
+                ></div>
+              \`
+            })
+            export class MyComponent {}
+
+            @NgModule({declarations: [MyComponent]})
+            export class MyModule {}
+        `
+        }
+      };
+      const template = `
+        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("static text");
+        const $_c1$ = ["id", "dynamic-1", "aria-description", $MSG_APP_SPEC_TS_0$];
+        /**
+         * @desc d
+         * @meaning m
+         */
+        const $MSG_APP_SPEC_TS_2$ = goog.getMsg("intro ɵ0ɵ");
+        /**
+         * @desc d1
+         * @meaning m1
+         */
+        const $MSG_APP_SPEC_TS_3$ = goog.getMsg("�0�");
+        const $_c4$ = ["id", "dynamic-2"];
+        /**
+         * @desc d2
+         * @meaning m2
+         */
+        const $MSG_APP_SPEC_TS_5$ = goog.getMsg("�0� and �1� and again �2�");
+        …
+        template: function MyComponent_Template(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵelementStart(0, "div", $_c1$);
+            $r3$.ɵpipe(1, "uppercase");
+            $r3$.ɵi18nAttribute(2, "title", $MSG_APP_SPEC_TS_2$);
+            $r3$.ɵi18nAttribute(3, "aria-label", $MSG_APP_SPEC_TS_3$);
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementStart(4, "div", $_c4$);
+            $r3$.ɵi18nAttribute(5, "title", $MSG_APP_SPEC_TS_5$);
+            $r3$.ɵelementEnd();
+          }
+          if (rf & 2) {
+            $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(1, 0, ctx.valueA)));
+            $r3$.ɵi18nApply(2);
+            $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueB));
+            $r3$.ɵi18nApply(3);
+            $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueA));
+            $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueB));
+            $r3$.ɵi18nExp($r3$.ɵbind((ctx.valueA + ctx.valueB)));
+            $r3$.ɵi18nApply(5);
+          }
+        }
+      `;
+
+      const result = compile(files, angularFiles);
+
+      expectEmit(result.source, template, 'Incorrect template');
+    });
+
+    it('should correctly bind to context in nested template', () => {
+      const files = {
+        app: {
+          'spec.ts': `
+            import {Component, NgModule} from '@angular/core';
+
+            @Component({
+              selector: 'my-component',
+              template: \`
+                <div *ngFor="let outer of items">
+                  <div i18n-title="m|d" title="different scope {{ outer | uppercase }}">
+                </div>
+              \`
+            })
+            export class MyComponent {}
+
+            @NgModule({declarations: [MyComponent]})
+            export class MyModule {}
+        `
+        }
+      };
+
+      const template = `
+        const $_c0$ = ["ngFor", "", 1, "ngForOf"];
+        /**
+         * @desc d
+         * @meaning m
+         */
+        const $MSG_APP_SPEC_TS__1$ = goog.getMsg("different scope �0�");
+        function MyComponent_div_Template_0(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵelementStart(0, "div");
+            $r3$.ɵelementStart(1, "div");
+            $r3$.ɵpipe(2, "uppercase");
+            $r3$.ɵi18nAttribute(3, "title", $MSG_APP_SPEC_TS__1$);
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementEnd();
+          }
+          if (rf & 2) {
+            const $outer_r1$ = ctx.$implicit;
+            $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(2, 0, $outer_r1$)));
+            $r3$.ɵi18nApply(3);
+          }
+        }
+        …
+        template: function MyComponent_Template(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵtemplate(0, MyComponent_div_Template_0, 4, 2, null, $_c0$);
+          }
+          if (rf & 2) {
+            $r3$.ɵelementProperty(0, "ngForOf", $r3$.ɵbind(ctx.items));
+          }
+        }
+      `;
+
+      const result = compile(files, angularFiles);
+
       expectEmit(result.source, template, 'Incorrect template');
     });
   });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -9,8 +9,6 @@
 import {setup} from '@angular/compiler/test/aot/test_util';
 import {compile, expectEmit} from './mock_compile';
 
-const TRANSLATION_NAME_REGEXP = /^MSG_[A-Z0-9]+/;
-
 describe('i18n support in the view compiler', () => {
   const angularFiles = setup({
     compileAngular: false,
@@ -18,56 +16,7 @@ describe('i18n support in the view compiler', () => {
     compileAnimations: false,
   });
 
-  describe('single text nodes', () => {
-    it('should translate single text nodes with the i18n attribute', () => {
-      const files = {
-        app: {
-          'spec.ts': `
-            import {Component, NgModule} from '@angular/core';
-
-            @Component({
-              selector: 'my-component',
-              template: \`
-                <div i18n>Hello world</div>
-                <div>&</div>
-                <div i18n>farewell</div>
-                <div i18n>farewell</div>
-              \`
-            })
-            export class MyComponent {}
-
-            @NgModule({declarations: [MyComponent]})
-            export class MyModule {}
-          `
-        }
-      };
-
-      const template = `
-        const $msg_1$ = goog.getMsg("Hello world");
-        const $msg_2$ = goog.getMsg("farewell");
-        …
-        template: function MyComponent_Template(rf, ctx) {
-          if (rf & 1) {
-            …
-            $r3$.ɵtext(1, $msg_1$);
-            …
-            $r3$.ɵtext(3,"&");
-            …
-            $r3$.ɵtext(5, $msg_2$);
-            …
-            $r3$.ɵtext(7, $msg_2$);
-            …
-          }
-        }
-      `;
-
-      const result = compile(files, angularFiles);
-      expectEmit(result.source, template, 'Incorrect template', {
-        '$msg_1$': TRANSLATION_NAME_REGEXP,
-        '$msg_2$': TRANSLATION_NAME_REGEXP,
-      });
-    });
-
+  describe('element attributes', () => {
     it('should add the meaning and description as JsDoc comments', () => {
       const files = {
         app: {
@@ -77,7 +26,7 @@ describe('i18n support in the view compiler', () => {
             @Component({
               selector: 'my-component',
               template: \`
-                <div i18n="meaning|desc@@id" i18n-title="desc" title="introduction">Hello world</div>
+                <div i18n-title="meaning|desc@@id" title="introduction">Hello world</div>
               \`
             })
             export class MyComponent {}
@@ -91,21 +40,16 @@ describe('i18n support in the view compiler', () => {
       const template = `
         /**
          * @desc desc
+         * @meaning meaning
          */
         const $MSG_APP_SPEC_TS_0$ = goog.getMsg("introduction");
         const $_c1$ = ["title", $MSG_APP_SPEC_TS_0$, 0];
-        …
-        /**
-         * @desc desc
-         * @meaning meaning
-         */
-        const $MSG_APP_SPEC_TS_2$ = goog.getMsg("Hello world");
         …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵelementStart(0, "div");
             $r3$.ɵi18nAttribute(1, $_c1$);
-            $r3$.ɵtext(2, $MSG_APP_SPEC_TS_2$);
+            $r3$.ɵtext(2, "Hello world");
             $r3$.ɵelementEnd();
           }
         }
@@ -114,9 +58,6 @@ describe('i18n support in the view compiler', () => {
       const result = compile(files, angularFiles);
       expectEmit(result.source, template, 'Incorrect template');
     });
-  });
-
-  describe('element attributes', () => {
 
     it('should translate static attributes', () => {
       const files = {
@@ -127,7 +68,7 @@ describe('i18n support in the view compiler', () => {
             @Component({
               selector: 'my-component',
               template: \`
-                <div i18n id="static" i18n-title="m|d" title="introduction"></div>
+                <div id="static" i18n-title="m|d" title="introduction"></div>
               \`
             })
             export class MyComponent {}
@@ -169,12 +110,12 @@ describe('i18n support in the view compiler', () => {
             @Component({
               selector: 'my-component',
               template: \`
-                <div i18n id="dynamic-1"
+                <div id="dynamic-1"
                   i18n-title="m|d" title="intro {{ valueA | uppercase }}"
                   i18n-aria-label="m1|d1" aria-label="{{ valueB }}"
                   i18n-aria-roledescription aria-roledescription="static text"
                 ></div>
-                <div i18n id="dynamic-2"
+                <div id="dynamic-2"
                   i18n-title="m2|d2" title="{{ valueA }} and {{ valueB }} and again {{ valueA + valueB }}"
                   i18n-aria-roledescription aria-roledescription="{{ valueC }}"
                 ></div>
@@ -184,7 +125,7 @@ describe('i18n support in the view compiler', () => {
 
             @NgModule({declarations: [MyComponent]})
             export class MyModule {}
-        `
+          `
         }
       };
 
@@ -307,12 +248,12 @@ describe('i18n support in the view compiler', () => {
             @Component({
               selector: 'my-component',
               template: \`
-                <div i18n id="dynamic-1"
+                <div id="dynamic-1"
                   i18n-title="m|d" title="intro {{ valueA | uppercase }}"
                   i18n-aria-label="m1|d1" aria-label="{{ valueB }}"
                   i18n-aria-roledescription aria-roledescription="static text"
                 ></div>
-                <div i18n id="dynamic-2"
+                <div id="dynamic-2"
                   i18n-title="m2|d2" title="{{ valueA }} and {{ valueB }} and again {{ valueA + valueB }}"
                   i18n-aria-roledescription aria-roledescription="{{ valueC }}"
                 ></div>
@@ -590,7 +531,7 @@ describe('i18n support in the view compiler', () => {
 
       const template = String.raw `
         const $MSG_APP_SPEC_TS_0$ = goog.getMsg("\uFFFD#0\uFFFD My i18n block #\uFFFD0\uFFFD \uFFFD#2\uFFFDPlain text in nested element\uFFFD/#2\uFFFD\uFFFD/#0\uFFFD");
-        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("\uFFFD#3\uFFFD My i18n block #\uFFFD0\uFFFD \uFFFD#6\uFFFD\uFFFD#7\uFFFD\uFFFD#8\uFFFD More bindings in more nested element: \uFFFD0\uFFFD \uFFFD/#8\uFFFD\uFFFD/#7\uFFFD\uFFFD/#6\uFFFD\uFFFD/#3\uFFFD");
+        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("\uFFFD#3\uFFFD My i18n block #\uFFFD0\uFFFD \uFFFD#6\uFFFD\uFFFD#7\uFFFD\uFFFD#8\uFFFD More bindings in more nested element: \uFFFD1\uFFFD \uFFFD/#8\uFFFD\uFFFD/#7\uFFFD\uFFFD/#6\uFFFD\uFFFD/#3\uFFFD");
         …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
@@ -618,6 +559,81 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(5, 0, ctx.two)));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.nestedInBlockTwo));
             $r3$.ɵi18nApply(4);
+          }
+        }
+      `;
+
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect template');
+    });
+
+    it('should handle i18n attributes with bindings in content and element attributes', () => {
+      const files = {
+        app: {
+          'spec.ts': `
+            import {Component, NgModule} from '@angular/core';
+
+            @Component({
+              selector: 'my-component',
+              template: \`
+                <div i18n>
+                  My i18n block #1 with value: {{ valueA }}
+                  <span i18n-title title="Span title {{ valueB }} and {{ valueC }}">
+                    Plain text in nested element (block #1)
+                  </span>
+                </div>
+                <div i18n>
+                  My i18n block #2 with value {{ valueD | uppercase }}
+                  <span i18n-title title="Span title {{ valueE }}">
+                    Plain text in nested element (block #2)
+                  </span>
+                </div>
+              \`
+            })
+            export class MyComponent {}
+
+            @NgModule({declarations: [MyComponent]})
+            export class MyModule {}
+          `
+        }
+      };
+
+      const template = String.raw `
+        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("\uFFFD#0\uFFFD My i18n block #1 with value: \uFFFD0\uFFFD \uFFFD#2\uFFFD Plain text in nested element (block #1) \uFFFD/#2\uFFFD\uFFFD/#0\uFFFD");
+        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("Span title \uFFFD0\uFFFD and \uFFFD1\uFFFD");
+        const $_c2$ = ["title", $MSG_APP_SPEC_TS_1$, 2];
+        const $MSG_APP_SPEC_TS_3$ = goog.getMsg("\uFFFD#4\uFFFD My i18n block #2 with value \uFFFD0\uFFFD \uFFFD#7\uFFFD Plain text in nested element (block #2) \uFFFD/#7\uFFFD\uFFFD/#4\uFFFD");
+        const $MSG_APP_SPEC_TS_4$ = goog.getMsg("Span title \uFFFD0\uFFFD");
+        const $_c5$ = ["title", $MSG_APP_SPEC_TS_4$, 1];
+        …
+        template: function MyComponent_Template(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵelementStart(0, "div");
+            $r3$.ɵi18nStart(1, $MSG_APP_SPEC_TS_0$);
+            $r3$.ɵelementStart(2, "span");
+            $r3$.ɵi18nAttribute(3, $_c2$);
+            $r3$.ɵelementEnd();
+            $r3$.ɵi18nEnd();
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementStart(4, "div");
+            $r3$.ɵi18nStart(5, $MSG_APP_SPEC_TS_3$);
+            $r3$.ɵpipe(6, "uppercase");
+            $r3$.ɵelementStart(7, "span");
+            $r3$.ɵi18nAttribute(8, $_c5$);
+            $r3$.ɵelementEnd();
+            $r3$.ɵi18nEnd();
+            $r3$.ɵelementEnd();
+          }
+          if (rf & 2) {
+            $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueB));
+            $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueC));
+            $r3$.ɵi18nApply(3);
+            $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueA));
+            $r3$.ɵi18nApply(1);
+            $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueE));
+            $r3$.ɵi18nApply(8);
+            $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(6, 0, ctx.valueD)));
+            $r3$.ɵi18nApply(5);
           }
         }
       `;
@@ -679,6 +695,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵi18nApply(2);
           }
         }
+        …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
             $r3$.ɵelementStart(0, "div");
@@ -696,7 +713,7 @@ describe('i18n support in the view compiler', () => {
       expectEmit(result.source, template, 'Incorrect template');
     });
 
-    fit('should handle i18n context in nested templates', () => {
+    it('should handle i18n context in nested templates', () => {
       const files = {
         app: {
           'spec.ts': `
@@ -810,54 +827,6 @@ describe('i18n support in the view compiler', () => {
       `;
 
       const result = compile(files, angularFiles);
-      console.log(result.source);
-      expectEmit(result.source, template, 'Incorrect template');
-    });
-
-    it('should generate i18nStart and i18nEnd instructions', () => {
-      const files = {
-        app: {
-          'spec.ts': `
-            import {Component, NgModule} from '@angular/core';
-
-            @Component({
-              selector: 'my-component',
-              template: \`
-                <div id="a" i18n>Test1</div>
-                <div id="b">Test2</div>
-                <div id="c" i18n>Test with binding {{ valueA }} and {{ valueB }}</div>
-                <div i18n>
-                  <div id="c" i18n-title="m|d" title="inside i18n">Test3</div>
-                  <div *ngFor="let outer of items">
-                    <div i18n-title="m|d" title="different scope {{ outer | uppercase }}">different scope</div>
-                    <span *ngIf="!outer2">Not outer 2!</span>
-                    <span *ngIf="!outer">
-                      Not outer
-                      <span *ngIf="!outer1">
-                        Not outer 1
-                      </span>
-                    </span>
-                    Some additional text! {{ valueC }}
-                    <div>Additional div</div>
-                  </div>
-                </div>
-              \`
-            })
-            export class MyComponent {}
-
-            @NgModule({declarations: [MyComponent]})
-            export class MyModule {}
-          `
-        }
-      };
-
-      const template = `
-        const $r1$ = {"b":[2], "i":[4, 6]};
-        const $r2$ = {"i":[13]};
-      `;
-
-      const result = compile(files, angularFiles);
-      console.log(result.source);
       expectEmit(result.source, template, 'Incorrect template');
     });
   });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -555,7 +555,7 @@ describe('i18n support in the view compiler', () => {
       expectEmit(result.source, template, 'Incorrect template');
     });
 
-    fit('should handle i18n attributes with bindings and nested elements in content', () => {
+    it('should handle i18n attributes with bindings and nested elements in content', () => {
       const files = {
         app: {
           'spec.ts': `
@@ -618,6 +618,193 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(5, 0, ctx.two)));
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.nestedInBlockTwo));
             $r3$.ɵi18nApply(4);
+          }
+        }
+      `;
+
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect template');
+    });
+
+    it('should handle i18n attributes in nested templates', () => {
+      const files = {
+        app: {
+          'spec.ts': `
+            import {Component, NgModule} from '@angular/core';
+
+            @Component({
+              selector: 'my-component',
+              template: \`
+                <div>
+                  Some content
+                  <div *ngIf="visible">
+                    <div i18n>
+                      Some other content {{ valueA }}
+                      <div>
+                        More nested levels with bindings {{ valueB | uppercase }}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              \`
+            })
+            export class MyComponent {}
+
+            @NgModule({declarations: [MyComponent]})
+            export class MyModule {}
+          `
+        }
+      };
+
+      const template = String.raw `
+        const $_c0$ = [1, "ngIf"];
+        const $MSG_APP_SPEC_TS__1$ = goog.getMsg("\uFFFD#1\uFFFD Some other content \uFFFD0\uFFFD \uFFFD#3\uFFFD More nested levels with bindings \uFFFD1\uFFFD \uFFFD/#3\uFFFD\uFFFD/#1\uFFFD");
+        …
+        function MyComponent_div_Template_2(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵelementStart(0, "div");
+            $r3$.ɵelementStart(1, "div");
+            $r3$.ɵi18nStart(2, $MSG_APP_SPEC_TS__1$);
+            $r3$.ɵelementStart(3, "div");
+            $r3$.ɵpipe(4, "uppercase");
+            $r3$.ɵelementEnd();
+            $r3$.ɵi18nEnd();
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementEnd();
+          }
+          if (rf & 2) {
+            const $$ctx_r0$$ = $r3$.ɵnextContext();
+            $r3$.ɵi18nExp($r3$.ɵbind($$ctx_r0$$.valueA));
+            $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(4, 0, $$ctx_r0$$.valueB)));
+            $r3$.ɵi18nApply(2);
+          }
+        }
+        template: function MyComponent_Template(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵelementStart(0, "div");
+            $r3$.ɵtext(1, " Some content ");
+            $r3$.ɵtemplate(2, MyComponent_div_Template_2, 5, 2, null, $_c0$);
+            $r3$.ɵelementEnd();
+          }
+          if (rf & 2) {
+            $r3$.ɵelementProperty(2, "ngIf", $r3$.ɵbind(ctx.visible));
+          }
+        }
+      `;
+
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect template');
+    });
+
+    fit('should handle i18n context in nested templates', () => {
+      const files = {
+        app: {
+          'spec.ts': `
+            import {Component, NgModule} from '@angular/core';
+
+            @Component({
+              selector: 'my-component',
+              template: \`
+                <div i18n>
+                  Some content
+                  <div *ngIf="visible">
+                    Some other content {{ valueA }}
+                    <div>
+                      More nested levels with bindings {{ valueB | uppercase }}
+                      <div *ngIf="exists">
+                        Content inside sub-template {{ valueC }}
+                        <div>
+                          Bottom level element {{ valueD }}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div *ngIf="!visible">
+                    Some other content {{ valueE + valueF }}
+                    <div>
+                      More nested levels with bindings {{ valueG | uppercase }}
+                    </div>
+                  </div>
+                </div>
+              \`
+            })
+            export class MyComponent {}
+
+            @NgModule({declarations: [MyComponent]})
+            export class MyModule {}
+          `
+        }
+      };
+
+      const template = String.raw `
+        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("\uFFFD#0\uFFFD Some content \uFFFD*2:1\uFFFD\uFFFD#1:1\uFFFD Some other content \uFFFD0:1\uFFFD \uFFFD#2:1\uFFFD More nested levels with bindings \uFFFD1:1\uFFFD \uFFFD*4:2\uFFFD\uFFFD#1:2\uFFFD Content inside sub-template \uFFFD0:2\uFFFD \uFFFD#2:2\uFFFD Bottom level element \uFFFD1:2\uFFFD \uFFFD/#2:2\uFFFD\uFFFD/#1:2\uFFFD\uFFFD/*4:2\uFFFD\uFFFD/#2:1\uFFFD\uFFFD/#1:1\uFFFD\uFFFD/*2:1\uFFFD\uFFFD*3:3\uFFFD\uFFFD#1:3\uFFFD Some other content \uFFFD0:3\uFFFD \uFFFD#2:3\uFFFD More nested levels with bindings \uFFFD1:3\uFFFD \uFFFD/#2:3\uFFFD\uFFFD/#1:3\uFFFD\uFFFD/*3:3\uFFFD\uFFFD/#0\uFFFD");
+        const $_c1$ = [1, "ngIf"];
+        …
+        function MyComponent_div_div_Template_4(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵi18nStart(0, $MSG_APP_SPEC_TS_0$, 2);
+            $r3$.ɵelementStart(1, "div");
+            $r3$.ɵelementStart(2, "div");
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementEnd();
+            $r3$.ɵi18nEnd();
+          }
+          if (rf & 2) {
+            const $ctx_r2$ = $r3$.ɵnextContext(2);
+            $r3$.ɵi18nExp($r3$.ɵbind($ctx_r2$.valueC));
+            $r3$.ɵi18nExp($r3$.ɵbind($ctx_r2$.valueD));
+            $r3$.ɵi18nApply(0);
+          }
+        }
+        function MyComponent_div_Template_2(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵi18nStart(0, $MSG_APP_SPEC_TS_0$, 1);
+            $r3$.ɵelementStart(1, "div");
+            $r3$.ɵelementStart(2, "div");
+            $r3$.ɵpipe(3, "uppercase");
+            $r3$.ɵtemplate(4, MyComponent_div_div_Template_4, 3, 0, null, $_c1$);
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementEnd();
+            $r3$.ɵi18nEnd();
+          }
+          if (rf & 2) {
+            const $ctx_r0$ = $r3$.ɵnextContext();
+            $r3$.ɵelementProperty(4, "ngIf", $r3$.ɵbind($ctx_r0$.exists));
+            $r3$.ɵi18nExp($r3$.ɵbind($ctx_r0$.valueA));
+            $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(3, 0, $ctx_r0$.valueB)));
+            $r3$.ɵi18nApply(0);
+          }
+        }
+        function MyComponent_div_Template_3(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵi18nStart(0, $MSG_APP_SPEC_TS_0$, 3);
+            $r3$.ɵelementStart(1, "div");
+            $r3$.ɵelementStart(2, "div");
+            $r3$.ɵpipe(3, "uppercase");
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementEnd();
+            $r3$.ɵi18nEnd();
+          }
+          if (rf & 2) {
+            const $ctx_r1$ = $r3$.ɵnextContext();
+            $r3$.ɵi18nExp($r3$.ɵbind(($ctx_r1$.valueE + $ctx_r1$.valueF)));
+            $r3$.ɵi18nExp($r3$.ɵbind($r3$.ɵpipeBind1(3, 0, $ctx_r1$.valueG)));
+            $r3$.ɵi18nApply(0);
+          }
+        }
+        …
+        template: function MyComponent_Template(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵelementStart(0, "div");
+            $r3$.ɵi18nStart(1, $MSG_APP_SPEC_TS_0$);
+            $r3$.ɵtemplate(2, MyComponent_div_Template_2, 5, 3, null, $_c1$);
+            $r3$.ɵtemplate(3, MyComponent_div_Template_3, 4, 2, null, $_c1$);
+            $r3$.ɵi18nEnd();
+            $r3$.ɵelementEnd();
+          }
+          if (rf & 2) {
+            $r3$.ɵelementProperty(2, "ngIf", $r3$.ɵbind(ctx.visible));
+            $r3$.ɵelementProperty(3, "ngIf", $r3$.ɵbind(!ctx.visible));
           }
         }
       `;

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -440,6 +440,63 @@ describe('i18n support in the view compiler', () => {
   describe('nested nodes', () => {
     // TODO: test with ng-template:
     // <ng-template i18n><span title="a">My Template Test</span></ng-template>
+    it('should handle top level i18n attributes', () => {
+      const files = {
+        app: {
+          'spec.ts': `
+            import {Component, NgModule} from '@angular/core';
+
+            @Component({
+              selector: 'my-component',
+              template: \`
+                <div i18n>My i18n block #1</div>
+                <div>My non-i18n block #1</div>
+                <div i18n>My i18n block #2</div>
+                <div>My non-i18n block #2</div>
+                <div i18n>My i18n block #3</div>
+              \`
+            })
+            export class MyComponent {}
+
+            @NgModule({declarations: [MyComponent]})
+            export class MyModule {}
+          `
+        }
+      };
+
+      const template = String.raw `
+        const $MSG_APP_SPEC_TS_0$ = goog.getMsg("\uFFFD#0\uFFFDMy i18n block #1\uFFFD/#0\uFFFD");
+        const $MSG_APP_SPEC_TS_1$ = goog.getMsg("\uFFFD#4\uFFFDMy i18n block #2\uFFFD/#4\uFFFD");
+        const $MSG_APP_SPEC_TS_2$ = goog.getMsg("\uFFFD#8\uFFFDMy i18n block #3\uFFFD/#8\uFFFD");
+        …
+        template: function MyComponent_Template(rf, ctx) {
+          if (rf & 1) {
+            $r3$.ɵelementStart(0, "div");
+            $r3$.ɵi18nStart(1, $MSG_APP_SPEC_TS_0$);
+            $r3$.ɵi18nEnd();
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementStart(2, "div");
+            $r3$.ɵtext(3, "My non-i18n block #1");
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementStart(4, "div");
+            $r3$.ɵi18nStart(5, $MSG_APP_SPEC_TS_1$);
+            $r3$.ɵi18nEnd();
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementStart(6, "div");
+            $r3$.ɵtext(7, "My non-i18n block #2");
+            $r3$.ɵelementEnd();
+            $r3$.ɵelementStart(8, "div");
+            $r3$.ɵi18nStart(9, $MSG_APP_SPEC_TS_2$);
+            $r3$.ɵi18nEnd();
+            $r3$.ɵelementEnd();
+          }
+        }
+      `;
+
+      const result = compile(files, angularFiles);
+      expectEmit(result.source, template, 'Incorrect template');
+    });
+
     fit('should generate i18nStart and i18nEnd instructions', () => {
       const files = {
         app: {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -326,7 +326,7 @@ describe('i18n support in the view compiler', () => {
         }
       };
 
-      const template = String.raw`
+      const template = String.raw `
         const $MSG_APP_SPEC_TS_0$ = goog.getMsg("static text");
         const $_c1$ = ["id", "dynamic-1", "aria-roledescription", $MSG_APP_SPEC_TS_0$];
         /**
@@ -400,7 +400,7 @@ describe('i18n support in the view compiler', () => {
         }
       };
 
-      const template = String.raw`
+      const template = String.raw `
         const $_c0$ = ["ngFor", "", 1, "ngForOf"];
         /**
          * @desc d

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -437,9 +437,10 @@ describe('i18n support in the view compiler', () => {
     });
   });
 
-  // TODO(vicb): this feature is not supported yet
-  xdescribe('nested nodes', () => {
-    it('should generate the placeholders maps', () => {
+  describe('nested nodes', () => {
+    // TODO: test with ng-template:
+    // <ng-template i18n><span title="a">My Template Test</span></ng-template>
+    fit('should generate i18nStart and i18nEnd instructions', () => {
       const files = {
         app: {
           'spec.ts': `
@@ -448,26 +449,41 @@ describe('i18n support in the view compiler', () => {
             @Component({
               selector: 'my-component',
               template: \`
-                <div i18n>Hello <b>{{name}}<i>!</i><i>!</i></b></div>
-                <div>Other</div>
-                <div i18n>2nd</div>
-                <div i18n><i>3rd</i></div>
+                <div id="a" i18n>Test1</div>
+                <div id="b">Test2</div>
+                <div id="c" i18n>Test with binding {{ valueA }} and {{ valueB }}</div>
+                <div i18n>
+                  <div id="c" i18n-title="m|d" title="inside i18n">Test3</div>
+                  <div *ngFor="let outer of items">
+                    <div i18n-title="m|d" title="different scope {{ outer | uppercase }}">different scope</div>
+                    <span *ngIf="!outer2">Not outer 2!</span>
+                    <span *ngIf="!outer">
+                      Not outer
+                      <span *ngIf="!outer1">
+                        Not outer 1
+                      </span>
+                    </span>
+                    Some additional text! {{ valueC }}
+                    <div>Additional div</div>
+                  </div>
+                </div>
               \`
             })
             export class MyComponent {}
 
             @NgModule({declarations: [MyComponent]})
             export class MyModule {}
-        `
+          `
         }
       };
 
       const template = `
-      const $r1$ = {"b":[2], "i":[4, 6]};
-      const $r2$ = {"i":[13]};
-    `;
+        const $r1$ = {"b":[2], "i":[4, 6]};
+        const $r2$ = {"i":[13]};
+      `;
 
       const result = compile(files, angularFiles);
+      console.log(result.source);
       expectEmit(result.source, template, 'Incorrect template');
     });
   });

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -296,7 +296,7 @@ describe('i18n support in the view compiler', () => {
       expectEmit(result.source, template, 'Incorrect template');
     });
 
-    it('should support interpolation', () => {
+    fit('should support interpolation', () => {
       const files = {
         app: {
           'spec.ts': `
@@ -308,10 +308,11 @@ describe('i18n support in the view compiler', () => {
                 <div i18n id="dynamic-1"
                   i18n-title="m|d" title="intro {{ valueA | uppercase }}"
                   i18n-aria-label="m1|d1" aria-label="{{ valueB }}"
-                  i18n-aria-description aria-description="static text"
+                  i18n-aria-roledescription aria-roledescription="static text"
                 ></div>
                 <div i18n id="dynamic-2"
                   i18n-title="m2|d2" title="{{ valueA }} and {{ valueB }} and again {{ valueA + valueB }}"
+                  i18n-aria-roledescription aria-roledescription="{{ valueC }}"
                 ></div>
               \`
             })
@@ -324,12 +325,12 @@ describe('i18n support in the view compiler', () => {
       };
       const template = `
         const $MSG_APP_SPEC_TS_0$ = goog.getMsg("static text");
-        const $_c1$ = ["id", "dynamic-1", "aria-description", $MSG_APP_SPEC_TS_0$];
+        const $_c1$ = ["id", "dynamic-1", "aria-roledescription", $MSG_APP_SPEC_TS_0$];
         /**
          * @desc d
          * @meaning m
          */
-        const $MSG_APP_SPEC_TS_2$ = goog.getMsg("intro ɵ0ɵ");
+        const $MSG_APP_SPEC_TS_2$ = goog.getMsg("intro �0�");
         /**
          * @desc d1
          * @meaning m1
@@ -341,6 +342,7 @@ describe('i18n support in the view compiler', () => {
          * @meaning m2
          */
         const $MSG_APP_SPEC_TS_5$ = goog.getMsg("�0� and �1� and again �2�");
+        const $MSG_APP_SPEC_TS_6$ = goog.getMsg("�0�");
         …
         template: function MyComponent_Template(rf, ctx) {
           if (rf & 1) {
@@ -351,6 +353,7 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵelementEnd();
             $r3$.ɵelementStart(4, "div", $_c4$);
             $r3$.ɵi18nAttribute(5, "title", $MSG_APP_SPEC_TS_5$);
+            $r3$.ɵi18nAttribute(6, "aria-roledescription", $MSG_APP_SPEC_TS_6$);
             $r3$.ɵelementEnd();
           }
           if (rf & 2) {
@@ -362,12 +365,13 @@ describe('i18n support in the view compiler', () => {
             $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueB));
             $r3$.ɵi18nExp($r3$.ɵbind((ctx.valueA + ctx.valueB)));
             $r3$.ɵi18nApply(5);
+            $r3$.ɵi18nExp($r3$.ɵbind(ctx.valueC));
+            $r3$.ɵi18nApply(6);
           }
         }
       `;
 
       const result = compile(files, angularFiles);
-
       expectEmit(result.source, template, 'Incorrect template');
     });
 
@@ -427,7 +431,6 @@ describe('i18n support in the view compiler', () => {
       `;
 
       const result = compile(files, angularFiles);
-
       expectEmit(result.source, template, 'Incorrect template');
     });
   });

--- a/packages/compiler/src/constant_pool.ts
+++ b/packages/compiler/src/constant_pool.ts
@@ -122,7 +122,7 @@ export class ConstantPool {
   }
 
   setDeferredTranslationConst(variable: o.ReadVarExpr, message: string): void {
-    const index = this.deferredTranslations.get(variable)!;
+    const index = this.deferredTranslations.get(variable) !;
     this.statements[index] = this.getTranslationDeclStmt(variable, message);
   }
 

--- a/packages/compiler/src/constant_pool.ts
+++ b/packages/compiler/src/constant_pool.ts
@@ -351,13 +351,14 @@ function isVariable(e: o.Expression): e is o.ReadVarExpr {
   return e instanceof o.ReadVarExpr;
 }
 
-// Converts i18n meta informations for a message (description, meaning) to a JsDoc statement
-// formatted as expected by the Closure compiler.
+// Converts i18n meta informations for a message (id, description, meaning)
+// to a JsDoc statement formatted as expected by the Closure compiler.
 function i18nMetaToDocStmt(meta: I18nMeta): o.JSDocCommentStmt|null {
   const tags: o.JSDocTag[] = [];
 
-  if (meta.description) {
-    tags.push({tagName: o.JSDocTagName.Desc, text: meta.description});
+  if (meta.id || meta.description) {
+    const text = meta.id ? `[BACKUP_MESSAGE_ID:${meta.id}] ${meta.description}` : meta.description;
+    tags.push({tagName: o.JSDocTagName.Desc, text: text !.trim()});
   }
 
   if (meta.meaning) {

--- a/packages/compiler/src/constant_pool.ts
+++ b/packages/compiler/src/constant_pool.ts
@@ -131,6 +131,13 @@ export class ConstantPool {
     return variable.set(fnCall).toDeclStmt(o.INFERRED_TYPE, [o.StmtModifier.Final]);
   }
 
+  appendTranslationMeta(meta: {description?: string, meaning?: string}) {
+    const docStmt = i18nMetaToDocStmt(meta);
+    if (docStmt) {
+      this.statements.push(docStmt);
+    }
+  }
+
   // Generates closure specific code for translation.
   //
   // ```
@@ -152,10 +159,7 @@ export class ConstantPool {
     }
 
     const variable = o.variable(this.freshTranslationName(suffix));
-    const docStmt = i18nMetaToDocStmt(meta);
-    if (docStmt) {
-      this.statements.push(docStmt);
-    }
+    this.appendTranslationMeta(meta);
     this.statements.push(this.getTranslationDeclStmt(variable, message));
 
     this.translations.set(key, variable);

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -205,8 +205,8 @@ export function compileComponentFromMetadata(
 
   const template = meta.template;
   const templateBuilder = new TemplateDefinitionBuilder(
-      constantPool, BindingScope.ROOT_SCOPE, 0, templateTypeName, null, null, templateName, meta.viewQueries,
-      directiveMatcher, directivesUsed, meta.pipes, pipesUsed, R3.namespaceHTML,
+      constantPool, BindingScope.ROOT_SCOPE, 0, templateTypeName, null, null, templateName,
+      meta.viewQueries, directiveMatcher, directivesUsed, meta.pipes, pipesUsed, R3.namespaceHTML,
       meta.template.relativeContextFilePath);
 
   const templateFunctionExpression = templateBuilder.buildTemplateFunction(

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -205,7 +205,7 @@ export function compileComponentFromMetadata(
 
   const template = meta.template;
   const templateBuilder = new TemplateDefinitionBuilder(
-      constantPool, BindingScope.ROOT_SCOPE, 0, templateTypeName, templateName, meta.viewQueries,
+      constantPool, BindingScope.ROOT_SCOPE, 0, templateTypeName, null, null, templateName, meta.viewQueries,
       directiveMatcher, directivesUsed, meta.pipes, pipesUsed, R3.namespaceHTML,
       meta.template.relativeContextFilePath);
 

--- a/packages/compiler/src/render3/view/i18n.ts
+++ b/packages/compiler/src/render3/view/i18n.ts
@@ -29,7 +29,6 @@ export function parseI18nMeta(meta?: string): I18nMeta {
   let description: string|undefined;
 
   if (meta) {
-    // TODO(vicb): figure out how to force a message ID with closure ?
     const idIndex = meta.indexOf(I18N_ID_SEPARATOR);
     const descIndex = meta.indexOf(I18N_MEANING_SEPARATOR);
     let meaningAndDesc: string;

--- a/packages/compiler/src/render3/view/i18n.ts
+++ b/packages/compiler/src/render3/view/i18n.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/** I18n separators for metadata **/
+const I18N_MEANING_SEPARATOR = '|';
+const I18N_ID_SEPARATOR = '@@';
+
+/** Name of the i18n attributes **/
+export const I18N_ATTR = 'i18n';
+export const I18N_ATTR_PREFIX = 'i18n-';
+
+/** Placeholder wrapper for i18n expressions **/
+export const I18N_PLACEHOLDER_SYMBOL = '�';
+
+// Parse i18n metas like:
+// - "@@id",
+// - "description[@@id]",
+// - "meaning|description[@@id]"
+export function parseI18nMeta(i18n?: string): {description?: string, id?: string, meaning?: string} {
+  let meaning: string|undefined;
+  let description: string|undefined;
+  let id: string|undefined;
+
+  if (i18n) {
+    // TODO(vicb): figure out how to force a message ID with closure ?
+    const idIndex = i18n.indexOf(I18N_ID_SEPARATOR);
+
+    const descIndex = i18n.indexOf(I18N_MEANING_SEPARATOR);
+    let meaningAndDesc: string;
+    [meaningAndDesc, id] =
+        (idIndex > -1) ? [i18n.slice(0, idIndex), i18n.slice(idIndex + 2)] : [i18n, ''];
+    [meaning, description] = (descIndex > -1) ?
+        [meaningAndDesc.slice(0, descIndex), meaningAndDesc.slice(descIndex + 1)] :
+        ['', meaningAndDesc];
+  }
+
+  return {description, id, meaning};
+}
+
+export function isI18NAttribute(name: string): boolean {
+  return name === I18N_ATTR || name.startsWith(I18N_ATTR_PREFIX);
+}
+
+export function wrapI18nPlaceholder(content: string | number): string {
+  return `${I18N_PLACEHOLDER_SYMBOL}${content}${I18N_PLACEHOLDER_SYMBOL}`;
+}
+
+export function assembleI18nTemplate(strings: Array<string>): string {
+  if (!strings.length) return '';
+  let acc = '';
+  const lastIdx = strings.length - 1;
+  for (let i = 0; i < lastIdx; i++) {
+    acc += `${strings[i]}${wrapI18nPlaceholder(i)}`;
+  }
+  acc += strings[lastIdx];
+  return acc;
+}
+
+export class I18nContext {
+  private content: string = '';
+
+  constructor(private index: number, private ref: any, private level: number = 0) {}
+
+  getIndex() {
+    return this.index;
+  }
+  getRef() {
+    return this.ref;
+  }
+  getLevel() {
+    return this.level;
+  }
+  getContent() {
+    return this.content;
+  }
+  wrap(symbol: string, elementIndex: number, templateIndex?: number, closed?: boolean) {
+    const state = closed ? '/' : '';
+    const tmplIndex = templateIndex ? `:${templateIndex}` : '';
+    return wrapI18nPlaceholder(`${state}${symbol}${elementIndex}${tmplIndex}`);
+
+  }
+  append(content: string) {
+    this.content += content;
+  }
+  appendText(content: string) {
+    this.append(content);
+  }
+  appendElement(elementIndex: number, templateIndex?: number, closed?: boolean) {
+    this.append(this.wrap('#', elementIndex, templateIndex, closed));
+  }
+  appendTemplate(index: number, templateIndex?: number) {
+    this.append(this.wrap('*', index, templateIndex));
+    this.append(`tmpl${index}`);
+    this.append(this.wrap('*', index, templateIndex, true));
+  }
+  resolved() {
+    return !/tmpl/g.test(this.content);
+  }
+  reconcile(templateIndex: any, templateContent: any) {
+    this.content = this.content.replace(new RegExp(`tmpl${templateIndex}`), templateContent);
+  }
+}

--- a/packages/compiler/src/render3/view/i18n.ts
+++ b/packages/compiler/src/render3/view/i18n.ts
@@ -75,6 +75,15 @@ export type I18nMeta = {
   meaning?: string
 };
 
+/**
+ * I18nContext is a helper class which keeps track of all i18n-related aspects
+ * (accumulates content, bindings, etc) between i18nStart and i18nEnd instructions.
+ *
+ * When we enter a nested template, the top-level context is being passed down
+ * to the nested component, which uses this context to generate a child instance
+ * of I18nContext class (to handle nested template) and at the end, reconciles it back
+ * with the parent context.
+ */
 export class I18nContext {
   private id: number;
   private content: string = '';

--- a/packages/compiler/src/render3/view/i18n.ts
+++ b/packages/compiler/src/render3/view/i18n.ts
@@ -86,6 +86,9 @@ export class I18nContext {
     return wrapI18nPlaceholder(`${state}${symbol}${elementIndex}`, contextId);
   }
   private append(content: string) { this.content += content; }
+  private genTemplatePattern(contextId: number|string, templateId: number|string): string {
+    return wrapI18nPlaceholder(`tmpl:${contextId}:${templateId}`);
+  }
 
   getId() { return this.id; }
   getRef() { return this.ref; }
@@ -97,10 +100,13 @@ export class I18nContext {
   appendBinding(binding: o.Expression) { this.bindings.add(binding); }
 
   isRoot() { return this.level === 0; }
-  isResolved() { return !/\[tmpl:\d+:\d+\]/.test(this.content); }
+  isResolved() {
+    const regex = new RegExp(this.genTemplatePattern('\\d+', '\\d+'));
+    return !regex.test(this.content);
+  }
 
   appendText(content: string) { this.append(content); }
-  appendTemplate(index: number) { this.append(`[tmpl:${this.id}:${index}]`); }
+  appendTemplate(index: number) { this.append(this.genTemplatePattern(this.id, index)); }
   appendElement(elementIndex: number, closed?: boolean) {
     this.append(this.wrap('#', elementIndex, this.id, closed));
   }
@@ -112,7 +118,7 @@ export class I18nContext {
     const id = context.getId();
     const content = context.getContent();
     const templateIndex = context.getTemplateIndex() !;
-    const pattern = new RegExp(`\\[tmpl\\:${this.id}\\:${templateIndex}\\]`);
+    const pattern = new RegExp(this.genTemplatePattern(this.id, templateIndex));
     const replacement =
         `${this.wrap('*', templateIndex, id)}${content}${this.wrap('*', templateIndex, id, true)}`;
     this.content = this.content.replace(pattern, replacement);

--- a/packages/compiler/src/render3/view/i18n.ts
+++ b/packages/compiler/src/render3/view/i18n.ts
@@ -48,16 +48,17 @@ export function isI18NAttribute(name: string): boolean {
   return name === I18N_ATTR || name.startsWith(I18N_ATTR_PREFIX);
 }
 
-export function wrapI18nPlaceholder(content: string | number): string {
-  return `${I18N_PLACEHOLDER_SYMBOL}${content}${I18N_PLACEHOLDER_SYMBOL}`;
+export function wrapI18nPlaceholder(content: string | number, contextId: number = 0): string {
+  const blockId = contextId > 0 ? `:${contextId}` : '';
+  return `${I18N_PLACEHOLDER_SYMBOL}${content}${blockId}${I18N_PLACEHOLDER_SYMBOL}`;
 }
 
-export function assembleI18nTemplate(strings: Array<string>): string {
+export function assembleI18nBoundString(strings: Array<string>, bindingStartIndex: number = 0, contextId: number = 0): string {
   if (!strings.length) return '';
   let acc = '';
   const lastIdx = strings.length - 1;
   for (let i = 0; i < lastIdx; i++) {
-    acc += `${strings[i]}${wrapI18nPlaceholder(i)}`;
+    acc += `${strings[i]}${wrapI18nPlaceholder(bindingStartIndex + i, contextId)}`;
   }
   acc += strings[lastIdx];
   return acc;
@@ -79,10 +80,9 @@ export class I18nContext {
     this.id = this.uniqueIdGen();
   }
 
-  private wrap(symbol: string, elementIndex: number, contextIdx: number|null, closed?: boolean) {
+  private wrap(symbol: string, elementIndex: number, contextId: number, closed?: boolean) {
     const state = closed ? '/' : '';
-    const blockIndex = contextIdx && contextIdx > 0 ? `:${contextIdx}` : '';
-    return wrapI18nPlaceholder(`${state}${symbol}${elementIndex}${blockIndex}`);
+    return wrapI18nPlaceholder(`${state}${symbol}${elementIndex}`, contextId);
   }
   private append(content: string) { this.content += content; }
 

--- a/packages/compiler/src/render3/view/i18n.ts
+++ b/packages/compiler/src/render3/view/i18n.ts
@@ -105,7 +105,7 @@ export class I18nContext {
     return !regex.test(this.content);
   }
 
-  appendText(content: string) { this.append(content); }
+  appendText(content: string) { this.append(content.trim()); }
   appendTemplate(index: number) { this.append(this.genTemplatePattern(this.id, index)); }
   appendElement(elementIndex: number, closed?: boolean) {
     this.append(this.wrap('#', elementIndex, this.id, closed));

--- a/packages/compiler/src/render3/view/i18n.ts
+++ b/packages/compiler/src/render3/view/i18n.ts
@@ -23,25 +23,24 @@ export const I18N_PLACEHOLDER_SYMBOL = '�';
 // - "@@id",
 // - "description[@@id]",
 // - "meaning|description[@@id]"
-export function parseI18nMeta(i18n?: string):
-    {description?: string, id?: string, meaning?: string} {
+export function parseI18nMeta(meta?: string): I18nMeta {
+  let id: string|undefined;
   let meaning: string|undefined;
   let description: string|undefined;
-  let id: string|undefined;
 
-  if (i18n) {
+  if (meta) {
     // TODO(vicb): figure out how to force a message ID with closure ?
-    const idIndex = i18n.indexOf(I18N_ID_SEPARATOR);
-    const descIndex = i18n.indexOf(I18N_MEANING_SEPARATOR);
+    const idIndex = meta.indexOf(I18N_ID_SEPARATOR);
+    const descIndex = meta.indexOf(I18N_MEANING_SEPARATOR);
     let meaningAndDesc: string;
     [meaningAndDesc, id] =
-        (idIndex > -1) ? [i18n.slice(0, idIndex), i18n.slice(idIndex + 2)] : [i18n, ''];
+        (idIndex > -1) ? [meta.slice(0, idIndex), meta.slice(idIndex + 2)] : [meta, ''];
     [meaning, description] = (descIndex > -1) ?
         [meaningAndDesc.slice(0, descIndex), meaningAndDesc.slice(descIndex + 1)] :
         ['', meaningAndDesc];
   }
 
-  return {description, id, meaning};
+  return {id, meaning, description};
 }
 
 export function isI18NAttribute(name: string): boolean {
@@ -69,6 +68,13 @@ function getSeqNubmerGenerator(startsAt: number = 0): () => number {
   let current = startsAt;
   return () => current++;
 }
+
+export type I18nMeta = {
+  id?: string,
+  description?: string,
+  meaning?: string
+};
+
 export class I18nContext {
   private id: number;
   private content: string = '';

--- a/packages/compiler/src/render3/view/i18n.ts
+++ b/packages/compiler/src/render3/view/i18n.ts
@@ -86,9 +86,11 @@ export class I18nContext {
   getId() { return this.id; }
   getRef() { return this.ref; }
   getIndex() { return this.index; }
-  getLevel() { return this.level; }
   getContent() { return this.content; }
   getTemplateIndex() { return this.templateIndex; }
+
+  isRoot() { return this.level === 0; }
+  isResolved() { return !/\[tmpl:\d+:\d+\]/.test(this.content); }
 
   appendText(content: string) { this.append(content); }
   appendTemplate(index: number) { this.append(`[tmpl:${this.id}:${index}]`); }
@@ -96,7 +98,6 @@ export class I18nContext {
     this.append(this.wrap('#', elementIndex, this.id, closed));
   }
 
-  resolved() { return !/\[tmpl:\d+:\d+\]/.test(this.content); }
   forkChildContext(index: number, templateIndex: number) {
     return new I18nContext(index, templateIndex, this.ref, this.level + 1, this.uniqueIdGen);
   }

--- a/packages/compiler/src/render3/view/i18n.ts
+++ b/packages/compiler/src/render3/view/i18n.ts
@@ -53,7 +53,8 @@ export function wrapI18nPlaceholder(content: string | number, contextId: number 
   return `${I18N_PLACEHOLDER_SYMBOL}${content}${blockId}${I18N_PLACEHOLDER_SYMBOL}`;
 }
 
-export function assembleI18nBoundString(strings: Array<string>, bindingStartIndex: number = 0, contextId: number = 0): string {
+export function assembleI18nBoundString(
+    strings: Array<string>, bindingStartIndex: number = 0, contextId: number = 0): string {
   if (!strings.length) return '';
   let acc = '';
   const lastIdx = strings.length - 1;

--- a/packages/compiler/src/render3/view/i18n.ts
+++ b/packages/compiler/src/render3/view/i18n.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as o from '../../output/output_ast';
+
 /** I18n separators for metadata **/
 const I18N_MEANING_SEPARATOR = '|';
 const I18N_ID_SEPARATOR = '@@';
@@ -68,6 +70,7 @@ function getSeqNubmerGenerator(startsAt: number = 0): () => number {
 export class I18nContext {
   private id: number;
   private content: string = '';
+  private bindings = new Set<o.Expression>();
 
   constructor(
       private index: number, private templateIndex: number|null = null, private ref: any,
@@ -88,6 +91,9 @@ export class I18nContext {
   getIndex() { return this.index; }
   getContent() { return this.content; }
   getTemplateIndex() { return this.templateIndex; }
+
+  getBindings() { return this.bindings; }
+  appendBinding(binding: o.Expression) { this.bindings.add(binding); }
 
   isRoot() { return this.level === 0; }
   isResolved() { return !/\[tmpl:\d+:\d+\]/.test(this.content); }

--- a/packages/compiler/src/render3/view/i18n.ts
+++ b/packages/compiler/src/render3/view/i18n.ts
@@ -21,7 +21,8 @@ export const I18N_PLACEHOLDER_SYMBOL = '�';
 // - "@@id",
 // - "description[@@id]",
 // - "meaning|description[@@id]"
-export function parseI18nMeta(i18n?: string): {description?: string, id?: string, meaning?: string} {
+export function parseI18nMeta(i18n?: string):
+    {description?: string, id?: string, meaning?: string} {
   let meaning: string|undefined;
   let description: string|undefined;
   let id: string|undefined;
@@ -66,42 +67,31 @@ export class I18nContext {
 
   constructor(private index: number, private ref: any, private level: number = 0) {}
 
-  getIndex() {
-    return this.index;
-  }
-  getRef() {
-    return this.ref;
-  }
-  getLevel() {
-    return this.level;
-  }
-  getContent() {
-    return this.content;
-  }
-  wrap(symbol: string, elementIndex: number, templateIndex?: number, closed?: boolean) {
+  private wrap(symbol: string, elementIndex: number, templateIndex: number|null, closed?: boolean) {
     const state = closed ? '/' : '';
     const tmplIndex = templateIndex ? `:${templateIndex}` : '';
     return wrapI18nPlaceholder(`${state}${symbol}${elementIndex}${tmplIndex}`);
+  }
+  private append(content: string) { this.content += content; }
 
-  }
-  append(content: string) {
-    this.content += content;
-  }
-  appendText(content: string) {
-    this.append(content);
-  }
-  appendElement(elementIndex: number, templateIndex?: number, closed?: boolean) {
+  getIndex() { return this.index; }
+  getRef() { return this.ref; }
+  getLevel() { return this.level; }
+  getContent() { return this.content; }
+  appendText(content: string) { this.append(content); }
+  appendElement(elementIndex: number, templateIndex: number|null, closed?: boolean) {
     this.append(this.wrap('#', elementIndex, templateIndex, closed));
   }
-  appendTemplate(index: number, templateIndex?: number) {
+  appendTemplate(index: number, templateIndex: number|null) {
     this.append(this.wrap('*', index, templateIndex));
     this.append(`tmpl${index}`);
     this.append(this.wrap('*', index, templateIndex, true));
   }
   resolved() {
+    // TODO: WIP, come up with better approach
     return !/tmpl/g.test(this.content);
   }
-  reconcile(templateIndex: any, templateContent: any) {
+  reconcile(templateIndex: number, templateContent: string) {
     this.content = this.content.replace(new RegExp(`tmpl${templateIndex}`), templateContent);
   }
 }

--- a/packages/compiler/src/render3/view/i18n.ts
+++ b/packages/compiler/src/render3/view/i18n.ts
@@ -64,7 +64,7 @@ export function assembleI18nBoundString(
   return acc;
 }
 
-function getSeqNubmerGenerator(startsAt: number = 0): () => number {
+function getSeqNumberGenerator(startsAt: number = 0): () => number {
   let current = startsAt;
   return () => current++;
 }
@@ -81,9 +81,9 @@ export class I18nContext {
   private bindings = new Set<o.Expression>();
 
   constructor(
-      private index: number, private templateIndex: number|null = null, private ref: any,
-      private level: number = 0, private uniqueIdGen?: (() => number)) {
-    this.uniqueIdGen = uniqueIdGen || getSeqNubmerGenerator();
+      private index: number, private templateIndex: number|null, private ref: any,
+      private level: number = 0, private uniqueIdGen?: () => number) {
+    this.uniqueIdGen = uniqueIdGen || getSeqNumberGenerator();
     this.id = this.uniqueIdGen();
   }
 

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -29,7 +29,7 @@ import {Identifiers as R3} from '../r3_identifiers';
 import {htmlAstToRender3Ast} from '../r3_template_transform';
 
 import {R3QueryMetadata} from './api';
-import {I18N_ATTR, I18N_ATTR_PREFIX, I18nContext, assembleI18nTemplate, parseI18nMeta} from './i18n';
+import {I18N_ATTR, I18N_ATTR_PREFIX, I18nContext, assembleI18nBoundString, parseI18nMeta} from './i18n';
 import {parseStyle} from './styling';
 import {CONTEXT_NAME, IMPLICIT_REFERENCE, NON_BINDABLE_ATTR, REFERENCE_PREFIX, RENDER_FLAGS, asLiteral, getAttrsForDirectiveMatching, invalid, trimTrailingNulls, unsupported} from './util';
 
@@ -554,7 +554,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
             const converted = value.visit(this._valueConverter);
             if (converted instanceof Interpolation) {
               const {strings, expressions} = converted;
-              const label = assembleI18nTemplate(strings);
+              const label = assembleI18nBoundString(strings);
               i18nAttrArgs.push(
                   o.literal(name), this.i18nTranslate(label, meta), o.literal(expressions.length));
               expressions.forEach(expression => {
@@ -845,7 +845,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       const value = text.value.visit(this._valueConverter);
       if (value instanceof Interpolation) {
         const {strings, expressions} = value;
-        const label = assembleI18nTemplate(strings);
+        const label = assembleI18nBoundString(strings, this.i18n.getBindings().size, this.i18n.getId());
         const implicit = o.variable(CONTEXT_NAME);
         expressions.forEach(expression => {
           const binding = this.convertExpressionBinding(implicit, expression);

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -248,7 +248,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   }
 
   i18nUpdateRef(context: I18nContext): void {
-    if (context.resolved() && context.getLevel() === 0) {
+    if (context.isRoot() && context.isResolved()) {
       this.constantPool.setDeferredTranslationConst(context.getRef(), context.getContent());
     }
   }

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -176,7 +176,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     }
 
     if (this.i18nContext) {
-      this.i18nStart(null);
+      this.i18nStart();
     }
 
     // This is the initial pass through the nodes of this template. In this pass, we
@@ -199,7 +199,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     this._nestedTemplateFns.forEach(buildTemplateFn => buildTemplateFn());
 
     if (this.i18nContext) {
-      this.i18nEnd(null);
+      this.i18nEnd();
     }
 
     // Generate all the creation mode instructions (e.g. resolve bindings in listeners)
@@ -239,7 +239,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   // LocalResolver
   getLocal(name: string): o.Expression|null { return this._bindingScope.get(name); }
 
-  i18nTranslate(label: string, meta?: string): any {
+  i18nTranslate(label: string, meta?: string): o.Expression {
     return this.constantPool.getTranslation(label, parseI18nMeta(meta), this.fileBasedI18nSuffix);
   }
 
@@ -253,7 +253,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     }
   }
 
-  i18nStart(span: ParseSourceSpan|null): void {
+  i18nStart(span: ParseSourceSpan|null = null): void {
     // console.log('[i18nStart]', this.templateIndex);
     const index = this.allocateDataSlot();
     const context = this.i18nContext;
@@ -270,10 +270,10 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     this.creationInstruction(span, R3.i18nStart, params);
   }
 
-  i18nEnd(span: ParseSourceSpan|null): void {
+  i18nEnd(span: ParseSourceSpan|null = null): void {
     // console.log('[i18nEnd]', this.templateIndex);
     if (this.i18nContext) {
-      this.i18nContext.reconcile(this.templateIndex, this.i18n !.getContent());
+      this.i18nContext.reconcile(this.templateIndex as number, this.i18n !.getContent());
     }
     this.i18nUpdateRef(this.i18nContext || this.i18n!);
     this.i18n = null; // reset local i18n context
@@ -723,7 +723,6 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
     if (!createSelfClosingInstruction) {
       if (this.i18n) {
-        // const templateIndex = this.templateIndex ? `:${this.templateIndex}` : '';
         this.i18n.appendElement(elementIndex, this.templateIndex, true);
       }
       // Finish element construction mode.

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -29,7 +29,7 @@ import {Identifiers as R3} from '../r3_identifiers';
 import {htmlAstToRender3Ast} from '../r3_template_transform';
 
 import {R3QueryMetadata} from './api';
-import {I18N_ATTR, I18N_ATTR_PREFIX, I18nContext, assembleI18nBoundString, parseI18nMeta} from './i18n';
+import {I18N_ATTR, I18N_ATTR_PREFIX, I18nContext, assembleI18nBoundString} from './i18n';
 import {parseStyle} from './styling';
 import {CONTEXT_NAME, IMPLICIT_REFERENCE, NON_BINDABLE_ATTR, REFERENCE_PREFIX, RENDER_FLAGS, asLiteral, getAttrsForDirectiveMatching, invalid, trimTrailingNulls, unsupported} from './util';
 
@@ -239,13 +239,11 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   // LocalResolver
   getLocal(name: string): o.Expression|null { return this._bindingScope.get(name); }
 
-  i18nTranslate(label: string, meta?: string): o.Expression {
-    return this.constantPool.getTranslation(label, parseI18nMeta(meta), this.fileBasedI18nSuffix);
+  i18nTranslate(label: string, meta: string = ''): o.Expression {
+    return this.constantPool.getTranslation(label, meta, this.fileBasedI18nSuffix);
   }
 
-  i18nAppendTranslationMeta(meta?: string) {
-    this.constantPool.appendTranslationMeta(parseI18nMeta(meta));
-  }
+  i18nAppendTranslationMeta(meta: string = '') { this.constantPool.appendTranslationMeta(meta); }
 
   i18nAllocateRef(): o.ReadVarExpr {
     return this.constantPool.getDeferredTranslationConst(this.fileBasedI18nSuffix);

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -29,8 +29,8 @@ import {Identifiers as R3} from '../r3_identifiers';
 import {htmlAstToRender3Ast} from '../r3_template_transform';
 
 import {R3QueryMetadata} from './api';
-import {parseStyle} from './styling';
 import {I18N_ATTR, I18N_ATTR_PREFIX, I18nContext, assembleI18nTemplate, parseI18nMeta} from './i18n';
+import {parseStyle} from './styling';
 import {CONTEXT_NAME, IMPLICIT_REFERENCE, NON_BINDABLE_ATTR, REFERENCE_PREFIX, RENDER_FLAGS, asLiteral, getAttrsForDirectiveMatching, invalid, trimTrailingNulls, unsupported} from './util';
 
 function mapBindingToInstruction(type: BindingType): o.ExternalReference|undefined {
@@ -99,8 +99,8 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
   constructor(
       private constantPool: ConstantPool, parentBindingScope: BindingScope, private level = 0,
-      private contextName: string|null, private i18nContext: I18nContext|null, private templateIndex: number|null,
-      private templateName: string|null,
+      private contextName: string|null, private i18nContext: I18nContext|null,
+      private templateIndex: number|null, private templateName: string|null,
       private viewQueries: R3QueryMetadata[], private directiveMatcher: SelectorMatcher|null,
       private directives: Set<o.Expression>, private pipeTypeByName: Map<string, o.Expression>,
       private pipes: Set<o.Expression>, private _namespace: o.ExternalReference,
@@ -257,9 +257,8 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     // console.log('[i18nStart]', this.templateIndex);
     const index = this.allocateDataSlot();
     const context = this.i18nContext;
-    const [ref, level] = context
-      ? [context.getRef(), context.getLevel() + 1]
-      : [this.i18nAllocateRef(), 0];
+    const [ref, level] =
+        context ? [context.getRef(), context.getLevel() + 1] : [this.i18nAllocateRef(), 0];
     this.i18n = new I18nContext(index, ref, level);
 
     // generate i18nStart instruction
@@ -275,8 +274,8 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     if (this.i18nContext) {
       this.i18nContext.reconcile(this.templateIndex as number, this.i18n !.getContent());
     }
-    this.i18nUpdateRef(this.i18nContext || this.i18n!);
-    this.i18n = null; // reset local i18n context
+    this.i18nUpdateRef(this.i18nContext || this.i18n !);
+    this.i18n = null;  // reset local i18n context
     this.creationInstruction(span, R3.i18nEnd);
   }
 
@@ -792,9 +791,9 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
     // Create the template function
     const templateVisitor = new TemplateDefinitionBuilder(
-        this.constantPool, this._bindingScope, this.level + 1, contextName, this.i18n, templateIndex, templateName, [],
-        this.directiveMatcher, this.directives, this.pipeTypeByName, this.pipes, this._namespace,
-        this.fileBasedI18nSuffix);
+        this.constantPool, this._bindingScope, this.level + 1, contextName, this.i18n,
+        templateIndex, templateName, [], this.directiveMatcher, this.directives,
+        this.pipeTypeByName, this.pipes, this._namespace, this.fileBasedI18nSuffix);
 
     // Nested templates must not be visited until after their parent templates have completed
     // processing, so they are queued here until after the initial pass. Otherwise, we wouldn't

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -532,10 +532,10 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
       if (isI18nRootElement) {
         this.i18nStart(element.sourceSpan);
-      }
-
-      if (this.i18n) {
-        this.i18n.appendElement(elementIndex);
+      } else {
+        if (this.i18n) {
+          this.i18n.appendElement(elementIndex);
+        }
       }
 
       // process i18n element attributes
@@ -731,13 +731,14 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     t.visitAll(this, element.children);
 
     if (!createSelfClosingInstruction) {
-      if (this.i18n) {
-        this.i18n.appendElement(elementIndex, true);
-      }
       // Finish element construction mode.
       const span = element.endSourceSpan || element.sourceSpan;
       if (isI18nRootElement) {
         this.i18nEnd(span);
+      } else {
+        if (this.i18n) {
+          this.i18n.appendElement(elementIndex, true);
+        }
       }
       if (isNonBindableMode) {
         this.creationInstruction(span, R3.enableBindings);

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -280,9 +280,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     // setup accumulated bindings
     const bindings = this.i18n !.getBindings();
     if (bindings.size) {
-      bindings.forEach(binding => {
-        this.updateInstruction(span, R3.i18nExp, [binding]);
-      });
+      bindings.forEach(binding => { this.updateInstruction(span, R3.i18nExp, [binding]); });
       const index: o.Expression = o.literal(this.i18n !.getIndex());
       this.updateInstruction(span, R3.i18nApply, [index]);
     }
@@ -845,7 +843,8 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       const value = text.value.visit(this._valueConverter);
       if (value instanceof Interpolation) {
         const {strings, expressions} = value;
-        const label = assembleI18nBoundString(strings, this.i18n.getBindings().size, this.i18n.getId());
+        const label =
+            assembleI18nBoundString(strings, this.i18n.getBindings().size, this.i18n.getId());
         const implicit = o.variable(CONTEXT_NAME);
         expressions.forEach(expression => {
           const binding = this.convertExpressionBinding(implicit, expression);

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -262,6 +262,8 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     // generate i18nStart instruction
     const params: o.Expression[] = [o.literal(index), this.i18n.getRef()];
     if (this.i18n.getId() > 0) {
+      // do not push 3rd argument (sub-block id)
+      // into i18nStart call for top level i18n context
       params.push(o.literal(this.i18n.getId()));
     }
     this.creationInstruction(span, R3.i18nStart, params);

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -533,7 +533,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
             this.updateInstruction(element.sourceSpan, R3.i18nApply, [index]);
           }
         }
-      }
+      });
 
       // initial styling for static style="..." attributes
       if (hasStylingInstructions) {

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -533,7 +533,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
             this.updateInstruction(element.sourceSpan, R3.i18nApply, [index]);
           }
         }
-      });
+      }
 
       // initial styling for static style="..." attributes
       if (hasStylingInstructions) {

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -11,6 +11,7 @@ import * as o from '../../output/output_ast';
 import * as t from '../r3_ast';
 
 import {R3QueryMetadata} from './api';
+import {isI18NAttribute} from './i18n';
 
 /** Name of the temporary to use during data binding */
 export const TEMPORARY_NAME = '_t';
@@ -26,17 +27,6 @@ export const REFERENCE_PREFIX = '_r';
 
 /** The name of the implicit context reference */
 export const IMPLICIT_REFERENCE = '$implicit';
-
-/** Name of the i18n attributes **/
-export const I18N_ATTR = 'i18n';
-export const I18N_ATTR_PREFIX = 'i18n-';
-
-/** I18n separators for metadata **/
-export const MEANING_SEPARATOR = '|';
-export const ID_SEPARATOR = '@@';
-
-/** Placeholder wrapper for i18n expressions **/
-export const I18N_PLACEHOLDER_SYMBOL = '�';
 
 /** Non bindable attribute name **/
 export const NON_BINDABLE_ATTR = 'ngNonBindable';
@@ -68,25 +58,6 @@ export function unsupported(feature: string): never {
 export function invalid<T>(arg: o.Expression | o.Statement | t.Node): never {
   throw new Error(
       `Invalid state: Visitor ${this.constructor.name} doesn't handle ${o.constructor.name}`);
-}
-
-export function isI18NAttribute(name: string): boolean {
-  return name === I18N_ATTR || name.startsWith(I18N_ATTR_PREFIX);
-}
-
-export function wrapI18nPlaceholder(content: string | number): string {
-  return `${I18N_PLACEHOLDER_SYMBOL}${content}${I18N_PLACEHOLDER_SYMBOL}`;
-}
-
-export function assembleI18nTemplate(strings: Array<string>): string {
-  if (!strings.length) return '';
-  let acc = '';
-  const lastIdx = strings.length - 1;
-  for (let i = 0; i < lastIdx; i++) {
-    acc += `${strings[i]}${wrapI18nPlaceholder(i)}`;
-  }
-  acc += strings[lastIdx];
-  return acc;
 }
 
 export function asLiteral(value: any): o.Expression {

--- a/packages/compiler/test/render3/view/i18n_spec.ts
+++ b/packages/compiler/test/render3/view/i18n_spec.ts
@@ -50,7 +50,7 @@ describe('I18nContext', () => {
     const childCtx = ctx.forkChildContext(6, templateIndex);
     expect(childCtx.getContent()).toBe('');
     expect(childCtx.getBindings().size).toBe(0);
-    expect(childCtx.getRef()).toBe(ctx.getRef()); // ref should be passed into child ctx
+    expect(childCtx.getRef()).toBe(ctx.getRef());  // ref should be passed into child ctx
     expect(childCtx.isRoot()).toBe(false);
 
     childCtx.appendText('Bar');

--- a/packages/compiler/test/render3/view/i18n_spec.ts
+++ b/packages/compiler/test/render3/view/i18n_spec.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../src/output/output_ast';
+import {I18nContext} from '../../../src/render3/view/i18n';
+
+describe('I18nContext', () => {
+  it('should support i18n content collection', () => {
+    const ctx = new I18nContext(5, null, 'myRef');
+
+    // basic checks
+    expect(ctx.isRoot()).toBe(true);
+    expect(ctx.isResolved()).toBe(true);
+    expect(ctx.getId()).toBe(0);
+    expect(ctx.getIndex()).toBe(5);
+    expect(ctx.getTemplateIndex()).toBeNull();
+    expect(ctx.getRef()).toBe('myRef');
+
+    // data collection checks
+    expect(ctx.getContent()).toBe('');
+    ctx.appendText('Foo');
+    ctx.appendElement(1);
+    ctx.appendText('Bar');
+    ctx.appendElement(1, true);
+    expect(ctx.getContent()).toBe('Foo�#1�Bar�/#1�');
+
+    // binding collection checks
+    expect(ctx.getBindings().size).toBe(0);
+    ctx.appendBinding(o.literal(1));
+    ctx.appendBinding(o.literal(2));
+    expect(ctx.getBindings().size).toBe(2);
+  });
+
+  it('should support nested contexts', () => {
+    const ctx = new I18nContext(5, null, 'myRef');
+    const templateIndex = 1;
+
+    // set some data for root ctx
+    ctx.appendText('Foo');
+    ctx.appendBinding(o.literal(1));
+    ctx.appendTemplate(templateIndex);
+    expect(ctx.isResolved()).toBe(false);
+
+    // create child context
+    const childCtx = ctx.forkChildContext(6, templateIndex);
+    expect(childCtx.getContent()).toBe('');
+    expect(childCtx.getBindings().size).toBe(0);
+    expect(childCtx.getRef()).toBe(ctx.getRef()); // ref should be passed into child ctx
+    expect(childCtx.isRoot()).toBe(false);
+
+    childCtx.appendText('Bar');
+    childCtx.appendElement(2);
+    childCtx.appendText('Baz');
+    childCtx.appendElement(2, true);
+    childCtx.appendBinding(o.literal(2));
+    childCtx.appendBinding(o.literal(3));
+
+    expect(childCtx.getContent()).toBe('Bar�#2:1�Baz�/#2:1�');
+    expect(childCtx.getBindings().size).toBe(2);
+
+    // reconcile
+    ctx.reconcileChildContext(childCtx);
+    expect(ctx.getContent()).toBe('Foo�*1:1�Bar�#2:1�Baz�/#2:1��/*1:1�');
+  });
+});

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -738,6 +738,12 @@
     "name": "I18NHtmlParser"
   },
   {
+    "name": "I18N_ID_SEPARATOR"
+  },
+  {
+    "name": "I18N_MEANING_SEPARATOR"
+  },
+  {
     "name": "I18nError"
   },
   {
@@ -3448,6 +3454,9 @@
   },
   {
     "name": "parseCookieValue"
+  },
+  {
+    "name": "parseI18nMeta"
   },
   {
     "name": "parseIntAutoRadix"


### PR DESCRIPTION
## PR Description
This PR introduces `i18nStart` and `i18nEnd` instructions support in i18n compiler, according to the [I18n Design Doc](https://github.com/angular/angular/blob/dfbb79ac72c1715a1506d2ab8441ef036a5f7bca/packages/core/src/render3/i18n.md). The main idea is to maintain an instance of `I18nContext` between start and end instructions, which keeps track of all i18n-related aspects (accumulates content, bindings, etc). When we enter a nested template (for ex. as a result of *ngIf), the top-level context is being passed down to the nested component, which uses this context to generate a child instance of `I18nContext` class (to handle nested template) and at the end, reconciles it back with the parent context.

### Notes

- `<ng-template i18n>`, `<ng-content i18n>` and `<ng-container i18n>` are not supported yet (coming next)
- the logic of `goog.getMsg` generation remained as is (was not changed in this PR)
- no ICU support introduced in this PR (coming next)

### Next steps (in followup PRs)

- `<ng-*>` tags support
- updates to tests logic to support � symbol in templates
- (to be discussed) `ConstantPool` refactoring to provide API to support Translation needs. Currently (historically) Translation-related logic to generate  constants, is located in `ConstantPool` - we can probably extract it out to `i18n.ts`.
- (to be discussed) introduce `i18n` instruction in case there is no other content in between `i18nStart` and `i18nEnd`, a-la `element` instruction

## PR Type

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
