### PR TITLE
build: release scripts should use bazel from yarn

### DIFF
--- a/scripts/release/publish-latest
+++ b/scripts/release/publish-latest
@@ -6,13 +6,17 @@ set -u -e -o pipefail
 # Query Bazel for npm_package and ng_package rules with tags=["release-with-framework"]
 # Publish them to npm (tagged next)
 
+# We need to resolve the Bazel binary in the node modules because running Bazel
+# through `yarn bazel` causes additional output that throws off the command stdout.
+BAZEL_BIN=$(yarn bin)/bazel
+
 # query for all npm packages to be released as part of the framework release
-NPM_PACKAGE_LABELS=`bazel query --output=label 'attr("tags", "\[.*release-with-framework.*\]", //packages/...) intersect kind(".*_package", //packages/...)'`
+NPM_PACKAGE_LABELS=`${BAZEL_BIN} query --output=label 'attr("tags", "\[.*release-with-framework.*\]", //packages/...) intersect kind(".*_package", //packages/...)'`
 # build all npm packages in parallel
-bazel build $NPM_PACKAGE_LABELS
+${BAZEL_BIN} build $NPM_PACKAGE_LABELS
 # publish all packages in sequence to make it easier to spot any errors or warnings
 for packageLabel in $NPM_PACKAGE_LABELS; do
   echo "publishing $packageLabel"
-  bazel run -- ${packageLabel}.publish --access public --tag latest
+  ${BAZEL_BIN} run -- ${packageLabel}.publish --access public --tag latest
 done
 

--- a/scripts/release/publish-next
+++ b/scripts/release/publish-next
@@ -6,12 +6,16 @@ set -u -e -o pipefail
 # Query Bazel for npm_package and ng_package rules with tags=["release-with-framework"]
 # Publish them to npm (tagged next)
 
+# We need to resolve the Bazel binary in the node modules because running Bazel
+# through `yarn bazel` causes additional output that throws off the command stdout.
+BAZEL_BIN=$(yarn bin)/bazel
+
 # query for all npm packages to be released as part of the framework release
-NPM_PACKAGE_LABELS=`bazel query --output=label 'attr("tags", "\[.*release-with-framework.*\]", //packages/...) intersect kind(".*_package", //packages/...)'`
+NPM_PACKAGE_LABELS=`${BAZEL_BIN} query --output=label 'attr("tags", "\[.*release-with-framework.*\]", //packages/...) intersect kind(".*_package", //packages/...)'`
 # build all npm packages in parallel
-bazel build $NPM_PACKAGE_LABELS
+${BAZEL_BIN} build $NPM_PACKAGE_LABELS
 # publish all packages in sequence to make it easier to spot any errors or warnings
 for packageLabel in $NPM_PACKAGE_LABELS; do
   echo "publishing $packageLabel"
-  bazel run -- ${packageLabel}.publish --access public --tag next
+  ${BAZEL_BIN} run -- ${packageLabel}.publish --access public --tag next
 done


### PR DESCRIPTION
With ec29fd3e7b70953c7886af91ef840d54c46d166f, the prefix for the `bazel` command has been removed because it threw off the Bash variables. 

In order to fix this while still running Bazel from the `node_modules` (keeping the bazel versions consistent), we should run Bazel without Yarn (similar to how it's done for `build-packages-dist.sh`)