### PR TITLE
build: fix ts-api-guardian not working on windows

### DIFF
--- a/tools/public_api_guard/public_api_guard.bzl
+++ b/tools/public_api_guard/public_api_guard.bzl
@@ -16,7 +16,7 @@ def generate_targets(golden_files):
         [package_name, entry_point_tail] = entry_point.split("/", 1)
         directory_name = entry_point_tail.split("/")[-1]
         target_suffix = "/" + entry_point_tail if package_name != entry_point_tail else ""
-        actual_file = "packages/%s%s/%s.d.ts" % (package_name, target_suffix, directory_name)
+        actual_file = "angular/packages/%s%s/%s.d.ts" % (package_name, target_suffix, directory_name)
         label_name = package_name + target_suffix.replace("/", "_")
 
         ts_api_guardian_test(
@@ -25,7 +25,7 @@ def generate_targets(golden_files):
             data = [golden_file] + [
                 "//packages/%s:%s" % (package_name + target_suffix, directory_name),
             ],
-            golden = "tools/public_api_guard/%s" % golden_file,
+            golden = "angular/tools/public_api_guard/%s" % golden_file,
             tags = [
                 "fixme-ivy-aot",  # ivy no longer emits generated index file
                 "no-ivy-jit",  # we will not ship JIT compiled packages to npm

--- a/tools/ts-api-guardian/BUILD.bazel
+++ b/tools/ts-api-guardian/BUILD.bazel
@@ -78,6 +78,8 @@ jasmine_node_test(
     ]) + [
         ":ts-api-guardian",
         "@ts-api-guardian_deps//chalk",
+        # TODO: remove this once the boostrap.js workaround has been removed.
+        ":package.json",
     ],
     node_modules = "@ts-api-guardian_deps//typescript:typescript__typings",
     tags = ["local"],

--- a/tools/ts-api-guardian/index.bzl
+++ b/tools/ts-api-guardian/index.bzl
@@ -19,7 +19,15 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary", "nodejs_test")
 
 COMMON_MODULE_IDENTIFIERS = ["angular", "jasmine", "protractor"]
 
-def ts_api_guardian_test(name, golden, actual, data = [], strip_export_pattern = ["^__", "^ɵ"], allow_module_identifiers = COMMON_MODULE_IDENTIFIERS, **kwargs):
+def ts_api_guardian_test(
+        name,
+        golden,
+        actual,
+        data = [],
+        strip_export_pattern = ["^__", "^ɵ"],
+        allow_module_identifiers = COMMON_MODULE_IDENTIFIERS,
+        use_angular_tag_rules = True,
+        **kwargs):
     """Runs ts_api_guardian
     """
     data += [
@@ -38,6 +46,9 @@ def ts_api_guardian_test(name, golden, actual, data = [], strip_export_pattern =
 
     for i in allow_module_identifiers:
         args += ["--allowModuleIdentifiers", i]
+
+    if use_angular_tag_rules:
+        args += ["--useAngularTagRules"]
 
     nodejs_test(
         name = name,

--- a/tools/ts-api-guardian/lib/cli.ts
+++ b/tools/ts-api-guardian/lib/cli.ts
@@ -24,10 +24,27 @@ export function startCli() {
   const options: SerializationOptions = {
     stripExportPattern: [].concat(argv['stripExportPattern']),
     allowModuleIdentifiers: [].concat(argv['allowModuleIdentifiers']),
-    exportTags: {required: ['publicApi'], banned: ['experimental'], toCopy: ['deprecated']},
-    memberTags: {required: [], banned: ['experimental', 'publicApi'], toCopy: ['deprecated']},
-    paramTags: {required: [], banned: ['experimental', 'publicApi'], toCopy: ['deprecated']}
   };
+
+  // Since the API guardian can be also used by other projects, we should not set up the default
+  // Angular project tag rules unless specified explicitly through a given option.
+  if (argv['useAngularTagRules']) {
+    options.exportTags = {
+      required: ['publicApi'],
+      banned: ['experimental'],
+      toCopy: ['deprecated']
+    };
+    options.memberTags = {
+      required: [],
+      banned: ['experimental', 'publicApi'],
+      toCopy: ['deprecated']
+    };
+    options.paramTags = {
+      required: [],
+      banned: ['experimental', 'publicApi'],
+      toCopy: ['deprecated']
+    };
+  }
 
   for (const error of errors) {
     console.warn(error);
@@ -85,7 +102,7 @@ export function parseArguments(input: string[]):
       'allowModuleIdentifiers'
     ],
     boolean: [
-      'help',
+      'help', 'useAngularTagRules',
       // Options used by chalk automagically
       'color', 'no-color'
     ],
@@ -156,6 +173,7 @@ Options:
 
         --rootDir <dir>                 Specify the root directory of input files
 
+        --useAngularTagRules <boolean>  Whether the Angular specific tag rules should be used.                                        
         --stripExportPattern <regexp>   Do not output exports matching the pattern
         --allowModuleIdentifiers <identifier>
                                         Whitelist identifier for "* as foo" imports`);

--- a/tools/ts-api-guardian/test/bootstrap.ts
+++ b/tools/ts-api-guardian/test/bootstrap.ts
@@ -7,6 +7,12 @@
  */
 
 import * as path from 'path';
-// Before running tests, change directories to our directory under the runfiles
-// From runfiles we want to go to the angular/tools/ts-api-guardian subfolder.
-process.chdir(path.join(process.env['TEST_SRCDIR'], 'angular', 'tools', 'ts-api-guardian'));
+
+// Resolve the path to the package.json of the ts-api-guardian. We need to resolve an actual
+// path of a runfile because we want to determine the path to the directory that includes all
+// test fixture runfiles. On Windows this is usually the original non-sandboxed disk location,
+// otherwise this just refers to the runfile directory with all the proper symlinked files.
+// TODO: remove the whole bootstrap file once the tests are Bazel and Windows compatible.
+const runfilesDirectory = path.dirname(require.resolve('../package.json'));
+
+process.chdir(runfilesDirectory);

--- a/tools/ts-api-guardian/test/cli_e2e_test.ts
+++ b/tools/ts-api-guardian/test/cli_e2e_test.ts
@@ -12,7 +12,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import {assertFileEqual, unlinkRecursively} from './helpers';
 
-const BINARY = 'ts-api-guardian/bin/ts-api-guardian';
+const BINARY_PATH = require.resolve('../ts-api-guardian/bin/ts-api-guardian');
 
 describe('cli: e2e test', () => {
   const outDir = path.join(process.env['TEST_TMPDIR'], 'tmp');
@@ -78,7 +78,7 @@ describe('cli: e2e test', () => {
   });
 
   it('should generate respecting --stripExportPattern', () => {
-    const {stdout, status} = execute([
+    const {status} = execute([
       '--out', path.join(outDir, 'underscored.d.ts'), '--stripExportPattern', '^__.*',
       'test/fixtures/underscored.d.ts'
     ]);
@@ -88,7 +88,7 @@ describe('cli: e2e test', () => {
   });
 
   it('should not throw for aliased stripped exports', () => {
-    const {stdout, status} = execute([
+    const {status} = execute([
       '--out', path.join(outDir, 'stripped_alias.d.ts'), '--stripExportPattern', '^__.*',
       'test/fixtures/stripped_alias.d.ts'
     ]);
@@ -121,9 +121,13 @@ function copyFile(sourceFile: string, targetFile: string) {
 }
 
 function execute(args: string[]): {stdout: string, stderr: string, status: number} {
-  const output = child_process.spawnSync(process.execPath, [path.resolve(BINARY), ...args], {
+  // We need to determine the directory that includes the `ts-api-guardian` npm_package that
+  // will be used to spawn the CLI binary. This is a workaround because technically we shouldn't
+  // spawn a child process that doesn't have the custom NodeJS module resolution for Bazel.
+  const nodePath = path.join(path.dirname(require.resolve('../lib/cli.js')), '../');
+  const output = child_process.spawnSync(process.execPath, [BINARY_PATH, ...args], {
     env: {
-      'NODE_PATH': process.cwd(),
+      'NODE_PATH': nodePath,
     }
   });
   chai.assert(!output.error, 'Child process failed or timed out: ' + output.error);

--- a/tools/ts-api-guardian/test/cli_unit_test.ts
+++ b/tools/ts-api-guardian/test/cli_unit_test.ts
@@ -7,45 +7,42 @@
  */
 
 import chai = require('chai');
-import * as ts from 'typescript';
-import {parseArguments, generateFileNamePairs} from '../lib/cli';
-
+import {parseArguments} from '../lib/cli';
 
 describe('cli: parseArguments', () => {
   it('should show usage with error when supplied with no arguments', () => {
-    const {argv, mode, errors} = parseArguments([]);
+    const {mode, errors} = parseArguments([]);
     chai.assert.equal(mode, 'help');
     chai.assert.deepEqual(errors, ['No input file specified.']);
   });
 
   it('should show usage without error when supplied with --help', () => {
-    const {argv, mode, errors} = parseArguments(['--help']);
+    const {mode, errors} = parseArguments(['--help']);
     chai.assert.equal(mode, 'help');
     chai.assert.deepEqual(errors, []);
   });
 
   it('should show usage with error when supplied with none of --out/verify[Dir]', () => {
-    const {argv, mode, errors} = parseArguments(['input.d.ts']);
+    const {mode, errors} = parseArguments(['input.d.ts']);
     chai.assert.equal(mode, 'help');
     chai.assert.deepEqual(errors, ['Specify either --out[Dir] or --verify[Dir]']);
   });
 
   it('should show usage with error when supplied with both of --out/verify[Dir]', () => {
-    const {argv, mode, errors} =
+    const {mode, errors} =
         parseArguments(['--out', 'out.d.ts', '--verifyDir', 'golden.d.ts', 'input.d.ts']);
     chai.assert.equal(mode, 'help');
     chai.assert.deepEqual(errors, ['Specify either --out[Dir] or --verify[Dir]']);
   });
 
   it('should show usage with error when supplied without input file', () => {
-    const {argv, mode, errors} = parseArguments(['--out', 'output.d.ts']);
+    const {mode, errors} = parseArguments(['--out', 'output.d.ts']);
     chai.assert.equal(mode, 'help');
     chai.assert.deepEqual(errors, ['No input file specified.']);
   });
 
   it('should show usage with error when supplied without input file', () => {
-    const {argv, mode, errors} =
-        parseArguments(['--out', 'output.d.ts', 'first.d.ts', 'second.d.ts']);
+    const {mode, errors} = parseArguments(['--out', 'output.d.ts', 'first.d.ts', 'second.d.ts']);
     chai.assert.equal(mode, 'help');
     chai.assert.deepEqual(errors, ['More than one input specified. Use --outDir instead.']);
   });
@@ -64,31 +61,5 @@ describe('cli: parseArguments', () => {
     chai.assert.deepEqual(argv._, ['input.d.ts']);
     chai.assert.equal(mode, 'verify');
     chai.assert.deepEqual(errors, []);
-  });
-});
-
-describe('cli: generateFileNamePairs', () => {
-  it('should generate one file pair in one-file mode', () => {
-    chai.assert.deepEqual(
-        generateFileNamePairs({_: ['input.d.ts'], out: 'output.d.ts'}, 'out'),
-        [{entrypoint: 'input.d.ts', goldenFile: 'output.d.ts'}]);
-  });
-
-  it('should generate file pairs in multi-file mode according to current directory', () => {
-    chai.assert.deepEqual(
-        generateFileNamePairs({_: ['src/first.d.ts', 'src/second.d.ts'], outDir: 'bank'}, 'out'), [
-          {entrypoint: 'src/first.d.ts', goldenFile: 'bank/src/first.d.ts'},
-          {entrypoint: 'src/second.d.ts', goldenFile: 'bank/src/second.d.ts'}
-        ]);
-  });
-
-  it('should generate file pairs according to rootDir if provided', () => {
-    chai.assert.deepEqual(
-        generateFileNamePairs(
-            {_: ['src/first.d.ts', 'src/second.d.ts'], outDir: 'bank', rootDir: 'src'}, 'out'),
-        [
-          {entrypoint: 'src/first.d.ts', goldenFile: 'bank/first.d.ts'},
-          {entrypoint: 'src/second.d.ts', goldenFile: 'bank/second.d.ts'}
-        ]);
   });
 });


### PR DESCRIPTION
* Fixes that `ts-api-guardian` does not work on Windows
* Introduces an option that can be used to disable the default Angular project "tag rules".