### PR TITLE
docs: update release info now that v7 is released

### DIFF
--- a/aio/content/guide/releases.md
+++ b/aio/content/guide/releases.md
@@ -83,15 +83,16 @@ All of our major releases are supported for 18 months.
 
 * 12 months of *long-term support (LTS)*, during which only critical fixes and security patches are released.
 
-The following table provides the support status and key dates for Angular version 4.0.0 and higher. 
+The following table provides the support status and key dates for Angular version 5.0.0 and higher. 
 
 
-Version | Status | Released | Active Ends | LTS Ends
-------- | ------ | -------- | ----------- | -------- 
-^7.0.0 | Active | Oct 18, 2018 | Apr 18, 2019 | Apr 18, 2020
-^6.0.0 | LTS | May 3, 2018 | Nov 3, 2018 | Nov 3, 2019
-^5.0.0 | LTS | Nov 1, 2017 | May 1, 2018 | May 1, 2019
-^4.0.0 | LTS | Mar 23, 2017 | Sep 23, 2017 | Sep 23, 2018
+Version | Status | Released     | Active Ends  | LTS Ends
+------- | ------ | ------------ | ------------ | ------------ 
+^7.0.0  | Active | Oct 18, 2018 | Apr 18, 2019 | Apr 18, 2020
+^6.0.0  | LTS    | May 3, 2018  | Nov 3, 2018  | Nov 3, 2019
+^5.0.0  | LTS    | Nov 1, 2017  | May 1, 2018  | May 1, 2019
+
+LTS for Angular version 4.0.0 ended on September 23, 2018.
 
 
 {@a deprecation}

--- a/aio/content/guide/releases.md
+++ b/aio/content/guide/releases.md
@@ -65,68 +65,33 @@ Disclaimer: The dates are offered as general guidance and may be adjusted by us 
 
 The following table contains our current target release dates for the next two major versions of Angular: 
 
- Date                   | Stable Release | Compatibility
- ---------------------- | -------------- | ----------------
- September/October 2018 | 7.0.0          | ^6.0.0
+ Date                   | Stable Release | Compatibility 
+ ---------------------- | -------------- | -------------
  March/April 2019       | 8.0.0          | ^7.0.0
+ September/October 2019 | 9.0.0          | ^8.0.0
 
  Compatibility note: The primary goal of the backward compatibility promise is to ensure that changes in the core framework and tooling don't break the existing ecosystem of components and applications and don't put undue upgrade/migration burden on Angular application and component authors.
 
 
 {@a lts}
 {@a support}
-## Support policy
+## Support policy and schedule
 
 All of our major releases are supported for 18 months. 
 
-* 6 months of active support, during which regularly-scheduled updates and patches are released, as described above in [Release frequency](#frequency "Release frequency").
+* 6 months of *active support*, during which regularly-scheduled updates and patches are released.
 
-* 12 months of long-term support (LTS). During the LTS period, only critical fixes and security patches will be released.
+* 12 months of *long-term support (LTS)*, during which only critical fixes and security patches are released.
 
 The following table provides the support status and key dates for Angular version 4.0.0 and higher. 
 
-<style>
 
-    td, th {vertical-align: top}
-
-</style>
-
-<table>
-
-    <tr>
-        <th>Version</th>
-        <th>Status</th>
-        <th>Release Date</th>
-        <th>LTS Start Date</th>
-        <th>LTS End Date</th>
-    </tr>
-
-    <tr>
-        <td>^4.0.0</td>
-        <td>LTS</td>
-        <td>March 23, 2017</td>
-        <td>September 23, 2017</td>
-        <td>September 23, 2018</td>
-    </tr>
-
-    <tr>
-        <td>^5.0.0</td>
-        <td>LTS</td>
-        <td>November 1, 2017</td>
-        <td>May 1, 2018</td>
-        <td>May 1, 2019</td>
-    </tr>
-
-    <tr>
-        <td>^6.0.0</td>
-        <td>Active</td>
-        <td>May 3, 2018</td>
-        <td>November 3, 2018</td>
-        <td>November 3, 2019</td>
-    </tr>
-
-</table>
-
+Version | Status | Released | Active Ends | LTS Ends
+------- | ------ | -------- | ----------- | -------- 
+^7.0.0 | Active | Oct 18, 2018 | Apr 18, 2019 | Apr 18, 2020
+^6.0.0 | LTS | May 3, 2018 | Nov 3, 2018 | Nov 3, 2019
+^5.0.0 | LTS | Nov 1, 2017 | May 1, 2018 | May 1, 2019
+^4.0.0 | LTS | Mar 23, 2017 | Sep 23, 2017 | Sep 23, 2018
 
 
 {@a deprecation}

--- a/aio/content/guide/releases.md
+++ b/aio/content/guide/releases.md
@@ -92,7 +92,7 @@ Version | Status | Released     | Active Ends  | LTS Ends
 ^6.0.0  | LTS    | May 3, 2018  | Nov 3, 2018  | Nov 3, 2019
 ^5.0.0  | LTS    | Nov 1, 2017  | May 1, 2018  | May 1, 2019
 
-LTS for Angular version 4.0.0 ended on September 23, 2018.
+LTS for Angular version ^4.0.0 ended on September 23, 2018.
 
 
 {@a deprecation}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://angular.io/guide/releases
was written at v6, so the release schedule and support dates are now out-of-date

Issue Number: N/A


## What is the new behavior?

* Release schedule section lists upcoming at v8 and v9
* Support section lists v4-v7
* Minor edits and table rework for consistency and readability

Note: Technically, v6 is still in Active Support time window until Nov 3, but rather than update this doc again then I went ahead and marked it as LTS. In practice, we don't have any plans I know of to put out a v6+ "active support" release now that v7 is released. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
