### PR TITLE
fix(common): expose request url in network error

### DIFF
--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -232,10 +232,12 @@ export class HttpXhrBackend implements HttpBackend {
       // Connection timeout, DNS error, offline, etc. These are actual errors, and are
       // transmitted on the error channel.
       const onError = (error: ErrorEvent) => {
+        const {url} = partialFromXhr();
         const res = new HttpErrorResponse({
           error,
           status: xhr.status || 0,
           statusText: xhr.statusText || 'Unknown Error',
+          url: url || undefined,
         });
         observer.error(res);
       };

--- a/packages/common/http/test/xhr_spec.ts
+++ b/packages/common/http/test/xhr_spec.ts
@@ -142,6 +142,7 @@ const XSSI_PREFIX = ')]}\'\n';
       backend.handle(TEST_POST).subscribe(undefined, (err: HttpErrorResponse) => {
         expect(err instanceof HttpErrorResponse).toBe(true);
         expect(err.error instanceof Error);
+        expect(err.url).toBe('/test');
         done();
       });
       factory.mock.mockErrorEvent(new Error('blah'));


### PR DESCRIPTION
closes #27029

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #27029


## What is the new behavior?

Make `url` available in `HttpErrorResponse` when having network error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
