### PR TITLE
test(ivy): enable @angular/service-worker targets to run on CI (FW-730)

### DIFF
--- a/packages/service-worker/test/BUILD.bazel
+++ b/packages/service-worker/test/BUILD.bazel
@@ -20,7 +20,6 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
-    tags = ["fixme-ivy-aot"],
     deps = [
         ":test_lib",
         "//tools/testing:node",
@@ -29,7 +28,6 @@ jasmine_node_test(
 
 ts_web_test_suite(
     name = "test_web",
-    tags = ["fixme-ivy-aot"],
     deps = [
         ":test_lib",
     ],

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -8,12 +8,12 @@
 
 import {PLATFORM_ID} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {NgswCommChannel} from '@angular/service-worker/src/low_level';
+import {RegistrationOptions, ngswCommChannelFactory} from '@angular/service-worker/src/module';
+import {SwPush} from '@angular/service-worker/src/push';
+import {SwUpdate} from '@angular/service-worker/src/update';
+import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockServiceWorkerRegistration, patchDecodeBase64} from '@angular/service-worker/testing/mock';
 
-import {NgswCommChannel} from '../src/low_level';
-import {RegistrationOptions, ngswCommChannelFactory} from '../src/module';
-import {SwPush} from '../src/push';
-import {SwUpdate} from '../src/update';
-import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockServiceWorkerRegistration, patchDecodeBase64} from '../testing/mock';
 import {async_fit, async_it} from './async';
 
 {

--- a/packages/service-worker/test/integration_spec.ts
+++ b/packages/service-worker/test/integration_spec.ts
@@ -6,19 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {NgswCommChannel} from '@angular/service-worker/src/low_level';
+import {SwPush} from '@angular/service-worker/src/push';
+import {SwUpdate} from '@angular/service-worker/src/update';
+import {MockServiceWorkerContainer, MockServiceWorkerRegistration} from '@angular/service-worker/testing/mock';
+import {CacheDatabase} from '@angular/service-worker/worker/src/db-cache';
+import {Driver} from '@angular/service-worker/worker/src/driver';
+import {Manifest} from '@angular/service-worker/worker/src/manifest';
+import {MockRequest} from '@angular/service-worker/worker/testing/fetch';
+import {MockFileSystemBuilder, MockServerStateBuilder, tmpHashTableForFs} from '@angular/service-worker/worker/testing/mock';
+import {SwTestHarness, SwTestHarnessBuilder} from '@angular/service-worker/worker/testing/scope';
 import {Observable} from 'rxjs';
 import {take} from 'rxjs/operators';
-
-import {NgswCommChannel} from '../src/low_level';
-import {SwPush} from '../src/push';
-import {SwUpdate} from '../src/update';
-import {MockServiceWorkerContainer, MockServiceWorkerRegistration} from '../testing/mock';
-import {CacheDatabase} from '../worker/src/db-cache';
-import {Driver} from '../worker/src/driver';
-import {Manifest} from '../worker/src/manifest';
-import {MockRequest} from '../worker/testing/fetch';
-import {MockFileSystemBuilder, MockServerStateBuilder, tmpHashTableForFs} from '../worker/testing/mock';
-import {SwTestHarness, SwTestHarnessBuilder} from '../worker/testing/scope';
 
 import {async_beforeEach, async_fit, async_it} from './async';
 


### PR DESCRIPTION
This PR enables @angular/service-worker tests to run on CI + updates relative -> absolute import paths to make them run.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
