### PR TITLE
fix(ivy): host injection flag should not throw for embedded views

### DIFF
--- a/packages/core/src/render3/interfaces/injector.ts
+++ b/packages/core/src/render3/interfaces/injector.ts
@@ -26,7 +26,8 @@ export interface RelativeInjectorLocation { __brand__: 'RelativeInjectorLocation
 
 export const enum RelativeInjectorLocationFlags {
   InjectorIndexMask = 0b111111111111111,
-  ViewOffsetShift = 15,
+  AcrossHostBoundary = 0b1000000000000000,
+  ViewOffsetShift = 16,
   NO_PARENT = -1,
 }
 


### PR DESCRIPTION
This PR fixes a bug where the `@Host()` injection flag would cause DI to throw if the dependency was found in any parent view, even if that view was an embedded view (and not passing the component boundary). Now when we resolve the parent injector, we add a special flag if the component boundary has been crossed, so we don't need to walk up the view tree to check each time we resolve a dependency on that node.