### PR TITLE
build(docs-infra): upgrade cli command docs sources to b50950b97

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -18,7 +18,7 @@
     "build-for": "yarn ~~build --configuration",
     "prebuild-local": "yarn setup-local",
     "build-local": "yarn ~~build --configuration=stable",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 4faa81e25",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js b50950b97",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
[Changed files](https://github.com/angular/cli-builds/compare/4faa81e25...b50950b97):
- help/add.json
- help/build.json
- help/config.json
- help/doc.json
- help/e2e.json
- help/eject.json
- help/generate.json
- help/get.json
- help/help.json
- help/lint.json
- help/make-this-awesome.json
- help/new.json
- help/run.json
- help/serve.json
- help/set.json
- help/test.json
- help/update.json
- help/version.json
- help/xi18n.json