### PR TITLE
feat(service-worker): support multiple apps in same domain

### DIFF
--- a/packages/service-worker/worker/src/adapter.ts
+++ b/packages/service-worker/worker/src/adapter.ts
@@ -56,10 +56,10 @@ export class Adapter {
     return new Promise<void>(resolve => { setTimeout(() => resolve(), ms); });
   }
 
-  /**
-  * suffixing the baseHref with `ngsw` string to avoid clash of cache files
-  * in same domain with multiple apps
-  */
+   /**
+   * suffixing the baseHref with `ngsw` string to avoid clash of cache files
+   * in same domain with multiple apps
+   */
   setBaseHref(baseHref: string) {
     if (baseHref && ['/'].indexOf(baseHref) == -1) {
       const str = baseHref.replace(/^\//, '').replace(/\/$/, '').replace(/\//, ':');

--- a/packages/service-worker/worker/src/adapter.ts
+++ b/packages/service-worker/worker/src/adapter.ts
@@ -13,6 +13,7 @@
  * from the global scope.
  */
 export class Adapter {
+  ngsw = 'ngsw';
   /**
    * Wrapper around the `Request` constructor.
    */
@@ -53,6 +54,17 @@ export class Adapter {
    */
   timeout(ms: number): Promise<void> {
     return new Promise<void>(resolve => { setTimeout(() => resolve(), ms); });
+  }
+
+   /**
+   * suffixing the baseHref with `ngsw` string to avoid clash of cache files
+   * in same domain with multiple apps
+   */
+  setBaseHref(baseHref: string) {
+    if (baseHref && ['/'].indexOf(baseHref) == -1) {
+      const str = baseHref.replace(/^\//, '').replace(/\/$/, '').replace(/\//, ':');
+      this.ngsw += ':' + str;
+    }
   }
 }
 

--- a/packages/service-worker/worker/src/adapter.ts
+++ b/packages/service-worker/worker/src/adapter.ts
@@ -56,10 +56,10 @@ export class Adapter {
     return new Promise<void>(resolve => { setTimeout(() => resolve(), ms); });
   }
 
-   /**
-   * suffixing the baseHref with `ngsw` string to avoid clash of cache files
-   * in same domain with multiple apps
-   */
+  /**
+  * suffixing the baseHref with `ngsw` string to avoid clash of cache files
+  * in same domain with multiple apps
+  */
   setBaseHref(baseHref: string) {
     if (baseHref && ['/'].indexOf(baseHref) == -1) {
       const str = baseHref.replace(/^\//, '').replace(/\/$/, '').replace(/\//, ':');

--- a/packages/service-worker/worker/src/app-version.ts
+++ b/packages/service-worker/worker/src/app-version.ts
@@ -66,7 +66,7 @@ export class AppVersion implements UpdateSource {
     this.assetGroups = (manifest.assetGroups || []).map(config => {
       // Every asset group has a cache that's prefixed by the manifest hash and the name of the
       // group.
-      const prefix = `ngsw:${this.manifestHash}:assets`;
+      const prefix = `${adapter.ngsw}:${this.manifestHash}:assets`;
       // Check the caching mode, which determines when resources will be fetched/updated.
       switch (config.installMode) {
         case 'prefetch':
@@ -83,7 +83,7 @@ export class AppVersion implements UpdateSource {
                           .map(
                               config => new DataGroup(
                                   this.scope, this.adapter, config, this.database,
-                                  `ngsw:${config.version}:data`));
+                                  `${adapter.ngsw}:${config.version}:data`));
 
     // Create `include`/`exclude` RegExps for the `navigationUrls` declared in the manifest.
     const includeUrls = manifest.navigationUrls.filter(spec => spec.positive);

--- a/packages/service-worker/worker/src/db-cache.ts
+++ b/packages/service-worker/worker/src/db-cache.ts
@@ -23,16 +23,16 @@ export class CacheDatabase implements Database {
     if (this.tables.has(name)) {
       this.tables.delete(name);
     }
-    return this.scope.caches.delete(`ngsw:db:${name}`);
+    return this.scope.caches.delete(`${this.adapter.ngsw}:db:${name}`);
   }
 
   list(): Promise<string[]> {
-    return this.scope.caches.keys().then(keys => keys.filter(key => key.startsWith('ngsw:db:')));
+    return this.scope.caches.keys().then(keys => keys.filter(key => key.startsWith(`${this.adapter.ngsw}:db:`)));
   }
 
   open(name: string): Promise<Table> {
     if (!this.tables.has(name)) {
-      const table = this.scope.caches.open(`ngsw:db:${name}`)
+      const table = this.scope.caches.open(`${this.adapter.ngsw}:db:${name}`)
                         .then(cache => new CacheTable(name, cache, this.adapter));
       this.tables.set(name, table);
     }

--- a/packages/service-worker/worker/src/db-cache.ts
+++ b/packages/service-worker/worker/src/db-cache.ts
@@ -27,8 +27,7 @@ export class CacheDatabase implements Database {
   }
 
   list(): Promise<string[]> {
-    return this.scope.caches.keys().then(
-        keys => keys.filter(key => key.startsWith(`${this.adapter.ngsw}:db:`)));
+    return this.scope.caches.keys().then(keys => keys.filter(key => key.startsWith(`${this.adapter.ngsw}:db:`)));
   }
 
   open(name: string): Promise<Table> {

--- a/packages/service-worker/worker/src/db-cache.ts
+++ b/packages/service-worker/worker/src/db-cache.ts
@@ -27,7 +27,8 @@ export class CacheDatabase implements Database {
   }
 
   list(): Promise<string[]> {
-    return this.scope.caches.keys().then(keys => keys.filter(key => key.startsWith(`${this.adapter.ngsw}:db:`)));
+    return this.scope.caches.keys().then(
+        keys => keys.filter(key => key.startsWith(`${this.adapter.ngsw}:db:`)));
   }
 
   open(name: string): Promise<Table> {

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -919,8 +919,9 @@ export class Driver implements Debuggable, UpdateSource {
    */
   async cleanupOldSwCaches(): Promise<void> {
     const cacheNames = await this.scope.caches.keys();
-    const regex = new RegExp(`^${this.adapter.ngsw}:(?:active|staged|manifest:.+)$`);
-    const oldSwCacheNames = cacheNames.filter(name => regex.test(name));
+    const regex = new RegExp(`^${this.adapter.ngsw}:(?:active|staged|manifest:.+)$`)
+    const oldSwCacheNames =
+        cacheNames.filter(name => regex.test(name));
 
     await Promise.all(oldSwCacheNames.map(name => this.scope.caches.delete(name)));
   }

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -919,9 +919,8 @@ export class Driver implements Debuggable, UpdateSource {
    */
   async cleanupOldSwCaches(): Promise<void> {
     const cacheNames = await this.scope.caches.keys();
-    const regex = new RegExp(`^${this.adapter.ngsw}:(?:active|staged|manifest:.+)$`)
-    const oldSwCacheNames =
-        cacheNames.filter(name => regex.test(name));
+    const regex = new RegExp(`^${this.adapter.ngsw}:(?:active|staged|manifest:.+)$`);
+    const oldSwCacheNames = cacheNames.filter(name => regex.test(name));
 
     await Promise.all(oldSwCacheNames.map(name => this.scope.caches.delete(name)));
   }


### PR DESCRIPTION
Current behavior of the service-worker is caching data of multiple apps in cache DB file in a domain.
Due to this behavior service-worker makes the apps to break when switching from one app to other app in same domain. This PR will solve this issue by suffixing the base-href with `ngsw` string to separate caches files of an apps in a domain

Fixes issue #21388

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #21388 
Currently service-worker doen't seperate the cache files based on base-href. Due to this caches files get clashes with multiple apps hosted in one domain


## What is the new behavior?
In this PR seperating the caches files by suffing the base-href with `ngsw` string like this `ngsw:<base-href>` to seperate the caches files of an app. This will avoid the storing of cache data in same file for multiple apps in one domain


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
