### PR TITLE
set encapsulation to `None` when there is no style / set `ng-version` attribute on root component

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -427,7 +427,8 @@ describe('compiler compliance', () => {
                 $r3$.ɵelementClassProp(0, 0, ctx.error);
                 $r3$.ɵelementStylingApply(0);
               }
-            }
+            },
+            encapsulation: 2
         });
       `;
 
@@ -474,7 +475,8 @@ describe('compiler compliance', () => {
             if (rf & 1) {
               $r3$.ɵtext(0, "child-view");
             }
-          }
+          },
+          encapsulation: 2
         });`;
 
       // SomeDirective definition should be:
@@ -502,7 +504,8 @@ describe('compiler compliance', () => {
               $r3$.ɵtext(1, "!");
             }
           },
-          directives: [ChildComponent, SomeDirective]
+          directives: [ChildComponent, SomeDirective],
+          encapsulation: 2
         });
       `;
 
@@ -591,7 +594,8 @@ describe('compiler compliance', () => {
           },
           consts: 0,
           vars: 0,
-          template:  function MyComponent_Template(rf, ctx) {}
+          template:  function MyComponent_Template(rf, ctx) {},
+          encapsulation: 2
         });`;
 
          const result = compile(files, angularFiles);
@@ -660,7 +664,8 @@ describe('compiler compliance', () => {
               $r3$.ɵelementEnd();
             }
           },
-          directives:[IfDirective]
+          directives:[IfDirective],
+           encapsulation: 2
         });`;
 
       const result = compile(files, angularFiles);
@@ -723,7 +728,8 @@ describe('compiler compliance', () => {
                 $r3$.ɵelementProperty(0, "names", $r3$.ɵbind($r3$.ɵpureFunction1(1, $e0_ff$, ctx.customName)));
               }
             },
-           directives: [MyComp]
+           directives: [MyComp],
+           encapsulation: 2
           });
         `;
 
@@ -806,7 +812,8 @@ describe('compiler compliance', () => {
                     $r3$.ɵbind($r3$.ɵpureFunctionV(1, $e0_ff$, [ctx.n0, ctx.n1, ctx.n2, ctx.n3, ctx.n4, ctx.n5, ctx.n6, ctx.n7, ctx.n8])));
               }
             },
-            directives: [MyComp]
+            directives: [MyComp],
+            encapsulation: 2
           });
         `;
 
@@ -867,7 +874,8 @@ describe('compiler compliance', () => {
                 $r3$.ɵelementProperty(0, "config", $r3$.ɵbind($r3$.ɵpureFunction1(1, $e0_ff$, ctx.name)));
               }
             },
-            directives: [ObjectComp]
+            directives: [ObjectComp],
+            encapsulation: 2
           });
         `;
 
@@ -936,7 +944,8 @@ describe('compiler compliance', () => {
                     $r3$.ɵbind($r3$.ɵpureFunction2(5, $e0_ff_2$, ctx.name, $r3$.ɵpureFunction1(3, $e0_ff_1$, $r3$.ɵpureFunction1(1, $e0_ff$, ctx.duration)))));
               }
             },
-            directives: [NestedComp]
+            directives: [NestedComp],
+            encapsulation: 2
           });
         `;
 
@@ -991,7 +1000,8 @@ describe('compiler compliance', () => {
               $r3$.ɵprojection(1);
               $r3$.ɵelementEnd();
             }
-          }
+          },
+          encapsulation: 2
         });`;
 
       const ComplexComponentDefinition = `
@@ -1016,7 +1026,8 @@ describe('compiler compliance', () => {
               $r3$.ɵprojection(3, 2);
               $r3$.ɵelementEnd();
             }
-          }
+          },
+          encapsulation: 2
         });
       `;
 
@@ -1088,7 +1099,8 @@ describe('compiler compliance', () => {
                 $r3$.ɵelement(1, "div", $e0_attrs$);
               }
             },
