### PR TITLE
feat(service-worker): support multiple apps in one domain

### DIFF
--- a/packages/service-worker/test/integration_spec.ts
+++ b/packages/service-worker/test/integration_spec.ts
@@ -21,56 +21,58 @@ import {take} from 'rxjs/operators';
 
 import {async_beforeEach, async_fit, async_it} from './async';
 
-const dist = new MockFileSystemBuilder().addFile('/only.txt', 'this is only').build();
-
-const distUpdate = new MockFileSystemBuilder().addFile('/only.txt', 'this is only v2').build();
-
-function obsToSinglePromise<T>(obs: Observable<T>): Promise<T> {
-  return obs.pipe(take(1)).toPromise();
-}
-
-const manifest: Manifest = {
-  configVersion: 1,
-  timestamp: 1234567890123,
-  appData: {version: '1'},
-  index: '/only.txt',
-  assetGroups: [{
-    name: 'assets',
-    installMode: 'prefetch',
-    updateMode: 'prefetch',
-    urls: ['/only.txt'],
-    patterns: [],
-  }],
-  navigationUrls: [],
-  hashTable: tmpHashTableForFs(dist),
-};
-
-const manifestUpdate: Manifest = {
-  configVersion: 1,
-  timestamp: 1234567890123,
-  appData: {version: '2'},
-  index: '/only.txt',
-  assetGroups: [{
-    name: 'assets',
-    installMode: 'prefetch',
-    updateMode: 'prefetch',
-    urls: ['/only.txt'],
-    patterns: [],
-  }],
-  navigationUrls: [],
-  hashTable: tmpHashTableForFs(distUpdate),
-};
-
-const server = new MockServerStateBuilder().withStaticFiles(dist).withManifest(manifest).build();
-
-const serverUpdate =
-    new MockServerStateBuilder().withStaticFiles(distUpdate).withManifest(manifestUpdate).build();
-
 (function() {
   // Skip environments that don't support the minimum APIs needed to run the SW tests.
   if (!SwTestHarness.envIsSupported()) {
     return;
   }
+
+  const dist = new MockFileSystemBuilder().addFile('/only.txt', 'this is only').build();
+
+  const distUpdate = new MockFileSystemBuilder().addFile('/only.txt', 'this is only v2').build();
+
+  function obsToSinglePromise<T>(obs: Observable<T>): Promise<T> {
+    return obs.pipe(take(1)).toPromise();
+  }
+
+  const manifest: Manifest = {
+    configVersion: 1,
+    timestamp: 1234567890123,
+    appData: {version: '1'},
+    index: '/only.txt',
+    assetGroups: [{
+      name: 'assets',
+      installMode: 'prefetch',
+      updateMode: 'prefetch',
+      urls: ['/only.txt'],
+      patterns: [],
+    }],
+    navigationUrls: [],
+    hashTable: tmpHashTableForFs(dist),
+  };
+
+  const manifestUpdate: Manifest = {
+    configVersion: 1,
+    timestamp: 1234567890123,
+    appData: {version: '2'},
+    index: '/only.txt',
+    assetGroups: [{
+      name: 'assets',
+      installMode: 'prefetch',
+      updateMode: 'prefetch',
+      urls: ['/only.txt'],
+      patterns: [],
+    }],
+    navigationUrls: [],
+    hashTable: tmpHashTableForFs(distUpdate),
+  };
+
+  const server = new MockServerStateBuilder().withStaticFiles(dist).withManifest(manifest).build();
+
+  const serverUpdate =
+      new MockServerStateBuilder().withStaticFiles(distUpdate).withManifest(manifestUpdate).build();
+
+
   describe('ngsw + companion lib', () => {
     let mock: MockServiceWorkerContainer;
     let comm: NgswCommChannel;

--- a/packages/service-worker/worker/main.ts
+++ b/packages/service-worker/worker/main.ts
@@ -12,5 +12,5 @@ import {Driver} from './src/driver';
 
 const scope = self as any as ServiceWorkerGlobalScope;
 
-const adapter = new Adapter();
+const adapter = new Adapter(scope);
 const driver = new Driver(scope, adapter, new CacheDatabase(scope, adapter));

--- a/packages/service-worker/worker/src/adapter.ts
+++ b/packages/service-worker/worker/src/adapter.ts
@@ -43,7 +43,7 @@ export class Adapter {
   /**
    * Extract the pathname of a URL.
    */
-  parseUrl(url: string, relativeTo: string): {origin: string, path: string} {
+  parseUrl(url: string, relativeTo?: string): {origin: string, path: string} {
     const parsed = new URL(url, relativeTo);
     return {origin: parsed.origin, path: parsed.pathname};
   }

--- a/packages/service-worker/worker/src/adapter.ts
+++ b/packages/service-worker/worker/src/adapter.ts
@@ -18,7 +18,7 @@ export class Adapter {
   constructor(scope: ServiceWorkerGlobalScope) {
     // Suffixing `ngsw` with the baseHref to avoid clash of cache names
     // for SWs with different scopes on the same domain.
-    const baseHref = new URL(scope.registration.scope).pathname;
+    const baseHref = this.parseUrl(scope.registration.scope).path;
     this.cacheNamePrefix = 'ngsw:' + baseHref;
   }
 

--- a/packages/service-worker/worker/src/adapter.ts
+++ b/packages/service-worker/worker/src/adapter.ts
@@ -13,12 +13,15 @@
  * from the global scope.
  */
 export class Adapter {
-  cacheNamePrefix: string;
+  readonly cacheNamePrefix: string;
+
   constructor(scope: ServiceWorkerGlobalScope) {
-    // Suffixing the baseHref with `ngsw` string to avoid clash of cache files
+    // Suffixing `ngsw` with the baseHref to avoid clash of cache names
+    // for SWs with different scopes on the same domain.
     const baseHref = new URL(scope.registration.scope).pathname;
     this.cacheNamePrefix = 'ngsw:' + baseHref;
   }
+
   /**
    * Wrapper around the `Request` constructor.
    */

--- a/packages/service-worker/worker/src/adapter.ts
+++ b/packages/service-worker/worker/src/adapter.ts
@@ -13,6 +13,12 @@
  * from the global scope.
  */
 export class Adapter {
+  cacheNamePrefix: string;
+  constructor(scope: ServiceWorkerGlobalScope) {
+    // Suffixing the baseHref with `ngsw` string to avoid clash of cache files
+    const baseHref = new URL(scope.registration.scope).pathname;
+    this.cacheNamePrefix = 'ngsw:' + baseHref;
+  }
   /**
    * Wrapper around the `Request` constructor.
    */

--- a/packages/service-worker/worker/src/app-version.ts
+++ b/packages/service-worker/worker/src/app-version.ts
@@ -72,7 +72,7 @@ export class AppVersion implements UpdateSource {
     this.assetGroups = (manifest.assetGroups || []).map(config => {
       // Every asset group has a cache that's prefixed by the manifest hash and the name of the
       // group.
-      const prefix = `ngsw:${this.manifestHash}:assets`;
+      const prefix = `${adapter.cacheNamePrefix}:${this.manifestHash}:assets`;
       // Check the caching mode, which determines when resources will be fetched/updated.
       switch (config.installMode) {
         case 'prefetch':
@@ -89,7 +89,7 @@ export class AppVersion implements UpdateSource {
                           .map(
                               config => new DataGroup(
                                   this.scope, this.adapter, config, this.database,
-                                  `ngsw:${config.version}:data`));
+                                  `${adapter.cacheNamePrefix}:${config.version}:data`));
 
     // This keeps backwards compatibility with app versions without navigation urls.
     // Fix: https://github.com/angular/angular/issues/27209

--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -69,8 +69,7 @@ export abstract class AssetGroup {
 
     // Determine the origin from the registration scope. This is used to differentiate between
     // relative and absolute URLs.
-    this.origin =
-        this.adapter.parseUrl(this.scope.registration.scope, this.scope.registration.scope).origin;
+    this.origin = this.adapter.parseUrl(this.scope.registration.scope).origin;
   }
 
   async cacheStatus(url: string): Promise<UpdateCacheStatus> {

--- a/packages/service-worker/worker/src/db-cache.ts
+++ b/packages/service-worker/worker/src/db-cache.ts
@@ -23,16 +23,17 @@ export class CacheDatabase implements Database {
     if (this.tables.has(name)) {
       this.tables.delete(name);
     }
-    return this.scope.caches.delete(`ngsw:db:${name}`);
+    return this.scope.caches.delete(`${this.adapter.cacheNamePrefix}:db:${name}`);
   }
 
   list(): Promise<string[]> {
-    return this.scope.caches.keys().then(keys => keys.filter(key => key.startsWith('ngsw:db:')));
+    return this.scope.caches.keys().then(
+        keys => keys.filter(key => key.startsWith(`${this.adapter.cacheNamePrefix}:db:`)));
   }
 
   open(name: string): Promise<Table> {
     if (!this.tables.has(name)) {
-      const table = this.scope.caches.open(`ngsw:db:${name}`)
+      const table = this.scope.caches.open(`${this.adapter.cacheNamePrefix}:db:${name}`)
                         .then(cache => new CacheTable(name, cache, this.adapter));
       this.tables.set(name, table);
     }

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -705,7 +705,7 @@ export class Driver implements Debuggable, UpdateSource {
 
   private async deleteAllCaches(): Promise<void> {
     await(await this.scope.caches.keys())
-        .filter(key => key.startsWith('ngsw:'))
+        .filter(key => key.startsWith(`${this.adapter.cacheNamePrefix}:`))
         .reduce(async(previous, key) => {
           await Promise.all([
             previous,
@@ -924,9 +924,7 @@ export class Driver implements Debuggable, UpdateSource {
    */
   async cleanupOldSwCaches(): Promise<void> {
     const cacheNames = await this.scope.caches.keys();
-    const oldSwCacheNames =
-        cacheNames.filter(name => /^ngsw:(?:active|staged|manifest:.+)$/.test(name));
-
+    const oldSwCacheNames = cacheNames.filter(name => /^ngsw:(?!\/)/.test(name));
     await Promise.all(oldSwCacheNames.map(name => this.scope.caches.delete(name)));
   }
 

--- a/packages/service-worker/worker/test/data_spec.ts
+++ b/packages/service-worker/worker/test/data_spec.ts
@@ -138,7 +138,7 @@ import {async_beforeEach, async_fit, async_it} from './async';
       async_it('names the caches correctly', async() => {
         expect(await makeRequest(scope, '/api/test')).toEqual('version 1');
         const keys = await scope.caches.keys();
-        expect(keys.every(key => key.startsWith('ngsw:'))).toEqual(true);
+        expect(keys.every(key => key.startsWith('ngsw:/:'))).toEqual(true);
       });
 
       async_it('caches a basic request', async() => {

--- a/packages/service-worker/worker/test/data_spec.ts
+++ b/packages/service-worker/worker/test/data_spec.ts
@@ -15,112 +15,110 @@ import {SwTestHarness, SwTestHarnessBuilder} from '../testing/scope';
 
 import {async_beforeEach, async_fit, async_it} from './async';
 
-const dist = new MockFileSystemBuilder()
-                 .addFile('/foo.txt', 'this is foo')
-                 .addFile('/bar.txt', 'this is bar')
-                 .addFile('/api/test', 'version 1')
-                 .addFile('/api/a', 'version A')
-                 .addFile('/api/b', 'version B')
-                 .addFile('/api/c', 'version C')
-                 .addFile('/api/d', 'version D')
-                 .addFile('/api/e', 'version E')
-                 .addFile('/fresh/data', 'this is fresh data')
-                 .addFile('/refresh/data', 'this is some data')
-                 .build();
-
-
-const distUpdate = new MockFileSystemBuilder()
-                       .addFile('/foo.txt', 'this is foo v2')
-                       .addFile('/bar.txt', 'this is bar')
-                       .addFile('/api/test', 'version 2')
-                       .addFile('/fresh/data', 'this is fresher data')
-                       .addFile('/refresh/data', 'this is refreshed data')
-                       .build();
-
-const manifest: Manifest = {
-  configVersion: 1,
-  timestamp: 1234567890123,
-  index: '/index.html',
-  assetGroups: [
-    {
-      name: 'assets',
-      installMode: 'prefetch',
-      updateMode: 'prefetch',
-      urls: [
-        '/foo.txt',
-        '/bar.txt',
-      ],
-      patterns: [],
-    },
-  ],
-  dataGroups: [
-    {
-      name: 'testPerf',
-      maxSize: 3,
-      strategy: 'performance',
-      patterns: ['^/api/.*$'],
-      timeoutMs: 1000,
-      maxAge: 5000,
-      version: 1,
-    },
-    {
-      name: 'testRefresh',
-      maxSize: 3,
-      strategy: 'performance',
-      patterns: ['^/refresh/.*$'],
-      timeoutMs: 1000,
-      refreshAheadMs: 1000,
-      maxAge: 5000,
-      version: 1,
-    },
-    {
-      name: 'testFresh',
-      maxSize: 3,
-      strategy: 'freshness',
-      patterns: ['^/fresh/.*$'],
-      timeoutMs: 1000,
-      maxAge: 5000,
-      version: 1,
-    },
-  ],
-  navigationUrls: [],
-  hashTable: tmpHashTableForFs(dist),
-};
-
-const seqIncreasedManifest: Manifest = {
-  ...manifest,
-  dataGroups: [
-    {
-      ...manifest.dataGroups ![0],
-      version: 2,
-    },
-    manifest.dataGroups ![1],
-    manifest.dataGroups ![2],
-  ],
-};
-
-
-const server = new MockServerStateBuilder().withStaticFiles(dist).withManifest(manifest).build();
-
-const serverUpdate =
-    new MockServerStateBuilder().withStaticFiles(distUpdate).withManifest(manifest).build();
-
-const serverSeqUpdate = new MockServerStateBuilder()
-                            .withStaticFiles(distUpdate)
-                            .withManifest(seqIncreasedManifest)
-                            .build();
-
-const scope = new SwTestHarnessBuilder().withServerState(server).build();
-
-function asyncWrap(fn: () => Promise<void>): (done: DoneFn) => void {
-  return (done: DoneFn) => { fn().then(() => done(), err => done.fail(err)); };
-}
-
 (function() {
   // Skip environments that don't support the minimum APIs needed to run the SW tests.
   if (!SwTestHarness.envIsSupported()) {
     return;
   }
+
+  const dist = new MockFileSystemBuilder()
+                   .addFile('/foo.txt', 'this is foo')
+                   .addFile('/bar.txt', 'this is bar')
+                   .addFile('/api/test', 'version 1')
+                   .addFile('/api/a', 'version A')
+                   .addFile('/api/b', 'version B')
+                   .addFile('/api/c', 'version C')
+                   .addFile('/api/d', 'version D')
+                   .addFile('/api/e', 'version E')
+                   .addFile('/fresh/data', 'this is fresh data')
+                   .addFile('/refresh/data', 'this is some data')
+                   .build();
+
+
+  const distUpdate = new MockFileSystemBuilder()
+                         .addFile('/foo.txt', 'this is foo v2')
+                         .addFile('/bar.txt', 'this is bar')
+                         .addFile('/api/test', 'version 2')
+                         .addFile('/fresh/data', 'this is fresher data')
+                         .addFile('/refresh/data', 'this is refreshed data')
+                         .build();
+
+  const manifest: Manifest = {
+    configVersion: 1,
+    timestamp: 1234567890123,
+    index: '/index.html',
+    assetGroups: [
+      {
+        name: 'assets',
+        installMode: 'prefetch',
+        updateMode: 'prefetch',
+        urls: [
+          '/foo.txt',
+          '/bar.txt',
+        ],
+        patterns: [],
+      },
+    ],
+    dataGroups: [
+      {
+        name: 'testPerf',
+        maxSize: 3,
+        strategy: 'performance',
+        patterns: ['^/api/.*$'],
+        timeoutMs: 1000,
+        maxAge: 5000,
+        version: 1,
+      },
+      {
+        name: 'testRefresh',
+        maxSize: 3,
+        strategy: 'performance',
+        patterns: ['^/refresh/.*$'],
+        timeoutMs: 1000,
+        refreshAheadMs: 1000,
+        maxAge: 5000,
+        version: 1,
+      },
+      {
+        name: 'testFresh',
+        maxSize: 3,
+        strategy: 'freshness',
+        patterns: ['^/fresh/.*$'],
+        timeoutMs: 1000,
+        maxAge: 5000,
+        version: 1,
+      },
+    ],
+    navigationUrls: [],
+    hashTable: tmpHashTableForFs(dist),
+  };
+
+  const seqIncreasedManifest: Manifest = {
+    ...manifest,
+    dataGroups: [
+      {
+        ...manifest.dataGroups ![0],
+        version: 2,
+      },
+      manifest.dataGroups ![1],
+      manifest.dataGroups ![2],
+    ],
+  };
+
+
+  const server = new MockServerStateBuilder().withStaticFiles(dist).withManifest(manifest).build();
+
+  const serverUpdate =
+      new MockServerStateBuilder().withStaticFiles(distUpdate).withManifest(manifest).build();
+
+  const serverSeqUpdate = new MockServerStateBuilder()
+                              .withStaticFiles(distUpdate)
+                              .withManifest(seqIncreasedManifest)
+                              .build();
+
+  const scope = new SwTestHarnessBuilder().withServerState(server).build();
+
+
   describe('data cache', () => {
     let scope: SwTestHarness;
     let driver: Driver;

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -225,6 +225,7 @@ import {async_beforeEach, async_fit, async_it} from './async';
   describe('Driver', () => {
     let scope: SwTestHarness;
     let driver: Driver;
+    let baseHref = '/';
 
     beforeEach(() => {
       server.reset();
@@ -311,7 +312,7 @@ import {async_beforeEach, async_fit, async_it} from './async';
       expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
       await driver.initialized;
       server.clearRequests();
-      expect(await makeRequest(scope, 'http://localhost/foo.txt')).toEqual('this is foo');
+      expect(await makeRequest(scope, `http://localhost${baseHref}foo.txt`)).toEqual('this is foo');
       server.assertNoOtherRequests();
     });
 
@@ -587,7 +588,8 @@ import {async_beforeEach, async_fit, async_it} from './async';
       serverUpdate.assertNoOtherRequests();
 
       let keys = await scope.caches.keys();
-      let hasOriginalCaches = keys.some(name => name.startsWith(`ngsw:${manifestHash}:`));
+      let hasOriginalCaches =
+          keys.some(name => name.startsWith(`ngsw:${baseHref}:${manifestHash}:`));
       expect(hasOriginalCaches).toEqual(true);
 
       scope.clients.remove('default');
@@ -600,7 +602,7 @@ import {async_beforeEach, async_fit, async_it} from './async';
       expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo v2');
 
       keys = await scope.caches.keys();
-      hasOriginalCaches = keys.some(name => name.startsWith(`ngsw:${manifestHash}:`));
+      hasOriginalCaches = keys.some(name => name.startsWith(`ngsw:${baseHref}:${manifestHash}:`));
       expect(hasOriginalCaches).toEqual(false);
     });
 
@@ -843,7 +845,7 @@ import {async_beforeEach, async_fit, async_it} from './async';
       });
 
       async_it('redirects to index on a request to the origin URL request', async() => {
-        expect(await navRequest('http://localhost/')).toEqual('this is foo');
+        expect(await navRequest(`http://localhost${baseHref}`)).toEqual('this is foo');
         server.assertNoOtherRequests();
       });
 
@@ -929,7 +931,7 @@ import {async_beforeEach, async_fit, async_it} from './async';
         });
 
         async_it('strips registration scope before checking `navigationUrls`', async() => {
-          expect(await navRequest('http://localhost/ignored/file1'))
+          expect(await navRequest(`http://localhost${baseHref}ignored/file1`))
               .toBe('this is not handled by the SW');
           serverUpdate.assertSawRequestFor('/ignored/file1');
         });
@@ -940,11 +942,11 @@ import {async_beforeEach, async_fit, async_it} from './async';
       async_it('should delete the correct caches', async() => {
         const oldSwCacheNames = ['ngsw:active', 'ngsw:staged', 'ngsw:manifest:a1b2c3:super:duper'];
         const otherCacheNames = [
-          'ngsuu:active',
-          'not:ngsw:active',
-          'ngsw:staged:not',
-          'NgSw:StAgEd',
-          'ngsw:manifest',
+          `ngsuu:${baseHref}:active`,
+          `not:${baseHref}:ngsw:active`,
+          `ngsw:${baseHref}:staged:not`,
+          `NgSw:${baseHref}:StAgEd`,
+          `ngsw:${baseHref}:manifest`,
         ];
         const allCacheNames = oldSwCacheNames.concat(otherCacheNames);
 

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -225,7 +225,6 @@ import {async_beforeEach, async_fit, async_it} from './async';
   describe('Driver', () => {
     let scope: SwTestHarness;
     let driver: Driver;
-    let baseHref = '/';
 
     beforeEach(() => {
       server.reset();
@@ -312,7 +311,7 @@ import {async_beforeEach, async_fit, async_it} from './async';
       expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
       await driver.initialized;
       server.clearRequests();
-      expect(await makeRequest(scope, `http://localhost${baseHref}foo.txt`)).toEqual('this is foo');
+      expect(await makeRequest(scope, 'http://localhost/foo.txt')).toEqual('this is foo');
       server.assertNoOtherRequests();
     });
 
@@ -588,8 +587,7 @@ import {async_beforeEach, async_fit, async_it} from './async';
       serverUpdate.assertNoOtherRequests();
 
       let keys = await scope.caches.keys();
-      let hasOriginalCaches =
-          keys.some(name => name.startsWith(`ngsw:${baseHref}:${manifestHash}:`));
+      let hasOriginalCaches = keys.some(name => name.startsWith(`ngsw:/:${manifestHash}:`));
       expect(hasOriginalCaches).toEqual(true);
 
       scope.clients.remove('default');
@@ -602,7 +600,7 @@ import {async_beforeEach, async_fit, async_it} from './async';
       expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo v2');
 
       keys = await scope.caches.keys();
-      hasOriginalCaches = keys.some(name => name.startsWith(`ngsw:${baseHref}:${manifestHash}:`));
+      hasOriginalCaches = keys.some(name => name.startsWith(`ngsw:/:${manifestHash}:`));
       expect(hasOriginalCaches).toEqual(false);
     });
 
@@ -845,7 +843,7 @@ import {async_beforeEach, async_fit, async_it} from './async';
       });
 
       async_it('redirects to index on a request to the origin URL request', async() => {
-        expect(await navRequest(`http://localhost${baseHref}`)).toEqual('this is foo');
+        expect(await navRequest('http://localhost/')).toEqual('this is foo');
         server.assertNoOtherRequests();
       });
 
@@ -931,7 +929,7 @@ import {async_beforeEach, async_fit, async_it} from './async';
         });
 
         async_it('strips registration scope before checking `navigationUrls`', async() => {
-          expect(await navRequest(`http://localhost${baseHref}ignored/file1`))
+          expect(await navRequest('http://localhost/ignored/file1'))
               .toBe('this is not handled by the SW');
           serverUpdate.assertSawRequestFor('/ignored/file1');
         });
@@ -940,13 +938,21 @@ import {async_beforeEach, async_fit, async_it} from './async';
 
     describe('cleanupOldSwCaches()', () => {
       async_it('should delete the correct caches', async() => {
-        const oldSwCacheNames = ['ngsw:active', 'ngsw:staged', 'ngsw:manifest:a1b2c3:super:duper'];
+        const oldSwCacheNames = [
+          // Example cache names from the beta versions of `@angular/service-worker`.
+          'ngsw:active',
+          'ngsw:staged',
+          'ngsw:manifest:a1b2c3:super:duper',
+          // Example cache names from the beta versions of `@angular/service-worker`.
+          'ngsw:a1b2c3:assets:foo',
+          'ngsw:db:a1b2c3:assets:bar',
+        ];
         const otherCacheNames = [
-          `ngsuu:${baseHref}:active`,
-          `not:${baseHref}:ngsw:active`,
-          `ngsw:${baseHref}:staged:not`,
-          `NgSw:${baseHref}:StAgEd`,
-          `ngsw:${baseHref}:manifest`,
+          'ngsuu:active',
+          'not:ngsw:active',
+          'NgSw:StAgEd',
+          'ngsw:/:active',
+          'ngsw:/foo/:staged',
         ];
         const allCacheNames = oldSwCacheNames.concat(otherCacheNames);
 

--- a/packages/service-worker/worker/test/idle_spec.ts
+++ b/packages/service-worker/worker/test/idle_spec.ts
@@ -15,6 +15,7 @@ import {async_beforeEach, async_fit, async_it} from './async';
   if (!SwTestHarness.envIsSupported()) {
     return;
   }
+
   describe('IdleScheduler', () => {
     let scope: SwTestHarness;
     let idle: IdleScheduler;

--- a/packages/service-worker/worker/test/prefetch_spec.ts
+++ b/packages/service-worker/worker/test/prefetch_spec.ts
@@ -14,26 +14,26 @@ import {SwTestHarness, SwTestHarnessBuilder} from '../testing/scope';
 
 import {async_fit, async_it} from './async';
 
-const dist = new MockFileSystemBuilder()
-                 .addFile('/foo.txt', 'this is foo')
-                 .addFile('/bar.txt', 'this is bar')
-                 .build();
-
-const manifest = tmpManifestSingleAssetGroup(dist);
-
-const server = new MockServerStateBuilder().withStaticFiles(dist).withManifest(manifest).build();
-
-const scope = new SwTestHarnessBuilder().withServerState(server).build();
-
-const db = new CacheDatabase(scope, scope);
-
-
-
 (function() {
   // Skip environments that don't support the minimum APIs needed to run the SW tests.
   if (!SwTestHarness.envIsSupported()) {
     return;
   }
+
+  const dist = new MockFileSystemBuilder()
+                   .addFile('/foo.txt', 'this is foo')
+                   .addFile('/bar.txt', 'this is bar')
+                   .build();
+
+  const manifest = tmpManifestSingleAssetGroup(dist);
+
+  const server = new MockServerStateBuilder().withStaticFiles(dist).withManifest(manifest).build();
+
+  const scope = new SwTestHarnessBuilder().withServerState(server).build();
+
+  const db = new CacheDatabase(scope, scope);
+
+
   describe('prefetch assets', () => {
     let group: PrefetchAssetGroup;
     let idle: IdleScheduler;

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -116,9 +116,9 @@ export class SwTestHarness implements ServiceWorkerGlobalScope, Adapter, Context
 
   constructor(
       private server: MockServerState, readonly caches: MockCacheStorage, private origin: string) {
-    this.time = Date.now();
-    const baseHref = new URL(this.registration.scope).pathname;
+    const baseHref = this.parseUrl(origin).path;
     this.cacheNamePrefix = 'ngsw:' + baseHref;
+    this.time = Date.now();
   }
 
   async resolveSelfMessages(): Promise<void> {

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -175,7 +175,7 @@ export class SwTestHarness implements ServiceWorkerGlobalScope, Adapter, Context
     }, new MockHeaders());
   }
 
-  parseUrl(url: string, relativeTo: string): {origin: string, path: string} {
+  parseUrl(url: string, relativeTo?: string): {origin: string, path: string} {
     if (typeof URL === 'function') {
       const obj = new URL(url, relativeTo);
       return {origin: obj.origin, path: obj.pathname};

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -74,10 +74,10 @@ export class MockClients implements Clients {
 }
 
 export class SwTestHarness implements ServiceWorkerGlobalScope, Adapter, Context {
+  readonly cacheNamePrefix: string;
   readonly clients = new MockClients();
   private eventHandlers = new Map<string, Function>();
   private skippedWaiting = true;
-  cacheNamePrefix: string;
 
   private selfMessageQueue: any[] = [];
   autoAdvanceTime = false;

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -77,6 +77,7 @@ export class SwTestHarness implements ServiceWorkerGlobalScope, Adapter, Context
   readonly clients = new MockClients();
   private eventHandlers = new Map<string, Function>();
   private skippedWaiting = true;
+  cacheNamePrefix: string;
 
   private selfMessageQueue: any[] = [];
   autoAdvanceTime = false;
@@ -115,6 +116,8 @@ export class SwTestHarness implements ServiceWorkerGlobalScope, Adapter, Context
 
   constructor(private server: MockServerState, readonly caches: MockCacheStorage) {
     this.time = Date.now();
+    const baseHref = new URL(this.registration.scope).pathname;
+    this.cacheNamePrefix = 'ngsw:' + baseHref;
   }
 
   async resolveSelfMessages(): Promise<void> {


### PR DESCRIPTION
Current behavior of the service-worker is caching data of multiple apps in cache DB file in a domain.
Due to this behavior service-worker makes the apps to break when switching from one app to other app in same domain. This PR will solve this issue by suffixing the base-href with `ngsw` string to separate caches files of an apps in a domain

Fixes issue #21388

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #21388 
Currently service-worker doen't seperate the cache files based on base-href. Due to this caches files get clashes with multiple apps hosted in one domain


## What is the new behavior?
In this PR seperating the caches files by suffing the base-href with `ngsw` string like this `ngsw:<base-href>` to seperate the caches files of an app. This will avoid the storing of cache data in same file for multiple apps in one domain


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
