### PR TITLE
refactor(core): add type for creating a PlatformFactory

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -52,6 +52,12 @@ export function compileNgModuleFactory__POST_R3__<M>(
 
 export const ALLOW_MULTIPLE_PLATFORMS = new InjectionToken<boolean>('AllowMultipleToken');
 
+/**
+ * Factory for a platform
+ *
+ * @publicApi
+ */
+export type PlatformFactory = (extraProviders?: StaticProvider[]) => PlatformRef;
 
 
 /**
@@ -87,9 +93,8 @@ export function createPlatform(injector: Injector): PlatformRef {
  * @publicApi
  */
 export function createPlatformFactory(
-    parentPlatformFactory: ((extraProviders?: StaticProvider[]) => PlatformRef) | null,
-    name: string, providers: StaticProvider[] = []): (extraProviders?: StaticProvider[]) =>
-    PlatformRef {
+    parentPlatformFactory: PlatformFactory | null, name: string,
+    providers: StaticProvider[] = []): PlatformFactory {
   const desc = `Platform: ${name}`;
   const marker = new InjectionToken(desc);
   return (extraProviders: StaticProvider[] = []) => {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -15,7 +15,7 @@ export * from './metadata';
 export * from './version';
 export {TypeDecorator} from './util/decorators';
 export * from './di';
-export {createPlatform, assertPlatform, destroyPlatform, getPlatform, PlatformRef, ApplicationRef, createPlatformFactory, NgProbeToken} from './application_ref';
+export {createPlatform, assertPlatform, destroyPlatform, getPlatform, PlatformRef, ApplicationRef, createPlatformFactory, NgProbeToken, PlatformFactory} from './application_ref';
 export {enableProdMode, isDevMode} from './is_dev_mode';
 export {APP_ID, PACKAGE_ROOT_URL, PLATFORM_INITIALIZER, PLATFORM_ID, APP_BOOTSTRAP_LISTENER} from './application_tokens';
 export {APP_INITIALIZER, ApplicationInitStatus} from './application_init';

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule, PlatformLocation, ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {APP_ID, ApplicationModule, ErrorHandler, Inject, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, PlatformRef, RendererFactory2, Sanitizer, SkipSelf, StaticProvider, Testability, createPlatformFactory, platformCore, ɵAPP_ROOT as APP_ROOT, ɵConsole as Console} from '@angular/core';
+import {APP_ID, ApplicationModule, ErrorHandler, Inject, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, PlatformFactory, PlatformRef, RendererFactory2, Sanitizer, SkipSelf, StaticProvider, Testability, createPlatformFactory, platformCore, ɵAPP_ROOT as APP_ROOT, ɵConsole as Console} from '@angular/core';
 
 import {BrowserDomAdapter} from './browser/browser_adapter';
 import {BrowserPlatformLocation} from './browser/location/browser_platform_location';
@@ -44,7 +44,7 @@ export const BROWSER_SANITIZATION_PROVIDERS: StaticProvider[] = [
 /**
  * @publicApi
  */
-export const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef =
+export const platformBrowser: PlatformFactory =
     createPlatformFactory(platformCore, 'browser', INTERNAL_BROWSER_PLATFORM_PROVIDERS);
 
 export function initDomAdapter() {

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -165,7 +165,7 @@ export declare function createInjector(defType: any, parent?: Injector | null, a
 
 export declare function createPlatform(injector: Injector): PlatformRef;
 
-export declare function createPlatformFactory(parentPlatformFactory: ((extraProviders?: StaticProvider[]) => PlatformRef) | null, name: string, providers?: StaticProvider[]): (extraProviders?: StaticProvider[]) => PlatformRef;
+export declare function createPlatformFactory(parentPlatformFactory: PlatformFactory | null, name: string, providers?: StaticProvider[]): PlatformFactory;
 
 export declare const CUSTOM_ELEMENTS_SCHEMA: SchemaMetadata;
 
@@ -560,7 +560,9 @@ export declare const PLATFORM_ID: InjectionToken<Object>;
 
 export declare const PLATFORM_INITIALIZER: InjectionToken<(() => void)[]>;
 
-export declare const platformCore: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
+export declare const platformCore: PlatformFactory;
+
+export declare type PlatformFactory = (extraProviders?: StaticProvider[]) => PlatformRef;
 
 export declare class PlatformRef {
     readonly destroyed: boolean;

--- a/tools/public_api_guard/platform-browser-dynamic/platform-browser-dynamic.d.ts
+++ b/tools/public_api_guard/platform-browser-dynamic/platform-browser-dynamic.d.ts
@@ -2,7 +2,7 @@ export declare class JitCompilerFactory implements CompilerFactory {
     createCompiler(options?: CompilerOptions[]): Compiler;
 }
 
-export declare const platformBrowserDynamic: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
+export declare const platformBrowserDynamic: PlatformFactory;
 
 export declare const RESOURCE_CACHE_PROVIDER: Provider[];
 

--- a/tools/public_api_guard/platform-browser-dynamic/testing.d.ts
+++ b/tools/public_api_guard/platform-browser-dynamic/testing.d.ts
@@ -1,4 +1,4 @@
 export declare class BrowserDynamicTestingModule {
 }
 
-export declare const platformBrowserDynamicTesting: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
+export declare const platformBrowserDynamicTesting: PlatformFactory;

--- a/tools/public_api_guard/platform-browser/platform-browser.d.ts
+++ b/tools/public_api_guard/platform-browser/platform-browser.d.ts
@@ -90,7 +90,7 @@ export declare type MetaDefinition = {
     [prop: string]: string;
 };
 
-export declare const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef;
+export declare const platformBrowser: PlatformFactory;
 
 export interface SafeHtml extends SafeValue {
 }

--- a/tools/public_api_guard/platform-browser/testing.d.ts
+++ b/tools/public_api_guard/platform-browser/testing.d.ts
@@ -1,4 +1,4 @@
 export declare class BrowserTestingModule {
 }
 
-export declare const platformBrowserTesting: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
+export declare const platformBrowserTesting: PlatformFactory;

--- a/tools/public_api_guard/platform-server/platform-server.d.ts
+++ b/tools/public_api_guard/platform-server/platform-server.d.ts
@@ -7,9 +7,9 @@ export interface PlatformConfig {
     url?: string;
 }
 
-export declare const platformDynamicServer: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
+export declare const platformDynamicServer: PlatformFactory;
 
-export declare const platformServer: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
+export declare const platformServer: PlatformFactory;
 
 export declare class PlatformState {
     constructor(_doc: any);

--- a/tools/public_api_guard/platform-server/testing.d.ts
+++ b/tools/public_api_guard/platform-server/testing.d.ts
@@ -1,4 +1,4 @@
-export declare const platformServerTesting: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
+export declare const platformServerTesting: PlatformFactory;
 
 export declare class ServerTestingModule {
 }

--- a/tools/public_api_guard/platform-webworker-dynamic/platform-webworker-dynamic.d.ts
+++ b/tools/public_api_guard/platform-webworker-dynamic/platform-webworker-dynamic.d.ts
@@ -1,3 +1,3 @@
-export declare const platformWorkerAppDynamic: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
+export declare const platformWorkerAppDynamic: PlatformFactory;
 
 export declare const VERSION: Version;

--- a/tools/public_api_guard/platform-webworker/platform-webworker.d.ts
+++ b/tools/public_api_guard/platform-webworker/platform-webworker.d.ts
@@ -33,9 +33,9 @@ export interface MessageBusSource {
     initChannel(channel: string, runInZone: boolean): void;
 }
 
-export declare const platformWorkerApp: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
+export declare const platformWorkerApp: PlatformFactory;
 
-export declare const platformWorkerUi: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
+export declare const platformWorkerUi: PlatformFactory;
 
 export interface ReceivedMessage {
     args: any[];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The function `createPlatformFactory` is hard to understand, especially because of `parentPlatformFactory`-type and of its return type which is:

```TypeScript
(extraProviders?: StaticProvider[]) => PlatformRef
```


## What is the new behavior?

To prevent further headaches I have refactored this redundant type `(extraProviders?: StaticProvider[]) => PlatformRef` into an alias type called `PlatformFactory` and adjusted the source code.

**`PlatformFactory` will be exposed in the public API**

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
