### PR TITLE
test(ivy): add more reason for skipping test in ivy / non-ivy mode

### DIFF
--- a/packages/private/testing/src/fixme.ts
+++ b/packages/private/testing/src/fixme.ts
@@ -8,6 +8,10 @@
 
 import {bazelDefineCompileValue} from './bazel_define_compile_value';
 
+function isIvyMode(): boolean {
+  return (bazelDefineCompileValue as string) === 'aot';
+}
+
 /**
  * A global method which is used to conditionally block the execution of tests.
  *
@@ -18,5 +22,43 @@ import {bazelDefineCompileValue} from './bazel_define_compile_value';
  * The above will prevent the execution of the test(s) in Ivy mode, until they can be fixed.
  */
 export function fixmeIvy(reason: string): boolean {
-  return 'aot' !== (bazelDefineCompileValue as string);
+  return !isIvyMode();
+}
+
+/**
+ * A global method to indicate that a given (existing) test should not be executed in the Ivy mode
+ * as the existing behaviour changed. This might indicate a bug fix available only in Ivy or an
+ * unavoidable breaking change. Ideally an existing test marked with `obsoleteInIvy` should be
+ * accompanied by a new test illustrating Ivy-specific behaviour. Such a new test should be marked
+ * with `fixedInIvy`.
+ *
+ * During the post-Ivy-release cleanup effort, tests marked with `obsoleteInIvy` should be removed.
+ *
+ * ```
+ * obsoleteInIvy('some reason') && describe(...);
+ * ```
+ *
+ * The above will prevent the execution of the test(s) in Ivy mode and serve as an indicator of
+ * behaviour change.
+ */
+export function obsoleteInIvy(reason: string): boolean {
+  return !isIvyMode();
+}
+
+/**
+ * A global method to indicate that a given test is only valid in the ivy mode. This is useful for
+ * cases where ivy behaves differently as compared to the view engine but we still want to add a
+ * test verifying new behaviour.
+ *
+ * During the post-Ivy-release cleanup effort, tests marked with `fixedInIvy` should loose this
+ * marker.
+ *
+ * ```
+ * fixedInIvy('some reason') && describe(...);
+ * ```
+ *
+ * The above will run the test(s) in Ivy mode only.
+ */
+export function fixedInIvy(reason: string): boolean {
+  return isIvyMode();
 }


### PR DESCRIPTION
This PR adds more reasons to skip existing `TestBed` tests so we can track Ivy bug fixes and small breaking changes (as well as add tests fro the changed Ivy behaviour). 

@IgorMinar I think that you were planning to send such PR but since I start to need it a took a stab at it.