### PR TITLE
fix(ivy): compile animations into correct data key

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -139,7 +139,7 @@ describe('compiler compliance: styling', () => {
           template:  function MyComponent_Template(rf, $ctx$) {
           },
           data: {
-            animations: [{name: 'foo123'}, {name: 'trigger123'}]
+            animation: [{name: 'foo123'}, {name: 'trigger123'}]
           }
         });
       `;
@@ -180,7 +180,7 @@ describe('compiler compliance: styling', () => {
           template:  function MyComponent_Template(rf, $ctx$) {
           },
           data: {
-            animations: []
+            animation: []
           }
         });
       `;

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -303,7 +303,7 @@ export function compileComponentFromMetadata(
   // e.g. `animations: [trigger('123', [])]`
   if (meta.animations !== null) {
     definitionMap.set(
-        'data', o.literalMap([{key: 'animations', value: meta.animations, quoted: false}]));
+        'data', o.literalMap([{key: 'animation', value: meta.animations, quoted: false}]));
   }
 
   // On the type side, remove newlines from the selector as it will need to fit into a TypeScript

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -1772,7 +1772,7 @@ describe('render3 integration test', () => {
           consts: 0,
           vars: 0,
           data: {
-            animations: [
+            animation: [
               animA,
               animB,
             ],
@@ -1785,7 +1785,7 @@ describe('render3 integration test', () => {
       const rendererFactory = new ProxyRenderer3Factory();
       new ComponentFixture(AnimComp, {rendererFactory});
 
-      const capturedAnimations = rendererFactory.lastCapturedType !.data !['animations'];
+      const capturedAnimations = rendererFactory.lastCapturedType !.data !['animation'];
       expect(Array.isArray(capturedAnimations)).toBeTruthy();
       expect(capturedAnimations.length).toEqual(2);
       expect(capturedAnimations).toContain(animA);


### PR DESCRIPTION
The old ViewCompiler uses 'animation' as key, not 'animations'. The
animations renderer infrastructure will kick in if the 'animation' key
is present as component data, so this commit causes the runtime to use
the animation renderer now.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Ivy compiler produces animations data under a different key as compared to ViewCompiler:

https://github.com/angular/angular/blob/81e975ad93bee06a80841f3e50b3d5879a05a1da/packages/compiler/src/view_compiler/view_compiler.ts#L46-L49

## What is the new behavior?

The Ivy compiler uses the same data key for animations as the ViewCompiler does.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information