### PR TITLE
fix(platform-browser): only one hammer instance is created in one element

### DIFF
--- a/packages/platform-browser/src/dom/events/hammer_gestures.ts
+++ b/packages/platform-browser/src/dom/events/hammer_gestures.ts
@@ -137,11 +137,14 @@ export class HammerGestureConfig {
    * @returns A HammerJS event-manager object.
    */
   buildHammer(element: HTMLElement): HammerInstance {
-    const mc = new Hammer !(element, this.options);
+    let mc = (element as any)['__hammer__'];
 
-    mc.get('pinch').set({enable: true});
-    mc.get('rotate').set({enable: true});
-
+    if (!mc) {
+      mc = new Hammer !(element, this.options);
+      mc.get('pinch').set({enable: true});
+      mc.get('rotate').set({enable: true});
+      (element as any)['__hammer__'] = mc;
+    }
     for (const eventName in this.overrides) {
       mc.get(eventName).set(this.overrides[eventName]);
     }

--- a/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
+++ b/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
@@ -10,6 +10,7 @@ import {fakeAsync, inject, tick} from '@angular/core/testing';
 import {afterEach, beforeEach, describe, expect, it,} from '@angular/core/testing/src/testing_internal';
 import {EventManager} from '@angular/platform-browser';
 import {HammerGestureConfig, HammerGesturesPlugin,} from '@angular/platform-browser/src/dom/events/hammer_gestures';
+import {el} from '@angular/platform-browser/testing/src/browser_util';
 
 {
   describe('HammerGesturesPlugin', () => {
@@ -149,6 +150,34 @@ import {HammerGestureConfig, HammerGesturesPlugin,} from '@angular/platform-brow
                .toHaveBeenCalledWith(
                    `The custom HAMMER_LOADER completed, but Hammer.JS is not present.`);
          }));
+    });
+    describe('with FakeHammer class', () => {
+      let originalHammerGlobal: any;
+      beforeEach(() => {
+        originalHammerGlobal = (window as any).Hammer;
+        (window as any).Hammer = class FakeHammer {
+          get() { return this; }
+          set() { return this; }
+        };
+      });
+      afterEach(() => { (window as any).Hammer = originalHammerGlobal; });
+
+      it('should create an instance of hammer for each element', () => {
+        const config = new HammerGestureConfig();
+        const element = el('<div></div>');
+        const onceInstance = config.buildHammer(element);
+        let multiInstance = config.buildHammer(element);
+
+        expect(onceInstance).not.toBeUndefined();
+        expect(onceInstance).toEqual(multiInstance);
+
+        multiInstance = config.buildHammer(element);
+        expect(onceInstance).toEqual(multiInstance);
+        multiInstance = config.buildHammer(element);
+        expect(onceInstance).toEqual(multiInstance);
+        multiInstance = config.buildHammer(element);
+        expect(onceInstance).toEqual(multiInstance);
+      });
     });
   });
 }


### PR DESCRIPTION
I did wrong git rebase. so, I deleted #17064
I resend this pr

Close #16333

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe:


## What is the current behavior?

Issue Number: #16333


## What is the new behavior?
When Hammer instance is created I check it.
If instance is created, reuse it!

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
