### PR TITLE
docs: remove interface prefixing recommendation from TS Wiki

### DIFF
--- a/aio/content/guide/styleguide.md
+++ b/aio/content/guide/styleguide.md
@@ -1979,18 +1979,6 @@ It is rarely worth the effort to change them at the risk of breaking existing co
 
 
 
-**Why?** <a href="https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines">TypeScript guidelines</a>
-discourage the `I` prefix.
-
-
-</div>
-
-
-
-<div class="s-why">
-
-
-
 **Why?** A class alone is less code than a _class-plus-interface_.
 
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

```
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
```


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:
```

## Does this PR introduce a breaking change?

```
- [ ] Yes
- [x] No
```


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I understand of discouraging of using the `I` prefix on interface, but referring to TypeScript's own guide probably not a good idea, as they [guide](https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines) starts with following warning:



# STOP READING IMMEDIATELY
# THIS PAGE PROBABLY DOES NOT PERTAIN TO YOU
# These are Coding Guidelines for Contributors to TypeScript
# This is NOT a prescriptive guideline for the TypeScript community
# These guidelines are meant for contributors to the TypeScript project's codebase.
# We have chosen many of them for team consistency. Feel free to adopt them for your own team.
# AGAIN: This is NOT a prescriptive guideline for the TypeScript community


