### PR TITLE
fix(bazel): ng_package should correctly map to source maps in secondary entry-points

### DIFF
--- a/packages/bazel/src/ng_package/packager.ts
+++ b/packages/bazel/src/ng_package/packager.ts
@@ -253,6 +253,12 @@ function main(args: string[]): number {
       const outputPath = path.join(dir, ...path.basename(file).split('__'));
       shx.mkdir('-p', path.dirname(outputPath));
       shx.mv(path.join(dir, path.basename(file)), outputPath);
+
+      // if we are renaming the .js file, we'll also need to update the sourceMappingURL in the file
+      if (file.endsWith('.js')) {
+        shx.chmod('+w', outputPath);
+        shx.sed('-i', `${path.basename(file)}.map`, `${path.basename(outputPath)}.map`, outputPath);
+      }
     }
   }
 

--- a/packages/bazel/test/ng_package/common_package.spec.ts
+++ b/packages/bazel/test/ng_package/common_package.spec.ts
@@ -70,6 +70,26 @@ describe('@angular/common ng_package', () => {
     expect(shx.ls('-R', 'fesm2015').stdout.split('\n').filter(n => !!n).sort()).toEqual(expected);
   });
 
+  it('should have the correct source map paths', () => {
+    expect(shx.grep('sourceMappingURL', 'fesm5/common.js'))
+        .toMatch('//# sourceMappingURL=common.js.map');
+    expect(shx.grep('sourceMappingURL', 'fesm2015/common.js'))
+        .toMatch('//# sourceMappingURL=common.js.map');
+    expect(shx.grep('sourceMappingURL', 'fesm5/http.js'))
+        .toMatch('//# sourceMappingURL=http.js.map');
+    expect(shx.grep('sourceMappingURL', 'fesm2015/http.js'))
+        .toMatch('//# sourceMappingURL=http.js.map');
+    expect(shx.grep('sourceMappingURL', 'fesm5/http/testing.js'))
+        .toMatch('//# sourceMappingURL=testing.js.map');
+    expect(shx.grep('sourceMappingURL', 'fesm2015/http/testing.js'))
+        .toMatch('//# sourceMappingURL=testing.js.map');
+    expect(shx.grep('sourceMappingURL', 'fesm5/testing.js'))
+        .toMatch('//# sourceMappingURL=testing.js.map');
+    expect(shx.grep('sourceMappingURL', 'fesm2015/testing.js'))
+        .toMatch('//# sourceMappingURL=testing.js.map');
+  });
+
+
   describe('should have module resolution properties in the package.json file for', () => {
     // https://github.com/angular/common-builds/blob/master/package.json
     it('/', () => {


### PR DESCRIPTION
This fixes the issue with broken source maps for @angular/common/http/testing.

Fixes #25510
