### PR TITLE
fix(core): fix HTML Sanitizer breaking Safari 10.1

### DIFF
--- a/packages/core/src/sanitization/inert_body.ts
+++ b/packages/core/src/sanitization/inert_body.ts
@@ -77,13 +77,21 @@ export class InertBodyHelper {
     } catch (e) {
       return null;
     }
-    const xhr = new XMLHttpRequest();
-    xhr.responseType = 'document';
-    xhr.open('GET', 'data:text/html;charset=utf-8,' + html, false);
-    xhr.send(undefined);
-    const body: HTMLBodyElement = xhr.response.body;
-    body.removeChild(body.firstChild !);
-    return body;
+
+    // Wrap in a try/catch because if your Content Security Policy
+    // does not allow data urls this will crash the application.
+    // See https://github.com/cure53/DOMPurify/issues/215
+    try {
+      const xhr = new XMLHttpRequest();
+      xhr.responseType = 'document';
+      xhr.open('GET', 'data:text/html;charset=utf-8,' + html, false);
+      xhr.send(undefined);
+      const body: HTMLBodyElement = xhr.response.body;
+      body.removeChild(body.firstChild !);
+      return body;
+    } catch (e) {
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
We create an inert element with a data URI via XHR that will throw an error
unless the content security policy allows it. To prevent crashing the app this
commit wraps this in a try/catch.
Relevant issue: https://github.com/cure53/DOMPurify/issues/215

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Breaks in Safari 10.1 if CSP does not accept connect data.

Issue Number: N/A


## What is the new behavior?
Does not break Safari 10.1

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 https://github.com/cure53/DOMPurify/issues/215