### PR TITLE
fix(router): add relativeLinkResolution to recognize operator

### DIFF
--- a/packages/router/src/operators/recognize.ts
+++ b/packages/router/src/operators/recognize.ts
@@ -17,13 +17,13 @@ import {UrlTree} from '../url_tree';
 
 export function recognize(
     rootComponentType: Type<any>| null, config: Route[], serializer: (url: UrlTree) => string,
-    paramsInheritanceStrategy: 'emptyOnly' |
-        'always'): MonoTypeOperatorFunction<NavigationTransition> {
+    paramsInheritanceStrategy: 'emptyOnly' | 'always', relativeLinkResolution: 'legacy' |
+        'corrected'): MonoTypeOperatorFunction<NavigationTransition> {
   return function(source: Observable<NavigationTransition>) {
     return source.pipe(mergeMap(
         t => recognizeFn(
                  rootComponentType, config, t.urlAfterRedirects, serializer(t.urlAfterRedirects),
-                 paramsInheritanceStrategy)
+                 paramsInheritanceStrategy, relativeLinkResolution)
                  .pipe(map(targetSnapshot => ({...t, targetSnapshot})))));
   };
 }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -414,7 +414,7 @@ export class Router {
                       // Recognize
                       recognize(
                           this.rootComponentType, this.config, (url) => this.serializeUrl(url),
-                          this.paramsInheritanceStrategy),
+                          this.paramsInheritanceStrategy, this.relativeLinkResolution),
 
                       // Fire RoutesRecognized
                       tap(t => {


### PR DESCRIPTION
Close #26983

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In #22394, a new parameter called `relativeLinkResolution` had been added to `recogize` function, but due to router refactorisation in #25740, it has been wrapped by `recognize` operator, which misses this newly added parameter.
Issue Number: #26983


## What is the new behavior?
The `recognize` operator now includes `relativeLinkResolution` parameter.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
