### PR TITLE
ci: don't run ivy tests on upstream non-master branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,14 +134,14 @@ jobs:
     steps:
       - *define_env_vars
       - run:
-        name: Skip this job for non upstream/master jobs to save resources
-        # Note, `|| true` on the end makes this step always exit 0
-        command: '[[
-            "$CI_PULL_REQUEST" == "false"
-            && "$CI_REPO_OWNER" == "angular"
-            && "$CI_REPO_NAME" == "angular"
-            && "$CI_BRANCH" != "master"
-        ]] && circleci step halt || true'
+          name: Skip this job for non upstream/master jobs to save resources
+          # Note, `|| true` on the end makes this step always exit 0
+          command: '[[
+              "$CI_PULL_REQUEST" == "false"
+              && "$CI_REPO_OWNER" == "angular"
+              && "$CI_REPO_NAME" == "angular"
+              && "$CI_BRANCH" != "master"
+              ]] && circleci step halt || true'
       - checkout:
           <<: *post_checkout
       - run: sudo cp .circleci/bazel.rc /etc/bazel.bazelrc
@@ -156,14 +156,14 @@ jobs:
     steps:
       - *define_env_vars
       - run:
-        name: Skip this job for non upstream/master jobs to save resources
-        # Note, `|| true` on the end makes this step always exit 0
-        command: '[[
-            "$CI_PULL_REQUEST" == "false"
-            && "$CI_REPO_OWNER" == "angular"
-            && "$CI_REPO_NAME" == "angular"
-            && "$CI_BRANCH" != "master"
-        ]] && circleci step halt || true'
+          name: Skip this job for non upstream/master jobs to save resources
+          # Note, `|| true` on the end makes this step always exit 0
+          command: '[[
+              "$CI_PULL_REQUEST" == "false"
+              && "$CI_REPO_OWNER" == "angular"
+              && "$CI_REPO_NAME" == "angular"
+              && "$CI_BRANCH" != "master"
+              ]] && circleci step halt || true'
       - checkout:
           <<: *post_checkout
       - run: sudo cp .circleci/bazel.rc /etc/bazel.bazelrc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,15 @@ jobs:
     resource_class: xlarge
     steps:
       - *define_env_vars
+      - run:
+        name: Skip this job for non upstream/master jobs to save resources
+        # Note, `|| true` on the end makes this step always exit 0
+        command: '[[
+            "$CI_PULL_REQUEST" == "false"
+            && "$CI_REPO_OWNER" == "angular"
+            && "$CI_REPO_NAME" == "angular"
+            && "$CI_BRANCH" != "master"
+        ]] && circleci step halt || true'
       - checkout:
           <<: *post_checkout
       - run: sudo cp .circleci/bazel.rc /etc/bazel.bazelrc
@@ -146,6 +155,15 @@ jobs:
     resource_class: xlarge
     steps:
       - *define_env_vars
+      - run:
+        name: Skip this job for non upstream/master jobs to save resources
+        # Note, `|| true` on the end makes this step always exit 0
+        command: '[[
+            "$CI_PULL_REQUEST" == "false"
+            && "$CI_REPO_OWNER" == "angular"
+            && "$CI_REPO_NAME" == "angular"
+            && "$CI_BRANCH" != "master"
+        ]] && circleci step halt || true'
       - checkout:
           <<: *post_checkout
       - run: sudo cp .circleci/bazel.rc /etc/bazel.bazelrc


### PR DESCRIPTION
this implementation can be in both master and patch branch so we reduce the
risk of conflicts during cherry-picking.