### PR TITLE
fix(compiler): generate inputs with aliases properly

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -518,7 +518,10 @@ function tcbGetInputBindingExpressions(
   // is desired. Invert `dir.inputs` into `propMatch` to create this map.
   const propMatch = new Map<string, string>();
   const inputs = dir.inputs;
-  Object.keys(inputs).forEach(key => propMatch.set(inputs[key], key));
+  Object.keys(inputs).forEach(key => {
+    Array.isArray(inputs[key]) ? propMatch.set(inputs[key][0], key) :
+                                 propMatch.set(inputs[key] as string, key);
+  });
 
   // Add a binding expression to the map for each input of the directive that has a
   // matching binding.

--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -1887,7 +1887,7 @@ describe('compiler compliance', () => {
             type: LifecycleComp,
             selectors: [["lifecycle-comp"]],
             factory: function LifecycleComp_Factory(t) { return new (t || LifecycleComp)(); },
-            inputs: {nameMin: "name"},
+            inputs: {nameMin: ["name", "nameMin"]},
             features: [$r3$.ɵNgOnChangesFeature],
             consts: 0,
             vars: 0,
@@ -2227,7 +2227,7 @@ describe('compiler compliance', () => {
     });
   });
 
-  describe('inherited bare classes', () => {
+  describe('inherited base classes', () => {
     it('should add ngBaseDef if one or more @Input is present', () => {
       const files = {
         app: {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_input_outputs_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_input_outputs_spec.ts
@@ -56,7 +56,7 @@ describe('compiler compliance: listen()', () => {
           …
           inputs:{
             componentInput: "componentInput",
-            originalComponentInput: "renamedComponentInput"
+            originalComponentInput: ["renamedComponentInput", "originalComponentInput"]
           },
           outputs: {
             componentOutput: "componentOutput",
@@ -70,7 +70,7 @@ describe('compiler compliance: listen()', () => {
         …
         inputs:{
           directiveInput: "directiveInput",
-          originalDirectiveInput: "renamedDirectiveInput"
+          originalDirectiveInput: ["renamedDirectiveInput", "originalDirectiveInput"]
         },
         outputs: {
           directiveOutput: "directiveOutput",

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -86,7 +86,7 @@ export interface R3DirectiveMetadata {
   /**
    * A mapping of input field names to the property names.
    */
-  inputs: {[field: string]: string};
+  inputs: {[field: string]: string | string[]};
 
   /**
    * A mapping of output field names to the property names.

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -529,11 +529,14 @@ function stringAsType(str: string): o.Type {
 }
 
 function stringMapAsType(map: {[key: string]: string | string[]}): o.Type {
-  const mapValues = Object.keys(map).map(key => ({
-                                           key,
-                                           value: o.literal(map[key]),
-                                           quoted: true,
-                                         }));
+  const mapValues = Object.keys(map).map(key => {
+    const value = Array.isArray(map[key]) ? map[key][0] : map[key];
+    return {
+      key,
+      value: o.literal(value),
+      quoted: true,
+    };
+  });
   return o.expressionType(o.literalMap(mapValues));
 }
 

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -528,7 +528,7 @@ function stringAsType(str: string): o.Type {
   return o.expressionType(o.literal(str));
 }
 
-function stringMapAsType(map: {[key: string]: string}): o.Type {
+function stringMapAsType(map: {[key: string]: string | string[]}): o.Type {
   const mapValues = Object.keys(map).map(key => ({
                                            key,
                                            value: o.literal(map[key]),

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -44,7 +44,7 @@ export interface DirectiveMeta {
    *
    * Goes from property names to field names.
    */
-  inputs: {[property: string]: string};
+  inputs: {[property: string]: string | string[]};
 
   /**
    * Set of outputs which this directive claims.

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -67,8 +67,8 @@ export function asLiteral(value: any): o.Expression {
   return o.literal(value, o.INFERRED_TYPE);
 }
 
-export function conditionallyCreateMapObjectLiteral(keys: {[key: string]: string}): o.Expression|
-    null {
+export function conditionallyCreateMapObjectLiteral(keys: {[key: string]: string | string[]}):
+    o.Expression|null {
   if (Object.getOwnPropertyNames(keys).length > 0) {
     return mapToExpression(keys);
   }

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -153,13 +153,14 @@ function directiveMetadata(type: Type<any>, metadata: Directive): R3DirectiveMet
   const inputsFromMetadata = parseInputOutputs(metadata.inputs || []);
   const outputsFromMetadata = parseInputOutputs(metadata.outputs || []);
 
-  const inputsFromType: StringMap = {};
+  const inputsFromType: {[key: string]: string | string[]} = {};
   const outputsFromType: StringMap = {};
   for (const field in propMetadata) {
     if (propMetadata.hasOwnProperty(field)) {
       propMetadata[field].forEach(ann => {
         if (isInput(ann)) {
-          inputsFromType[field] = ann.bindingPropertyName || field;
+          inputsFromType[field] =
+              ann.bindingPropertyName ? [ann.bindingPropertyName, field] : field;
         } else if (isOutput(ann)) {
           outputsFromType[field] = ann.bindingPropertyName || field;
         }

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -12,7 +12,7 @@ import {InjectorDef, defineInjectable} from '@angular/core/src/di/defs';
 import {Injectable} from '@angular/core/src/di/injectable';
 import {inject, setCurrentInjector} from '@angular/core/src/di/injector_compatibility';
 import {ivyEnabled} from '@angular/core/src/ivy_switch';
-import {Component, HostBinding, HostListener, Input, Output, Pipe} from '@angular/core/src/metadata/directives';
+import {Component, Directive, HostBinding, HostListener, Input, Output, Pipe} from '@angular/core/src/metadata/directives';
 import {NgModule, NgModuleDef} from '@angular/core/src/metadata/ng_module';
 import {ComponentDef, PipeDef} from '@angular/core/src/render3/interfaces/definition';
 
@@ -250,6 +250,33 @@ ivyEnabled && describe('render3 jit', () => {
 
     const pipeDef = (P as any).ngPipeDef as PipeDef<P>;
     expect(pipeDef.pure).toBe(true, 'pipe should be pure');
+  });
+
+  it('should add @Input properties to a component', () => {
+    @Component({
+      selector: 'input-comp',
+      template: 'test',
+    })
+    class InputComp {
+      @Input('publicName') privateName = 'name1';
+    }
+
+    const InputCompAny = InputComp as any;
+    expect(InputCompAny.ngComponentDef.inputs).toEqual({publicName: 'privateName'});
+    expect(InputCompAny.ngComponentDef.declaredInputs).toEqual({privateName: 'privateName'});
+  });
+
+  it('should add @Input properties to a directive', () => {
+    @Directive({
+      selector: '[dir]',
+    })
+    class InputDir {
+      @Input('publicName') privateName = 'name1';
+    }
+
+    const InputDirAny = InputDir as any;
+    expect(InputDirAny.ngDirectiveDef.inputs).toEqual({publicName: 'privateName'});
+    expect(InputDirAny.ngDirectiveDef.declaredInputs).toEqual({privateName: 'privateName'});
   });
 
   it('should add ngBaseDef to types with @Input properties', () => {


### PR DESCRIPTION
This PR fixes a problem where the Ivy compiler was generating an outdated input property format (the runtime was updated, but not the compiler). As a result, `SimpleChange` objects were not being generated properly, which broke some `ngOnChanges` hooks in forms tests. 