### PR TITLE
fix(ivy): account for `useValue: undefined` providers in module injector

### DIFF
--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -250,7 +250,7 @@ export class R3Injector {
 
     // Track the InjectorType and add a provider for it.
     this.injectorDefTypes.add(defType);
-    this.records.set(defType, makeRecord(def.factory));
+    this.records.set(defType, makeRecord(def.factory, NOT_YET));
 
     // Add providers in the same way that @NgModule resolution did:
 
@@ -393,7 +393,7 @@ export function providerToFactory(provider: SingleProvider): () => any {
 }
 
 function makeRecord<T>(
-    factory: (() => T) | undefined, value: T | {} = NOT_YET, multi: boolean = false): Record<T> {
+    factory: (() => T) | undefined, value: T | {}, multi: boolean = false): Record<T> {
   return {
     factory: factory,
     value: value,

--- a/packages/core/test/di/r3_injector_spec.ts
+++ b/packages/core/test/di/r3_injector_spec.ts
@@ -44,6 +44,9 @@ describe('InjectorDef-based createInjector()', () => {
 
   const LOCALE = new InjectionToken<string[]>('LOCALE');
 
+  const PRIMITIVE_VALUE = new InjectionToken<string>('PRIMITIVE_VALUE');
+  const UNDEFINED_VALUE = new InjectionToken<undefined>('UNDEFINED_VALUE');
+
   class ServiceWithDep {
     constructor(readonly service: Service) {}
 
@@ -127,6 +130,8 @@ describe('InjectorDef-based createInjector()', () => {
         ServiceWithMultiDep,
         {provide: LOCALE, multi: true, useValue: 'en'},
         {provide: LOCALE, multi: true, useValue: 'es'},
+        {provide: PRIMITIVE_VALUE, useValue: 'foo'},
+        {provide: UNDEFINED_VALUE, useValue: undefined},
         Service,
         {provide: SERVICE_TOKEN, useExisting: Service},
         CircularA,
@@ -202,6 +207,16 @@ describe('InjectorDef-based createInjector()', () => {
   it('injects a token with useExisting', () => {
     const instance = injector.get(SERVICE_TOKEN);
     expect(instance).toBe(injector.get(Service));
+  });
+
+  it('injects a useValue token with a primitive value', () => {
+    const value = injector.get(PRIMITIVE_VALUE);
+    expect(value).toEqual('foo');
+  });
+
+  it('injects a useValue token with value undefined', () => {
+    const value = injector.get(UNDEFINED_VALUE);
+    expect(value).toBeUndefined();
   });
 
   it('instantiates a class with useClass and deps', () => {


### PR DESCRIPTION
This fixes a crash when resolving a token from a module injector that
is provided using a useValue provider with a value of `undefined`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolving a token from a module injector that is provided as `useValue: undefined` will crash.

## What is the new behavior?

The token is correctly resolved to `undefined`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

