### PR TITLE
test(ivy): turn ivy test selectors into real functions

### DIFF
--- a/packages/private/testing/src/ivy_test_selectors.ts
+++ b/packages/private/testing/src/ivy_test_selectors.ts
@@ -63,8 +63,9 @@ export function fixmeIvy(reason: string): boolean {
  * obsoleteInIvy('some reason') && it(...);
  * ```
  */
-export const obsoleteInIvy = fixmeIvy;
-
+export function obsoleteInIvy(reason: string): boolean {
+  return !ivyEnabled;
+}
 
 /**
  * A function to conditionally skip the execution of tests that have intentionally
@@ -83,4 +84,6 @@ export const obsoleteInIvy = fixmeIvy;
  * modifiedInIvy('some reason') && it(...);
  * ```
  */
-export const modifiedInIvy = fixmeIvy;
+export function modifiedInIvy(reason: string): boolean {
+  return !ivyEnabled;
+}


### PR DESCRIPTION
Having real functions allows me to bypass individual checks, ex.:

```
export function fixmeIvy(reason: string): boolean {
  return true;
}
```

This is useful for situation where I want to see if previously disabled tests
were fixed (ex. some PRs merged). In this case I don't want to run tests that
I know are not passing (obsolete / modified).
