### PR TITLE
fix(ivy): run initialializers in TestBed on init

### DIFF
--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -176,13 +176,12 @@ class SomeComponent {
           });
         });
 
-        fixmeIvy('FW-776: Cannot bootstrap as there are still asynchronous initializers running') &&
-            it('should be called when a component is bootstrapped',
-               inject([ApplicationRef], (ref: ApplicationRef) => {
-                 createRootEl();
-                 const compRef = ref.bootstrap(SomeComponent);
-                 expect(capturedCompRefs).toEqual([compRef]);
-               }));
+        it('should be called when a component is bootstrapped',
+           inject([ApplicationRef], (ref: ApplicationRef) => {
+             createRootEl();
+             const compRef = ref.bootstrap(SomeComponent);
+             expect(capturedCompRefs).toEqual([compRef]);
+           }));
       });
 
       describe('bootstrap', () => {

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, Injector, NgModule, NgZone, Pipe, PlatformRef, Provider, RendererFactory2, SchemaMetadata, Type, ɵInjectableDef as InjectableDef, ɵNgModuleDef as NgModuleDef, ɵNgModuleTransitiveScopes as NgModuleTransitiveScopes, ɵRender3ComponentFactory as ComponentFactory, ɵRender3NgModuleRef as NgModuleRef, ɵcompileComponent as compileComponent, ɵcompileDirective as compileDirective, ɵcompileNgModuleDefs as compileNgModuleDefs, ɵcompilePipe as compilePipe, ɵgetInjectableDef as getInjectableDef, ɵpatchComponentDefWithScope as patchComponentDefWithScope, ɵstringify as stringify} from '@angular/core';
+import {ApplicationInitStatus, Component, Directive, Injector, NgModule, NgZone, Pipe, PlatformRef, Provider, RendererFactory2, SchemaMetadata, Type, ɵInjectableDef as InjectableDef, ɵNgModuleDef as NgModuleDef, ɵNgModuleTransitiveScopes as NgModuleTransitiveScopes, ɵRender3ComponentFactory as ComponentFactory, ɵRender3NgModuleRef as NgModuleRef, ɵcompileComponent as compileComponent, ɵcompileDirective as compileDirective, ɵcompileNgModuleDefs as compileNgModuleDefs, ɵcompilePipe as compilePipe, ɵgetInjectableDef as getInjectableDef, ɵpatchComponentDefWithScope as patchComponentDefWithScope, ɵstringify as stringify} from '@angular/core';
 
 import {ComponentFixture} from './component_fixture';
 import {MetadataOverride} from './metadata_override';
@@ -392,6 +392,9 @@ export class TestBedRender3 implements Injector, TestBed {
     const parentInjector = this.platform.injector;
     this._moduleRef = new NgModuleRef(testModuleType, parentInjector);
 
+    // ApplicationInitStatus.runInitializers() is marked @internal
+    // to core. Cast it to any before accessing it.
+    (this._moduleRef.injector.get(ApplicationInitStatus) as any).runInitializers();
     this._instantiated = true;
   }
 


### PR DESCRIPTION
Fixes the initializers not being run by `TestBed` when creating a fixture.

This fixes one test failure in the `ApplicationRef` tests and removes some of the noise for the remaining failures.