### PR TITLE
fix(ivy): take preserveWhitespaces config option into account (FW-650)

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -68,7 +68,8 @@ export class ComponentDecoratorHandler implements
     return undefined;
   }
 
-  analyze(node: ts.ClassDeclaration, decorator: Decorator): AnalysisOutput<ComponentHandlerData> {
+  analyze(node: ts.ClassDeclaration, decorator: Decorator, options: ts.CompilerOptions):
+      AnalysisOutput<ComponentHandlerData> {
     const meta = this._resolveLiteral(decorator);
     this.literalCache.delete(decorator);
 
@@ -118,6 +119,8 @@ export class ComponentDecoratorHandler implements
             ErrorCode.VALUE_HAS_WRONG_TYPE, expr, 'preserveWhitespaces must be a boolean');
       }
       preserveWhitespaces = value;
+    } else if (typeof options.preserveWhitespaces === 'boolean') {
+      preserveWhitespaces = options.preserveWhitespaces;
     }
 
     const viewProviders: Expression|null = component.has('viewProviders') ?

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -68,7 +68,7 @@ export class ComponentDecoratorHandler implements
     return undefined;
   }
 
-  analyze(node: ts.ClassDeclaration, decorator: Decorator, options: ts.CompilerOptions):
+  analyze(node: ts.ClassDeclaration, decorator: Decorator, options?: ts.CompilerOptions):
       AnalysisOutput<ComponentHandlerData> {
     const meta = this._resolveLiteral(decorator);
     this.literalCache.delete(decorator);
@@ -119,7 +119,7 @@ export class ComponentDecoratorHandler implements
             ErrorCode.VALUE_HAS_WRONG_TYPE, expr, 'preserveWhitespaces must be a boolean');
       }
       preserveWhitespaces = value;
-    } else if (typeof options.preserveWhitespaces === 'boolean') {
+    } else if (options && typeof options.preserveWhitespaces === 'boolean') {
       preserveWhitespaces = options.preserveWhitespaces;
     }
 

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -126,7 +126,7 @@ export class NgtscProgram implements api.Program {
     }
     await Promise.all(this.tsProgram.getSourceFiles()
                           .filter(file => !file.fileName.endsWith('.d.ts'))
-                          .map(file => this.compilation !.analyzeAsync(file))
+                          .map(file => this.compilation !.analyzeAsync(file, this.options))
                           .filter((result): result is Promise<void> => result !== undefined));
   }
 
@@ -149,7 +149,7 @@ export class NgtscProgram implements api.Program {
       this.compilation = this.makeCompilation();
       this.tsProgram.getSourceFiles()
           .filter(file => !file.fileName.endsWith('.d.ts'))
-          .forEach(file => this.compilation !.analyzeSync(file));
+          .forEach(file => this.compilation !.analyzeSync(file, this.options));
     }
     return this.compilation;
   }

