### PR TITLE
docs: fix indentation for note in architecture guide

### DIFF
--- a/aio/content/guide/architecture-modules.md
+++ b/aio/content/guide/architecture-modules.md
@@ -56,7 +56,9 @@ A component and its template together define a *view*. A component can contain a
 When you create a component, it's associated directly with a single view, called the *host view*. The host view can be the root of a view hierarchy, which can contain *embedded views*, which are in turn the host views of other components. Those components can be in the same NgModule, or can be imported from other NgModules. Views in the tree can be nested to any depth.
 
 <div class="alert is-helpful">
-    **Note:** The hierarchical structure of views is a key factor in the way Angular detects and responds to changes in the DOM and app data. 
+
+**Note:** The hierarchical structure of views is a key factor in the way Angular detects and responds to changes in the DOM and app data.
+
 </div>
 
 ## NgModules and JavaScript modules


### PR DESCRIPTION
Fixed the formatting and made Note bold.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?


- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Note was not bolded.

Issue Number: N/A


## What is the new behavior?
Note is bolded

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No




## Other information
