### PR TITLE
docs: update link to post on redirects in router guide

### DIFF
--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -1055,7 +1055,7 @@ The default route should redirect to the `HeroListComponent` _only_ when the _en
 Remember to restore the redirect to `pathMatch = 'full'`.
 
 Learn more in Victor Savkin's
-[post on redirects](http://victorsavkin.com/post/146722301646/angular-router-empty-paths-componentless-routes).
+[post on redirects](http://vsavkin.tumblr.com/post/146722301646/angular-router-empty-paths-componentless-routes).
 
 
 </div>


### PR DESCRIPTION
## PR Checklist

- [] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In Routing and Navigation doc : (https://angular.io/guide/router)
The url of Victor savkin's url post on redirects is no longer accessible

Issue Number: N/A


## What is the new behavior?
Change victor savkin's url post on redirects to:
http://vsavkin.tumblr.com/post/146722301646/angular-router-empty-paths-componentless-routes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
