### PR TITLE
build(docs-infra): Add github links to CLI docs

### DIFF
--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -34,6 +34,7 @@ module.exports = new Package('angular-api', [basePackage, typeScriptPackage])
   .processor(require('./processors/removeInjectableConstructors'))
   .processor(require('./processors/processPackages'))
   .processor(require('./processors/processNgModuleDocs'))
+  .processor(require('./processors/fixupRealProjectRelativePath'))
 
 
   /**

--- a/aio/tools/transforms/angular-api-package/processors/fixupRealProjectRelativePath.js
+++ b/aio/tools/transforms/angular-api-package/processors/fixupRealProjectRelativePath.js
@@ -1,0 +1,14 @@
+module.exports = function fixupRealProjectRelativePath(API_DOC_TYPES) {
+  return {
+    $runAfter: ['readTypeScriptModules'],
+    $runBefore: ['processing-docs'],
+    $process(docs) {
+      docs.forEach(doc => {
+        if (API_DOC_TYPES.indexOf(doc.docType) !== -1 && doc.fileInfo && doc.fileInfo.realProjectRelativePath) {
+          // this is an API doc - so fix up its real path
+          doc.fileInfo.realProjectRelativePath = 'packages/' + doc.fileInfo.realProjectRelativePath;
+        }
+      });
+    }
+  };
+};

--- a/aio/tools/transforms/angular-api-package/processors/fixupRealProjectRelativePath.spec.js
+++ b/aio/tools/transforms/angular-api-package/processors/fixupRealProjectRelativePath.spec.js
@@ -1,0 +1,36 @@
+const testPackage = require('../../helpers/test-package');
+const processorFactory = require('./fixupRealProjectRelativePath');
+const Dgeni = require('dgeni');
+
+describe('fixupRealProjectRelativePath processor', () => {
+
+  it('should be available on the injector', () => {
+    const dgeni = new Dgeni([testPackage('angular-api-package')]);
+    const injector = dgeni.configureInjector();
+    const processor = injector.get('fixupRealProjectRelativePath');
+    expect(processor.$process).toBeDefined();
+    expect(processor.$runAfter).toContain('readTypeScriptModules');
+    expect(processor.$runBefore).toContain('processing-docs');
+  });
+
+  it('should add `packages` segment to the start of `realProjectRelativePath` for API docs', () => {
+    const processor = processorFactory(['class', 'member']);
+    const docs = [
+      { docType: 'class', fileInfo: { realProjectRelativePath: 'a/b/c' } },
+      { docType: 'member', fileInfo: { realProjectRelativePath: 'a/b/c/d' } },
+      { docType: 'cli-command', fileInfo: { realProjectRelativePath: 'a/b/c' } },
+      { docType: 'class', fileInfo: { } },
+      { docType: 'class' },
+    ];
+    processor.$process(docs);
+
+    expect(docs).toEqual([
+      { docType: 'class', fileInfo: { realProjectRelativePath: 'packages/a/b/c' } },
+      { docType: 'member', fileInfo: { realProjectRelativePath: 'packages/a/b/c/d' } },
+      { docType: 'cli-command', fileInfo: { realProjectRelativePath: 'a/b/c' } },
+      { docType: 'class', fileInfo: { } },
+      { docType: 'class' },
+    ]);
+  });
+});
+

--- a/aio/tools/transforms/cli-docs-package/readers/cli-command.js
+++ b/aio/tools/transforms/cli-docs-package/readers/cli-command.js
@@ -15,6 +15,7 @@ module.exports = function cliCommandFileReader(log) {
     name: 'cliCommandFileReader',
     defaultPattern: /\.json$/,
     getDocs(fileInfo) {
+      fileInfo.realProjectRelativePath = 'packages/angular/cli/commands/' + fileInfo.relativePath;
       try {
         const doc = json5.parse(fileInfo.content);
         const name = fileInfo.baseName;
@@ -23,7 +24,6 @@ module.exports = function cliCommandFileReader(log) {
         const result = Object.assign(doc, {
           content: doc.description,
           docType: 'cli-command',
-          startingLine: 1,
           id: `cli-${doc.name}`,
           commandAliases: doc.aliases || [],
           aliases: computeAliases(doc),

--- a/aio/tools/transforms/cli-docs-package/readers/cli-command.spec.js
+++ b/aio/tools/transforms/cli-docs-package/readers/cli-command.spec.js
@@ -82,11 +82,6 @@ describe('cli-command reader', () => {
       ]);
     });
 
-    it('should start at line 1', () => {
-      const docs = reader.getDocs(fileInfo);
-      expect(docs[0].startingLine).toEqual(1);
-    });
-
     it('should extract the short description into the content', () => {
       const docs = reader.getDocs(fileInfo);
       expect(docs[0].content).toEqual('Add support for a library to your project.');

--- a/aio/tools/transforms/content-package/readers/content.js
+++ b/aio/tools/transforms/content-package/readers/content.js
@@ -18,7 +18,7 @@ module.exports = function contentFileReader() {
     getDocs: function(fileInfo) {
 
       // We return a single element array because content files only contain one document
-      return [{docType: 'content', content: fileInfo.content, startingLine: 1}];
+      return [{docType: 'content', content: fileInfo.content}];
     }
   };
 };

--- a/aio/tools/transforms/content-package/readers/content.spec.js
+++ b/aio/tools/transforms/content-package/readers/content.spec.js
@@ -37,7 +37,7 @@ describe('contentFileReader', function() {
           'project/path/modules/someModule/foo/docs/subfolder/bar.ngdoc', 'A load of content',
           'project/path');
       expect(fileReader.getDocs(fileInfo)).toEqual([
-        {docType: 'content', content: 'A load of content', startingLine: 1}
+        {docType: 'content', content: 'A load of content'}
       ]);
     });
   });

--- a/aio/tools/transforms/templates/cli/cli-command.template.html
+++ b/aio/tools/transforms/templates/cli/cli-command.template.html
@@ -1,6 +1,8 @@
 {% import 'lib/cli.html' as cli %}
+{% import "../lib/githubLinks.html" as github -%}
 
 <article>
+  {$ github.githubLinks(doc, cliVersionInfo) $}
   {% include 'include/cli-breadcrumb.html' %}
   {% include 'include/cli-header.html' %}
 

--- a/aio/tools/transforms/templates/cli/cli-container.template.html
+++ b/aio/tools/transforms/templates/cli/cli-container.template.html
@@ -1,3 +1,6 @@
+{% extends 'content.template.html' -%}
+
+{% block content %}
 <div class="content">
 {$ doc.description | marked $}
 </div>
@@ -21,3 +24,4 @@
 {% endfor %}
 </tbody>
 </table>
+{% endblock %}

--- a/aio/tools/transforms/templates/content.template.html
+++ b/aio/tools/transforms/templates/content.template.html
@@ -2,11 +2,13 @@
 
 {% set relativePath = doc.fileInfo.relativePath %}
 {% if doc.title %}{$ ('# ' + doc.title.trim()) | marked $}{% endif %}
-{% if 'guide/' in relativePath or 'tutorial/' in relativePath or 'docs.md' in relativePath %}
+{% if '/' in relativePath or 'docs.md' in relativePath %}
   <div class="github-links">
     {$ github.githubEditLink(doc, versionInfo) $}
   </div>
 {% endif %}
+{% block content %}
 <div class="content">
 {$ doc.description | marked $}
 </div>
+{% endblock %}

--- a/aio/tools/transforms/templates/lib/githubLinks.html
+++ b/aio/tools/transforms/templates/lib/githubLinks.html
@@ -3,16 +3,21 @@
 {%- endmacro %}
 
 {% macro githubViewHref(doc, versionInfo) -%}
-https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInfo.repo $}/tree/{$ versionInfo.currentVersion.isSnapshot and versionInfo.currentVersion.SHA or versionInfo.currentVersion.raw $}/packages/{$ doc.fileInfo.realProjectRelativePath $}#L{$ doc.startingLine + 1 $}-L{$ doc.endingLine + 1 $}
+{% set githubUrl = 'https://github.com/' + versionInfo.gitRepoInfo.owner + '/' + versionInfo.gitRepoInfo.repo -%}
+{% set version = versionInfo.currentVersion.isSnapshot and versionInfo.currentVersion.SHA or versionInfo.currentVersion.raw -%}
+{% set lineInfo = doc.startingLine and ('#L' + (doc.startingLine + 1) + '-L' + (doc.endingLine + 1)) or '' -%}
+{$ githubUrl $}/tree/{$ version $}/{$ projectRelativePath(doc.fileInfo) $}{$ lineInfo $}
 {%- endmacro %}
 
-{% macro githubEditHref(doc, versionInfo) -%}
-https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInfo.repo $}/edit/master{$ '/packages' if doc.docType !== 'content' $}/{$ projectRelativePath(doc.fileInfo) $}?message=docs
+{% macro githubEditHref(doc, versionInfo, pathPrefix) -%}
+{% set githubUrl = 'https://github.com/' + versionInfo.gitRepoInfo.owner + '/' + versionInfo.gitRepoInfo.repo -%}
+{% set lineInfo = doc.startingLine and ('#L' + (doc.startingLine + 1) + '-L' + (doc.endingLine + 1)) or '' -%}
+{$ githubUrl $}/edit/master/{$ projectRelativePath(doc.fileInfo) $}?message=docs
   {%- if doc.moduleDoc %}({$ doc.moduleDoc.id.split('/')[0] $})
   {%- elseif doc.docType === 'module' %}({$ doc.id.split('/')[0] $})
   {%- elseif doc.docType === 'content' %}
   {%- else %}(...){%- endif -%}
-%3A%20describe%20your%20change...{% if doc.docType !== 'content' %}#L{$ doc.startingLine + 1 $}-L{$ doc.endingLine + 1 $}{% endif %}
+%3A%20describe%20your%20change...{$ lineInfo $}
 {%- endmacro %}
 
 {% macro githubEditLink(doc, versionInfo) -%}

--- a/scripts/ci/test-aio-tools.sh
+++ b/scripts/ci/test-aio-tools.sh
@@ -10,6 +10,7 @@ source ${thisDir}/_travis-fold.sh
 travisFoldStart "test.docs"
   (
     cd ${PROJECT_ROOT}/aio
+    yarn setup
     yarn tools-test
   )
 travisFoldEnd "test.docs"


### PR DESCRIPTION
This is the best I can do with the information we have at doc-gen time.

If you want the links to be more sophisticated (e.g. linking to long descriptions, schematics or shared options), then we would need more information in the generated help JSON files.