### PR TITLE
fix(docs-infra): remove duplicated line (short description of ng serve)

### DIFF
--- a/aio/content/cli/index.md
+++ b/aio/content/cli/index.md
@@ -49,8 +49,6 @@ You can edit the generated files directly, or add to and modify them using CLI c
 Use the [ng generate](cli/generate) command to add new files for additional components and services, and code for new pipes, directives, and so on. 
 Commands such as [add](cli/add) and [generate](cli/generate), which create or operate on apps and libraries, must be executed from within a workspace or project folder.
 
-When you use the [ng serve](cli/serve) command to build an app and serve it locally, the server automatically rebuilds the app and reloads the page when you change any of the source files.
-
 * See more about the [Workspace file structure](guide/file-structure).
 
 When you use the [ng serve](cli/serve) command to build an app and serve it locally, the server automatically rebuilds the app and reloads the page when you change any of the source files.


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

![doc-bug](https://user-images.githubusercontent.com/24238283/47361260-c962bb80-d6d1-11e8-8b9c-21ececf985d8.png)

That line is duplicated and wrongly placed, as 'See more about the Workspace file structure' should be the one preceded by the short description of add and generate commands.

Issue number: #26677

## What is the new behavior?

![fixed-doc](https://user-images.githubusercontent.com/24238283/47361278-d1baf680-d6d1-11e8-88f0-a7112e3792d2.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

It can be seen at https://angular.io/cli#workspaces-and-project-files.
