### PR TITLE
ci: exclude symbol golden files from build-and-ci pullapprove group

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -108,8 +108,9 @@ groups:
           - "*.lock"
           - "tools/*"
         exclude:
-          - "tools/public_api_guard/*"
           - "aio/*"
+          - "packages/core/test/bundling/*"
+          - "tools/public_api_guard/*"
     users:
       - IgorMinar #primary
       - alexeagle


### PR DESCRIPTION
these files are test data and note test infrastructure, so they don't belong to this group.

this means that the core group can now approve the golden symbol changes
