### PR TITLE
feat(compiler-cli): use ts.compilerHost as moduleResolutionHost for tsickle.emitWithTsickle to support tsickle 0.33.1

### DIFF
--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -89,7 +89,7 @@ function createEmitCallback(options: api.CompilerOptions): api.TsEmitCallback|un
            }) =>
                // tslint:disable-next-line:no-require-imports only depend on tsickle if requested
         require('tsickle').emitWithTsickle(
-            program, {...tsickleHost, options, host}, host, options, targetSourceFile, writeFile,
+            program, {...tsickleHost, options, ...{host}}, host, options, targetSourceFile, writeFile,
             cancellationToken, emitOnlyDtsFiles, {
               beforeTs: customTransformers.before,
               afterTs: customTransformers.after,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Compilation fails with exception of get directoryExists on undefined
```
TypeError: Cannot read property 'directoryExists' of undefined
    at Object.directoryProbablyExists
```
Because of moduleResolutionHost is undefined due TsickleHost created does not contain `host` property
Related lines:
https://github.com/angular/tsickle/blob/master/src/tsickle.ts#L172
https://github.com/Microsoft/TypeScript/blob/0a7c92864d628c02e450f23ab2547ed1f5954b56/src/compiler/utilities.ts#L4019

Issue Number: N/A


## What is the new behavior?
Compilation success.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
