### PR TITLE
fix(ivy): inject null for missing attributes

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -262,7 +262,7 @@ export function diPublicInInjector(
  *
  * @publicApi
  */
-export function injectAttributeImpl(tNode: TNode, attrNameToInject: string): string|undefined {
+export function injectAttributeImpl(tNode: TNode, attrNameToInject: string): string|null {
   ngDevMode && assertNodeOfPossibleTypes(
                    tNode, TNodeType.Container, TNodeType.Element, TNodeType.ElementContainer);
   ngDevMode && assertDefined(tNode, 'expecting tNode');
@@ -276,7 +276,7 @@ export function injectAttributeImpl(tNode: TNode, attrNameToInject: string): str
       }
     }
   }
-  return undefined;
+  return null;
 }
 
 

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -2758,7 +2758,7 @@ export function directiveInject<T>(
 /**
  * Facade for the attribute injection from DI.
  */
-export function injectAttribute(attrNameToInject: string): string|undefined {
+export function injectAttribute(attrNameToInject: string): string|null {
   return injectAttributeImpl(getPreviousOrParentTNode(), attrNameToInject);
 }
 

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -1268,7 +1268,7 @@ function declareTests(config?: {useJit: boolean}) {
 
       });
 
-      fixmeIvy('unknown') && it('should support static attributes', () => {
+      it('should support static attributes', () => {
         TestBed.configureTestingModule({declarations: [MyComp, NeedsAttribute]});
         const template = '<input static type="text" title>';
         TestBed.overrideComponent(MyComp, {set: {template}});

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -1751,11 +1751,11 @@ describe('di', () => {
     let myDirectiveInstance !: MyDirective | null;
 
     class MyDirective {
-      exists = 'wrong' as string | undefined;
-      myDirective = 'wrong' as string | undefined;
+      exists = 'wrong' as string | null;
+      myDirective = 'wrong' as string | null;
       constructor(
-          @Attribute('exist') existAttrValue: string|undefined,
-          @Attribute('myDirective') myDirectiveAttrValue: string|undefined) {
+          @Attribute('exist') existAttrValue: string|null,
+          @Attribute('myDirective') myDirectiveAttrValue: string|null) {
         this.exists = existAttrValue;
         this.myDirective = myDirectiveAttrValue;
       }
@@ -1771,8 +1771,8 @@ describe('di', () => {
     beforeEach(() => myDirectiveInstance = null);
 
     it('should inject attribute', () => {
-      let exist = 'wrong' as string | undefined;
-      let nonExist = 'wrong' as string | undefined;
+      let exist = 'wrong' as string | null;
+      let nonExist = 'wrong' as string | null;
 
       const MyApp = createComponent('my-app', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
@@ -1784,7 +1784,7 @@ describe('di', () => {
 
       new ComponentFixture(MyApp);
       expect(exist).toEqual('existValue');
-      expect(nonExist).toEqual(undefined);
+      expect(nonExist).toBeNull();
     });
 
     // https://stackblitz.com/edit/angular-scawyi?file=src%2Fapp%2Fapp.component.ts
@@ -1831,8 +1831,8 @@ describe('di', () => {
 
     // https://stackblitz.com/edit/angular-8ytqkp?file=src%2Fapp%2Fapp.component.ts
     it('should not inject attributes representing bindings and outputs', () => {
-      let exist = 'wrong' as string | undefined;
-      let nonExist = 'wrong' as string | undefined;
+      let exist = 'wrong' as string | null;
+      let nonExist = 'wrong' as string | null;
 
       const MyApp = createComponent('my-app', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
@@ -1844,12 +1844,12 @@ describe('di', () => {
 
       new ComponentFixture(MyApp);
       expect(exist).toEqual('existValue');
-      expect(nonExist).toEqual(undefined);
+      expect(nonExist).toBeNull();
     });
 
     it('should not accidentally inject attributes representing bindings and outputs', () => {
-      let exist = 'wrong' as string | undefined;
-      let nonExist = 'wrong' as string | undefined;
+      let exist = 'wrong' as string | null;
+      let nonExist = 'wrong' as string | null;
 
       const MyApp = createComponent('my-app', function(rf: RenderFlags, ctx: any) {
         if (rf & RenderFlags.Create) {
@@ -1863,7 +1863,7 @@ describe('di', () => {
 
       new ComponentFixture(MyApp);
       expect(exist).toEqual('existValue');
-      expect(nonExist).toEqual(undefined);
+      expect(nonExist).toBeNull();
     });
   });
 


### PR DESCRIPTION
Tiny fix to align ivy's impl with the view engine one. Found while analysing root causes for the existing tests failures. 

tl;dr; is that view engine injects `null` when injected `@Attribute` is not found.