### PR TITLE
feat(router): add additional route information for RouteReuseStrategy

### DIFF
--- a/packages/router/src/route_reuse_strategy.ts
+++ b/packages/router/src/route_reuse_strategy.ts
@@ -40,7 +40,8 @@ export type DetachedRouteHandleInternal = {
  */
 export abstract class RouteReuseStrategy {
   /** Determines if this route (and its subtree) should be detached to be reused later */
-  abstract shouldDetach(route: ActivatedRouteSnapshot): boolean;
+  abstract shouldDetach(currentRoute: ActivatedRouteSnapshot, futureRoute?: ActivatedRouteSnapshot):
+      boolean;
 
   /**
    * Stores the detached route.
@@ -50,7 +51,8 @@ export abstract class RouteReuseStrategy {
   abstract store(route: ActivatedRouteSnapshot, handle: DetachedRouteHandle|null): void;
 
   /** Determines if this route (and its subtree) should be reattached */
-  abstract shouldAttach(route: ActivatedRouteSnapshot): boolean;
+  abstract shouldAttach(
+      futureRoute: ActivatedRouteSnapshot, currentRoute?: ActivatedRouteSnapshot|null): boolean;
 
   /** Retrieves the previously stored route */
   abstract retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle|null;
@@ -63,9 +65,14 @@ export abstract class RouteReuseStrategy {
  * Does not detach any subtrees. Reuses routes as long as their route config is the same.
  */
 export class DefaultRouteReuseStrategy implements RouteReuseStrategy {
-  shouldDetach(route: ActivatedRouteSnapshot): boolean { return false; }
+  shouldDetach(currentRoute: ActivatedRouteSnapshot, futureRoute: ActivatedRouteSnapshot): boolean {
+    return false;
+  }
   store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void {}
-  shouldAttach(route: ActivatedRouteSnapshot): boolean { return false; }
+  shouldAttach(futureRoute: ActivatedRouteSnapshot, currentRoute: ActivatedRouteSnapshot|null):
+      boolean {
+    return false;
+  }
   retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle|null { return null; }
   shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
     return future.routeConfig === curr.routeConfig;

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -349,8 +349,8 @@ export declare const ROUTER_INITIALIZER: InjectionToken<(compRef: ComponentRef<a
 /** @experimental */
 export declare abstract class RouteReuseStrategy {
     abstract retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle | null;
-    abstract shouldAttach(route: ActivatedRouteSnapshot): boolean;
-    abstract shouldDetach(route: ActivatedRouteSnapshot): boolean;
+    abstract shouldAttach(futureRoute: ActivatedRouteSnapshot, currentRoute?: ActivatedRouteSnapshot|null): boolean;
+    abstract shouldDetach(currentRoute: ActivatedRouteSnapshot, futureRoute?: ActivatedRouteSnapshot): boolean;
     abstract shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean;
     abstract store(route: ActivatedRouteSnapshot, handle: DetachedRouteHandle | null): void;
 }

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -349,7 +349,7 @@ export declare const ROUTER_INITIALIZER: InjectionToken<(compRef: ComponentRef<a
 /** @experimental */
 export declare abstract class RouteReuseStrategy {
     abstract retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle | null;
-    abstract shouldAttach(futureRoute: ActivatedRouteSnapshot, currentRoute?: ActivatedRouteSnapshot|null): boolean;
+    abstract shouldAttach(futureRoute: ActivatedRouteSnapshot, currentRoute?: ActivatedRouteSnapshot | null): boolean;
     abstract shouldDetach(currentRoute: ActivatedRouteSnapshot, futureRoute?: ActivatedRouteSnapshot): boolean;
     abstract shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean;
     abstract store(route: ActivatedRouteSnapshot, handle: DetachedRouteHandle | null): void;


### PR DESCRIPTION
RouteReuseStrategy implementors logic might be complex and additional information would be needed in order to detach or attach a route.

Improved the RouteReuseStrategy interface methods as follows:
* shouldDetach: add the futureRoute parameter with the snapshot of the route we are navigating to.
* shouldAttach: add the currentRoute parameter with the snapshot of the route we are navigating from.
The parameters are added as optional ones for backward compatibility.

This modification tries to cover the following use case: say we have a very complex view (view1) and from this view the user can navigate to view2 or view3. From view2 and view3 the user can navigate back to view1. When navigating back from view2 to view1, view1 must be completely reloaded, but not when navigating back from view3.

The solution might be to detach and attach view1 but only when navigating to and from view3, ignoring when navigating to and from view2.

[StackBlitz](https://stackblitz.com/edit/angular-knytde) with the current implementation that always detach the view1.

No tests have been added as the pr only modifies private methods.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

At the moment there is no way to know both, the current and future routes in the RouteReuseStrategy interface.

## What is the new behavior?

The future route is added to the shouldDetach method as an optional parameter, and the current route is added to the shouldAttach method as an optional parameter.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
