### PR TITLE
build: fix //tools/testing:node target deps and ivy build-dist packages

### DIFF
--- a/scripts/build-packages-dist.sh
+++ b/scripts/build-packages-dist.sh
@@ -63,6 +63,12 @@ buildTargetPackages "$LEGACY_TARGETS" "dist/packages-dist" "legacy" "Production"
 
 IVY_JIT_TARGETS=`bazel query --output=label 'attr("tags", "\[.*ivy-jit.*\]", //packages/...) intersect kind(".*_package", //packages/...)'`
 IVY_LOCAL_TARGETS=`bazel query --output=label 'attr("tags", "\[.*ivy-local.*\]", //packages/...) intersect kind(".*_package", //packages/...)'`
+
+# A clean is needed since build artifacts from previous build can break the following build
+bazel clean
 buildTargetPackages "$IVY_JIT_TARGETS" "dist/packages-dist-ivy-jit" "jit" "Ivy JIT"
+
+# A clean is needed since build artifacts from previous build can break the following build
+bazel clean
 buildTargetPackages "$IVY_LOCAL_TARGETS" "dist/packages-dist-ivy-local" "local" "Ivy AOT"
 

--- a/tools/testing/BUILD.bazel
+++ b/tools/testing/BUILD.bazel
@@ -21,6 +21,7 @@ ts_library(
         "//packages/core/testing",
         "//packages/platform-server",
         "//packages/platform-server/testing",
+        "@ngdeps//domino",
     ],
 )
 


### PR DESCRIPTION
Fixes Ivy package-dist generation.

For some reason, artifacts in the legacy package-dist build break the ivy package-dist build. `bazel clean` in between package-dists generation fixes this.