### PR TITLE
fix(ivy): consider providers for view/content queries

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -396,9 +396,6 @@ function searchTokensOnInjector<T>(
     previousTView: TView | null) {
   const currentTView = injectorView[TVIEW];
   const tNode = currentTView.data[injectorIndex + TNODE] as TNode;
-  const nodeFlags = tNode.flags;
-  const nodeProviderIndexes = tNode.providerIndexes;
-  const tInjectables = currentTView.data;
   // First, we step through providers
   let canAccessViewProviders = false;
   // We need to determine if view providers can be accessed by the starting element.
@@ -412,9 +409,35 @@ function searchTokensOnInjector<T>(
   // and check the host node of the current view to identify component views.
   if (previousTView == null && isComponent(tNode) && includeViewProviders ||
       previousTView != null && previousTView != currentTView &&
-          (currentTView.node == null || currentTView.node !.type === TNodeType.Element)) {
+          (currentTView.node == null || currentTView.node.type === TNodeType.Element)) {
     canAccessViewProviders = true;
   }
+  const injectableIdx =
+      locateDirectiveOrProvider(tNode, injectorView, token, canAccessViewProviders);
+  if (injectableIdx !== null) {
+    return getNodeInjectable(currentTView.data, injectorView, injectableIdx, tNode as TElementNode);
+  } else {
+    return NOT_FOUND;
+  }
+}
+
+/**
+ * Searches for the given token among the node's directives and providers.
+ *
+ * @param tNode TNode on which directives are present.
+ * @param view The view we are currently processing
+ * @param token Provider token or type of a directive to look for.
+ * @param canAccessViewProviders Whether view providers should be considered.
+ * @returns Index of a found directive or provider, or null when none found.
+ */
+export function locateDirectiveOrProvider<T>(
+    tNode: TNode, view: LViewData, token: Type<T>| InjectionToken<T>,
+    canAccessViewProviders: boolean): number|null {
+  const tView = view[TVIEW];
+  const nodeFlags = tNode.flags;
+  const nodeProviderIndexes = tNode.providerIndexes;
+  const tInjectables = tView.data;
+
   const startInjectables = nodeProviderIndexes & TNodeProviderIndexes.ProvidersStartIndexMask;
   const startDirectives = nodeFlags >> TNodeFlags.DirectiveStartingIndexShift;
   const cptViewProvidersCount =
@@ -426,10 +449,10 @@ function searchTokensOnInjector<T>(
     const providerTokenOrDef = tInjectables[i] as InjectionToken<any>| Type<any>| DirectiveDef<any>;
     if (i < startDirectives && token === providerTokenOrDef ||
         i >= startDirectives && (providerTokenOrDef as DirectiveDef<any>).type === token) {
-      return getNodeInjectable(tInjectables, injectorView, i, tNode as TElementNode);
+      return i;
     }
   }
-  return NOT_FOUND;
+  return null;
 }
 
 /**

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -243,19 +243,6 @@ function getIdxOfMatchingSelector(tNode: TNode, selector: string): number|null {
   return null;
 }
 
-/**
- * Attempts to find the directive or provider of a given type on the given node and returns the
- * index, or null if not found.
- *
- * @param tNode TNode on which directives are present.
- * @param currentView The view we are currently processing
- * @param type Type of a directive to look for.
- * @returns Index of a found directive or null when none found.
- */
-function getIdxOfMatchingDirective(tNode: TNode, currentView: LViewData, type: Type<any>): number|
-    null {
-  return locateDirectiveOrProvider(tNode, currentView, type, false);
-}
 
 // TODO: "read" should be an AbstractType (FW-486)
 function queryByReadToken(read: any, tNode: TNode, currentView: LViewData): any {
@@ -263,7 +250,7 @@ function queryByReadToken(read: any, tNode: TNode, currentView: LViewData): any 
   if (typeof factoryFn === 'function') {
     return factoryFn();
   } else {
-    const matchingIdx = getIdxOfMatchingDirective(tNode, currentView, read as Type<any>);
+    const matchingIdx = locateDirectiveOrProvider(tNode, currentView, read as Type<any>, false);
     if (matchingIdx !== null) {
       return getNodeInjectable(
           currentView[TVIEW].data, currentView, matchingIdx, tNode as TElementNode);
@@ -317,7 +304,7 @@ function add(
       if (type === ViewEngine_TemplateRef) {
         result = queryByTemplateRef(type, tNode, currentView, predicate.read);
       } else {
-        const matchingIdx = getIdxOfMatchingDirective(tNode, currentView, type);
+        const matchingIdx = locateDirectiveOrProvider(tNode, currentView, type, false);
         if (matchingIdx !== null) {
           result = queryRead(tNode, currentView, predicate.read, matchingIdx);
         }

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -930,6 +930,9 @@
     "name": "loadContext"
   },
   {
+    "name": "locateDirectiveOrProvider"
+  },
+  {
     "name": "locateHostElement"
   },
   {

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -1101,6 +1101,9 @@
     "name": "leaveView"
   },
   {
+    "name": "locateDirectiveOrProvider"
+  },
+  {
     "name": "locateHostElement"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -948,6 +948,9 @@
     "name": "loadInternal"
   },
   {
+    "name": "locateDirectiveOrProvider"
+  },
+  {
     "name": "locateHostElement"
   },
   {

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -2199,6 +2199,9 @@
     "name": "localeEn"
   },
   {
+    "name": "locateDirectiveOrProvider"
+  },
+  {
     "name": "locateHostElement"
   },
   {

--- a/packages/core/test/render3/providers_spec.ts
+++ b/packages/core/test/render3/providers_spec.ts
@@ -1298,7 +1298,7 @@ function expectProvidersScenario(defs: {
   }
 
   class ViewChildDirective {
-    static ngComponentDef = defineDirective({
+    static ngDirectiveDef = defineDirective({
       type: ViewChildDirective,
       selectors: [['view-child']],
       factory: () => testDirectiveInjection(defs.viewChild, new ViewChildDirective()),
@@ -1325,7 +1325,7 @@ function expectProvidersScenario(defs: {
   }
 
   class ContentChildDirective {
-    static ngComponentDef = defineDirective({
+    static ngDirectiveDef = defineDirective({
       type: ContentChildDirective,
       selectors: [['content-child']],
       factory: () => testDirectiveInjection(defs.contentChild, new ContentChildDirective()),
@@ -1353,7 +1353,7 @@ function expectProvidersScenario(defs: {
   }
 
   class ParentDirective {
-    static ngComponentDef = defineDirective({
+    static ngDirectiveDef = defineDirective({
       type: ParentDirective,
       selectors: [['parent']],
       factory: () => testDirectiveInjection(defs.parent, new ParentDirective()),
@@ -1362,7 +1362,7 @@ function expectProvidersScenario(defs: {
   }
 
   class ParentDirective2 {
-    static ngComponentDef = defineDirective({
+    static ngDirectiveDef = defineDirective({
       type: ParentDirective2,
       selectors: [['parent']],
       factory: () => testDirectiveInjection(defs.parent, new ParentDirective2()),

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -215,9 +215,9 @@ describe('query', () => {
       class MyDirective {
         constructor(public service: Service) {}
 
-        static ngComponentDef = defineDirective({
+        static ngDirectiveDef = defineDirective({
           type: MyDirective,
-          selectors: [['myDir']],
+          selectors: [['', 'myDir', '']],
           factory: function MyDirective_Factory() {
             return directive = new MyDirective(directiveInject(Service));
           },
@@ -251,7 +251,7 @@ describe('query', () => {
             factory: function App_Factory() { return new App(); },
             template: function App_Template(rf: RenderFlags, ctx: App) {
               if (rf & RenderFlags.Create) {
-                element(3, 'myDir', ['myDir']);
+                element(3, 'div', ['myDir']);
               }
             },
             viewQuery: function(rf: RenderFlags, ctx: App) {
@@ -296,7 +296,7 @@ describe('query', () => {
             factory: function App_Factory() { return new App(); },
             template: function App_Template(rf: RenderFlags, ctx: App) {
               if (rf & RenderFlags.Create) {
-                element(1, 'myDir', ['myDir']);
+                element(1, 'div', ['myDir']);
               }
             },
             viewQuery: function(rf: RenderFlags, ctx: App) {

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -10,9 +10,9 @@ import {NgForOfContext} from '@angular/common';
 import {ElementRef, TemplateRef, ViewContainerRef} from '@angular/core';
 
 import {EventEmitter} from '../..';
-
-import {AttributeMarker, QueryList, defineComponent, defineDirective, detectChanges} from '../../src/render3/index';
+import {AttributeMarker, ProvidersFeature, QueryList, defineComponent, defineDirective, detectChanges} from '../../src/render3/index';
 import {getNativeByIndex} from '../../src/render3/util';
+
 import {bind, container, containerRefreshEnd, containerRefreshStart, directiveInject, element, elementContainerEnd, elementContainerStart, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, load, loadQueryList, reference, registerContentQuery, template, text} from '../../src/render3/instructions';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {query, queryRefresh} from '../../src/render3/query';
@@ -203,6 +203,119 @@ describe('query', () => {
         const qList = (cmptInstance.query as QueryList<any>);
         expect(qList.length).toBe(0);
       });
+    });
+
+    describe('providers', () => {
+
+      class Service {}
+      class Alias {}
+
+      let directive: MyDirective|null = null;
+
+      class MyDirective {
+        constructor(public service: Service) {}
+
+        static ngComponentDef = defineDirective({
+          type: MyDirective,
+          selectors: [['myDir']],
+          factory: function MyDirective_Factory() {
+            return directive = new MyDirective(directiveInject(Service));
+          },
+          features: [ProvidersFeature([Service, {provide: Alias, useExisting: Service}])],
+        });
+      }
+
+      beforeEach(() => directive = null);
+
+      // https://stackblitz.com/edit/ng-viewengine-viewchild-providers?file=src%2Fapp%2Fapp.component.ts
+      it('should query for providers that are present on a directive', () => {
+
+        /**
+         * <div myDir></div>
+         * class App {
+         *  @ViewChild(MyDirective) directive: MyDirective;
+         *  @ViewChild(Service) service: Service;
+         *  @ViewChild(Alias) alias: Alias;
+         * }
+         */
+        class App {
+          directive?: MyDirective;
+          service?: Service;
+          alias?: Alias;
+
+          static ngComponentDef = defineComponent({
+            type: App,
+            selectors: [['app']],
+            consts: 4,
+            vars: 0,
+            factory: function App_Factory() { return new App(); },
+            template: function App_Template(rf: RenderFlags, ctx: App) {
+              if (rf & RenderFlags.Create) {
+                element(3, 'myDir', ['myDir']);
+              }
+            },
+            viewQuery: function(rf: RenderFlags, ctx: App) {
+              let tmp: any;
+              if (rf & RenderFlags.Create) {
+                query(0, MyDirective, false);
+                query(1, Service, false);
+                query(2, Alias, false);
+              }
+              if (rf & RenderFlags.Update) {
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.directive = tmp.first);
+                queryRefresh(tmp = load<QueryList<any>>(1)) && (ctx.service = tmp.first);
+                queryRefresh(tmp = load<QueryList<any>>(2)) && (ctx.alias = tmp.first);
+              }
+            },
+            directives: [MyDirective]
+          });
+        }
+
+        const componentFixture = new ComponentFixture(App);
+        expect(componentFixture.component.directive).toBe(directive !);
+        expect(componentFixture.component.service).toBe(directive !.service);
+        expect(componentFixture.component.alias).toBe(directive !.service);
+      });
+
+      it('should resolve a provider if given as read token', () => {
+
+        /**
+         * <div myDir></div>
+         * class App {
+         *  @ViewChild(MyDirective, {read: Alias}}) service: Service;
+         * }
+         */
+        class App {
+          service?: Service;
+
+          static ngComponentDef = defineComponent({
+            type: App,
+            selectors: [['app']],
+            consts: 2,
+            vars: 0,
+            factory: function App_Factory() { return new App(); },
+            template: function App_Template(rf: RenderFlags, ctx: App) {
+              if (rf & RenderFlags.Create) {
+                element(1, 'myDir', ['myDir']);
+              }
+            },
+            viewQuery: function(rf: RenderFlags, ctx: App) {
+              let tmp: any;
+              if (rf & RenderFlags.Create) {
+                query(0, MyDirective, false, Alias);
+              }
+              if (rf & RenderFlags.Update) {
+                queryRefresh(tmp = load<QueryList<any>>(0)) && (ctx.service = tmp.first);
+              }
+            },
+            directives: [MyDirective]
+          });
+        }
+
+        const componentFixture = new ComponentFixture(App);
+        expect(componentFixture.component.service).toBe(directive !.service);
+      });
+
     });
 
     describe('local names', () => {

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -2235,7 +2235,7 @@ describe('query', () => {
         this.contentCheckedQuerySnapshot = this.foos ? this.foos.length : 0;
       }
 
-      static ngComponentDef = defineDirective({
+      static ngDirectiveDef = defineDirective({
         type: WithContentDirective,
         selectors: [['', 'with-content', '']],
         factory: () => new WithContentDirective(),


### PR DESCRIPTION
In ViewEngine it is possible to query for a token that is provided by
a directive that is in scope. See StackBlitz for example:
https://stackblitz.com/edit/ng-viewengine-viewchild-providers

Material uses this pattern with its `MatFormFieldControl` setup, see
https://bit.ly/2zgCUxD for documentation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In Ivy, querying for providers will fail to resolve.

## What is the new behavior?

Providers are taken into account during querying.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This adds support on par with ViewEngine [to support Materials's `MatFormFieldControl` setup](https://bit.ly/2zgCUxD). Standalone example [provided on StackBlitz](https://stackblitz.com/edit/ng-viewengine-viewchild-providers).