### PR TITLE
docs: reorganize events to highlight recent events before older event…

### DIFF
--- a/aio/content/marketing/events.html
+++ b/aio/content/marketing/events.html
@@ -13,12 +13,6 @@
     </tr>
     </thead>
     <tbody>
-    <!-- AngularMix -->
-    <tr>
-        <th><a href="https://angularmix.com/" title="AngularMix">AngularMix</a></th>
-        <td>Orlando, Florida</td>
-        <td>October 10-12, 2018</td>
-    </tr>
     <!-- ReactiveConf -->
     <tr>
       <th><a href="https://reactiveconf.com/" title="ReactiveConf">ReactiveConf</a></th>
@@ -44,35 +38,17 @@
     </tr>
     </thead>
     <tbody>
-    <!-- AngularConnect-->
-    <tr>
-      <th><a href="http://angularconnect.com" title="AngularConnect">AngularConnect</a></th>
-      <td>London, United Kingdom</td>
-      <td>November 7-8, 2017</td>
+      <!-- AngularMix -->
+      <tr>
+        <th><a href="https://angularmix.com/" title="AngularMix">AngularMix</a></th>
+        <td>Orlando, Florida</td>
+        <td>October 10-12, 2018</td>
     </tr>
-    <!-- ngAtlanta-->
+    <!-- Angular Conf Australia-->
     <tr>
-      <th><a href="http://ng-atl.org/" title="ngAtlanta">ngAtlanta</a></th>
-      <td>Atlanta, Georgia</td>
-      <td>January 30, 2018</td>
-    </tr>
-    <!-- ngVikings-->
-    <tr>
-      <th><a href="https://ngvikings.org/" title="ngVikings">ngVikings</a></th>
-      <td>Helsinki, Finland</td>
-      <td>March 1-2, 2018</td>
-    </tr>
-    <!-- ngconf 2018-->
-    <tr>
-      <th><a href="https://www.ng-conf.org/" title="ng-conf">ng-conf</a></th>
-      <td>Salt Lake City, Utah</td>
-      <td>April 18-20, 2018</td>
-    </tr>
-    <!-- WeRDevs-->
-    <tr>
-      <th><a href="https://www.wearedevelopers.com/" title="WeAreDevs">WeAreDevelopers</a></th>
-      <td>Vienna, Austria</td>
-      <td>May 16-18, 2018</td>
+      <th><a href="https://www.angularconf.com.au/" title="Angular Conf Australia">Angular Conf Australia</a></th>
+      <td>Melbourne, Australia</td>
+      <td>Jun 22, 2018</td>
     </tr>
     <!-- ngJapan-->
     <tr>
@@ -80,11 +56,29 @@
       <td>Tokyo, Japan</td>
       <td>Jun 16, 2018</td>
     </tr>
-    <!-- Angular Conf Australia-->
+    <!-- WeRDevs-->
     <tr>
-      <th><a href="https://www.angularconf.com.au/" title="Angular Conf Australia">Angular Conf Australia</a></th>
-      <td>Melbourne, Australia</td>
-      <td>Jun 22, 2018</td>
+      <th><a href="https://www.wearedevelopers.com/" title="WeAreDevs">WeAreDevelopers</a></th>
+      <td>Vienna, Austria</td>
+      <td>May 16-18, 2018</td>
+    </tr>
+    <!-- ngconf 2018-->
+    <tr>
+      <th><a href="https://www.ng-conf.org/" title="ng-conf">ng-conf</a></th>
+      <td>Salt Lake City, Utah</td>
+      <td>April 18-20, 2018</td>
+    </tr>
+    <!-- ngVikings-->
+    <tr>
+      <th><a href="https://ngvikings.org/" title="ngVikings">ngVikings</a></th>
+      <td>Helsinki, Finland</td>
+      <td>March 1-2, 2018</td>
+    </tr>
+    <!-- ngAtlanta-->
+    <tr>
+      <th><a href="http://ng-atl.org/" title="ngAtlanta">ngAtlanta</a></th>
+      <td>Atlanta, Georgia</td>
+      <td>January 30, 2018</td>
     </tr>
     </tbody>
   </table>


### PR DESCRIPTION
…s and move mix to past

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
* AngularMix was listed as upcoming
* Past events were listed with the oldest first, which is probably the one people are least interested in replaying, rediscovering

Issue Number: N/A


## What is the new behavior?
* AngularMix moved to past events
* Past events reorganized to have most recent at the top
* Removed 2017 events

## Does this PR introduce a breaking change?

- [ ] Yes
- [X ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
