### PR TITLE
fix(ivy): deduplicate imported module in r3_injector

### DIFF
--- a/packages/compiler-cli/integrationtest/bazel/injector_def/ivy_build/app/test/module_spec.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injector_def/ivy_build/app/test/module_spec.ts
@@ -54,7 +54,8 @@ describe('Ivy NgModule', () => {
       }
 
       expect(() => createInjector(AModule))
-          .toThrowError('Circular dependency: type AModule ends up importing itself.');
+          .toThrowError(
+              'Circular dependency in DI detected for type AModule. Dependency path: AModule > BModule > AModule.');
     });
 
     it('merges imports and exports', () => {

--- a/packages/platform-server/test/BUILD.bazel
+++ b/packages/platform-server/test/BUILD.bazel
@@ -17,6 +17,7 @@ ts_library(
         "//packages/http/testing",
         "//packages/platform-browser",
         "//packages/platform-server",
+        "//packages/private/testing",
         "@rxjs",
         "@rxjs//operators",
     ],
@@ -26,7 +27,6 @@ jasmine_node_test(
     name = "test",
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
     tags = [
-        "fixme-ivy-aot",
     ],
     deps = [
         ":test_lib",

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -433,21 +433,20 @@ class HiddenModule {
          });
        }));
 
-    fixmeIvy('no deduplication of imported modules') &&
-        it('adds styles with ng-transition attribute', async(() => {
-             const platform = platformDynamicServer([{
-               provide: INITIAL_CONFIG,
-               useValue: {document: '<html><head></head><body><app></app></body></html>'}
-             }]);
-             platform.bootstrapModule(ExampleStylesModule).then(ref => {
-               const doc = ref.injector.get(DOCUMENT);
-               const head = getDOM().getElementsByTagName(doc, 'head')[0];
-               const styles: any[] = head.children as any;
-               expect(styles.length).toBe(1);
-               expect(getDOM().getText(styles[0])).toContain('color: red');
-               expect(getDOM().getAttribute(styles[0], 'ng-transition')).toBe('example-styles');
-             });
-           }));
+    it('adds styles with ng-transition attribute', async(() => {
+         const platform = platformDynamicServer([{
+           provide: INITIAL_CONFIG,
+           useValue: {document: '<html><head></head><body><app></app></body></html>'}
+         }]);
+         platform.bootstrapModule(ExampleStylesModule).then(ref => {
+           const doc = ref.injector.get(DOCUMENT);
+           const head = getDOM().getElementsByTagName(doc, 'head')[0];
+           const styles: any[] = head.children as any;
+           expect(styles.length).toBe(1);
+           expect(getDOM().getText(styles[0])).toContain('color: red');
+           expect(getDOM().getAttribute(styles[0], 'ng-transition')).toBe('example-styles');
+         });
+       }));
 
     it('copies known properties to attributes', async(() => {
          const platform = platformDynamicServer(
@@ -718,27 +717,25 @@ class HiddenModule {
            });
          }));
 
-      fixmeIvy('no deduplication of imported modules') &&
-          it('requests are macrotasks', async(() => {
-               const platform = platformDynamicServer(
-                   [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
-               platform.bootstrapModule(ExampleModule).then(ref => {
-                 const mock = ref.injector.get(MockBackend);
-                 const http = ref.injector.get(Http);
-                 expect(ref.injector.get<NgZone>(NgZone).hasPendingMacrotasks).toBeFalsy();
-                 ref.injector.get<NgZone>(NgZone).run(() => {
-                   NgZone.assertInAngularZone();
-                   mock.connections.subscribe((mc: MockConnection) => {
-                     expect(ref.injector.get<NgZone>(NgZone).hasPendingMacrotasks).toBeTruthy();
-                     mc.mockRespond(
-                         new Response(new ResponseOptions({body: 'success!', status: 200})));
-                   });
-                   http.get('http://localhost/testing').subscribe(resp => {
-                     expect(resp.text()).toBe('success!');
-                   });
-                 });
+      it('requests are macrotasks', async(() => {
+           const platform = platformDynamicServer(
+               [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+           platform.bootstrapModule(ExampleModule).then(ref => {
+             const mock = ref.injector.get(MockBackend);
+             const http = ref.injector.get(Http);
+             expect(ref.injector.get<NgZone>(NgZone).hasPendingMacrotasks).toBeFalsy();
+             ref.injector.get<NgZone>(NgZone).run(() => {
+               NgZone.assertInAngularZone();
+               mock.connections.subscribe((mc: MockConnection) => {
+                 expect(ref.injector.get<NgZone>(NgZone).hasPendingMacrotasks).toBeTruthy();
+                 mc.mockRespond(new Response(new ResponseOptions({body: 'success!', status: 200})));
                });
-             }));
+               http.get('http://localhost/testing').subscribe(resp => {
+                 expect(resp.text()).toBe('success!');
+               });
+             });
+           });
+         }));
 
       it('works when HttpModule is included before ServerModule', async(() => {
            const platform = platformDynamicServer(
@@ -760,27 +757,25 @@ class HiddenModule {
            });
          }));
 
-      fixmeIvy('no deduplication of imported modules') &&
-          it('works when HttpModule is included after ServerModule', async(() => {
-               const platform = platformDynamicServer(
-                   [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
-               platform.bootstrapModule(HttpAfterExampleModule).then(ref => {
-                 const mock = ref.injector.get(MockBackend);
-                 const http = ref.injector.get(Http);
-                 expect(ref.injector.get<NgZone>(NgZone).hasPendingMacrotasks).toBeFalsy();
-                 ref.injector.get<NgZone>(NgZone).run(() => {
-                   NgZone.assertInAngularZone();
-                   mock.connections.subscribe((mc: MockConnection) => {
-                     expect(ref.injector.get<NgZone>(NgZone).hasPendingMacrotasks).toBeTruthy();
-                     mc.mockRespond(
-                         new Response(new ResponseOptions({body: 'success!', status: 200})));
-                   });
-                   http.get('http://localhost/testing').subscribe(resp => {
-                     expect(resp.text()).toBe('success!');
-                   });
-                 });
+      it('works when HttpModule is included after ServerModule', async(() => {
+           const platform = platformDynamicServer(
+               [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+           platform.bootstrapModule(HttpAfterExampleModule).then(ref => {
+             const mock = ref.injector.get(MockBackend);
+             const http = ref.injector.get(Http);
+             expect(ref.injector.get<NgZone>(NgZone).hasPendingMacrotasks).toBeFalsy();
+             ref.injector.get<NgZone>(NgZone).run(() => {
+               NgZone.assertInAngularZone();
+               mock.connections.subscribe((mc: MockConnection) => {
+                 expect(ref.injector.get<NgZone>(NgZone).hasPendingMacrotasks).toBeTruthy();
+                 mc.mockRespond(new Response(new ResponseOptions({body: 'success!', status: 200})));
                });
-             }));
+               http.get('http://localhost/testing').subscribe(resp => {
+                 expect(resp.text()).toBe('success!');
+               });
+             });
+           });
+         }));
 
       it('throws when given a relative URL', async(() => {
            const platform = platformDynamicServer(


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the current behavior?
The r3_injector doesn't deduplicate imported modules, meaning that you can import the same module multiple times and the providers will be overwritten everytime


## What is the new behavior?
We deduplicate imports, only the first one matters like it is the case with the current renderer.
This also enables the tests from platform-server for ivy.


## Does this PR introduce a breaking change?

- [x] No
