### PR TITLE
feat(common): make `HttpParameterCodec` injectable

### DIFF
--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable} from '@angular/core';
+import {Injectable, Optional} from '@angular/core';
 import {Observable, of } from 'rxjs';
 import {concatMap, filter, map} from 'rxjs/operators';
 
 import {HttpHandler} from './backend';
 import {HttpHeaders} from './headers';
-import {HttpParams, HttpParamsOptions} from './params';
+import {HttpParameterCodec, HttpParams, HttpParamsOptions} from './params';
 import {HttpRequest} from './request';
 import {HttpEvent, HttpResponse} from './response';
 
@@ -87,7 +87,8 @@ export type HttpObserve = 'body' | 'events' | 'response';
  */
 @Injectable()
 export class HttpClient {
-  constructor(private handler: HttpHandler) {}
+  constructor(
+      private handler: HttpHandler, @Optional() private httpParamCodec?: HttpParameterCodec) {}
 
   /**
    * Sends an `HTTPRequest` and returns a stream of `HTTPEvents`.
@@ -466,7 +467,11 @@ export class HttpClient {
         if (options.params instanceof HttpParams) {
           params = options.params;
         } else {
-          params = new HttpParams({ fromObject: options.params } as HttpParamsOptions);
+          const paramOptions: HttpParamsOptions = {fromObject: options.params};
+          if (!!this.httpParamCodec) {
+            paramOptions.encoder = this.httpParamCodec;
+          }
+          params = new HttpParams(paramOptions);
         }
       }
 

--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -13,12 +13,12 @@
  *
  * @publicApi
  **/
-export interface HttpParameterCodec {
-  encodeKey(key: string): string;
-  encodeValue(value: string): string;
+export abstract class HttpParameterCodec {
+  abstract encodeKey(key: string): string;
+  abstract encodeValue(value: string): string;
 
-  decodeKey(key: string): string;
-  decodeValue(value: string): string;
+  abstract decodeKey(key: string): string;
+  abstract decodeValue(value: string): string;
 }
 
 /**
@@ -31,7 +31,7 @@ export interface HttpParameterCodec {
  *
  * @publicApi
  */
-export class HttpUrlEncodingCodec implements HttpParameterCodec {
+export class HttpUrlEncodingCodec extends HttpParameterCodec {
   /**
    * Encodes a key name for a URL parameter or query-string.
    * @param key The key name.

--- a/packages/common/http/test/module_spec.ts
+++ b/packages/common/http/test/module_spec.ts
@@ -9,6 +9,7 @@
 import {HttpHandler} from '@angular/common/http/src/backend';
 import {HttpClient} from '@angular/common/http/src/client';
 import {HTTP_INTERCEPTORS, HttpInterceptor} from '@angular/common/http/src/interceptor';
+import {HttpParameterCodec} from '@angular/common/http/src/params';
 import {HttpRequest} from '@angular/common/http/src/request';
 import {HttpEvent, HttpResponse} from '@angular/common/http/src/response';
 import {HttpTestingController} from '@angular/common/http/testing/src/api';
@@ -100,6 +101,20 @@ class ReentrantInterceptor implements HttpInterceptor {
       });
       injector.get(HttpClient).get('/test').subscribe(() => { done(); });
       injector.get(HttpTestingController).expectOne('/test').flush('ok!');
+    });
+    it('should injected custom http parameter encoder', () => {
+      class TestHttpParameterEncoder extends HttpParameterCodec {
+        encodeKey(key: string): string { return key + 'a'; }
+        encodeValue(value: string): string { return value + 'b'; }
+        decodeKey(key: string): string { return key + 'a'; }
+        decodeValue(value: string): string { return value + 'b'; }
+      }
+      TestBed.resetTestingModule();
+      injector = TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule],
+        providers: [{provide: HttpParameterCodec, useClass: TestHttpParameterEncoder}]
+      });
+      expect(injector.get(HttpParameterCodec).encodeKey('a')).toBe('aa');
     });
   });
 }

--- a/tools/public_api_guard/common/http.d.ts
+++ b/tools/public_api_guard/common/http.d.ts
@@ -5,7 +5,7 @@ export declare abstract class HttpBackend implements HttpHandler {
 }
 
 export declare class HttpClient {
-    constructor(handler: HttpHandler);
+    constructor(handler: HttpHandler, httpParamCodec?: HttpParameterCodec | undefined);
     delete<T>(url: string, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1556,11 +1556,11 @@ export interface HttpInterceptor {
     intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>>;
 }
 
-export interface HttpParameterCodec {
-    decodeKey(key: string): string;
-    decodeValue(value: string): string;
-    encodeKey(key: string): string;
-    encodeValue(value: string): string;
+export declare abstract class HttpParameterCodec {
+    abstract decodeKey(key: string): string;
+    abstract decodeValue(value: string): string;
+    abstract encodeKey(key: string): string;
+    abstract encodeValue(value: string): string;
 }
 
 export declare class HttpParams {
@@ -1698,7 +1698,7 @@ export interface HttpUploadProgressEvent extends HttpProgressEvent {
     type: HttpEventType.UploadProgress;
 }
 
-export declare class HttpUrlEncodingCodec implements HttpParameterCodec {
+export declare class HttpUrlEncodingCodec extends HttpParameterCodec {
     decodeKey(key: string): string;
     decodeValue(value: string): string;
     encodeKey(key: string): string;


### PR DESCRIPTION
You can inject custom `HttpParameterCodec` to not use default parameter encoder.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Specific API server can't accept character. '+' so we need to encode that.

https://github.com/angular/angular/blob/5298b2bda34a8766b28c8425e447f94598b23901/packages/common/http/src/params.ts#L64

But angular's standard encoder decode that.

So developer needs to add custom encoder every http method invokes. and it's very annoying.

Related Issue Numbers: #19710, #23157 #18261, #18719, #11058

## What is the new behavior?

User can provide default custom http parameter codec.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
