### PR TITLE
fix(ivy): clone ts.SourceFile in ivy_switch when triggered

### DIFF
--- a/packages/compiler-cli/src/ngtsc/switch/src/switch.ts
+++ b/packages/compiler-cli/src/ngtsc/switch/src/switch.ts
@@ -42,6 +42,7 @@ function flipIvySwitchInFile(sf: ts.SourceFile): ts.SourceFile {
 
   // Only update the statements in the SourceFile if any have changed.
   if (newStatements !== undefined) {
+    sf = ts.getMutableClone(sf);
     sf.statements = ts.createNodeArray(newStatements);
   }
   return sf;


### PR DESCRIPTION
Make a copy of the ts.SourceFile before modifying it in the ivy_switch transform. It's suspected that the Bazel tsc_wrapped host's SourceFile cache has issues when the ts.SourceFiles are mutated.