### PR TITLE
ngcc: fix esm5 definition rendering

### DIFF
--- a/packages/compiler-cli/src/ngcc/src/packages/transformer.ts
+++ b/packages/compiler-cli/src/ngcc/src/packages/transformer.ts
@@ -15,6 +15,7 @@ import {SwitchMarkerAnalyzer} from '../analysis/switch_marker_analyzer';
 import {Esm2015ReflectionHost} from '../host/esm2015_host';
 import {Esm5ReflectionHost} from '../host/esm5_host';
 import {NgccReflectionHost} from '../host/ngcc_host';
+import {Esm5Renderer} from '../rendering/esm5_renderer';
 import {EsmRenderer} from '../rendering/esm_renderer';
 import {FileInfo, Renderer} from '../rendering/renderer';
 
@@ -128,10 +129,12 @@ export class Transformer {
       rewriteCoreImportsTo: ts.SourceFile|null, transformDts: boolean): Renderer {
     switch (format) {
       case 'esm2015':
-      case 'esm5':
       case 'fesm2015':
-      case 'fesm5':
         return new EsmRenderer(
+            host, isCore, rewriteCoreImportsTo, this.sourcePath, this.targetPath, transformDts);
+      case 'esm5':
+      case 'fesm5':
+        return new Esm5Renderer(
             host, isCore, rewriteCoreImportsTo, this.sourcePath, this.targetPath, transformDts);
       default:
         throw new Error(`Renderer for "${format}" not yet implemented.`);

--- a/packages/compiler-cli/src/ngcc/src/rendering/esm5_renderer.ts
+++ b/packages/compiler-cli/src/ngcc/src/rendering/esm5_renderer.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+import MagicString from 'magic-string';
+import {NgccReflectionHost} from '../host/ngcc_host';
+import {CompiledClass} from '../analysis/decoration_analyzer';
+import {EsmRenderer} from './esm_renderer';
+
+export class Esm5Renderer extends EsmRenderer {
+  constructor(
+      protected host: NgccReflectionHost, protected isCore: boolean,
+      protected rewriteCoreImportsTo: ts.SourceFile|null, protected sourcePath: string,
+      protected targetPath: string, transformDts: boolean) {
+    super(host, isCore, rewriteCoreImportsTo, sourcePath, targetPath, transformDts);
+  }
+
+  /**
+   * Add the definitions to each decorated class
+   */
+  addDefinitions(output: MagicString, compiledClass: CompiledClass, definitions: string): void {
+    const classSymbol = this.host.getClassSymbol(compiledClass.declaration);
+    if (!classSymbol) {
+      throw new Error(`Compiled class does not have a valid symbol: ${compiledClass.name}`);
+    }
+    const parent = classSymbol.valueDeclaration && classSymbol.valueDeclaration.parent;
+    if (parent && ts.isBlock(parent)) {
+      const returnStatement = parent.statements.find(statement => ts.isReturnStatement(statement));
+      if (returnStatement) {
+        const insertionPoint = returnStatement.getFullStart();
+        output.appendLeft(insertionPoint, '\n' + definitions);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

ESM5 definitions are rendered before lifecycle hooks, which causes them to be ignored by ivy.

Issue Number: #26849


## What is the new behavior?

ESM5 definitions are rendered after lifecycle hooks.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This PR sits on top of https://github.com/angular/angular/pull/26403. Only the last commit is relevant.
