### PR TITLE
fix(service-worker): ngsw.json navigationUrls breaks all service worker versions < 6.0.0

### DIFF
--- a/packages/service-worker/worker/src/app-version.ts
+++ b/packages/service-worker/worker/src/app-version.ts
@@ -15,6 +15,12 @@ import {IdleScheduler} from './idle';
 import {Manifest} from './manifest';
 
 
+const BACKWARDS_COMPATIBILITY_NAVIGATION_URLS = [
+  {positive: true, regex: '^/.*$'},
+  {positive: false, regex: '^/.*\\.[^/]*$'},
+  {positive: false, regex: '^/.*__'},
+];
+
 /**
  * A specific version of the application, identified by a unique manifest
  * as determined by its hash.
@@ -84,6 +90,10 @@ export class AppVersion implements UpdateSource {
                               config => new DataGroup(
                                   this.scope, this.adapter, config, this.database,
                                   `ngsw:${config.version}:data`));
+
+    // This keeps backwards compatibility with app versions without navigation urls.
+    // Fix: https://github.com/angular/angular/issues/27209
+    manifest.navigationUrls = manifest.navigationUrls || BACKWARDS_COMPATIBILITY_NAVIGATION_URLS;
 
     // Create `include`/`exclude` RegExps for the `navigationUrls` declared in the manifest.
     const includeUrls = manifest.navigationUrls.filter(spec => spec.positive);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: 27209
https://github.com/angular/angular/issues/27209


## What is the new behavior?

Fix the bug, I explain how I fixed in the issue comments.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

