### PR TITLE
fix(ivy): sync exported r3 symbol with compiler generated symbol

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -25,7 +25,7 @@ export {
   getFactoryOf as ɵgetFactoryOf,
   getInheritedFactory as ɵgetInheritedFactory,
   templateRefExtractor as ɵtemplateRefExtractor,
-  ProvidersFeature as ɵProvidersResolver,
+  ProvidersFeature as ɵProvidersFeature,
   InheritDefinitionFeature as ɵInheritDefinitionFeature,
   NgOnChangesFeature as ɵNgOnChangesFeature,
   NgModuleType as ɵNgModuleType,


### PR DESCRIPTION
Small PR to fix `i0.ÉµProvidersFeature is not a function` test failure in Ivy. We were not exporting `ProvidersFeature` under the same name that we were generating it in the compiler, so the function could not be found.
