### PR TITLE
test(ivy): run more common tests with ivy on ci

### DIFF
--- a/packages/common/test/directives/ng_template_outlet_spec.ts
+++ b/packages/common/test/directives/ng_template_outlet_spec.ts
@@ -10,9 +10,8 @@ import {CommonModule} from '@angular/common';
 import {Component, ContentChildren, Directive, Injectable, NO_ERRORS_SCHEMA, OnDestroy, QueryList, TemplateRef} from '@angular/core';
 import {ComponentFixture, TestBed, async} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {fixmeIvy} from '@angular/private/testing';
 
-fixmeIvy('expr.visitExpression is not a function - fixed by #26968') && describe('NgTemplateOutlet', () => {
+describe('NgTemplateOutlet', () => {
   let fixture: ComponentFixture<any>;
 
   function setTplRef(value: any): void { fixture.componentInstance.currentTplRef = value; }


### PR DESCRIPTION
With https://github.com/angular/angular/pull/27068 merged we can activate
more ivy tests on CI.

With this change the number of disabled tests goes down to 6.