### PR TITLE
fix(ivy): compiler should generate restoreView() for local refs in li…

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
@@ -206,8 +206,10 @@ describe('compiler compliance: listen()', () => {
           vars: 0,
           template:  function MyComponent_Template(rf, ctx) {
             if (rf & 1) {
+              const $s$ = $r3$.ɵgetCurrentView();
               $r3$.ɵelementStart(0, "button", $e0_attrs$);
                 $r3$.ɵlistener("click", function MyComponent_Template_button_click_listener($event) {
+                   $r3$.ɵrestoreView($s$);
                    const $user$ = $r3$.ɵreference(3);
                    return ctx.onClick($user$.value);
                 });

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -1491,36 +1491,35 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            expect(required.nativeElement.getAttribute('pattern')).toEqual(null);
          }));
 
-      fixmeIvy('ngModelChange callback never called') &&
-          it('should update control status', fakeAsync(() => {
-               const fixture = initTest(NgModelChangeState);
-               const inputEl = fixture.debugElement.query(By.css('input'));
-               const inputNativeEl = inputEl.nativeElement;
-               const onNgModelChange = jasmine.createSpy('onNgModelChange');
-               fixture.componentInstance.onNgModelChange = onNgModelChange;
-               fixture.detectChanges();
-               tick();
+      it('should update control status', fakeAsync(() => {
+           const fixture = initTest(NgModelChangeState);
+           const inputEl = fixture.debugElement.query(By.css('input'));
+           const inputNativeEl = inputEl.nativeElement;
+           const onNgModelChange = jasmine.createSpy('onNgModelChange');
+           fixture.componentInstance.onNgModelChange = onNgModelChange;
+           fixture.detectChanges();
+           tick();
 
-               expect(onNgModelChange).not.toHaveBeenCalled();
+           expect(onNgModelChange).not.toHaveBeenCalled();
 
-               inputNativeEl.value = 'updated';
-               onNgModelChange.and.callFake((ngModel: NgModel) => {
-                 expect(ngModel.invalid).toBe(true);
-                 expect(ngModel.value).toBe('updated');
-               });
-               dispatchEvent(inputNativeEl, 'input');
-               expect(onNgModelChange).toHaveBeenCalled();
-               tick();
+           inputNativeEl.value = 'updated';
+           onNgModelChange.and.callFake((ngModel: NgModel) => {
+             expect(ngModel.invalid).toBe(true);
+             expect(ngModel.value).toBe('updated');
+           });
+           dispatchEvent(inputNativeEl, 'input');
+           expect(onNgModelChange).toHaveBeenCalled();
+           tick();
 
-               inputNativeEl.value = '333';
-               onNgModelChange.and.callFake((ngModel: NgModel) => {
-                 expect(ngModel.invalid).toBe(false);
-                 expect(ngModel.value).toBe('333');
-               });
-               dispatchEvent(inputNativeEl, 'input');
-               expect(onNgModelChange).toHaveBeenCalledTimes(2);
-               tick();
-             }));
+           inputNativeEl.value = '333';
+           onNgModelChange.and.callFake((ngModel: NgModel) => {
+             expect(ngModel.invalid).toBe(false);
+             expect(ngModel.value).toBe('333');
+           });
+           dispatchEvent(inputNativeEl, 'input');
+           expect(onNgModelChange).toHaveBeenCalledTimes(2);
+           tick();
+         }));
 
     });
 


### PR DESCRIPTION
This PR fixes a bug where local refs accessed inside listeners did not work properly because the `getCurrentView()` and `restoreView` instructions weren't being generated. These instructions are necessary to give a listener access to the template view whenever the handler is called.