-            directives: function () { return [SomeDirective]; }
+            directives: function () { return [SomeDirective]; },
+            encapsulation: 2
           });`;
 
         const result = compile(files, angularFiles);
@@ -1267,7 +1279,8 @@ describe('compiler compliance', () => {
                 $r3$.ɵprojection(1);
                 $r3$.ɵelementEnd();
               }
-            }
+            },
+            encapsulation: 2
           });`;
 
         const result = compile(files, angularFiles);
@@ -1468,7 +1481,8 @@ describe('compiler compliance', () => {
                   $r3$.ɵtextBinding(4, $r3$.ɵinterpolation1("", $r3$.ɵpipeBindV(5, 8, $r3$.ɵpureFunction1(15, $c0$, ctx.name)), ""));
                 }
               },
-              pipes: [MyPurePipe, MyPipe]
+              pipes: [MyPurePipe, MyPipe],
+              encapsulation: 2
             });`;
 
         const result = compile(files, angularFiles);
@@ -1536,7 +1550,8 @@ describe('compiler compliance', () => {
                   ));
                 }
               },
-              pipes: [MyPipe]
+              pipes: [MyPipe],
+              encapsulation: 2
             });`;
 
         const result = compile(files, angularFiles);
@@ -1579,7 +1594,8 @@ describe('compiler compliance', () => {
               const $user$ = $r3$.ɵreference(1);
               $r3$.ɵtextBinding(2, $r3$.ɵinterpolation1("Hello ", $user$.value, "!"));
             }
-          }
+          },
+          encapsulation: 2
         });
       `;
 
@@ -1675,7 +1691,8 @@ describe('compiler compliance', () => {
               $r3$.ɵtextBinding(2, $r3$.ɵinterpolation1(" ", $foo$, " "));
             }
           },
-          directives:[IfDirective]
+          directives:[IfDirective],
+          encapsulation: 2
         });`;
 
       const result = compile(files, angularFiles);
@@ -1809,7 +1826,8 @@ describe('compiler compliance', () => {
             features: [$r3$.ɵNgOnChangesFeature],
             consts: 0,
             vars: 0,
-            template:  function LifecycleComp_Template(rf, ctx) {}
+            template:  function LifecycleComp_Template(rf, ctx) {},
+            encapsulation: 2
           });`;
 
         const SimpleLayoutDefinition = `
@@ -1829,7 +1847,8 @@ describe('compiler compliance', () => {
                 $r3$.ɵelementProperty(1, "name", $r3$.ɵbind(ctx.name2));
               }
             },
-            directives: [LifecycleComp]
+            directives: [LifecycleComp],
+           encapsulation: 2
           });`;
 
         const result = compile(files, angularFiles);
@@ -1957,7 +1976,8 @@ describe('compiler compliance', () => {
                   }
                   if (rf & 2) { $r3$.ɵelementProperty(1,"forOf",$r3$.ɵbind(ctx.items)); }
                 },
-                directives: function() { return [ForOfDirective]; }
+                directives: function() { return [ForOfDirective]; },
+                encapsulation: 2
               });
             `;
 
@@ -2036,7 +2056,8 @@ describe('compiler compliance', () => {
                 $r3$.ɵelementProperty(1, "forOf", $r3$.ɵbind(ctx.items));
               }
             },
-            directives: function() { return [ForOfDirective]; }
+            directives: function() { return [ForOfDirective]; },
+            encapsulation: 2
           });
         `;
 
@@ -2135,7 +2156,8 @@ describe('compiler compliance', () => {
                 $r3$.ɵelementProperty(1, "forOf", $r3$.ɵbind(ctx.items));
               }
             },
-            directives: function () { return [ForOfDirective]; }
+            directives: function () { return [ForOfDirective]; },
+            encapsulation: 2
           });`;
 
         const result = compile(files, angularFiles);

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -194,7 +194,8 @@ describe('compiler compliance: bindings', () => {
           hostVars: 3,
           consts: 0,
           vars: 0,
-          template: function HostBindingComp_Template(rf, ctx) {}
+          template: function HostBindingComp_Template(rf, ctx) {},
+          encapsulation: 2
         });
       `;
 

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_directives_spec.ts
@@ -48,7 +48,8 @@ describe('compiler compliance: directives', () => {
                     if (rf & 1) {
                         $r3$.ɵelement(0, "div");
                     }
-                }
+                },
+                encapsulation: 2
             });
         `;
 
