### PR TITLE
test(ivy): fix handful of unit test failures in core

### DIFF
--- a/packages/platform-browser/animations/src/module.ts
+++ b/packages/platform-browser/animations/src/module.ts
@@ -29,6 +29,7 @@ export class BrowserAnimationsModule {
 @NgModule({
   exports: [BrowserModule],
   providers: BROWSER_NOOP_ANIMATIONS_PROVIDERS,
+  jit: true,
 })
 export class NoopAnimationsModule {
 }

--- a/packages/platform-server/testing/src/server.ts
+++ b/packages/platform-server/testing/src/server.ts
@@ -28,7 +28,8 @@ export const platformServerTesting = createPlatformFactory(
 @NgModule({
   exports: [BrowserDynamicTestingModule],
   imports: [NoopAnimationsModule],
-  providers: SERVER_RENDER_PROVIDERS
+  providers: SERVER_RENDER_PROVIDERS,
+  jit: true,
 })
 export class ServerTestingModule {
 }


### PR DESCRIPTION
Fixes a handful of unit tests (~200) that were failing in core.

@alxhub I can see this making sense for the `ServerTestingModule`, but I'm not sure whether adding `jit: true` to the `NoopAnimationsModule` is the correct approach. 

cc @mhevery 