### PR TITLE
docs: architecture next step - fix links to setup and cli docs

### DIFF
--- a/aio/content/guide/architecture-next-steps.md
+++ b/aio/content/guide/architecture-next-steps.md
@@ -4,13 +4,13 @@ After you understand the basic Angular building blocks, you can begin to learn m
 about the features and tools that are available to help you develop and deliver Angular applications.
 Here are some key features.
 
-## Responsive programming tools
+## Responsive programming
 
 * [Lifecycle hooks](guide/lifecycle-hooks): Tap into key moments in the lifetime of a component, from its creation to its destruction, by implementing the lifecycle hook interfaces.
 
 * [Observables and event processing](guide/observables): How to use observables with components and services to publish and subscribe to messages of any type, such as user-interaction events and asynchronous operation results.
 
-## Client-server interaction tools
+## Client-server interaction
 
 * [HTTP](guide/http): Communicate with a server to get data, save data, and invoke server-side actions with an HTTP client.
 
@@ -28,23 +28,28 @@ without deep knowledge of animation techniques or CSS.
 
 ## Support for the development cycle
 
+* [Compilation](guide/aot-compiler): Angular provides just-in-time (JIT) compilation for the development environment, and ahead-of-time (AOT) compilation for the production environment.
+
 * [Testing platform](guide/testing): Run unit tests on your application parts as they interact with the Angular framework.
 
 * [Internationalization](guide/i18n):  Make your app available in multiple languages with Angular's internationalization (i18n) tools.
 
-* [Compilation](guide/aot-compiler): Angular provides just-in-time (JIT) compilation for the development environment, and ahead-of-time (AOT) compilation for the production environment.
-
 * [Security guidelines](guide/security): Learn about Angular's built-in protections against common web-app vulnerabilities and attacks such as cross-site scripting attacks.
 
-## Setup and deployment tools
+## Setup, build, and deployment configuration
 
-* [Setup for local development](guide/setup): Set up a new project for development with QuickStart.
+* [CLI Command Reference](cli): The Angular CLI is a command-line tool that you use to create projects, generate application and library code, and perform a variety of ongoing development tasks such as testing, bundling, and deployment.
 
-* [Installation](guide/npm-packages): The [Angular CLI](https://cli.angular.io/), Angular applications, and Angular itself depend on features and functionality provided by libraries that are available as [npm](https://docs.npmjs.com/) packages.
+* [Workspace and File Structure](guide/file-structure): Understand the structure of Angular workspace and project folders. 
+
+* [npm Packages](guide/npm-packages): The Angular Framework, Angular CLI, and components used by Angular applications are packaged as [npm](https://docs.npmjs.com/) packages and distributed via the npm registry. The Angular CLI creates a default `package.json` file, which specifies a starter set of packages that work well together and jointly support many common application scenarios.
 
 * [TypeScript configuration](guide/typescript-configuration): TypeScript is the primary language for Angular application development.
 
 * [Browser support](guide/browser-support): Make your apps compatible across a wide range of browsers.
 
+* [Building and Serving](guide/build): Learn to define different build and proxy server configurations for your project, such as development, staging, and production.
+
 * [Deployment](guide/deployment): Learn techniques for deploying your Angular application to a remote server.
+
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ X] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
http://angular.io/guide/architecture-next-steps "Setup and deployment tools" section contains:
* Link to old QuickStart repo
* Link to old CLI wiki

It also positions npm packages incorrectly as an installation subject. 

Entire doc uses "tools" in an unusual way, so I removed it from subheadings. 

Issue Number: N/A


## What is the new behavior?
* Subheadings don't use the word "tools"
* "Setup and deployment tools" heading is changed
* Cross-reference items in "Setup and deployment tools" have been updated

In retrospect, Getting Started seemed like an odd link to have here, so I removed it. Most users will find Architecture after finding Getting Started. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[X ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
There's probably more work to do here, but I wanted to get out a quick update to fix the 2 bad references. 