### PR TITLE
feat(router): able to provide base URL with APP_BASE_HREF 

### DIFF
--- a/aio/content/examples/upgrade-phonecat-3-final/app/app-routing.module.ts
+++ b/aio/content/examples/upgrade-phonecat-3-final/app/app-routing.module.ts
@@ -16,7 +16,7 @@ const routes: Routes = [
   imports: [ RouterModule.forRoot(routes) ],
   exports: [ RouterModule ],
   providers: [
-    { provide: APP_BASE_HREF, useValue: '!' },
+    { provide: APP_BASE_HREF, useValue: '/index.html#!' },
     { provide: LocationStrategy, useClass: HashLocationStrategy },
   ]
 })

--- a/packages/common/src/location/hash_location_strategy.ts
+++ b/packages/common/src/location/hash_location_strategy.ts
@@ -25,6 +25,17 @@ import {LocationChangeListener, PlatformLocation} from './platform_location';
  * For instance, if you call `location.go('/foo')`, the browser's URL will become
  * `example.com#/foo`.
  *
+ * You can provide a {@link APP_BASE_HREF} or add a base element to the document.
+ * This URL prefix that will be preserved when generating and recognizing URLs.
+ *
+ * For example, if you provide an `APP_BASE_HREF` of `'/my/app'` and call
+ * `location.go('/foo')`, the browser's URL will become
+ * `example.com/my/app#/foo`.
+ *
+ * Similarly, if you add `<base href='/my/app'/>` to the document and call
+ * `location.go('/foo')`, the browser's URL will become
+ * `example.com/my/app#/foo`.
+ *
  * @usageNotes
  *
  * ### Example
