### PR TITLE
docs(router): reword relativeLinkResolution docs to not mention version numbers

### DIFF
--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -444,8 +444,8 @@ export interface ExtraOptions {
    *
    * `<a [routerLink]="['../a']">Link to A</a>`
    *
-   * In other words, you're required to use `../` rather than `./`. The current default in v6
-   * is `legacy`, and this option will be removed in v7 to default to the corrected behavior.
+   * In other words, you're required to use `../` rather than `./`. This is currently the default
+   * behavior. Setting this option to `corrected` enables the fix.
    */
   relativeLinkResolution?: 'legacy'|'corrected';
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The current documentation for `relativeLinkResolution` does mention that the behavior will change in v7. But as the behavior is still not change, this sentence needs to be updated.

Issue Number: N/A


## What is the new behavior?
New documentation does not mention version numbers.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
