### PR TITLE
build(docs-infra): upgrade cli command docs sources to 15367949c

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -18,7 +18,7 @@
     "build-for": "yarn ~~build --configuration",
     "prebuild-local": "yarn setup-local",
     "build-local": "yarn ~~build --configuration=stable",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js b50950b97",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 15367949c",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/b50950b97...15367949c):

**Modified**
- help/add.json
- help/build.json
- help/config.json
- help/e2e.json
- help/generate.json
- help/lint.json
- help/new.json
- help/run.json
- help/serve.json
- help/test.json
- help/update.json
- help/xi18n.json

Closes #27088
Closes #27110