### PR TITLE
fix(ivy): fix reference to pipeBind instruction with 2 args

### DIFF
--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -78,7 +78,7 @@ export const angularCoreEnv: {[name: string]: Function} = {
   'ɵprojection': r3.projection,
   'ɵelementProperty': r3.elementProperty,
   'ɵpipeBind1': r3.pipeBind1,
-  'ɵpipeBind2': r3.pipeBind1,
+  'ɵpipeBind2': r3.pipeBind2,
   'ɵpipeBind3': r3.pipeBind3,
   'ɵpipeBind4': r3.pipeBind4,
   'ɵpipeBindV': r3.pipeBindV,


### PR DESCRIPTION
This PR fixes reference to the `pipeBind` instruction with 2 arguments. Discovered while running existing `TestBed` tests with Ivy enabled.