### PR TITLE
fix(docs-infra): don't call locationService.setSearch when clicking outside of the search box and searchResults are empty

### DIFF
--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -742,7 +742,7 @@ describe('AppComponent', () => {
           expect(component.showSearchResults).toBe(true);
         });
 
-        it('should not intercept clicks om the searchBox', () => {
+        it('should not intercept clicks on the searchBox', () => {
           component.showSearchResults = true;
           fixture.detectChanges();
 
@@ -751,6 +751,11 @@ describe('AppComponent', () => {
           fixture.detectChanges();
 
           expect(component.showSearchResults).toBe(true);
+        });
+
+        it('should not call `locationService.setSearch` when searchResults are not shown', () => {
+          docViewer.click();
+          expect(locationService.setSearch).not.toHaveBeenCalled();
         });
       });
 

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -389,7 +389,10 @@ export class AppComponent implements OnInit {
 
   hideSearchResults() {
     this.showSearchResults = false;
-    this.locationService.setSearch('', { ...this.locationService.search(), search: undefined });
+    const oldSearch = this.locationService.search();
+    if (oldSearch.search !== undefined) {
+      this.locationService.setSearch('', { ...oldSearch, search: undefined });
+    }
   }
 
   focusSearchBox() {


### PR DESCRIPTION
Partially fixes #26544 by not calling locationService.setSearch on every click outside of the search box.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
On every click on the `aio-shell` `locationService.setSearch` gets called, which fetches all favicons because of [this Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=895175).

Issue Number: #26544 


## What is the new behavior?
`locationService.setSearch` is not getting called when the search is empty.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Favicons still get fetched on a click on an \<a\>-tag, which is a [known Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=895175), because Chromium doesn't support the `size` attribute on \<link\>-tags.