### PR TITLE
fix(ivy): ngcc should not fail on invalid package.json 

### DIFF
--- a/packages/compiler-cli/src/ngcc/test/packages/entry_point_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/packages/entry_point_spec.ts
@@ -78,6 +78,11 @@ describe('getEntryPointInfo()', () => {
       umd: `/some_package/material_style/bundles/material_style.umd.js`,
     });
   });
+
+  it('should return null if the package.json is not valid JSON', () => {
+    const entryPoint = getEntryPointInfo('/some_package', '/some_package/unexpected_symbols');
+    expect(entryPoint).toBe(null);
+  });
 });
 
 function createMockFileSystem() {
@@ -115,8 +120,15 @@ function createMockFileSystem() {
           "module": "./esm5/material_style.es5.js",
           "es2015": "./esm2015/material_style.js"
         }`,
-        'material_style.metadata.json': 'some meta data'
-      }
+        'material_style.metadata.json': 'some meta data',
+      },
+      'unexpected_symbols': {
+        // package.json might not be a valid JSON
+        // for example, @schematics/angular contains a package.json blueprint
+        // with unexpected symbols
+        'package.json':
+            '{"devDependencies": {<% if (!minimal) { %>"@types/jasmine": "~2.8.8" <% } %>}}',
+      },
     }
   });
 }


### PR DESCRIPTION
Some package.json files may have invalid JSON, for example package.json blueprints from `@schematics/angular` (see https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/workspace/files/package.json).

This makes ngcc more resilient, by simpling logging a warning if an error is encountered, instead of failing as it does right now.

cc @petebacondarwin as we talked about it on Slack.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

An invalid package.json file would make `ngcc` fail.

## What is the new behavior?

Simply logs a warning with the path of the invalid package.json and goes on.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No