### PR TITLE
fix(ivy): stub TestBed.compileComponents implementation

### DIFF
--- a/packages/core/test/test_bed_async_spec.ts
+++ b/packages/core/test/test_bed_async_spec.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {TestBed} from '@angular/core/testing/src/test_bed';
+import {AsyncTestCompleter, ddescribe, describe, inject, it} from '@angular/core/testing/src/testing_internal';
+
+describe('TestBed with async processing', () => {
+
+  beforeEach(() => { TestBed.resetTestingModule(); });
+
+  it('should allow injecting AsyncTestCompleter',
+     inject([AsyncTestCompleter], (async: AsyncTestCompleter) => { async.done(); }));
+});

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -270,9 +270,10 @@ export class TestBedRender3 implements Injector, TestBed {
     }
   }
 
-  // TODO(vicb): implement
   compileComponents(): Promise<any> {
-    throw new Error('Render3TestBed.compileComponents is not implemented yet');
+    // assume for now that components don't use templateUrl / stylesUrl to unblock further testing
+    // TODO(pk): plug into the ivy's resource fetching pipeline
+    return Promise.resolve();
   }
 
   get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND): any {


### PR DESCRIPTION
This is a quick PR to unblock some of the `TestBed` tests with ivy. It takes care of the situation where the existing TestBed infrastructure calls `compileComponents` but in fact doesn't do any async processing. This is the case for tests that use `AsyncTestCompleter` but don't do async compilation of components (that is, there are no components with `templateUrl` / `stylesUrl`).

We still need to add proper support for components with `templateUrl` / `stylesUrl` but this is a larger topics that will require more work. Still, this PR is valuable as it makes several existing tests pass with ivy.