### PR TITLE
fix(ivy): resolve forward refs in providers

### DIFF
--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -356,20 +356,19 @@ function providerToRecord(provider: SingleProvider): Record<any> {
  * @param provider provider to convert to factory
  */
 export function providerToFactory(provider: SingleProvider): () => any {
-  let token = resolveForwardRef(provider);
   let factory: (() => any)|undefined = undefined;
   if (isTypeProvider(provider)) {
-    return injectableDefFactory(provider);
+    return injectableDefFactory(resolveForwardRef(provider));
   } else {
-    token = resolveForwardRef(provider.provide);
     if (isValueProvider(provider)) {
-      factory = () => provider.useValue;
+      factory = () => resolveForwardRef(provider.useValue);
     } else if (isExistingProvider(provider)) {
-      factory = () => inject(provider.useExisting);
+      factory = () => inject(resolveForwardRef(provider.useExisting));
     } else if (isFactoryProvider(provider)) {
       factory = () => provider.useFactory(...injectArgs(provider.deps || []));
     } else {
-      const classRef = (provider as StaticClassProvider | ClassProvider).useClass || token;
+      const classRef = resolveForwardRef(
+          (provider as StaticClassProvider | ClassProvider).useClass || provider.provide);
       if (hasDeps(provider)) {
         factory = () => new (classRef)(...injectArgs(provider.deps));
       } else {

--- a/packages/core/test/render3/component_spec.ts
+++ b/packages/core/test/render3/component_spec.ts
@@ -708,20 +708,54 @@ describe('providers', () => {
       });
     });
 
-    it('forwardRef', (done) => {
-      setTimeout(() => {
-        expectProvidersScenario({
-          parent: {
-            providers: [forwardRef(() => ForLater)],
-            componentAssertion:
-                () => { expect(directiveInject(ForLater) instanceof ForLater).toBeTruthy(); }
-          }
-        });
-        done();
-      }, 0);
+    describe('forwardRef', () => {
+      it('forwardRef resolves later', (done) => {
+        setTimeout(() => {
+          expectProvidersScenario({
+            parent: {
+              providers: [forwardRef(() => ForLater)],
+              componentAssertion:
+                  () => { expect(directiveInject(ForLater) instanceof ForLater).toBeTruthy(); }
+            }
+          });
+          done();
+        }, 0);
+      });
 
       class ForLater {}
+
+      // The following test that forwardRefs are called, so we don't search for an anon fn
+      it('ValueProvider wrapped in forwardRef', () => {
+        expectProvidersScenario({
+          parent: {
+            providers:
+                [{provide: GREETER, useValue: forwardRef(() => { return {greet: 'Value'}; })}],
+            componentAssertion: () => { expect(directiveInject(GREETER).greet).toEqual('Value'); }
+          }
+        });
+      });
+
+      it('ClassProvider wrapped in forwardRef', () => {
+        expectProvidersScenario({
+          parent: {
+            providers: [{provide: GREETER, useClass: forwardRef(() => GreeterClass)}],
+            componentAssertion: () => { expect(directiveInject(GREETER).greet).toEqual('Class'); }
+          }
+        });
+      });
+
+      it('ExistingProvider wrapped in forwardRef', () => {
+        expectProvidersScenario({
+          parent: {
+            providers:
+                [GreeterClass, {provide: GREETER, useExisting: forwardRef(() => GreeterClass)}],
+            componentAssertion: () => { expect(directiveInject(GREETER).greet).toEqual('Class'); }
+          }
+        });
+      });
+
     });
+
   });
 
   /*


### PR DESCRIPTION
This PR fixes a bug where forwardRefs were not resolved in non-type providers. This broke multi-providers in forms that use this pattern, e.g.

```ts
export const DEFAULT_VALUE_ACCESSOR: any = {
  provide: NG_VALUE_ACCESSOR,
  useExisting: forwardRef(() => DefaultValueAccessor),
  multi: true
};
```