### PR TITLE
fix(ivy): ngcc should not emit TypeScript syntax

### DIFF
--- a/packages/compiler-cli/src/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/rendering/renderer_spec.ts
@@ -79,6 +79,12 @@ describe('Renderer', () => {
     contents: `export declare class A {\nfoo(x: number): number;\n}\n`
   };
 
+  const COMPONENT_PROGRAM = {
+    name: '/src/component.js',
+    contents:
+        `import { Component } from '@angular/core';\nexport class A {}\nA.decorators = [\n    { type: Component, args: [{ selector: 'a', template: '{{ person!.name }}' }] }\n];\n`
+  };
+
   const INPUT_PROGRAM_MAP = fromObject({
     'version': 3,
     'file': '/src/file.js',
@@ -125,6 +131,25 @@ describe('Renderer', () => {
          expect(result[1].path).toEqual('/dist/file.js.map');
          expect(result[1].contents).toEqual(OUTPUT_PROGRAM_MAP.toJSON());
        });
+
+
+    it('should render as JavaScript', () => {
+      const {renderer, decorationAnalyses, switchMarkerAnalyses, privateDeclarationsAnalyses} =
+          createTestRenderer('test-package', [COMPONENT_PROGRAM]);
+      renderer.renderProgram(decorationAnalyses, switchMarkerAnalyses, privateDeclarationsAnalyses);
+      const addDefinitionsSpy = renderer.addDefinitions as jasmine.Spy;
+      expect(addDefinitionsSpy.calls.first().args[2])
+          .toEqual(`/*@__PURE__*/ ɵngcc0.ɵsetClassMetadata(A, [{
+        type: Component,
+        args: [{ selector: 'a', template: '{{ person!.name }}' }]
+    }], null, null);
+A.ngComponentDef = ɵngcc0.ɵdefineComponent({ type: A, selectors: [["a"]], factory: function A_Factory(t) { return new (t || A)(); }, consts: 1, vars: 1, template: function A_Template(rf, ctx) { if (rf & 1) {
+        ɵngcc0.ɵtext(0);
+    } if (rf & 2) {
+        ɵngcc0.ɵtextBinding(0, ɵngcc0.ɵinterpolation1("", ctx.person.name, ""));
+    } }, encapsulation: 2 });`);
+    });
+
 
     describe('calling abstract methods', () => {
       it('should call addImports with the source code and info about the core Angular library.',

--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -252,7 +252,7 @@ class ExpressionTranslatorVisitor implements ExpressionVisitor, StatementVisitor
   }
 
   visitAssertNotNullExpr(ast: AssertNotNull, context: Context): ts.NonNullExpression {
-    return ts.createNonNullExpression(ast.condition.visitExpression(this, context));
+    return ast.condition.visitExpression(this, context);
   }
 
   visitCastExpr(ast: CastExpr, context: Context): ts.Expression {


### PR DESCRIPTION
Previously, ngcc used ngtsc's logic to transform the Angular AST
to a TypeScript AST and then leverages TypeScript's node printer to
obtain the source text to insert. This turns out to be a problem when
specific TypeScript syntax is represented in the AST; the printer cannot
be configured to output only JavaScript syntax.

A full-blown TypeScript emit of a complete `ts.SourceFile` would be
required to be able to emit JS and possibly downlevel into a lower
language target, which is not an option for ngcc as it currently
operates on partial ASTs, not full source files.

Instead, the Angular AST itself is used to emit source files, using the
emitter logic that is also used in JIT compilations. As the Angular AST
produced by ngtsc may contain literal TypeScript nodes inside of
`WrappedNodeExpr`, a TypeScript printer is still used to obtain source
text for such nodes (assuming no TypeScript specific syntax is present
within that node's subtree).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

ngcc may output TypeScript specific syntax into JavaScript bundles, which fail to be parsed.

## What is the new behavior?

ngcc uses existing emitter logic that operates on Angular AST to produce JavaScript code instead of TypeScript.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

@alxhub Can you comment on my assumption that we can safely print `WrappedNodeExpr` using TypeScript's printing logic, as doing so still has a risk of producing TS specific syntax.