### PR TITLE
fix(ivy): restore missing match operation in View and Content Queries

### DIFF
--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -292,7 +292,8 @@ function queryByTNodeType(tNode: TNode, currentView: LViewData): any {
   return null;
 }
 
-function queryByTemplateRef(tNode: TNode, currentView: LViewData, read: any, templateRef: any): any {
+function queryByTemplateRef(
+    tNode: TNode, currentView: LViewData, read: any, templateRef: any): any {
   const factoryFn = templateRef[NG_ELEMENT_ID];
   if (read) {
     if (factoryFn()) {
@@ -305,19 +306,15 @@ function queryByTemplateRef(tNode: TNode, currentView: LViewData, read: any, tem
 }
 
 function queryRead(tNode: TNode, currentView: LViewData, read: any, matchingIdx: number): any {
-  let result: any = null;
   if (read) {
-    result = queryByReadToken(tNode, currentView, read);
-  } else {
-    if (matchingIdx > -1) {
-      result = currentView[matchingIdx];
-    } else {
-      // if read token and / or strategy is not specified,
-      // detect it using appropriate tNode type
-      result = queryByTNodeType(tNode, currentView);
-    }
+    return queryByReadToken(tNode, currentView, read);
   }
-  return result;
+  if (matchingIdx > -1) {
+    return currentView[matchingIdx];
+  }
+  // if read token and / or strategy is not specified,
+  // detect it using appropriate tNode type
+  return queryByTNodeType(tNode, currentView);
 }
 
 function add(

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -316,22 +316,18 @@ function add(
     const predicate = query.predicate;
     const type = predicate.type as any;
     if (type) {
+      let result = null;
       if (type === ViewEngine_TemplateRef) {
-        const factoryFn = type[NG_ELEMENT_ID];
-        if (factoryFn()) {
-          const result = queryRead(tNode, currentView, predicate.read || type);
-          if (result !== null) {
-            addMatch(query, result);
-          }
-        }
+        result =
+            predicate.read ? queryRead(tNode, currentView, predicate.read) : type[NG_ELEMENT_ID]();
       } else {
         const matchingIdx = getIdxOfMatchingDirective(tNode, currentView, type);
         if (matchingIdx !== null) {
-          const result = read(tNode, currentView, predicate.read, matchingIdx);
-          if (result !== null) {
-            addMatch(query, result);
-          }
+          result = read(tNode, currentView, predicate.read, matchingIdx);
         }
+      }
+      if (result !== null) {
+        addMatch(query, result);
       }
     } else {
       const selector = predicate.selector !;

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -293,16 +293,13 @@ function queryByTNodeType(tNode: TNode, currentView: LViewData): any {
 }
 
 function queryByTemplateRef(
-    templateRef: any, tNode: TNode, currentView: LViewData, read: any): any {
-  const factoryFn = templateRef[NG_ELEMENT_ID];
+    templateRefToken: ViewEngine_TemplateRef<any>, tNode: TNode, currentView: LViewData,
+    read: any): any {
+  const templateRefResult = (templateRefToken as any)[NG_ELEMENT_ID]();
   if (read) {
-    if (factoryFn()) {
-      return queryByReadToken(read, tNode, currentView);
-    }
-  } else {
-    return factoryFn();
+    return templateRefResult ? queryByReadToken(read, tNode, currentView) : null;
   }
-  return null;
+  return templateRefResult;
 }
 
 function queryRead(tNode: TNode, currentView: LViewData, read: any, matchingIdx: number): any {

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -269,7 +269,7 @@ function getIdxOfMatchingDirective(tNode: TNode, currentView: LViewData, type: T
 }
 
 // TODO: "read" should be an AbstractType (FW-486)
-function queryByReadToken(tNode: TNode, currentView: LViewData, read: any): any {
+function queryByReadToken(read: any, tNode: TNode, currentView: LViewData): any {
   const factoryFn = (read as any)[NG_ELEMENT_ID];
   if (typeof factoryFn === 'function') {
     return factoryFn();
@@ -293,11 +293,11 @@ function queryByTNodeType(tNode: TNode, currentView: LViewData): any {
 }
 
 function queryByTemplateRef(
-    tNode: TNode, currentView: LViewData, read: any, templateRef: any): any {
+    templateRef: any, tNode: TNode, currentView: LViewData, read: any): any {
   const factoryFn = templateRef[NG_ELEMENT_ID];
   if (read) {
     if (factoryFn()) {
-      return queryByReadToken(tNode, currentView, read);
+      return queryByReadToken(read, tNode, currentView);
     }
   } else {
     return factoryFn();
@@ -307,7 +307,7 @@ function queryByTemplateRef(
 
 function queryRead(tNode: TNode, currentView: LViewData, read: any, matchingIdx: number): any {
   if (read) {
-    return queryByReadToken(tNode, currentView, read);
+    return queryByReadToken(read, tNode, currentView);
   }
   if (matchingIdx > -1) {
     return currentView[matchingIdx];
@@ -327,7 +327,7 @@ function add(
     if (type) {
       let result = null;
       if (type === ViewEngine_TemplateRef) {
-        result = queryByTemplateRef(tNode, currentView, predicate.read, type);
+        result = queryByTemplateRef(type, tNode, currentView, predicate.read);
       } else {
         const matchingIdx = getIdxOfMatchingDirective(tNode, currentView, type);
         if (matchingIdx !== null) {

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -1047,6 +1047,36 @@ describe('query', () => {
         expect(qList.length).toBe(0);
       });
 
+      it('should not add results to TemplateRef-based query if only read token matches', () => {
+        /**
+         * <div></div>
+         * class Cmpt {
+         *  @ViewChildren(TemplateRef, {read: ElementRef}) query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                element(1, 'div');
+              }
+            },
+            2, 0, [], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, TemplateRef as any, false, ElementRef);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const {component} = new ComponentFixture(Cmpt);
+        const qList = component.query;
+        expect(qList.length).toBe(0);
+      });
+
       it('should match using string selector and directive as a read argument', () => {
         const Child = createDirective('child');
 

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -949,7 +949,7 @@ describe('query', () => {
         expect(qList.last).toBe(childInstance);
       });
 
-      it('should not add results to query if a requested token cant be read', () => {
+      it('should not add results to selector-based query if a requested token cant be read', () => {
         const Child = createDirective('child');
 
         /**
@@ -969,6 +969,72 @@ describe('query', () => {
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
                 query(0, ['foo'], false, Child);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(0);
+      });
+
+      it('should not add results to directive-based query if requested token cant be read', () => {
+        const Child = createDirective('child');
+        const OtherChild = createDirective('otherchild');
+
+        /**
+         * <div child></div>
+         * class Cmpt {
+         *  @ViewChildren(Child, {read: OtherChild}) query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                element(1, 'div', ['foo', '']);
+              }
+            },
+            3, 0, [Child, OtherChild], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, Child, false, OtherChild);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const cmptInstance = renderComponent(Cmpt);
+        const qList = (cmptInstance.query as QueryList<any>);
+        expect(qList.length).toBe(0);
+      });
+
+      it('should not add results to directive-based query if only read token matches', () => {
+        const Child = createDirective('child');
+        const OtherChild = createDirective('otherchild');
+
+        /**
+         * <div child></div>
+         * class Cmpt {
+         *  @ViewChildren(OtherChild, {read: Child}) query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                element(1, 'div', ['foo', '']);
+              }
+            },
+            3, 0, [Child, OtherChild], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, OtherChild, false, Child);
               }
               if (rf & RenderFlags.Update) {
                 let tmp: any;

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -998,7 +998,7 @@ describe('query', () => {
                 element(1, 'div', ['child', '']);
               }
             },
-            3, 0, [Child, OtherChild], [],
+            2, 0, [Child, OtherChild], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
                 query(0, Child, false, OtherChild);
@@ -1031,7 +1031,7 @@ describe('query', () => {
                 element(1, 'div', ['child', '']);
               }
             },
-            3, 0, [Child, OtherChild], [],
+            2, 0, [Child, OtherChild], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
                 query(0, OtherChild, false, Child);
@@ -1047,7 +1047,7 @@ describe('query', () => {
         expect(qList.length).toBe(0);
       });
 
-      it('should not add results to the query in case no match found (via TemplateRef)', () => {
+      it('should match using string selector and directive as a read argument', () => {
         const Child = createDirective('child');
 
         /**
@@ -1063,7 +1063,7 @@ describe('query', () => {
                 element(1, 'div', ['child', ''], ['foo', '']);
               }
             },
-            2, 0, [Child], [],
+            3, 0, [Child], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
                 query(0, ['foo'], false, Child);
@@ -1096,7 +1096,7 @@ describe('query', () => {
                 element(1, 'div', ['child', '']);
               }
             },
-            3, 0, [Child], [],
+            2, 0, [Child], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
                 query(0, TemplateRef as any, false);
@@ -1115,8 +1115,8 @@ describe('query', () => {
       it('should query templates if the type is TemplateRef (and respect "read" option)', () => {
         function Cmpt_Template_1(rf: RenderFlags, ctx1: any) {
           if (rf & RenderFlags.Create) {
-            elementStart(1, 'div');
-            text(2, 'Test');
+            elementStart(0, 'div');
+            text(1, 'Test');
             elementEnd();
           }
         }
@@ -1138,7 +1138,7 @@ describe('query', () => {
                 template(4, Cmpt_Template_1, 2, 0, null, null, ['baz', ''], templateRefExtractor);
               }
             },
-            3, 0, [], [],
+            5, 0, [], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
                 query(0, TemplateRef as any, false);

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -13,7 +13,7 @@ import {EventEmitter} from '../..';
 
 import {AttributeMarker, QueryList, defineComponent, defineDirective, detectChanges} from '../../src/render3/index';
 import {getNativeByIndex} from '../../src/render3/util';
-import {bind, container, containerRefreshEnd, containerRefreshStart, directiveInject, element, elementContainerEnd, elementContainerStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, load, loadQueryList, reference, registerContentQuery, template} from '../../src/render3/instructions';
+import {bind, container, containerRefreshEnd, containerRefreshStart, directiveInject, element, elementContainerEnd, elementContainerStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, load, loadQueryList, reference, registerContentQuery, template, text} from '../../src/render3/instructions';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {query, queryRefresh} from '../../src/render3/query';
 import {getViewData} from '../../src/render3/state';
@@ -976,8 +976,8 @@ describe('query', () => {
               }
             });
 
-        const cmptInstance = renderComponent(Cmpt);
-        const qList = (cmptInstance.query as QueryList<any>);
+        const {component} = new ComponentFixture(Cmpt);
+        const qList = component.query;
         expect(qList.length).toBe(0);
       });
 
@@ -995,7 +995,7 @@ describe('query', () => {
             'cmpt',
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                element(1, 'div', ['foo', '']);
+                element(1, 'div', ['child', '']);
               }
             },
             3, 0, [Child, OtherChild], [],
@@ -1009,8 +1009,8 @@ describe('query', () => {
               }
             });
 
-        const cmptInstance = renderComponent(Cmpt);
-        const qList = (cmptInstance.query as QueryList<any>);
+        const {component} = new ComponentFixture(Cmpt);
+        const qList = component.query;
         expect(qList.length).toBe(0);
       });
 
@@ -1028,7 +1028,7 @@ describe('query', () => {
             'cmpt',
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
-                element(1, 'div', ['foo', '']);
+                element(1, 'div', ['child', '']);
               }
             },
             3, 0, [Child, OtherChild], [],
@@ -1042,9 +1042,128 @@ describe('query', () => {
               }
             });
 
-        const cmptInstance = renderComponent(Cmpt);
-        const qList = (cmptInstance.query as QueryList<any>);
+        const {component} = new ComponentFixture(Cmpt);
+        const qList = component.query;
         expect(qList.length).toBe(0);
+      });
+
+      it('should not add results to the query in case no match found (via TemplateRef)', () => {
+        const Child = createDirective('child');
+
+        /**
+         * <div child #foo></div>
+         * class Cmpt {
+         *  @ViewChildren('foo', {read: Child}) query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                element(1, 'div', ['child', ''], ['foo', '']);
+              }
+            },
+            2, 0, [Child], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, ['foo'], false, Child);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const {component} = new ComponentFixture(Cmpt);
+        const qList = component.query;
+        expect(qList.length).toBe(1);
+        expect(qList.first instanceof Child).toBeTruthy();
+      });
+
+      it('should not add results to the query in case no match found (via TemplateRef)', () => {
+        const Child = createDirective('child');
+
+        /**
+         * <div child></div>
+         * class Cmpt {
+         *  @ViewChildren(TemplateRef) query;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                element(1, 'div', ['child', '']);
+              }
+            },
+            3, 0, [Child], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, TemplateRef as any, false);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.query = tmp as QueryList<any>);
+              }
+            });
+
+        const {component} = new ComponentFixture(Cmpt);
+        const qList = component.query;
+        expect(qList.length).toBe(0);
+      });
+
+      it('should query templates if the type is TemplateRef (and respect "read" option)', () => {
+        function Cmpt_Template_1(rf: RenderFlags, ctx1: any) {
+          if (rf & RenderFlags.Create) {
+            elementStart(1, 'div');
+            text(2, 'Test');
+            elementEnd();
+          }
+        }
+        /**
+         * <ng-template #foo><div>Test</div></ng-template>
+         * <ng-template #bar><div>Test</div></ng-template>
+         * <ng-template #baz><div>Test</div></ng-template>
+         * class Cmpt {
+         *   @ViewChildren(TemplateRef) tmplQuery;
+         *   @ViewChildren(TemplateRef, {read: ElementRef}) elemQuery;
+         * }
+         */
+        const Cmpt = createComponent(
+            'cmpt',
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                template(2, Cmpt_Template_1, 2, 0, null, null, ['foo', ''], templateRefExtractor);
+                template(3, Cmpt_Template_1, 2, 0, null, null, ['bar', ''], templateRefExtractor);
+                template(4, Cmpt_Template_1, 2, 0, null, null, ['baz', ''], templateRefExtractor);
+              }
+            },
+            3, 0, [], [],
+            function(rf: RenderFlags, ctx: any) {
+              if (rf & RenderFlags.Create) {
+                query(0, TemplateRef as any, false);
+                query(1, TemplateRef as any, false, ElementRef);
+              }
+              if (rf & RenderFlags.Update) {
+                let tmp: any;
+                queryRefresh(tmp = load<QueryList<any>>(0)) &&
+                    (ctx.tmplQuery = tmp as QueryList<any>);
+                queryRefresh(tmp = load<QueryList<any>>(1)) &&
+                    (ctx.elemQuery = tmp as QueryList<any>);
+              }
+            });
+
+        const {component} = new ComponentFixture(Cmpt);
+
+        // check template-based query set
+        const tmplQList = component.tmplQuery;
+        expect(tmplQList.length).toBe(3);
+        expect(isTemplateRef(tmplQList.first)).toBeTruthy();
+
+        // check element-based query set
+        const elemQList = component.elemQuery;
+        expect(elemQList.length).toBe(3);
+        expect(isElementRef(elemQList.first)).toBeTruthy();
       });
 
     });


### PR DESCRIPTION
This PR restores missing check when we query (view or content) using type predicate. Currently query logic may false-positively return more elements than needed. Also this PR unifies query logic for selector and predicate-based queries.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No