### PR TITLE
fix(ivy): host bindings should support content children and content h…

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -83,8 +83,6 @@ export function refreshDescendantViews(viewData: LViewData, rf: RenderFlags | nu
       executeInitHooks(viewData, tView, creationMode);
     }
 
-    setHostBindings(tView, viewData);
-
     refreshDynamicEmbeddedViews(viewData);
 
     // Content query results must be refreshed before content hooks are called.
@@ -93,6 +91,8 @@ export function refreshDescendantViews(viewData: LViewData, rf: RenderFlags | nu
     if (!checkNoChangesMode) {
       executeHooks(viewData, tView.contentHooks, tView.contentCheckHooks, creationMode);
     }
+
+    setHostBindings(tView, viewData);
   }
 
   refreshChildComponents(tView.components, parentFirstTemplatePass, rf);


### PR DESCRIPTION
Host bindings need to support `ContentChildren` and anything executed in content hooks. This fix is necessary for Material demo app to run.