### PR TITLE
refactor(core): use a void promise and type scheduleMicroTask better

### DIFF
--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -21,7 +21,9 @@ const __global = typeof global !== 'undefined' && global;
 // should be __global in that case.
 const _global: {[name: string]: any} = __global || __window || __self;
 
-const promise: Promise<any> = Promise.resolve(0);
+/** Promise used to schedule a microtask. */
+const promise = Promise.resolve();
+
 /**
  * Attention: whenever providing a new value, be sure to add an
  * entry into the corresponding `....externs.js` file,
@@ -52,10 +54,10 @@ export function getSymbolIterator(): string|symbol {
   return _symbolIterator;
 }
 
-export function scheduleMicroTask(fn: Function) {
+export function scheduleMicroTask(fn: () => void) {
   if (typeof Zone === 'undefined') {
     // use promise to schedule microTask instead of use Zone
-    promise.then(() => { fn && fn.apply(null, null); });
+    promise.then(() => fn.apply(null));
   } else {
     Zone.current.scheduleMicroTask('scheduleMicrotask', fn);
   }

--- a/packages/core/test/testability/testability_spec.ts
+++ b/packages/core/test/testability/testability_spec.ts
@@ -16,7 +16,7 @@ import {SpyObject, beforeEach, describe, expect, it} from '@angular/core/testing
 import {scheduleMicroTask} from '../../src/util';
 
 // Schedules a microtasks (using a resolved promise .then())
-function microTask(fn: Function): void {
+function microTask(fn: () => void): void {
   scheduleMicroTask(() => {
     // We do double dispatch so that we  can wait for scheduleMicrotask in the Testability when
     // NgZone becomes stable.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

n/a


## What is the new behavior?

Improved the typing for the `scheduleMicroTask` utility method and made the microtask promise to be a void one. This allowed to shave off some bytes and improve types which can only be a good thing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