@@ -93,7 +94,8 @@ describe('compiler compliance: directives', () => {
                     if (rf & 1) {
                         $r3$.ɵelement(0, "div");
                     }
-                }
+                },
+                encapsulation: 2
             });
         `;
 
@@ -141,7 +143,8 @@ describe('compiler compliance: directives', () => {
                         }
                     },
                     …
-                    directives: [SomeDirective]
+                    directives: [SomeDirective],
+                    encapsulation: 2
                 });
             `;
 
@@ -189,7 +192,8 @@ describe('compiler compliance: directives', () => {
                         }
                     },
                     …
-                    directives: [SomeDirective]
+                    directives: [SomeDirective],
+                    encapsulation: 2
                 });
             `;
 
@@ -233,7 +237,8 @@ describe('compiler compliance: directives', () => {
                         }
                     },
                     …
-                    directives: [SomeDirective]
+                    directives: [SomeDirective],
+                    encapsulation: 2
                 });
             `;
 
@@ -283,7 +288,8 @@ describe('compiler compliance: directives', () => {
                         }
                     },
                     …
-                    directives: [SomeDirective]
+                    directives: [SomeDirective],
+                    encapsulation: 2
                 });
             `;
 

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_listener_spec.ts
@@ -217,7 +217,8 @@ describe('compiler compliance: listen()', () => {
               $r3$.ɵelementEnd();
               $r3$.ɵelement(2, "input", null, $e2_refs$);
             }
-          }
+          },
+          encapsulation: 2
         });
       `;
 

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -138,6 +138,7 @@ describe('compiler compliance: styling', () => {
           vars: 0,
           template:  function MyComponent_Template(rf, $ctx$) {
           },
+          encapsulation: 2,
           data: {
             animations: [{name: 'foo123'}, {name: 'trigger123'}]
           }
@@ -179,6 +180,7 @@ describe('compiler compliance: styling', () => {
           vars: 0,
           template:  function MyComponent_Template(rf, $ctx$) {
           },
+          encapsulation: 2,
           data: {
             animations: []
           }
@@ -227,7 +229,8 @@ describe('compiler compliance: styling', () => {
             if (rf & 2) {
               $r3$.ɵelementAttribute(0, "@foo", $r3$.ɵbind(ctx.exp));
             }
-          }
+          },
+          encapsulation: 2
         });
       `;
 
@@ -327,7 +330,8 @@ describe('compiler compliance: styling', () => {
                   $r3$.ɵelementStylingApply(0);
                   $r3$.ɵelementAttribute(0, "style", $r3$.ɵbind("border-width: 10px"), $r3$.ɵsanitizeStyle);
                 }
-              }
+              },
+              encapsulation: 2
             });
         `;
 
@@ -382,7 +386,8 @@ describe('compiler compliance: styling', () => {
                 $r3$.ɵelementStyleProp(0, 0, ctx.myImage);
                 $r3$.ɵelementStylingApply(0);
               }
-            }
+            },
+            encapsulation: 2
           });
         `;
 
@@ -523,7 +528,8 @@ describe('compiler compliance: styling', () => {
                   $r3$.ɵelementStylingApply(0);
                   $r3$.ɵelementAttribute(0, "class", $r3$.ɵbind("banana"));
                 }
-              }
+              },
+              encapsulation: 2
             });
         `;
 
