### PR TITLE
build(docs-infra): throw error if using `title` on code snippets

### DIFF
--- a/aio/tools/transforms/examples-package/inline-tag-defs/example.js
+++ b/aio/tools/transforms/examples-package/inline-tag-defs/example.js
@@ -23,7 +23,7 @@ module.exports = function exampleInlineTagDef(parseArgString, createDocMessage) 
       var unnamedArgs = tagArgs._;
       var relativePath = unnamedArgs[0];
       var regionName = tagArgs.region || (unnamedArgs.length > 1 ? unnamedArgs[1] : '');
-      if (regionName === '\'\'') regionName = '';
+      if (regionName === '\'\'' || regionName === '""') regionName = '';
       var header = tagArgs.header || (unnamedArgs.length > 2 ? unnamedArgs.slice(2).join(' ') : '');
       var linenums = tagArgs.linenums;
       // var stylePattern = tagArgs.stylePattern;  // TODO: not yet implemented here

--- a/aio/tools/transforms/examples-package/inline-tag-defs/example.js
+++ b/aio/tools/transforms/examples-package/inline-tag-defs/example.js
@@ -11,7 +11,7 @@ var entities = require('entities');
  * {@example core/application_spec.ts -region=hello-app -header='Sample component' }
  * @kind function
  */