@@ -35,13 +46,27 @@ import {LocationChangeListener, PlatformLocation} from './platform_location';
  */
 @Injectable()
 export class HashLocationStrategy extends LocationStrategy {
-  private _baseHref: string = '';
+  private _baseHref: string;
+  private _hashFragmentPrefix: string;
   constructor(
       private _platformLocation: PlatformLocation,
       @Optional() @Inject(APP_BASE_HREF) _baseHref?: string) {
     super();
-    if (_baseHref != null) {
+    _baseHref = _baseHref || '';
+    if (!_baseHref.startsWith('/')) {
+      if (_baseHref.startsWith('#')) {
+        _baseHref = _baseHref.substring(1);
+      }
+      _baseHref = ('' === _baseHref) ? _baseHref : ('#' + _baseHref);
+    }
+    const hashSignAt = _baseHref.indexOf('#');
+    if (hashSignAt >= 0) {
+      this._baseHref = _baseHref.substring(0, hashSignAt);
+      this._hashFragmentPrefix =
+          '#' + Location.stripTrailingSlash(_baseHref.substring(hashSignAt + 1));
+    } else {
       this._baseHref = _baseHref;
+      this._hashFragmentPrefix = '#';
     }
   }
 
@@ -50,20 +75,28 @@ export class HashLocationStrategy extends LocationStrategy {
     this._platformLocation.onHashChange(fn);
   }
 
-  getBaseHref(): string { return this._baseHref; }
+  getBaseHref(): string { return this._baseHref + this._hashFragmentPrefix; }
 
   path(includeHash: boolean = false): string {
     // the hash value is always prefixed with a `#`
     // and if it is empty then it will stay empty
     let path = this._platformLocation.hash;
-    if (path == null) path = '#';
-
+    if (path == null) {
+      path = this._hashFragmentPrefix;
+    }
+    if (path.startsWith(this._hashFragmentPrefix)) {
+      return path.substring(this._hashFragmentPrefix.length);
+    }
     return path.length > 0 ? path.substring(1) : path;
   }
 
   prepareExternalUrl(internal: string): string {
-    const url = Location.joinWithSlash(this._baseHref, internal);
-    return url.length > 0 ? ('#' + url) : url;
+    if (internal.length === 0) {
+      return this._baseHref + this._hashFragmentPrefix + '/';
+    }
+    const mark =
+        internal.startsWith('/') ? this._hashFragmentPrefix : (this._hashFragmentPrefix + '/');
+    return this._baseHref + mark + internal;
   }
 
   pushState(state: any, title: string, path: string, queryParams: string) {


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number:  #13482, #20033

For routing with `HashLocationStrategy`:

If dist files (`main.*.js`, `runtime.*.js`, `asset/*` ...) and host page (`index.html`) have different deploy path, (eg. `/static-content/my-app/` for dist files and `/my/app` for host page), a base-href tag is required for loading resources correctly.

The expected routed URL for component is based on host page's URL path (eg. `/my/app#/ui/component`).

However the routed URL is based on path provided by base-href tag (eg. `/static-content/my-app/#/ui/component`) with current implementation.

An example reproduces this issue is [aio/contents/examples/upgrade-phonecat-3-final](/angular/angular/tree/master/aio/content/examples/upgrade-phonecat-3-final) (in test_docs_examples_1) - User cannot visit the application page with routed URL (ie: http://127.0.0.1:8080/app/#!/phones). Instead of application page, the content of app/ folder will be shown.

I made an experiment to reproduce and explore this issue: [angular-hashlocationstrategy-experiments](https://github.com/yinyin/angular-hashlocationstrategy-experiments)

In summary, for an application serving its host page from http://example.com/my/app and serving other files from http://example.com/static-content/my-app/ (base-href=`/static-content/my-app/`), the flow with current implementation is:

1. User open app URL: http://example.com/my/app
2. User click on router link to navigate to a component with route link `/ui/component`
3. `HashLocationStrategy` generates external URL `#/ui/component`
4. The external URL `#/ui/component` pushed to history API
5. Browser resolves URL with path from base-href tag (`http://example.com/static-content/my-app/`) and `#/ui/component` to form a new URL http://example.com/static-content/my-app/#/ui/component
6. The new URL is placed on browser's address bar: http://example.com/static-content/my-app/#/ui/component.


## What is the new behavior?

If `APP_BASE_HREF` is not starting with slash (eg. `!`), original behavior (ie. emit `#!/ui/path` to history API) will be use.

New behavior will use `APP_BASE_HREF` as base URL to pin the part of URL in front of hash fragment.

Based on previous example, for an application serving its host page from http://example.com/my/app (APP_BASE_HREF=`/my/app`) and serving other files from http://example.com/static-content/my-app/ (base-href=`/static-content/my-app/`), the flow with current implementation is:

1. User open app URL: http://example.com/my/app
2. User click on router link to navigate to a component with route link `/ui/component`
3. `HashLocationStrategy` generates external URL `/my/app#/ui/component` by concatenating APP_BASE_HERF, hash-mark (`#`) and route link
4. The external URL `/my/app#/ui/component` pushed to history API
5. Browser resolves URL with base-href tag (`http://example.com/static-content/my-app/`) and `/my/app#/ui/component` to form a new URL http://example.com/my/app#/ui/component
6. The new URL is placed on browser's address bar: http://example.com/my/app#/ui/component.

If application have to compatible with AngularJS routing, set `APP_BASE_HREF` to `/my/app#!` will lead to routed URL like `http://example.com/my/app#!/ui/component`.

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

If existed application set `APP_BASE_HREF` to something start with slash ('/') or hash (`#`), `APP_BASE_HREF` will be treat as path of host page. Prefix the value with `#` to keep treating it as fragment prefix.

Here are some examples:

| Existed `APP_BASE_HREF` value  | Expect URL | Broken ? | Fix |
| ------------------------------ | ---------- | -------- | --- |
| `!`                            | http://dom.ain/app#!/ui/path   | No  | `!` (won't break) |
| `/Prefix/Fragment/With/Slash`  | http://dom.ain/app#/Prefix/Fragment/With/Slash/ui/path  | Yes  | `#/Prefix/Fragment/With/Slash` |
| `#PrefixFragmentWithHash`      | http://dom.ain/app##PrefixFragmentWithHash/ui/path  | Yes  | `##PrefixFragmentWithHash` |
