### PR TITLE
fix(router): respect matrix parameters when comparing exact active route

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -7,7 +7,7 @@
  */
 
 import {PRIMARY_OUTLET, ParamMap, Params, convertToParamMap} from './shared';
-import {forEach, shallowEqual} from './utils/collection';
+import {forEach, shallowEqual, shallowEqualArrays} from './utils/collection';
 
 export function createEmptyUrlTree() {
   return new UrlTree(new UrlSegmentGroup([], {}), {}, null);
@@ -16,16 +16,27 @@ export function createEmptyUrlTree() {
 export function containsTree(container: UrlTree, containee: UrlTree, exact: boolean): boolean {
   if (exact) {
     return equalQueryParams(container.queryParams, containee.queryParams) &&
-        equalSegmentGroups(container.root, containee.root);
+        equalSegmentGroups(container.root, containee.root) &&
+        equalMatrixParams(container.root, containee.root);
   }
 
-  return containsQueryParams(container.queryParams, containee.queryParams) &&
+  return containsParams(container.queryParams, containee.queryParams) &&
       containsSegmentGroup(container.root, containee.root);
 }
 
 function equalQueryParams(container: Params, containee: Params): boolean {
   // TODO: This does not handle array params correctly.
   return shallowEqual(container, containee);
+}
+
+function equalMatrixParams(container: UrlSegmentGroup, containee: UrlSegmentGroup): boolean {
+  const containerParams = container.children[PRIMARY_OUTLET] ?
+      container.children[PRIMARY_OUTLET].segments.map((s) => s.parameters) :
+      [];
+  const containeeParams = containee.children[PRIMARY_OUTLET] ?
+      containee.children[PRIMARY_OUTLET].segments.map((s) => s.parameters) :
+      [];
+  return shallowEqualArrays(containerParams, containeeParams);
 }
 
 function equalSegmentGroups(container: UrlSegmentGroup, containee: UrlSegmentGroup): boolean {
@@ -38,7 +49,7 @@ function equalSegmentGroups(container: UrlSegmentGroup, containee: UrlSegmentGro
   return true;
 }
 
-function containsQueryParams(container: Params, containee: Params): boolean {
+function containsParams(container: Params, containee: Params): boolean {
   // TODO: This does not handle array params correctly.
   return Object.keys(containee).length <= Object.keys(container).length &&
       Object.keys(containee).every(key => containee[key] === container[key]);

--- a/packages/router/test/url_tree.spec.ts
+++ b/packages/router/test/url_tree.spec.ts
@@ -35,6 +35,12 @@ describe('UrlTree', () => {
         expect(containsTree(t2, t1, true)).toBe(true);
       });
 
+      it('should return true for root', () => {
+        const t1 = serializer.parse('/');
+        const t2 = serializer.parse('/');
+        expect(containsTree(t1, t2, true)).toBe(true);
+      });
+
       it('should return true when queryParams are the same', () => {
         const t1 = serializer.parse('/one/two?test=1&page=5');
         const t2 = serializer.parse('/one/two?test=1&page=5');
@@ -69,6 +75,30 @@ describe('UrlTree', () => {
         const t1 = serializer.parse('/one/two');
         const t2 = serializer.parse('/one/two(right:three)');
         expect(containsTree(t1, t2, true)).toBe(false);
+      });
+
+      it('should return false when containee has an extra matrix param', () => {
+        const t1 = serializer.parse('/one/two');
+        const t2 = serializer.parse('/one;page=1/two');
+        expect(containsTree(t1, t2, true)).toBe(false);
+      });
+
+      it('should return false when containee has varying param', () => {
+        const t1 = serializer.parse('/one/two;page=4');
+        const t2 = serializer.parse('/one/two;page=1');
+        expect(containsTree(t1, t2, true)).toBe(false);
+      });
+
+      it('should return true when matrix params are identical', () => {
+        const t1 = serializer.parse('/one/two;page=4');
+        const t2 = serializer.parse('/one/two;page=4');
+        expect(containsTree(t1, t2, true)).toBe(true);
+      });
+
+      it('should return true when matrix params on lower levels are identical', () => {
+        const t1 = serializer.parse('/one;test=1/two;box=foo');
+        const t2 = serializer.parse('/one;test=1/two;box=foo');
+        expect(containsTree(t1, t2, true)).toBe(true);
       });
     });
 
@@ -143,6 +173,24 @@ describe('UrlTree', () => {
         const t1 = serializer.parse('/one/two?page=5');
         const t2 = serializer.parse('/one/two?page=5&test=1');
         expect(containsTree(t1, t2, false)).toBe(false);
+      });
+
+      it('should return true when matrix params are different', () => {
+        const t1 = serializer.parse('/one/two;page=2');
+        const t2 = serializer.parse('/one/two;page=4');
+        expect(containsTree(t1, t2, false)).toBe(true);
+      });
+
+      it('should return true when containee has more matrix params', () => {
+        const t1 = serializer.parse('/one/two');
+        const t2 = serializer.parse('/one/two;page=4');
+        expect(containsTree(t1, t2, false)).toBe(true);
+      });
+
+      it('should return true when containee has fewer matrix params', () => {
+        const t1 = serializer.parse('/one;test=box/two');
+        const t2 = serializer.parse('/one/two');
+        expect(containsTree(t1, t2, false)).toBe(true);
       });
     });
   });


### PR DESCRIPTION
Matrix parameters are compared for each URL segment if exact = true

Closes #19399

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, matrix parameters are ignored in the routerLinkActive mechanic, whether exact is true or false.

Issue Number: #19399
(There was discussion started by @ppham27 to make matrix params mismatch even when exact = false: #20698 )

## What is the new behavior?
If exact = false, the behavior is as-is, matrix params are ignored.
If exact = true, matrix params have to match at every level for two URL's to be equal. Matrix params from compared routes are extracted into a list of objects and compared using the library function shallowEqualArrays().

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The only case I can imagine breaking would be an "exact = true" URL comparison where BOTH query params and matrix params are used; with only query params being stateful, and matrix params being unstateful. 

## Other information

I'd be open to changing it as suggested in #20698 / #20699 -- this is a less-heavy-handed version of that change. Deeply thankful to @ppham27 for his contribution.
