### PR TITLE
ci: cleanup ivy bazel tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
 
       - run: bazel run @yarn//:yarn
       - *setup_bazel_remote_execution
-      - run: bazel test //... --define=compile=jit --build_tag_filters=ivy-jit --test_tag_filters=ivy-jit
+      - run: bazel test //... --define=compile=jit --build_tag_filters=-no-ivy-jit,-fixme-ivy-jit --test_tag_filters=-no-ivy-jit,-fixme-ivy-jit
 
   test_ivy_aot:
     <<: *job_defaults
@@ -152,7 +152,7 @@ jobs:
 
       - run: bazel run @yarn//:yarn
       - *setup_bazel_remote_execution
-      - run: bazel test //... --define=compile=aot --build_tag_filters=ivy-aot --test_tag_filters=ivy-aot
+      - run: bazel test //... --define=compile=aot --build_tag_filters=-no-ivy-aot,-fixme-ivy-aot --test_tag_filters=-no-ivy-aot,-fixme-ivy-aot
 
   test_and_deploy_aio:
     <<: *job_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
 
       - run: bazel run @yarn//:yarn
       - *setup_bazel_remote_execution
-      - run: bazel test //... --define=compile=jit --build_tag_filters=-no-ivy-jit,-fixme-ivy-jit --test_tag_filters=-no-ivy-jit,-fixme-ivy-jit
+      - run: yarn test-ivy-jit //...
 
   test_ivy_aot:
     <<: *job_defaults
@@ -152,7 +152,7 @@ jobs:
 
       - run: bazel run @yarn//:yarn
       - *setup_bazel_remote_execution
-      - run: bazel test //... --define=compile=aot --build_tag_filters=-no-ivy-aot,-fixme-ivy-aot --test_tag_filters=-no-ivy-aot,-fixme-ivy-aot
+      - run: yarn test-ivy-aot //...
 
   test_and_deploy_aio:
     <<: *job_defaults

--- a/docs/BAZEL.md
+++ b/docs/BAZEL.md
@@ -72,7 +72,7 @@ keeps the outputs up-to-date as you save sources.
 
 If you're experiencing problems with seemingly unrelated tests failing, it may be because you're not using the proper flags with your Bazel test runs in Angular.
 
