### PR TITLE
build: align ivy golden symbols file with the code

### DIFF
--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -705,7 +705,7 @@
     "name": "getRootContext"
   },
   {
-    "name": "getRootContext$2"
+    "name": "getRootContext$1"
   },
   {
     "name": "getRootView"


### PR DESCRIPTION
This fixes CI breakage on `master`