### PR TITLE
docs: update observable from examples to RxJS V6 (#21572)

### DIFF
--- a/aio/content/examples/rx-library/src/simple-creation.ts
+++ b/aio/content/examples/rx-library/src/simple-creation.ts
@@ -1,10 +1,10 @@
 
 // #docregion promise
 
-import { fromPromise } from 'rxjs';
+import { from } from 'rxjs';
 
 // Create an Observable out of a promise
-const data = fromPromise(fetch('/api/endpoint'));
+const data = from(fetch('/api/endpoint'));
 // Subscribe to begin listening for async result
 data.subscribe({
  next(response) { console.log(response); },

--- a/aio/content/guide/rx-library.md
+++ b/aio/content/guide/rx-library.md
@@ -53,7 +53,7 @@ RxJS provides many operators, but only a handful are used frequently. For a list
 
 | Area | Operators |
 | :------------| :----------|
-| Creation |  `from`, `fromPromise`,`fromEvent`, `of` |
+| Creation |  `from`, `fromEvent`, `of` |
 | Combination | `combineLatest`, `concat`, `merge`, `startWith` , `withLatestFrom`, `zip` |
 | Filtering | `debounceTime`, `distinctUntilChanged`, `filter`, `take`, `takeUntil` |
 | Transformation | `bufferTime`, `concatMap`, `map`, `mergeMap`, `scan`, `switchMap` |

--- a/aio/src/app/custom-elements/code/pretty-printer.service.ts
+++ b/aio/src/app/custom-elements/code/pretty-printer.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { from as fromPromise, Observable } from 'rxjs';
+import { from, Observable } from 'rxjs';
 import { first, map, share } from 'rxjs/operators';
 
 import { Logger } from 'app/shared/logger.service';
@@ -20,7 +20,7 @@ export class PrettyPrinter {
   private prettyPrintOne: Observable<PrettyPrintOne>;
 
   constructor(private logger: Logger) {
-    this.prettyPrintOne = fromPromise(this.getPrettyPrintOne()).pipe(share());
+    this.prettyPrintOne = from(this.getPrettyPrintOne()).pipe(share());
   }
 
   private getPrettyPrintOne(): Promise<PrettyPrintOne> {

--- a/aio/src/app/custom-elements/elements-loader.ts
+++ b/aio/src/app/custom-elements/elements-loader.ts
@@ -5,7 +5,7 @@ import {
   NgModuleRef,
 } from '@angular/core';
 import { ELEMENT_MODULE_PATHS_TOKEN } from './element-registry';
-import { from as fromPromise, Observable, of } from 'rxjs';
+import { from, Observable, of } from 'rxjs';
 import { createCustomElement } from '@angular/elements';
 
 @Injectable()
@@ -34,7 +34,7 @@ export class ElementsLoader {
 
     // Returns observable that completes when all discovered elements have been registered.
     const allRegistered = Promise.all(unregisteredSelectors.map(s => this.loadCustomElement(s)));
-    return fromPromise(allRegistered.then(() => undefined));
+    return from(allRegistered.then(() => undefined));
   }
 
   /** Loads and registers the custom element defined on the `WithCustomElement` module factory. */


### PR DESCRIPTION
From RxJS 6.0.0 there is just `from`, no `fromPromise` method.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #21572


## What is the new behavior?
Documentation contains just a `from` method from RxJS.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
My first PR :)