### PR TITLE
fix(compiler-cli): add missing tslib dependency

### DIFF
--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -19,6 +19,7 @@
     "magic-string": "^0.25.0",
     "shelljs": "^0.8.1",
     "source-map": "^0.6.1",
+    "tslib": "^1.9.0",
     "yargs": "9.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`@angular/compiler-cli` require'd `tslib` in its built output but it was not listed as a dependency and as a result relied on package manager hoisting behavior to function.


## What is the new behavior?

`tslib` is now a direct dependency of the package.

## Does this PR introduce a breaking change?

- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
