### PR TITLE
 fix(common): http/testing expectOne lists the received requests

### DIFF
--- a/packages/common/http/testing/src/backend.ts
+++ b/packages/common/http/testing/src/backend.ts
@@ -90,7 +90,19 @@ export class HttpClientTestingBackend implements HttpBackend, HttpTestingControl
           `Expected one matching request for criteria "${description}", found ${matches.length} requests.`);
     }
     if (matches.length === 0) {
-      throw new Error(`Expected one matching request for criteria "${description}", found none.`);
+      let message = `Expected one matching request for criteria "${description}", found none.`;
+      if (this.open.length > 0) {
+        // Show the methods and URLs of open requests in the error, for convenience.
+        const requests = this.open
+                             .map(testReq => {
+                               const url = testReq.request.urlWithParams;
+                               const method = testReq.request.method;
+                               return `${method} ${url}`;
+                             })
+                             .join(', ');
+        message += ` Requests received are: ${requests}.`;
+      }
+      throw new Error(message);
     }
     return matches[0];
   }

--- a/packages/common/http/testing/test/request_spec.ts
+++ b/packages/common/http/testing/test/request_spec.ts
@@ -36,7 +36,9 @@ describe('HttpClient TestRequest', () => {
       fail();
     } catch (error) {
       expect(error.message)
-          .toBe('Expected one matching request for criteria "Match URL: /some-url", found none.');
+          .toBe(
+              'Expected one matching request for criteria "Match URL: /some-url", found none.' +
+              ' Requests received are: GET /some-other-url.');
     }
   });
 
@@ -55,7 +57,8 @@ describe('HttpClient TestRequest', () => {
     } catch (error) {
       expect(error.message)
           .toBe(
-              'Expected one matching request for criteria "Match URL: /some-url?query=world", found none.');
+              'Expected one matching request for criteria "Match URL: /some-url?query=world", found none.' +
+              ' Requests received are: GET /some-url?query=hello.');
     }
   });
 });

--- a/packages/common/http/testing/test/request_spec.ts
+++ b/packages/common/http/testing/test/request_spec.ts
@@ -61,4 +61,24 @@ describe('HttpClient TestRequest', () => {
               ' Requests received are: GET /some-url?query=hello.');
     }
   });
+
+  it('throws if no request matches with several requests received', () => {
+    const mock = new HttpClientTestingBackend();
+    const client = new HttpClient(mock);
+
+    let resp: any;
+    client.get('/some-other-url?query=world').subscribe(body => { resp = body; });
+    client.post('/and-another-url', {}).subscribe(body => { resp = body; });
+
+    try {
+      // expect different URL
+      mock.expectOne('/some-url').flush(null);
+      fail();
+    } catch (error) {
+      expect(error.message)
+          .toBe(
+              'Expected one matching request for criteria "Match URL: /some-url", found none.' +
+              ' Requests received are: GET /some-other-url?query=world, POST /and-another-url.');
+    }
+  });
 });

--- a/packages/common/http/testing/test/request_spec.ts
+++ b/packages/common/http/testing/test/request_spec.ts
@@ -22,4 +22,40 @@ describe('HttpClient TestRequest', () => {
 
     expect(resp).toBeNull();
   });
+
+  it('throws if no request matches', () => {
+    const mock = new HttpClientTestingBackend();
+    const client = new HttpClient(mock);
+
+    let resp: any;
+    client.get('/some-other-url').subscribe(body => { resp = body; });
+
+    try {
+      // expect different URL
+      mock.expectOne('/some-url').flush(null);
+      fail();
+    } catch (error) {
+      expect(error.message)
+          .toBe('Expected one matching request for criteria "Match URL: /some-url", found none.');
+    }
+  });
+
+  it('throws if no request matches the exact parameters', () => {
+    const mock = new HttpClientTestingBackend();
+    const client = new HttpClient(mock);
+
+    let resp: any;
+    const params = {query: 'hello'};
+    client.get('/some-url', {params}).subscribe(body => { resp = body; });
+
+    try {
+      // expect different query parameters
+      mock.expectOne('/some-url?query=world').flush(null);
+      fail();
+    } catch (error) {
+      expect(error.message)
+          .toBe(
+              'Expected one matching request for criteria "Match URL: /some-url?query=world", found none.');
+    }
+  });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Previously it was hard to debug an `expectOne` if the request had no match, as the error message was:

     Expected one matching request for criteria "Match URL: /some-url?query=hello", found none.

Issue Number: #18013

## What is the new behavior?

This commit adds a bit more info to the error, by listing the actual requests received, if there are some (doesn't change the message if no requests were received):

     Expected one matching request for criteria "Match URL: /some-url?query=hello", found none. Requests received are: POST /some-url?query=world.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
