### PR TITLE
fix(router): add condition on href rewrite if routerLink has null value

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -268,7 +268,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
 
   private updateTargetUrlAndHref(): void {
     if (this.commands.length || !this.href ||
-      (typeof this.href === 'string' && !this.href.length)) {
+        (typeof this.href === 'string' && !this.href.length)) {
       this.href = this.locationStrategy.prepareExternalUrl(this.router.serializeUrl(this.urlTree));
     }
   }

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -267,7 +267,9 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   }
 
   private updateTargetUrlAndHref(): void {
-    this.href = this.locationStrategy.prepareExternalUrl(this.router.serializeUrl(this.urlTree));
+    if (this.commands.length || !this.href || (typeof this.href === 'string' && !this.href.length)) {
+      this.href = this.locationStrategy.prepareExternalUrl(this.router.serializeUrl(this.urlTree));
+    }
   }
 
   get urlTree(): UrlTree {

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -257,10 +257,6 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
       return true;
     }
 
-    if (!this.commands.length && this.href !== undefined && this.href !== '') {
-      return true;
-    }
-
     const extras = {
       skipLocationChange: attrBoolValue(this.skipLocationChange),
       replaceUrl: attrBoolValue(this.replaceUrl),

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -267,7 +267,8 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   }
 
   private updateTargetUrlAndHref(): void {
-    if (this.commands.length || !this.href || (typeof this.href === 'string' && !this.href.length)) {
+    if (this.commands.length || !this.href ||
+      (typeof this.href === 'string' && !this.href.length)) {
       this.href = this.locationStrategy.prepareExternalUrl(this.router.serializeUrl(this.urlTree));
     }
   }

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -215,7 +215,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
 
   // the url displayed on the anchor element.
   // TODO(issue/24571): remove '!'.
-  @HostBinding() href !: string;
+  @HostBinding('attr.href') @Input() href !: string;
 
   constructor(
       private router: Router, private route: ActivatedRoute,
@@ -257,6 +257,10 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
       return true;
     }
 
+    if (!this.commands.length && this.href !== undefined && this.href !== '') {
+      return true;
+    }
+
     const extras = {
       skipLocationChange: attrBoolValue(this.skipLocationChange),
       replaceUrl: attrBoolValue(this.replaceUrl),
@@ -267,7 +271,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   }
 
   private updateTargetUrlAndHref(): void {
-    if (this.commands.length || !this.href) {
+    if (this.commands.length || this.href === undefined || this.href === '') {
       this.href = this.locationStrategy.prepareExternalUrl(this.router.serializeUrl(this.urlTree));
     }
   }

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -267,8 +267,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   }
 
   private updateTargetUrlAndHref(): void {
-    if (this.commands.length || !this.href ||
-        (typeof this.href === 'string' && !this.href.length)) {
+    if (this.commands.length || !this.href) {
       this.href = this.locationStrategy.prepareExternalUrl(this.router.serializeUrl(this.urlTree));
     }
   }

--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -327,7 +327,7 @@ export class ActivatedRouteSnapshot {
   }
 
   toString(): string {
-    const url = this.url.map(segment => segment.toString()).join('/');
+    const url = this.url ? this.url.map(segment => segment.toString()).join('/') : '';
     const matched = this.routeConfig ? this.routeConfig.path : '';
     return `Route(url:'${url}', path:'${matched}')`;
   }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1698,7 +1698,7 @@ describe('Integration', () => {
     it('should not change existing href if routerLink is null', fakeAsync(() => {
          @Component({
            selector: 'someRoot',
-           template: `<router-outlet></router-outlet><a href="/home" routerLink="null">Link</a>`
+           template: `<router-outlet></router-outlet><a href="/home" [routerLink]="null">Link</a>`
          })
          class RootCmpWithLink {
          }
@@ -1720,7 +1720,7 @@ describe('Integration', () => {
     it('should set missing href to current location if routerLink is null', fakeAsync(() => {
          @Component({
            selector: 'someRoot',
-           template: `<router-outlet></router-outlet><a routerLink="null">Link</a>`
+           template: `<router-outlet></router-outlet><a [routerLink]="null">Link</a>`
          })
          class RootCmpWithLink {
          }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1697,39 +1697,39 @@ describe('Integration', () => {
 
     it('should not change existing href if routerLink is null', fakeAsync(() => {
          @Component({
-           selector: 'someRoot',
-           template: `<router-outlet></router-outlet><a href="/home" [routerLink]="null">Link</a>`
+           selector: 'someCmp',
+           template: `<router-outlet></router-outlet><a href="link" [routerLink]="null">Link</a>`
          })
-         class RootCmpWithLink {
+         class CmpWithLink {
          }
 
-         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
+         TestBed.configureTestingModule({declarations: [CmpWithLink]});
          const router: Router = TestBed.get(Router);
 
-         const fixture = createRoot(router, RootCmpWithLink);
+         let fixture: ComponentFixture<CmpWithLink> = createRoot(router, CmpWithLink);
 
          const native = fixture.nativeElement.querySelector('a');
-
-         advance(fixture);
-         expect(native.getAttribute('href')).toEqual('/home');
+         expect(native.getAttribute('href')).toEqual('link');
        }));
 
-    it('should set missing href to current location if routerLink is null', fakeAsync(() => {
+    it('should set href to current location if routerLink is null', fakeAsync(() => {
          @Component({
-           selector: 'someRoot',
+           selector: 'someCmp',
            template: `<router-outlet></router-outlet><a [routerLink]="null">Link</a>`
          })
-         class RootCmpWithLink {
+         class CmpWithLink {
          }
 
-         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
+         TestBed.configureTestingModule({declarations: [CmpWithLink]});
          const router: Router = TestBed.get(Router);
 
-         const fixture = createRoot(router, RootCmpWithLink);
-
+         let fixture: ComponentFixture<CmpWithLink> = createRoot(router, CmpWithLink);
+         router.resetConfig([{path: 'home', component: SimpleCmp}]);
          const native = fixture.nativeElement.querySelector('a');
 
+         router.navigateByUrl('/home');
          advance(fixture);
+
          expect(native.getAttribute('href')).toEqual('/home');
        }));
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1695,7 +1695,7 @@ describe('Integration', () => {
          expect(native.getAttribute('href')).toEqual('/home');
        }));
 
-    it('should not change existing href if routerLink is null', fakeAsync(() => {
+    it('should not change href if routerLink is null', fakeAsync(() => {
          @Component({
            selector: 'someCmp',
            template: `<router-outlet></router-outlet><a href="link" [routerLink]="null">Link</a>`
@@ -1708,6 +1708,7 @@ describe('Integration', () => {
 
          let fixture: ComponentFixture<CmpWithLink> = createRoot(router, CmpWithLink);
 
+         advance(fixture);
          const native = fixture.nativeElement.querySelector('a');
          expect(native.getAttribute('href')).toEqual('link');
        }));
@@ -1724,13 +1725,10 @@ describe('Integration', () => {
          const router: Router = TestBed.get(Router);
 
          let fixture: ComponentFixture<CmpWithLink> = createRoot(router, CmpWithLink);
-         router.resetConfig([{path: 'home', component: SimpleCmp}]);
-         const native = fixture.nativeElement.querySelector('a');
 
-         router.navigateByUrl('/home');
          advance(fixture);
-
-         expect(native.getAttribute('href')).toEqual('/home');
+         const native = fixture.nativeElement.querySelector('a');
+         expect(native.getAttribute('href')).toEqual('/');
        }));
 
     it('should not throw when commands is null', fakeAsync(() => {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1708,11 +1708,8 @@ describe('Integration', () => {
 
          const fixture = createRoot(router, RootCmpWithLink);
 
-         router.resetConfig([{path: 'home', component: SimpleCmp}]);
-
          const native = fixture.nativeElement.querySelector('a');
 
-         router.navigateByUrl('/');
          advance(fixture);
          expect(native.getAttribute('href')).toEqual('/home');
        }));
@@ -1730,11 +1727,8 @@ describe('Integration', () => {
 
          const fixture = createRoot(router, RootCmpWithLink);
 
-         router.resetConfig([{path: 'home', component: SimpleCmp}]);
-
          const native = fixture.nativeElement.querySelector('a');
 
-         router.navigateByUrl('/home');
          advance(fixture);
          expect(native.getAttribute('href')).toEqual('/home');
        }));

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1695,6 +1695,50 @@ describe('Integration', () => {
          expect(native.getAttribute('href')).toEqual('/home');
        }));
 
+    it('should not change existing href if routerLink is null', fakeAsync(() => {
+         @Component({
+           selector: 'someRoot',
+           template: `<router-outlet></router-outlet><a href="/home" routerLink="null">Link</a>`
+         })
+         class RootCmpWithLink {
+         }
+
+         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
+         const router: Router = TestBed.get(Router);
+
+         const fixture = createRoot(router, RootCmpWithLink);
+
+         router.resetConfig([{path: 'home', component: SimpleCmp}]);
+
+         const native = fixture.nativeElement.querySelector('a');
+
+         router.navigateByUrl('/');
+         advance(fixture);
+         expect(native.getAttribute('href')).toEqual('/home');
+       }));
+
+    it('should set missing href to current location if routerLink is null', fakeAsync(() => {
+         @Component({
+           selector: 'someRoot',
+           template: `<router-outlet></router-outlet><a routerLink="null">Link</a>`
+         })
+         class RootCmpWithLink {
+         }
+
+         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
+         const router: Router = TestBed.get(Router);
+
+         const fixture = createRoot(router, RootCmpWithLink);
+
+         router.resetConfig([{path: 'home', component: SimpleCmp}]);
+
+         const native = fixture.nativeElement.querySelector('a');
+
+         router.navigateByUrl('/home');
+         advance(fixture);
+         expect(native.getAttribute('href')).toEqual('/home');
+       }));
+
     it('should not throw when commands is null', fakeAsync(() => {
          @Component({
            selector: 'someCmp',
@@ -4976,7 +5020,6 @@ class RootCmpWithNamedOutlet {
 class ThrowingCmp {
   constructor() { throw new Error('Throwing Cmp'); }
 }
-
 
 
 function advance(fixture: ComponentFixture<any>, millis?: number): void {


### PR DESCRIPTION
Fix a bug where a null value passed to routerLink directive overrides the existing href.

fixes #26040


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature


## What is the current behavior?
Description and full Stackblitz example are in the issue below: 

Issue Number: #26040 


## What is the new behavior?
If a `null` value is passed to `routerLink` directive and if an `href` attribute is defined and not empty, `href` will remain unchanged. 


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
