### PR TITLE
style: whitespaces in import statement and rename classname

### DIFF
--- a/packages/examples/forms/ts/simpleForm/e2e_test/simple_form_spec.ts
+++ b/packages/examples/forms/ts/simpleForm/e2e_test/simple_form_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ElementArrayFinder, browser, by, element} from 'protractor';
-import {verifyNoBrowserErrors} from '../../../../_common/e2e_util';
+import { ElementArrayFinder, browser, by, element } from 'protractor';
+import { verifyNoBrowserErrors } from '../../../../_common/e2e_util';
 
 describe('simpleForm example', () => {
   afterEach(verifyNoBrowserErrors);

--- a/packages/examples/forms/ts/simpleForm/module.ts
+++ b/packages/examples/forms/ts/simpleForm/module.ts
@@ -6,15 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModule} from '@angular/core';
-import {FormsModule} from '@angular/forms';
-import {BrowserModule} from '@angular/platform-browser';
-import {SimpleFormComp} from './simple_form_example';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BrowserModule } from '@angular/platform-browser';
+import { SimpleFormComponent } from './simple_form_example';
 
 @NgModule({
   imports: [BrowserModule, FormsModule],
-  declarations: [SimpleFormComp],
-  bootstrap: [SimpleFormComp]
+  declarations: [SimpleFormComponent],
+  bootstrap: [SimpleFormComponent]
 })
 export class AppModule {
 }

--- a/packages/examples/forms/ts/simpleForm/simple_form_example.ts
+++ b/packages/examples/forms/ts/simpleForm/simple_form_example.ts
@@ -8,8 +8,8 @@
 
 /* tslint:disable:no-console  */
 // #docregion Component
-import {Component} from '@angular/core';
-import {NgForm} from '@angular/forms';
+import { Component } from '@angular/core';
+import { NgForm } from '@angular/forms';
 
 @Component({
   selector: 'example-app',
@@ -26,7 +26,7 @@ import {NgForm} from '@angular/forms';
     <p>Form valid: {{ f.valid }}</p>
   `,
 })
-export class SimpleFormComp {
+export class SimpleFormComponent {
   onSubmit(f: NgForm) {
     console.log(f.value);  // { first: '', last: '' }
     console.log(f.valid);  // false


### PR DESCRIPTION
Adding whitespaces in import statement and renamed classname from `SimpleFormComp` to `SimpleFormComponent`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
