### PR TITLE
fix(ivy): host bindings after dirs without host bindings should work

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -14,6 +14,7 @@ import {QueryList} from '../linker';
 import {Sanitizer} from '../sanitization/security';
 import {StyleSanitizeFn} from '../sanitization/style_sanitizer';
 import {Type} from '../type';
+import {noop} from '../util/noop';
 
 import {assertDefined, assertEqual, assertLessThan, assertNotEqual} from './assert';
 import {attachPatchData, getComponentViewByInstance} from './context_discovery';
@@ -39,7 +40,6 @@ import {BoundPlayerFactory} from './styling/player_factory';
 import {getStylingContext} from './styling/util';
 import {NO_CHANGE} from './tokens';
 import {getComponentViewByIndex, getNativeByIndex, getNativeByTNode, getRootContext, getRootView, getTNode, isComponent, isComponentDef, isDifferent, loadInternal, readPatchedLViewData, stringify} from './util';
-
 
 
 /**
@@ -1499,7 +1499,8 @@ function queueComponentIndexForCheck(previousOrParentTNode: TNode): void {
 function queueHostBindingForCheck(tView: TView, def: DirectiveDef<any>| ComponentDef<any>): void {
   ngDevMode &&
       assertEqual(getFirstTemplatePass(), true, 'Should only be called in first template pass.');
-  tView.expandoInstructions !.push(def.hostBindings !, def.hostVars);
+  tView.expandoInstructions !.push(def.hostBindings || noop);
+  if (def.hostVars) tView.expandoInstructions !.push(def.hostVars);
 }
 
 /** Caches local names and their matching directive indices for query and template lookups. */
@@ -1561,7 +1562,7 @@ function baseResolveDirective<T>(
   tView.blueprint.push(nodeInjectorFactory);
   viewData.push(nodeInjectorFactory);
 
-  if (def.hostBindings) queueHostBindingForCheck(tView, def);
+  queueHostBindingForCheck(tView, def);
 }
 
 function addComponentLogic<T>(

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -942,6 +942,9 @@
     "name": "noSideEffects"
   },
   {
+    "name": "noop"
+  },
+  {
     "name": "pointers"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -366,6 +366,9 @@
     "name": "noSideEffects"
   },
   {
+    "name": "noop"
+  },
+  {
     "name": "postProcessBaseDirective"
   },
   {

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -4020,6 +4020,9 @@
     "name": "nodeValue"
   },
   {
+    "name": "noop"
+  },
+  {
     "name": "noop$1"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -960,6 +960,9 @@
     "name": "noSideEffects"
   },
   {
+    "name": "noop"
+  },
+  {
     "name": "pointers"
   },
   {

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -2244,6 +2244,9 @@
     "name": "noSideEffects"
   },
   {
+    "name": "noop"
+  },
+  {
     "name": "noop$1"
   },
   {


### PR DESCRIPTION
This PR fixes a bug where the directive index would not be incremented properly if a directive without host bindings preceded a directive with host bindings. Now directives without host bindings insert a `noop` function to ensure they are skipped over.