### PR TITLE
feat(router): add ability to set root level filtering of router events

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -239,7 +239,7 @@ export class Router {
   private console: Console;
   private isNgZoneEnabled: boolean = false;
 
-  public readonly events: Observable<Event> = new Subject<Event>();
+  public readonly events: Observable<Event>;
   public readonly routerState: RouterState;
 
   /**
@@ -257,6 +257,11 @@ export class Router {
   malformedUriErrorHandler:
       (error: URIError, urlSerializer: UrlSerializer,
        url: string) => UrlTree = defaultMalformedUriErrorHandler;
+
+  /**
+   * Global filter for router events. See {@link ExtraOptions} for more information.
+   */
+  filterEventsPredicate: (event: Event) => boolean = () => true;
 
   /**
    * Indicates if at least one navigation happened.
@@ -338,6 +343,8 @@ export class Router {
 
     this.configLoader = new RouterConfigLoader(loader, compiler, onLoadStart, onLoadEnd);
     this.routerState = createEmptyState(this.currentUrlTree, this.rootComponentType);
+
+    this.events = (new Subject<Event>()).pipe(filter((e: Event) => this.filterEventsPredicate(e)));
 
     this.transitions = new BehaviorSubject<NavigationTransition>({
       id: 0,

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -16,7 +16,7 @@ import {Route, Routes} from './config';
 import {RouterLink, RouterLinkWithHref} from './directives/router_link';
 import {RouterLinkActive} from './directives/router_link_active';
 import {RouterOutlet} from './directives/router_outlet';
-import {RouterEvent} from './events';
+import {Event, RouterEvent} from './events';
 import {RouteReuseStrategy} from './route_reuse_strategy';
 import {ErrorHandler, Router} from './router';
 import {ROUTES} from './router_config_loader';
@@ -448,6 +448,22 @@ export interface ExtraOptions {
    * is `legacy`, and this option will be removed in v7 to default to the corrected behavior.
    */
   relativeLinkResolution?: 'legacy'|'corrected';
+
+  /**
+   * Allows a filter to be applied to all published routing events. This can be useful if
+   * your application should ignore all events of a certain type. For example:
+   *
+   * ```
+   * // Ignore (and do not publish) scroll events
+   * @NgModule({
+   *   import: [RouterModule.forRoot(ROUTES, {
+   *     filterEventsPredicate: e => !(e instanceof Scroll)
+   *   })]
+   * })
+   * export class MyAppModule {}
+   * ```
+   */
+  filterEventsPredicate?: (event: Event) => boolean;
 }
 
 export function setupRouter(
@@ -498,6 +514,10 @@ export function setupRouter(
 
   if (opts.relativeLinkResolution) {
     router.relativeLinkResolution = opts.relativeLinkResolution;
+  }
+
+  if (opts.filterEventsPredicate) {
+    router.filterEventsPredicate = opts.filterEventsPredicate;
   }
 
   return router;

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -76,6 +76,52 @@ describe('Integration', () => {
          ]);
        })));
 
+    it('should allow filtering of routing events', fakeAsync(inject([Router], (router: Router) => {
+         router.onSameUrlNavigation = 'reload';
+         router.resetConfig([
+           {path: '', component: SimpleCmp},
+           {path: 'simple', component: SimpleCmp},
+         ]);
+
+         const fixture = createRoot(router, RootCmp);
+         const events: Event[] = [];
+         router.events.subscribe(e => events.push(e));
+
+         router.navigateByUrl('/simple');
+         tick();
+
+         // Verify that all events are published by default
+         expectEvents(events, [
+           [NavigationStart, '/simple'],
+           [RoutesRecognized, '/simple'],
+           [GuardsCheckStart, '/simple'],
+           [ChildActivationStart],
+           [ActivationStart],
+           [GuardsCheckEnd, '/simple'],
+           [ResolveStart, '/simple'],
+           [ResolveEnd, '/simple'],
+           [ActivationEnd],
+           [ChildActivationEnd],
+           [NavigationEnd, '/simple'],
+         ]);
+
+         events.length = 0;
+
+         // Turn on event filtering to only RouterEvent instances
+         router.filterEventsPredicate = e => e instanceof RouterEvent;
+         router.navigateByUrl('/simple');
+         tick();
+
+         // Verify events are filtered properly
+         expectEvents(events, [
+           [NavigationStart, '/simple'],
+           [RoutesRecognized, '/simple'],
+           [GuardsCheckStart, '/simple'],
+           [GuardsCheckEnd, '/simple'],
+           [NavigationEnd, '/simple'],
+         ]);
+       })));
+
     it('should set the restoredState to null when executing imperative navigations',
        fakeAsync(inject([Router], (router: Router) => {
          router.resetConfig([

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -130,6 +130,10 @@ export function setupTestingRouter(
       if (opts.paramsInheritanceStrategy) {
         router.paramsInheritanceStrategy = opts.paramsInheritanceStrategy;
       }
+
+      if (opts.filterEventsPredicate) {
+        router.filterEventsPredicate = opts.filterEventsPredicate;
+      }
     }
   }
 

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -109,6 +109,7 @@ export interface ExtraOptions {
     anchorScrolling?: 'disabled' | 'enabled';
     enableTracing?: boolean;
     errorHandler?: ErrorHandler;
+    filterEventsPredicate?: (event: Event) => boolean;
     initialNavigation?: InitialNavigation;
     malformedUriErrorHandler?: (error: URIError, urlSerializer: UrlSerializer, url: string) => UrlTree;
     onSameUrlNavigation?: 'reload' | 'ignore';
@@ -303,6 +304,7 @@ export declare class Router {
     config: Routes;
     errorHandler: ErrorHandler;
     readonly events: Observable<Event>;
+    filterEventsPredicate: (event: Event) => boolean;
     malformedUriErrorHandler: (error: URIError, urlSerializer: UrlSerializer, url: string) => UrlTree;
     navigated: boolean;
     onSameUrlNavigation: 'reload' | 'ignore';


### PR DESCRIPTION
Adds a `filterEventsPredicate` that can be used to filter out router
events. Used at the top level with `RouterModule.forRoot`'s `ExtraOptions`.

Related to #24617
FW-29
