### PR TITLE
docs(service-worker): use timer instead of interval

### DIFF
--- a/aio/content/examples/service-worker-getting-started/src/app/check-for-update.service.ts
+++ b/aio/content/examples/service-worker-getting-started/src/app/check-for-update.service.ts
@@ -3,13 +3,13 @@ import { SwUpdate } from '@angular/service-worker';
 
 
 // #docregion sw-check-update
-import { interval } from 'rxjs';
+import { timer } from 'rxjs';
 
 @Injectable()
 export class CheckForUpdateService {
 
   constructor(updates: SwUpdate) {
-    interval(6 * 60 * 60).subscribe(() => updates.checkForUpdate());
+    timer(1000, 1000 * 60 * 60).subscribe(() => updates.checkForUpdate());
   }
 }
 // #enddocregion sw-check-update


### PR DESCRIPTION
Use RxJS timer creation operator instead of interval so that first check for updates happens shortly after app startup. Change recurring check interval to 1 hour, rather than seemingly arbitrary 21.6 seconds.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
