### PR TITLE
build: introduce remote bazel caching

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,11 @@
+# Load any settings specific to the current user
+try-import .bazelrc.user
+################################
+# Settings for Angular team members only
+################################
+# To enable this feature check the "Remote caching" section in docs/BAZEL.md.
+build:angular-team --remote_http_cache=https://storage.googleapis.com/angular-team-cache
+
 ###############################
 # Typescript / Angular / Sass #
 ###############################

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ yarn-error.log
 
 # rollup-test output
 /modules/rollup-test/dist/
+
+# User specific bazel settings
+.bazelrc.user
+

--- a/docs/BAZEL.md
+++ b/docs/BAZEL.md
@@ -165,8 +165,23 @@ Of course, non-hermeticity in an action can cause problems.
 At worst, you can fetch a broken artifact from the cache, making your build non-reproducible.
 For this reason, we are careful to implement our Bazel rules to depend only on their inputs.
 
-Currently we only use remote caching on CircleCI.
-We could enable it for developer builds as well, which would make initial builds much faster for developers by fetching already-built artifacts from the cache.
+Currently we only use remote caching on CircleCI and we let Angular core developers enable remote caching to speed up their builds.
+
+### Remote cache in development
+
+To enable remote caching for your build:
+
+1. Go to the service accounts for the ["internal" project](https://console.cloud.google.com/iam-admin/serviceaccounts?project=internal-200822)
+1. Select "Angular local dev", click on "Edit", scroll to the bottom, and click "Create key"
+1. When the pop-up shows, select "JSON" for "Key type" and click "Create"
+1. Save the key in a secure location
+1. Create a file called `.bazelrc.user` in the root directory of the workspace, and add the following content:
+
+```
+build --config=angular-team --google_credentials=[ABSOLUTE_PATH_TO_SERVICE_KEY]
+```
+
+### Remote cache for Circle CI
 
 This feature is experimental, and developed by the CircleCI team with guidance from Angular.
 Contact Alex Eagle with questions.


### PR DESCRIPTION
This PR introduces:

1. Google Cloud Store bucket which contains build artifacts
2. Documentation on how to enable remote caching in development

Each team member should download a service key. More convenient ways of authentication would be more obscure and prevent us from doing identity tracking of the produced artifacts.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

No remote caching for Angular core developers.


## What is the new behavior?

Enables remote caching.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
