### PR TITLE
 fix(ivy): let ngcc not consider deep imports as missing dependencies

### DIFF
--- a/packages/compiler-cli/src/ngcc/src/packages/dependency_host.ts
+++ b/packages/compiler-cli/src/ngcc/src/packages/dependency_host.ts
@@ -55,7 +55,11 @@ export class DependencyHost {
             if (externalDependency !== null) {
               resolved.add(externalDependency);
             } else {
-              missing.add(importPath);
+              // If the import cannot be resolved at all, register it as missing dependency.
+              const resolvedFile = this.tryResolve(from, importPath);
+              if (resolvedFile === null) {
+                missing.add(importPath);
+              }
             }
           }
         });

--- a/packages/compiler-cli/src/ngcc/src/packages/dependency_host.ts
+++ b/packages/compiler-cli/src/ngcc/src/packages/dependency_host.ts
@@ -19,8 +19,8 @@ export class DependencyHost {
    * @param from An absolute path to the file whose dependencies we want to get.
    * @param resolved A set that will have the absolute paths of resolved entry points added to it.
    * @param missing A set that will have the dependencies that could not be found added to it.
-   * @param deepImports A set that will have the dependencies that refer to deep imports added to
-   * it.
+   * @param deepImports A set that will have the import paths that exist but cannot be mapped to
+   * entry-points, i.e. deep-imports.
    * @param internal A set that is used to track internal dependencies to prevent getting stuck in a
    * circular dependency loop.
    */

--- a/packages/compiler-cli/src/ngcc/src/packages/dependency_host.ts
+++ b/packages/compiler-cli/src/ngcc/src/packages/dependency_host.ts
@@ -17,12 +17,10 @@ export class DependencyHost {
   /**
    * Get a list of the resolved paths to all the dependencies of this entry point.
    * @param from An absolute path to the file whose dependencies we want to get.
-   * @param resolved A set that will have the resolved dependencies added to it.
+   * @param resolved A set that will have the absolute paths of resolved entry points added to it.
    * @param missing A set that will have the dependencies that could not be found added to it.
    * @param internal A set that is used to track internal dependencies to prevent getting stuck in a
    * circular dependency loop.
-   * @returns an object containing an array of absolute paths to `resolved` depenendencies and an
-   * array of import specifiers for dependencies that were `missing`.
    */
   computeDependencies(
       from: string, resolved: Set<string>, missing: Set<string>,
@@ -51,9 +49,9 @@ export class DependencyHost {
               this.computeDependencies(internalDependency, resolved, missing, internal);
             }
           } else {
-            const externalDependency = this.tryResolveExternal(from, importPath);
-            if (externalDependency !== null) {
-              resolved.add(externalDependency);
+            const resolvedEntryPoint = this.tryResolveEntryPoint(from, importPath);
+            if (resolvedEntryPoint !== null) {
+              resolved.add(resolvedEntryPoint);
             } else {
               // If the import cannot be resolved at all, register it as missing dependency.
               const resolvedFile = this.tryResolve(from, importPath);
@@ -95,9 +93,9 @@ export class DependencyHost {
    * @returns the resolved path to the entry point directory of the import or null
    * if it cannot be resolved.
    */
-  tryResolveExternal(from: string, to: string): string|null {
-    const externalDependency = this.tryResolve(from, `${to}/package.json`);
-    return externalDependency && path.dirname(externalDependency);
+  tryResolveEntryPoint(from: string, to: string): string|null {
+    const entryPoint = this.tryResolve(from, `${to}/package.json`);
+    return entryPoint && path.dirname(entryPoint);
   }
 
   /**

--- a/packages/compiler-cli/src/ngcc/src/packages/dependency_resolver.ts
+++ b/packages/compiler-cli/src/ngcc/src/packages/dependency_resolver.ts
@@ -115,7 +115,7 @@ export class DependencyResolver {
         const imports = Array.from(deepImports).map(i => `'${i}'`).join(', ');
         console.warn(
             `Entry point '${entryPoint.name}' contains deep imports into ${imports}. ` +
-            `This may cause compilation errors if the package that is deeply imported also needs to be processed by ngcc.`);
+            `This is probably not a problem, but may cause the compilation of entry points to be out of order.`);
       }
     });
 

--- a/packages/compiler-cli/src/ngcc/src/packages/dependency_resolver.ts
+++ b/packages/compiler-cli/src/ngcc/src/packages/dependency_resolver.ts
@@ -87,7 +87,8 @@ export class DependencyResolver {
 
       const dependencies = new Set<string>();
       const missing = new Set<string>();
-      this.host.computeDependencies(entryPointPath, dependencies, missing);
+      const deepImports = new Set<string>();
+      this.host.computeDependencies(entryPointPath, dependencies, missing, deepImports);
 
       if (missing.size > 0) {
         // This entry point has dependencies that are missing
@@ -108,6 +109,13 @@ export class DependencyResolver {
             ignoredDependencies.push({entryPoint, dependencyPath});
           }
         });
+      }
+
+      if (deepImports.size) {
+        const imports = Array.from(deepImports).map(i => `'${i}'`).join(', ');
+        console.warn(
+            `Entry point '${entryPoint.name}' contains deep imports into ${imports}. ` +
+            `This may cause compilation errors if the package that is deeply imported also needs to be processed by ngcc.`);
       }
     });
 

--- a/packages/compiler-cli/src/ngcc/test/packages/dependency_host_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/packages/dependency_host_spec.ts
@@ -32,7 +32,7 @@ describe('DependencyHost', () => {
        });
 
     it('should resolve all the external imports of the source file', () => {
-      spyOn(host, 'tryResolveExternal')
+      spyOn(host, 'tryResolveEntryPoint')
           .and.callFake((from: string, importPath: string) => `RESOLVED/${importPath}`);
       const resolved = new Set();
       const missing = new Set();
@@ -43,7 +43,7 @@ describe('DependencyHost', () => {
     });
 
     it('should resolve all the external re-exports of the source file', () => {
-      spyOn(host, 'tryResolveExternal')
+      spyOn(host, 'tryResolveEntryPoint')
           .and.callFake((from: string, importPath: string) => `RESOLVED/${importPath}`);
       const resolved = new Set();
       const missing = new Set();
@@ -54,7 +54,7 @@ describe('DependencyHost', () => {
     });
 
     it('should capture missing external imports', () => {
-      spyOn(host, 'tryResolveExternal')
+      spyOn(host, 'tryResolveEntryPoint')
           .and.callFake(
               (from: string, importPath: string) =>
                   importPath === 'missing' ? null : `RESOLVED/${importPath}`);
@@ -69,7 +69,7 @@ describe('DependencyHost', () => {
     });
 
     it('should not register deep imports as missing', () => {
-      spyOn(host, 'tryResolveExternal')
+      spyOn(host, 'tryResolveEntryPoint')
           .and.callFake(
               (from: string, importPath: string) =>
                   importPath === 'deep/import' ? null : `RESOLVED/${importPath}`);
@@ -86,7 +86,7 @@ describe('DependencyHost', () => {
       spyOn(host, 'resolveInternal')
           .and.callFake(
               (from: string, importPath: string) => path.join('/internal', importPath + '.js'));
-      spyOn(host, 'tryResolveExternal')
+      spyOn(host, 'tryResolveEntryPoint')
           .and.callFake((from: string, importPath: string) => `RESOLVED/${importPath}`);
       const getDependenciesSpy = spyOn(host, 'computeDependencies').and.callThrough();
       const resolved = new Set();
@@ -104,7 +104,7 @@ describe('DependencyHost', () => {
       spyOn(host, 'resolveInternal')
           .and.callFake(
               (from: string, importPath: string) => path.join('/internal', importPath + '.js'));
-      spyOn(host, 'tryResolveExternal')
+      spyOn(host, 'tryResolveEntryPoint')
           .and.callFake((from: string, importPath: string) => `RESOLVED/${importPath}`);
       const resolved = new Set();
       const missing = new Set();
@@ -147,18 +147,18 @@ describe('DependencyHost', () => {
   describe('tryResolveExternal', () => {
     it('should call `tryResolve`, appending `package.json` to the target path', () => {
       const tryResolveSpy = spyOn(host, 'tryResolve').and.returnValue('PATH/TO/RESOLVED');
-      host.tryResolveExternal('SOURCE_PATH', 'TARGET_PATH');
+      host.tryResolveEntryPoint('SOURCE_PATH', 'TARGET_PATH');
       expect(tryResolveSpy).toHaveBeenCalledWith('SOURCE_PATH', 'TARGET_PATH/package.json');
     });
 
     it('should return the directory containing the result from `tryResolve', () => {
       spyOn(host, 'tryResolve').and.returnValue('PATH/TO/RESOLVED');
-      expect(host.tryResolveExternal('SOURCE_PATH', 'TARGET_PATH')).toEqual('PATH/TO');
+      expect(host.tryResolveEntryPoint('SOURCE_PATH', 'TARGET_PATH')).toEqual('PATH/TO');
     });
 
     it('should return null if `tryResolve` returns null', () => {
       spyOn(host, 'tryResolve').and.returnValue(null);
-      expect(host.tryResolveExternal('SOURCE_PATH', 'TARGET_PATH')).toEqual(null);
+      expect(host.tryResolveEntryPoint('SOURCE_PATH', 'TARGET_PATH')).toEqual(null);
     });
   });
 

--- a/packages/compiler-cli/src/ngcc/test/packages/dependency_host_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/packages/dependency_host_spec.ts
@@ -69,13 +69,16 @@ describe('DependencyHost', () => {
       expect(resolved.has('RESOLVED/path/to/x')).toBe(true);
       expect(missing.size).toBe(1);
       expect(missing.has('missing')).toBe(true);
+      expect(deepImports.size).toBe(0);
     });
 
     it('should not register deep imports as missing', () => {
-      spyOn(host, 'tryResolveEntryPoint')
-          .and.callFake(
-              (from: string, importPath: string) =>
-                  importPath === 'deep/import' ? null : `RESOLVED/${importPath}`);
+      // This scenario verifies the behavior of the dependency analysis when an external import
+      // is found that does not map to an entry-point but still exists on disk, i.e. a deep import.
+      // Such deep imports are captured for diagnostics purposes.
+      const tryResolveEntryPoint = (from: string, importPath: string) =>
+          importPath === 'deep/import' ? null : `RESOLVED/${importPath}`;
+      spyOn(host, 'tryResolveEntryPoint').and.callFake(tryResolveEntryPoint);
       spyOn(host, 'tryResolve')
           .and.callFake((from: string, importPath: string) => `RESOLVED/${importPath}`);
       const resolved = new Set();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

NGCC would incorrectly skip packages that contain RxJS 5 style imports


## What is the new behavior?

RxJS 5 style imports (deep imports in general) will no longer cause a package to be skipped over by NGCC.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
