### PR TITLE
docs: change links to cli wiki to link to new aio docs files m to z

### DIFF
--- a/aio/content/guide/ngmodule-vs-jsmodule.md
+++ b/aio/content/guide/ngmodule-vs-jsmodule.md
@@ -29,7 +29,7 @@ JavaScript modules help you namespace, preventing accidental global variables.
 <!-- KW-- perMisko: let's discuss. This does not answer the question why it is different. Also, last sentence is confusing.-->
 NgModules are classes decorated with `@NgModule`. The `@NgModule` decorator’s `imports` array tells Angular what other NgModules the current module needs. The modules in the `imports` array are different than JavaScript modules because they are NgModules rather than regular JavaScript modules. Classes with an `@NgModule` decorator are by convention kept in their own files, but what makes them an `NgModule` isn’t being in their own file, like JavaScript modules; it’s the presence of `@NgModule` and its metadata.
 
-The `AppModule` generated from the Angular CLI demonstrates both kinds of modules in action:
+The `AppModule` generated from the [Angular CLI](cli) demonstrates both kinds of modules in action:
 
 ```typescript
 /* These are JavaScript import statements. Angular doesn’t know anything about these. */

--- a/aio/content/guide/ngmodules.md
+++ b/aio/content/guide/ngmodules.md
@@ -57,7 +57,7 @@ You then import these modules into the root module.
 
 ## The basic NgModule
 
-The CLI generates the following basic app module when creating a new app.
+The [Angular CLI](cli) generates the following basic app module when creating a new app.
 
 <code-example path="bootstrapping/src/app/app.module.ts" region="whole-ngmodule" title="src/app/app.module.ts" linenums="false">
 </code-example>

--- a/aio/content/guide/pipes.md
+++ b/aio/content/guide/pipes.md
@@ -223,7 +223,7 @@ Note the following:
 
 You must register custom pipes.
 If you don't, Angular reports an error.
-Angular CLI's generator registers the pipe automatically.
+The [Angular CLI's](cli) generator registers the pipe automatically.
 
 
 </div>

--- a/aio/content/guide/providers.md
+++ b/aio/content/guide/providers.md
@@ -13,7 +13,7 @@ A provider is an instruction to the DI system on how to obtain a value for a dep
 
 ## Providing a service
 
-If you already have a CLI generated app, create a service using the following CLI command in the root project directory. Replace _User_ with the name of your service.
+If you already have an app that was created with the [Angular CLI](cli), you can create a service using the [`ng generate`](cli/generate) CLI command in the root project directory. Replace _User_ with the name of your service.
 
 ```sh
 ng generate service User
@@ -46,7 +46,7 @@ The example above shows the preferred way to provide a service in a module. This
 
 ## Limiting provider scope by lazy loading modules
 
-In the basic CLI generated app, modules are eagerly loaded which means that they are all loaded when the app launches. Angular uses an injector system to make things available between modules. In an eagerly loaded app, the root application injector makes all of the providers in all of the modules available throughout the app.
+In the basic CLI-generated app, modules are eagerly loaded which means that they are all loaded when the app launches. Angular uses an injector system to make things available between modules. In an eagerly loaded app, the root application injector makes all of the providers in all of the modules available throughout the app.
 
 This behavior necessarily changes when you use lazy loading. Lazy loading is when you load modules only when you need them; for example, when routing. They aren’t loaded right away like with eagerly loaded modules. This means that any services listed in their provider arrays aren’t available because the root injector doesn’t know about these modules.
 

--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -1280,8 +1280,8 @@ The **Routing Module** has several characteristics:
 ### Integrate routing with your app
 
 The sample routing application does not include routing by default.
-When you use the CLI to create a project that will use routing, set the `--routing` option for the project or app, and for each NgModule. 
-When you create or initialize a new project (using the CLI `new` command) or a new app (using the `generate app` command), specify the `--routing` option.  This tells the CLI to include the `@angular/router` npm package and create a file named `app-routing.module.ts`.
+When you use the [Angular CLI](cli) to create a project that will use routing, set the `--routing` option for the project or app, and for each NgModule. 
+When you create or initialize a new project (using the CLI [`ng new`](cli/new) command) or a new app (using the [`ng generate app`](cli/generate) command), specify the `--routing` option.  This tells the CLI to include the `@angular/router` npm package and create a file named `app-routing.module.ts`.
 You can then use routing in any NgModule that you add to the project or app.
 
 For example, the following command generates an NgModule that can use routing.

--- a/aio/content/guide/service-worker-config.md
+++ b/aio/content/guide/service-worker-config.md
@@ -9,7 +9,7 @@ A basic understanding of the following:
 
 The `src/ngsw-config.json` configuration file specifies which files and data URLs the Angular
 service worker should cache and how it should update the cached files and data. The
