### PR TITLE
feat(forms): add `moveControl(from, to)` to `FormArray`

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -1755,6 +1755,50 @@ export class FormArray extends AbstractControl {
   }
 
   /**
+   * Move a control from one position to another. The controls
+   * in between move one position towards the moved controls
+   * origin.
+   *
+   * @usageNotes
+   * ### Move a control inside of a FormArray
+   *
+   * ```typescript
+   * const arr = new FormArray([
+   *   new FormControl(0),
+   *   new FormControl(1),
+   *   new FormControl(2)
+   * ]);
+   *
+   * arr.moveControl(0, 2);
+   * console.log(arr.value);   // [1, 2, 0]
+   * ```
+   *
+   * This can be used with Material CDK drag and drop. See its
+   * docs here: https://material.angular.io/cdk/drag-drop/overview
+   *
+   * @param from Index of the array item to move
+   * @param to Index of the target item position
+   */
+  moveControl(from: number, to: number): void {
+    this._throwIfControlMissing(from);
+    this._throwIfControlMissing(to);
+
+    if (from === to) {
+      return;
+    }
+
+    const delta = to > from ? 1 : -1;
+    const controlToMove = this.at(from);
+
+    for (let i = from; i * delta < to * delta; i += delta) {
+      this._throwIfControlMissing(i + delta);
+      this.setControl(i, this.at(i + delta));
+    }
+
+    this.setControl(to, controlToMove);
+  }
+
+  /**
    * Length of the control array.
    */
   get length(): number { return this.controls.length; }

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -1787,15 +1787,11 @@ export class FormArray extends AbstractControl {
       return;
     }
 
-    const delta = to > from ? 1 : -1;
-    const controlToMove = this.at(from);
+    const controlToMove = this.controls.splice(from, 1)[0];
+    this.controls.splice(to, 0, controlToMove);
 
-    for (let i = from; i * delta < to * delta; i += delta) {
-      this._throwIfControlMissing(i + delta);
-      this.setControl(i, this.at(i + delta));
-    }
-
-    this.setControl(to, controlToMove);
+    this.updateValueAndValidity();
+    this._onCollectionChange();
   }
 
   /**

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -162,6 +162,77 @@ import {of } from 'rxjs';
       });
     });
 
+    describe('moveControl', () => {
+      let a: FormArray;
+
+      it('should move item from position 1 to 3', () => {
+        a = new FormArray(
+            [new FormControl(0), new FormControl(1), new FormControl(2), new FormControl(3)]);
+
+        a.moveControl(1, 3);
+        expect(a.getRawValue()).toEqual([0, 2, 3, 1]);
+      });
+
+      it('should work with nested forms', () => {
+        a = new FormArray([
+          new FormGroup({'c2': new FormControl('v2'), 'c3': new FormControl('v3')}),
+          new FormArray([new FormControl('v4'), new FormControl('v5')])
+        ]);
+
+        a.moveControl(0, 1);
+        expect(a.getRawValue()).toEqual([['v4', 'v5'], {'c2': 'v2', 'c3': 'v3'}]);
+      });
+
+      it('should work from higher position to lower position', () => {
+        a = new FormArray([new FormControl(0), new FormControl(1)]);
+
+        a.moveControl(1, 0);
+        expect(a.getRawValue()).toEqual([1, 0]);
+      });
+
+      it('should throw error when from-index out of bounds', () => {
+        a = new FormArray([new FormControl(0), new FormControl(1)]);
+        expect(() => a.moveControl(2, 0))
+            .toThrowError(new RegExp(`Cannot find form control at index 2`));
+        expect(a.getRawValue()).toEqual([0, 1]);
+      });
+
+      it('should throw error when to-index out of bounds', () => {
+        a = new FormArray([new FormControl(0), new FormControl(1)]);
+        expect(() => a.moveControl(0, 2))
+            .toThrowError(new RegExp(`Cannot find form control at index 2`));
+        expect(a.getRawValue()).toEqual([0, 1]);
+      });
+
+      it('should throw error when from-index is negative', () => {
+        a = new FormArray([new FormControl(0)]);
+
+        expect(() => a.moveControl(-1, 0))
+            .toThrowError(new RegExp(`Cannot find form control at index -1`));
+      });
+
+      it('should throw error when formarray is empty', () => {
+        a = new FormArray([]);
+
+        expect(() => a.moveControl(0, 1))
+            .toThrowError(new RegExp(`There are no form controls registered`));
+      });
+
+      it('should throw error if indices are equal and control does not exist', () => {
+        a = new FormArray([new FormControl(0), new FormControl(1)]);
+
+        expect(() => a.moveControl(3, 3))
+            .toThrowError(new RegExp(`Cannot find form control at index 3`));
+      });
+
+      it('should do nothing if indices are equal and control exists', () => {
+        a = new FormArray([new FormControl(0), new FormControl(1)]);
+
+        a.moveControl(0, 0);
+        expect(a.getRawValue()).toEqual([0, 1]);
+      });
+    });
+
     describe('setValue', () => {
       let c: FormControl, c2: FormControl, a: FormArray;
 

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -173,6 +173,7 @@ export declare class FormArray extends AbstractControl {
     clear(): void;
     getRawValue(): any[];
     insert(index: number, control: AbstractControl): void;
+    moveControl(from: number, to: number): void;
     patchValue(value: any[], options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)

Not sure about the next one, since this is my first PR in this repo. Is it meant to update the public_api_guard? In the *packages/forms/PACKAGE.md* there is no section regarding FormArrays.

- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Particularly for using cdk drag-drop, there should be a function that savely moves an item in a FormArray, but there is none and one has to reorder the items manually. It should be similar to the CDK `moveItemInArray()` function provided for Angular 7 cdk drag and drop package.

Issue Number: N/A


## What is the new behavior?

With this patch one can create a formarray, say `a` with 4 elements having formcontrols with values [0, 1, 2, 3] and use `a.moveItem(0, 2)` which moves the item at position 0 to position 2 in the formarray results in [1, 2, 0, 3]. It throws an error using the private `_throwIfControlMissing`, if one of the items in between does not exist. Also works with nested forms.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

Have opened a feature request before in this post https://github.com/angular/angular/issues/27171.