### PR TITLE
 fix(ivy): dynamically created components should run init hooks

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -25,7 +25,7 @@ import {ComponentDef, RenderFlags} from './interfaces/definition';
 import {TElementNode, TNode, TNodeType, TViewNode} from './interfaces/node';
 import {RElement, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
 import {FLAGS, HEADER_OFFSET, INJECTOR, LViewData, LViewFlags, RootContext, TVIEW} from './interfaces/view';
-import {enterView} from './state';
+import {enterView, leaveView} from './state';
 import {getTNode} from './util';
 import {createElementRef} from './view_engine_compatibility';
 import {RootViewRef, ViewRef} from './view_ref';
@@ -179,7 +179,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
 
       refreshDescendantViews(rootView, RenderFlags.Create);
     } finally {
-      enterView(oldView, null);
+      leaveView(oldView, true);
       if (rendererFactory.end) rendererFactory.end();
     }
 

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -20,7 +20,7 @@ import {Type} from '../type';
 import {assertComponentType, assertDefined} from './assert';
 import {LifecycleHooksFeature, createRootComponent, createRootComponentView, createRootContext} from './component';
 import {getComponentDef} from './definition';
-import {createLViewData, createNodeAtIndex, createTView, createViewNode, elementCreate, locateHostElement, renderEmbeddedTemplate} from './instructions';
+import {createLViewData, createNodeAtIndex, createTView, createViewNode, elementCreate, locateHostElement, refreshDescendantViews} from './instructions';
 import {ComponentDef, RenderFlags} from './interfaces/definition';
 import {TElementNode, TNode, TNodeType, TViewNode} from './interfaces/node';
 import {RElement, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
@@ -177,9 +177,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
           hostRNode, componentView, this.componentDef, rootView, rootContext,
           [LifecycleHooksFeature]);
 
