### PR TITLE
fix(core): export a value for InjectFlags

### DIFF
--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -19,7 +19,9 @@ import {Inject, Optional, Self, SkipSelf} from './metadata';
  *
  * @publicApi
  */
-export const enum InjectFlags {
+export enum InjectFlags {
+  // TODO(alxhub): make this 'const' when ngc no longer writes exports of it into ngfactory files.
+
   Default = 0b0000,
 
   /**

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -87,6 +87,9 @@
     "name": "INJECTOR_SIZE"
   },
   {
+    "name": "InjectFlags"
+  },
+  {
     "name": "IterableChangeRecord_"
   },
   {

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -177,6 +177,9 @@
     "name": "Inject"
   },
   {
+    "name": "InjectFlags"
+  },
+  {
     "name": "InjectionToken"
   },
   {

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -18,6 +18,9 @@
     "name": "Inject"
   },
   {
+    "name": "InjectFlags"
+  },
+  {
     "name": "InjectionToken"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -75,6 +75,9 @@
     "name": "INJECTOR_SIZE"
   },
   {
+    "name": "InjectFlags"
+  },
+  {
     "name": "IterableChangeRecord_"
   },
   {

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -372,6 +372,9 @@
     "name": "Inject"
   },
   {
+    "name": "InjectFlags"
+  },
+  {
     "name": "InjectionToken"
   },
   {

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -347,7 +347,7 @@ export interface InjectDecorator {
     new (token: any): Inject;
 }
 
-export declare const enum InjectFlags {
+export declare enum InjectFlags {
     Default = 0,
     Host = 1,
     Self = 2,


### PR DESCRIPTION
A recent commit (probably 2c7386c) has changed the import graph of the
DI types in core, and somehow results in the ngc compiler deciding to
re-export core DI types from application factories which tangentially
use inject(). This is not really surprising; ngc's import graph can be
very unstable.

However, this results in a re-export of InjectFlags surviving JS
compilation. InjectFlags was a const enum, akin to an interface in TS,
with no runtime repesentation. This causes a warning to be emitted by
Webpack when it sees the re-export of InjectFlags.

This commit avoids the issue by removing 'const' from the declaration
of InjectFlags, causing it to have a runtime value. This is a temporary
fix. The real fix will be for ngc to no longer write exports of const
enums.

Fixes #27251.