### PR TITLE
fix(router): fix regression where navigateByUrl promise didn't resolve on CanLoad failure

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -606,6 +606,7 @@ export class Router {
                   const navCancel =
                       new NavigationCancel(t.id, this.serializeUrl(t.extractedUrl), e.message);
                   eventsSubject.next(navCancel);
+                  t.resolve(false);
                   /* All other errors should reset to the router's internal URL reference to the
                    * pre-error state. */
                 } else {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -2796,6 +2796,45 @@ describe('Integration', () => {
            ]);
          })));
 
+      // Regression where navigateByUrl with false CanLoad no longer resolved `false` value on
+      // navigateByUrl promise: https://github.com/angular/angular/issues/26284
+      it('should resolve navigateByUrl promise after CanLoad executes',
+          fakeAsync(inject(
+              [Router, Location, NgModuleFactoryLoader],
+              (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+
+                @Component({selector: 'lazy', template: 'lazy-loaded'})
+                class LazyLoadedComponent {
+                }
+
+                @NgModule({
+                  declarations: [LazyLoadedComponent],
+                  imports:
+                      [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])]
+                })
+                class LazyLoadedModule {
+                }
+
+                loader.stubbedModules = {lazy: LazyLoadedModule};
+                const fixture = createRoot(router, RootCmp);
+
+                router.resetConfig([
+                  {path: 'lazy-false', canLoad: ['alwaysFalse'], loadChildren: 'lazy'},
+                  {path: 'lazy-true', canLoad: ['alwaysTrue'], loadChildren: 'lazy'},
+                ]);
+
+                let navFalseResult: any;
+                let navTrueResult: any;
+                router.navigateByUrl('/lazy-false').then(v => { navFalseResult = v; });
+                advance(fixture);
+                router.navigateByUrl('/lazy-true').then(v => { navTrueResult = v; });
+                advance(fixture);
+
+                expect(navFalseResult).toBe(false);
+                expect(navTrueResult).toBe(true);
+
+              })));
+
       it('should execute CanLoad only once',
          fakeAsync(inject(
              [Router, Location, NgModuleFactoryLoader],

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -2799,41 +2799,41 @@ describe('Integration', () => {
       // Regression where navigateByUrl with false CanLoad no longer resolved `false` value on
       // navigateByUrl promise: https://github.com/angular/angular/issues/26284
       it('should resolve navigateByUrl promise after CanLoad executes',
-          fakeAsync(inject(
-              [Router, Location, NgModuleFactoryLoader],
-              (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+         fakeAsync(inject(
+             [Router, Location, NgModuleFactoryLoader],
+             (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
 
-                @Component({selector: 'lazy', template: 'lazy-loaded'})
-                class LazyLoadedComponent {
-                }
+               @Component({selector: 'lazy', template: 'lazy-loaded'})
+               class LazyLoadedComponent {
+               }
 
-                @NgModule({
-                  declarations: [LazyLoadedComponent],
-                  imports:
-                      [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])]
-                })
-                class LazyLoadedModule {
-                }
+               @NgModule({
+                 declarations: [LazyLoadedComponent],
+                 imports:
+                     [RouterModule.forChild([{path: 'loaded', component: LazyLoadedComponent}])]
+               })
+               class LazyLoadedModule {
+               }
 
-                loader.stubbedModules = {lazy: LazyLoadedModule};
-                const fixture = createRoot(router, RootCmp);
+               loader.stubbedModules = {lazy: LazyLoadedModule};
+               const fixture = createRoot(router, RootCmp);
 
-                router.resetConfig([
-                  {path: 'lazy-false', canLoad: ['alwaysFalse'], loadChildren: 'lazy'},
-                  {path: 'lazy-true', canLoad: ['alwaysTrue'], loadChildren: 'lazy'},
-                ]);
+               router.resetConfig([
+                 {path: 'lazy-false', canLoad: ['alwaysFalse'], loadChildren: 'lazy'},
+                 {path: 'lazy-true', canLoad: ['alwaysTrue'], loadChildren: 'lazy'},
+               ]);
 
-                let navFalseResult: any;
-                let navTrueResult: any;
-                router.navigateByUrl('/lazy-false').then(v => { navFalseResult = v; });
-                advance(fixture);
-                router.navigateByUrl('/lazy-true').then(v => { navTrueResult = v; });
-                advance(fixture);
+               let navFalseResult: any;
+               let navTrueResult: any;
+               router.navigateByUrl('/lazy-false').then(v => { navFalseResult = v; });
+               advance(fixture);
+               router.navigateByUrl('/lazy-true').then(v => { navTrueResult = v; });
+               advance(fixture);
 
-                expect(navFalseResult).toBe(false);
-                expect(navTrueResult).toBe(true);
+               expect(navFalseResult).toBe(false);
+               expect(navTrueResult).toBe(true);
 
-              })));
+             })));
 
       it('should execute CanLoad only once',
          fakeAsync(inject(


### PR DESCRIPTION
Fixes #26284

