### PR TITLE
fix(ivy): TestBed should use an NgZone

### DIFF
--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, Injector, NgModule, Pipe, PlatformRef, Provider, RendererFactory2, SchemaMetadata, Type, ɵInjectableDef as InjectableDef, ɵNgModuleDef as NgModuleDef, ɵNgModuleTransitiveScopes as NgModuleTransitiveScopes, ɵRender3ComponentFactory as ComponentFactory, ɵRender3DebugRendererFactory2 as Render3DebugRendererFactory2, ɵRender3NgModuleRef as NgModuleRef, ɵWRAP_RENDERER_FACTORY2 as WRAP_RENDERER_FACTORY2, ɵcompileComponent as compileComponent, ɵcompileDirective as compileDirective, ɵcompileNgModuleDefs as compileNgModuleDefs, ɵcompilePipe as compilePipe, ɵgetInjectableDef as getInjectableDef, ɵpatchComponentDefWithScope as patchComponentDefWithScope, ɵstringify as stringify} from '@angular/core';
+import {Component, Directive, Injector, NgModule, NgZone, Pipe, PlatformRef, Provider, RendererFactory2, SchemaMetadata, Type, ɵInjectableDef as InjectableDef, ɵNgModuleDef as NgModuleDef, ɵNgModuleTransitiveScopes as NgModuleTransitiveScopes, ɵRender3ComponentFactory as ComponentFactory, ɵRender3DebugRendererFactory2 as Render3DebugRendererFactory2, ɵRender3NgModuleRef as NgModuleRef, ɵWRAP_RENDERER_FACTORY2 as WRAP_RENDERER_FACTORY2, ɵcompileComponent as compileComponent, ɵcompileDirective as compileDirective, ɵcompileNgModuleDefs as compileNgModuleDefs, ɵcompilePipe as compilePipe, ɵgetInjectableDef as getInjectableDef, ɵpatchComponentDefWithScope as patchComponentDefWithScope, ɵstringify as stringify} from '@angular/core';
 
 import {ComponentFixture} from './component_fixture';
 import {MetadataOverride} from './metadata_override';
@@ -361,7 +361,7 @@ export class TestBedRender3 implements Injector, TestBed {
     const componentRef =
         componentFactory.create(Injector.NULL, [], `#${rootElId}`, this._moduleRef);
     const autoDetect: boolean = this.get(ComponentFixtureAutoDetect, false);
-    const fixture = new ComponentFixture<any>(componentRef, null, autoDetect);
+    const fixture = new ComponentFixture<any>(componentRef, this.get(NgZone), autoDetect);
     this._activeFixtures.push(fixture);
     return fixture;
   }
@@ -424,7 +424,9 @@ export class TestBedRender3 implements Injector, TestBed {
     class RootScopeModule {
     }
 
-    const providers = [...this._providers, ...this._providerOverrides];
+    const ngZone = new NgZone({enableLongStackTrace: true});
+    const providers =
+        [{provide: NgZone, useValue: ngZone}, ...this._providers, ...this._providerOverrides];
 
     const declarations = this._declarations;
     const imports = [RootScopeModule, this.ngModule, this._imports];

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -149,7 +149,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            expect(form.value).toEqual({});
          }));
 
-      fixmeIvy('whenStable not working') &&
+      fixmeIvy('host bindings do not yet work with classes or styles') &&
           it('should set status classes with ngModel', async(() => {
                const fixture = initTest(NgModelForm);
                fixture.componentInstance.name = 'aa';
@@ -176,7 +176,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                });
              }));
 
-      fixmeIvy('whenStable not working') &&
+      fixmeIvy('host bindings do not yet work with classes or styles') &&
           it('should set status classes with ngModel and async validators', fakeAsync(() => {
 
                const fixture = initTest(NgModelAsyncValidation, NgAsyncValidator);
@@ -204,7 +204,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                });
              }));
 
-      fixmeIvy('whenStable not working') &&
+      fixmeIvy('host bindings do not yet work with classes or styles') &&
           it('should set status classes with ngModelGroup and ngForm', async(() => {
                const fixture = initTest(NgModelGroupForm);
                fixture.componentInstance.first = '';
@@ -1184,23 +1184,22 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            expect(input.nativeElement.disabled).toBe(true);
          }));
 
-      fixmeIvy('whenStable not working') &&
-          it('should disable a custom control if disabled attr is added', async(() => {
-               const fixture = initTest(NgModelCustomWrapper, NgModelCustomComp);
-               fixture.componentInstance.name = 'Nancy';
-               fixture.componentInstance.isDisabled = true;
-               fixture.detectChanges();
-               fixture.whenStable().then(() => {
-                 fixture.detectChanges();
-                 fixture.whenStable().then(() => {
-                   const form = fixture.debugElement.children[0].injector.get(NgForm);
-                   expect(form.control.get('name') !.disabled).toBe(true);
+      it('should disable a custom control if disabled attr is added', async(() => {
+           const fixture = initTest(NgModelCustomWrapper, NgModelCustomComp);
+           fixture.componentInstance.name = 'Nancy';
+           fixture.componentInstance.isDisabled = true;
+           fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
+               const form = fixture.debugElement.children[0].injector.get(NgForm);
+               expect(form.control.get('name') !.disabled).toBe(true);
 
-                   const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
-                   expect(customInput.nativeElement.disabled).toEqual(true);
-                 });
-               });
-             }));
+               const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
+               expect(customInput.nativeElement.disabled).toEqual(true);
+             });
+           });
+         }));
 
       it('should disable a control with unbound disabled attr', fakeAsync(() => {
            TestBed.overrideComponent(NgModelForm, {

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -1059,28 +1059,26 @@ import {fixmeIvy} from '@angular/private/testing';
       });
 
       describe('in template-driven forms', () => {
-        fixmeIvy('whenStable not working') &&
-            it('should support standard writing to view and model', async(() => {
-                 const fixture = initTest(NgModelCustomWrapper, NgModelCustomComp);
-                 fixture.componentInstance.name = 'Nancy';
+        it('should support standard writing to view and model', async(() => {
+             const fixture = initTest(NgModelCustomWrapper, NgModelCustomComp);
+             fixture.componentInstance.name = 'Nancy';
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
+               fixture.detectChanges();
+               fixture.whenStable().then(() => {
+                 // model -> view
+                 const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
+                 expect(customInput.nativeElement.value).toEqual('Nancy');
+
+                 customInput.nativeElement.value = 'Carson';
+                 dispatchEvent(customInput.nativeElement, 'input');
                  fixture.detectChanges();
-                 fixture.whenStable().then(() => {
-                   fixture.detectChanges();
-                   fixture.whenStable().then(() => {
-                     // model -> view
-                     const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
-                     expect(customInput.nativeElement.value).toEqual('Nancy');
 
-                     customInput.nativeElement.value = 'Carson';
-                     dispatchEvent(customInput.nativeElement, 'input');
-                     fixture.detectChanges();
-
-                     // view -> model
-                     expect(fixture.componentInstance.name).toEqual('Carson');
-                   });
-                 });
-               }));
-
+                 // view -> model
+                 expect(fixture.componentInstance.name).toEqual('Carson');
+               });
+             });
+           }));
       });
 
     });


### PR DESCRIPTION
This PR fixes TestBed tests that use `ComponentFixture.whenStable` with Ivy.