### PR TITLE
Fixmeivy platform webworker

### DIFF
--- a/packages/platform-webworker/test/BUILD.bazel
+++ b/packages/platform-webworker/test/BUILD.bazel
@@ -14,13 +14,13 @@ ts_library(
         "//packages/platform-browser-dynamic/testing",
         "//packages/platform-browser/testing",
         "//packages/platform-webworker",
+        "//packages/private/testing",
     ],
 )
 
 jasmine_node_test(
     name = "test",
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
-    tags = ["fixme-ivy-aot"],
     deps = [
         ":test_lib",
         "//tools/testing:node",
@@ -29,9 +29,6 @@ jasmine_node_test(
 
 ts_web_test_suite(
     name = "test_web",
-    tags = [
-        "fixme-ivy-aot",
-    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
+++ b/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
@@ -15,12 +15,12 @@ import {BrowserTestingModule} from '@angular/platform-browser/testing';
 import {browserDetection, dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-import {ClientMessageBrokerFactory} from '../../../src/web_workers/shared/client_message_broker';
-import {RenderStore} from '../../../src/web_workers/shared/render_store';
-import {Serializer} from '../../../src/web_workers/shared/serializer';
-import {ServiceMessageBrokerFactory} from '../../../src/web_workers/shared/service_message_broker';
-import {MessageBasedRenderer2} from '../../../src/web_workers/ui/renderer';
-import {WebWorkerRendererFactory2} from '../../../src/web_workers/worker/renderer';
+import {ClientMessageBrokerFactory} from '@angular/platform-webworker/src/web_workers/shared/client_message_broker';
+import {RenderStore} from '@angular/platform-webworker/src/web_workers/shared/render_store';
+import {Serializer} from '@angular/platform-webworker/src/web_workers/shared/serializer';
+import {ServiceMessageBrokerFactory} from '@angular/platform-webworker/src/web_workers/shared/service_message_broker';
+import {MessageBasedRenderer2} from '@angular/platform-webworker/src/web_workers/ui/renderer';
+import {WebWorkerRendererFactory2} from '@angular/platform-webworker/src/web_workers/worker/renderer';
 import {PairedMessageBuses, createPairedMessageBuses} from '../shared/web_worker_test_util';
 
 let lastCreatedRenderer: Renderer2;

--- a/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
+++ b/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
@@ -14,13 +14,14 @@ import {DomRendererFactory2} from '@angular/platform-browser/src/dom/dom_rendere
 import {BrowserTestingModule} from '@angular/platform-browser/testing';
 import {browserDetection, dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-
 import {ClientMessageBrokerFactory} from '@angular/platform-webworker/src/web_workers/shared/client_message_broker';
 import {RenderStore} from '@angular/platform-webworker/src/web_workers/shared/render_store';
 import {Serializer} from '@angular/platform-webworker/src/web_workers/shared/serializer';
 import {ServiceMessageBrokerFactory} from '@angular/platform-webworker/src/web_workers/shared/service_message_broker';
 import {MessageBasedRenderer2} from '@angular/platform-webworker/src/web_workers/ui/renderer';
 import {WebWorkerRendererFactory2} from '@angular/platform-webworker/src/web_workers/worker/renderer';
+import {fixmeIvy} from '@angular/private/testing';
+
 import {PairedMessageBuses, createPairedMessageBuses} from '../shared/web_worker_test_util';
 
 let lastCreatedRenderer: Renderer2;
@@ -94,50 +95,52 @@ let lastCreatedRenderer: Renderer2;
       expect(renderEl).toHaveText('Hello World!');
     });
 
-    it('should update any element property/attributes/class/style(s) independent of the compilation on the root element and other elements',
-       () => {
-         const fixture =
-             TestBed.overrideTemplate(MyComp2, '<input [title]="y" style="position:absolute">')
-                 .createComponent(MyComp2);
+    fixmeIvy('#FW-750 - fixture.debugElement is null') &&
+        it('should update any element property/attributes/class/style(s) independent of the compilation on the root element and other elements',
+           () => {
+             const fixture =
+                 TestBed.overrideTemplate(MyComp2, '<input [title]="y" style="position:absolute">')
+                     .createComponent(MyComp2);
 
-         const checkSetters = (componentRef: ComponentRef<any>, workerEl: any) => {
-           expect(lastCreatedRenderer).not.toBeNull();
+             const checkSetters = (componentRef: ComponentRef<any>, workerEl: any) => {
+               expect(lastCreatedRenderer).not.toBeNull();
 
-           const el = getRenderElement(workerEl);
-           lastCreatedRenderer.setProperty(workerEl, 'tabIndex', 1);
-           expect(el.tabIndex).toEqual(1);
+               const el = getRenderElement(workerEl);
+               lastCreatedRenderer.setProperty(workerEl, 'tabIndex', 1);
+               expect(el.tabIndex).toEqual(1);
 
-           lastCreatedRenderer.addClass(workerEl, 'a');
-           expect(getDOM().hasClass(el, 'a')).toBe(true);
+               lastCreatedRenderer.addClass(workerEl, 'a');
+               expect(getDOM().hasClass(el, 'a')).toBe(true);
 
-           lastCreatedRenderer.removeClass(workerEl, 'a');
-           expect(getDOM().hasClass(el, 'a')).toBe(false);
+               lastCreatedRenderer.removeClass(workerEl, 'a');
+               expect(getDOM().hasClass(el, 'a')).toBe(false);
 
-           lastCreatedRenderer.setStyle(workerEl, 'width', '10px');
-           expect(getDOM().getStyle(el, 'width')).toEqual('10px');
+               lastCreatedRenderer.setStyle(workerEl, 'width', '10px');
+               expect(getDOM().getStyle(el, 'width')).toEqual('10px');
 
-           lastCreatedRenderer.removeStyle(workerEl, 'width');
-           expect(getDOM().getStyle(el, 'width')).toEqual('');
+               lastCreatedRenderer.removeStyle(workerEl, 'width');
+               expect(getDOM().getStyle(el, 'width')).toEqual('');
 
-           lastCreatedRenderer.setAttribute(workerEl, 'someattr', 'someValue');
-           expect(getDOM().getAttribute(el, 'someattr')).toEqual('someValue');
-         };
+               lastCreatedRenderer.setAttribute(workerEl, 'someattr', 'someValue');
+               expect(getDOM().getAttribute(el, 'someattr')).toEqual('someValue');
+             };
 
-         // root element
-         checkSetters(fixture.componentRef, fixture.nativeElement);
-         // nested elements
-         checkSetters(fixture.componentRef, fixture.debugElement.children[0].nativeElement);
-       });
+             // root element
+             checkSetters(fixture.componentRef, fixture.nativeElement);
+             // nested elements
+             checkSetters(fixture.componentRef, fixture.debugElement.children[0].nativeElement);
+           });
 
-    it('should update any template comment property/attributes', () => {
-      const fixture =
-          TestBed.overrideTemplate(MyComp2, '<ng-container *ngIf="ctxBoolProp"></ng-container>')
-              .createComponent(MyComp2);
-      fixture.componentInstance.ctxBoolProp = true;
-      fixture.detectChanges();
-      const el = getRenderElement(fixture.nativeElement);
-      expect(getDOM().getInnerHTML(el)).toContain('"ng-reflect-ng-if": "true"');
-    });
+    fixmeIvy('#FW-664 ng-reflect-* is not supported') &&
+        it('should update any template comment property/attributes', () => {
+          const fixture =
+              TestBed.overrideTemplate(MyComp2, '<ng-container *ngIf="ctxBoolProp"></ng-container>')
+                  .createComponent(MyComp2);
+          fixture.componentInstance.ctxBoolProp = true;
+          fixture.detectChanges();
+          const el = getRenderElement(fixture.nativeElement);
+          expect(getDOM().getInnerHTML(el)).toContain('"ng-reflect-ng-if": "true"');
+        });
 
     it('should add and remove fragments', () => {
       const fixture =

--- a/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
+++ b/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
@@ -161,7 +161,7 @@ let lastCreatedRenderer: Renderer2;
     });
 
     if (getDOM().supportsDOMEvents()) {
-      it('should listen to events', () => {
+      fixmeIvy('#FW-750 - fixture.debugElement is null') && it('should listen to events', () => {
         const fixture = TestBed.overrideTemplate(MyComp2, '<input (change)="ctxNumProp = 1">')
                             .createComponent(MyComp2);
 


### PR DESCRIPTION
depends on #27309

Simply adds `fixmeIvy` blocks to tests that fail with ivy AOT compilation.