### PR TITLE
Fix and condense wording to avoid wrong interpretation

### DIFF
--- a/aio/content/guide/universal.md
+++ b/aio/content/guide/universal.md
@@ -210,7 +210,7 @@ export class AppServerModule {}
 
 ### 2c. Create a main file to export AppServerModule
 
-Create a main file for your Universal bundle in the app `src/` folder  to export your `AppServerModule` instance. This example calls the file `main.server.ts`.
+Create a main file `main.server.ts` for your Universal bundle in the app `src/` folder  to export your `AppServerModule` instance.
 
 <code-example format="." language="typescript" linenums="false">
 export { AppServerModule } from './app/app.server.module';


### PR DESCRIPTION
"This example calls the file main.server.ts" could erroneously be interpreted as "this snippet of code calls main.server.ts" rather than "the file, in this example, is called main.server.ts".

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
"This example calls the file main.server.ts" could erroneously be interpreted as "this snippet of code calls main.server.ts" rather than "the file, in this example, is called main.server.ts".

Issue Number: N/A


## What is the new behavior?
Explicitly states that the file name for the example is main.server.ts

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

