### PR TITLE
fix(ivy): add polyfill for goog.getMsg to unblock tests (FW-663)

### DIFF
--- a/packages/core/test/linker/ng_container_integration_spec.ts
+++ b/packages/core/test/linker/ng_container_integration_spec.ts
@@ -11,7 +11,7 @@ import {AfterContentInit, AfterViewInit, Component, ContentChildren, Directive, 
 import {TestBed} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {fixmeIvy} from '@angular/private/testing';
+import {fixmeIvy, polyfillGoogGetMsg} from '@angular/private/testing';
 
 {
   if (ivyEnabled) {
@@ -26,6 +26,7 @@ function declareTests(config?: {useJit: boolean}) {
   describe('<ng-container>', function() {
 
     beforeEach(() => {
+      polyfillGoogGetMsg();
       TestBed.configureCompiler({...config});
       TestBed.configureTestingModule({
         declarations: [
@@ -38,17 +39,16 @@ function declareTests(config?: {useJit: boolean}) {
       });
     });
 
-    fixmeIvy('FW-663: ReferenceError: goog is not defined') &&
-        it('should support the "i18n" attribute', () => {
-          const template = '<ng-container i18n>foo</ng-container>';
-          TestBed.overrideComponent(MyComp, {set: {template}});
-          const fixture = TestBed.createComponent(MyComp);
+    it('should support the "i18n" attribute', () => {
+      const template = '<ng-container i18n>foo</ng-container>';
+      TestBed.overrideComponent(MyComp, {set: {template}});
+      const fixture = TestBed.createComponent(MyComp);
 
-          fixture.detectChanges();
+      fixture.detectChanges();
 
-          const el = fixture.nativeElement;
-          expect(el).toHaveText('foo');
-        });
+      const el = fixture.nativeElement;
+      expect(el).toHaveText('foo');
+    });
 
     fixmeIvy('FW-678: ivy generates different DOM structure for <ng-container>') &&
         it('should be rendered as comment with children as siblings', () => {

--- a/packages/core/test/linker/ng_container_integration_spec.ts
+++ b/packages/core/test/linker/ng_container_integration_spec.ts
@@ -26,7 +26,11 @@ function declareTests(config?: {useJit: boolean}) {
   describe('<ng-container>', function() {
 
     beforeEach(() => {
+      // Injecting goog.getMsg-like function into global scope to unblock tests run outside of
+      // Closure Compiler. It's a *temporary* measure until runtime translation service support is
+      // introduced.
       polyfillGoogGetMsg();
+
       TestBed.configureCompiler({...config});
       TestBed.configureTestingModule({
         declarations: [

--- a/packages/private/testing/index.ts
+++ b/packages/private/testing/index.ts
@@ -8,3 +8,4 @@
 
 export * from './src/render3';
 export * from './src/fixme';
+export * from './src/goog_get_msg';

--- a/packages/private/testing/src/goog_get_msg.ts
+++ b/packages/private/testing/src/goog_get_msg.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * A method that injects goog.getMsg-like function into global scope.
+ *
+ * This method is required as a *temporary* measure to prevent i18n tests from being blocked while
+ * running outside of Closure Compiler. This method will not be needed once runtime translation
+ * service support is introduced.
+ */
+export function polyfillGoogGetMsg(): void {
+  const glob = (global as any);
+  glob.goog = glob.goog || {};
+  glob.goog.getMsg =
+      glob.goog.getMsg || function(input: string, placeholders: {[key: string]: string} = {}) {
+        return Object.keys(placeholders).length ?
+            input.replace(/\{\$(.*?)\}/g, (match, key) => placeholders[key] || '') :
+            input;
+      };
+}


### PR DESCRIPTION
This PR adds `goog.getMsg` polyfill to let i18n-related tests running correctly outside of Closure Compiler. This polyfill will not be needed once runtime translation service support is added.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No