### PR TITLE
fix(ivy): support ViewContainerRef on ng-container children

### DIFF
--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -502,6 +502,11 @@ function executePipeOnDestroys(viewData: LViewData): void {
 export function getRenderParent(tNode: TNode, currentView: LViewData): RElement|null {
   if (canInsertNativeNode(tNode, currentView)) {
     const hostTNode = currentView[HOST_NODE];
+
+    if (tNode.parent != null && tNode.parent.type === TNodeType.ElementContainer) {
+      tNode = getHighestElementContainer(tNode.parent);
+    }
+
     return tNode.parent == null && hostTNode !.type === TNodeType.View ?
         getContainerRenderParent(hostTNode as TViewNode, currentView) :
         getParentNative(tNode, currentView) as RElement;
@@ -626,8 +631,7 @@ export function appendChild(
           renderer, lContainer[RENDER_PARENT] !, childEl,
           getBeforeNodeForView(index, views, lContainer[NATIVE]));
     } else if (parentTNode.type === TNodeType.ElementContainer) {
-      let elementContainer = getHighestElementContainer(childTNode);
-      let renderParent: RElement = getRenderParent(elementContainer, currentView) !;
+      let renderParent: RElement = getRenderParent(childTNode, currentView) !;
       nativeInsertBefore(renderer, renderParent, childEl, parentEl);
     } else {
       isProceduralRenderer(renderer) ? renderer.appendChild(parentEl !as RElement, childEl) :

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -503,8 +503,9 @@ export function getRenderParent(tNode: TNode, currentView: LViewData): RElement|
   if (canInsertNativeNode(tNode, currentView)) {
     const hostTNode = currentView[HOST_NODE];
 
-    if (tNode.parent != null && tNode.parent.type === TNodeType.ElementContainer) {
-      tNode = getHighestElementContainer(tNode.parent);
+    const tNodeParent = tNode.parent;
+    if (tNodeParent != null && tNodeParent.type === TNodeType.ElementContainer) {
+      tNode = getHighestElementContainer(tNodeParent);
     }
 
     return tNode.parent == null && hostTNode !.type === TNodeType.View ?
@@ -631,7 +632,7 @@ export function appendChild(
           renderer, lContainer[RENDER_PARENT] !, childEl,
           getBeforeNodeForView(index, views, lContainer[NATIVE]));
     } else if (parentTNode.type === TNodeType.ElementContainer) {
-      let renderParent: RElement = getRenderParent(childTNode, currentView) !;
+      const renderParent: RElement = getRenderParent(childTNode, currentView) !;
       nativeInsertBefore(renderer, renderParent, childEl, parentEl);
     } else {
       isProceduralRenderer(renderer) ? renderer.appendChild(parentEl !as RElement, childEl) :


### PR DESCRIPTION
Issue found while running NgPlural tests with ivy. 

The root cause here is that we need to account for `<ng-container>` LNode why looking for a render parent. `<ng-container>` is not a "real" element and can't act as a render parent so we need to skip "past" it.
