### PR TITLE
fix(ivy): ngtsc should include generic types on injectable definitions

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -74,6 +74,7 @@ function extractInjectableMetadata(
   const name = clazz.name.text;
   const type = new WrappedNodeExpr(clazz.name);
   const ctorDeps = getConstructorDependencies(clazz, reflector, isCore);
+  const typeArgumentCount = reflector.getGenericArityOfClass(clazz) || 0;
   if (decorator.args === null) {
     throw new FatalDiagnosticError(
         ErrorCode.DECORATOR_NOT_CALLED, decorator.node, '@Injectable must be called');
@@ -82,6 +83,7 @@ function extractInjectableMetadata(
     return {
       name,
       type,
+      typeArgumentCount,
       providedIn: new LiteralExpr(null), ctorDeps,
     };
   } else if (decorator.args.length === 1) {
@@ -118,6 +120,7 @@ function extractInjectableMetadata(
       return {
         name,
         type,
+        typeArgumentCount,
         ctorDeps,
         providedIn,
         useValue: new WrappedNodeExpr(meta.get('useValue') !)
@@ -126,6 +129,7 @@ function extractInjectableMetadata(
       return {
         name,
         type,
+        typeArgumentCount,
         ctorDeps,
         providedIn,
         useExisting: new WrappedNodeExpr(meta.get('useExisting') !)
@@ -134,6 +138,7 @@ function extractInjectableMetadata(
       return {
         name,
         type,
+        typeArgumentCount,
         ctorDeps,
         providedIn,
         useClass: new WrappedNodeExpr(meta.get('useClass') !), userDeps
@@ -141,9 +146,9 @@ function extractInjectableMetadata(
     } else if (meta.has('useFactory')) {
       // useFactory is special - the 'deps' property must be analyzed.
       const factory = new WrappedNodeExpr(meta.get('useFactory') !);
-      return {name, type, providedIn, useFactory: factory, ctorDeps, userDeps};
+      return {name, type, typeArgumentCount, providedIn, useFactory: factory, ctorDeps, userDeps};
     } else {
-      return {name, type, providedIn, ctorDeps};
+      return {name, type, typeArgumentCount, providedIn, ctorDeps};
     }
   } else {
     throw new FatalDiagnosticError(

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -44,6 +44,24 @@ describe('ngtsc behavioral tests', () => {
     expect(dtsContents).toContain('static ngInjectableDef: i0.ɵInjectableDef<Service>;');
   });
 
+  it('should compile Injectables with a generic service', () => {
+    env.tsconfig();
+    env.write('test.ts', `
+        import {Injectable} from '@angular/core';
+
+        @Injectable()
+        export class Store<T> {}
+    `);
+
+    env.driveMain();
+
+
+    const jsContents = env.getContents('test.js');
+    expect(jsContents).toContain('Store.ngInjectableDef =');
+    const dtsContents = env.getContents('test.d.ts');
+    expect(dtsContents).toContain('static ngInjectableDef: i0.ɵInjectableDef<Store<any>>;');
+  });
+
   it('should compile Components without errors', () => {
     env.tsconfig();
     env.write('test.ts', `

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -78,6 +78,7 @@ export interface R3PipeMetadataFacade {
 export interface R3InjectableMetadataFacade {
   name: string;
   type: any;
+  typeArgumentCount: number;
   ctorDeps: R3DependencyMetadataFacade[]|null;
   providedIn: any;
   useClass?: any;

--- a/packages/compiler/src/injectable_compiler_2.ts
+++ b/packages/compiler/src/injectable_compiler_2.ts
@@ -10,7 +10,7 @@ import {InjectFlags} from './core';
 import {Identifiers} from './identifiers';
 import * as o from './output/output_ast';
 import {R3DependencyMetadata, R3FactoryDelegateType, R3FactoryMetadata, compileFactoryFunction} from './render3/r3_factory';
-import {mapToMapExpression} from './render3/util';
+import {mapToMapExpression, typeWithParameters} from './render3/util';
 
 export interface InjectableDef {
   expression: o.Expression;
@@ -21,6 +21,7 @@ export interface InjectableDef {
 export interface R3InjectableMetadata {
   name: string;
   type: o.Expression;
+  typeArgumentCount: number;
   ctorDeps: R3DependencyMetadata[]|null;
   providedIn: o.Expression;
   useClass?: o.Expression;
@@ -32,10 +33,6 @@ export interface R3InjectableMetadata {
 
 export function compileInjectable(meta: R3InjectableMetadata): InjectableDef {
   let result: {factory: o.Expression, statements: o.Statement[]}|null = null;
-
-  function makeFn(ret: o.Expression): o.Expression {
-    return o.fn([], [new o.ReturnStatement(ret)], undefined, undefined, `${meta.name}_Factory`);
-  }
 
   const factoryMeta = {
     name: meta.name,
@@ -101,8 +98,8 @@ export function compileInjectable(meta: R3InjectableMetadata): InjectableDef {
 
   const expression = o.importExpr(Identifiers.defineInjectable).callFn([mapToMapExpression(
       {token, factory: result.factory, providedIn})]);
-  const type = new o.ExpressionType(
-      o.importExpr(Identifiers.InjectableDef, [new o.ExpressionType(meta.type)]));
+  const type = new o.ExpressionType(o.importExpr(
+      Identifiers.InjectableDef, [typeWithParameters(meta.type, meta.typeArgumentCount)]));
 
   return {
     expression,

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -42,7 +42,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
     const {expression, statements} = compileInjectable({
       name: facade.name,
       type: new WrappedNodeExpr(facade.type),
-      typeArgumentCount: 0,
+      typeArgumentCount: facade.typeArgumentCount,
       providedIn: computeProvidedIn(facade.providedIn),
       useClass: wrapExpression(facade, USE_CLASS),
       useFactory: wrapExpression(facade, USE_FACTORY),

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -42,6 +42,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
     const {expression, statements} = compileInjectable({
       name: facade.name,
       type: new WrappedNodeExpr(facade.type),
+      typeArgumentCount: 0,
       providedIn: computeProvidedIn(facade.providedIn),
       useClass: wrapExpression(facade, USE_CLASS),
       useFactory: wrapExpression(facade, USE_FACTORY),

--- a/packages/core/src/render3/jit/compiler_facade_interface.ts
+++ b/packages/core/src/render3/jit/compiler_facade_interface.ts
@@ -78,6 +78,7 @@ export interface R3PipeMetadataFacade {
 export interface R3InjectableMetadataFacade {
   name: string;
   type: any;
+  typeArgumentCount: number;
   ctorDeps: R3DependencyMetadataFacade[]|null;
   providedIn: any;
   useClass?: any;

--- a/packages/core/src/render3/jit/injectable.ts
+++ b/packages/core/src/render3/jit/injectable.ts
@@ -23,13 +23,11 @@ import {convertDependencies, reflectDependencies} from './util';
  * `ngInjectableDef` onto the injectable type.
  */
 export function compileInjectable(type: Type<any>, srcMeta?: Injectable): void {
-  // Allow the compilation of a class with a `@Injectable()` decorator without parameters
-  const meta: Injectable = srcMeta || {providedIn: null};
-
   let def: any = null;
   Object.defineProperty(type, NG_INJECTABLE_DEF, {
     get: () => {
       if (def === null) {
+        // Allow the compilation of a class with a `@Injectable()` decorator without parameters
         const meta: Injectable = srcMeta || {providedIn: null};
         const hasAProvider = isUseClassProvider(meta) || isUseFactoryProvider(meta) ||
             isUseValueProvider(meta) || isUseExistingProvider(meta);
@@ -38,6 +36,7 @@ export function compileInjectable(type: Type<any>, srcMeta?: Injectable): void {
         const compilerMeta: R3InjectableMetadataFacade = {
           name: type.name,
           type: type,
+          typeArgumentCount: 0,
           providedIn: meta.providedIn,
           ctorDeps: reflectDependencies(type),
           userDeps: undefined


### PR DESCRIPTION
Analogously to directives, the `ngInjectableDef` field in .d.ts files is
annotated with the type of service that it represents. If the service
contains required generic type arguments, these must be included in
the .d.ts file.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Ivy type definition for injectables would be invalid if the service has a required generic type argument.

## What is the new behavior?

Type arguments are specified as `any` in the definition of the `ngInjectableDef` field.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
