### PR TITLE
fix(router): Fix arguments order for call to shouldReuseRoute

### DIFF
--- a/packages/router/src/create_router_state.ts
+++ b/packages/router/src/create_router_state.ts
@@ -65,7 +65,7 @@ function createOrReuseChildren(
     prevState: TreeNode<ActivatedRoute>) {
   return curr.children.map(child => {
     for (const p of prevState.children) {
-      if (routeReuseStrategy.shouldReuseRoute(p.value.snapshot, child.value)) {
+      if (routeReuseStrategy.shouldReuseRoute(child.value, p.value.snapshot)) {
         return createNode(routeReuseStrategy, child, p);
       }
     }


### PR DESCRIPTION
Fix #16192

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features) [**I couldn't find any example of or existing unit tests for this bit of code. I need some help with writing them to be sure it's done correctly**]
- [x] Docs have been added / updated (for bug fixes / features) [**Docs update is not necessary as the documentation was already describing the correct behavior.**]


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## What is the current behavior?
createOrReuseChildren invokes the method in the wrong order and then calls createNode which invokes the method again, but with the arguments in the correct order this time.

Issue Number: #16192

## What is the new behavior?
The method is always invoked with the arguments in the correct order.

## Does this PR introduce a breaking change?

- [x] No

## Other information

Docs update is not necessary as the documentation was already describing the correct behavior.

Tests have not been written because I'm not sure where or how to write the test. If you don't mind, I would need a bit of help for this.