### PR TITLE
refactor(core): format values for `ExpressionChangedAfterItHasBeenCheckedError` error

### DIFF
--- a/packages/core/src/view/errors.ts
+++ b/packages/core/src/view/errors.ts
@@ -7,7 +7,7 @@
  */
 
 import {ERROR_DEBUG_CONTEXT, ERROR_LOGGER, getDebugContext} from '../errors';
-import {DebugContext, ViewState} from './types';
+import {DebugContext} from './types';
 
 export function expressionChangedAfterItHasBeenCheckedError(
     context: DebugContext, oldValue: any, currValue: any, isFirstCheck: boolean): Error {

--- a/packages/core/src/view/errors.ts
+++ b/packages/core/src/view/errors.ts
@@ -11,6 +11,8 @@ import {DebugContext, ViewState} from './types';
 
 export function expressionChangedAfterItHasBeenCheckedError(
     context: DebugContext, oldValue: any, currValue: any, isFirstCheck: boolean): Error {
+  [oldValue, currValue] =
+      [oldValue, currValue].map(val => typeof val === 'object' ? JSON.stringify(val) : val);
   let msg =
       `ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked. Previous value: '${oldValue}'. Current value: '${currValue}'.`;
   if (isFirstCheck) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`ExpressionChangedAfterItHasBeenCheckedError` error message doesn't show helpful values if they are of type `object` (they look like this `[object Object]`)

## What is the new behavior?

If either previous or current value is of type `object` it's properly formatted with `JSON.stringify()`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
