### PR TITLE
test(upgrade): re-enable tests that have been fixed

### DIFF
--- a/packages/upgrade/test/BUILD.bazel
+++ b/packages/upgrade/test/BUILD.bazel
@@ -23,7 +23,6 @@ ts_web_test_suite(
     static_files = [
         "//:angularjs_scripts",
     ],
-    tags = [],
     deps = [
         ":test_lib",
     ],

--- a/packages/upgrade/test/common/downgrade_component_adapter_spec.ts
+++ b/packages/upgrade/test/common/downgrade_component_adapter_spec.ts
@@ -178,28 +178,26 @@ withEachNg1Version(() => {
       beforeEach(() => registry.unregisterAllApplications());
       afterEach(() => registry.unregisterAllApplications());
 
-      fixmeIvy('FW-561: Runtime compiler is not loaded') &&
-          it('should add testabilities hook when creating components', () => {
+      it('should add testabilities hook when creating components', () => {
 
-            let registry = TestBed.get(TestabilityRegistry);
-            adapter.createComponent([]);
-            expect(registry.getAllTestabilities().length).toEqual(1);
+        let registry = TestBed.get(TestabilityRegistry);
+        adapter.createComponent([]);
+        expect(registry.getAllTestabilities().length).toEqual(1);
 
-            adapter = getAdaptor();  // get a new adaptor to creat a new component
-            adapter.createComponent([]);
-            expect(registry.getAllTestabilities().length).toEqual(2);
-          });
+        adapter = getAdaptor();  // get a new adaptor to creat a new component
+        adapter.createComponent([]);
+        expect(registry.getAllTestabilities().length).toEqual(2);
+      });
 
-      fixmeIvy('FW-561: Runtime compiler is not loaded') &&
-          it('should remove the testability hook when destroy a component', () => {
-            const registry = TestBed.get(TestabilityRegistry);
-            expect(registry.getAllTestabilities().length).toEqual(0);
-            adapter.createComponent([]);
-            expect(registry.getAllTestabilities().length).toEqual(1);
-            adapter.registerCleanup();
-            element.remove !();
-            expect(registry.getAllTestabilities().length).toEqual(0);
-          });
+      it('should remove the testability hook when destroy a component', () => {
+        const registry = TestBed.get(TestabilityRegistry);
+        expect(registry.getAllTestabilities().length).toEqual(0);
+        adapter.createComponent([]);
+        expect(registry.getAllTestabilities().length).toEqual(1);
+        adapter.registerCleanup();
+        element.remove !();
+        expect(registry.getAllTestabilities().length).toEqual(0);
+      });
     });
 
   });


### PR DESCRIPTION
The fix in #27223 unblocks these tests
