### PR TITLE
fix(ivy): component ref injector should support change detector ref

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1497,
-        "main": 181839,
+        "main": 185238,
         "polyfills": 59608
       }
     }

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -121,8 +121,8 @@ export function renderComponent<T>(
 
   const renderer = rendererFactory.createRenderer(hostRNode, componentDef);
   const rootView: LViewData = createLViewData(
-      renderer, createTView(-1, null, 1, 0, null, null, null), rootContext, rootFlags);
-  rootView[INJECTOR] = opts.injector || null;
+      renderer, createTView(-1, null, 1, 0, null, null, null), rootContext, rootFlags, undefined,
+      opts.injector || null);
 
   const oldView = enterView(rootView, null);
   let component: T;

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -163,7 +163,8 @@ export function createLViewData<T>(
   instance[FLAGS] = flags | LViewFlags.CreationMode | LViewFlags.Attached | LViewFlags.RunInit;
   instance[PARENT] = instance[DECLARATION_VIEW] = viewData;
   instance[CONTEXT] = context;
-  instance[INJECTOR as any] = injector == null ? (viewData ? viewData[INJECTOR] : null) : injector;
+  instance[INJECTOR as any] =
+      injector === undefined ? (viewData ? viewData[INJECTOR] : null) : injector;
   instance[RENDERER] = renderer;
   instance[SANITIZER] = sanitizer || null;
   return instance;
@@ -681,7 +682,7 @@ export function createTView(
   // that has a host binding, we will update the blueprint with that def's hostVars count.
   const initialViewLength = bindingStartIndex + vars;
   const blueprint = createViewBlueprint(bindingStartIndex, initialViewLength);
-  return blueprint[TVIEW] = {
+  return blueprint[TVIEW as any] = {
     id: viewIndex,
     blueprint: blueprint,
     template: templateFn,

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -163,8 +163,7 @@ export function createLViewData<T>(
   instance[FLAGS] = flags | LViewFlags.CreationMode | LViewFlags.Attached | LViewFlags.RunInit;
   instance[PARENT] = instance[DECLARATION_VIEW] = viewData;
   instance[CONTEXT] = context;
-  instance[INJECTOR as any] =
-      injector === undefined ? (viewData ? viewData[INJECTOR] : null) : injector;
+  instance[INJECTOR as any] = injector == null ? (viewData ? viewData[INJECTOR] : null) : injector;
   instance[RENDERER] = renderer;
   instance[SANITIZER] = sanitizer || null;
   return instance;

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -9,6 +9,7 @@
 import './ng_dev_mode';
 import {resolveForwardRef} from '../di/forward_ref';
 import {InjectionToken} from '../di/injection_token';
+import {Injector} from '../di/injector';
 import {InjectFlags} from '../di/injector_compatibility';
 import {QueryList} from '../linker';
 import {Sanitizer} from '../sanitization/security';
@@ -156,13 +157,14 @@ function refreshChildComponents(
 
 export function createLViewData<T>(
     renderer: Renderer3, tView: TView, context: T | null, flags: LViewFlags,
-    sanitizer?: Sanitizer | null): LViewData {
+    sanitizer?: Sanitizer | null, injector?: Injector | null): LViewData {
   const viewData = getViewData();
   const instance = tView.blueprint.slice() as LViewData;
   instance[FLAGS] = flags | LViewFlags.CreationMode | LViewFlags.Attached | LViewFlags.RunInit;
   instance[PARENT] = instance[DECLARATION_VIEW] = viewData;
   instance[CONTEXT] = context;
-  instance[INJECTOR] = viewData ? viewData[INJECTOR] : null;
+  instance[INJECTOR as any] =
+      injector === undefined ? (viewData ? viewData[INJECTOR] : null) : injector;
   instance[RENDERER] = renderer;
   instance[SANITIZER] = sanitizer || null;
   return instance;

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -147,7 +147,7 @@ export interface LViewData extends Array<any> {
   [CONTEXT]: {}|RootContext|null;
 
   /** An optional Module Injector to be used as fall back after Element Injectors are consulted. */
-  [INJECTOR]: Injector|null;
+  readonly[INJECTOR]: Injector|null;
 
   /** Renderer to be used for this view. */
   [RENDERER]: Renderer3;

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -69,7 +69,7 @@ export interface LViewData extends Array<any> {
    * node tree in DI and get the TView.data array associated with a node (where the
    * directive defs are stored).
    */
-  [TVIEW]: TView;
+  readonly[TVIEW]: TView;
 
   /** Flags for this view. See LViewFlags for more info. */
   [FLAGS]: LViewFlags;
@@ -103,7 +103,7 @@ export interface LViewData extends Array<any> {
    *
    * If this is an embedded view, HOST will be null.
    */
-  [HOST]: RElement|StylingContext|null;
+  readonly[HOST]: RElement|StylingContext|null;
 
   /**
    * Pointer to the `TViewNode` or `TElementNode` which represents the root of the view.

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -103,7 +103,7 @@ export interface LViewData extends Array<any> {
    *
    * If this is an embedded view, HOST will be null.
    */
-  readonly[HOST]: RElement|StylingContext|null;
+  [HOST]: RElement|StylingContext|null;
 
   /**
    * Pointer to the `TViewNode` or `TElementNode` which represents the root of the view.

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -275,6 +275,10 @@ export class RootViewRef<T> extends ViewRef<T> {
   detectChanges(): void { detectChangesInRootView(this._view); }
 
   checkNoChanges(): void { checkNoChangesInRootView(this._view); }
+
+  get context(): T {
+    return ({} as T);
+  }
 }
 
 function collectNativeNodes(lView: LViewData, parentTNode: TNode, result: any[]): any[] {

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -276,9 +276,7 @@ export class RootViewRef<T> extends ViewRef<T> {
 
   checkNoChanges(): void { checkNoChangesInRootView(this._view); }
 
-  get context(): T {
-    return ({} as T);
-  }
+  get context(): T { return null !; }
 }
 
 function collectNativeNodes(lView: LViewData, parentTNode: TNode, result: any[]): any[] {

--- a/packages/core/src/testability/testability.ts
+++ b/packages/core/src/testability/testability.ts
@@ -67,11 +67,14 @@ export class Testability implements PublicTestability {
   private _didWork: boolean = false;
   private _callbacks: WaitCallback[] = [];
 
-  private taskTrackingZone: any;
+  private taskTrackingZone: {macroTasks: Task[]}|null = null;
 
   constructor(private _ngZone: NgZone) {
     this._watchAngularEvents();
-    _ngZone.run(() => { this.taskTrackingZone = Zone.current.get('TaskTrackingZone'); });
+    _ngZone.run(() => {
+      this.taskTrackingZone =
+          typeof Zone == 'undefined' ? null : Zone.current.get('TaskTrackingZone');
+    });
   }
 
   private _watchAngularEvents(): void {

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -1080,7 +1080,7 @@ describe('ViewContainerRef', () => {
           // DynamicComp, so the doCheck hook for DynamicComp should run upon ref.detectChanges().
           ref.changeDetectorRef.detectChanges();
           expect(dynamicComp.doCheckCount).toEqual(2);
-          expect((ref.changeDetectorRef as any).context).toEqual({});
+          expect((ref.changeDetectorRef as any).context).toBeNull();
         });
 
         it('should return ComponentRef that can retrieve component ChangeDetectorRef through its injector',

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component as _Component, ComponentFactoryResolver, ElementRef, EmbeddedViewRef, NgModuleRef, Pipe, PipeTransform, QueryList, RendererFactory2, TemplateRef, ViewContainerRef, createInjector, defineInjector, ɵAPP_ROOT as APP_ROOT, ɵNgModuleDef as NgModuleDef} from '../../src/core';
+import {ChangeDetectorRef, Component as _Component, ComponentFactoryResolver, ElementRef, EmbeddedViewRef, NgModuleRef, Pipe, PipeTransform, QueryList, RendererFactory2, TemplateRef, ViewContainerRef, createInjector, defineInjector, ɵAPP_ROOT as APP_ROOT, ɵNgModuleDef as NgModuleDef} from '../../src/core';
 import {ViewEncapsulation} from '../../src/metadata';
 import {AttributeMarker, NO_CHANGE, NgOnChangesFeature, defineComponent, defineDirective, definePipe, injectComponentFactoryResolver, load, query, queryRefresh} from '../../src/render3/index';
 
@@ -1033,6 +1033,72 @@ describe('ViewContainerRef', () => {
             .toEqual(
                 '<p vcref=""></p><embedded-cmp>foo</embedded-cmp><embedded-cmp>foo</embedded-cmp>');
         expect(templateExecutionCounter).toEqual(5);
+      });
+
+      describe('ComponentRef', () => {
+        let dynamicComp !: DynamicComp;
+
+        class AppComp {
+          constructor(public vcr: ViewContainerRef, public cfr: ComponentFactoryResolver) {}
+
+          static ngComponentDef = defineComponent({
+            type: AppComp,
+            selectors: [['app-comp']],
+            factory:
+                () => new AppComp(
+                    directiveInject(ViewContainerRef as any), injectComponentFactoryResolver()),
+            consts: 0,
+            vars: 0,
+            template: (rf: RenderFlags, cmp: AppComp) => {}
+          });
+        }
+
+        class DynamicComp {
+          doCheckCount = 0;
+
+          ngDoCheck() { this.doCheckCount++; }
+
+          static ngComponentDef = defineComponent({
+            type: DynamicComp,
+            selectors: [['dynamic-comp']],
+            factory: () => dynamicComp = new DynamicComp(),
+            consts: 0,
+            vars: 0,
+            template: (rf: RenderFlags, cmp: DynamicComp) => {}
+          });
+        }
+
+        it('should return ComponentRef with ChangeDetectorRef attached to root view', () => {
+          const fixture = new ComponentFixture(AppComp);
+
+          const dynamicCompFactory = fixture.component.cfr.resolveComponentFactory(DynamicComp);
+          const ref = fixture.component.vcr.createComponent(dynamicCompFactory);
+          fixture.update();
+          expect(dynamicComp.doCheckCount).toEqual(1);
+
+          // The change detector ref should be attached to the root view that contains
+          // DynamicComp, so the doCheck hook for DynamicComp should run upon ref.detectChanges().
+          ref.changeDetectorRef.detectChanges();
+          expect(dynamicComp.doCheckCount).toEqual(2);
+          expect((ref.changeDetectorRef as any).context).toEqual({});
+        });
+
+        it('should return ComponentRef that can retrieve component ChangeDetectorRef through its injector',
+           () => {
+             const fixture = new ComponentFixture(AppComp);
+
+             const dynamicCompFactory = fixture.component.cfr.resolveComponentFactory(DynamicComp);
+             const ref = fixture.component.vcr.createComponent(dynamicCompFactory);
+             fixture.update();
+             expect(dynamicComp.doCheckCount).toEqual(1);
+
+             // The injector should retrieve the change detector ref for DynamicComp. As such,
+             // the doCheck hook for DynamicComp should NOT run upon ref.detectChanges().
+             const changeDetector = ref.injector.get(ChangeDetectorRef);
+             changeDetector.detectChanges();
+             expect(dynamicComp.doCheckCount).toEqual(1);
+             expect(changeDetector.context).toEqual(dynamicComp);
+           });
       });
 
       class EmbeddedComponentWithNgContent {


### PR DESCRIPTION
This PR fixes the injector in component refs, reducing TestBed failures in `@angular/upgrade` from 307 to 235.