### PR TITLE
fix(ivy): set encapsulation metadata

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -94,7 +94,13 @@ describe('compiler compliance: styling', () => {
            }
          };
 
-         const template = 'div.cool { color: blue; }", ":host.nice p { color: gold; }';
+         const template = `
+         MyComponent.ngComponentDef = $r3$.ɵdefineComponent({
+           …
+           styles: ["div.cool { color: blue; }", ":host.nice p { color: gold; }"],
+           encapsulation: 1
+         })
+         `;
          const result = compile(files, angularFiles);
          expectEmit(result.source, template, 'Incorrect template');
        });

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -269,6 +269,11 @@ export function compileComponentFromMetadata(
     definitionMap.set('styles', o.literalArr(strings));
   }
 
+  // Only set view encapsulation if it's not the default value
+  if (meta.encapsulation !== null && meta.encapsulation !== core.ViewEncapsulation.Emulated) {
+    definitionMap.set('encapsulation', o.literal(meta.encapsulation));
+  }
+
   // e.g. `animations: [trigger('123', [])]`
   if (meta.animations !== null) {
     definitionMap.set(


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We never set the `encapsulation` metadata that is extracted from the components by render3


## What is the new behavior?
The value is set and passed to the renderer

## Does this PR introduce a breaking change?
- [x] No
