### PR TITLE
fix(ivy): jit compilation should support content queries with type pr…

### DIFF
--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -185,6 +185,7 @@ function convertDirectiveFacadeToMetadata(facade: R3DirectiveMetadataFacade): R3
     host: extractHostBindings(facade.host, facade.propMetadata),
     inputs: {...inputsFromMetadata, ...inputsFromType},
     outputs: {...outputsFromMetadata, ...outputsFromType},
+    queries: facade.queries.map(convertToR3QueryMetadata),
     providers: facade.providers != null ? new WrappedNodeExpr(facade.providers) : null,
   };
 }

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -442,7 +442,7 @@ function createQueryDefinition(
     query: R3QueryMetadata, constantPool: ConstantPool, idx: number | null): o.Expression {
   const predicate = getQueryPredicate(query, constantPool);
 
-  // e.g. r3.Q(null, somePredicate, false) or r3.Q(0, ['div'], false)
+  // e.g. r3.query(null, somePredicate, false) or r3.query(0, ['div'], false)
   const parameters = [
     o.literal(idx, o.INFERRED_TYPE),
     predicate,

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -306,7 +306,7 @@ ivyEnabled && describe('render3 jit', () => {
     expect((C as any).ngBaseDef.outputs).toEqual({prop1: 'alias1', prop2: 'alias2'});
   });
 
-  it('should compile ContentChildren query on a directive', () => {
+  it('should compile ContentChildren query with string predicate on a directive', () => {
     @Directive({selector: '[test]'})
     class TestDirective {
       @ContentChildren('foo') foos: QueryList<ElementRef>|undefined;
@@ -316,10 +316,34 @@ ivyEnabled && describe('render3 jit', () => {
     expect((TestDirective as any).ngDirectiveDef.contentQueriesRefresh).not.toBeNull();
   });
 
-  it('should compile ContentChild query on a directive', () => {
+  it('should compile ContentChild query with string predicate on a directive', () => {
     @Directive({selector: '[test]'})
     class TestDirective {
       @ContentChild('foo') foo: ElementRef|undefined;
+    }
+
+    expect((TestDirective as any).ngDirectiveDef.contentQueries).not.toBeNull();
+    expect((TestDirective as any).ngDirectiveDef.contentQueriesRefresh).not.toBeNull();
+  });
+
+  it('should compile ContentChildren query with type predicate on a directive', () => {
+    class SomeDir {}
+
+    @Directive({selector: '[test]'})
+    class TestDirective {
+      @ContentChildren(SomeDir) dirs: QueryList<SomeDir>|undefined;
+    }
+
+    expect((TestDirective as any).ngDirectiveDef.contentQueries).not.toBeNull();
+    expect((TestDirective as any).ngDirectiveDef.contentQueriesRefresh).not.toBeNull();
+  });
+
+  it('should compile ContentChild query with type predicate on a directive', () => {
+    class SomeDir {}
+
+    @Directive({selector: '[test]'})
+    class TestDirective {
+      @ContentChild(SomeDir) dir: SomeDir|undefined;
     }
 
     expect((TestDirective as any).ngDirectiveDef.contentQueries).not.toBeNull();


### PR DESCRIPTION
This PR fixes JIT compilation of content queries with type predicates. e.g.

```ts
@ContentChildren(SomeDir) dirs: QueryList<SomeDir>;
```

JIT's version of metadata returns the raw type instead of a `WrappedNodeExpr`, so we have to account for this case when building the `contentQuery` function.

This fixes the `expr.visitExpression is not a function` error showing up in TestBed failures.