### PR TITLE
Fixes for ivy tests with platform server

### DIFF
--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -227,9 +227,7 @@ export class R3Injector {
     }
 
     // Check for multiple imports of the same module
-    if (dedupStack.indexOf(defType) !== -1) {
-      return;
-    }
+    const isDuplicate = dedupStack.indexOf(defType) !== -1;
 
     // If defOrWrappedType was an InjectorDefTypeWithProviders, then .providers may hold some
     // extra providers.
@@ -255,7 +253,7 @@ export class R3Injector {
     // Add providers in the same way that @NgModule resolution did:
 
     // First, include providers from any imports.
-    if (def.imports != null) {
+    if (def.imports != null && !isDuplicate) {
       // Before processing defType's imports, add it to the set of parents. This way, if it ends
       // up deeply importing itself, this can be detected.
       ngDevMode && parents.push(defType);
@@ -272,7 +270,7 @@ export class R3Injector {
     }
 
     // Next, include providers listed on the definition itself.
-    if (def.providers != null) {
+    if (def.providers != null && !isDuplicate) {
       deepForEach(def.providers, provider => this.processProvider(provider));
     }
 

--- a/packages/core/src/util/ng_reflect.ts
+++ b/packages/core/src/util/ng_reflect.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export function normalizeDebugBindingName(name: string) {
+  // Attribute names with `$` (eg `x-y$`) are valid per spec, but unsupported by some browsers
+  name = camelCaseToDashCase(name.replace(/[$@]/g, '_'));
+  return `ng-reflect-${name}`;
+}
+
+const CAMEL_CASE_REGEXP = /([A-Z])/g;
+
+function camelCaseToDashCase(input: string): string {
+  return input.replace(CAMEL_CASE_REGEXP, (...m: any[]) => '-' + m[1].toLowerCase());
+}
+
+export function normalizeDebugBindingValue(value: any): string {
+  try {
+    // Limit the size of the value as otherwise the DOM just gets polluted.
+    return value != null ? value.toString().slice(0, 30) : value;
+  } catch (e) {
+    return '[ERROR] Exception while trying to serialize the value';
+  }
+}

--- a/packages/core/src/view/services.ts
+++ b/packages/core/src/view/services.ts
@@ -18,14 +18,13 @@ import {NgModuleRef} from '../linker/ng_module_factory';
 import {Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2} from '../render/api';
 import {Sanitizer} from '../sanitization/security';
 import {Type} from '../type';
-import {tokenKey} from '../view/util';
-
+import {normalizeDebugBindingName, normalizeDebugBindingValue} from '../util/ng_reflect';
 import {isViewDebugError, viewDestroyedError, viewWrappedDebugError} from './errors';
 import {resolveDep} from './provider';
 import {dirtyParentQueries, getQueryValue} from './query';
 import {createInjector, createNgModuleRef, getComponentViewDefinitionFactory} from './refs';
 import {ArgumentType, BindingFlags, CheckType, DebugContext, ElementData, NgModuleDefinition, NodeDef, NodeFlags, NodeLogger, ProviderOverride, RootData, Services, ViewData, ViewDefinition, ViewState, asElementData, asPureExpressionData} from './types';
-import {NOOP, isComponentView, renderNode, resolveDefinition, splitDepsDsl, viewParentEl} from './util';
+import {NOOP, isComponentView, renderNode, resolveDefinition, splitDepsDsl, tokenKey, viewParentEl} from './util';
 import {checkAndUpdateNode, checkAndUpdateView, checkNoChangesNode, checkNoChangesView, createComponentView, createEmbeddedView, createRootView, destroyView} from './view';
 
 
@@ -465,27 +464,6 @@ function debugCheckAndUpdateNode(
 function debugCheckNoChangesNode(
     view: ViewData, nodeDef: NodeDef, argStyle: ArgumentType, values: any[]): void {
   (<any>checkNoChangesNode)(view, nodeDef, argStyle, ...values);
-}
-
-function normalizeDebugBindingName(name: string) {
-  // Attribute names with `$` (eg `x-y$`) are valid per spec, but unsupported by some browsers
-  name = camelCaseToDashCase(name.replace(/[$@]/g, '_'));
-  return `ng-reflect-${name}`;
-}
-
-const CAMEL_CASE_REGEXP = /([A-Z])/g;
-
-function camelCaseToDashCase(input: string): string {
-  return input.replace(CAMEL_CASE_REGEXP, (...m: any[]) => '-' + m[1].toLowerCase());
-}
-
-function normalizeDebugBindingValue(value: any): string {
-  try {
-    // Limit the size of the value as otherwise the DOM just gets polluted.
-    return value != null ? value.toString().slice(0, 30) : value;
-  } catch (e) {
-    return '[ERROR] Exception while trying to serialize the value';
-  }
 }
 
 function nextDirectiveWithBinding(view: ViewData, nodeIndex: number): number|null {

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -218,11 +218,11 @@ export function resetDOM() {
 export function renderToHtml(
     template: ComponentTemplate<any>, ctx: any, consts: number = 0, vars: number = 0,
     directives?: DirectiveTypesOrFactory | null, pipes?: PipeTypesOrFactory | null,
-    providedRendererFactory?: RendererFactory3 | null) {
+    providedRendererFactory?: RendererFactory3 | null, keepNgReflect = false) {
   hostView = renderTemplate(
       containerEl, template, consts, vars, ctx, providedRendererFactory || testRendererFactory,
       hostView, toDefs(directives, extractDirectiveDef), toDefs(pipes, extractPipeDef));
-  return toHtml(containerEl);
+  return toHtml(containerEl, keepNgReflect);
 }
 
 function toDefs(
@@ -263,7 +263,7 @@ export function renderComponent<T>(type: ComponentType<T>, opts?: CreateComponen
 /**
  * @deprecated use `TemplateFixture` or `ComponentFixture`
  */
-export function toHtml<T>(componentOrElement: T | RElement): string {
+export function toHtml<T>(componentOrElement: T | RElement, keepNgReflect = false): string {
   let element: any;
   if (isComponentInstance(componentOrElement)) {
     const context = getContext(componentOrElement);
@@ -273,13 +273,17 @@ export function toHtml<T>(componentOrElement: T | RElement): string {
   }
 
   if (element) {
-    return stringifyElement(element)
-        .replace(/^<div host="">(.*)<\/div>$/, '$1')
-        .replace(/^<div fixture="mark">(.*)<\/div>$/, '$1')
-        .replace(/^<div host="mark">(.*)<\/div>$/, '$1')
-        .replace(' style=""', '')
-        .replace(/<!--container-->/g, '')
-        .replace(/<!--ng-container-->/g, '');
+    let html = stringifyElement(element)
+                   .replace(/^<div host="">(.*)<\/div>$/, '$1')
+                   .replace(/^<div fixture="mark">(.*)<\/div>$/, '$1')
+                   .replace(/^<div host="mark">(.*)<\/div>$/, '$1')
+                   .replace(' style=""', '')
+                   .replace(/<!--container-->/g, '')
+                   .replace(/<!--ng-container-->/g, '');
+    if (!keepNgReflect) {
+      html = html.replace(/\sng-reflect-\S*="[^"]*"/g, '');
+    }
+    return html;
   } else {
     return '';
   }

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -614,15 +614,14 @@ class HiddenModule {
            });
          }));
 
-      fixmeIvy('to investigate') &&
-          it('should handle false values on attributes', async(() => {
-               renderModule(FalseAttributesModule, {document: doc}).then(output => {
-                 expect(output).toBe(
-                     '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
-                     '<my-child ng-reflect-attr="false">Works!</my-child></app></body></html>');
-                 called = true;
-               });
-             }));
+      it('should handle false values on attributes', async(() => {
+           renderModule(FalseAttributesModule, {document: doc}).then(output => {
+             expect(output).toBe(
+                 '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
+                 '<my-child ng-reflect-attr="false">Works!</my-child></app></body></html>');
+             called = true;
+           });
+         }));
 
       it('should handle element property "name"', async(() => {
            renderModule(NameModule, {document: doc}).then(output => {

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -624,15 +624,14 @@ class HiddenModule {
                });
              }));
 
-      fixmeIvy('to investigate') &&
-          it('should handle element property "name"', async(() => {
-               renderModule(NameModule, {document: doc}).then(output => {
-                 expect(output).toBe(
-                     '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
-                     '<input name=""></app></body></html>');
-                 called = true;
-               });
-             }));
+      it('should handle element property "name"', async(() => {
+           renderModule(NameModule, {document: doc}).then(output => {
+             expect(output).toBe(
+                 '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
+                 '<input name=""></app></body></html>');
+             called = true;
+           });
+         }));
 
       fixmeIvy('to investigate') &&
           it('should work with sanitizer to handle "innerHTML"', async(() => {
@@ -648,15 +647,14 @@ class HiddenModule {
                });
              }));
 
-      fixmeIvy('to investigate') &&
-          it('should handle element property "hidden"', async(() => {
-               renderModule(HiddenModule, {document: doc}).then(output => {
-                 expect(output).toBe(
-                     '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
-                     '<input hidden=""><input></app></body></html>');
-                 called = true;
-               });
-             }));
+      it('should handle element property "hidden"', async(() => {
+           renderModule(HiddenModule, {document: doc}).then(output => {
+             expect(output).toBe(
+                 '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
+                 '<input hidden=""><input></app></body></html>');
+             called = true;
+           });
+         }));
 
       it('should call render hook', async(() => {
            renderModule(RenderHookModule, {document: doc}).then(output => {

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -534,8 +534,12 @@ class HiddenModule {
         // PlatformConfig takes in a parsed document so that it can be cached across requests.
         doc = '<html><head></head><body><app></app></body></html>';
         called = false;
-        (global as any)['window'] = undefined;
-        (global as any)['document'] = undefined;
+        // We use `window` and `document` directly in some parts of render3 for ivy
+        // Only set it to undefined for legacy
+        if (fixmeIvy()) {
+          (global as any)['window'] = undefined;
+          (global as any)['document'] = undefined;
+        }
       });
       afterEach(() => { expect(called).toBe(true); });
 
@@ -632,19 +636,18 @@ class HiddenModule {
            });
          }));
 
-      fixmeIvy('to investigate') &&
-          it('should work with sanitizer to handle "innerHTML"', async(() => {
-               // Clear out any global states. These should be set when platform-server
-               // is initialized.
-               (global as any).Node = undefined;
-               (global as any).Document = undefined;
-               renderModule(HTMLTypesModule, {document: doc}).then(output => {
-                 expect(output).toBe(
-                     '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
-                     '<div><b>foo</b> bar</div></app></body></html>');
-                 called = true;
-               });
-             }));
+      it('should work with sanitizer to handle "innerHTML"', async(() => {
+           // Clear out any global states. These should be set when platform-server
+           // is initialized.
+           (global as any).Node = undefined;
+           (global as any).Document = undefined;
+           renderModule(HTMLTypesModule, {document: doc}).then(output => {
+             expect(output).toBe(
+                 '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
+                 '<div><b>foo</b> bar</div></app></body></html>');
+             called = true;
+           });
+         }));
 
       it('should handle element property "hidden"', async(() => {
            renderModule(HiddenModule, {document: doc}).then(output => {

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -20,6 +20,7 @@ import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, PlatformState, ServerModule, Serv
 import {fixmeIvy} from '@angular/private/testing';
 import {Observable} from 'rxjs';
 import {first} from 'rxjs/operators';
+import {ivyEnabled} from '../../core/src/ivy_switch';
 
 @Component({selector: 'app', template: `Works!`})
 class MyServerApp {
@@ -536,7 +537,7 @@ class HiddenModule {
         called = false;
         // We use `window` and `document` directly in some parts of render3 for ivy
         // Only set it to undefined for legacy
-        if (fixmeIvy()) {
+        if (!ivyEnabled) {
           (global as any)['window'] = undefined;
           (global as any)['document'] = undefined;
         }

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -579,7 +579,7 @@ class HiddenModule {
            });
          })));
 
-      fixmeIvy('to investigate') &&
+      fixmeIvy('FW-672: SVG xlink:href is sanitized to :xlink:href (extra ":")') &&
           it('works with SVG elements', async(() => {
                renderModule(SVGServerModule, {document: doc}).then(output => {
                  expect(output).toBe(
@@ -589,7 +589,8 @@ class HiddenModule {
                });
              }));
 
-      fixmeIvy('to investigate') &&
+      fixmeIvy(
+          `FW-643: Components with animations throw with "Failed to execute 'setAttribute' on 'Element'`) &&
           it('works with animation', async(() => {
                renderModule(AnimationServerModule, {document: doc}).then(output => {
                  expect(output).toContain('Works!');

--- a/packages/private/testing/src/fixme.ts
+++ b/packages/private/testing/src/fixme.ts
@@ -17,6 +17,6 @@ import {bazelDefineCompileValue} from './bazel_define_compile_value';
  *
  * The above will prevent the execution of the test(s) in Ivy mode, until they can be fixed.
  */
-export function fixmeIvy(reason: string): boolean {
+export function fixmeIvy(reason?: string): boolean {
   return 'aot' !== (bazelDefineCompileValue as string);
 }

--- a/packages/private/testing/src/fixme.ts
+++ b/packages/private/testing/src/fixme.ts
@@ -17,6 +17,6 @@ import {bazelDefineCompileValue} from './bazel_define_compile_value';
  *
  * The above will prevent the execution of the test(s) in Ivy mode, until they can be fixed.
  */
-export function fixmeIvy(reason?: string): boolean {
+export function fixmeIvy(reason: string): boolean {
   return 'aot' !== (bazelDefineCompileValue as string);
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## List of changes
- When I introduced deduplication of modules for ivy, I didn't take into account `ModuleWithProviders` which means that calling a specific function from a module didn't register the providers when you imported that module if it had been imported previously. The first commit fixes that.
- The view engine would define `ng-reflect-...` attributes on elements in dev mode to help with debugging properties. The second commit enables that for ivy (disabled by default on render3 tests, because it would change too many of them and add noise).
- the platform-server module lets you define a document that will be cached and reused. It'll define the provider `DOCUMENT` that is injected in different modules. Because ivy works tries to avoid depending on injection so much, the third commit fixes the tests to take into account that we actually use the global `document` instead of this injected provider in DomRendererFactory3 as an alternative renderer when there is no renderer available and in InertBodyHelper for html sanitization. In both cases the document is only used for its functions (like creating elements), not for its actual content. I haven’t noticed any difference in either case when using the global document object for that.
- the last commit defines the root cause for the last failing tests of platform-server

## Does this PR introduce a breaking change?

- [x] No