### PR TITLE
fix(upgrade): make ng1 typings compatible with older versions

### DIFF
--- a/packages/upgrade/src/common/angular1.ts
+++ b/packages/upgrade/src/common/angular1.ts
@@ -10,7 +10,12 @@ export type Ng1Token = string;
 
 export type Ng1Expression = string | Function;
 
-export interface IAnnotatedFunction extends Function { $inject?: ReadonlyArray<Ng1Token>; }
+export interface IAnnotatedFunction extends Function {
+  // Older versions of `@types/angular` typings extend the global `Function` interface with
+  // `$inject?: string[]`, which is not compatible with `$inject?: ReadonlyArray<string>` (used in
+  // latest versions).
+  $inject?: Function extends{$inject?: string[]}? Ng1Token[]: ReadonlyArray<Ng1Token>;
+}
 
 export type IInjectable = (Ng1Token | Function)[] | IAnnotatedFunction;
 


### PR DESCRIPTION
Make angular1 typings compatible with older versions

closes #26420

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Allows angular1.d.ts to compile without error when using angular 1.5.x.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 26420


## What is the new behavior?
Allows angular1.d.ts compile without error when using angular 1.5.x.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
