### PR TITLE
test(ivy): fix paths for http tests to work with ivy

### DIFF
--- a/packages/common/http/test/BUILD.bazel
+++ b/packages/common/http/test/BUILD.bazel
@@ -19,9 +19,6 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
-    tags = [
-        "fixme-ivy-aot",
-    ],
     deps = [
         ":test_lib",
         "//tools/testing:node",
@@ -30,9 +27,6 @@ jasmine_node_test(
 
 ts_web_test_suite(
     name = "test_web",
-    tags = [
-        "fixme-ivy-aot",
-    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {HttpClient} from '@angular/common/http/src/client';
+import {HttpErrorResponse, HttpEventType, HttpResponse} from '@angular/common/http/src/response';
+import {HttpClientTestingBackend} from '@angular/common/http/testing/src/backend';
 import {ddescribe, describe, fit, it} from '@angular/core/testing/src/testing_internal';
 import {toArray} from 'rxjs/operators';
-
-import {HttpClient} from '../src/client';
-import {HttpErrorResponse, HttpEventType, HttpResponse} from '../src/response';
-import {HttpClientTestingBackend} from '../testing/src/backend';
 
 {
   describe('HttpClient', () => {

--- a/packages/common/http/test/headers_spec.ts
+++ b/packages/common/http/test/headers_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpHeaders} from '../src/headers';
+import {HttpHeaders} from '@angular/common/http/src/headers';
 
 {
   describe('HttpHeaders', () => {

--- a/packages/common/http/test/jsonp_spec.ts
+++ b/packages/common/http/test/jsonp_spec.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {JSONP_ERR_NO_CALLBACK, JSONP_ERR_WRONG_METHOD, JSONP_ERR_WRONG_RESPONSE_TYPE, JsonpClientBackend} from '@angular/common/http/src/jsonp';
+import {HttpRequest} from '@angular/common/http/src/request';
+import {HttpErrorResponse, HttpEventType} from '@angular/common/http/src/response';
 import {ddescribe, describe, it} from '@angular/core/testing/src/testing_internal';
 import {toArray} from 'rxjs/operators';
-
-import {JSONP_ERR_NO_CALLBACK, JSONP_ERR_WRONG_METHOD, JSONP_ERR_WRONG_RESPONSE_TYPE, JsonpClientBackend} from '../src/jsonp';
-import {HttpRequest} from '../src/request';
-import {HttpErrorResponse, HttpEventType} from '../src/response';
 
 import {MockDocument} from './jsonp_mock';
 

--- a/packages/common/http/test/module_spec.ts
+++ b/packages/common/http/test/module_spec.ts
@@ -6,19 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {HttpHandler} from '@angular/common/http/src/backend';
+import {HttpClient} from '@angular/common/http/src/client';
+import {HTTP_INTERCEPTORS, HttpInterceptor} from '@angular/common/http/src/interceptor';
+import {HttpRequest} from '@angular/common/http/src/request';
+import {HttpEvent, HttpResponse} from '@angular/common/http/src/response';
+import {HttpTestingController} from '@angular/common/http/testing/src/api';
+import {HttpClientTestingModule} from '@angular/common/http/testing/src/module';
+import {TestRequest} from '@angular/common/http/testing/src/request';
 import {Injectable, Injector} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
-
-import {HttpHandler} from '../src/backend';
-import {HttpClient} from '../src/client';
-import {HTTP_INTERCEPTORS, HttpInterceptor} from '../src/interceptor';
-import {HttpRequest} from '../src/request';
-import {HttpEvent, HttpResponse} from '../src/response';
-import {HttpTestingController} from '../testing/src/api';
-import {HttpClientTestingModule} from '../testing/src/module';
-import {TestRequest} from '../testing/src/request';
 
 class TestInterceptor implements HttpInterceptor {
   constructor(private value: string) {}

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpParams} from '../src/params';
+import {HttpParams} from '@angular/common/http/src/params';
 
 {
   describe('HttpUrlEncodedParams', () => {

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -6,11 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {HttpHeaders} from '@angular/common/http/src/headers';
+import {HttpParams} from '@angular/common/http/src/params';
+import {HttpRequest} from '@angular/common/http/src/request';
 import {ddescribe, describe, it} from '@angular/core/testing/src/testing_internal';
-
-import {HttpHeaders} from '../src/headers';
-import {HttpParams} from '../src/params';
-import {HttpRequest} from '../src/request';
 
 const TEST_URL = 'http://angular.io';
 const TEST_STRING = `I'm a body!`;

--- a/packages/common/http/test/response_spec.ts
+++ b/packages/common/http/test/response_spec.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {HttpHeaders} from '@angular/common/http/src/headers';
+import {HttpResponse} from '@angular/common/http/src/response';
 import {ddescribe, describe, it} from '@angular/core/testing/src/testing_internal';
-
-import {HttpHeaders} from '../src/headers';
-import {HttpResponse} from '../src/response';
 
 {
   describe('HttpResponse', () => {

--- a/packages/common/http/test/xhr_mock.ts
+++ b/packages/common/http/test/xhr_mock.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpHeaders} from '../src/headers';
-import {XhrFactory} from '../src/xhr';
+import {HttpHeaders} from '@angular/common/http/src/headers';
+import {XhrFactory} from '@angular/common/http/src/xhr';
 
 export class MockXhrFactory implements XhrFactory {
   // TODO(issue/24571): remove '!'.

--- a/packages/common/http/test/xhr_spec.ts
+++ b/packages/common/http/test/xhr_spec.ts
@@ -6,13 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {HttpRequest} from '@angular/common/http/src/request';
+import {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpResponse, HttpResponseBase, HttpUploadProgressEvent} from '@angular/common/http/src/response';
+import {HttpXhrBackend} from '@angular/common/http/src/xhr';
 import {ddescribe, describe, fit, it} from '@angular/core/testing/src/testing_internal';
 import {Observable} from 'rxjs';
 import {toArray} from 'rxjs/operators';
-
-import {HttpRequest} from '../src/request';
-import {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpResponse, HttpResponseBase, HttpUploadProgressEvent} from '../src/response';
-import {HttpXhrBackend} from '../src/xhr';
 
 import {MockXhrFactory} from './xhr_mock';
 

--- a/packages/common/http/test/xsrf_spec.ts
+++ b/packages/common/http/test/xsrf_spec.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpHeaders} from '../src/headers';
-import {HttpRequest} from '../src/request';
-import {HttpXsrfCookieExtractor, HttpXsrfInterceptor, HttpXsrfTokenExtractor} from '../src/xsrf';
+import {HttpHeaders} from '@angular/common/http/src/headers';
+import {HttpRequest} from '@angular/common/http/src/request';
+import {HttpXsrfCookieExtractor, HttpXsrfInterceptor, HttpXsrfTokenExtractor} from '@angular/common/http/src/xsrf';
 
-import {HttpClientTestingBackend} from '../testing/src/backend';
+import {HttpClientTestingBackend} from '@angular/common/http/testing/src/backend';
 
 class SampleTokenExtractor extends HttpXsrfTokenExtractor {
   constructor(private token: string|null) { super(); }

--- a/packages/http/test/BUILD.bazel
+++ b/packages/http/test/BUILD.bazel
@@ -18,7 +18,6 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
-    tags = ["fixme-ivy-aot"],
     deps = [
         ":test_lib",
         "//tools/testing:node",
@@ -27,7 +26,6 @@ jasmine_node_test(
 
 ts_web_test_suite(
     name = "test_web",
-    tags = ["fixme-ivy-aot"],
     deps = [
         ":test_lib",
         "@ngdeps//karma",

--- a/packages/http/test/http_spec.ts
+++ b/packages/http/test/http_spec.ts
@@ -10,11 +10,11 @@ import {Injector} from '@angular/core';
 import {TestBed, getTestBed} from '@angular/core/testing';
 import {AsyncTestCompleter, afterEach, beforeEach, describe, inject, it} from '@angular/core/testing/src/testing_internal';
 import {stringToArrayBuffer} from '@angular/http/src/http_utils';
+import {MockBackend, MockConnection} from '@angular/http/testing/src/mock_backend';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {Observable, zip} from 'rxjs';
 
 import {BaseRequestOptions, ConnectionBackend, Http, HttpModule, JSONPBackend, Jsonp, JsonpModule, Request, RequestMethod, RequestOptions, Response, ResponseContentType, ResponseOptions, URLSearchParams, XHRBackend} from '../index';
-import {MockBackend, MockConnection} from '../testing/src/mock_backend';
 
 {
   describe('injectables', () => {


### PR DESCRIPTION
This PR fixes paths for `common/http` and `http` and turns on the Ivy tests in CI.