### PR TITLE
fix(core): More precise return type for `InjectableDecorator`

### DIFF
--- a/packages/core/src/di/injectable.ts
+++ b/packages/core/src/di/injectable.ts
@@ -8,7 +8,7 @@
 
 import {compileInjectable as render3CompileInjectable} from '../render3/jit/injectable';
 import {Type} from '../type';
-import {makeDecorator} from '../util/decorators';
+import {TypeDecorator, makeDecorator} from '../util/decorators';
 
 import {InjectableDef, InjectableType, defineInjectable, getInjectableDef} from './defs';
 import {ClassSansProvider, ConstructorSansProvider, ExistingSansProvider, FactorySansProvider, StaticClassSansProvider, ValueSansProvider} from './provider';
@@ -45,8 +45,8 @@ export interface InjectableDecorator {
    * {@example core/di/ts/metadata_spec.ts region='InjectableThrows'}
    *
    */
-  (): any;
-  (options?: {providedIn: Type<any>| 'root' | null}&InjectableProvider): any;
+  (): TypeDecorator;
+  (options?: {providedIn: Type<any>| 'root' | null}&InjectableProvider): TypeDecorator;
   new (): Injectable;
   new (options?: {providedIn: Type<any>| 'root' | null}&InjectableProvider): Injectable;
 }

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -382,10 +382,10 @@ export interface Injectable {
 export declare const Injectable: InjectableDecorator;
 
 export interface InjectableDecorator {
-    (): any;
+    (): TypeDecorator;
     (options?: {
         providedIn: Type<any> | 'root' | null;
-    } & InjectableProvider): any;
+    } & InjectableProvider): TypeDecorator;
     new (): Injectable;
     new (options?: {
         providedIn: Type<any> | 'root' | null;


### PR DESCRIPTION
closes #26942

