### PR TITLE
ci(ng-bot): add triage PRs config for the ngbot

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -124,3 +124,23 @@ triage:
     -
       - "type: RFC / Discussion / question"
       - "comp: *"
+
+# options for the triage PR plugin
+triagePR:
+  # set to true to disable
+  disabled: false
+  # number of the milestone to apply when the PR has not been triaged yet
+  needsTriageMilestone: 83,
+  # number of the milestone to apply when the PR is triaged
+  defaultMilestone: 82,
+  # arrays of labels that determine if a PR has been triaged by the caretaker
+  l1TriageLabels:
+    -
+      - "comp: *"
+  # arrays of labels that determine if a PR has been fully triaged
+  l2TriageLabels:
+    -
+      - "type: *"
+      - "effort*"
+      - "risk*"
+      - "comp: *"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] CI related changes
```

## What is the new behavior?
Config to triage PRs

See ng bot PR: https://github.com/angular/github-robot/pull/33

## Does this PR introduce a breaking change?
```
[x] No
```