### PR TITLE
fix(ivy): optional dependencies should not throw with module injector

### DIFF
--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -178,8 +178,8 @@ export class R3Injector {
 
       // Select the next injector based on the Self flag - if self is set, the next injector is
       // the NullInjector, otherwise it's the parent.
-      let next = !(flags & InjectFlags.Self) ? this.parent : getNullInjector();
-      return this.parent.get(token, notFoundValue);
+      const nextInjector = !(flags & InjectFlags.Self) ? this.parent : getNullInjector();
+      return nextInjector.get(token, notFoundValue);
     } finally {
       // Lastly, clean up the state by restoring the previous injector.
       setCurrentInjector(previousInjector);

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -363,6 +363,11 @@ export function getOrCreateInjectable<T>(
     }
   }
 
+  if (flags & InjectFlags.Optional && notFoundValue === undefined) {
+    // This must be set or the NullInjector will throw for optional deps
+    notFoundValue = null;
+  }
+
   if ((flags & (InjectFlags.Self | InjectFlags.Host)) === 0) {
     const moduleInjector = lViewData[INJECTOR];
     if (moduleInjector) {

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -1565,10 +1565,8 @@ describe('providers', () => {
         parent: {
           componentAssertion: () => {
             expect(directiveInject(String)).toEqual('Module');
-            expect(directiveInject(String, InjectFlags.Optional | InjectFlags.Self))
-                .toEqual(undefined as any);
-            expect(directiveInject(String, InjectFlags.Optional | InjectFlags.Host))
-                .toEqual(undefined as any);
+            expect(directiveInject(String, InjectFlags.Optional | InjectFlags.Self)).toBeNull();
+            expect(directiveInject(String, InjectFlags.Optional | InjectFlags.Host)).toBeNull();
           }
         }
       });


### PR DESCRIPTION
This PR fixes a bug where optional dependencies would throw if the module injector was defined. This is because eventually the injector would fall back to the `NullInjector`, which expects the `notFoundValue` to already be set to `null` if dependency is optional.