### PR TITLE
test: make e2e tests for element and upgrade docs examples less flaky

### DIFF
--- a/aio/content/examples/elements/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/elements/e2e/src/app.e2e-spec.ts
@@ -1,6 +1,6 @@
 'use strict'; // necessary for es6 output in node
 
-import { browser, by, element, ElementFinder, ExpectedConditions as EC, until } from 'protractor';
+import { browser, by, element, ElementFinder, ExpectedConditions as EC } from 'protractor';
 
 /* tslint:disable:quotemark */
 describe('Elements', () => {
@@ -15,7 +15,7 @@ describe('Elements', () => {
   };
   const waitForText = (elem: ElementFinder) => {
     // Waiting for the element to have some text, makes the tests less flaky.
-    browser.wait(until.elementTextMatches(elem, /\S/), 5000);
+    browser.wait(async () => /\S/.test(await elem.getText()), 5000);
   }
 
   beforeEach(() => browser.get(''));

--- a/aio/content/examples/elements/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/elements/e2e/src/app.e2e-spec.ts
@@ -1,6 +1,6 @@
 'use strict'; // necessary for es6 output in node
 
-import { browser, by, element, ElementFinder, ExpectedConditions as EC } from 'protractor';
+import { browser, by, element, ElementFinder, ExpectedConditions as EC, until } from 'protractor';
 
 /* tslint:disable:quotemark */
 describe('Elements', () => {
@@ -13,6 +13,10 @@ describe('Elements', () => {
     browser.wait(EC.elementToBeClickable(elem), 5000);
     elem.click();
   };
+  const waitForText = (elem: ElementFinder) => {
+    // Waiting for the element to have some text, makes the tests less flaky.
+    browser.wait(until.elementTextMatches(elem, /\S/), 5000);
+  }
 
   beforeEach(() => browser.get(''));
 
@@ -33,6 +37,8 @@ describe('Elements', () => {
       messageInput.sendKeys('Angular rocks!');
 
       click(popupComponentButton);
+      waitForText(popupComponent);
+
       expect(popupComponent.getText()).toContain('Popup: Angular rocks!');
     });
 
@@ -62,6 +68,8 @@ describe('Elements', () => {
       messageInput.sendKeys('Angular rocks!');
 
       click(popupElementButton);
+      waitForText(popupElement);
+
       expect(popupElement.getText()).toContain('Popup: Angular rocks!');
     });
 

--- a/aio/content/examples/upgrade-phonecat-1-typescript/e2e-spec.ts
+++ b/aio/content/examples/upgrade-phonecat-1-typescript/e2e-spec.ts
@@ -1,6 +1,6 @@
 'use strict'; // necessary for es6 output in node
 
-import { browser, element, by, ElementFinder } from 'protractor';
+import { browser, element, by, ElementArrayFinder, ElementFinder } from 'protractor';
 
 // Angular E2E Testing Guide:
 // https://docs.angularjs.org/guide/e2e-testing
@@ -20,6 +20,12 @@ describe('PhoneCat Application', function() {
 
   describe('View: Phone list', function() {
 
+    // Helpers
+    const waitForCount = (elems: ElementArrayFinder, count: number) => {
+      // Wait for the list to stabilize, which may take a while (e.g. due to animations).
+      browser.wait(() => elems.count().then(c => c === count), 5000);
+    };
+
     beforeEach(function() {
       browser.get('index.html#!/phones');
     });
@@ -28,13 +34,16 @@ describe('PhoneCat Application', function() {
       let phoneList = element.all(by.repeater('phone in $ctrl.phones'));
       let query = element(by.model('$ctrl.query'));
 
+      waitForCount(phoneList, 20);
       expect(phoneList.count()).toBe(20);
 
       query.sendKeys('nexus');
+      waitForCount(phoneList, 1);
       expect(phoneList.count()).toBe(1);
 
       query.clear();
       query.sendKeys('motorola');
+      waitForCount(phoneList, 8);
       expect(phoneList.count()).toBe(8);
     });
 
@@ -51,6 +60,7 @@ describe('PhoneCat Application', function() {
       }
 
       queryField.sendKeys('tablet');   // Let's narrow the dataset to make the assertions shorter
+      waitForCount(phoneNameColumn, 2);
 
       expect(getNames()).toEqual([
         'Motorola XOOM\u2122 with Wi-Fi',
@@ -66,10 +76,16 @@ describe('PhoneCat Application', function() {
     });
 
     it('should render phone specific links', function() {
+      let phoneList = element.all(by.repeater('phone in $ctrl.phones'));
       let query = element(by.model('$ctrl.query'));
-      query.sendKeys('nexus');
 
-      element.all(by.css('.phones li a')).first().click();
+      query.sendKeys('nexus');
+      waitForCount(phoneList, 1);
+
+      let nexusPhone = phoneList.first();
+      let detailLink = nexusPhone.all(by.css('a')).first()
+
+      detailLink.click();
       expect(browser.getLocationAbsUrl()).toBe('/phones/nexus-s');
     });
 


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
- [x] Other... Please describe: Test changes.


## What is the current behavior?
A little flaky e2e tests for `elements` and `upgrade` docs examples.

Issue Number: N/A


## What is the new behavior?
Less flaky e2e tests for `elements` and `upgrade` docs examples.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
