### PR TITLE
fix(router): remove type bludgeoning of context and outlet when running CanDeactivate

### DIFF
--- a/packages/router/src/utils/preactivation.ts
+++ b/packages/router/src/utils/preactivation.ts
@@ -121,8 +121,8 @@ function getRouteGuards(
     }
 
     if (shouldRun) {
-      const outlet = context !.outlet !;
-      checks.canDeactivateChecks.push(new CanDeactivate(outlet.component, curr));
+      const component = context && context.outlet && context.outlet.component || null;
+      checks.canDeactivateChecks.push(new CanDeactivate(component, curr));
     }
   } else {
     if (curr) {


### PR DESCRIPTION
Fixes #18253

Based on https://github.com/angular/angular/pull/19374

This PR doesn't have associated tests because it should have been a type failure from the beginning. We had used `!` to tell TS these objects couldn't be null when they clearly can. Existing tests continue to work, which should be the requirement to fix this issue.