### PR TITLE
docs: fix dynamic-component-loader example for Adblock Plus + EasyList combination

### DIFF
--- a/aio/content/examples/dynamic-component-loader/src/app/ad-banner.component.ts
+++ b/aio/content/examples/dynamic-component-loader/src/app/ad-banner.component.ts
@@ -9,7 +9,7 @@ import { AdComponent } from './ad.component';
   selector: 'app-ad-banner',
   // #docregion ad-host
   template: `
-              <div class="ad-banner">
+              <div class="ad-banner-example">
                 <h3>Advertisements</h3>
                 <ng-template ad-host></ng-template>
               </div>

--- a/aio/content/examples/dynamic-component-loader/src/assets/sample.css
+++ b/aio/content/examples/dynamic-component-loader/src/assets/sample.css
@@ -18,6 +18,6 @@
   color: black;
 }
 
-.ad-banner {
+.ad-banner-example {
   width: 400px;
 }


### PR DESCRIPTION
Reported issue in #18138 is due to EasyList being selected in ABP. It injects display:none in elements with the ad-banner class name. Changing the class name to ad-banner-example fixes the issue in this case.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Please see issue 18138: https://github.com/angular/angular/issues/18138

Issue Number: 18138


## What is the new behavior?
AdBlock Plus (in combination with EasyList) no longer blocks displaying the sample ads in the given example.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
