### PR TITLE
add ng-reflect debug text for containers / support inputs & outputs with aliases in component decorators

### DIFF
--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -30,7 +30,7 @@ import {typeWithParameters} from '../util';
 import {R3ComponentDef, R3ComponentMetadata, R3DirectiveDef, R3DirectiveMetadata, R3QueryMetadata} from './api';
 import {StylingBuilder, StylingInstruction} from './styling';
 import {BindingScope, TemplateDefinitionBuilder, ValueConverter, renderFlagCheckIfStmt} from './template';
-import {CONTEXT_NAME, DefinitionMap, RENDER_FLAGS, TEMPORARY_NAME, asLiteral, conditionallyCreateMapObjectLiteral, getQueryPredicate, mapToExpression, temporaryAllocator} from './util';
+import {CONTEXT_NAME, DefinitionMap, RENDER_FLAGS, TEMPORARY_NAME, asLiteral, conditionallyCreateMapObjectLiteral, getQueryPredicate, temporaryAllocator} from './util';
 
 const EMPTY_ARRAY: any[] = [];
 

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -8,8 +8,8 @@
 
 import {ConstantPool} from '../../constant_pool';
 import * as o from '../../output/output_ast';
+import {splitAtColon} from '../../util';
 import * as t from '../r3_ast';
-
 import {R3QueryMetadata} from './api';
 import {isI18nAttribute} from './i18n/util';
 