-CLI processes the configuration file during `ng build --prod`. Manually, you can process
+[Angular CLI](cli) processes the configuration file during `ng build --prod`. Manually, you can process
 it with the `ngsw-config` tool:
 
 ```sh

--- a/aio/content/guide/service-worker-devops.md
+++ b/aio/content/guide/service-worker-devops.md
@@ -55,7 +55,7 @@ gets the correct content.
 
 To ensure resource integrity, the Angular service worker validates
 the hashes of all resources for which it has a hash. Typically for
-a CLI app, this is everything in the `dist` directory covered by
+an app created with the [Angular CLI](cli), this is everything in the `dist` directory covered by
 the user's `src/ngsw-config.json` configuration.
 
 If a particular file fails validation, the Angular service worker

--- a/aio/content/guide/service-worker-getting-started.md
+++ b/aio/content/guide/service-worker-getting-started.md
@@ -1,15 +1,11 @@
 # Getting started with service workers
 
 
-This document explains how to enable Angular service worker support in your CLI projects. It then uses a simple example to show you a service worker in action, demonstrating loading and basic caching. 
+This document explains how to enable Angular service worker support in projects that you created with the [Angular CLI](cli). It then uses a simple example to show you a service worker in action, demonstrating loading and basic caching. 
 
 #### Prerequisites
 
-A basic understanding of the following:
-* [Introduction to Angular service workers](guide/service-worker-intro).
-* Angular v6, including Angular CLI v6.
-
-<hr />
+A basic understanding of the information in [Introduction to Angular service workers](guide/service-worker-intro).
 
 
 ## Adding a service worker to your project

--- a/aio/content/guide/styleguide.md
+++ b/aio/content/guide/styleguide.md
@@ -4697,7 +4697,7 @@ Compare with the less preferred `host` metadata alternative.
 
 
 
-**Why?** When you register a service in the `@Injectable` decorator of the service, optimization tools such as those used by the CLI's production builds can perform tree shaking and remove services that aren't used by your app.
+**Why?** When you register a service in the `@Injectable` decorator of the service, optimization tools such as those used by the [Angular CLI's](cli) production builds can perform tree shaking and remove services that aren't used by your app.
 
 </div>
 

--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -3,7 +3,7 @@
 
 This guide offers tips and techniques for unit and integration testing Angular applications.
 
-The guide presents tests of a sample CLI application that is much like the [_Tour of Heroes_ tutorial](tutorial).
+The guide presents tests of a sample application created with the [Angular CLI](cli). This sample application is much like the one created in the [_Tour of Heroes_ tutorial](tutorial).
 The sample application and all tests in this guide are available for inspection and experimentation:
 
 - <live-example embedded-style>Sample app</live-example>
@@ -16,7 +16,7 @@ The sample application and all tests in this guide are available for inspection 
 The Angular CLI downloads and install everything you need to test an Angular application with the [Jasmine test framework](https://jasmine.github.io/).
 
 The project you create with the CLI is immediately ready to test.
-Just run this one CLI command:
+Just run the [`ng test`](cli/test) CLI command:
 
 <code-example language="sh" class="code-shell">
   ng test

--- a/aio/content/guide/updating.md
+++ b/aio/content/guide/updating.md
@@ -39,7 +39,7 @@ To check your app's version of Angular: From within your project directory, use 
 
 The most recent stable released version of Angular appears in the [Angular documentation](https://angular.io/docs "Angular documentation") at the bottom of the left side navigation. For example, `stable (v5.2.9)`.
 
-You can also find the most current version of Angular by using the [CLI command `ng update`](https://github.com/angular/angular-cli/wiki/update "Angular CLI update documentation"). By default, `ng update` (without additional arguments) lists the updates that are available to you.  
+You can also find the most current version of Angular by using the CLI command [`ng update`](cli/update). By default, `ng update` (without additional arguments) lists the updates that are available to you.  
 
 
 {@a updating}
@@ -49,7 +49,7 @@ To make updating easy, we provide complete instructions in the interactive [Angu
 
 The Angular Update Guide provides customized update instructions, based on the current and target versions that you specify. It includes basic and advanced update paths, to match the complexity of your applications. It also includes troubleshooting information and any recommended manual changes to help you get the most out of the new release. 
 
-For simple updates, the [CLI command `ng update`](https://github.com/angular/angular-cli/wiki/update "Angular CLI update documentation") is all you need. Without additional arguments, `ng update` lists the updates that are available to you and provides recommended steps to update your application to the most current version. 
+For simple updates, the CLI command [`ng update`](cli/update) is all you need. Without additional arguments, `ng update` lists the updates that are available to you and provides recommended steps to update your application to the most current version. 
 
 {@a resources}
 ## Resource summary
@@ -62,7 +62,7 @@ For simple updates, the [CLI command `ng update`](https://github.com/angular/ang
 
 * Update instructions: [Angular Update Guide](https://update.angular.io/ "Angular Update Guide")
 
-* Update command reference: [Angular CLI update documentation](https://github.com/angular/angular-cli/wiki/update "Angular CLI update documentation")
+* Update command reference: [Angular CLI `ng update` command reference](cli/update)
 
 * Versioning, release, support, and deprecation practices: [Angular versioning and releases](guide/releases "Angular versioning and releases")
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
See PR https://github.com/angular/angular/pull/26489
This PR does the same changes for guide files that begin with letters m-z.


Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
