### PR TITLE
build(docs-infra): upgrade cli command docs sources to 70a36d5df

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -18,7 +18,7 @@
     "build-for": "yarn ~~build --configuration",
     "prebuild-local": "yarn setup-local",
     "build-local": "yarn ~~build --configuration=stable",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js b50950b97",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 70a36d5df",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
[Changed files](https://github.com/angular/cli-builds/compare/b50950b97...70a36d5df):
- help/add.json
- help/build.json
- help/config.json
- help/e2e.json
- help/generate.json
- help/lint.json
- help/new.json
- help/run.json
- help/serve.json
- help/test.json
- help/xi18n.json