@@ -75,9 +75,13 @@ export function conditionallyCreateMapObjectLiteral(keys: {[key: string]: string
   return null;
 }
 
-export function mapToExpression(map: {[key: string]: any}, quoted = false): o.Expression {
-  return o.literalMap(
-      Object.getOwnPropertyNames(map).map(key => ({key, quoted, value: asLiteral(map[key])})));
+function mapToExpression(map: {[key: string]: any}): o.Expression {
+  return o.literalMap(Object.getOwnPropertyNames(map).map(key => {
+    // canonical syntax: `dirProp: elProp`
+    // if there is no `:`, use dirProp = elProp
+    const parts = splitAtColon(key, [key, map[key]]);
+    return {key: parts[0], quoted: false, value: asLiteral(parts[1])};
+  }));
 }
 
 /**

--- a/packages/core/src/render3/interfaces/renderer.ts
+++ b/packages/core/src/render3/interfaces/renderer.ts
@@ -83,7 +83,7 @@ export interface ProceduralRenderer3 {
       flags?: RendererStyleFlags2|RendererStyleFlags3): void;
   removeStyle(el: RElement, style: string, flags?: RendererStyleFlags2|RendererStyleFlags3): void;
   setProperty(el: RElement, name: string, value: any): void;
-  setValue(node: RText, value: string): void;
+  setValue(node: RText|RComment, value: string): void;
 
   // TODO(misko): Deprecate in favor of addEventListener/removeEventListener
   listen(target: RNode, eventName: string, callback: (event: any) => boolean | void): () => void;
@@ -152,7 +152,7 @@ export interface RDomTokenList {
 
 export interface RText extends RNode { textContent: string|null; }
 
-export interface RComment extends RNode {}
+export interface RComment extends RNode { textContent: string|null; }
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency
 // failure based on types.

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -238,44 +238,42 @@ function declareTests(config?: {useJit: boolean}) {
         expect(getDOM().getProperty(nativeEl, 'htmlFor')).toBe('foo');
       });
 
-      fixmeIvy('FW-587: Inputs with aliases in component decorators don\'t work')
-          .it('should consume directive watch expression change.', () => {
-            TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
-            const template = '<span>' +
-                '<div my-dir [elprop]="ctxProp"></div>' +
-                '<div my-dir elprop="Hi there!"></div>' +
-                '<div my-dir elprop="Hi {{\'there!\'}}"></div>' +
-                '<div my-dir elprop="One more {{ctxProp}}"></div>' +
-                '</span>';
-            TestBed.overrideComponent(MyComp, {set: {template}});
-            const fixture = TestBed.createComponent(MyComp);
+      it('should consume directive watch expression change.', () => {
+        TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
+        const template = '<span>' +
+            '<div my-dir [elprop]="ctxProp"></div>' +
+            '<div my-dir elprop="Hi there!"></div>' +
+            '<div my-dir elprop="Hi {{\'there!\'}}"></div>' +
+            '<div my-dir elprop="One more {{ctxProp}}"></div>' +
+            '</span>';
+        TestBed.overrideComponent(MyComp, {set: {template}});
+        const fixture = TestBed.createComponent(MyComp);
 
-            fixture.componentInstance.ctxProp = 'Hello World!';
-            fixture.detectChanges();
+        fixture.componentInstance.ctxProp = 'Hello World!';
+        fixture.detectChanges();
 
-            const containerSpan = fixture.debugElement.children[0];
+        const containerSpan = fixture.debugElement.children[0];
 
-            expect(containerSpan.children[0].injector.get(MyDir).dirProp).toEqual('Hello World!');
-            expect(containerSpan.children[1].injector.get(MyDir).dirProp).toEqual('Hi there!');
-            expect(containerSpan.children[2].injector.get(MyDir).dirProp).toEqual('Hi there!');
-            expect(containerSpan.children[3].injector.get(MyDir).dirProp)
-                .toEqual('One more Hello World!');
-          });
+        expect(containerSpan.children[0].injector.get(MyDir).dirProp).toEqual('Hello World!');
+        expect(containerSpan.children[1].injector.get(MyDir).dirProp).toEqual('Hi there!');
+        expect(containerSpan.children[2].injector.get(MyDir).dirProp).toEqual('Hi there!');
+        expect(containerSpan.children[3].injector.get(MyDir).dirProp)
+            .toEqual('One more Hello World!');
+      });
 
       describe('pipes', () => {
-        fixmeIvy('FW-587: Inputs with aliases in component decorators don\'t work')
-            .it('should support pipes in bindings', () => {
-              TestBed.configureTestingModule({declarations: [MyComp, MyDir, DoublePipe]});
-              const template = '<div my-dir #dir="mydir" [elprop]="ctxProp | double"></div>';
-              TestBed.overrideComponent(MyComp, {set: {template}});
-              const fixture = TestBed.createComponent(MyComp);
+        it('should support pipes in bindings', () => {
+          TestBed.configureTestingModule({declarations: [MyComp, MyDir, DoublePipe]});
+          const template = '<div my-dir #dir="mydir" [elprop]="ctxProp | double"></div>';
+          TestBed.overrideComponent(MyComp, {set: {template}});
+          const fixture = TestBed.createComponent(MyComp);
 
-              fixture.componentInstance.ctxProp = 'a';
-              fixture.detectChanges();
+          fixture.componentInstance.ctxProp = 'a';
+          fixture.detectChanges();
 
-              const dir = fixture.debugElement.children[0].references !['dir'];
-              expect(dir.dirProp).toEqual('aa');
-            });
+          const dir = fixture.debugElement.children[0].references !['dir'];
+          expect(dir.dirProp).toEqual('aa');
+        });
       });
 
       it('should support nested components.', () => {
@@ -290,21 +288,20 @@ function declareTests(config?: {useJit: boolean}) {
       });
 
       // GH issue 328 - https://github.com/angular/angular/issues/328
-      fixmeIvy('FW-587: Inputs with aliases in component decorators don\'t work')
-          .it('should support different directive types on a single node', () => {
-            TestBed.configureTestingModule({declarations: [MyComp, ChildComp, MyDir]});
-            const template = '<child-cmp my-dir [elprop]="ctxProp"></child-cmp>';
-            TestBed.overrideComponent(MyComp, {set: {template}});
-            const fixture = TestBed.createComponent(MyComp);
+      it('should support different directive types on a single node', () => {
+        TestBed.configureTestingModule({declarations: [MyComp, ChildComp, MyDir]});
+        const template = '<child-cmp my-dir [elprop]="ctxProp"></child-cmp>';
+        TestBed.overrideComponent(MyComp, {set: {template}});
+        const fixture = TestBed.createComponent(MyComp);
 
-            fixture.componentInstance.ctxProp = 'Hello World!';
-            fixture.detectChanges();
+        fixture.componentInstance.ctxProp = 'Hello World!';
+        fixture.detectChanges();
 
-            const tc = fixture.debugElement.children[0];
+        const tc = fixture.debugElement.children[0];
 
-            expect(tc.injector.get(MyDir).dirProp).toEqual('Hello World!');
-            expect(tc.injector.get(ChildComp).dirProp).toEqual(null);
-          });
+        expect(tc.injector.get(MyDir).dirProp).toEqual('Hello World!');
+        expect(tc.injector.get(ChildComp).dirProp).toEqual(null);
+      });
 
       it('should support directives where a binding attribute is not given', () => {
         TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
@@ -1688,21 +1685,20 @@ function declareTests(config?: {useJit: boolean}) {
     });
 
     describe('logging property updates', () => {
-      fixmeIvy('FW-587: Inputs with aliases in component decorators don\'t work')
-          .it('should reflect property values as attributes', () => {
-            TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
-            const template = '<div>' +
-                '<div my-dir [elprop]="ctxProp"></div>' +
-                '</div>';
-            TestBed.overrideComponent(MyComp, {set: {template}});
-            const fixture = TestBed.createComponent(MyComp);
+      it('should reflect property values as attributes', () => {
+        TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
+        const template = '<div>' +
+            '<div my-dir [elprop]="ctxProp"></div>' +
+            '</div>';
+        TestBed.overrideComponent(MyComp, {set: {template}});
+        const fixture = TestBed.createComponent(MyComp);
 
-            fixture.componentInstance.ctxProp = 'hello';
-            fixture.detectChanges();
+        fixture.componentInstance.ctxProp = 'hello';
+        fixture.detectChanges();
 
-            expect(getDOM().getInnerHTML(fixture.nativeElement))
-                .toContain('ng-reflect-dir-prop="hello"');
-          });
+        expect(getDOM().getInnerHTML(fixture.nativeElement))
+            .toContain('ng-reflect-dir-prop="hello"');
+      });
 
       it(`should work with prop names containing '$'`, () => {
         TestBed.configureTestingModule({declarations: [ParentCmp, SomeCmpWithInput]});
@@ -1726,17 +1722,15 @@ function declareTests(config?: {useJit: boolean}) {
             .toContain('"ng\-reflect\-ng\-if"\: "true"');
       });
 
-      // also affected by FW-587: Inputs with aliases in component decorators don't work
-      fixmeIvy('FW-664: ng-reflect-* is not supported')
-          .it('should indicate when toString() throws', () => {
-            TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
-            const template = '<div my-dir [elprop]="toStringThrow"></div>';
-            TestBed.overrideComponent(MyComp, {set: {template}});
-            const fixture = TestBed.createComponent(MyComp);
+      it('should indicate when toString() throws', () => {
+        TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
+        const template = '<div my-dir [elprop]="toStringThrow"></div>';
+        TestBed.overrideComponent(MyComp, {set: {template}});
+        const fixture = TestBed.createComponent(MyComp);
 
-            fixture.detectChanges();
-            expect(getDOM().getInnerHTML(fixture.nativeElement)).toContain('[ERROR]');
-          });
+        fixture.detectChanges();
+        expect(getDOM().getInnerHTML(fixture.nativeElement)).toContain('[ERROR]');
+      });
     });
 
     describe('property decorators', () => {

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -1688,7 +1688,7 @@ function declareTests(config?: {useJit: boolean}) {
     });
 
     describe('logging property updates', () => {
-      fixmeIvy('FW-664: ng-reflect-* is not supported')
+      fixmeIvy('FW-587: Inputs with aliases in component decorators don\'t work')
           .it('should reflect property values as attributes', () => {
             TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
             const template = '<div>' +
@@ -1712,21 +1712,19 @@ function declareTests(config?: {useJit: boolean}) {
         expect(getDOM().getInnerHTML(fixture.nativeElement)).toContain('ng-reflect-test_="hello"');
       });
 
-      fixmeIvy('FW-664: ng-reflect-* is not supported')
-          .it('should reflect property values on template comments', () => {
-            const fixture =
-                TestBed.configureTestingModule({declarations: [MyComp]})
-                    .overrideComponent(
-                        MyComp,
-                        {set: {template: '<ng-template [ngIf]="ctxBoolProp"></ng-template>'}})
-                    .createComponent(MyComp);
+      it('should reflect property values on template comments', () => {
+        const fixture =
+            TestBed.configureTestingModule({declarations: [MyComp]})
+                .overrideComponent(
+                    MyComp, {set: {template: '<ng-template [ngIf]="ctxBoolProp"></ng-template>'}})
+                .createComponent(MyComp);
 
-            fixture.componentInstance.ctxBoolProp = true;
-            fixture.detectChanges();
+        fixture.componentInstance.ctxBoolProp = true;
+        fixture.detectChanges();
 
-            expect(getDOM().getInnerHTML(fixture.nativeElement))
-                .toContain('"ng\-reflect\-ng\-if"\: "true"');
-          });
+        expect(getDOM().getInnerHTML(fixture.nativeElement))
+            .toContain('"ng\-reflect\-ng\-if"\: "true"');
+      });
 
       // also affected by FW-587: Inputs with aliases in component decorators don't work
       fixmeIvy('FW-664: ng-reflect-* is not supported')

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -273,16 +273,19 @@ export function toHtml<T>(componentOrElement: T | RElement, keepNgReflect = fals
   }
 
   if (element) {
-    let html = stringifyElement(element)
-                   .replace(/^<div host="">(.*)<\/div>$/, '$1')
-                   .replace(/^<div fixture="mark">(.*)<\/div>$/, '$1')
-                   .replace(/^<div host="mark">(.*)<\/div>$/, '$1')
-                   .replace(' style=""', '')
-                   .replace(/<!--container-->/g, '')
-                   .replace(/<!--ng-container-->/g, '');
+    let html = stringifyElement(element);
+
     if (!keepNgReflect) {
-      html = html.replace(/\sng-reflect-\S*="[^"]*"/g, '');
+      html = html.replace(/\sng-reflect-\S*="[^"]*"/g, '')
+                 .replace(/<!--bindings=\{(\W.*\W\s*)?\}-->/g, '');
     }
+
+    html = html.replace(/^<div host="">(.*)<\/div>$/, '$1')
+               .replace(/^<div fixture="mark">(.*)<\/div>$/, '$1')
+               .replace(/^<div host="mark">(.*)<\/div>$/, '$1')
+               .replace(' style=""', '')
+               .replace(/<!--container-->/g, '')
+               .replace(/<!--ng-container-->/g, '');
     return html;
   } else {
     return '';

--- a/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
+++ b/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
@@ -131,16 +131,15 @@ let lastCreatedRenderer: Renderer2;
               checkSetters(fixture.componentRef, fixture.debugElement.children[0].nativeElement);
             });
 
-    fixmeIvy('#FW-664 ng-reflect-* is not supported')
-        .it('should update any template comment property/attributes', () => {
-          const fixture =
-              TestBed.overrideTemplate(MyComp2, '<ng-container *ngIf="ctxBoolProp"></ng-container>')
-                  .createComponent(MyComp2);
-          fixture.componentInstance.ctxBoolProp = true;
-          fixture.detectChanges();
-          const el = getRenderElement(fixture.nativeElement);
-          expect(getDOM().getInnerHTML(el)).toContain('"ng-reflect-ng-if": "true"');
-        });
+    it('should update any template comment property/attributes', () => {
+      const fixture =
+          TestBed.overrideTemplate(MyComp2, '<ng-container *ngIf="ctxBoolProp"></ng-container>')
+              .createComponent(MyComp2);
+      fixture.componentInstance.ctxBoolProp = true;
+      fixture.detectChanges();
+      const el = getRenderElement(fixture.nativeElement);
+      expect(getDOM().getInnerHTML(el)).toContain('"ng-reflect-ng-if": "true"');
+    });
 
     it('should add and remove fragments', () => {
       const fixture =


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Feature


## What is the current behavior?
- We don't add ng-reflect debug text on comment nodes for containers.
- We don't support input/output with aliases in component decorators

## What is the new behavior?
We add ng-reflect debug text on comment nodes for containers. I've used the same format as what was used with the view engine.
We support input/output with aliases in component decorators.

## Does this PR introduce a breaking change?

- [x] No