### PR TITLE
build: fix api guardian path for windows

### DIFF
--- a/tools/ts-api-guardian/lib/cli.ts
+++ b/tools/ts-api-guardian/lib/cli.ts
@@ -191,7 +191,7 @@ function resolveBazelFilePath(fileName: string): string {
   // are not available in the working directory. In order to resolve the real path for the
   // runfile, we need to use `require.resolve` which handles runfiles properly on Windows.
   if (process.env['BAZEL_TARGET']) {
-    return path.posix.relative(process.cwd(), require.resolve(fileName));
+    return path.relative(process.cwd(), require.resolve(fileName));
   }
 
   return fileName;

--- a/tools/ts-api-guardian/lib/serializer.ts
+++ b/tools/ts-api-guardian/lib/serializer.ts
@@ -381,7 +381,7 @@ const memberDeclarationOrder: {[key: number]: number} = {
 };
 
 function stripEmptyLines(text: string): string {
-  return text.split('\n').filter(x => !!x.length).join('\n');
+  return text.split(/\r?\n/).filter(x => !!x.length).join('\n');
 }
 
 /**


### PR DESCRIPTION
At the moment, `path.posix.relative` will break paths in windows as it will return something like
```
Error: Source file "../C:/users/alag/_bazel_alag/3tbqurya/execroot/angular/bazel-out/x64_windows-fastbuild/bin/packages/core/core.d.ts" not found
```

Remove `\r`  followed by `\n` as in windows these causes golden files to be different.
