### PR TITLE
fix(ivy): init hooks should be called before host bindings

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -78,11 +78,13 @@ export function refreshDescendantViews(viewData: LViewData, rf: RenderFlags | nu
   if (rf !== RenderFlags.Create) {
     const creationMode = getCreationMode();
     const checkNoChangesMode = getCheckNoChangesMode();
-    setHostBindings(tView, viewData);
 
     if (!checkNoChangesMode) {
       executeInitHooks(viewData, tView, creationMode);
     }
+
+    setHostBindings(tView, viewData);
+
     refreshDynamicEmbeddedViews(viewData);
 
     // Content query results must be refreshed before content hooks are called.


### PR DESCRIPTION
Small PR to ensure host bindings are set after init hooks are called to preserve backwards compatibility. 