### PR TITLE
build: fix a PR collision for the tree benchmark

### DIFF
--- a/modules/benchmarks/src/tree/BUILD.bazel
+++ b/modules/benchmarks/src/tree/BUILD.bazel
@@ -23,5 +23,6 @@ ts_library(
     deps = [
         "//modules/e2e_util:lib",
         "//packages:types",
+        "@ngdeps//protractor",
     ],
 )


### PR DESCRIPTION
This commit fixes a PR collision where NPM deps are now specified
explicitly.
