### PR TITLE
build(ivy): fix benchmarks

### DIFF
--- a/protractor-perf.conf.js
+++ b/protractor-perf.conf.js
@@ -20,7 +20,8 @@ require(`./${BASE}/e2e_util/perf_util`).readCommandLine();
 var CHROME_OPTIONS = {
   'args': ['--js-flags=--expose-gc', '--no-sandbox'],
   'perfLoggingPrefs': {
-    'traceCategories': 'v8,blink.console,devtools.timeline,disabled-by-default-devtools.timeline'
+    'traceCategories':
+        'v8,blink.console,devtools.timeline,disabled-by-default-devtools.timeline,blink.user_timing'
   }
 };
 


### PR DESCRIPTION
Our benchmarks weren't running properly because Benchpress now uses performance mark events and we hadn't turned on "user timing" events in our protractor config. This small PR should fix that.