### PR TITLE
fix(ivy): don't update parent pointers in the ivy switch transform

### DIFF
--- a/packages/compiler-cli/src/ngtsc/switch/src/switch.ts
+++ b/packages/compiler-cli/src/ngtsc/switch/src/switch.ts
@@ -120,9 +120,6 @@ function flipIvySwitchesInVariableStatement(
         /* name */ decl.name,
         /* type */ decl.type,
         /* initializer */ newIdentifier);
-
-    // Keeping parent pointers up to date is important for emit.
-    newIdentifier.parent = newDeclarations[i];
   }
 
   const newDeclList = ts.updateVariableDeclarationList(
@@ -134,12 +131,6 @@ function flipIvySwitchesInVariableStatement(
       /* modifiers */ stmt.modifiers,
       /* declarationList */ newDeclList);
 
-  // Keeping parent pointers up to date is important for emit.
-  for (const decl of newDeclarations) {
-    decl.parent = newDeclList;
-  }
-  newDeclList.parent = newStmt;
-  newStmt.parent = stmt.parent;
   return newStmt;
 }
 


### PR DESCRIPTION
Now that the Ivy switch transform uses ts.getMutableClone() to copy
statements, there's no need to set .parent pointers on the resulting
updated nodes. Doing this was causing assertion failures deep in
TypeScript in some cases.
