### PR TITLE
fix(core): improve global variable detection

### DIFF
--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -12,22 +12,33 @@ declare var WorkerGlobalScope: any /** TODO #9100 */;
 // We don't want to include the whole node.d.ts this this compilation unit so we'll just fake
 // the global "global" var for now.
 declare var global: any /** TODO #9100 */;
-const __window = typeof window !== 'undefined' && window;
-const __self = typeof self !== 'undefined' && typeof WorkerGlobalScope !== 'undefined' &&
-    self instanceof WorkerGlobalScope && self;
-const __global = typeof global !== 'undefined' && global;
-
-// Check __global first, because in Node tests both __global and __window may be defined and _global
-// should be __global in that case.
-const _global: {[name: string]: any} = __global || __window || __self;
-
 const promise: Promise<any> = Promise.resolve(0);
 /**
  * Attention: whenever providing a new value, be sure to add an
  * entry into the corresponding `....externs.js` file,
  * so that closure won't use that global for its purposes.
  */
+
+const _global = getGlobal();
 export {_global as global};
+export function getGlobal(): any {
+  let _global: any;
+  try {
+    _global = new Function('return this')();
+  } catch (e) {
+    // Content Security Policy with disabled eval
+    const __window = typeof window !== 'undefined' && window;
+    const __self = typeof self !== 'undefined' && typeof WorkerGlobalScope !== 'undefined' &&
+        self instanceof WorkerGlobalScope && self;
+    const __global = typeof global !== 'undefined' && global;
+
+    // Check __global first, because in Node tests both __global and __window may be defined and
+    // _global
+    // should be __global in that case.
+    _global = __global || __window || __self;
+  }
+  return _global;
+}
 
 // When Symbol.iterator doesn't exist, retrieves the key used in es6-shim
 declare const Symbol: any;

--- a/packages/core/test/util_spec.ts
+++ b/packages/core/test/util_spec.ts
@@ -6,9 +6,68 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {stringify} from '../src/util';
+import {getGlobal, global, stringify} from '../src/util';
 
 {
+  describe('getGlobal', () => {
+    const _global: any = new Function('return this')();
+    const originalWGSDescriptor = Object.getOwnPropertyDescriptor(_global, 'WorkerGlobalScope');
+    const originalFunctionDescriptor = Object.getOwnPropertyDescriptor(_global, 'Function');
+    const OriginalFunction = Function;
+    let FunctionSpy: Function;
+
+    beforeEach(() => {
+      FunctionSpy = jasmine.createSpy('Function').and.callFake(function (...args) {
+        return new OriginalFunction(...args);
+      });
+      _global.Function = FunctionSpy;
+    });
+
+    afterEach(() => {
+      delete _global.Function;
+      Object.defineProperty(_global, 'Function', originalFunctionDescriptor!);
+
+      delete _global['WorkerGlobalScope'];
+      if (originalWGSDescriptor) {
+        Object.defineProperty(_global, 'WorkerGlobalScope', originalWGSDescriptor);
+      }
+    });
+
+    it('should return evaluated this', () => {
+      expect(getGlobal()).toBe(_global);
+      expect(FunctionSpy).toHaveBeenCalledWith('return this');
+    });
+
+    it('should fall back to duck typed global when eval is restricted', () => {
+      FunctionSpy.and.throwError(EvalError);
+      expect(getGlobal).not.toThrow();
+      expect(FunctionSpy).toHaveBeenCalledWith('return this');
+    });
+
+    if (isBrowser) {
+      it('should fall back to self if it is an instance of WorkerGlobalScope in web worker', () => {
+        FunctionSpy.and.throwError(EvalError);
+        const wgsGetter = jasmine.createSpy('wgsGetter').and.returnValue(_global.constructor);
+        Object.defineProperty(
+            _global, 'WorkerGlobalScope', {get: wgsGetter, enumerable: true, configurable: true});
+        expect(getGlobal()).toBe(_global);
+        expect(wgsGetter).toHaveBeenCalled();
+      });
+      it('should fall back to window in browser', () => {
+        FunctionSpy.and.throwError(new EvalError());
+        expect(getGlobal()).toBe(_global);
+      });
+    } else {
+      it('should not fall back in Node and return undefined', () => {
+        FunctionSpy.and.throwError(new EvalError());
+        expect(getGlobal()).toBe(undefined);
+      });
+    }
+  });
+  describe('global', () => {
+    it('should get value from getGlobal()', () => { expect(global).toBe(getGlobal()); });
+  });
+
   describe('stringify', () => {
     it('should return string undefined when toString returns undefined',
        () => expect(stringify({toString: (): any => undefined})).toBe('undefined'));


### PR DESCRIPTION
Adds accurate detection of global variable with eval in non-CSP environment, since it cannot be
reliably duck-typed for supported platforms. Keeps duck typing as fallback method for CSP.

Closes #16545
