### PR TITLE
fix(docs-infra): boolean options default value is incorrect when it's…

### DIFF
--- a/aio/tools/transforms/cli-docs-package/processors/processCliCommands.js
+++ b/aio/tools/transforms/cli-docs-package/processors/processCliCommands.js
@@ -30,11 +30,6 @@ function processOptions(container, options) {
   container.namedOptions = [];
 
   options.forEach(option => {
-
-    if (option.type === 'boolean' && option.default === undefined) {
-      option.default = false;
-    }
-
     // Ignore any hidden options
     if (option.hidden) { return; }
 


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the CLI when it's undefined it can mean `false`, or sometimes it will be overwritten by a runtime value.

## What is the new behavior?
No default value set. Unless specified.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

//cc @filipesilva 