### PR TITLE
ci: only publish builds if relevant `aio` jobs pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,6 +423,10 @@ workflows:
             - test_ivy_jit
             - test_ivy_aot
             - integration_test
+            # Only publish if `aio`/`docs` tests using the locally built Angular packages pass
+            - test_aio_local
+            - test_docs_examples_0
+            - test_docs_examples_1
             # Get the artifacts to publish from the build-packages-dist job
             # since the publishing script expects the legacy outputs layout.
             - build-packages-dist


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
- [x] CI related changes


## What is the current behavior?
Some of the `aio`-/`docs`-related jobs rely on the locally built Angular packages. When these jobs fail, it could mean that there is an issue with the Angular packages (e.g. an unintentional breaking change).

The `publish_artifacts` job ignores such failures and runs anyway.

Issue Number: N/A


## What is the new behavior?
The `publish_artifacts` job is not run, unless those `aio`-/`docs`-related jobs pass.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
(The `test_aio_tools` job also uses the locally built Angular packages, but it does not exercise them in a meaningful way to be worth making it a prerequisite for `publish_artifacts`.)
