### PR TITLE
feat(ivy): add "allocHostVars" instruction as a replacement for "hostVars" field (FW-692)

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -145,9 +145,9 @@ describe('compiler compliance: bindings', () => {
           type: HostBindingDir,
           selectors: [["", "hostBindingDir", ""]],
           factory: function HostBindingDir_Factory(t) { return new (t || HostBindingDir)(); },
-          hostBindings: function HostBindingDir_HostBindings(rf, ctx, dirIndex, elIndex) {
+          hostBindings: function HostBindingDir_HostBindings(rf, ctx, elIndex) {
             if (rf & 1) {
-              $r3$.ɵallocHostVars(1, dirIndex);
+              $r3$.ɵallocHostVars(1);
             }
             if (rf & 2) {
               $r3$.ɵelementProperty(elIndex, "id", $r3$.ɵbind(ctx.dirId));
@@ -192,9 +192,9 @@ describe('compiler compliance: bindings', () => {
           type: HostBindingComp,
           selectors: [["host-binding-comp"]],
           factory: function HostBindingComp_Factory(t) { return new (t || HostBindingComp)(); },
-          hostBindings: function HostBindingComp_HostBindings(rf, ctx, dirIndex, elIndex) {
+          hostBindings: function HostBindingComp_HostBindings(rf, ctx, elIndex) {
             if (rf & 1) {
-              $r3$.ɵallocHostVars(3, dirIndex);
+              $r3$.ɵallocHostVars(3);
             }
             if (rf & 2) {
               $r3$.ɵelementProperty(elIndex, "id", $r3$.ɵbind($r3$.ɵpureFunction1(1, $ff$, ctx.id)));
@@ -240,9 +240,9 @@ describe('compiler compliance: bindings', () => {
           type: HostAttributeDir,
           selectors: [["", "hostAttributeDir", ""]],
           factory: function HostAttributeDir_Factory(t) { return new (t || HostAttributeDir)(); },
-          hostBindings: function HostAttributeDir_HostBindings(rf, ctx, dirIndex, elIndex) {
+          hostBindings: function HostAttributeDir_HostBindings(rf, ctx, elIndex) {
             if (rf & 1) {
-              $r3$.ɵallocHostVars(1, dirIndex);
+              $r3$.ɵallocHostVars(1);
             }
             if (rf & 2) {
               $r3$.ɵelementAttribute(elIndex, "required", $r3$.ɵbind(ctx.required));

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -145,12 +145,14 @@ describe('compiler compliance: bindings', () => {
           type: HostBindingDir,
           selectors: [["", "hostBindingDir", ""]],
           factory: function HostBindingDir_Factory(t) { return new (t || HostBindingDir)(); },
-          hostBindings: function HostBindingDir_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function HostBindingDir_HostBindings(rf, ctx, dirIndex, elIndex) {
+            if (rf & 1) {
+              $r3$.ɵallocHostVars(1, dirIndex);
+            }
             if (rf & 2) {
               $r3$.ɵelementProperty(elIndex, "id", $r3$.ɵbind(ctx.dirId));
             }
-          },
-          hostVars: 1
+          }
         });
       `;
 
@@ -190,12 +192,14 @@ describe('compiler compliance: bindings', () => {
           type: HostBindingComp,
           selectors: [["host-binding-comp"]],
           factory: function HostBindingComp_Factory(t) { return new (t || HostBindingComp)(); },
-          hostBindings: function HostBindingComp_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function HostBindingComp_HostBindings(rf, ctx, dirIndex, elIndex) {
+            if (rf & 1) {
+              $r3$.ɵallocHostVars(3, dirIndex);
+            }
             if (rf & 2) {
               $r3$.ɵelementProperty(elIndex, "id", $r3$.ɵbind($r3$.ɵpureFunction1(1, $ff$, ctx.id)));
             }
           },
-          hostVars: 3,
           consts: 0,
           vars: 0,
           template: function HostBindingComp_Template(rf, ctx) {},
@@ -236,12 +240,14 @@ describe('compiler compliance: bindings', () => {
           type: HostAttributeDir,
           selectors: [["", "hostAttributeDir", ""]],
           factory: function HostAttributeDir_Factory(t) { return new (t || HostAttributeDir)(); },
-          hostBindings: function HostAttributeDir_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function HostAttributeDir_HostBindings(rf, ctx, dirIndex, elIndex) {
+            if (rf & 1) {
+              $r3$.ɵallocHostVars(1, dirIndex);
+            }
             if (rf & 2) {
               $r3$.ɵelementAttribute(elIndex, "required", $r3$.ɵbind(ctx.required));
             }
-          },
-          hostVars: 1
+          }
         });
       `;
 

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -771,8 +771,9 @@ describe('compiler compliance: styling', () => {
           const _c0 = ["foo", "baz", ${InitialStylingFlags.VALUES_MODE}, "foo", true, "baz", true];
           const _c1 = ["width", "height", "color", ${InitialStylingFlags.VALUES_MODE}, "width", "200px", "height", "500px"];
           …
-          hostBindings: function MyComponent_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function MyComponent_HostBindings(rf, ctx, dirIndex, elIndex) {
             if (rf & 1) {
+              $r3$.ɵallocHostVars(4, dirIndex);
               $r3$.ɵelementStyling(_c0, _c1, $r3$.ɵdefaultStyleSanitizer, ctx);
             }
             if (rf & 2) {
@@ -829,8 +830,9 @@ describe('compiler compliance: styling', () => {
           const _c0 = ["bar", "foo"];
           const _c1 = ["height", "width"];
           …
-          hostBindings: function MyComponent_HostBindings(rf, ctx, elIndex) {
+          hostBindings: function MyComponent_HostBindings(rf, ctx, dirIndex, elIndex) {
             if (rf & 1) {
+              $r3$.ɵallocHostVars(6, dirIndex);
               $r3$.ɵelementStyling(_c0, _c1, $r3$.ɵdefaultStyleSanitizer, ctx);
             }
             if (rf & 2) {
@@ -894,8 +896,9 @@ describe('compiler compliance: styling', () => {
           const _c2 = ["bar"];
           const _c3 = ["height"];
           …
-          function WidthDirective_HostBindings(rf, ctx, elIndex) {
+          function WidthDirective_HostBindings(rf, ctx, dirIndex, elIndex) {
             if (rf & 1) {
+              $r3$.ɵallocHostVars(2, dirIndex);
               $r3$.ɵelementStyling(_c0, _c1, null, ctx);
             }
             if (rf & 2) {
@@ -905,8 +908,9 @@ describe('compiler compliance: styling', () => {
             }
           }
           …
-          function HeightDirective_HostBindings(rf, ctx, elIndex) {
+          function HeightDirective_HostBindings(rf, ctx, dirIndex, elIndex) {
             if (rf & 1) {
+              $r3$.ɵallocHostVars(2, dirIndex);
               $r3$.ɵelementStyling(_c2, _c3, null, ctx);
             }
             if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -771,9 +771,9 @@ describe('compiler compliance: styling', () => {
           const _c0 = ["foo", "baz", ${InitialStylingFlags.VALUES_MODE}, "foo", true, "baz", true];
           const _c1 = ["width", "height", "color", ${InitialStylingFlags.VALUES_MODE}, "width", "200px", "height", "500px"];
           …
-          hostBindings: function MyComponent_HostBindings(rf, ctx, dirIndex, elIndex) {
+          hostBindings: function MyComponent_HostBindings(rf, ctx, elIndex) {
             if (rf & 1) {
-              $r3$.ɵallocHostVars(4, dirIndex);
+              $r3$.ɵallocHostVars(4);
               $r3$.ɵelementStyling(_c0, _c1, $r3$.ɵdefaultStyleSanitizer, ctx);
             }
             if (rf & 2) {
@@ -830,9 +830,9 @@ describe('compiler compliance: styling', () => {
           const _c0 = ["bar", "foo"];
           const _c1 = ["height", "width"];
           …
-          hostBindings: function MyComponent_HostBindings(rf, ctx, dirIndex, elIndex) {
+          hostBindings: function MyComponent_HostBindings(rf, ctx, elIndex) {
             if (rf & 1) {
-              $r3$.ɵallocHostVars(6, dirIndex);
+              $r3$.ɵallocHostVars(6);
               $r3$.ɵelementStyling(_c0, _c1, $r3$.ɵdefaultStyleSanitizer, ctx);
             }
             if (rf & 2) {
@@ -896,9 +896,9 @@ describe('compiler compliance: styling', () => {
           const _c2 = ["bar"];
           const _c3 = ["height"];
           …
-          function WidthDirective_HostBindings(rf, ctx, dirIndex, elIndex) {
+          function WidthDirective_HostBindings(rf, ctx, elIndex) {
             if (rf & 1) {
-              $r3$.ɵallocHostVars(2, dirIndex);
+              $r3$.ɵallocHostVars(2);
               $r3$.ɵelementStyling(_c0, _c1, null, ctx);
             }
             if (rf & 2) {
@@ -908,9 +908,9 @@ describe('compiler compliance: styling', () => {
             }
           }
           …
-          function HeightDirective_HostBindings(rf, ctx, dirIndex, elIndex) {
+          function HeightDirective_HostBindings(rf, ctx, elIndex) {
             if (rf & 1) {
-              $r3$.ɵallocHostVars(2, dirIndex);
+              $r3$.ɵallocHostVars(2);
               $r3$.ɵelementStyling(_c2, _c3, null, ctx);
             }
             if (rf & 2) {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -472,7 +472,7 @@ describe('ngtsc behavioral tests', () => {
     env.driveMain();
     const jsContents = env.getContents('test.js');
     const hostBindingsFn = `
-      hostBindings: function FooCmp_HostBindings(rf, ctx, dirIndex, elIndex) {
+      hostBindings: function FooCmp_HostBindings(rf, ctx, elIndex) {
         if (rf & 1) {
           i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick($event.target); });
           i0.ɵlistener("scroll", function FooCmp_scroll_HostBindingHandler($event) { return ctx.onScroll(); });
@@ -510,9 +510,9 @@ describe('ngtsc behavioral tests', () => {
     env.driveMain();
     const jsContents = env.getContents('test.js');
     const hostBindingsFn = `
-      hostBindings: function FooCmp_HostBindings(rf, ctx, dirIndex, elIndex) {
+      hostBindings: function FooCmp_HostBindings(rf, ctx, elIndex) {
         if (rf & 1) {
-          i0.ɵallocHostVars(3, dirIndex);
+          i0.ɵallocHostVars(3);
           i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick($event); });
           i0.ɵlistener("change", function FooCmp_change_HostBindingHandler($event) { return ctx.onChange(ctx.arg1, ctx.arg2, ctx.arg3); });
           i0.ɵelementStyling(_c0, null, null, ctx);
@@ -545,7 +545,7 @@ describe('ngtsc behavioral tests', () => {
     env.driveMain();
     const jsContents = env.getContents('test.js');
     const hostBindingsFn = `
-      hostBindings: function Dir_HostBindings(rf, ctx, dirIndex, elIndex) {
+      hostBindings: function Dir_HostBindings(rf, ctx, elIndex) {
         if (rf & 1) {
           i0.ɵlistener("change", function Dir_change_HostBindingHandler($event) { return ctx.onChange(ctx.arg); });
         }

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -472,7 +472,7 @@ describe('ngtsc behavioral tests', () => {
     env.driveMain();
     const jsContents = env.getContents('test.js');
     const hostBindingsFn = `
-      hostBindings: function FooCmp_HostBindings(rf, ctx, elIndex) {
+      hostBindings: function FooCmp_HostBindings(rf, ctx, dirIndex, elIndex) {
         if (rf & 1) {
           i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick($event.target); });
           i0.ɵlistener("scroll", function FooCmp_scroll_HostBindingHandler($event) { return ctx.onScroll(); });
@@ -510,8 +510,9 @@ describe('ngtsc behavioral tests', () => {
     env.driveMain();
     const jsContents = env.getContents('test.js');
     const hostBindingsFn = `
-      hostBindings: function FooCmp_HostBindings(rf, ctx, elIndex) {
+      hostBindings: function FooCmp_HostBindings(rf, ctx, dirIndex, elIndex) {
         if (rf & 1) {
+          i0.ɵallocHostVars(3, dirIndex);
           i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick($event); });
           i0.ɵlistener("change", function FooCmp_change_HostBindingHandler($event) { return ctx.onChange(ctx.arg1, ctx.arg2, ctx.arg3); });
           i0.ɵelementStyling(_c0, null, null, ctx);
@@ -544,7 +545,7 @@ describe('ngtsc behavioral tests', () => {
     env.driveMain();
     const jsContents = env.getContents('test.js');
     const hostBindingsFn = `
-      hostBindings: function Dir_HostBindings(rf, ctx, elIndex) {
+      hostBindings: function Dir_HostBindings(rf, ctx, dirIndex, elIndex) {
         if (rf & 1) {
           i0.ɵlistener("change", function Dir_change_HostBindingHandler($event) { return ctx.onChange(ctx.arg); });
         }

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -66,6 +66,8 @@ export class Identifiers {
 
   static disableBindings: o.ExternalReference = {name: 'ɵdisableBindings', moduleName: CORE};
 
+  static allocHostVars: o.ExternalReference = {name: 'ɵallocHostVars', moduleName: CORE};
+
   static getCurrentView: o.ExternalReference = {name: 'ɵgetCurrentView', moduleName: CORE};
 
   static restoreView: o.ExternalReference = {name: 'ɵrestoreView', moduleName: CORE};

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -66,7 +66,6 @@ function baseDirectiveFields(
   const hostVarsCount = Object.keys(meta.host.properties).length;
 
   const elVarExp = o.variable('elIndex');
-  const dirVarExp = o.variable('dirIndex');
   const contextVarExp = o.variable(CONTEXT_NAME);
   const styleBuilder = new StylingBuilder(elVarExp, contextVarExp);
 
@@ -95,9 +94,9 @@ function baseDirectiveFields(
 
   // e.g. `hostBindings: (rf, ctx, dirIndex, elIndex) => { ... }
   definitionMap.set(
-      'hostBindings', createHostBindingsFunction(
-                          meta, elVarExp, dirVarExp, contextVarExp, styleBuilder, bindingParser,
-                          constantPool, hostVarsCount));
+      'hostBindings',
+      createHostBindingsFunction(
+          meta, elVarExp, contextVarExp, styleBuilder, bindingParser, constantPool, hostVarsCount));
 
   // e.g 'inputs: {a: 'a'}`
   definitionMap.set('inputs', conditionallyCreateMapObjectLiteral(meta.inputs));
@@ -634,9 +633,9 @@ function createViewQueriesFunction(
 
 // Return a host binding function or null if one is not necessary.
 function createHostBindingsFunction(
-    meta: R3DirectiveMetadata, elVarExp: o.ReadVarExpr, dirVarExp: o.ReadVarExpr,
-    bindingContext: o.ReadVarExpr, styleBuilder: StylingBuilder, bindingParser: BindingParser,
-    constantPool: ConstantPool, hostVarsCount: number): o.Expression|null {
+    meta: R3DirectiveMetadata, elVarExp: o.ReadVarExpr, bindingContext: o.ReadVarExpr,
+    styleBuilder: StylingBuilder, bindingParser: BindingParser, constantPool: ConstantPool,
+    hostVarsCount: number): o.Expression|null {
   const createStatements: o.Statement[] = [];
   const updateStatements: o.Statement[] = [];
 
@@ -713,7 +712,7 @@ function createHostBindingsFunction(
 
   if (totalHostVarsCount) {
     createStatements.unshift(
-        o.importExpr(R3.allocHostVars).callFn([o.literal(totalHostVarsCount), dirVarExp]).toStmt());
+        o.importExpr(R3.allocHostVars).callFn([o.literal(totalHostVarsCount)]).toStmt());
   }
 
   if (createStatements.length > 0 || updateStatements.length > 0) {
@@ -728,7 +727,7 @@ function createHostBindingsFunction(
     return o.fn(
         [
           new o.FnParam(RENDER_FLAGS, o.NUMBER_TYPE), new o.FnParam(CONTEXT_NAME, null),
-          new o.FnParam(dirVarExp.name !, null), new o.FnParam(elVarExp.name !, o.NUMBER_TYPE)
+          new o.FnParam(elVarExp.name !, o.NUMBER_TYPE)
         ],
         statements, o.INFERRED_TYPE, null, hostBindingsFnName);
   }

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -92,7 +92,7 @@ function baseDirectiveFields(
   // e.g. `attributes: ['role', 'listbox']`
   definitionMap.set('attributes', createHostAttributesArray(allOtherAttributes));
 
-  // e.g. `hostBindings: (rf, ctx, dirIndex, elIndex) => { ... }
+  // e.g. `hostBindings: (rf, ctx, elIndex) => { ... }
   definitionMap.set(
       'hostBindings',
       createHostBindingsFunction(

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -85,6 +85,7 @@ export {
   reference as ɵreference,
   enableBindings as ɵenableBindings,
   disableBindings as ɵdisableBindings,
+  allocHostVars as ɵallocHostVars,
   elementAttribute as ɵelementAttribute,
   elementContainerStart as ɵelementContainerStart,
   elementContainerEnd as ɵelementContainerEnd,

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -17,13 +17,13 @@ import {getComponentDef} from './definition';
 import {diPublicInInjector, getOrCreateNodeInjectorForNode} from './di';
 import {publishDefaultGlobalUtils} from './global_utils';
 import {queueInitHooks, queueLifecycleHooks} from './hooks';
-import {CLEAN_PROMISE, createLView, createNodeAtIndex, createTView, getOrCreateTView, initNodeFlags, instantiateRootComponent, locateHostElement, prefillHostVars, queueComponentIndexForCheck, refreshDescendantViews} from './instructions';
-import {ComponentDef, ComponentType} from './interfaces/definition';
+import {CLEAN_PROMISE, createLView, createNodeAtIndex, createTView, getOrCreateTView, initNodeFlags, instantiateRootComponent, locateHostElement, queueComponentIndexForCheck, refreshDescendantViews} from './instructions';
+import {ComponentDef, ComponentType, RenderFlags} from './interfaces/definition';
 import {TElementNode, TNodeFlags, TNodeType} from './interfaces/node';
 import {PlayerHandler} from './interfaces/player';
 import {RElement, Renderer3, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
 import {CONTEXT, HEADER_OFFSET, HOST, HOST_NODE, INJECTOR, LView, LViewFlags, RootContext, RootContextFlags, TVIEW} from './interfaces/view';
-import {enterView, leaveView, resetComponentState} from './state';
+import {enterView, getPreviousOrParentTNode, leaveView, resetComponentState} from './state';
 import {defaultScheduler, getRootView, readPatchedLView, stringify} from './util';
 
 
@@ -195,7 +195,12 @@ export function createRootComponent<T>(
 
   hostFeatures && hostFeatures.forEach((feature) => feature(component, componentDef));
 
-  if (tView.firstTemplatePass) prefillHostVars(tView, rootView, componentDef.hostVars);
+  if (tView.firstTemplatePass && componentDef.hostBindings) {
+    const rootTNode = getPreviousOrParentTNode();
+    const dirIndex = rootView.length - 1;
+    componentDef.hostBindings(RenderFlags.Create, component, dirIndex, rootTNode.index);
+  }
+
   return component;
 }
 

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -23,7 +23,7 @@ import {TElementNode, TNodeFlags, TNodeType} from './interfaces/node';
 import {PlayerHandler} from './interfaces/player';
 import {RElement, Renderer3, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
 import {CONTEXT, HEADER_OFFSET, HOST, HOST_NODE, INJECTOR, LView, LViewFlags, RootContext, RootContextFlags, TVIEW} from './interfaces/view';
-import {enterView, getPreviousOrParentTNode, leaveView, resetComponentState} from './state';
+import {enterView, getPreviousOrParentTNode, leaveView, resetComponentState, setCurrentDirectiveDef} from './state';
 import {defaultScheduler, getRootView, readPatchedLView, stringify} from './util';
 
 
@@ -197,8 +197,9 @@ export function createRootComponent<T>(
 
   if (tView.firstTemplatePass && componentDef.hostBindings) {
     const rootTNode = getPreviousOrParentTNode();
-    const dirIndex = rootView.length - 1;
-    componentDef.hostBindings(RenderFlags.Create, component, dirIndex, rootTNode.index);
+    setCurrentDirectiveDef(componentDef);
+    componentDef.hostBindings(RenderFlags.Create, component, rootTNode.index);
+    setCurrentDirectiveDef(null);
   }
 
   return component;

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -74,14 +74,6 @@ export function defineComponent<T>(componentDefinition: {
   vars: number;
 
   /**
-   * The number of host bindings (including pure fn bindings) in this component.
-   *
-   * Used to calculate the length of the LView array for the *parent* component
-   * of this component.
-   */
-  hostVars?: number;
-
-  /**
    * Static attributes to set on host element.
    *
    * Even indices: attribute name
@@ -262,7 +254,6 @@ export function defineComponent<T>(componentDefinition: {
     providersResolver: null,
     consts: componentDefinition.consts,
     vars: componentDefinition.vars,
-    hostVars: componentDefinition.hostVars || 0,
     factory: componentDefinition.factory,
     template: componentDefinition.template || null !,
     hostBindings: componentDefinition.hostBindings || null,
@@ -585,14 +576,6 @@ export const defineDirective = defineComponent as any as<T>(directiveDefinition:
    * See: {@link NgOnChangesFeature}, {@link ProvidersFeature}, {@link InheritDefinitionFeature}
    */
   features?: DirectiveDefFeature[];
-
-  /**
-   * The number of host bindings (including pure fn bindings) in this directive.
-   *
-   * Used to calculate the length of the LView array for the *parent* component
-   * of this directive.
-   */
-  hostVars?: number;
 
   /**
    * Function executed by the parent template to allow child directive to apply host bindings.

--- a/packages/core/src/render3/features/inherit_definition_feature.ts
+++ b/packages/core/src/render3/features/inherit_definition_feature.ts
@@ -72,11 +72,10 @@ export function InheritDefinitionFeature(definition: DirectiveDef<any>| Componen
       const superHostBindings = superDef.hostBindings;
       if (superHostBindings) {
         if (prevHostBindings) {
-          definition.hostBindings =
-              (rf: RenderFlags, ctx: any, dirIndex: number, elementIndex: number) => {
-                superHostBindings(rf, ctx, dirIndex, elementIndex);
-                prevHostBindings(rf, ctx, dirIndex, elementIndex);
-              };
+          definition.hostBindings = (rf: RenderFlags, ctx: any, elementIndex: number) => {
+            superHostBindings(rf, ctx, elementIndex);
+            prevHostBindings(rf, ctx, elementIndex);
+          };
         } else {
           definition.hostBindings = superHostBindings;
         }

--- a/packages/core/src/render3/features/inherit_definition_feature.ts
+++ b/packages/core/src/render3/features/inherit_definition_feature.ts
@@ -72,11 +72,11 @@ export function InheritDefinitionFeature(definition: DirectiveDef<any>| Componen
       const superHostBindings = superDef.hostBindings;
       if (superHostBindings) {
         if (prevHostBindings) {
-          definition.hostBindings = (rf: RenderFlags, ctx: any, elementIndex: number) => {
-            superHostBindings(rf, ctx, elementIndex);
-            prevHostBindings(rf, ctx, elementIndex);
-          };
-          (definition as any).hostVars += superDef.hostVars;
+          definition.hostBindings =
+              (rf: RenderFlags, ctx: any, dirIndex: number, elementIndex: number) => {
+                superHostBindings(rf, ctx, dirIndex, elementIndex);
+                prevHostBindings(rf, ctx, dirIndex, elementIndex);
+              };
         } else {
           definition.hostBindings = superHostBindings;
         }

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -21,6 +21,7 @@ export {CssSelectorList} from './interfaces/projection';
 
 // clang-format off
 export {
+  allocHostVars,
   bind,
   interpolation1,
   interpolation2,

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -45,7 +45,6 @@ import {NO_CHANGE} from './tokens';
 import {getComponentViewByIndex, getNativeByIndex, getNativeByTNode, getRootContext, getRootView, getTNode, isComponent, isComponentDef, loadInternal, readElementValue, readPatchedLView, stringify} from './util';
 
 
-
 /**
  * A permanent marker promise which signifies that the current CD tree is
  * clean.
@@ -1516,6 +1515,8 @@ export function generateExpandoInstructionBlock(
 * Because we are updating the blueprint, we only need to do this once.
 */
 function prefillHostVars(tView: TView, lView: LView, totalHostVars: number): void {
+  ngDevMode &&
+      assertEqual(getFirstTemplatePass(), true, 'Should only be called in first template pass.');
   for (let i = 0; i < totalHostVars; i++) {
     lView.push(NO_CHANGE);
     tView.blueprint.push(NO_CHANGE);
@@ -1625,9 +1626,7 @@ function queueHostBindingForCheck(
   // check whether a given `hostBindings` function already exists in expandoInstructions,
   // which can happen in case directive definition was extended from base definition (as a part of
   // the `InheritDefinitionFeature` logic)
-  if (expando.length < 2 ||
-      !(typeof expando[expando.length - 1] === 'number' &&
-        expando[expando.length - 2] === def.hostBindings)) {
+  if (expando.length < 2 || expando[expando.length - 2] !== def.hostBindings) {
     expando.push(def.hostBindings !, hostVars);
   }
 }

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -325,8 +325,7 @@ export type DirectiveTypeList =
     (DirectiveDef<any>| ComponentDef<any>|
      Type<any>/* Type as workaround for: Microsoft/TypeScript/issues/4881 */)[];
 
-export type HostBindingsFunction<T> =
-    (rf: RenderFlags, ctx: T, dirIndex: number, elementIndex: number) => void;
+export type HostBindingsFunction<T> = (rf: RenderFlags, ctx: T, elementIndex: number) => void;
 
 /**
  * Type used for PipeDefs on component definition.

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -136,14 +136,6 @@ export interface DirectiveDef<T> extends BaseDef<T> {
   /** Refreshes content queries associated with directives in a given view */
   contentQueriesRefresh: ((directiveIndex: number, queryIndex: number) => void)|null;
 
-  /**
-   * The number of host bindings (including pure fn bindings) in this directive/component.
-   *
-   * Used to calculate the length of the LView array for the *parent* component
-   * of this directive/component.
-   */
-  readonly hostVars: number;
-
   /** Refreshes host bindings on the associated directive. */
   hostBindings: HostBindingsFunction<T>|null;
 
@@ -333,7 +325,8 @@ export type DirectiveTypeList =
     (DirectiveDef<any>| ComponentDef<any>|
      Type<any>/* Type as workaround for: Microsoft/TypeScript/issues/4881 */)[];
 
-export type HostBindingsFunction<T> = (rf: RenderFlags, ctx: T, elementIndex: number) => void;
+export type HostBindingsFunction<T> =
+    (rf: RenderFlags, ctx: T, dirIndex: number, elementIndex: number) => void;
 
 /**
  * Type used for PipeDefs on component definition.

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -346,7 +346,7 @@ export interface TView {
    *
    * See VIEW_DATA.md for more information.
    */
-  expandoInstructions: (number|HostBindingsFunction<any>)[]|null;
+  expandoInstructions: (number|HostBindingsFunction<any>|null)[]|null;
 
   /**
    * Full registry of directives and components that may be found in this view.

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -46,6 +46,7 @@ export const angularCoreEnv: {[name: string]: Function} = {
   'ɵnamespaceSVG': r3.namespaceSVG,
   'ɵenableBindings': r3.enableBindings,
   'ɵdisableBindings': r3.disableBindings,
+  'ɵallocHostVars': r3.allocHostVars,
   'ɵelementStart': r3.elementStart,
   'ɵelementEnd': r3.elementEnd,
   'ɵelement': r3.element,

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -8,6 +8,7 @@
 
 import {assertDefined} from './assert';
 import {executeHooks} from './hooks';
+import {ComponentDef, DirectiveDef} from './interfaces/definition';
 import {TElementNode, TNode, TNodeFlags, TViewNode} from './interfaces/node';
 import {LQueries} from './interfaces/query';
 import {BINDING_INDEX, CONTEXT, DECLARATION_VIEW, FLAGS, HOST_NODE, LView, LViewFlags, OpaqueViewState, QUERIES, TVIEW} from './interfaces/view';
@@ -32,6 +33,17 @@ export function increaseElementDepthCount() {
 
 export function decreaseElementDepthCount() {
   elementDepthCount--;
+}
+
+let currentDirectiveDef: DirectiveDef<any>|ComponentDef<any>|null = null;
+
+export function getCurrentDirectiveDef(): DirectiveDef<any>|ComponentDef<any>|null {
+  // top level variables should not be exported for performance reasons (PERF_NOTES.md)
+  return currentDirectiveDef;
+}
+
+export function setCurrentDirectiveDef(def: DirectiveDef<any>| ComponentDef<any>| null): void {
+  currentDirectiveDef = def;
 }
 
 /**

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -1089,9 +1089,6 @@
     "name": "setCurrentDirectiveDef"
   },
   {
-    "name": "setCurrentQueries"
-  },
-  {
     "name": "setDirty"
   },
   {

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -843,6 +843,9 @@
     "name": "invertObject"
   },
   {
+    "name": "invokeDirectivesHostBindings"
+  },
+  {
     "name": "isClassBased"
   },
   {
@@ -969,9 +972,6 @@
     "name": "noSideEffects"
   },
   {
-    "name": "noop"
-  },
-  {
     "name": "onChangesWrapper"
   },
   {
@@ -982,9 +982,6 @@
   },
   {
     "name": "postProcessDirective"
-  },
-  {
-    "name": "prefillHostVars"
   },
   {
     "name": "prepareInitialFlag"
@@ -1000,9 +997,6 @@
   },
   {
     "name": "queueDestroyHooks"
-  },
-  {
-    "name": "queueHostBindingForCheck"
   },
   {
     "name": "queueInitHooks"
@@ -1090,6 +1084,12 @@
   },
   {
     "name": "setContextPlayersDirty"
+  },
+  {
+    "name": "setCurrentDirectiveDef"
+  },
+  {
+    "name": "setCurrentQueries"
   },
   {
     "name": "setDirty"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -378,22 +378,13 @@
     "name": "noSideEffects"
   },
   {
-    "name": "noop"
-  },
-  {
     "name": "onChangesWrapper"
   },
   {
     "name": "postProcessBaseDirective"
   },
   {
-    "name": "prefillHostVars"
-  },
-  {
     "name": "queueComponentIndexForCheck"
-  },
-  {
-    "name": "queueHostBindingForCheck"
   },
   {
     "name": "readElementValue"
@@ -430,6 +421,9 @@
   },
   {
     "name": "setBindingRoot"
+  },
+  {
+    "name": "setCurrentDirectiveDef"
   },
   {
     "name": "setFirstTemplatePass"

--- a/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world_r2/bundle.golden_symbols.json
@@ -1143,9 +1143,6 @@
     "name": "noSideEffects"
   },
   {
-    "name": "noop"
-  },
-  {
     "name": "noop$1"
   },
   {
@@ -1185,9 +1182,6 @@
     "name": "postProcessBaseDirective"
   },
   {
-    "name": "prefillHostVars"
-  },
-  {
     "name": "projectionNodeStack"
   },
   {
@@ -1207,9 +1201,6 @@
   },
   {
     "name": "queueDestroyHooks"
-  },
-  {
-    "name": "queueHostBindingForCheck"
   },
   {
     "name": "queueInitHooks"
@@ -1291,6 +1282,9 @@
   },
   {
     "name": "setCheckNoChangesMode"
+  },
+  {
+    "name": "setCurrentDirectiveDef"
   },
   {
     "name": "setCurrentInjector"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -873,6 +873,9 @@
     "name": "invertObject"
   },
   {
+    "name": "invokeDirectivesHostBindings"
+  },
+  {
     "name": "isComponent"
   },
   {
@@ -987,9 +990,6 @@
     "name": "noSideEffects"
   },
   {
-    "name": "noop"
-  },
-  {
     "name": "onChangesWrapper"
   },
   {
@@ -1000,9 +1000,6 @@
   },
   {
     "name": "postProcessDirective"
-  },
-  {
-    "name": "prefillHostVars"
   },
   {
     "name": "prepareInitialFlag"
@@ -1018,9 +1015,6 @@
   },
   {
     "name": "queueDestroyHooks"
-  },
-  {
-    "name": "queueHostBindingForCheck"
   },
   {
     "name": "queueInitHooks"
@@ -1111,6 +1105,12 @@
   },
   {
     "name": "setContextPlayersDirty"
+  },
+  {
+    "name": "setCurrentDirectiveDef"
+  },
+  {
+    "name": "setCurrentQueries"
   },
   {
     "name": "setDirty"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1110,9 +1110,6 @@
     "name": "setCurrentDirectiveDef"
   },
   {
-    "name": "setCurrentQueries"
-  },
-  {
     "name": "setDirty"
   },
   {

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -2106,6 +2106,9 @@
     "name": "invertObject"
   },
   {
+    "name": "invokeDirectivesHostBindings"
+  },
+  {
     "name": "isArray"
   },
   {
@@ -2334,9 +2337,6 @@
     "name": "noSideEffects"
   },
   {
-    "name": "noop"
-  },
-  {
     "name": "noop$1"
   },
   {
@@ -2400,9 +2400,6 @@
     "name": "postProcessDirective"
   },
   {
-    "name": "prefillHostVars"
-  },
-  {
     "name": "prepareInitialFlag"
   },
   {
@@ -2425,9 +2422,6 @@
   },
   {
     "name": "queueDestroyHooks"
-  },
-  {
-    "name": "queueHostBindingForCheck"
   },
   {
     "name": "queueInitHooks"
@@ -2545,6 +2539,9 @@
   },
   {
     "name": "setContextPlayersDirty"
+  },
+  {
+    "name": "setCurrentDirectiveDef"
   },
   {
     "name": "setCurrentInjector"

--- a/packages/core/test/render3/Inherit_definition_feature_spec.ts
+++ b/packages/core/test/render3/Inherit_definition_feature_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {Inject, InjectionToken} from '../../src/core';
-import {ComponentDef, DirectiveDef, InheritDefinitionFeature, NgOnChangesFeature, ProvidersFeature, RenderFlags, bind, defineBase, defineComponent, defineDirective, directiveInject, element, elementProperty, load} from '../../src/render3/index';
+import {ComponentDef, DirectiveDef, InheritDefinitionFeature, NgOnChangesFeature, ProvidersFeature, RenderFlags, allocHostVars, bind, defineBase, defineComponent, defineDirective, directiveInject, element, elementProperty, load} from '../../src/render3/index';
 
 import {ComponentFixture, createComponent} from './render_util';
 
@@ -308,12 +308,15 @@ describe('InheritDefinitionFeature', () => {
       static ngDirectiveDef = defineDirective({
         type: SuperDirective,
         selectors: [['', 'superDir', '']],
-        hostBindings: (rf: RenderFlags, ctx: SuperDirective, elementIndex: number) => {
-          if (rf & RenderFlags.Update) {
-            elementProperty(elementIndex, 'id', bind(ctx.id));
-          }
-        },
-        hostVars: 1,
+        hostBindings:
+            (rf: RenderFlags, ctx: SuperDirective, dirIndex: number, elementIndex: number) => {
+              if (rf & RenderFlags.Create) {
+                allocHostVars(1, dirIndex);
+              }
+              if (rf & RenderFlags.Update) {
+                elementProperty(elementIndex, 'id', bind(ctx.id));
+              }
+            },
         factory: () => new SuperDirective(),
       });
     }
@@ -324,12 +327,15 @@ describe('InheritDefinitionFeature', () => {
       static ngDirectiveDef = defineDirective({
         type: SubDirective,
         selectors: [['', 'subDir', '']],
-        hostBindings: (rf: RenderFlags, ctx: SubDirective, elementIndex: number) => {
-          if (rf & RenderFlags.Update) {
-            elementProperty(elementIndex, 'title', bind(ctx.title));
-          }
-        },
-        hostVars: 1,
+        hostBindings:
+            (rf: RenderFlags, ctx: SubDirective, dirIndex: number, elementIndex: number) => {
+              if (rf & RenderFlags.Create) {
+                allocHostVars(1, dirIndex);
+              }
+              if (rf & RenderFlags.Update) {
+                elementProperty(elementIndex, 'title', bind(ctx.title));
+              }
+            },
         factory: () => subDir = new SubDirective(),
         features: [InheritDefinitionFeature]
       });

--- a/packages/core/test/render3/Inherit_definition_feature_spec.ts
+++ b/packages/core/test/render3/Inherit_definition_feature_spec.ts
@@ -308,15 +308,14 @@ describe('InheritDefinitionFeature', () => {
       static ngDirectiveDef = defineDirective({
         type: SuperDirective,
         selectors: [['', 'superDir', '']],
-        hostBindings:
-            (rf: RenderFlags, ctx: SuperDirective, dirIndex: number, elementIndex: number) => {
-              if (rf & RenderFlags.Create) {
-                allocHostVars(1, dirIndex);
-              }
-              if (rf & RenderFlags.Update) {
-                elementProperty(elementIndex, 'id', bind(ctx.id));
-              }
-            },
+        hostBindings: (rf: RenderFlags, ctx: SuperDirective, elementIndex: number) => {
+          if (rf & RenderFlags.Create) {
+            allocHostVars(1);
+          }
+          if (rf & RenderFlags.Update) {
+            elementProperty(elementIndex, 'id', bind(ctx.id));
+          }
+        },
         factory: () => new SuperDirective(),
       });
     }
@@ -327,15 +326,14 @@ describe('InheritDefinitionFeature', () => {
       static ngDirectiveDef = defineDirective({
         type: SubDirective,
         selectors: [['', 'subDir', '']],
-        hostBindings:
-            (rf: RenderFlags, ctx: SubDirective, dirIndex: number, elementIndex: number) => {
-              if (rf & RenderFlags.Create) {
-                allocHostVars(1, dirIndex);
-              }
-              if (rf & RenderFlags.Update) {
-                elementProperty(elementIndex, 'title', bind(ctx.title));
-              }
-            },
+        hostBindings: (rf: RenderFlags, ctx: SubDirective, elementIndex: number) => {
+          if (rf & RenderFlags.Create) {
+            allocHostVars(1);
+          }
+          if (rf & RenderFlags.Update) {
+            elementProperty(elementIndex, 'title', bind(ctx.title));
+          }
+        },
         factory: () => subDir = new SubDirective(),
         features: [InheritDefinitionFeature]
       });

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -654,9 +654,9 @@ describe('di', () => {
             type: HostBindingDir,
             selectors: [['', 'hostBindingDir', '']],
             factory: () => hostBindingDir = new HostBindingDir(),
-            hostBindings: (rf: RenderFlags, ctx: any, dirIndex: number, elementIndex: number) => {
+            hostBindings: (rf: RenderFlags, ctx: any, elementIndex: number) => {
               if (rf & RenderFlags.Create) {
-                allocHostVars(1, dirIndex);
+                allocHostVars(1);
               }
               if (rf & RenderFlags.Update) {
                 elementProperty(elementIndex, 'id', bind(ctx.id));

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -13,7 +13,7 @@ import {defineComponent} from '../../src/render3/definition';
 import {bloomAdd, bloomHasToken, bloomHashBitOrFactory as bloomHash, getOrCreateNodeInjectorForNode} from '../../src/render3/di';
 import {defineDirective, elementProperty, load, templateRefExtractor} from '../../src/render3/index';
 
-import {bind, container, containerRefreshEnd, containerRefreshStart, createNodeAtIndex, createLView, createTView, directiveInject, element, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, injectAttribute, interpolation2, projection, projectionDef, reference, template, text, textBinding, elementContainerStart, elementContainerEnd} from '../../src/render3/instructions';
+import {allocHostVars, bind, container, containerRefreshEnd, containerRefreshStart, createNodeAtIndex, createLView, createTView, directiveInject, element, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, injectAttribute, interpolation2, projection, projectionDef, reference, template, text, textBinding, elementContainerStart, elementContainerEnd} from '../../src/render3/instructions';
 import {isProceduralRenderer, RElement} from '../../src/render3/interfaces/renderer';
 import {AttributeMarker, TNodeType} from '../../src/render3/interfaces/node';
 import {getNativeByIndex} from '../../src/render3/util';
@@ -654,8 +654,10 @@ describe('di', () => {
             type: HostBindingDir,
             selectors: [['', 'hostBindingDir', '']],
             factory: () => hostBindingDir = new HostBindingDir(),
-            hostVars: 1,
-            hostBindings: (rf: RenderFlags, ctx: any, elementIndex: number) => {
+            hostBindings: (rf: RenderFlags, ctx: any, dirIndex: number, elementIndex: number) => {
+              if (rf & RenderFlags.Create) {
+                allocHostVars(1, dirIndex);
+              }
               if (rf & RenderFlags.Update) {
                 elementProperty(elementIndex, 'id', bind(ctx.id));
               }

--- a/packages/core/test/render3/host_binding_spec.ts
+++ b/packages/core/test/render3/host_binding_spec.ts
@@ -9,7 +9,7 @@
 import {ElementRef, EventEmitter} from '@angular/core';
 
 import {AttributeMarker, defineComponent, template, defineDirective, ProvidersFeature, NgOnChangesFeature, QueryList} from '../../src/render3/index';
-import {allocHostVars, bind, directiveInject, element, elementEnd, elementProperty, elementStart, load, text, textBinding, loadQueryList, registerContentQuery} from '../../src/render3/instructions';
+import {allocHostVars, bind, directiveInject, element, elementEnd, elementProperty, elementStart, listener, load, text, textBinding, loadQueryList, registerContentQuery} from '../../src/render3/instructions';
 import {query, queryRefresh} from '../../src/render3/query';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {pureFunction1, pureFunction2} from '../../src/render3/pure_function';
@@ -49,9 +49,9 @@ describe('host bindings', () => {
       type: HostBindingDir,
       selectors: [['', 'hostBindingDir', '']],
       factory: () => hostBindingDir = new HostBindingDir(),
-      hostBindings: (rf: RenderFlags, ctx: any, dirIndex: number, elementIndex: number) => {
+      hostBindings: (rf: RenderFlags, ctx: any, elementIndex: number) => {
         if (rf & RenderFlags.Create) {
-          allocHostVars(1, dirIndex);
+          allocHostVars(1);
         }
         if (rf & RenderFlags.Update) {
           elementProperty(elementIndex, 'id', bind(ctx.id));
@@ -70,9 +70,9 @@ describe('host bindings', () => {
       factory: () => new HostBindingComp(),
       consts: 0,
       vars: 0,
-      hostBindings: (rf: RenderFlags, ctx: HostBindingComp, dirIndex: number, elIndex: number) => {
+      hostBindings: (rf: RenderFlags, ctx: HostBindingComp, elIndex: number) => {
         if (rf & RenderFlags.Create) {
-          allocHostVars(1, dirIndex);
+          allocHostVars(1);
         }
         if (rf & RenderFlags.Update) {
           elementProperty(elIndex, 'id', bind(ctx.id));
@@ -93,9 +93,9 @@ describe('host bindings', () => {
         type: Directive,
         selectors: [['', 'dir', '']],
         factory: () => directiveInstance = new Directive,
-        hostBindings: (rf: RenderFlags, ctx: any, dirIndex: number, elementIndex: number) => {
+        hostBindings: (rf: RenderFlags, ctx: any, elementIndex: number) => {
           if (rf & RenderFlags.Create) {
-            allocHostVars(1, dirIndex);
+            allocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
             elementProperty(elementIndex, 'className', bind(ctx.klass));
@@ -145,15 +145,14 @@ describe('host bindings', () => {
             () => new CompWithProviders(directiveInject(ServiceOne), directiveInject(ServiceTwo)),
         consts: 0,
         vars: 0,
-        hostBindings:
-            (rf: RenderFlags, ctx: CompWithProviders, dirIndex: number, elIndex: number) => {
-              if (rf & RenderFlags.Create) {
-                allocHostVars(1, dirIndex);
-              }
-              if (rf & RenderFlags.Update) {
-                elementProperty(elIndex, 'id', bind(ctx.id));
-              }
-            },
+        hostBindings: (rf: RenderFlags, ctx: CompWithProviders, elIndex: number) => {
+          if (rf & RenderFlags.Create) {
+            allocHostVars(1);
+          }
+          if (rf & RenderFlags.Update) {
+            elementProperty(elIndex, 'id', bind(ctx.id));
+          }
+        },
         template: (rf: RenderFlags, ctx: CompWithProviders) => {},
         features: [ProvidersFeature([[ServiceOne], [ServiceTwo]])]
       });
@@ -182,9 +181,9 @@ describe('host bindings', () => {
         factory: () => new HostTitleComp(),
         consts: 0,
         vars: 0,
-        hostBindings: (rf: RenderFlags, ctx: HostTitleComp, dirIndex: number, elIndex: number) => {
+        hostBindings: (rf: RenderFlags, ctx: HostTitleComp, elIndex: number) => {
           if (rf & RenderFlags.Create) {
-            allocHostVars(1, dirIndex);
+            allocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
             elementProperty(elIndex, 'title', bind(ctx.title));
@@ -218,7 +217,7 @@ describe('host bindings', () => {
     expect(hostBindingDiv.id).toEqual('bar');
   });
 
-  it('should support consecutive components with with host bindings', () => {
+  it('should support consecutive components with host bindings', () => {
     let comps: HostBindingComp[] = [];
 
     class HostBindingComp {
@@ -235,15 +234,14 @@ describe('host bindings', () => {
         },
         consts: 0,
         vars: 0,
-        hostBindings:
-            (rf: RenderFlags, ctx: HostBindingComp, dirIndex: number, elIndex: number) => {
-              if (rf & RenderFlags.Create) {
-                allocHostVars(1, dirIndex);
-              }
-              if (rf & RenderFlags.Update) {
-                elementProperty(elIndex, 'id', bind(ctx.id));
-              }
-            },
+        hostBindings: (rf: RenderFlags, ctx: HostBindingComp, elIndex: number) => {
+          if (rf & RenderFlags.Create) {
+            allocHostVars(1);
+          }
+          if (rf & RenderFlags.Update) {
+            elementProperty(elIndex, 'id', bind(ctx.id));
+          }
+        },
         template: (rf: RenderFlags, ctx: HostBindingComp) => {}
       });
     }
@@ -326,9 +324,9 @@ describe('host bindings', () => {
         consts: 0,
         vars: 0,
         features: [NgOnChangesFeature],
-        hostBindings: (rf: RenderFlags, ctx: InitHookComp, dirIndex: number, elIndex: number) => {
+        hostBindings: (rf: RenderFlags, ctx: InitHookComp, elIndex: number) => {
           if (rf & RenderFlags.Create) {
-            allocHostVars(1, dirIndex);
+            allocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
             elementProperty(elIndex, 'title', bind(ctx.value));
@@ -494,19 +492,18 @@ describe('host bindings', () => {
         factory: () => hostBindingComp = new HostBindingComp(),
         consts: 0,
         vars: 0,
-        hostBindings:
-            (rf: RenderFlags, ctx: HostBindingComp, dirIndex: number, elIndex: number) => {
-              // LView: [..., id, dir, title, ctx.id, pf1, ctx.title, ctx.otherTitle, pf2]
-              if (rf & RenderFlags.Create) {
-                allocHostVars(8, dirIndex);
-              }
-              if (rf & RenderFlags.Update) {
-                elementProperty(elIndex, 'id', bind(pureFunction1(3, ff, ctx.id)));
-                elementProperty(elIndex, 'dir', bind(ctx.dir));
-                elementProperty(
-                    elIndex, 'title', bind(pureFunction2(5, ff2, ctx.title, ctx.otherTitle)));
-              }
-            },
+        hostBindings: (rf: RenderFlags, ctx: HostBindingComp, elIndex: number) => {
+          // LView: [..., id, dir, title, ctx.id, pf1, ctx.title, ctx.otherTitle, pf2]
+          if (rf & RenderFlags.Create) {
+            allocHostVars(8);
+          }
+          if (rf & RenderFlags.Update) {
+            elementProperty(elIndex, 'id', bind(pureFunction1(3, ff, ctx.id)));
+            elementProperty(elIndex, 'dir', bind(ctx.dir));
+            elementProperty(
+                elIndex, 'title', bind(pureFunction2(5, ff2, ctx.title, ctx.otherTitle)));
+          }
+        },
         template: (rf: RenderFlags, ctx: HostBindingComp) => {}
       });
     }
@@ -573,16 +570,15 @@ describe('host bindings', () => {
         factory: () => hostBindingComp = new HostBindingComp(),
         consts: 0,
         vars: 0,
-        hostBindings:
-            (rf: RenderFlags, ctx: HostBindingComp, dirIndex: number, elIndex: number) => {
-              // LView: [..., id, ctx.id, pf1]
-              if (rf & RenderFlags.Create) {
-                allocHostVars(1, dirIndex);
-              }
-              if (rf & RenderFlags.Update) {
-                elementProperty(elIndex, 'id', bind(pureFunction1(1, ff, ctx.id)));
-              }
-            },
+        hostBindings: (rf: RenderFlags, ctx: HostBindingComp, elIndex: number) => {
+          // LView: [..., id, ctx.id, pf1]
+          if (rf & RenderFlags.Create) {
+            allocHostVars(3);
+          }
+          if (rf & RenderFlags.Update) {
+            elementProperty(elIndex, 'id', bind(pureFunction1(1, ff, ctx.id)));
+          }
+        },
         template: (rf: RenderFlags, ctx: HostBindingComp) => {}
       });
     }
@@ -605,10 +601,10 @@ describe('host bindings', () => {
         type: HostBindingDir,
         selectors: [['', 'hostDir', '']],
         factory: () => hostBindingDir = new HostBindingDir(),
-        hostBindings: (rf: RenderFlags, ctx: HostBindingDir, dirIndex: number, elIndex: number) => {
-          // LView [..., title, ctx.title, pf1]
+        hostBindings: (rf: RenderFlags, ctx: HostBindingDir, elIndex: number) => {
+          // LView: [..., title, ctx.title, pf1]
           if (rf & RenderFlags.Create) {
-            allocHostVars(3, dirIndex);
+            allocHostVars(3);
           }
           if (rf & RenderFlags.Update) {
             elementProperty(elIndex, 'title', bind(pureFunction1(1, ff1, ctx.title)));
@@ -641,6 +637,69 @@ describe('host bindings', () => {
     expect(hostElement.id).toBe('red,green');
   });
 
+  it('should support directives with and without allocHostVars on the same component', () => {
+    let events: string[] = [];
+
+    const ff1 = (v: any) => [v, 'other title'];
+
+    /**
+     * @Directive({
+     *   ...
+     *   host: {
+     *     '[title]': '[title, 'other title']'
+     *   }
+     * })
+     *
+     */
+    class HostBindingDir {
+      title = 'my title';
+
+      static ngDirectiveDef = defineDirective({
+        type: HostBindingDir,
+        selectors: [['', 'hostDir', '']],
+        factory: () => new HostBindingDir(),
+        hostBindings: (rf: RenderFlags, ctx: HostBindingDir, elIndex: number) => {
+          // LViewData [..., title, ctx.title, pf1]
+          if (rf & RenderFlags.Create) {
+            allocHostVars(3);
+          }
+          if (rf & RenderFlags.Update) {
+            elementProperty(elIndex, 'title', bind(pureFunction1(1, ff1, ctx.title)));
+          }
+        }
+      });
+    }
+
+    class HostListenerDir {
+      /* @HostListener('click') */
+      onClick() { events.push('click!'); }
+
+      static ngDirectiveDef = defineDirective({
+        type: HostListenerDir,
+        selectors: [['', 'hostListenerDir', '']],
+        factory: function HostListenerDir_Factory() { return new HostListenerDir(); },
+        hostBindings: function HostListenerDir_HostBindings(
+            rf: RenderFlags, ctx: any, elIndex: number) {
+          if (rf & RenderFlags.Create) {
+            listener('click', function() { return ctx.onClick(); });
+          }
+        }
+      });
+    }
+
+    // <button hostListenerDir hostDir>Click</button>
+    const fixture = new TemplateFixture(() => {
+      elementStart(0, 'button', ['hostListenerDir', '', 'hostDir', '']);
+      text(1, 'Click');
+      elementEnd();
+    }, () => {}, 2, 0, [HostListenerDir, HostBindingDir]);
+
+    const button = fixture.hostElement.querySelector('button') !;
+    button.click();
+    expect(events).toEqual(['click!']);
+    expect(button.title).toEqual('my title,other title');
+  });
+
   it('should support ternary expressions in host bindings', () => {
     let hostBindingComp !: HostBindingComp;
 
@@ -669,20 +728,19 @@ describe('host bindings', () => {
         factory: () => hostBindingComp = new HostBindingComp(),
         consts: 0,
         vars: 0,
-        hostBindings:
-            (rf: RenderFlags, ctx: HostBindingComp, dirIndex: number, elIndex: number) => {
-              // LView: [..., id, title, ctx.id, pf1, ctx.title, pf1]
-              if (rf & RenderFlags.Create) {
-                allocHostVars(6, dirIndex);
-              }
-              if (rf & RenderFlags.Update) {
-                elementProperty(
-                    elIndex, 'id', bind(ctx.condition ? pureFunction1(2, ff, ctx.id) : 'green'));
-                elementProperty(
-                    elIndex, 'title',
-                    bind(ctx.otherCondition ? pureFunction1(4, ff1, ctx.title) : 'other title'));
-              }
-            },
+        hostBindings: (rf: RenderFlags, ctx: HostBindingComp, elIndex: number) => {
+          // LView: [..., id, title, ctx.id, pf1, ctx.title, pf1]
+          if (rf & RenderFlags.Create) {
+            allocHostVars(6);
+          }
+          if (rf & RenderFlags.Update) {
+            elementProperty(
+                elIndex, 'id', bind(ctx.condition ? pureFunction1(2, ff, ctx.id) : 'green'));
+            elementProperty(
+                elIndex, 'title',
+                bind(ctx.otherCondition ? pureFunction1(4, ff1, ctx.title) : 'other title'));
+          }
+        },
         template: (rf: RenderFlags, ctx: HostBindingComp) => {}
       });
     }
@@ -762,10 +820,9 @@ describe('host bindings', () => {
         factory: () => new HostBindingWithContentChildren(),
         consts: 0,
         vars: 0,
-        hostBindings: (rf: RenderFlags, ctx: HostBindingWithContentChildren, dirIndex: number,
-                       elIndex: number) => {
+        hostBindings: (rf: RenderFlags, ctx: HostBindingWithContentChildren, elIndex: number) => {
           if (rf & RenderFlags.Create) {
-            allocHostVars(1, dirIndex);
+            allocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
             elementProperty(elIndex, 'id', bind(ctx.foos.length));
@@ -822,10 +879,9 @@ describe('host bindings', () => {
         factory: () => new HostBindingWithContentHooks(),
         consts: 0,
         vars: 0,
-        hostBindings: (rf: RenderFlags, ctx: HostBindingWithContentHooks, dirIndex: number,
-                       elIndex: number) => {
+        hostBindings: (rf: RenderFlags, ctx: HostBindingWithContentHooks, elIndex: number) => {
           if (rf & RenderFlags.Create) {
-            allocHostVars(1, dirIndex);
+            allocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
             elementProperty(elIndex, 'id', bind(ctx.myValue));

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -446,16 +446,15 @@ describe('render3 integration test', () => {
             }
           },
           factory: () => cmptInstance = new TodoComponentHostBinding,
-          hostBindings: function(rf: RenderFlags, ctx: any, dirIndex: number, elementIndex: number):
-              void {
-                if (rf & RenderFlags.Create) {
-                  allocHostVars(1, dirIndex);
-                }
-                if (rf & RenderFlags.Update) {
-                  // host bindings
-                  elementProperty(elementIndex, 'title', bind(ctx.title));
-                }
-              }
+          hostBindings: function(rf: RenderFlags, ctx: any, elementIndex: number): void {
+            if (rf & RenderFlags.Create) {
+              allocHostVars(1);
+            }
+            if (rf & RenderFlags.Update) {
+              // host bindings
+              elementProperty(elementIndex, 'title', bind(ctx.title));
+            }
+          }
         });
       }
 
@@ -1383,9 +1382,9 @@ describe('render3 integration test', () => {
               return hostBindingDir = new HostBindingDir();
             },
             hostBindings: function HostBindingDir_HostBindings(
-                rf: RenderFlags, ctx: any, dirIndex: number, elIndex: number) {
+                rf: RenderFlags, ctx: any, elIndex: number) {
               if (rf & RenderFlags.Create) {
-                allocHostVars(1, dirIndex);
+                allocHostVars(1);
               }
               if (rf & RenderFlags.Update) {
                 elementAttribute(elIndex, 'aria-label', bind(ctx.label));

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -10,7 +10,7 @@ import {ElementRef, TemplateRef, ViewContainerRef} from '@angular/core';
 import {RendererStyleFlags2, RendererType2} from '../../src/render/api';
 import {AttributeMarker, defineComponent, defineDirective, templateRefExtractor} from '../../src/render3/index';
 
-import {bind, container, containerRefreshEnd, containerRefreshStart, element, elementAttribute, elementClassProp, elementContainerEnd, elementContainerStart, elementEnd, elementProperty, elementStart, elementStyleProp, elementStyling, elementStylingApply, embeddedViewEnd, embeddedViewStart, interpolation1, interpolation2, interpolation3, interpolation4, interpolation5, interpolation6, interpolation7, interpolation8, interpolationV, load, projection, projectionDef, reference, text, textBinding, template, elementStylingMap, directiveInject} from '../../src/render3/instructions';
+import {allocHostVars, bind, container, containerRefreshEnd, containerRefreshStart, element, elementAttribute, elementClassProp, elementContainerEnd, elementContainerStart, elementEnd, elementProperty, elementStart, elementStyleProp, elementStyling, elementStylingApply, embeddedViewEnd, embeddedViewStart, interpolation1, interpolation2, interpolation3, interpolation4, interpolation5, interpolation6, interpolation7, interpolation8, interpolationV, load, projection, projectionDef, reference, text, textBinding, template, elementStylingMap, directiveInject} from '../../src/render3/instructions';
 import {InitialStylingFlags, RenderFlags} from '../../src/render3/interfaces/definition';
 import {RElement, Renderer3, RendererFactory3, domRendererFactory3, RText, RComment, RNode, RendererStyleFlags3, ProceduralRenderer3} from '../../src/render3/interfaces/renderer';
 import {NO_CHANGE} from '../../src/render3/tokens';
@@ -446,13 +446,16 @@ describe('render3 integration test', () => {
             }
           },
           factory: () => cmptInstance = new TodoComponentHostBinding,
-          hostVars: 1,
-          hostBindings: function(rf: RenderFlags, ctx: any, elementIndex: number): void {
-            if (rf & RenderFlags.Update) {
-              // host bindings
-              elementProperty(elementIndex, 'title', bind(ctx.title));
-            }
-          }
+          hostBindings: function(rf: RenderFlags, ctx: any, dirIndex: number, elementIndex: number):
+              void {
+                if (rf & RenderFlags.Create) {
+                  allocHostVars(1, dirIndex);
+                }
+                if (rf & RenderFlags.Update) {
+                  // host bindings
+                  elementProperty(elementIndex, 'title', bind(ctx.title));
+                }
+              }
         });
       }
 
@@ -1379,9 +1382,11 @@ describe('render3 integration test', () => {
             factory: function HostBindingDir_Factory() {
               return hostBindingDir = new HostBindingDir();
             },
-            hostVars: 1,
             hostBindings: function HostBindingDir_HostBindings(
-                rf: RenderFlags, ctx: any, elIndex: number) {
+                rf: RenderFlags, ctx: any, dirIndex: number, elIndex: number) {
+              if (rf & RenderFlags.Create) {
+                allocHostVars(1, dirIndex);
+              }
               if (rf & RenderFlags.Update) {
                 elementAttribute(elIndex, 'aria-label', bind(ctx.label));
               }

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -229,7 +229,7 @@ ivyEnabled && describe('render3 jit', () => {
     const cmpDef = (Cmp as any).ngComponentDef as ComponentDef<Cmp>;
 
     expect(cmpDef.hostBindings).toBeDefined();
-    expect(cmpDef.hostBindings !.length).toBe(3);
+    expect(cmpDef.hostBindings !.length).toBe(4);
   });
 
   it('should compile @Pipes without errors', () => {

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -229,7 +229,7 @@ ivyEnabled && describe('render3 jit', () => {
     const cmpDef = (Cmp as any).ngComponentDef as ComponentDef<Cmp>;
 
     expect(cmpDef.hostBindings).toBeDefined();
-    expect(cmpDef.hostBindings !.length).toBe(4);
+    expect(cmpDef.hostBindings !.length).toBe(3);
   });
 
   it('should compile @Pipes without errors', () => {

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -1837,10 +1837,9 @@ describe('ViewContainerRef', () => {
           vars: 0,
           template: (rf: RenderFlags, cmp: HostBindingCmpt) => {},
           attributes: ['id', 'attribute'],
-          hostBindings: function(
-              rf: RenderFlags, ctx: HostBindingCmpt, dirIndex: number, elIndex: number) {
+          hostBindings: function(rf: RenderFlags, ctx: HostBindingCmpt, elIndex: number) {
             if (rf & RenderFlags.Create) {
-              allocHostVars(1, dirIndex);
+              allocHostVars(1);
             }
             if (rf & RenderFlags.Update) {
               elementProperty(elIndex, 'title', bind(ctx.title));

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -10,7 +10,7 @@ import {ChangeDetectorRef, Component as _Component, ComponentFactoryResolver, El
 import {ViewEncapsulation} from '../../src/metadata';
 import {AttributeMarker, NO_CHANGE, NgOnChangesFeature, defineComponent, defineDirective, definePipe, injectComponentFactoryResolver, load, query, queryRefresh} from '../../src/render3/index';
 
-import {bind, container, containerRefreshEnd, containerRefreshStart, directiveInject, element, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, interpolation1, interpolation3, nextContext, projection, projectionDef, reference, template, text, textBinding} from '../../src/render3/instructions';
+import {allocHostVars, bind, container, containerRefreshEnd, containerRefreshStart, directiveInject, element, elementEnd, elementProperty, elementStart, embeddedViewEnd, embeddedViewStart, interpolation1, interpolation3, nextContext, projection, projectionDef, reference, template, text, textBinding} from '../../src/render3/instructions';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {RElement} from '../../src/render3/interfaces/renderer';
 import {templateRefExtractor} from '../../src/render3/view_engine_compatibility_prebound';
@@ -1836,9 +1836,12 @@ describe('ViewContainerRef', () => {
           consts: 0,
           vars: 0,
           template: (rf: RenderFlags, cmp: HostBindingCmpt) => {},
-          hostVars: 1,
           attributes: ['id', 'attribute'],
-          hostBindings: function(rf: RenderFlags, ctx: HostBindingCmpt, elIndex: number) {
+          hostBindings: function(
+              rf: RenderFlags, ctx: HostBindingCmpt, dirIndex: number, elIndex: number) {
+            if (rf & RenderFlags.Create) {
+              allocHostVars(1, dirIndex);
+            }
             if (rf & RenderFlags.Update) {
               elementProperty(elIndex, 'title', bind(ctx.title));
             }


### PR DESCRIPTION
The goal of this PR is to add a new "allocHostVars" instruction that replaces the "hostVars" field for Directives/Components. The "allocHostVars" instruction will be invoked within the "create" block of the `hostBindings` function.

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No