--- a/packages/compiler-cli/src/ngtsc/transform/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/api.ts
@@ -42,7 +42,7 @@ export interface DecoratorHandler<A, M> {
    * if successful, or an array of diagnostic messages if the analysis fails or the decorator
    * isn't valid.
    */
-  analyze(node: ts.Declaration, metadata: M): AnalysisOutput<A>;
+  analyze(node: ts.Declaration, metadata: M, options: ts.CompilerOptions): AnalysisOutput<A>;
 
   typeCheck?(ctx: TypeCheckContext, node: ts.Declaration, metadata: A): void;
 

--- a/packages/compiler-cli/src/ngtsc/transform/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/api.ts
@@ -42,7 +42,7 @@ export interface DecoratorHandler<A, M> {
    * if successful, or an array of diagnostic messages if the analysis fails or the decorator
    * isn't valid.
    */
-  analyze(node: ts.Declaration, metadata: M, options: ts.CompilerOptions): AnalysisOutput<A>;
+  analyze(node: ts.Declaration, metadata: M, options?: ts.CompilerOptions): AnalysisOutput<A>;
 
   typeCheck?(ctx: TypeCheckContext, node: ts.Declaration, metadata: A): void;
 

--- a/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
@@ -68,16 +68,22 @@ export class IvyCompilation {
       private sourceToFactorySymbols: Map<string, Set<string>>|null) {}
 
 
-  analyzeSync(sf: ts.SourceFile): void { return this.analyze(sf, false); }
+  analyzeSync(sf: ts.SourceFile, options: ts.CompilerOptions): void {
+    return this.analyze(sf, options, false);
+  }
 
-  analyzeAsync(sf: ts.SourceFile): Promise<void>|undefined { return this.analyze(sf, true); }
+  analyzeAsync(sf: ts.SourceFile, options: ts.CompilerOptions): Promise<void>|undefined {
+    return this.analyze(sf, options, true);
+  }
 
   /**
    * Analyze a source file and produce diagnostics for it (if any).
    */
-  private analyze(sf: ts.SourceFile, preanalyze: false): undefined;
-  private analyze(sf: ts.SourceFile, preanalyze: true): Promise<void>|undefined;
-  private analyze(sf: ts.SourceFile, preanalyze: boolean): Promise<void>|undefined {
+  private analyze(sf: ts.SourceFile, options: ts.CompilerOptions, preanalyze: false): undefined;
+  private analyze(sf: ts.SourceFile, options: ts.CompilerOptions, preanalyze: true):
+      Promise<void>|undefined;
+  private analyze(sf: ts.SourceFile, options: ts.CompilerOptions, preanalyze: boolean):
+      Promise<void>|undefined {
     const promises: Promise<void>[] = [];
 
     const analyzeClass = (node: ts.Declaration): void => {
@@ -103,7 +109,7 @@ export class IvyCompilation {
           // Run analysis on the metadata. This will produce either diagnostics, an
           // analysis result, or both.
           try {
-            const analysis = adapter.analyze(node, metadata);
+            const analysis = adapter.analyze(node, metadata, options);
             if (analysis.analysis !== undefined) {
               this.analysis.set(node, {
                 adapter,

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -529,6 +529,50 @@ describe('ngtsc behavioral tests', () => {
     expect(jsContents).toContain('var ɵDir_BaseFactory = i0.ɵgetInheritedFactory(Dir)');
   });
 
+  it('should take preserveWhitespaces config option into account', () => {
+    env.tsconfig({preserveWhitespaces: true});
+    env.write(`test.ts`, `
+      import {Component} from '@angular/core';
+
+      @Component({
+        selector: 'test',
+        template: \`
+          <div>
+            Template with whitespaces
+          </div>
+        \`
+      })
+      class FooCmp {}
+    `);
+
+    env.driveMain();
+    const jsContents = env.getContents('test.js');
+    expect(jsContents)
+        .toContain('text(2, "\\n            Template with whitespaces\\n          ");');
+  });
+
+  it('@Component\'s preserveWhitespaces should override the one defined in config', () => {
+    env.tsconfig({preserveWhitespaces: true});
+    env.write(`test.ts`, `
+      import {Component} from '@angular/core';
+
+      @Component({
+        selector: 'test',
+        preserveWhitespaces: false,
+        template: \`
+          <div>
+            Template with whitespaces
+          </div>
+        \`
+      })
+      class FooCmp {}
+    `);
+
+    env.driveMain();
+    const jsContents = env.getContents('test.js');
+    expect(jsContents).toContain('text(1, " Template with whitespaces ");');
+  });
+
   it('should correctly recognize local symbols', () => {
     env.tsconfig();
     env.write('module.ts', `


### PR DESCRIPTION
The goal of this PR is to take the `preserveWhitespaces` config option defined via tsconfig.json into account.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature


## What is the current behavior?
Currently the `preserveWhitespaces` config option defined via tsconfig.json is ignored and the deafult value (false) is always enforced.


## What is the new behavior?
Now the `preserveWhitespaces` config option is passed to the template rendering logic, which takes it into account.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
