### PR TITLE
fix(ivy): providers should not be inherited

### DIFF
--- a/packages/core/src/render3/features/inherit_definition_feature.ts
+++ b/packages/core/src/render3/features/inherit_definition_feature.ts
@@ -146,7 +146,7 @@ export function InheritDefinitionFeature(definition: DirectiveDef<any>| Componen
       const features = superDef.features;
       if (features) {
         for (const feature of features) {
-          if (feature && feature !== InheritDefinitionFeature) {
+          if (feature && feature.ngInherit) {
             (feature as DirectiveDefFeature)(definition);
           }
         }

--- a/packages/core/src/render3/features/inherit_definition_feature.ts
+++ b/packages/core/src/render3/features/inherit_definition_feature.ts
@@ -76,6 +76,7 @@ export function InheritDefinitionFeature(definition: DirectiveDef<any>| Componen
             superHostBindings(directiveIndex, elementIndex);
             prevHostBindings(directiveIndex, elementIndex);
           };
+          (definition as any).hostVars += superDef.hostVars;
         } else {
           definition.hostBindings = superHostBindings;
         }

--- a/packages/core/src/render3/features/ng_onchanges_feature.ts
+++ b/packages/core/src/render3/features/ng_onchanges_feature.ts
@@ -106,6 +106,10 @@ export function NgOnChangesFeature<T>(definition: DirectiveDef<T>): void {
   definition.doCheck = onChangesWrapper(definition.doCheck);
 }
 
+// This option ensures that the ngOnChanges lifecycle hook will be inherited
+// from superclasses (in InheritDefinitionFeature).
+(NgOnChangesFeature as any).ngInherit = true;
+
 function onChangesWrapper(delegateHook: (() => void) | null) {
   return function(this: OnChangesExpando) {
     const simpleChanges = this[PRIVATE_PREFIX];

--- a/packages/core/src/render3/features/ng_onchanges_feature.ts
+++ b/packages/core/src/render3/features/ng_onchanges_feature.ts
@@ -8,7 +8,7 @@
 
 import {SimpleChange} from '../../change_detection/change_detection_util';
 import {OnChanges, SimpleChanges} from '../../metadata/lifecycle_hooks';
-import {DirectiveDef} from '../interfaces/definition';
+import {DirectiveDef, DirectiveDefFeature} from '../interfaces/definition';
 
 const PRIVATE_PREFIX = '__ngOnChanges_';
 
@@ -108,7 +108,7 @@ export function NgOnChangesFeature<T>(definition: DirectiveDef<T>): void {
 
 // This option ensures that the ngOnChanges lifecycle hook will be inherited
 // from superclasses (in InheritDefinitionFeature).
-(NgOnChangesFeature as any).ngInherit = true;
+(NgOnChangesFeature as DirectiveDefFeature).ngInherit = true;
 
 function onChangesWrapper(delegateHook: (() => void) | null) {
   return function(this: OnChangesExpando) {

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -307,8 +307,16 @@ export interface PipeDef<T> {
 
 export type PipeDefWithMeta<T, Name extends string> = PipeDef<T>;
 
-export type DirectiveDefFeature = <T>(directiveDef: DirectiveDef<T>) => void;
-export type ComponentDefFeature = <T>(componentDef: ComponentDef<T>) => void;
+export interface DirectiveDefFeature {
+  <T>(directiveDef: DirectiveDef<T>): void;
+  ngInherit?: true;
+}
+
+export interface ComponentDefFeature {
+  <T>(componentDef: ComponentDef<T>): void;
+  ngInherit?: true;
+}
+
 
 /**
  * Type used for directiveDefs on component definition.

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -138,6 +138,9 @@
     "name": "NgModuleRef"
   },
   {
+    "name": "NgOnChangesFeature"
+  },
+  {
     "name": "NodeInjector$1"
   },
   {
@@ -160,6 +163,9 @@
   },
   {
     "name": "PARENT_INJECTOR"
+  },
+  {
+    "name": "PRIVATE_PREFIX"
   },
   {
     "name": "QUERIES"
@@ -187,6 +193,9 @@
   },
   {
     "name": "SWITCH_VIEW_CONTAINER_REF_FACTORY"
+  },
+  {
+    "name": "SimpleChange"
   },
   {
     "name": "SimpleKeyframePlayer"
@@ -943,6 +952,9 @@
   },
   {
     "name": "noop"
+  },
+  {
+    "name": "onChangesWrapper"
   },
   {
     "name": "pointers"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -84,6 +84,9 @@
     "name": "NO_PARENT_INJECTOR"
   },
   {
+    "name": "NgOnChangesFeature"
+  },
+  {
     "name": "NodeInjectorFactory"
   },
   {
@@ -96,6 +99,9 @@
     "name": "PARENT_INJECTOR"
   },
   {
+    "name": "PRIVATE_PREFIX"
+  },
+  {
     "name": "QUERIES"
   },
   {
@@ -106,6 +112,9 @@
   },
   {
     "name": "SANITIZER"
+  },
+  {
+    "name": "SimpleChange"
   },
   {
     "name": "TVIEW"
@@ -382,6 +391,9 @@
   },
   {
     "name": "noop"
+  },
+  {
+    "name": "onChangesWrapper"
   },
   {
     "name": "postProcessBaseDirective"

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -282,6 +282,9 @@
     "name": "NgModuleRef$1"
   },
   {
+    "name": "NgOnChangesFeature"
+  },
+  {
     "name": "NgZone"
   },
   {
@@ -328,6 +331,9 @@
   },
   {
     "name": "PLATFORM_INITIALIZER"
+  },
+  {
+    "name": "PRIVATE_PREFIX"
   },
   {
     "name": "PlatformLocation"
@@ -382,6 +388,9 @@
   },
   {
     "name": "Self"
+  },
+  {
+    "name": "SimpleChange"
   },
   {
     "name": "SkipSelf"
@@ -1141,6 +1150,9 @@
   },
   {
     "name": "observable"
+  },
+  {
+    "name": "onChangesWrapper"
   },
   {
     "name": "onEnter"

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -33,6 +33,9 @@
     "name": "NULL_INJECTOR$2"
   },
   {
+    "name": "NgOnChangesFeature"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -45,6 +48,9 @@
     "name": "PARAMETERS"
   },
   {
+    "name": "PRIVATE_PREFIX"
+  },
+  {
     "name": "R3Injector"
   },
   {
@@ -52,6 +58,9 @@
   },
   {
     "name": "Self"
+  },
+  {
+    "name": "SimpleChange"
   },
   {
     "name": "SkipSelf"
@@ -151,6 +160,9 @@
   },
   {
     "name": "makeRecord"
+  },
+  {
+    "name": "onChangesWrapper"
   },
   {
     "name": "providerToFactory"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -132,6 +132,9 @@
     "name": "NgModuleRef"
   },
   {
+    "name": "NgOnChangesFeature"
+  },
+  {
     "name": "NodeInjector$1"
   },
   {
@@ -154,6 +157,9 @@
   },
   {
     "name": "PARENT_INJECTOR"
+  },
+  {
+    "name": "PRIVATE_PREFIX"
   },
   {
     "name": "QUERIES"
@@ -181,6 +187,9 @@
   },
   {
     "name": "SWITCH_VIEW_CONTAINER_REF_FACTORY"
+  },
+  {
+    "name": "SimpleChange"
   },
   {
     "name": "SkipSelf"
@@ -961,6 +970,9 @@
   },
   {
     "name": "noop"
+  },
+  {
+    "name": "onChangesWrapper"
   },
   {
     "name": "pointers"

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -1231,42 +1231,41 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
 
     describe('validation directives', () => {
 
-      fixmeIvy('RequiredValidator provided instead of CheckboxRequiredValidator') &&
-          it('required validator should validate checkbox', fakeAsync(() => {
-               const fixture = initTest(NgModelCheckboxRequiredValidator);
-               fixture.detectChanges();
-               tick();
+      it('required validator should validate checkbox', fakeAsync(() => {
+           const fixture = initTest(NgModelCheckboxRequiredValidator);
+           fixture.detectChanges();
+           tick();
 
-               const control =
-                   fixture.debugElement.children[0].injector.get(NgForm).control.get('checkbox') !;
+           const control =
+               fixture.debugElement.children[0].injector.get(NgForm).control.get('checkbox') !;
 
-               const input = fixture.debugElement.query(By.css('input'));
-               expect(input.nativeElement.checked).toBe(false);
-               expect(control.hasError('required')).toBe(false);
+           const input = fixture.debugElement.query(By.css('input'));
+           expect(input.nativeElement.checked).toBe(false);
+           expect(control.hasError('required')).toBe(false);
 
-               fixture.componentInstance.required = true;
-               fixture.detectChanges();
-               tick();
+           fixture.componentInstance.required = true;
+           fixture.detectChanges();
+           tick();
 
-               expect(input.nativeElement.checked).toBe(false);
-               expect(control.hasError('required')).toBe(true);
+           expect(input.nativeElement.checked).toBe(false);
+           expect(control.hasError('required')).toBe(true);
 
-               input.nativeElement.checked = true;
-               dispatchEvent(input.nativeElement, 'change');
-               fixture.detectChanges();
-               tick();
+           input.nativeElement.checked = true;
+           dispatchEvent(input.nativeElement, 'change');
+           fixture.detectChanges();
+           tick();
 
-               expect(input.nativeElement.checked).toBe(true);
-               expect(control.hasError('required')).toBe(false);
+           expect(input.nativeElement.checked).toBe(true);
+           expect(control.hasError('required')).toBe(false);
 
-               input.nativeElement.checked = false;
-               dispatchEvent(input.nativeElement, 'change');
-               fixture.detectChanges();
-               tick();
+           input.nativeElement.checked = false;
+           dispatchEvent(input.nativeElement, 'change');
+           fixture.detectChanges();
+           tick();
 
-               expect(input.nativeElement.checked).toBe(false);
-               expect(control.hasError('required')).toBe(true);
-             }));
+           expect(input.nativeElement.checked).toBe(false);
+           expect(control.hasError('required')).toBe(true);
+         }));
 
       it('should validate email', fakeAsync(() => {
            const fixture = initTest(NgModelEmailValidator);


### PR DESCRIPTION
This PR fixes a few bugs with class inheritance. 

1) Providers in subclasses should not be overwritten by superclass providers (or inherited).

2) Merged host bindings functions need to take superclass `hostVars` into account