### PR TITLE
docs update to use option project instead of app

### DIFF
--- a/aio/content/guide/universal.md
+++ b/aio/content/guide/universal.md
@@ -451,7 +451,7 @@ You can add these in the `"server"` section of the Angular configuration file, `
       "serve:ssr": "node dist/server.js",
 
       // Helpers for the scripts
-      "build:client-and-server-bundles": "ng build --prod && ng build --prod --app 1 --output-hashing=false",
+      "build:client-and-server-bundles": "ng build --prod && ng build --prod --project=angular.io-example --output-hashing=false",
       "webpack:server": "webpack --config webpack.server.config.js --progress --colors"
     }
    ...


### PR DESCRIPTION
`--app` is not support anymore. refer [here](https://stackoverflow.com/a/50292095/2342289)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
