### PR TITLE
fix(ivy): add support for providers in TestBed.configureCompiler

### DIFF
--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -251,7 +251,13 @@ export class TestBedRender3 implements Injector, TestBed {
   }
 
   configureCompiler(config: {providers?: any[]; useJit?: boolean;}): void {
-    throw new Error('the Render3 compiler is not configurable !');
+    if (config.useJit != null) {
+      throw new Error('the Render3 compiler JiT mode is not configurable !');
+    }
+
+    if (config.providers) {
+      this._providerOverrides.push(...config.providers);
+    }
   }
 
   configureTestingModule(moduleDef: TestModuleMetadata): void {


### PR DESCRIPTION
Adds support for the `providers` that are passed in through `TestBed.configureCompiler` and scopes the error only if the consumer has passed in `useJit`.

This seems to fix ~60 of the failures when running with the `//packages/core/test:test_web_chromium-local` target. The local test failures went down from 298 to 239.