@@ -576,7 +582,8 @@ describe('compiler compliance: styling', () => {
                   $r3$.ɵelementAttribute(0, "class", $r3$.ɵbind("round"));
                   $r3$.ɵelementAttribute(0, "style", $r3$.ɵbind("height:100px"), $r3$.ɵsanitizeStyle);
                 }
-              }
+              },
+              encapsulation: 2
             });
         `;
 

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -286,6 +286,10 @@ export function compileComponentFromMetadata(
     definitionMap.set('pipes', pipesExpr);
   }
 
+  if (meta.encapsulation === null) {
+    meta.encapsulation = core.ViewEncapsulation.Emulated;
+  }
+
   // e.g. `styles: [str1, str2]`
   if (meta.styles && meta.styles.length) {
     const styleValues = meta.encapsulation == core.ViewEncapsulation.Emulated ?
@@ -293,10 +297,13 @@ export function compileComponentFromMetadata(
         meta.styles;
     const strings = styleValues.map(str => o.literal(str));
     definitionMap.set('styles', o.literalArr(strings));
+  } else if (meta.encapsulation === core.ViewEncapsulation.Emulated) {
+    // If there is no style, don't generate css selectors on elements
+    meta.encapsulation = core.ViewEncapsulation.None;
   }
 
   // Only set view encapsulation if it's not the default value
-  if (meta.encapsulation !== null && meta.encapsulation !== core.ViewEncapsulation.Emulated) {
+  if (meta.encapsulation !== core.ViewEncapsulation.Emulated) {
     definitionMap.set('encapsulation', o.literal(meta.encapsulation));
   }
 

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -16,16 +16,16 @@ import {ElementRef as viewEngine_ElementRef} from '../linker/element_ref';
 import {NgModuleRef as viewEngine_NgModuleRef} from '../linker/ng_module_factory';
 import {RendererFactory2} from '../render/api';
 import {Type} from '../type';
-
+import {VERSION} from '../version';
 import {assertComponentType, assertDefined} from './assert';
 import {LifecycleHooksFeature, createRootComponent, createRootComponentView, createRootContext} from './component';
 import {getComponentDef} from './definition';
 import {NodeInjector} from './di';
 import {createLViewData, createNodeAtIndex, createTView, createViewNode, elementCreate, locateHostElement, refreshDescendantViews} from './instructions';
 import {ComponentDef, RenderFlags} from './interfaces/definition';
-import {TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeType, TViewNode} from './interfaces/node';
-import {RElement, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
-import {FLAGS, HEADER_OFFSET, INJECTOR, LViewData, LViewFlags, RootContext, TVIEW} from './interfaces/view';
+import {TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeType} from './interfaces/node';
+import {RElement, RendererFactory3, domRendererFactory3, isProceduralRenderer} from './interfaces/renderer';
+import {HEADER_OFFSET, LViewData, LViewFlags, RootContext, TVIEW} from './interfaces/view';
 import {enterView, leaveView} from './state';
 import {defaultScheduler, getTNode} from './util';
 import {createElementRef} from './view_engine_compatibility';
@@ -141,6 +141,14 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
     const renderer = rendererFactory.createRenderer(hostRNode, this.componentDef);
     const rootViewInjector =
         ngModule ? createChainedInjector(injector, ngModule.injector) : injector;
+
+    if (rootSelectorOrNode && hostRNode) {
+      ngDevMode && ngDevMode.rendererSetAttribute++;
+      isProceduralRenderer(renderer) ?
+          renderer.setAttribute(hostRNode, 'ng-version', VERSION.full) :
+          hostRNode.setAttribute('ng-version', VERSION.full);
+    }
+
     // Create the root view. Uses empty TView and ContentTemplate.
     const rootView: LViewData = createLViewData(
         renderer, createTView(-1, null, 1, 0, null, null, null), rootContext, rootFlags, undefined,

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -441,6 +441,9 @@
     "name": "UnsubscriptionErrorImpl"
   },
   {
+    "name": "VERSION"
+  },
+  {
     "name": "VIEWS"
   },
   {

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -927,6 +927,9 @@
     "name": "VALID_ELEMENTS"
   },
   {
+    "name": "VERSION"
+  },
+  {
     "name": "VIEWS"
   },
   {

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -539,32 +539,29 @@ class HiddenModule {
       });
       afterEach(() => { expect(called).toBe(true); });
 
-      fixmeIvy('to investigate') &&
-          it('using long form should work', async(() => {
-               const platform =
-                   platformDynamicServer([{provide: INITIAL_CONFIG, useValue: {document: doc}}]);
+      it('using long form should work', async(() => {
+           const platform =
+               platformDynamicServer([{provide: INITIAL_CONFIG, useValue: {document: doc}}]);
 
-               platform.bootstrapModule(AsyncServerModule)
-                   .then((moduleRef) => {
-                     const applicationRef: ApplicationRef = moduleRef.injector.get(ApplicationRef);
-                     return applicationRef.isStable.pipe(first((isStable: boolean) => isStable))
-                         .toPromise();
-                   })
-                   .then((b) => {
-                     expect(platform.injector.get(PlatformState).renderToString())
-                         .toBe(expectedOutput);
-                     platform.destroy();
-                     called = true;
-                   });
-             }));
-
-      fixmeIvy('to investigate') &&
-          it('using renderModule should work', async(() => {
-               renderModule(AsyncServerModule, {document: doc}).then(output => {
-                 expect(output).toBe(expectedOutput);
+           platform.bootstrapModule(AsyncServerModule)
+               .then((moduleRef) => {
+                 const applicationRef: ApplicationRef = moduleRef.injector.get(ApplicationRef);
+                 return applicationRef.isStable.pipe(first((isStable: boolean) => isStable))
+                     .toPromise();
+               })
+               .then((b) => {
+                 expect(platform.injector.get(PlatformState).renderToString()).toBe(expectedOutput);
+                 platform.destroy();
                  called = true;
                });
-             }));
+         }));
+
+      it('using renderModule should work', async(() => {
+           renderModule(AsyncServerModule, {document: doc}).then(output => {
+             expect(output).toBe(expectedOutput);
+             called = true;
+           });
+         }));
 
       it('using renderModuleFactory should work',
          async(inject([PlatformRef], (defaultPlatform: PlatformRef) => {
@@ -609,14 +606,13 @@ class HiddenModule {
          }));
 
 
-      fixmeIvy('to investigate') &&
-          it('sets a prefix for the _nghost and _ngcontent attributes', async(() => {
-               renderModule(ExampleStylesModule, {document: doc}).then(output => {
-                 expect(output).toMatch(
-                     /<html><head><style ng-transition="example-styles">div\[_ngcontent-sc\d+\] {color: blue; } \[_nghost-sc\d+\] { color: red; }<\/style><\/head><body><app _nghost-sc\d+="" ng-version="0.0.0-PLACEHOLDER"><div _ngcontent-sc\d+="">Works!<\/div><\/app><\/body><\/html>/);
-                 called = true;
-               });
-             }));
+      it('sets a prefix for the _nghost and _ngcontent attributes', async(() => {
+           renderModule(ExampleStylesModule, {document: doc}).then(output => {
+             expect(output).toMatch(
+                 /<html><head><style ng-transition="example-styles">div\[_ngcontent-sc\d+\] {color: blue; } \[_nghost-sc\d+\] { color: red; }<\/style><\/head><body><app _nghost-sc\d+="" ng-version="0.0.0-PLACEHOLDER"><div _ngcontent-sc\d+="">Works!<\/div><\/app><\/body><\/html>/);
+             called = true;
+           });
+         }));
 
       fixmeIvy('to investigate') &&
           it('should handle false values on attributes', async(() => {
@@ -662,29 +658,27 @@ class HiddenModule {
                });
              }));
 
-      fixmeIvy('to investigate') &&
-          it('should call render hook', async(() => {
-               renderModule(RenderHookModule, {document: doc}).then(output => {
-                 // title should be added by the render hook.
-                 expect(output).toBe(
-                     '<html><head><title>RenderHook</title></head><body>' +
-                     '<app ng-version="0.0.0-PLACEHOLDER">Works!</app></body></html>');
-                 called = true;
-               });
-             }));
+      it('should call render hook', async(() => {
+           renderModule(RenderHookModule, {document: doc}).then(output => {
+             // title should be added by the render hook.
+             expect(output).toBe(
+                 '<html><head><title>RenderHook</title></head><body>' +
+                 '<app ng-version="0.0.0-PLACEHOLDER">Works!</app></body></html>');
+             called = true;
+           });
+         }));
 
-      fixmeIvy('to investigate') &&
-          it('should call multiple render hooks', async(() => {
-               const consoleSpy = spyOn(console, 'warn');
-               renderModule(MultiRenderHookModule, {document: doc}).then(output => {
-                 // title should be added by the render hook.
-                 expect(output).toBe(
-                     '<html><head><title>RenderHook</title><meta name="description"></head>' +
-                     '<body><app ng-version="0.0.0-PLACEHOLDER">Works!</app></body></html>');
-                 expect(consoleSpy).toHaveBeenCalled();
-                 called = true;
-               });
-             }));
+      it('should call multiple render hooks', async(() => {
+           const consoleSpy = spyOn(console, 'warn');
+           renderModule(MultiRenderHookModule, {document: doc}).then(output => {
+             // title should be added by the render hook.
+             expect(output).toBe(
+                 '<html><head><title>RenderHook</title><meta name="description"></head>' +
+                 '<body><app ng-version="0.0.0-PLACEHOLDER">Works!</app></body></html>');
+             expect(consoleSpy).toHaveBeenCalled();
+             called = true;
+           });
+         }));
     });
 
     describe('http', () => {
@@ -856,13 +850,12 @@ class HiddenModule {
       beforeEach(() => { called = false; });
       afterEach(() => { expect(called).toBe(true); });
 
-      fixmeIvy('to investigate') &&
-          it('adds transfer script tag when using renderModule', async(() => {
-               renderModule(TransferStoreModule, {document: '<app></app>'}).then(output => {
-                 expect(output).toBe(defaultExpectedOutput);
-                 called = true;
-               });
-             }));
+      it('adds transfer script tag when using renderModule', async(() => {
+           renderModule(TransferStoreModule, {document: '<app></app>'}).then(output => {
+             expect(output).toBe(defaultExpectedOutput);
+             called = true;
+           });
+         }));
 
       it('adds transfer script tag when using renderModuleFactory',
          async(inject([PlatformRef], (defaultPlatform: PlatformRef) => {
@@ -876,19 +869,18 @@ class HiddenModule {
            });
          })));
 
-      fixmeIvy('to investigate') &&
-          it('cannot break out of <script> tag in serialized output', async(() => {
-               renderModule(EscapedTransferStoreModule, {
-                 document: '<esc-app></esc-app>'
-               }).then(output => {
-                 expect(output).toBe(
-                     '<html><head></head><body><esc-app ng-version="0.0.0-PLACEHOLDER">Works!</esc-app>' +
-                     '<script id="transfer-state" type="application/json">' +
-                     '{&q;testString&q;:&q;&l;/script&g;&l;script&g;' +
-                     'alert(&s;Hello&a;&s; + \\&q;World\\&q;);&q;}</script></body></html>');
-                 called = true;
-               });
-             }));
+      it('cannot break out of <script> tag in serialized output', async(() => {
+           renderModule(EscapedTransferStoreModule, {
+             document: '<esc-app></esc-app>'
+           }).then(output => {
+             expect(output).toBe(
+                 '<html><head></head><body><esc-app ng-version="0.0.0-PLACEHOLDER">Works!</esc-app>' +
+                 '<script id="transfer-state" type="application/json">' +
+                 '{&q;testString&q;:&q;&l;/script&g;&l;script&g;' +
+                 'alert(&s;Hello&a;&s; + \\&q;World\\&q;);&q;}</script></body></html>');
+             called = true;
+           });
+         }));
     });
   });
 })();


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?
We used to set view encapsulation to `None` when there was no styles, but it's not the case with ivy, which will create css attribute selectors on elements when it's not needed.
Also we don't set the `ng-version` attribute on the root component.

## What is the new behavior?
We set encapsulation to `None` when there is no style.
We set `ng-version` attribute on root component.


## Does this PR introduce a breaking change?

- [x] No