### PR TITLE
feat(core): unify inject accessibility in constructor

### DIFF
--- a/packages/core/src/view/types.ts
+++ b/packages/core/src/view/types.ts
@@ -355,6 +355,7 @@ export interface ViewData {
   // and call the right accessor (e.g. `elementData`) based on
   // the NodeType.
   nodes: {[key: number]: NodeData};
+  nodeInjectors: (Injector|undefined)[];
   state: ViewState;
   oldValues: any[];
   disposables: DisposableFn[]|null;

--- a/packages/core/test/view/provider_spec.ts
+++ b/packages/core/test/view/provider_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, ChangeDetectorRef, DoCheck, ElementRef, ErrorHandler, EventEmitter, Injector, OnChanges, OnDestroy, OnInit, Renderer, Renderer2, SimpleChange, TemplateRef, ViewContainerRef,} from '@angular/core';
+import {inject as _inject, AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, ChangeDetectorRef, DoCheck, ElementRef, ErrorHandler, EventEmitter, Injector, OnChanges, OnDestroy, OnInit, Renderer, Renderer2, SimpleChange, TemplateRef, ViewContainerRef,} from '@angular/core';
 import {getDebugContext} from '@angular/core/src/errors';
 import {ArgumentType, DepFlags, NodeFlags, Services, anchorDef, asElementData, directiveDef, elementDef, providerDef, textDef} from '@angular/core/src/view/index';
 import {TestBed, withModule} from '@angular/core/testing';
@@ -52,6 +52,24 @@ import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, createRootView, createAndGetR
         expect(lazy).toBeUndefined();
         instance.dep.get(LazyService);
         expect(lazy instanceof LazyService).toBe(true);
+      });
+
+      it('should allow inject instruction with correct injector', () => {
+        let constructorInjector: Injector = undefined !;
+        let imperativeInjector: Injector = undefined !;
+        class InjectDir {
+          constructor(dep: any) {
+            constructorInjector = dep;
+            imperativeInjector = _inject(Injector as any);
+          }
+        }
+
+        createAndGetRootNodes(compViewDef([
+          elementDef(0, NodeFlags.None, null, null, 1, 'span'),
+          directiveDef(1, NodeFlags.None, null, 0, InjectDir, [Injector])
+        ]));
+
+        expect(imperativeInjector).toBe(constructorInjector);
       });
 
       it('should create value providers', () => {
@@ -178,6 +196,26 @@ import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, createRootView, createAndGetR
           ]));
 
           expect(instance.dep instanceof Dep).toBeTruthy();
+        });
+
+        it('should allow inject instruction in deps with correct injector', () => {
+          let constructorInjector: Injector = undefined !;
+          let imperativeInjector: Injector = undefined !;
+          class InjectDep {
+            constructor(dep: any) {
+              constructorInjector = dep;
+              imperativeInjector = _inject(Injector as any);
+            }
+          }
+
+          createAndGetRootNodes(compViewDef([
+            elementDef(0, NodeFlags.None, null, null, 3, 'span'),
+            directiveDef(1, NodeFlags.None, null, 0, InjectDep, [Injector]),
+            elementDef(2, NodeFlags.None, null, null, 1, 'span'),
+            directiveDef(3, NodeFlags.None, null, 0, SomeService, [InjectDep])
+          ]));
+
+          expect(imperativeInjector).toBe(constructorInjector);
         });
 
         it('should throw for missing dependencies', () => {


### PR DESCRIPTION
closes #25039

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/25039

Currently `inject` instruction availability is quite inconsistency across Angular types.

Can be used in:

+ [Tree-shakable Service](https://stackblitz.com/edit/angular-2ivh52)

Cannot be used in:

+ [Canonical Service](https://stackblitz.com/edit/angular-wlget6?file=src%2Fapp%2Fapp.component.ts)
+ [Directive/Component](https://stackblitz.com/edit/angular-muiqlp?file=src/app/app.component.ts)

Also, it ~is~ [will be](https://github.com/angular/angular/issues/23330) consistently supported in Ivy.

## What is the new behavior?

Make the behavior of `inject` consistent in ViewEngine and align with Ivy.

### Use cases

Dependencies injection in base class without passing `Injector`:

```typescript
class Base {
  cdr = inject(ChangeDetectorRef)
}

@Component()
class Derived extends Base {
  // ...
}
```

[Hooks](https://reactjs.org/docs/hooks-intro.html)-like state delegation

```typescript
function useState<T>(value: T) {
  const cdr = inject(ChangeDetectorRef)
  return {
    value,
    set(value: T) {
      this.value = value
      cdr.markForCheck()
    },
  }
}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
