### PR TITLE
ci: don't run ivy and aio_monitoring CI jobs on the patch branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,8 @@ jobs:
     <<: *job_defaults
     resource_class: xlarge
     steps:
+      # don't run this job on the patch branch (to preserve resources)
+      - run: circleci step halt
       - *define_env_vars
       - checkout:
           <<: *post_checkout
@@ -132,6 +134,8 @@ jobs:
     <<: *job_defaults
     resource_class: xlarge
     steps:
+      # don't run this job on the patch branch (to preserve resources)
+      - run: circleci step halt
       - *define_env_vars
       - checkout:
           <<: *post_checkout


### PR DESCRIPTION
We don't need these jobs to run on the patch branch - it would only drain
our VM queue.
