### PR TITLE
fix: Made getContext recursively look for named outlet if not found a…

### DIFF
--- a/packages/router/src/router_outlet_context.ts
+++ b/packages/router/src/router_outlet_context.ts
@@ -76,5 +76,26 @@ export class ChildrenOutletContexts {
     return context;
   }
 
-  getContext(childName: string): OutletContext|null { return this.contexts.get(childName) || null; }
+  getContext(childName: string): OutletContext|null 
+  {
+    /*
+      This method will recursively follow the "primary" RouterOutlet looking for an outlet named "childName".
+      It returns the first matching outlet found (ie: the closest to the root).
+      
+      Original behaviour was to only look at the first level (direct content of "this.contexts"). Because of that named router-outlets would
+      only work if they're introduced through the bootstraped component (AppComponent?).
+    */
+
+    const direct = this.contexts.get(childName);
+    if (direct) {
+      return direct;
+    } else {
+      const primary = this.contexts.get('primary');
+      if (primary) {
+        return primary.children.getContext(childName) || null;
+      } else {
+        return null;
+      }
+    }
+  }
 }

--- a/packages/router/src/router_outlet_context.ts
+++ b/packages/router/src/router_outlet_context.ts
@@ -76,12 +76,11 @@ export class ChildrenOutletContexts {
     return context;
   }
 
-  getContext(childName: string): OutletContext|null 
-  {
+  getContext(childName: string): OutletContext|null {
     /*
       This method will recursively follow the "primary" RouterOutlet looking for an outlet
       named "childName". It returns the first matching outlet found (ie: the closest to the root).
-      
+
       Original behaviour was to only look at the first level (direct content of "this.contexts").
       Because of that named router-outlets would only work if they're introduced through the
       bootstraped component (AppComponent?).

--- a/packages/router/src/router_outlet_context.ts
+++ b/packages/router/src/router_outlet_context.ts
@@ -79,11 +79,12 @@ export class ChildrenOutletContexts {
   getContext(childName: string): OutletContext|null 
   {
     /*
-      This method will recursively follow the "primary" RouterOutlet looking for an outlet named "childName".
-      It returns the first matching outlet found (ie: the closest to the root).
+      This method will recursively follow the "primary" RouterOutlet looking for an outlet
+      named "childName". It returns the first matching outlet found (ie: the closest to the root).
       
-      Original behaviour was to only look at the first level (direct content of "this.contexts"). Because of that named router-outlets would
-      only work if they're introduced through the bootstraped component (AppComponent?).
+      Original behaviour was to only look at the first level (direct content of "this.contexts").
+      Because of that named router-outlets would only work if they're introduced through the
+      bootstraped component (AppComponent?).
     */
 
     const direct = this.contexts.get(childName);


### PR DESCRIPTION
…t top level

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

When the Router needs to find the Outlet for new content it begins a search at the root component. Previously the search stopped there. New behavior: if the named outlet is not found at root level then the search continues recursively, following the 'primary' outlet until the correctly named outlet is found or we reach the "bottom" of the hierarchy.

I registered this as a bug since this information (hierarchical information on named router-outlets) was constructed but not used.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

Possibly breaking change: If an Angular application has a named router-outlet that's not in the root component and it also activates a secondary route for the given named router outlet then you could say this change is "breaking" in the sense that the route will now become activated and content would be shown in the previously ignored router-outlet.

