### PR TITLE
fix(common): make `HttpParameterCodec` injectable

### DIFF
--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -6,15 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable} from '@angular/core';
+import {Injectable, Optional} from '@angular/core';
 import {Observable, of } from 'rxjs';
 import {concatMap, filter, map} from 'rxjs/operators';
 
 import {HttpHandler} from './backend';
 import {HttpHeaders} from './headers';
-import {HttpParams, HttpParamsOptions} from './params';
+import {HttpParameterCodec, HttpParams, HttpParamsOptions} from './params';
 import {HttpRequest} from './request';
 import {HttpEvent, HttpResponse} from './response';
+
 
 
 /**
@@ -55,7 +56,12 @@ export type HttpObserve = 'body' | 'events' | 'response';
  */
 @Injectable()
 export class HttpClient {
-  constructor(private handler: HttpHandler) {}
+  constructor(
+      private handler: HttpHandler,
+      /**
+       * You can also provide custom `HttpParameterCodec`.
+       */
+      @Optional() private httpParameterCodec?: HttpParameterCodec, ) {}
 
   /**
    * Send the given `HttpRequest` and return a stream of `HttpEvents`.
@@ -358,7 +364,9 @@ export class HttpClient {
         if (options.params instanceof HttpParams) {
           params = options.params;
         } else {
-          params = new HttpParams({ fromObject: options.params } as HttpParamsOptions);
+          params = new HttpParams({
+            fromObject: options.params, encoder: this.httpParameterCodec,
+          } as HttpParamsOptions);
         }
       }
 

--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -13,12 +13,12 @@
  *
  * @publicApi
  **/
-export interface HttpParameterCodec {
-  encodeKey(key: string): string;
-  encodeValue(value: string): string;
+export abstract class HttpParameterCodec {
+  abstract encodeKey(key: string): string;
+  abstract encodeValue(value: string): string;
 
-  decodeKey(key: string): string;
-  decodeValue(value: string): string;
+  abstract decodeKey(key: string): string;
+  abstract decodeValue(value: string): string;
 }
 
 /**
@@ -27,7 +27,7 @@ export interface HttpParameterCodec {
  *
  * @publicApi
  */
-export class HttpUrlEncodingCodec implements HttpParameterCodec {
+export class HttpUrlEncodingCodec extends HttpParameterCodec {
   encodeKey(key: string): string { return standardEncoding(key); }
 
   encodeValue(value: string): string { return standardEncoding(value); }

--- a/packages/common/http/test/module_spec.ts
+++ b/packages/common/http/test/module_spec.ts
@@ -14,6 +14,7 @@ import {map} from 'rxjs/operators';
 import {HttpHandler} from '../src/backend';
 import {HttpClient} from '../src/client';
 import {HTTP_INTERCEPTORS, HttpInterceptor} from '../src/interceptor';
+import {HttpParameterCodec} from '../src/params';
 import {HttpRequest} from '../src/request';
 import {HttpEvent, HttpResponse} from '../src/response';
 import {HttpTestingController} from '../testing/src/api';
@@ -101,6 +102,23 @@ class ReentrantInterceptor implements HttpInterceptor {
       });
       injector.get(HttpClient).get('/test').subscribe(() => { done(); });
       injector.get(HttpTestingController).expectOne('/test').flush('ok!');
+    });
+
+    it('should injected custom http parameter encoder', () => {
+      class TestHttpParameterEncoder extends HttpParameterCodec {
+        encodeKey(key: string): string { return key + 'a'; }
+        encodeValue(value: string): string { return value + 'b'; }
+        decodeKey(key: string): string { return key + 'a'; }
+        decodeValue(value: string): string { return value + 'b'; }
+      }
+
+      TestBed.resetTestingModule();
+      injector = TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule],
+        providers: [{provide: HttpParameterCodec, useClass: TestHttpParameterEncoder}]
+      });
+
+      expect(injector.get(HttpParameterCodec).encodeKey('a')).toBe('aa');
     });
   });
 }


### PR DESCRIPTION
You can inject custom `HttpParameterCodec` for avoid to not use default encoder.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Specific API server can't accept character. '+' so we need to encode that.

But angular's standard encoder doesn't encode that. so developer add custom encoder each every http method invokes. it's very annoying.

https://github.com/angular/angular/blob/5298b2bda34a8766b28c8425e447f94598b23901/packages/common/http/src/params.ts#L64

Issue Number: #19710, #23157

## What is the new behavior?

User can provide default custom http parameter codec.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
