### PR TITLE
fix(ivy): allow root components to inject ViewContainerRef

### DIFF
--- a/packages/core/src/render3/interfaces/renderer.ts
+++ b/packages/core/src/render3/interfaces/renderer.ts
@@ -71,6 +71,9 @@ export interface ProceduralRenderer3 {
   removeChild(parent: RElement, oldChild: RNode): void;
   selectRootElement(selectorOrNode: string|any): RElement;
 
+  parentNode(node: RNode): RElement|null;
+  nextSibling(node: RNode): RNode|null;
+
   setAttribute(el: RElement, name: string, value: string, namespace?: string|null): void;
   removeAttribute(el: RElement, name: string, namespace?: string|null): void;
   addClass(el: RElement, name: string): void;
@@ -99,6 +102,10 @@ export const domRendererFactory3: RendererFactory3 = {
 
 /** Subset of API needed for appending elements and text nodes. */
 export interface RNode {
+  parentNode: RNode|null;
+
+  nextSibling: RNode|null;
+
   removeChild(oldChild: RNode): void;
 
   /**

--- a/packages/core/src/render3/util.ts
+++ b/packages/core/src/render3/util.ts
@@ -134,6 +134,10 @@ export function isLContainer(value: RElement | RComment | LContainer | StylingCo
   return Array.isArray(value) && typeof value[ACTIVE_INDEX] === 'number';
 }
 
+export function isRootView(target: LViewData): boolean {
+  return (target[FLAGS] & LViewFlags.IsRoot) !== 0;
+}
+
 /**
  * Retrieve the root view from any component by walking the parent `LViewData` until
  * reaching the root `LViewData`.

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -873,6 +873,9 @@
     "name": "isProceduralRenderer"
   },
   {
+    "name": "isRootView"
+  },
+  {
     "name": "isSanitizable"
   },
   {
@@ -919,6 +922,12 @@
   },
   {
     "name": "nativeInsertBefore"
+  },
+  {
+    "name": "nativeNextSibling"
+  },
+  {
+    "name": "nativeParentNode"
   },
   {
     "name": "nextContext"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -342,6 +342,9 @@
     "name": "isProceduralRenderer"
   },
   {
+    "name": "isRootView"
+  },
+  {
     "name": "leaveView"
   },
   {
@@ -352,6 +355,9 @@
   },
   {
     "name": "nativeInsertBefore"
+  },
+  {
+    "name": "nativeParentNode"
   },
   {
     "name": "nextNgElementId"

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -3804,6 +3804,9 @@
     "name": "isQuote"
   },
   {
+    "name": "isRootView"
+  },
+  {
     "name": "isScheduler"
   },
   {
@@ -3955,6 +3958,12 @@
   },
   {
     "name": "nativeInsertBefore"
+  },
+  {
+    "name": "nativeNextSibling"
+  },
+  {
+    "name": "nativeParentNode"
   },
   {
     "name": "needsAdditionalRootNode"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -894,6 +894,9 @@
     "name": "isProceduralRenderer"
   },
   {
+    "name": "isRootView"
+  },
+  {
     "name": "isStylingContext"
   },
   {
@@ -937,6 +940,12 @@
   },
   {
     "name": "nativeInsertBefore"
+  },
+  {
+    "name": "nativeNextSibling"
+  },
+  {
+    "name": "nativeParentNode"
   },
   {
     "name": "nextContext"

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -2124,6 +2124,9 @@
     "name": "isPromise$2"
   },
   {
+    "name": "isRootView"
+  },
+  {
     "name": "isScheduler"
   },
   {
@@ -2218,6 +2221,12 @@
   },
   {
     "name": "nativeInsertBefore"
+  },
+  {
+    "name": "nativeNextSibling"
+  },
+  {
+    "name": "nativeParentNode"
   },
   {
     "name": "nextContext"

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -2677,6 +2677,8 @@ class MockRenderer implements ProceduralRenderer3 {
   selectRootElement(selectorOrNode: string|any): RElement {
     return ({} as any);
   }
+  parentNode(node: RNode): RElement|null { return node.parentNode as RElement; }
+  nextSibling(node: RNode): RNode|null { return node.nextSibling; }
   setAttribute(el: RElement, name: string, value: string, namespace?: string|null): void {}
   removeAttribute(el: RElement, name: string, namespace?: string|null): void {}
   addClass(el: RElement, name: string): void {}


### PR DESCRIPTION
This PR introduces introduces ability to inject `ViewContainerRef` on the root / topmost / bootstrapped component. This is supported in the current view engine and used in some tests (ex.: https://github.com/angular/angular/blob/6737e91974c2f5d3bcbed68235cd9ff1730773b3/packages/common/src/directives/ng_component_outlet.ts#L85).

In case of `ViewContainerRef` injected on the topmost component we need to do low-level DOM manipulation to find parent of the host node (to insert a comment node) and a sibling of the host node (to place a comment node next to it). Since both the comment node and its parent will be outside of LTree we need to resort to DOM manipulation.  

I'm not super-happy about this change and open to discussing alternatives (where alternative could be simply banning ability to inject `ViewContainerRef` into the topmost component).