-module.exports = function exampleInlineTagDef(parseArgString, createDocMessage, getExampleRegion) {
+module.exports = function exampleInlineTagDef(parseArgString, createDocMessage) {
   return {
     name: 'example',
     description:
@@ -24,14 +24,17 @@ module.exports = function exampleInlineTagDef(parseArgString, createDocMessage, 
       var relativePath = unnamedArgs[0];
       var regionName = tagArgs.region || (unnamedArgs.length > 1 ? unnamedArgs[1] : '');
       if (regionName === '\'\'') regionName = '';
-      var header = tagArgs.header || (unnamedArgs.length > 2 ? unnamedArgs.slice(2).join(' ') : null);
+      var header = tagArgs.header || (unnamedArgs.length > 2 ? unnamedArgs.slice(2).join(' ') : '');
       var linenums = tagArgs.linenums;
       // var stylePattern = tagArgs.stylePattern;  // TODO: not yet implemented here
 
-      const sourceCode = getExampleRegion(doc, relativePath, regionName);
+      if (!relativePath) {
+        throw new Error(createDocMessage(
+          `Missing required "path" on @${tagName} inline tag "{@${tagName} ${tagDescription}}".\n` +
+          'Usage: {@example some/path [some-region [Some header [linenums="true|false"]]]}', doc));
+      }
 
-      const attributes = [];
-      if (relativePath) attributes.push(` path="${relativePath}"`);
+      const attributes = [` path="${relativePath}"`];
       if (regionName) attributes.push(` region="${regionName}"`);
       if (header) attributes.push(` header="${header}"`);
       if (linenums !== undefined) attributes.push(` linenums="${linenums}"`);
@@ -40,8 +43,7 @@ module.exports = function exampleInlineTagDef(parseArgString, createDocMessage, 
       // in order to throw an appropriate error in `renderExamples` later.
       if (tagArgs.title) attributes.push(` title="${tagArgs.title}"`);
 
-      return '<code-example' + attributes.join('') + '>\n' + sourceCode + '\n</code-example>';
+      return '<code-example' + attributes.join('') + '></code-example>';
     }
   };
 };
-

--- a/aio/tools/transforms/examples-package/inline-tag-defs/example.js
+++ b/aio/tools/transforms/examples-package/inline-tag-defs/example.js
@@ -31,8 +31,14 @@ module.exports = function exampleInlineTagDef(parseArgString, createDocMessage, 
       const sourceCode = getExampleRegion(doc, relativePath, regionName);
 
       const attributes = [];
+      if (relativePath) attributes.push(` path="${relativePath}"`);
+      if (regionName) attributes.push(` region="${regionName}"`);
       if (header) attributes.push(` header="${header}"`);
       if (linenums !== undefined) attributes.push(` linenums="${linenums}"`);
+
+      // Preserve the no-longer-supported `title` attribute,
+      // in order to throw an appripriate error in `renderExamples` later.
+      if (tagArgs.title) attributes.push(` title="${tagArgs.title}"`);
 
       return '<code-example' + attributes.join('') + '>\n' + sourceCode + '\n</code-example>';
     }

--- a/aio/tools/transforms/examples-package/inline-tag-defs/example.js
+++ b/aio/tools/transforms/examples-package/inline-tag-defs/example.js
@@ -37,7 +37,7 @@ module.exports = function exampleInlineTagDef(parseArgString, createDocMessage, 
       if (linenums !== undefined) attributes.push(` linenums="${linenums}"`);
 
       // Preserve the no-longer-supported `title` attribute,
-      // in order to throw an appripriate error in `renderExamples` later.
+      // in order to throw an appropriate error in `renderExamples` later.
       if (tagArgs.title) attributes.push(` title="${tagArgs.title}"`);
 
       return '<code-example' + attributes.join('') + '>\n' + sourceCode + '\n</code-example>';

--- a/aio/tools/transforms/examples-package/inline-tag-defs/example.spec.js
+++ b/aio/tools/transforms/examples-package/inline-tag-defs/example.spec.js
@@ -2,14 +2,12 @@ var testPackage = require('../../helpers/test-package');
 var Dgeni = require('dgeni');
 
 describe('example inline-tag-def', function() {
-  let injector, tag, collectExamples, exampleMap;
+  let tag;
 
   beforeEach(() => {
     const dgeni = new Dgeni([testPackage('examples-package', true)]);
-    injector = dgeni.configureInjector();
+    const injector = dgeni.configureInjector();
     tag = injector.get('exampleInlineTagDef');
-    collectExamples = injector.get('collectExamples');
-    exampleMap = injector.get('exampleMap');
   });
 
   it('should be available as a service', () => {
@@ -20,62 +18,63 @@ describe('example inline-tag-def', function() {
   describe('handler', () => {
     let handler;
 
-    beforeEach(() => {
-      handler = tag.handler;
-      collectExamples.exampleFolders = ['examples'];
-      exampleMap['examples'] = {
-        'test/url': { regions: {
-          '': { renderedContent: 'whole file' },
-          'region-1': { renderedContent: 'region 1 contents' }
-        } }
-      };
+    beforeEach(() => handler = tag.handler);
+
+    it('should throw if no path is specified add the specified path', () => {
+      expect(() => handler({}, 'example', '')).toThrowError(
+        'Missing required "path" on @example inline tag "{@example }".\n' +
+        'Usage: {@example some/path [some-region [Some header [linenums="true|false"]]]} - doc');
+
+      const tagDescription = 'region=\'region-1\' header="Some Header" linenums="true"';
+      expect(() => handler({}, 'example', tagDescription)).toThrowError(
+        `Missing required "path" on @example inline tag "{@example ${tagDescription}}".\n` +
+        'Usage: {@example some/path [some-region [Some header [linenums="true|false"]]]} - doc');
     });
 
-    it('should throw an error if there is no matching example', () => {
-      expect(function() {
-        handler({}, 'example', 'missing/uri');
-      }).toThrowError();
-
-      expect(function() {
-        handler({}, 'example', 'test/url missing-region');
-      }).toThrowError();
-    });
-
-    it('should contain the whole contents from the example file if no region is specified', () => {
-      expect(handler({}, 'example', 'test/url')).toEqual('<code-example path="test/url">\nwhole file\n</code-example>');
-    });
-
-    it('should contain the region contents from the example file if a region is specified', () => {
+    it('should add a region if specified', () => {
       expect(handler({}, 'example', 'test/url region-1')).toEqual(
-        '<code-example path="test/url" region="region-1">\nregion 1 contents\n</code-example>');
+        '<code-example path="test/url" region="region-1"></code-example>');
+
+      expect(handler({}, 'example', 'test/url -region=\'region-1\'')).toEqual(
+        '<code-example path="test/url" region="region-1"></code-example>');
+
+      expect(handler({}, 'example', 'test/url region="region-1"')).toEqual(
+        '<code-example path="test/url" region="region-1"></code-example>');
+    });
+
+    it('should add no region if an empty (\'\') region is specified', () => {
+      expect(handler({}, 'example', 'test/url \'\'')).toEqual(
+        '<code-example path="test/url"></code-example>');
+
+      expect(handler({}, 'example', 'test/url \'\' Some Header')).toEqual(
+        '<code-example path="test/url" header="Some Header"></code-example>');
     });
 
     it('should add a header if specified', () => {
       expect(handler({}, 'example', 'test/url region-1 \'Some Header\'')).toEqual(
-        '<code-example path="test/url" region="region-1" header="Some Header">\nregion 1 contents\n</code-example>');
+        '<code-example path="test/url" region="region-1" header="Some Header"></code-example>');
+
       expect(handler({}, 'example', 'test/url region-1 Some Header')).toEqual(
-        '<code-example path="test/url" region="region-1" header="Some Header">\nregion 1 contents\n</code-example>');
+        '<code-example path="test/url" region="region-1" header="Some Header"></code-example>');
+
+      expect(handler({}, 'example', 'test/url header="Some Header"')).toEqual(
+        '<code-example path="test/url" header="Some Header"></code-example>');
     });
 
-    it('should contain the whole contents from the example file if an empty ("") region is specified', () => {
-      expect(handler({}, 'example', 'test/url \'\'')).toEqual(
-        '<code-example path="test/url">\nwhole file\n</code-example>');
-      expect(handler({}, 'example', 'test/url \'\' Some Header')).toEqual(
-        '<code-example path="test/url" header="Some Header">\nwhole file\n</code-example>');
-    });
-
-    it('should add in linenum attribute if specified', () => {
+    it('should add a linenum attribute if specified', () => {
       expect(handler({}, 'example', 'test/url --linenums=\'false\'')).toEqual(
-        '<code-example path="test/url" linenums="false">\nwhole file\n</code-example>');
-      expect(handler({}, 'example', 'test/url --linenums=\'true\'')).toEqual(
-        '<code-example path="test/url" linenums="true">\nwhole file\n</code-example>');
-      expect(handler({}, 'example', 'test/url --linenums=\'15\'')).toEqual(
-        '<code-example path="test/url" linenums="15">\nwhole file\n</code-example>');
+        '<code-example path="test/url" linenums="false"></code-example>');
+
+      expect(handler({}, 'example', 'test/url -linenums=\'true\'')).toEqual(
+        '<code-example path="test/url" linenums="true"></code-example>');
+
+      expect(handler({}, 'example', 'test/url linenums=\'15\'')).toEqual(
+        '<code-example path="test/url" linenums="15"></code-example>');
     });
 
     it('should preserve the title if specified', () => {
       expect(handler({}, 'example', 'test/url title="Some Title"')).toEqual(
-        '<code-example path="test/url" title="Some Title">\nwhole file\n</code-example>');
+        '<code-example path="test/url" title="Some Title"></code-example>');
     });
   });
 });

--- a/aio/tools/transforms/examples-package/inline-tag-defs/example.spec.js
+++ b/aio/tools/transforms/examples-package/inline-tag-defs/example.spec.js
@@ -42,27 +42,40 @@ describe('example inline-tag-def', function() {
     });
 
     it('should contain the whole contents from the example file if no region is specified', () => {
-      expect(handler({}, 'example', 'test/url')).toEqual('<code-example>\nwhole file\n</code-example>');
+      expect(handler({}, 'example', 'test/url')).toEqual('<code-example path="test/url">\nwhole file\n</code-example>');
     });
 
     it('should contain the region contents from the example file if a region is specified', () => {
-      expect(handler({}, 'example', 'test/url region-1')).toEqual('<code-example>\nregion 1 contents\n</code-example>');
+      expect(handler({}, 'example', 'test/url region-1')).toEqual(
+        '<code-example path="test/url" region="region-1">\nregion 1 contents\n</code-example>');
     });
 
     it('should add a header if specified', () => {
-      expect(handler({}, 'example', 'test/url region-1 \'Some Header\'')).toEqual('<code-example header="Some Header">\nregion 1 contents\n</code-example>');
-      expect(handler({}, 'example', 'test/url region-1 Some Header')).toEqual('<code-example header="Some Header">\nregion 1 contents\n</code-example>');
+      expect(handler({}, 'example', 'test/url region-1 \'Some Header\'')).toEqual(
+        '<code-example path="test/url" region="region-1" header="Some Header">\nregion 1 contents\n</code-example>');
+      expect(handler({}, 'example', 'test/url region-1 Some Header')).toEqual(
+        '<code-example path="test/url" region="region-1" header="Some Header">\nregion 1 contents\n</code-example>');
     });
 
     it('should contain the whole contents from the example file if an empty ("") region is specified', () => {
-      expect(handler({}, 'example', 'test/url \'\'')).toEqual('<code-example>\nwhole file\n</code-example>');
-      expect(handler({}, 'example', 'test/url \'\' Some Header')).toEqual('<code-example header="Some Header">\nwhole file\n</code-example>');
+      expect(handler({}, 'example', 'test/url \'\'')).toEqual(
+        '<code-example path="test/url">\nwhole file\n</code-example>');
+      expect(handler({}, 'example', 'test/url \'\' Some Header')).toEqual(
+        '<code-example path="test/url" header="Some Header">\nwhole file\n</code-example>');
     });
 
     it('should add in linenum attribute if specified', () => {
-      expect(handler({}, 'example', 'test/url --linenums=\'false\'')).toEqual('<code-example linenums="false">\nwhole file\n</code-example>');
-      expect(handler({}, 'example', 'test/url --linenums=\'true\'')).toEqual('<code-example linenums="true">\nwhole file\n</code-example>');
-      expect(handler({}, 'example', 'test/url --linenums=\'15\'')).toEqual('<code-example linenums="15">\nwhole file\n</code-example>');
+      expect(handler({}, 'example', 'test/url --linenums=\'false\'')).toEqual(
+        '<code-example path="test/url" linenums="false">\nwhole file\n</code-example>');
+      expect(handler({}, 'example', 'test/url --linenums=\'true\'')).toEqual(
+        '<code-example path="test/url" linenums="true">\nwhole file\n</code-example>');
+      expect(handler({}, 'example', 'test/url --linenums=\'15\'')).toEqual(
+        '<code-example path="test/url" linenums="15">\nwhole file\n</code-example>');
+    });
+
+    it('should preserve the title if specified', () => {
+      expect(handler({}, 'example', 'test/url title="Some Title"')).toEqual(
+        '<code-example path="test/url" title="Some Title">\nwhole file\n</code-example>');
     });
   });
 });

--- a/aio/tools/transforms/examples-package/inline-tag-defs/example.spec.js
+++ b/aio/tools/transforms/examples-package/inline-tag-defs/example.spec.js
@@ -46,7 +46,7 @@ describe('example inline-tag-def', function() {
       expect(handler({}, 'example', 'test/url \'\'')).toEqual(
         '<code-example path="test/url"></code-example>');
 
-      expect(handler({}, 'example', 'test/url \'\' Some Header')).toEqual(
+      expect(handler({}, 'example', 'test/url "" Some Header')).toEqual(
         '<code-example path="test/url" header="Some Header"></code-example>');
     });
 

--- a/aio/tools/transforms/examples-package/inline-tag-defs/example.spec.js
+++ b/aio/tools/transforms/examples-package/inline-tag-defs/example.spec.js
@@ -42,9 +42,15 @@ describe('example inline-tag-def', function() {
         '<code-example path="test/url" region="region-1"></code-example>');
     });
 
-    it('should add no region if an empty (\'\') region is specified', () => {
+    it('should add no region if an empty (\'\'/"") region is specified', () => {
       expect(handler({}, 'example', 'test/url \'\'')).toEqual(
         '<code-example path="test/url"></code-example>');
+
+      expect(handler({}, 'example', 'test/url ""')).toEqual(
+        '<code-example path="test/url"></code-example>');
+
+      expect(handler({}, 'example', 'test/url \'\' Some Header')).toEqual(
+        '<code-example path="test/url" header="Some Header"></code-example>');
 
       expect(handler({}, 'example', 'test/url "" Some Header')).toEqual(
         '<code-example path="test/url" header="Some Header"></code-example>');

--- a/aio/tools/transforms/examples-package/processors/render-examples.spec.js
+++ b/aio/tools/transforms/examples-package/processors/render-examples.spec.js
@@ -84,10 +84,10 @@ describe('renderExamples processor', () => {
 
       it('should cope with spaces and double quotes inside attribute values', () => {
         const docs = [
-          { renderedContent: `<${CODE_TAG} title='a "quoted" value' path="test/url"></${CODE_TAG}>`}
+          { renderedContent: `<${CODE_TAG} header='a "quoted" value' path="test/url"></${CODE_TAG}>`}
         ];
         processor.$process(docs);
-        expect(docs[0].renderedContent).toEqual(`<${CODE_TAG} title="a &quot;quoted&quot; value" path="test/url">\nwhole file\n</${CODE_TAG}>`);
+        expect(docs[0].renderedContent).toEqual(`<${CODE_TAG} header="a &quot;quoted&quot; value" path="test/url">\nwhole file\n</${CODE_TAG}>`);
       });
 
       it('should throw an exception if the code-example tag is not closed correctly', () => {
@@ -116,6 +116,55 @@ describe('renderExamples processor', () => {
         expect(log.warn).toHaveBeenCalledWith(
           'Missing example file... relativePath: "missing/url". - doc\n' +
           'Example files can be found in the following relative paths: "examples" - doc');
+      });
+
+      it('should throw an exception if any code-example tag has a `title` attribute', () => {
+        const docs = [
+          {
+            name: 'Document A',
+            renderedContent: `
+              Example 1: <${CODE_TAG} path="test/url" header="This is a header "></${CODE_TAG}>
+              Example 2: <${CODE_TAG} path="test/url" title="This is a title 2"></${CODE_TAG}>
+            `,
+          },
+          {
+            name: 'Document B',
+            renderedContent: `
+              Example 3: <${CODE_TAG} path="test/url" title="This is a title 3"></${CODE_TAG}>
+              Example 4: <${CODE_TAG} path="test/url" header="This is a header 4"></${CODE_TAG}>
+            `,
+          },
+        ];
+
+        expect(() => processor.$process(docs)).toThrowError(
+          'Some code snippets use the `title` attribute instead of `header`.');
+
+        expect(log.error).toHaveBeenCalledTimes(2);
+        expect(log.error).toHaveBeenCalledWith(
+          `Using the "title" attribute for specifying a ${CODE_TAG} header is no longer supported. ` +
+          'Use the "header" attribute instead.\n' +
+          `<${CODE_TAG} path="test/url" title="This is a title 2"> - doc "Document A"`);
+        expect(log.error).toHaveBeenCalledWith(
+          `Using the "title" attribute for specifying a ${CODE_TAG} header is no longer supported. ` +
+          'Use the "header" attribute instead.\n' +
+          `<${CODE_TAG} path="test/url" title="This is a title 3"> - doc "Document B"`);
+      });
+
+      it('should throw an exception for `title` attribute even if `ignoreBrokenExamples` is set to true', () => {
+        processor.ignoreBrokenExamples = true;
+        const docs = [
+          { renderedContent: `<${CODE_TAG} path="test/url" title="This is a title"></${CODE_TAG}>` },
+        ];
+        expect(() => processor.$process(docs)).toThrowError(
+          'Some code snippets use the `title` attribute instead of `header`.');
+      });
+
+      it('should throw an exception for `title` attribute even if there is no `path` attribute', () => {
+        const docs = [
+          { renderedContent: `<${CODE_TAG} title="This is a title">Hard-coded contents.</${CODE_TAG}>` },
+        ];
+        expect(() => processor.$process(docs)).toThrowError(
+          'Some code snippets use the `title` attribute instead of `header`.');
       });
     })
   );

--- a/aio/tools/transforms/examples-package/services/getExampleRegion.js
+++ b/aio/tools/transforms/examples-package/services/getExampleRegion.js
@@ -15,7 +15,7 @@ module.exports = function getExampleRegion(exampleMap, createDocMessage, collect
     // If still no file then we error
     if (!exampleFile) {
       const gitIgnoreFile = collectExamples.isExampleIgnored(relativePath);
-      if( gitIgnoreFile) {
+      if (gitIgnoreFile) {
         const message = createDocMessage('Ignored example file... relativePath: "' + relativePath + '"', doc) + '\n' +
         'This example file exists but has been ignored by a rule, in "' + gitIgnoreFile + '".';
         throw new Error(message);


### PR DESCRIPTION
Since #26396, the `title` property is ignored and `header` should be used instead for specifying a code snippet's header.

This PR ensures that we don't accidentally set `title` have it be silently ignored.
