### PR TITLE
docs: fix release info navigation

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -577,30 +577,14 @@
       "tooltip": "Angular release practices, updating, and upgrading.",
       "children": [
         {
+          "url": "guide/updating",
+           "title": "Keeping Up-to-Date",
+           "tooltip": "Information about updating Angular applications and libraries to the latest version."
+       },
+        {
           "url": "guide/releases",
           "title": "Angular Releases",
           "tooltip": "Angular versioning, release, support, and deprecation policies and practices."
-        },
-        {
-           "url": "guide/updating",
-            "title": "Keeping Up-to-Date",
-            "tooltip": "Information about updating Angular applications and libraries to the latest version."
-        },
-        {
-          "title": "Upgrading from AngularJS",
-          "tooltip": "Incrementally upgrade an AngularJS application to Angular.",
-          "children": [
-            {
-              "url": "guide/upgrade",
-              "title": "Upgrading Instructions",
-              "tooltip": "Incrementally upgrade an AngularJS application to Angular."
-            },
-            {
-              "url": "guide/ajs-quick-reference",
-              "title": "AngularJS-Angular Concepts",
-              "tooltip": "Learn how AngularJS concepts and techniques map to Angular."
-            }
-          ]
         }
       ]
     },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
* Upgrading from AngularJS appears in nav twice. Once in Techniques and once in Release info.
* Keeping-up-to-date (the user actionable content) comes after Angular Releases (conceptual).

Issue Number: N/A


## What is the new behavior?
* Upgrading from AngularJS appears only in Techniques. Remove from Release info.
* Keeping-up-to-date (the user actionable content) comes before Angular Releases (conceptual).


## Does this PR introduce a breaking change?

- [ ] Yes
- [X ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
