### PR TITLE
fix(common): KeyValuePipe should return empty array for empty objects

### DIFF
--- a/packages/common/src/pipes/keyvalue_pipe.ts
+++ b/packages/common/src/pipes/keyvalue_pipe.ts
@@ -47,10 +47,8 @@ export interface KeyValue<K, V> {
 export class KeyValuePipe implements PipeTransform {
   constructor(private readonly differs: KeyValueDiffers) {}
 
-  // TODO(issue/24571): remove '!'.
   private differ !: KeyValueDiffer<any, any>;
-  // TODO(issue/24571): remove '!'.
-  private keyValues !: Array<KeyValue<any, any>>;
+  private keyValues: Array<KeyValue<any, any>> = [];
 
   transform<K, V>(input: null, compareFn?: (a: KeyValue<K, V>, b: KeyValue<K, V>) => number): null;
   transform<V>(

--- a/packages/common/test/pipes/keyvalue_pipe_spec.ts
+++ b/packages/common/test/pipes/keyvalue_pipe_spec.ts
@@ -25,6 +25,10 @@ describe('KeyValuePipe', () => {
     expect(pipe.transform(fn as any)).toEqual(null);
   });
   describe('object dictionary', () => {
+    it('should return empty array of an empty dictionary', () => {
+      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
+      expect(pipe.transform({})).toEqual([]);
+    });
     it('should transform a basic dictionary', () => {
       const pipe = new KeyValuePipe(defaultKeyValueDiffers);
       expect(pipe.transform({1: 2})).toEqual([{key: '1', value: 2}]);
@@ -62,6 +66,10 @@ describe('KeyValuePipe', () => {
   });
 
   describe('Map', () => {
+    it('should return an empty array for an empty Map', () => {
+      const pipe = new KeyValuePipe(defaultKeyValueDiffers);
+      expect(pipe.transform(new Map())).toEqual([]);
+    });
     it('should transform a basic Map', () => {
       const pipe = new KeyValuePipe(defaultKeyValueDiffers);
       expect(pipe.transform(new Map([[1, 2]]))).toEqual([{key: 1, value: 2}]);


### PR DESCRIPTION
This lets KeyValuePipe return an empty array (rather than undefined)
when the input is an empty object.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

I don't think this requires explicit clarification in the docs, so no changes there.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
KeyValuePipe returns undefined on empty objects.

Issue Number: #27243


## What is the new behavior?
KeyValuePipe returns empty array on empty objects.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
