### PR TITLE
fix(ivy): use the root view injector when resolving dependencies

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -72,6 +72,29 @@ export const SCHEDULER = new InjectionToken<((fn: () => void) => void)>('SCHEDUL
 export const WRAP_RENDERER_FACTORY2 =
     new InjectionToken<(rf: RendererFactory2) => RendererFactory2>('WRAP_RENDERER_FACTORY2');
 
+// TODO: use the token from ../view/provider
+const NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR = {};
+
+function createChainedInjector(rootViewInjector: Injector, moduleInjector: Injector): Injector {
+  return {
+    get: <T>(token: Type<T>| InjectionToken<T>, notFoundValue?: T): T => {
+      const value = rootViewInjector.get(token, NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR);
+
+      if (value !== NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR ||
+          notFoundValue === NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR) {
+        // Return the value from the root element injector when
+        // - it provides it
+        //   (value !== NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR)
+        // - the module injector should not be checked
+        //   (notFoundValue === NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR)
+        return value;
+      }
+
+      return moduleInjector.get(token, notFoundValue);
+    }
+  };
+}
+
 /**
  * Render3 implementation of {@link viewEngine_ComponentFactory}.
  */
@@ -122,7 +145,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
     // Create the root view. Uses empty TView and ContentTemplate.
     const rootView: LViewData = createLViewData(
         renderer, createTView(-1, null, 1, 0, null, null, null), rootContext, rootFlags);
-    rootView[INJECTOR] = ngModule && ngModule.injector || null;
+    rootView[INJECTOR] = ngModule ? createChainedInjector(injector, ngModule.injector) : injector;
 
     // rootView is the parent when bootstrapping
     const oldView = enterView(rootView, null);

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -72,7 +72,6 @@ export const SCHEDULER = new InjectionToken<((fn: () => void) => void)>('SCHEDUL
 export const WRAP_RENDERER_FACTORY2 =
     new InjectionToken<(rf: RendererFactory2) => RendererFactory2>('WRAP_RENDERER_FACTORY2');
 
-// TODO: use the token from ../view/provider
 const NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR = {};
 
 function createChainedInjector(rootViewInjector: Injector, moduleInjector: Injector): Injector {
@@ -80,13 +79,10 @@ function createChainedInjector(rootViewInjector: Injector, moduleInjector: Injec
     get: <T>(token: Type<T>| InjectionToken<T>, notFoundValue?: T): T => {
       const value = rootViewInjector.get(token, NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR);
 
-      if (value !== NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR ||
-          notFoundValue === NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR) {
+      if (value !== NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR) {
         // Return the value from the root element injector when
         // - it provides it
         //   (value !== NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR)
-        // - the module injector should not be checked
-        //   (notFoundValue === NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR)
         return value;
       }
 

--- a/packages/core/src/render3/util.ts
+++ b/packages/core/src/render3/util.ts
@@ -236,9 +236,12 @@ export function getParentInjectorTNode(
   }
 
   let viewOffset = getParentInjectorViewOffset(location);
+  // view offset is 1
   let parentView = startView;
   let parentTNode = startView[HOST_NODE] as TElementNode;
-  while (viewOffset > 0) {
+
+  // view offset is superior to 1
+  while (viewOffset > 1) {
     parentView = parentView[DECLARATION_VIEW] !;
     parentTNode = parentView[HOST_NODE] as TElementNode;
     viewOffset--;

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -8,6 +8,7 @@
 
 import {ChangeDetectorRef as ViewEngine_ChangeDetectorRef} from '../change_detection/change_detector_ref';
 import {Injector, NullInjector} from '../di/injector';
+import {InjectFlags} from '../di/injector_compatibility';
 import {ComponentFactory as viewEngine_ComponentFactory, ComponentRef as viewEngine_ComponentRef} from '../linker/component_factory';
 import {ElementRef as ViewEngine_ElementRef} from '../linker/element_ref';
 import {NgModuleRef as viewEngine_NgModuleRef} from '../linker/ng_module_factory';
@@ -159,7 +160,8 @@ export class NodeInjector implements Injector {
       private _hostView: LViewData) {}
 
   get(token: any, notFoundValue?: any): any {
-    return getOrCreateInjectable(this._tNode, this._hostView, token, notFoundValue);
+    return getOrCreateInjectable(
+        this._tNode, this._hostView, token, InjectFlags.Default, notFoundValue);
   }
 }
 

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -252,6 +252,9 @@
     "name": "NOT_FOUND"
   },
   {
+    "name": "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR"
+  },
+  {
     "name": "NOT_YET"
   },
   {
@@ -631,6 +634,9 @@
   },
   {
     "name": "couldBeInjectableType"
+  },
+  {
+    "name": "createChainedInjector"
   },
   {
     "name": "createElementRef"

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -504,6 +504,9 @@
     "name": "NOT_FOUND"
   },
   {
+    "name": "NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR"
+  },
+  {
     "name": "NOT_YET"
   },
   {
@@ -1309,6 +1312,9 @@
   },
   {
     "name": "couldBeInjectableType"
+  },
+  {
+    "name": "createChainedInjector"
   },
   {
     "name": "createContainerRef"


### PR DESCRIPTION
I've found this issue when executing the router test with Ivy.

When using the `ViewContainerRef.createComponent()` API, a root view is created with an injector which can be either provided as an argument, or defaults to the `parentInjector`.
When resolving a dependency within the dynamic view, the process should be (according to the ViewEngine implementation):
1) Climb the element injector tree until the root view boundary
2) If token found, use the root view injector
3) If token still not found, use the module injector