### PR TITLE
ci: exclude ngcc from g3sync check

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -50,6 +50,7 @@ merge:
       - "**/BUILD.bazel"
       - "packages/**/integrationtest/**"
       - "packages/**/test/**"
+      - "packages/compiler-cli/src/ngcc/**"
 
   # comment that will be added to a PR when there is a conflict, leave empty or set to false to disable
   mergeConflictComment: "Hi @{{PRAuthor}}! This PR has merge conflicts due to recent upstream merges.


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Changes to ngcc code are marked as requiring g3 sync

## What is the new behavior?

Changes to ngcc code are not marked as requiring g3 sync

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

As suggested by @alexeagle.