-      // Execute the template in creation mode only, and then turn off the CreationMode flag
-      renderEmbeddedTemplate(componentView, componentView[TVIEW], component, RenderFlags.Create);
-      componentView[FLAGS] &= ~LViewFlags.CreationMode;
+      refreshDescendantViews(rootView, RenderFlags.Create);
     } finally {
       enterView(oldView, null);
       if (rendererFactory.end) rendererFactory.end();

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -421,6 +421,7 @@ function renderComponentOrTemplate<T>(
       // Element was stored at 0 in data and directive was stored at 0 in directives
       // in renderComponent()
       setHostBindings(getTView(), hostView);
+      refreshDynamicEmbeddedViews(hostView);
       componentRefresh(HEADER_OFFSET, false);
     }
   } finally {
@@ -1827,7 +1828,7 @@ export function containerRefreshEnd(): void {
  * Goes over dynamic embedded views (ones created through ViewContainerRef APIs) and refreshes them
  * by executing an associated template function.
  */
-function refreshDynamicEmbeddedViews(lViewData: LViewData) {
+export function refreshDynamicEmbeddedViews(lViewData: LViewData) {
   for (let current = getLViewChild(lViewData); current !== null; current = current[NEXT]) {
     // Note: current can be an LViewData or an LContainer instance, but here we are only interested
     // in LContainer. We can tell it's an LContainer because its length is less than the LViewData

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -64,30 +64,36 @@ type SanitizerFn = (value: any) => string;
  * bindings, refreshes child components.
  * Note: view hooks are triggered later when leaving the view.
  */
-function refreshDescendantViews(viewData: LViewData) {
+export function refreshDescendantViews(viewData: LViewData, rf: RenderFlags | null) {
   const tView = getTView();
-  const creationMode = getCreationMode();
-  const checkNoChangesMode = getCheckNoChangesMode();
-  setHostBindings(tView, viewData);
   const parentFirstTemplatePass = getFirstTemplatePass();
 
   // This needs to be set before children are processed to support recursive components
   tView.firstTemplatePass = false;
   setFirstTemplatePass(false);
 
-  if (!checkNoChangesMode) {
-    executeInitHooks(viewData, tView, creationMode);
+  // Dynamically created views must run first only in creation mode. If this is a
+  // creation-only pass, we should not call lifecycle hooks or evaluate bindings.
+  // This will be done in the update-only pass.
+  if (rf !== RenderFlags.Create) {
+    const creationMode = getCreationMode();
+    const checkNoChangesMode = getCheckNoChangesMode();
+    setHostBindings(tView, viewData);
+
+    if (!checkNoChangesMode) {
+      executeInitHooks(viewData, tView, creationMode);
+    }
+    refreshDynamicEmbeddedViews(viewData);
+
+    // Content query results must be refreshed before content hooks are called.
+    refreshContentQueries(tView);
+
+    if (!checkNoChangesMode) {
+      executeHooks(viewData, tView.contentHooks, tView.contentCheckHooks, creationMode);
+    }
   }
-  refreshDynamicEmbeddedViews(viewData);
 
-  // Content query results must be refreshed before content hooks are called.
-  refreshContentQueries(tView);
-
-  if (!checkNoChangesMode) {
-    executeHooks(viewData, tView.contentHooks, tView.contentCheckHooks, creationMode);
-  }
-
-  refreshChildComponents(tView.components, parentFirstTemplatePass);
+  refreshChildComponents(tView.components, parentFirstTemplatePass, rf);
 }
 
 
@@ -144,20 +150,11 @@ function refreshContentQueries(tView: TView): void {
 
 /** Refreshes child components in the current view. */
 function refreshChildComponents(
-    components: number[] | null, parentFirstTemplatePass: boolean): void {
+    components: number[] | null, parentFirstTemplatePass: boolean, rf: RenderFlags | null): void {
   if (components != null) {
     for (let i = 0; i < components.length; i++) {
-      componentRefresh(components[i], parentFirstTemplatePass);
+      componentRefresh(components[i], parentFirstTemplatePass, rf);
     }
-  }
-}
-
-export function executeInitAndContentHooks(viewData: LViewData): void {
-  if (!getCheckNoChangesMode()) {
-    const tView = getTView();
-    const creationMode = getCreationMode();
-    executeInitHooks(viewData, tView, creationMode);
-    executeHooks(viewData, tView.contentHooks, tView.contentCheckHooks, creationMode);
   }
 }
 
@@ -304,7 +301,7 @@ export function renderTemplate<T>(
         createLViewData(renderer, componentTView, context, LViewFlags.CheckAlways, sanitizer);
     hostView[HOST_NODE] = createNodeAtIndex(0, TNodeType.Element, hostNode, null, null);
   }
-  renderComponentOrTemplate(hostView, context, templateFn);
+  renderComponentOrTemplate(hostView, context, null, templateFn);
 
   return hostView;
 }
@@ -369,7 +366,7 @@ export function renderEmbeddedTemplate<T>(
       namespaceHTML();
       tView.template !(rf, context);
       if (rf & RenderFlags.Update) {
-        refreshDescendantViews(viewToRender);
+        refreshDescendantViews(viewToRender, null);
       } else {
         // This must be set to false immediately after the first creation run because in an
         // ngFor loop, all the views will be created together before update mode runs and turns
@@ -404,7 +401,8 @@ export function nextContext<T = any>(level: number = 1): T {
 }
 
 function renderComponentOrTemplate<T>(
-    hostView: LViewData, componentOrContext: T, templateFn?: ComponentTemplate<T>) {
+    hostView: LViewData, componentOrContext: T, rf: RenderFlags | null,
+    templateFn?: ComponentTemplate<T>) {
   const rendererFactory = getRendererFactory();
   const oldView = enterView(hostView, hostView[HOST_NODE]);
   try {
@@ -413,17 +411,9 @@ function renderComponentOrTemplate<T>(
     }
     if (templateFn) {
       namespaceHTML();
-      templateFn(getRenderFlags(hostView), componentOrContext !);
-      refreshDescendantViews(hostView);
-    } else {
-      executeInitAndContentHooks(hostView);
-
-      // Element was stored at 0 in data and directive was stored at 0 in directives
-      // in renderComponent()
-      setHostBindings(getTView(), hostView);
-      refreshDynamicEmbeddedViews(hostView);
-      componentRefresh(HEADER_OFFSET, false);
+      templateFn(rf || getRenderFlags(hostView), componentOrContext !);
     }
+    refreshDescendantViews(hostView, rf);
   } finally {
     if (rendererFactory.end) {
       rendererFactory.end();
@@ -1487,7 +1477,7 @@ function findDirectiveMatches(tView: TView, viewData: LViewData, tNode: TNode): 
 }
 
 /** Stores index of component's host element so it will be queued for view refresh during CD. */
-function queueComponentIndexForCheck(previousOrParentTNode: TNode): void {
+export function queueComponentIndexForCheck(previousOrParentTNode: TNode): void {
   ngDevMode &&
       assertEqual(getFirstTemplatePass(), true, 'Should only be called in first template pass.');
   const tView = getTView();
@@ -1828,7 +1818,7 @@ export function containerRefreshEnd(): void {
  * Goes over dynamic embedded views (ones created through ViewContainerRef APIs) and refreshes them
  * by executing an associated template function.
  */
-export function refreshDynamicEmbeddedViews(lViewData: LViewData) {
+function refreshDynamicEmbeddedViews(lViewData: LViewData) {
   for (let current = getLViewChild(lViewData); current !== null; current = current[NEXT]) {
     // Note: current can be an LViewData or an LContainer instance, but here we are only interested
     // in LContainer. We can tell it's an LContainer because its length is less than the LViewData
@@ -1956,7 +1946,7 @@ function getOrCreateEmbeddedTView(
 export function embeddedViewEnd(): void {
   const viewData = getViewData();
   const viewHost = viewData[HOST_NODE];
-  refreshDescendantViews(viewData);
+  refreshDescendantViews(viewData, null);
   leaveView(viewData[PARENT] !);
   setPreviousOrParentTNode(viewHost !);
   setIsParent(false);
@@ -1970,7 +1960,7 @@ export function embeddedViewEnd(): void {
  * @param adjustedElementIndex  Element index in LViewData[] (adjusted for HEADER_OFFSET)
  */
 export function componentRefresh<T>(
-    adjustedElementIndex: number, parentFirstTemplatePass: boolean): void {
+    adjustedElementIndex: number, parentFirstTemplatePass: boolean, rf: RenderFlags | null): void {
   ngDevMode && assertDataInRange(adjustedElementIndex);
   const hostView = getComponentViewByIndex(adjustedElementIndex, getViewData());
   ngDevMode && assertNodeType(getTView().data[adjustedElementIndex] as TNode, TNodeType.Element);
@@ -1978,7 +1968,7 @@ export function componentRefresh<T>(
   // Only attached CheckAlways components or attached, dirty OnPush components should be checked
   if (viewAttached(hostView) && hostView[FLAGS] & (LViewFlags.CheckAlways | LViewFlags.Dirty)) {
     parentFirstTemplatePass && syncViewWithBlueprint(hostView);
-    detectChangesInternal(hostView, hostView[CONTEXT]);
+    detectChangesInternal(hostView, hostView[CONTEXT], rf);
   }
 }
 
@@ -2260,7 +2250,8 @@ export function tick<T>(component: T): void {
 function tickRootContext(rootContext: RootContext) {
   for (let i = 0; i < rootContext.components.length; i++) {
     const rootComponent = rootContext.components[i];
-    renderComponentOrTemplate(readPatchedLViewData(rootComponent) !, rootComponent);
+    renderComponentOrTemplate(
+        readPatchedLViewData(rootComponent) !, rootComponent, RenderFlags.Update);
   }
 }
 
@@ -2278,7 +2269,7 @@ function tickRootContext(rootContext: RootContext) {
  * @param component The component which the change detection should be performed on.
  */
 export function detectChanges<T>(component: T): void {
-  detectChangesInternal(getComponentViewByInstance(component) !, component);
+  detectChangesInternal(getComponentViewByInstance(component) !, component, null);
 }
 
 /**
@@ -2325,7 +2316,7 @@ export function checkNoChangesInRootView(lViewData: LViewData): void {
 }
 
 /** Checks the view of the component provided. Does not gate on dirty checks or execute doCheck. */
-export function detectChangesInternal<T>(hostView: LViewData, component: T) {
+function detectChangesInternal<T>(hostView: LViewData, component: T, rf: RenderFlags | null) {
   const hostTView = hostView[TVIEW];
   const oldView = enterView(hostView, hostView[HOST_NODE]);
   const templateFn = hostTView.template !;
@@ -2333,24 +2324,27 @@ export function detectChangesInternal<T>(hostView: LViewData, component: T) {
 
   try {
     namespaceHTML();
-    createViewQuery(viewQuery, hostView[FLAGS], component);
-    templateFn(getRenderFlags(hostView), component);
-    refreshDescendantViews(hostView);
-    updateViewQuery(viewQuery, component);
+    createViewQuery(viewQuery, rf, hostView[FLAGS], component);
+    templateFn(rf || getRenderFlags(hostView), component);
+    refreshDescendantViews(hostView, rf);
+    updateViewQuery(viewQuery, hostView[FLAGS], component);
   } finally {
-    leaveView(oldView);
+    leaveView(oldView, rf === RenderFlags.Create);
   }
 }
 
 function createViewQuery<T>(
-    viewQuery: ComponentQuery<{}>| null, flags: LViewFlags, component: T): void {
-  if (viewQuery && (flags & LViewFlags.CreationMode)) {
+    viewQuery: ComponentQuery<{}>| null, renderFlags: RenderFlags | null, viewFlags: LViewFlags,
+    component: T): void {
+  if (viewQuery && (renderFlags === RenderFlags.Create ||
+                    (renderFlags === null && (viewFlags & LViewFlags.CreationMode)))) {
     viewQuery(RenderFlags.Create, component);
   }
 }
 
-function updateViewQuery<T>(viewQuery: ComponentQuery<{}>| null, component: T): void {
-  if (viewQuery) {
+function updateViewQuery<T>(
+    viewQuery: ComponentQuery<{}>| null, flags: LViewFlags, component: T): void {
+  if (viewQuery && flags & RenderFlags.Update) {
     viewQuery(RenderFlags.Update, component);
   }
 }

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -501,9 +501,6 @@
     "name": "executeHooks"
   },
   {
-    "name": "executeInitAndContentHooks"
-  },
-  {
     "name": "executeInitHooks"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -201,9 +201,6 @@
     "name": "executeHooks"
   },
   {
-    "name": "executeInitAndContentHooks"
-  },
-  {
     "name": "executeInitHooks"
   },
   {
@@ -370,6 +367,9 @@
   },
   {
     "name": "prefillHostVars"
+  },
+  {
+    "name": "queueComponentIndexForCheck"
   },
   {
     "name": "queueHostBindingForCheck"

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -3195,9 +3195,6 @@
     "name": "executeHooks"
   },
   {
-    "name": "executeInitAndContentHooks"
-  },
-  {
     "name": "executeInitHooks"
   },
   {
@@ -4144,6 +4141,9 @@
   },
   {
     "name": "queryDef"
+  },
+  {
+    "name": "queueComponentIndexForCheck"
   },
   {
     "name": "queueContentHooks"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -555,9 +555,6 @@
     "name": "executeHooks"
   },
   {
-    "name": "executeInitAndContentHooks"
-  },
-  {
     "name": "executeInitHooks"
   },
   {

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -1506,9 +1506,6 @@
     "name": "executeHooks"
   },
   {
-    "name": "executeInitAndContentHooks"
-  },
-  {
     "name": "executeInitHooks"
   },
   {


### PR DESCRIPTION
This PR fixes a few bugs surrounding dynamically created components:

- Bindings weren't checked 
- Init hooks weren't run
- View queries weren't run
- Elements in child views (deep view tree) were created too late