-See also: [`//.bazelrc`](https://github.com/angular/angular/blob/master/.bazelrc) where `--define=ivy=false` is defined as default.
+See also: [`//.bazelrc`](https://github.com/angular/angular/blob/master/.bazelrc) where `--define=compile=legacy` is defined as default.
 
 - `--config=debug`: build and launch in debug mode (see [debugging](#debugging) instructions below)
 - `--test_arg=--node_options=--inspect=9228`: change the inspector port.
@@ -80,11 +80,12 @@ See also: [`//.bazelrc`](https://github.com/angular/angular/blob/master/.bazelrc
     - `legacy`: (default behavior) compile against View Engine, e.g. `--define=compile=legacy`
     - `jit`: Compile in ivy JIT mode, e.g. `--define=compile=jit`
     - `aot`: Compile in ivy AOT move, e.g. `--define=compile=aot`
-- `--test_tag_filters=<tag>`: filter tests down to tags defined in the `tag` config
-of your rules in any given `BUILD.bazel`.
-    - `ivy-jit`: This flag should be set for tests that should be excuted with ivy JIT, e.g. `--test_tag_filters=ivy-jit`. For this, you may have to include `--define=compile=jit`.
-    - `ivy-aot`: Only run tests that have to do with ivy AOT. For this, you may have to include `--define=compile=aot`, e.g. `--test_tag_filters=ivy-aot`..
-    - `ivy-only`: Only run ivy related tests, e.g. `--test_tag_filters=ivy-only`.
+- `--test_tag_filters=<tag>`: filter tests down to tags defined in the `tag` config of your rules in any given `BUILD.bazel`.
+    - `no-ivy-aot`: Useful for excluding build and test targets that are not meant to be executed in Ivy AOT mode (`--define=compile=aot`).
+    - `no-ivy-jit`: Useful for excluding build and test targets that are not meant to be executed in Ivy JIT mode (`--define=compile=jit`).
+    - `ivy-only`: Useful for excluding all Ivy build and tests targets with `--define=compile=legacy`.
+    - `fixme-ivy-aot`: Useful for including/excluding build and test targets that are currently broken in Ivy AOT mode (`--define=compile=aot`).
+    - `fixme-ivy-jit`: Useful for including/excluding build and test targets that are currently broken in Ivy JIT mode (`--define=compile=jit`).
 
 
 ### Debugging a Node Test

--- a/docs/BAZEL.md
+++ b/docs/BAZEL.md
@@ -79,11 +79,11 @@ See also: [`//.bazelrc`](https://github.com/angular/angular/blob/master/.bazelrc
 - `--define=compile=<option>` Controls if ivy or legacy mode is enabled. This switches which compiler is used (ngc, ngtsc, or a tsc pass-through mode).
     - `legacy`: (default behavior) compile against View Engine, e.g. `--define=compile=legacy`
     - `jit`: Compile in ivy JIT mode, e.g. `--define=compile=jit`
-    - `local`: Compile in ivy AOT move, e.g. `--define=compile=local`
+    - `aot`: Compile in ivy AOT move, e.g. `--define=compile=aot`
 - `--test_tag_filters=<tag>`: filter tests down to tags defined in the `tag` config
 of your rules in any given `BUILD.bazel`.
     - `ivy-jit`: This flag should be set for tests that should be excuted with ivy JIT, e.g. `--test_tag_filters=ivy-jit`. For this, you may have to include `--define=compile=jit`.
-    - `ivy-local`: Only run tests that have to do with ivy AOT. For this, you may have to include `--define=compile=local`, e.g. `--test_tag_filters=ivy-local`..
+    - `ivy-aot`: Only run tests that have to do with ivy AOT. For this, you may have to include `--define=compile=aot`, e.g. `--test_tag_filters=ivy-aot`..
     - `ivy-only`: Only run ivy related tests, e.g. `--test_tag_filters=ivy-only`.
 
 

--- a/modules/benchmarks/src/largetable/render3/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/render3/BUILD.bazel
@@ -19,6 +19,7 @@ ng_module(
         "//packages:types",
         "//packages/common",
         "//packages/core",
+        "@ngdeps//reflect-metadata",
     ],
 )
 

--- a/modules/benchmarks/src/largetable/render3/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/render3/BUILD.bazel
@@ -63,7 +63,11 @@ protractor_web_test(
     ],
     on_prepare = ":protractor.on_prepare.js",
     server = ":devserver",
-    tags = ["ivy-only"],
+    tags = [
+        "fixme-ivy-aot",
+        "fixme-ivy-jit",
+        "ivy-only",
+    ],
     deps = [
         "//modules/benchmarks/src/largetable:perf_lib",
     ],

--- a/modules/benchmarks/src/tree/render3/BUILD.bazel
+++ b/modules/benchmarks/src/tree/render3/BUILD.bazel
@@ -57,7 +57,11 @@ protractor_web_test(
     ],
     on_prepare = ":protractor.on_prepare.js",
     server = ":devserver",
-    tags = ["ivy-only"],
+    tags = [
+        "fixme-ivy-aot",
+        "fixme-ivy-jit",
+        "ivy-only",
+    ],
     deps = [
         "//modules/benchmarks/src/tree:perf_lib",
         "@ngdeps//node-uuid",

--- a/modules/benchmarks/src/tree/render3/BUILD.bazel
+++ b/modules/benchmarks/src/tree/render3/BUILD.bazel
@@ -17,6 +17,7 @@ ng_module(
         "//packages:types",
         "//packages/common",
         "//packages/core",
+        "@ngdeps//reflect-metadata",
     ],
 )
 
@@ -61,7 +62,6 @@ protractor_web_test(
         "//modules/benchmarks/src/tree:perf_lib",
         "@ngdeps//node-uuid",
         "@ngdeps//protractor",
-        "@ngdeps//reflect-metadata",
         "@ngdeps//yargs",
     ],
 )

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "update-webdriver": "webdriver-manager update --gecko false $CHROMEDRIVER_VERSION_ARG",
     "check-env": "gulp check-env",
     "commitmsg": "node ./scripts/git/commit-msg.js",
-    "test-ivy-jit": "bazel test --define=compile=jit --build_tag_filters=ivy-jit --test_tag_filters=ivy-jit",
-    "test-fixme-ivy-jit": "bazel test --define=compile=jit --build_tag_filters=-no-ivy --test_tag_filters=-no-ivy",
-    "test-ivy-aot": "bazel test --define=compile=aot --build_tag_filters=ivy-aot --test_tag_filters=ivy-aot",
-    "test-fixme-ivy-aot": "bazel test --define=compile=aot --build_tag_filters=-no-ivy --test_tag_filters=-no-ivy"
+    "test-ivy-jit": "bazel test --define=compile=jit --build_tag_filters=-no-ivy-jit,-fixme-ivy-jit --test_tag_filters=-no-ivy-jit,-fixme-ivy-jit",
+    "test-fixme-ivy-jit": "bazel test --define=compile=jit --build_tag_filters=-no-ivy-jit --test_tag_filters=-no-ivy-jit",
+    "test-ivy-aot": "bazel test --define=compile=aot --build_tag_filters=-no-ivy-aot,-fixme-ivy-aot --test_tag_filters=-no-ivy-aot,-fixme-ivy-aot",
+    "test-fixme-ivy-aot": "bazel test --define=compile=aot --build_tag_filters=-no-ivy-aot --test_tag_filters=-no-ivy-aot"
   },
   "dependencies": {
     "@angular-devkit/schematics": "^0.5.5",

--- a/packages/benchpress/BUILD.bazel
+++ b/packages/benchpress/BUILD.bazel
@@ -15,5 +15,6 @@ ts_library(
         "//packages:types",
         "//packages/core",
         "@ngdeps//@types/node",
+        "@ngdeps//reflect-metadata",
     ],
 )

--- a/packages/compiler-cli/integrationtest/bazel/ng_module/BUILD.bazel
+++ b/packages/compiler-cli/integrationtest/bazel/ng_module/BUILD.bazel
@@ -2,6 +2,7 @@ load("//packages/bazel:index.bzl", "ng_module")
 
 ng_module(
     name = "test_module",
+    testonly = True,
     srcs = glob(["*.ts"]),
     compiler = "//packages/bazel/src/ngc-wrapped",
     entry_point = "index.ts",
@@ -9,6 +10,10 @@ ng_module(
     module_name = "some_npm_module",
     ng_xi18n = "//packages/bazel/src/ngc-wrapped:xi18n",
     node_modules = "@ngdeps//typescript:typescript__typings",
+    tags = [
+        "fixme-ivy-aot",
+        "no-ivy-jit",
+    ],
     deps = [
         "//packages/core",
         "@ngdeps//@types",
@@ -19,6 +24,7 @@ load(":extract_flat_module_index.bzl", "extract_flat_module_index")
 
 extract_flat_module_index(
     name = "flat_module_index",
+    testonly = True,
     deps = [":test_module"],
 )
 

--- a/packages/core/test/bundling/animation_world/BUILD.bazel
+++ b/packages/core/test/bundling/animation_world/BUILD.bazel
@@ -7,7 +7,10 @@ load("//tools/http-server:http_server.bzl", "http_server")
 ng_module(
     name = "animation_world",
     srcs = ["index.ts"],
-    tags = ["ivy-only"],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     type_check = False,  # see #26462
     deps = [
         "//packages/common",
@@ -25,7 +28,10 @@ ng_rollup_bundle(
     # has an "external" directory for external dependencies.
     # This should probably start with "angular/" and let the rule deal with it.
     entry_point = "packages/core/test/bundling/animation_world/index.js",
-    tags = ["ivy-only"],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         ":animation_world",
         "//packages/core",
@@ -39,6 +45,7 @@ js_expected_symbol_test(
     tags = [
         "ivy-aot",
         "ivy-only",
+        "no-ivy-jit",
     ],
 )
 
@@ -50,5 +57,9 @@ http_server(
         "index.html",
         ":bundle.min.js",
         ":bundle.min_debug.js",
+    ],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
     ],
 )

--- a/packages/core/test/bundling/hello_world/BUILD.bazel
+++ b/packages/core/test/bundling/hello_world/BUILD.bazel
@@ -7,7 +7,10 @@ load("//tools/http-server:http_server.bzl", "http_server")
 ng_module(
     name = "hello_world",
     srcs = ["index.ts"],
-    tags = ["ivy-only"],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         "//packages/core",
     ],
@@ -22,7 +25,10 @@ ng_rollup_bundle(
     # has an "external" directory for external dependencies.
     # This should probably start with "angular/" and let the rule deal with it.
     entry_point = "packages/core/test/bundling/hello_world/index.js",
-    tags = ["ivy-only"],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         ":hello_world",
         "//packages/core",
@@ -33,6 +39,10 @@ ts_library(
     name = "test_lib",
     testonly = True,
     srcs = glob(["*_spec.ts"]),
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         "//packages:types",
         "//packages/core/testing",
@@ -50,6 +60,7 @@ jasmine_node_test(
     ],
     tags = [
         "ivy-only",
+        "no-ivy-jit",
     ],
     deps = [":test_lib"],
 )
@@ -61,6 +72,7 @@ js_expected_symbol_test(
     tags = [
         "ivy-aot",
         "ivy-only",
+        "no-ivy-jit",
     ],
 )
 
@@ -70,5 +82,9 @@ http_server(
         "index.html",
         ":bundle.min.js",
         ":bundle.min_debug.js",
+    ],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
     ],
 )

--- a/packages/core/test/bundling/hello_world_i18n/BUILD.bazel
+++ b/packages/core/test/bundling/hello_world_i18n/BUILD.bazel
@@ -6,6 +6,7 @@ load("//tools/http-server:http_server.bzl", "http_server")
 ivy_ng_module(
     name = "hello_world_i18n",
     srcs = ["index.ts"],
+    tags = ["ivy-only"],
     deps = [
         "//packages/core",
     ],
@@ -20,6 +21,7 @@ ng_rollup_bundle(
     # has an "external" directory for external dependencies.
     # This should probably start with "angular/" and let the rule deal with it.
     entry_point = "packages/core/test/bundling/hello_world_i18n/index.js",
+    tags = ["ivy-only"],
     deps = [
         ":hello_world_i18n",
         "//packages/core",
@@ -33,4 +35,5 @@ http_server(
         ":bundle.min.js",
         ":bundle.min_debug.js",
     ],
+    tags = ["ivy-only"],
 )

--- a/packages/core/test/bundling/hello_world_r2/BUILD.bazel
+++ b/packages/core/test/bundling/hello_world_r2/BUILD.bazel
@@ -7,6 +7,10 @@ load("//tools/http-server:http_server.bzl", "http_server")
 ng_module(
     name = "hello_world",
     srcs = ["index.ts"],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         "//packages/core",
         "//packages/platform-browser-dynamic",
@@ -22,6 +26,10 @@ ng_rollup_bundle(
     # has an "external" directory for external dependencies.
     # This should probably start with "angular/" and let the rule deal with it.
     entry_point = "packages/core/test/bundling/hello_world_r2/index.js",
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         ":hello_world",
         "//packages/core",
@@ -33,6 +41,10 @@ ts_library(
     name = "test_lib",
     testonly = True,
     srcs = glob(["*_spec.ts"]),
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         "//packages:types",
         "//packages/core/testing",
@@ -48,6 +60,10 @@ jasmine_node_test(
         ":bundle.min.js.br",
         ":bundle.min_debug.js",
     ],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [":test_lib"],
 )
 
@@ -55,6 +71,10 @@ js_expected_symbol_test(
     name = "symbol_test",
     src = ":bundle.min_debug.js",
     golden = ":bundle.golden_symbols.json",
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
 )
 
 http_server(
@@ -63,5 +83,9 @@ http_server(
         "index.html",
         ":bundle.min.js",
         ":bundle.min_debug.js",
+    ],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
     ],
 )

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -165,6 +165,9 @@
     "name": "$z"
   },
   {
+    "name": "ACTIVE_INDEX"
+  },
+  {
     "name": "ALLOW_DEFAULT_VAR"
   },
   {
@@ -228,16 +231,22 @@
     "name": "AttrAst"
   },
   {
-    "name": "Attribute$1"
+    "name": "Attribute"
   },
   {
     "name": "B64_DIGITS"
+  },
+  {
+    "name": "BINDING_INDEX"
   },
   {
     "name": "BIND_NAME_REGEXP"
   },
   {
     "name": "BLOCK_PLACEHOLDER"
+  },
+  {
+    "name": "BLOOM_MASK"
   },
   {
     "name": "BOOLEAN"
@@ -327,6 +336,9 @@
     "name": "CIRCULAR"
   },
   {
+    "name": "CIRCULAR$1"
+  },
+  {
     "name": "CLASS_ATTR"
   },
   {
@@ -334,6 +346,12 @@
   },
   {
     "name": "CLASS_PREFIX"
+  },
+  {
+    "name": "CLEANUP"
+  },
+  {
+    "name": "CLEAN_PROMISE"
   },
   {
     "name": "CLOSE_CURLY"
@@ -345,6 +363,9 @@
     "name": "COMPILER_PROVIDERS"
   },
   {
+    "name": "COMPONENT_FACTORY_RESOLVER"
+  },
+  {
     "name": "COMPONENT_VARIABLE"
   },
   {
@@ -354,7 +375,13 @@
     "name": "CONSTANT_PREFIX"
   },
   {
+    "name": "CONTAINER_INDEX"
+  },
+  {
     "name": "CONTENT_ATTR"
+  },
+  {
+    "name": "CONTEXT"
   },
   {
     "name": "CORE"
@@ -453,16 +480,25 @@
     "name": "ComponentFactory"
   },
   {
+    "name": "ComponentFactory$1"
+  },
+  {
     "name": "ComponentFactoryBoundToModule"
   },
   {
     "name": "ComponentFactoryResolver"
   },
   {
+    "name": "ComponentFactoryResolver$1"
+  },
+  {
     "name": "ComponentFactory_"
   },
   {
     "name": "ComponentRef"
+  },
+  {
+    "name": "ComponentRef$1"
   },
   {
     "name": "ComponentRef_"
@@ -499,6 +535,9 @@
   },
   {
     "name": "DASH_CASE_REGEXP"
+  },
+  {
+    "name": "DECLARATION_VIEW"
   },
   {
     "name": "DEFAULT_INTERPOLATION_CONFIG"
@@ -570,10 +609,16 @@
     "name": "DomElementSchemaRegistry"
   },
   {
+    "name": "EMPTY"
+  },
+  {
     "name": "EMPTY$1"
   },
   {
-    "name": "EMPTY_ARRAY$4"
+    "name": "EMPTY_ARRAY$1"
+  },
+  {
+    "name": "EMPTY_ARRAY$2"
   },
   {
     "name": "EMPTY_ARRAY$5"
@@ -702,6 +747,12 @@
     "name": "ExtractionResult"
   },
   {
+    "name": "FLAGS"
+  },
+  {
+    "name": "FactoryPrototype"
+  },
+  {
     "name": "FixupExpression"
   },
   {
@@ -717,7 +768,16 @@
     "name": "GOOG_GET_MSG"
   },
   {
+    "name": "HEADER_OFFSET"
+  },
+  {
+    "name": "HOST"
+  },
+  {
     "name": "HOST_ATTR"
+  },
+  {
+    "name": "HOST_NODE"
   },
   {
     "name": "HOST_REG_EXP"
@@ -780,6 +840,9 @@
     "name": "INHERITED_CLASS_WITH_CTOR"
   },
   {
+    "name": "INJECTOR"
+  },
+  {
     "name": "INJECTOR$1"
   },
   {
@@ -787,6 +850,9 @@
   },
   {
     "name": "INJECTORRefTokenKey$1"
+  },
+  {
+    "name": "INJECTOR_SIZE"
   },
   {
     "name": "INTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS"
@@ -814,9 +880,6 @@
   },
   {
     "name": "Inject"
-  },
-  {
-    "name": "Injectable"
   },
   {
     "name": "InjectionToken"
@@ -933,6 +996,9 @@
     "name": "LifecycleHooks"
   },
   {
+    "name": "LifecycleHooksFeature"
+  },
+  {
     "name": "LiteralArray"
   },
   {
@@ -958,6 +1024,9 @@
   },
   {
     "name": "MODULE_SUFFIX"
+  },
+  {
+    "name": "MONKEY_PATCH_KEY_NAME"
   },
   {
     "name": "MULTI_PROVIDER_FN"
@@ -996,22 +1065,49 @@
     "name": "NAMED_ENTITIES"
   },
   {
+    "name": "NATIVE"
+  },
+  {
     "name": "NEW_LINE"
+  },
+  {
+    "name": "NEXT"
   },
   {
     "name": "NGSP_UNICODE"
   },
   {
+    "name": "NG_COMPONENT_DEF"
+  },
+  {
     "name": "NG_CONTENT_SELECT_ATTR"
+  },
+  {
+    "name": "NG_DIRECTIVE_DEF"
+  },
+  {
+    "name": "NG_ELEMENT_ID"
   },
   {
     "name": "NG_INJECTABLE_DEF"
   },
   {
+    "name": "NG_INJECTOR_DEF"
+  },
+  {
+    "name": "NG_MODULE_DEF"
+  },
+  {
     "name": "NG_NON_BINDABLE_ATTR"
   },
   {
+    "name": "NG_PIPE_DEF"
+  },
+  {
     "name": "NG_PROJECT_AS"
+  },
+  {
+    "name": "NG_PROJECT_AS_ATTR_NAME"
   },
   {
     "name": "NG_TEMP_TOKEN_PATH"
@@ -1026,13 +1122,25 @@
     "name": "NOOP"
   },
   {
+    "name": "NOT_FOUND"
+  },
+  {
     "name": "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR"
+  },
+  {
+    "name": "NOT_YET"
+  },
+  {
+    "name": "NO_CHANGE"
   },
   {
     "name": "NO_ERRORS_SCHEMA"
   },
   {
     "name": "NO_NEW_LINE"
+  },
+  {
+    "name": "NO_PARENT_INJECTOR"
   },
   {
     "name": "NO_WS_REGEXP"
@@ -1045,6 +1153,9 @@
   },
   {
     "name": "NULL_INJECTOR"
+  },
+  {
+    "name": "NULL_INJECTOR$2"
   },
   {
     "name": "NUMBER"
@@ -1062,6 +1173,9 @@
     "name": "NgModuleFactory"
   },
   {
+    "name": "NgModuleFactory$1"
+  },
+  {
     "name": "NgModuleFactory_"
   },
   {
@@ -1069,6 +1183,9 @@
   },
   {
     "name": "NgModuleRef"
+  },
+  {
+    "name": "NgModuleRef$1"
   },
   {
     "name": "NgModuleRefTokenKey"
@@ -1081,6 +1198,15 @@
   },
   {
     "name": "NgZone"
+  },
+  {
+    "name": "NodeInjector"
+  },
+  {
+    "name": "NodeInjector$1"
+  },
+  {
+    "name": "NodeInjectorFactory"
   },
   {
     "name": "NonBindableVisitor"
@@ -1123,6 +1249,12 @@
   },
   {
     "name": "PARAMETERS"
+  },
+  {
+    "name": "PARENT"
+  },
+  {
+    "name": "PARENT_INJECTOR"
   },
   {
     "name": "PLATFORM_BROWSER_ID"
@@ -1239,6 +1371,9 @@
     "name": "ProviderViewContext"
   },
   {
+    "name": "QUERIES"
+  },
+  {
     "name": "QUERY_METADATA_IDENTIFIERS"
   },
   {
@@ -1249,6 +1384,21 @@
   },
   {
     "name": "Quote"
+  },
+  {
+    "name": "R3Injector"
+  },
+  {
+    "name": "RENDERER"
+  },
+  {
+    "name": "RENDER_PARENT"
+  },
+  {
+    "name": "ROOT_CONTEXT"
+  },
+  {
+    "name": "ROOT_EXPANDO_INSTRUCTIONS"
   },
   {
     "name": "ReadKeyExpr"
@@ -1299,10 +1449,22 @@
     "name": "ResourceLoader"
   },
   {
+    "name": "ResourceLoaderImpl"
+  },
+  {
     "name": "ReturnStatement"
   },
   {
     "name": "ReturnValue"
+  },
+  {
+    "name": "RootViewRef"
+  },
+  {
+    "name": "SANITIZER"
+  },
+  {
+    "name": "SCHEDULER"
   },
   {
     "name": "SCHEMA"
@@ -1336,9 +1498,6 @@
   },
   {
     "name": "SWITCH_CHANGE_DETECTOR_REF_FACTORY"
-  },
-  {
-    "name": "SWITCH_COMPILE_INJECTABLE"
   },
   {
     "name": "SWITCH_ELEMENT_REF_FACTORY"
@@ -1470,10 +1629,19 @@
     "name": "TAG_TO_PLACEHOLDER_NAMES"
   },
   {
+    "name": "TAIL"
+  },
+  {
     "name": "TEMPLATE_ATTR_PREFIX"
   },
   {
     "name": "TEXT_CSS_SELECTOR"
+  },
+  {
+    "name": "THROW_IF_NOT_FOUND"
+  },
+  {
+    "name": "TNODE"
   },
   {
     "name": "TRANSLATIONS"
@@ -1483,6 +1651,9 @@
   },
   {
     "name": "TRANSLATION_PREFIX"
+  },
+  {
+    "name": "TVIEW"
   },
   {
     "name": "TYPED_NULL_EXPR"
@@ -1605,9 +1776,6 @@
     "name": "USE_VALUE$1"
   },
   {
-    "name": "USE_VALUE$2"
-  },
-  {
     "name": "UnsubscriptionError"
   },
   {
@@ -1621,6 +1789,9 @@
   },
   {
     "name": "VERSION$2"
+  },
+  {
+    "name": "VIEWS"
   },
   {
     "name": "VIEW_VAR"
@@ -1662,7 +1833,13 @@
     "name": "ViewEncapsulation$1"
   },
   {
+    "name": "ViewRef"
+  },
+  {
     "name": "ViewRef_"
+  },
+  {
+    "name": "WRAP_RENDERER_FACTORY2"
   },
   {
     "name": "WS_CHARS"
@@ -1729,6 +1906,9 @@
   },
   {
     "name": "_BuiltinAstConverter"
+  },
+  {
+    "name": "_CLEAN_PROMISE"
   },
   {
     "name": "_CONTEXT_GROUP_TAG"
@@ -1938,9 +2118,6 @@
     "name": "__assign"
   },
   {
-    "name": "__decorate"
-  },
-  {
     "name": "__extends"
   },
   {
@@ -1972,12 +2149,6 @@
   },
   {
     "name": "__forward_ref__"
-  },
-  {
-    "name": "__metadata"
-  },
-  {
-    "name": "__param"
   },
   {
     "name": "__read"
@@ -2071,6 +2242,9 @@
   },
   {
     "name": "_currentInjector"
+  },
+  {
+    "name": "_currentNamespace"
   },
   {
     "name": "_declareFn"
@@ -2181,6 +2355,9 @@
     "name": "_removeDotSegments"
   },
   {
+    "name": "_renderCompCount"
+  },
+  {
     "name": "_renderCompCount$1"
   },
   {
@@ -2256,10 +2433,19 @@
     "name": "addBigInt"
   },
   {
+    "name": "addRemoveViewFromContainer"
+  },
+  {
     "name": "addToArray"
   },
   {
+    "name": "addToViewTree"
+  },
+  {
     "name": "anchorDef"
+  },
+  {
+    "name": "appendChild"
   },
   {
     "name": "appendNgContent"
@@ -2316,6 +2502,9 @@
     "name": "attachEmbeddedView"
   },
   {
+    "name": "attachPatchData"
+  },
+  {
     "name": "attachProjectedView"
   },
   {
@@ -2325,7 +2514,19 @@
     "name": "baseHtmlParser"
   },
   {
+    "name": "baseResolveDirective"
+  },
+  {
     "name": "blackListedEvents"
+  },
+  {
+    "name": "bloomAdd"
+  },
+  {
+    "name": "bloomHasToken"
+  },
+  {
+    "name": "bloomHashBitOrFactory"
   },
   {
     "name": "builtinExternalReferences"
@@ -2361,6 +2562,9 @@
     "name": "callFactory"
   },
   {
+    "name": "callHooks"
+  },
+  {
     "name": "callLifecycleHooksChildrenFirst"
   },
   {
@@ -2380,6 +2584,15 @@
   },
   {
     "name": "camelCaseToDashCase"
+  },
+  {
+    "name": "canInsertNativeChildOfElement"
+  },
+  {
+    "name": "canInsertNativeChildOfView"
+  },
+  {
+    "name": "canInsertNativeNode"
   },
   {
     "name": "canReportError"
@@ -2436,6 +2649,15 @@
     "name": "checkBindingNoChanges"
   },
   {
+    "name": "checkNoChanges"
+  },
+  {
+    "name": "checkNoChangesInRootView"
+  },
+  {
+    "name": "checkNoChangesMode"
+  },
+  {
     "name": "checkNoChangesNode"
   },
   {
@@ -2454,6 +2676,9 @@
     "name": "checkStable"
   },
   {
+    "name": "cleanUpView"
+  },
+  {
     "name": "cloneNgModuleDefinition"
   },
   {
@@ -2466,13 +2691,16 @@
     "name": "compileNgModuleFactory"
   },
   {
-    "name": "compileNgModuleFactory__PRE_R3__"
+    "name": "compileNgModuleFactory__POST_R3__"
   },
   {
     "name": "componentFactoryName"
   },
   {
     "name": "componentFactoryResolverProviderDef"
+  },
+  {
+    "name": "componentRefresh"
   },
   {
     "name": "componentStillLoadingError"
@@ -2499,9 +2727,6 @@
     "name": "convertBuiltins"
   },
   {
-    "name": "convertInjectableProviderToFactory"
-  },
-  {
     "name": "convertPropertyBinding"
   },
   {
@@ -2518,6 +2743,9 @@
   },
   {
     "name": "convertValueToOutputAst"
+  },
+  {
+    "name": "couldBeInjectableType"
   },
   {
     "name": "createAttribute"
@@ -2539,6 +2767,9 @@
   },
   {
     "name": "createComponentView"
+  },
+  {
+    "name": "createContainerRef"
   },
   {
     "name": "createContentChild"
@@ -2568,7 +2799,13 @@
     "name": "createElementCssSelector"
   },
   {
+    "name": "createElementRef"
+  },
+  {
     "name": "createEmbeddedView"
+  },
+  {
+    "name": "createEmbeddedViewAndNode"
   },
   {
     "name": "createHost"
@@ -2592,10 +2829,22 @@
     "name": "createInjectionToken"
   },
   {
+    "name": "createInjector"
+  },
+  {
     "name": "createInjector$1"
   },
   {
     "name": "createInput"
+  },
+  {
+    "name": "createLContainer"
+  },
+  {
+    "name": "createLContext"
+  },
+  {
+    "name": "createLViewData"
   },
   {
     "name": "createLazyProperty"
@@ -2608,6 +2857,9 @@
   },
   {
     "name": "createNgModuleRef"
+  },
+  {
+    "name": "createNodeAtIndex"
   },
   {
     "name": "createOptional"
@@ -2655,6 +2907,15 @@
     "name": "createRendererV1"
   },
   {
+    "name": "createRootComponent"
+  },
+  {
+    "name": "createRootComponentView"
+  },
+  {
+    "name": "createRootContext"
+  },
+  {
     "name": "createRootData"
   },
   {
@@ -2673,10 +2934,22 @@
     "name": "createSkipSelf"
   },
   {
+    "name": "createTNode"
+  },
+  {
+    "name": "createTView"
+  },
+  {
     "name": "createTemplateData"
   },
   {
+    "name": "createTemplateRef"
+  },
+  {
     "name": "createText"
+  },
+  {
+    "name": "createTextNode"
   },
   {
     "name": "createTokenForExternalReference"
@@ -2688,6 +2961,9 @@
     "name": "createView"
   },
   {
+    "name": "createViewBlueprint"
+  },
+  {
     "name": "createViewChild"
   },
   {
@@ -2697,7 +2973,16 @@
     "name": "createViewContainerData"
   },
   {
+    "name": "createViewNode"
+  },
+  {
     "name": "createViewNodes"
+  },
+  {
+    "name": "createViewQuery"
+  },
+  {
+    "name": "createViewRef"
   },
   {
     "name": "dashCaseToCamelCase"
@@ -2763,13 +3048,28 @@
     "name": "dedupeArray"
   },
   {
+    "name": "deepForEach"
+  },
+  {
     "name": "defaultErrorLogger"
+  },
+  {
+    "name": "defineComponent"
   },
   {
     "name": "defineInjectable"
   },
   {
+    "name": "defineInjector"
+  },
+  {
+    "name": "defineNgModule"
+  },
+  {
     "name": "depDef"
+  },
+  {
+    "name": "destroyLView"
   },
   {
     "name": "destroyView"
@@ -2778,16 +3078,34 @@
     "name": "destroyViewNodes"
   },
   {
+    "name": "destroyViewTree"
+  },
+  {
     "name": "detachEmbeddedView"
   },
   {
     "name": "detachProjectedView"
   },
   {
+    "name": "detachView"
+  },
+  {
+    "name": "detectChanges"
+  },
+  {
+    "name": "detectChangesInRootView"
+  },
+  {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "detectWTF"
   },
   {
     "name": "devModeEqual"
+  },
+  {
+    "name": "diPublicInInjector"
   },
   {
     "name": "digest"
@@ -2805,7 +3123,13 @@
     "name": "dispatchEvent"
   },
   {
+    "name": "domRendererFactory3"
+  },
+  {
     "name": "elementBindingDef"
+  },
+  {
+    "name": "elementCreate"
   },
   {
     "name": "elementDef"
@@ -2827,6 +3151,9 @@
   },
   {
     "name": "ensureStatementMode"
+  },
+  {
+    "name": "enterView"
   },
   {
     "name": "error"
@@ -2868,6 +3195,24 @@
     "name": "execRenderNodeAction"
   },
   {
+    "name": "executeHooks"
+  },
+  {
+    "name": "executeInitAndContentHooks"
+  },
+  {
+    "name": "executeInitHooks"
+  },
+  {
+    "name": "executeNodeAction"
+  },
+  {
+    "name": "executeOnDestroys"
+  },
+  {
+    "name": "executePipeOnDestroys"
+  },
+  {
     "name": "expandNodes"
   },
   {
@@ -2883,7 +3228,13 @@
     "name": "extractCommentsWithHash"
   },
   {
+    "name": "extractDirectiveDef"
+  },
+  {
     "name": "extractIdentifiers"
+  },
+  {
+    "name": "extractPipeDef"
   },
   {
     "name": "extractStyleUrls"
@@ -2893,6 +3244,9 @@
   },
   {
     "name": "findCompView"
+  },
+  {
+    "name": "findComponentView"
   },
   {
     "name": "findHostElement"
@@ -2907,7 +3261,13 @@
     "name": "findStaticQueryIds"
   },
   {
+    "name": "findViaComponent"
+  },
+  {
     "name": "fingerprint"
+  },
+  {
+    "name": "firstTemplatePass"
   },
   {
     "name": "fixedAttrsDef"
@@ -2967,16 +3327,43 @@
     "name": "getBaseElementHref"
   },
   {
+    "name": "getBeforeNodeForView"
+  },
+  {
+    "name": "getCheckNoChangesMode"
+  },
+  {
+    "name": "getCleanup"
+  },
+  {
     "name": "getClosureSafeProperty"
   },
   {
+    "name": "getComponentDef"
+  },
+  {
+    "name": "getComponentViewByIndex"
+  },
+  {
+    "name": "getComponentViewByInstance"
+  },
+  {
     "name": "getComponentViewDefinitionFactory"
+  },
+  {
+    "name": "getContainerRenderParent"
+  },
+  {
+    "name": "getCreationMode"
   },
   {
     "name": "getCtypeForTag"
   },
   {
     "name": "getCurrentDebugContext"
+  },
+  {
+    "name": "getCurrentSanitizer"
   },
   {
     "name": "getDOM"
@@ -2988,22 +3375,79 @@
     "name": "getDebugNode"
   },
   {
+    "name": "getDirectiveDef"
+  },
+  {
     "name": "getErrorLogger"
+  },
+  {
+    "name": "getFactoryOf"
+  },
+  {
+    "name": "getFirstTemplatePass"
+  },
+  {
+    "name": "getHighestElementContainer"
   },
   {
     "name": "getHookName"
   },
   {
+    "name": "getHostNative"
+  },
+  {
     "name": "getHtmlTagDefinition"
+  },
+  {
+    "name": "getInheritedFactory"
   },
   {
     "name": "getInjectableDef"
   },
   {
+    "name": "getInjectorDef"
+  },
+  {
+    "name": "getInjectorIndex"
+  },
+  {
+    "name": "getIsParent"
+  },
+  {
+    "name": "getLContainer"
+  },
+  {
+    "name": "getLViewChild"
+  },
+  {
+    "name": "getNativeByTNode"
+  },
+  {
+    "name": "getNgModuleDef"
+  },
+  {
     "name": "getNgZone"
   },
   {
+    "name": "getNodeInjectable"
+  },
+  {
     "name": "getNsPrefix"
+  },
+  {
+    "name": "getNullInjector"
+  },
+  {
+    "name": "getOrCreateInjectable"
+  },
+  {
+    "name": "getOrCreateNodeInjectorForNode"
+  },
+  {
+    "name": "getOrCreateRenderer2"
+  },
+  {
+    "name": "getOrCreateTView"
   },
   {
     "name": "getOriginalError"
@@ -3012,10 +3456,37 @@
     "name": "getParentCtor"
   },
   {
+    "name": "getParentInjectorIndex"
+  },
+  {
+    "name": "getParentInjectorLocation"
+  },
+  {
+    "name": "getParentInjectorTNode"
+  },
+  {
+    "name": "getParentInjectorView"
+  },
+  {
+    "name": "getParentInjectorViewOffset"
+  },
+  {
+    "name": "getParentNative"
+  },
+  {
     "name": "getParentRenderElement"
   },
   {
+    "name": "getParentState"
+  },
+  {
+    "name": "getPipeDef"
+  },
+  {
     "name": "getPlatform"
+  },
+  {
+    "name": "getPreviousOrParentTNode"
   },
   {
     "name": "getPromiseCtor"
@@ -3024,7 +3495,19 @@
     "name": "getQueryValue"
   },
   {
+    "name": "getRenderFlags"
+  },
+  {
     "name": "getRenderNodeIndex"
+  },
+  {
+    "name": "getRenderParent"
+  },
+  {
+    "name": "getRenderer"
+  },
+  {
+    "name": "getRendererFactory"
   },
   {
     "name": "getStylesVarName"
@@ -3036,16 +3519,37 @@
     "name": "getSymbolIterator$1"
   },
   {
+    "name": "getTNode"
+  },
+  {
+    "name": "getTView"
+  },
+  {
+    "name": "getTViewCleanup"
+  },
+  {
     "name": "getTypeForTag"
   },
   {
     "name": "getUrlScheme"
   },
   {
+    "name": "getViewData"
+  },
+  {
     "name": "getXmlTagDefinition"
   },
   {
+    "name": "hasDeps"
+  },
+  {
     "name": "hasLifecycleHook"
+  },
+  {
+    "name": "hasOnDestroy"
+  },
+  {
+    "name": "hasParentInjector"
   },
   {
     "name": "hasPreserveWhitespacesAttr"
@@ -3081,6 +3585,9 @@
     "name": "importType"
   },
   {
+    "name": "includeViewProviders"
+  },
+  {
     "name": "indexDebugNode"
   },
   {
@@ -3088,6 +3595,9 @@
   },
   {
     "name": "initNgModule"
+  },
+  {
+    "name": "initNodeFlags"
   },
   {
     "name": "initServicesIfNeeded"
@@ -3105,13 +3615,43 @@
     "name": "injectArgs"
   },
   {
+    "name": "injectChangeDetectorRef"
+  },
+  {
+    "name": "injectElementRef"
+  },
+  {
+    "name": "injectInjector"
+  },
+  {
     "name": "injectInjectorOnly"
+  },
+  {
+    "name": "injectRenderer2"
   },
   {
     "name": "injectRootLimpMode"
   },
   {
+    "name": "injectTemplateRef"
+  },
+  {
+    "name": "injectViewContainerRef"
+  },
+  {
+    "name": "injectableDefFactory"
+  },
+  {
     "name": "inlineInterpolate"
+  },
+  {
+    "name": "insertBloom"
+  },
+  {
+    "name": "insertView"
+  },
+  {
+    "name": "instantiateRootComponent"
   },
   {
     "name": "interpolate$1"
@@ -3121,6 +3661,9 @@
   },
   {
     "name": "invalid"
+  },
+  {
+    "name": "invertObject"
   },
   {
     "name": "isAnimationLabel"
@@ -3136,6 +3679,12 @@
   },
   {
     "name": "isAsciiLetter"
+  },
+  {
+    "name": "isComponent"
+  },
+  {
+    "name": "isComponentDef"
   },
   {
     "name": "isComponentView"
@@ -3162,6 +3711,9 @@
     "name": "isEmptyExpression"
   },
   {
+    "name": "isExistingProvider"
+  },
+  {
     "name": "isExpansionCaseStart"
   },
   {
@@ -3172,6 +3724,12 @@
   },
   {
     "name": "isExponentStart"
+  },
+  {
+    "name": "isFactory"
+  },
+  {
+    "name": "isFactoryProvider"
   },
   {
     "name": "isFunction"
@@ -3193,6 +3751,9 @@
   },
   {
     "name": "isJsObject"
+  },
+  {
+    "name": "isLContainer"
   },
   {
     "name": "isListLikeIterable"
@@ -3228,6 +3789,9 @@
     "name": "isPrefixEnd"
   },
   {
+    "name": "isProceduralRenderer"
+  },
+  {
     "name": "isPromise"
   },
   {
@@ -3252,7 +3816,13 @@
     "name": "isType"
   },
   {
+    "name": "isTypeProvider"
+  },
+  {
     "name": "isValidType"
+  },
+  {
+    "name": "isValueProvider"
   },
   {
     "name": "isVariable"
@@ -3279,6 +3849,9 @@
     "name": "leave"
   },
   {
+    "name": "leaveView"
+  },
+  {
     "name": "lifecycleHookToNodeFlag"
   },
   {
@@ -3294,10 +3867,10 @@
     "name": "literalMap"
   },
   {
-    "name": "looseIdentical"
+    "name": "locateHostElement"
   },
   {
-    "name": "makeDecorator"
+    "name": "looseIdentical"
   },
   {
     "name": "makeMetadataCtor"
@@ -3307,6 +3880,9 @@
   },
   {
     "name": "makeParamDecorator"
+  },
+  {
+    "name": "makeRecord"
   },
   {
     "name": "map"
@@ -3322,6 +3898,9 @@
   },
   {
     "name": "markProjectedViewsForCheck"
+  },
+  {
+    "name": "markViewDirty"
   },
   {
     "name": "merge"
@@ -3372,6 +3951,12 @@
     "name": "multicast"
   },
   {
+    "name": "namespaceHTML"
+  },
+  {
+    "name": "nativeInsertBefore"
+  },
+  {
     "name": "needsAdditionalRootNode"
   },
   {
@@ -3399,6 +3984,9 @@
     "name": "nextDirectiveWithBinding"
   },
   {
+    "name": "nextNgElementId"
+  },
+  {
     "name": "nextRenderNodeWithBinding"
   },
   {
@@ -3414,13 +4002,13 @@
     "name": "noComponentFactoryError"
   },
   {
+    "name": "noSideEffects"
+  },
+  {
     "name": "noUndefined"
   },
   {
     "name": "nodeValue"
-  },
-  {
-    "name": "noop$1"
   },
   {
     "name": "noop$2"
@@ -3489,6 +4077,12 @@
     "name": "platformCoreDynamic"
   },
   {
+    "name": "postProcessBaseDirective"
+  },
+  {
+    "name": "prefillHostVars"
+  },
+  {
     "name": "preparseElement"
   },
   {
@@ -3507,6 +4101,9 @@
     "name": "prodCheckNoChangesNode"
   },
   {
+    "name": "projectionNodeStack"
+  },
+  {
     "name": "promise"
   },
   {
@@ -3522,6 +4119,12 @@
     "name": "providerOverridesWithScope"
   },
   {
+    "name": "providerToFactory"
+  },
+  {
+    "name": "providerToRecord"
+  },
+  {
     "name": "pureArrayDef"
   },
   {
@@ -3534,10 +4137,49 @@
     "name": "queryDef"
   },
   {
+    "name": "queueContentHooks"
+  },
+  {
+    "name": "queueDestroyHooks"
+  },
+  {
+    "name": "queueHostBindingForCheck"
+  },
+  {
+    "name": "queueInitHooks"
+  },
+  {
+    "name": "queueLifecycleHooks"
+  },
+  {
+    "name": "queueViewHooks"
+  },
+  {
+    "name": "readElementValue"
+  },
+  {
+    "name": "readPatchedData"
+  },
+  {
+    "name": "readPatchedLViewData"
+  },
+  {
     "name": "recursivelyProcessProviders"
   },
   {
     "name": "refCount"
+  },
+  {
+    "name": "refreshChildComponents"
+  },
+  {
+    "name": "refreshContentQueries"
+  },
+  {
+    "name": "refreshDescendantViews"
+  },
+  {
+    "name": "refreshDynamicEmbeddedViews"
   },
   {
     "name": "registerContext"
@@ -3558,19 +4200,28 @@
     "name": "removeFromArray"
   },
   {
+    "name": "removeListeners"
+  },
+  {
     "name": "removeSummaryDuplicates"
+  },
+  {
+    "name": "removeView"
   },
   {
     "name": "removeWhitespaces"
   },
   {
-    "name": "render2CompileInjectable"
-  },
-  {
     "name": "renderAttachEmbeddedView"
   },
   {
+    "name": "renderComponentOrTemplate"
+  },
+  {
     "name": "renderDetachView"
+  },
+  {
+    "name": "renderEmbeddedTemplate"
   },
   {
     "name": "renderEventHandlerClosure"
@@ -3583,6 +4234,9 @@
   },
   {
     "name": "replaceNgsp"
+  },
+  {
+    "name": "resetComponentState"
   },
   {
     "name": "resolveDefinition"
@@ -3627,6 +4281,12 @@
     "name": "scheduleMicroTask"
   },
   {
+    "name": "scheduleTick"
+  },
+  {
+    "name": "searchTokensOnInjector"
+  },
+  {
     "name": "serialize"
   },
   {
@@ -3637,6 +4297,12 @@
   },
   {
     "name": "serializerVisitor"
+  },
+  {
+    "name": "setBindingRoot"
+  },
+  {
+    "name": "setCheckNoChangesMode"
   },
   {
     "name": "setCurrentInjector"
@@ -3654,10 +4320,37 @@
     "name": "setElementStyle"
   },
   {
+    "name": "setFirstTemplatePass"
+  },
+  {
+    "name": "setHostBindings"
+  },
+  {
+    "name": "setIncludeViewProviders"
+  },
+  {
+    "name": "setInjectImplementation"
+  },
+  {
+    "name": "setIsParent"
+  },
+  {
+    "name": "setPreviousOrParentTNode"
+  },
+  {
+    "name": "setRendererFactory"
+  },
+  {
     "name": "setRootDomAdapter"
   },
   {
+    "name": "setTNodeAndViewData"
+  },
+  {
     "name": "setTestabilityGetter"
+  },
+  {
+    "name": "setUpAttributes"
   },
   {
     "name": "sha1"
@@ -3676,6 +4369,9 @@
   },
   {
     "name": "shouldCallLifecycleInitHook"
+  },
+  {
+    "name": "shouldSearchParent"
   },
   {
     "name": "singleProviderDef"
@@ -3714,6 +4410,9 @@
     "name": "staticViewQueryIds"
   },
   {
+    "name": "storeCleanupFn"
+  },
+  {
     "name": "stringToWords32"
   },
   {
@@ -3721,6 +4420,9 @@
   },
   {
     "name": "stringify$1"
+  },
+  {
+    "name": "stringify$2"
   },
   {
     "name": "stringifyType"
@@ -3753,6 +4455,9 @@
     "name": "supportsState"
   },
   {
+    "name": "syncViewWithBlueprint"
+  },
+  {
     "name": "syntaxError"
   },
   {
@@ -3777,7 +4482,13 @@
     "name": "temporaryName"
   },
   {
+    "name": "text"
+  },
+  {
     "name": "textDef"
+  },
+  {
+    "name": "tickRootContext"
   },
   {
     "name": "toBase64Digit"
@@ -3790,6 +4501,9 @@
   },
   {
     "name": "toPublicName"
+  },
+  {
+    "name": "toRefArray"
   },
   {
     "name": "toSubscriber"
@@ -3834,6 +4548,9 @@
     "name": "updateProp"
   },
   {
+    "name": "updateViewQuery"
+  },
+  {
     "name": "utf8Encode"
   },
   {
@@ -3841,6 +4558,9 @@
   },
   {
     "name": "variable"
+  },
+  {
+    "name": "viewAttached"
   },
   {
     "name": "viewClassName"
@@ -3882,6 +4602,9 @@
     "name": "visitValue"
   },
   {
+    "name": "walkTNodeTree"
+  },
+  {
     "name": "word32ToByteString"
   },
   {
@@ -3898,5 +4621,8 @@
   },
   {
     "name": "wtfLeave"
+  },
+  {
+    "name": "ɵResourceLoaderImpl_BaseFactory"
   }
 ]

--- a/packages/core/test/bundling/injection/BUILD.bazel
+++ b/packages/core/test/bundling/injection/BUILD.bazel
@@ -9,6 +9,10 @@ ts_library(
         "index.ts",
         "usage.ts",
     ],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         "//packages/core",
     ],
@@ -23,6 +27,10 @@ ng_rollup_bundle(
     # has an "external" directory for external dependencies.
     # This should probably start with "angular/" and let the rule deal with it.
     entry_point = "packages/core/test/bundling/injection/index.js",
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         ":injection",
         "//packages/core",
@@ -33,6 +41,10 @@ ts_library(
     name = "test_lib",
     testonly = True,
     srcs = glob(["*_spec.ts"]),
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         ":injection",
         "//packages:types",
@@ -43,6 +55,10 @@ ts_library(
 
 jasmine_node_test(
     name = "test",
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [":test_lib"],
 )
 
@@ -50,4 +66,8 @@ js_expected_symbol_test(
     name = "symbol_test",
     src = ":bundle.min_debug.js",
     golden = ":bundle.golden_symbols.json",
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
 )

--- a/packages/core/test/bundling/todo/BUILD.bazel
+++ b/packages/core/test/bundling/todo/BUILD.bazel
@@ -8,7 +8,10 @@ load("@build_bazel_rules_typescript//:defs.bzl", "ts_devserver")
 ng_module(
     name = "todo",
     srcs = ["index.ts"],
-    tags = ["ivy-only"],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         "//packages/common",
         "//packages/core",
@@ -25,13 +28,15 @@ ng_rollup_bundle(
     # has an "external" directory for external dependencies.
     # This should probably start with "angular/" and let the rule deal with it.
     entry_point = "packages/core/test/bundling/todo/index.js",
-    tags = ["ivy-only"],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         ":todo",
         "//packages/common",
         "//packages/core",
         "//packages/core/test/bundling/util:reflect_metadata",
-        "@ngdeps//reflect-metadata",
     ],
 )
 
@@ -39,6 +44,10 @@ ts_library(
     name = "test_lib",
     testonly = True,
     srcs = glob(["*_spec.ts"]),
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         "//packages:types",
         "//packages/core",
@@ -57,6 +66,7 @@ jasmine_node_test(
     ],
     tags = [
         "ivy-only",
+        "no-ivy-jit",
     ],
     deps = [":test_lib"],
 )
@@ -68,6 +78,7 @@ js_expected_symbol_test(
     tags = [
         "ivy-aot",
         "ivy-only",
+        "no-ivy-jit",
     ],
 )
 
@@ -80,6 +91,10 @@ genrule(
         "tslib.js",
     ],
     cmd = "cp $< $@",
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
 )
 
 ts_devserver(
@@ -92,6 +107,10 @@ ts_devserver(
         "todo.css",
         "base.css",
     ],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [":todo"],
 )
 
@@ -103,5 +122,9 @@ http_server(
         "todo.css",
         ":bundle.min.js.br",
         ":bundle.min_debug.js",
+    ],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
     ],
 )

--- a/packages/core/test/bundling/todo_r2/BUILD.bazel
+++ b/packages/core/test/bundling/todo_r2/BUILD.bazel
@@ -8,7 +8,10 @@ load("@build_bazel_rules_typescript//:defs.bzl", "ts_devserver")
 ng_module(
     name = "todo",
     srcs = ["index.ts"],
-    tags = ["ivy-only"],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         "//packages/common",
         "//packages/core",
@@ -27,7 +30,10 @@ ng_rollup_bundle(
     # has an "external" directory for external dependencies.
     # This should probably start with "angular/" and let the rule deal with it.
     entry_point = "packages/core/test/bundling/todo_r2/index.js",
-    tags = ["ivy-only"],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         ":todo",
         "//packages/common",
@@ -35,7 +41,6 @@ ng_rollup_bundle(
         "//packages/core/test/bundling/util:reflect_metadata",
         "//packages/platform-browser",
         "//packages/platform-browser-dynamic",
-        "@ngdeps//reflect-metadata",
     ],
 )
 
@@ -43,6 +48,10 @@ ts_library(
     name = "test_lib",
     testonly = True,
     srcs = glob(["*_spec.ts"]),
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [
         "//packages:types",
         "//packages/core",
@@ -63,6 +72,7 @@ jasmine_node_test(
     ],
     tags = [
         "ivy-only",
+        "no-ivy-jit",
     ],
     deps = [":test_lib"],
 )
@@ -74,6 +84,7 @@ js_expected_symbol_test(
     tags = [
         "ivy-aot",
         "ivy-only",
+        "no-ivy-jit",
     ],
 )
 
@@ -86,6 +97,10 @@ genrule(
         "tslib.js",
     ],
     cmd = "cp $< $@",
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
 )
 
 ts_devserver(
@@ -98,6 +113,10 @@ ts_devserver(
         "todo.css",
         "base.css",
     ],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
+    ],
     deps = [":todo"],
 )
 
@@ -109,5 +128,9 @@ http_server(
         "todo.css",
         ":bundle.min.js.br",
         ":bundle.min_debug.js",
+    ],
+    tags = [
+        "ivy-only",
+        "no-ivy-jit",
     ],
 )

--- a/packages/core/test/bundling/util/BUILD.bazel
+++ b/packages/core/test/bundling/util/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
         ":metadata_switch",
     ],
     module_name = "@angular/core/test/bundling/util/src/reflect_metadata",
+    deps = ["@ngdeps//reflect-metadata"],
 )
 
 # See packages/core/BUILD.bazel.

--- a/packages/core/test/render3/ivy/BUILD.bazel
+++ b/packages/core/test/render3/ivy/BUILD.bazel
@@ -18,7 +18,7 @@ jasmine_node_test(
         "angular/packages/core/test/render3/load_domino",
     ],
     tags = [
-        "ivy-jit",
+        "ivy-only",
     ],
     deps = [
         ":ivy_lib",

--- a/packages/language-service/BUILD.bazel
+++ b/packages/language-service/BUILD.bazel
@@ -25,7 +25,6 @@ npm_package(
     name = "npm_package",
     srcs = ["package.json"],
     tags = [
-        "ivy-jit",
         "release-with-framework",
     ],
     deps = [

--- a/packages/platform-browser-dynamic/BUILD.bazel
+++ b/packages/platform-browser-dynamic/BUILD.bazel
@@ -28,7 +28,6 @@ ng_package(
     ],
     entry_point = "packages/platform-browser-dynamic/index.js",
     tags = [
-        "ivy-jit",
         "release-with-framework",
     ],
     deps = [

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -35,7 +35,6 @@ ng_package(
     ],
     entry_point = "packages/platform-server/index.js",
     tags = [
-        "ivy-jit",
         "release-with-framework",
     ],
     deps = [

--- a/packages/platform-webworker-dynamic/BUILD.bazel
+++ b/packages/platform-webworker-dynamic/BUILD.bazel
@@ -25,7 +25,6 @@ ng_package(
     srcs = ["package.json"],
     entry_point = "packages/platform-webworker-dynamic/index.js",
     tags = [
-        "ivy-jit",
         "release-with-framework",
     ],
     deps = [":platform-webworker-dynamic"],

--- a/packages/service-worker/BUILD.bazel
+++ b/packages/service-worker/BUILD.bazel
@@ -49,7 +49,6 @@ ng_package(
     ],
     entry_point = "packages/service-worker/index.js",
     tags = [
-        "ivy-jit",
         "release-with-framework",
     ],
     deps = [

--- a/protractor-perf.conf.js
+++ b/protractor-perf.conf.js
@@ -18,7 +18,7 @@ const BASE = isBazel ? 'angular/modules' : 'dist/all';
 require(`./${BASE}/e2e_util/perf_util`).readCommandLine();
 
 var CHROME_OPTIONS = {
-  'args': ['--js-flags=--expose-gc', '--no-sandbox'],
+  'args': ['--js-flags=--expose-gc', '--no-sandbox', '--headless', '--disable-dev-shm-usage'],
   'perfLoggingPrefs': {
     'traceCategories':
         'v8,blink.console,devtools.timeline,disabled-by-default-devtools.timeline,blink.user_timing'

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -210,6 +210,7 @@ def ng_rollup_bundle(deps = [], **kwargs):
     """Default values for ng_rollup_bundle"""
     deps = deps + [
         "@ngdeps//tslib",
+        "@ngdeps//reflect-metadata",
     ]
     _ng_rollup_bundle(
         deps = deps,

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -44,7 +44,7 @@ PKG_GROUP_REPLACEMENTS = {
     ]""" % ",\n      ".join(["\"%s\"" % s for s in ANGULAR_SCOPED_PACKAGES]),
 }
 
-def ts_library(tsconfig = None, testonly = False, deps = [], tags = [], **kwargs):
+def ts_library(tsconfig = None, testonly = False, deps = [], **kwargs):
     """Default values for ts_library"""
     deps = deps + ["@ngdeps//tslib"]
     if testonly:
@@ -62,11 +62,10 @@ def ts_library(tsconfig = None, testonly = False, deps = [], tags = [], **kwargs
         testonly = testonly,
         deps = deps,
         node_modules = _DEFAULT_TS_TYPINGS,
-        tags = ivy_tags(tags),
         **kwargs
     )
 
-def ng_module(name, tsconfig = None, entry_point = None, testonly = False, deps = [], tags = [], **kwargs):
+def ng_module(name, tsconfig = None, entry_point = None, testonly = False, deps = [], **kwargs):
     """Default values for ng_module"""
     deps = deps + ["@ngdeps//tslib"]
     if testonly:
@@ -90,7 +89,6 @@ def ng_module(name, tsconfig = None, entry_point = None, testonly = False, deps 
         compiler = _INTERNAL_NG_MODULE_COMPILER,
         ng_xi18n = _INTERNAL_NG_MODULE_XI18N,
         node_modules = _DEFAULT_TS_TYPINGS,
-        tags = ivy_tags(tags),
         **kwargs
     )
 
@@ -152,7 +150,7 @@ def npm_package(name, replacements = {}, **kwargs):
         **kwargs
     )
 
-def ts_web_test_suite(bootstrap = [], deps = [], tags = [], **kwargs):
+def ts_web_test_suite(bootstrap = [], deps = [], **kwargs):
     """Default values for ts_web_test_suite"""
     if not bootstrap:
         bootstrap = ["//:web_test_bootstrap_scripts"]
@@ -175,7 +173,6 @@ def ts_web_test_suite(bootstrap = [], deps = [], tags = [], **kwargs):
             # "@io_bazel_rules_webtesting//browsers:firefox-local",
             # TODO(alexeagle): add remote browsers on SauceLabs
         ],
-        tags = ivy_tags(tags),
         **kwargs
     )
 
@@ -188,7 +185,7 @@ def nodejs_binary(data = [], **kwargs):
         **kwargs
     )
 
-def jasmine_node_test(deps = [], tags = [], **kwargs):
+def jasmine_node_test(deps = [], **kwargs):
     """Default values for jasmine_node_test"""
     deps = deps + [
         # Very common dependencies for tests
@@ -204,7 +201,6 @@ def jasmine_node_test(deps = [], tags = [], **kwargs):
     ]
     _jasmine_node_test(
         deps = deps,
-        tags = ivy_tags(tags),
         # Pass-thru --define=compile=foo as an environment variable
         configuration_env_vars = ["compile"],
         **kwargs
@@ -219,16 +215,3 @@ def ng_rollup_bundle(deps = [], **kwargs):
         deps = deps,
         **kwargs
     )
-
-def ivy_tags(tags):
-    """Sets inclusive ivy-jit and ivy-local tags"""
-
-    # Set the tags by default unless no-ivy-jit, no-ivy-aot, fixme-ivy-jit, or fixme-ivy-aot were specified.
-    # We should remove this and use only explicitly defined tags once https://github.com/bazelbuild/rules_nodejs/pull/388 is fixed.
-    if not tags:
-        tags = ["ivy-jit", "ivy-aot"]
-    elif "no-ivy-jit" not in tags and "fixme-ivy-jit" not in tags:
-        tags = tags + ["ivy-jit"]
-    elif "no-ivy-aot" not in tags and "fixme-ivy-aot" not in tags:
-        tags = tags + ["ivy-aot"]
-    return tags

--- a/tools/public_api_guard/BUILD.bazel
+++ b/tools/public_api_guard/BUILD.bazel
@@ -18,6 +18,11 @@ load("//tools/ts-api-guardian:index.bzl", "ts_api_guardian_test")
         bundle[0],
         bundle[1],
     ),
+    # https://github.com/angular/angular/pull/26602 might be enough to fix the fixme-ivy-jit and fixme-ivy-aot issues
+    tags = [
+        "fixme-ivy-aot",
+        "fixme-ivy-jit",
+    ],
 ) for bundle in [b[:-len(".d.ts")].split("/", 1) for b in glob(
     ["**/*.d.ts"],
     # The API surface of the compiler is currently unstable - all of the important APIs are exposed

--- a/tools/symbol-extractor/index.bzl
+++ b/tools/symbol-extractor/index.bzl
@@ -27,6 +27,7 @@ def js_expected_symbol_test(name, src, golden, data = [], **kwargs):
         data = all_data,
         entry_point = entry_point,
         templated_args = ["$(location %s)" % src, "$(location %s)" % golden],
+        configuration_env_vars = ["compile"],
         **kwargs
     )
 
@@ -35,6 +36,7 @@ def js_expected_symbol_test(name, src, golden, data = [], **kwargs):
         testonly = True,
         data = all_data,
         entry_point = entry_point,
+        configuration_env_vars = ["compile"],
         templated_args = ["$(location %s)" % src, "$(location %s)" % golden, "--accept"],
         **kwargs
     )


### PR DESCRIPTION
we no longer need to rewrite the tags on the fly and can now rely on blacklisting via explicit tags set on individual targets. 

this change revealed that we were not running certain tests on CI which have always been broken or got broken just recently. especially the hello world symbol test fix is concerning because it highlights a size regression that we need to investigate.