### PR TITLE
build(bazel): fix //modules/benchmarks/src/largetable/render3:perf benchmark in CI

### DIFF
--- a/modules/benchmarks/src/largetable/render3/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/render3/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//tools:defaults.bzl", "ng_module", "ng_rollup_bundle")
-load("//packages/bazel:index.bzl", "protractor_web_test")
+load("//packages/bazel:index.bzl", "protractor_web_test_suite")
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_devserver")
 
 ng_module(
@@ -50,7 +50,7 @@ ts_devserver(
     tags = ["ivy-only"],
 )
 
-protractor_web_test(
+protractor_web_test_suite(
     name = "perf",
     configuration = "//:protractor-perf.conf.js",
     data = [
@@ -64,8 +64,6 @@ protractor_web_test(
     on_prepare = ":protractor.on_prepare.js",
     server = ":devserver",
     tags = [
-        "fixme-ivy-aot",
-        "fixme-ivy-jit",
         "ivy-only",
     ],
     deps = [

--- a/modules/benchmarks/src/tree/render3/BUILD.bazel
+++ b/modules/benchmarks/src/tree/render3/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//tools:defaults.bzl", "ng_module", "ng_rollup_bundle")
-load("//packages/bazel:index.bzl", "protractor_web_test")
+load("//packages/bazel:index.bzl", "protractor_web_test_suite")
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_devserver")
 
 ng_module(
@@ -48,7 +48,7 @@ ts_devserver(
     tags = ["ivy-only"],
 )
 
-protractor_web_test(
+protractor_web_test_suite(
     name = "perf",
     configuration = "//:protractor-perf.conf.js",
     data = [
@@ -58,8 +58,6 @@ protractor_web_test(
     on_prepare = ":protractor.on_prepare.js",
     server = ":devserver",
     tags = [
-        "fixme-ivy-aot",
-        "fixme-ivy-jit",
         "ivy-only",
     ],
     deps = [


### PR DESCRIPTION
Underlying issue was that `//modules/benchmarks/src/largetable/render3:perf ` relies on the locally installed version of chrome. It uses `protractor_web_test` and not `protractor_web_test_suite`. The latter provides its own version of chrome via `rules_webtesting`, the former does not.

To fix it, the `browsers_docker_image` docker image is now used for `test_ivy_aot` and `test_ivy_jit` and the benchmark is also run locally and not on RBE.