### PR TITLE
fix(ivy): jit should handle undefined type in constructor deps

### DIFF
--- a/packages/core/src/render3/jit/util.ts
+++ b/packages/core/src/render3/jit/util.ts
@@ -49,7 +49,10 @@ function reflectDependency(compiler: CompilerFacade, dep: any | any[]): R3Depend
     }
     for (let j = 0; j < dep.length; j++) {
       const param = dep[j];
-      if (param instanceof Optional || param.__proto__.ngMetadataName === 'Optional') {
+      if (param === undefined) {
+        // param may be undefined if type of dep is not set by ngtsc
+        continue;
+      } else if (param instanceof Optional || param.__proto__.ngMetadataName === 'Optional') {
         meta.optional = true;
       } else if (param instanceof SkipSelf || param.__proto__.ngMetadataName === 'SkipSelf') {
         meta.skipSelf = true;


### PR DESCRIPTION
ngtsc currently passes on an `undefined` type for constructor deps in certain cases, which jit should be able to handle with Ivy enabled. This change fixes 100s of existing TestBed tests, so no need to add a new test for this.

Still TODO: streamline ngtsc handling of arrays so it emits `Array` instead of `undefined` for something like:

```@Inject(NG_VALUE_ACCESSOR) valueAccessor: ControlValueAccessor[]```