### PR TITLE
fix(ivy): adding `projectDef` instructions to all templates where <ng-content> is present (FW-745)

### DIFF
--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -83,7 +83,7 @@ export class Template implements Node {
 
 export class Content implements Node {
   constructor(
-      public selectorIndex: number, public attributes: TextAttribute[],
+      public selector: string, public attributes: TextAttribute[],
       public sourceSpan: ParseSourceSpan, public i18n?: I18nAST) {}
   visit<Result>(visitor: Visitor<Result>): Result { return visitor.visitContent(this); }
 }

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -123,16 +123,6 @@ export interface R3ComponentMetadata extends R3DirectiveMetadata {
      * Parsed nodes of the template.
      */
     nodes: t.Node[];
-
-    /**
-     * Whether the template includes <ng-content> tags.
-     */
-    hasNgContent: boolean;
-
-    /**
-     * Selectors found in the <ng-content> tags in the template.
-     */
-    ngContentSelectors: string[];
   };
 
   /**

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -258,8 +258,7 @@ export function compileComponentFromMetadata(
       meta.viewQueries, directiveMatcher, directivesUsed, meta.pipes, pipesUsed, R3.namespaceHTML,
       meta.relativeContextFilePath, meta.i18nUseExternalIds);
 
-  const templateFunctionExpression = templateBuilder.buildTemplateFunction(
-      template.nodes, [], template.hasNgContent, template.ngContentSelectors);
+  const templateFunctionExpression = templateBuilder.buildTemplateFunction(template.nodes, []);
 
   // e.g. `consts: 2`
   definitionMap.set('consts', o.literal(templateBuilder.getConstCount()));
@@ -371,11 +370,7 @@ export function compileComponentFromRender2(
   const meta: R3ComponentMetadata = {
     ...directiveMetadataFromGlobalMetadata(component, outputCtx, reflector),
     selector: component.selector,
-    template: {
-      nodes: render3Ast.nodes,
-      hasNgContent: render3Ast.hasNgContent,
-      ngContentSelectors: render3Ast.ngContentSelectors,
-    },
+    template: {nodes: render3Ast.nodes},
     directives: [],
     pipes: typeMapToExpressionMap(pipeTypeByName, outputCtx),
     viewQueries: queriesFromGlobalMetadata(component.viewQueries, outputCtx),

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -39,7 +39,7 @@ class R3AstHumanizer implements t.Visitor<void> {
   }
 
   visitContent(content: t.Content) {
-    this.result.push(['Content', content.selectorIndex]);
+    this.result.push(['Content', content.selector]);
     t.visitAll(this, content.attributes);
   }
 
@@ -110,17 +110,15 @@ describe('R3 template transform', () => {
 
     it('should parse ngContent', () => {
       const res = parse('<ng-content select="a"></ng-content>');
-      expect(res.hasNgContent).toEqual(true);
-      expect(res.ngContentSelectors).toEqual(['a']);
       expectFromR3Nodes(res.nodes).toEqual([
-        ['Content', 1],
+        ['Content', 'a'],
         ['TextAttribute', 'select', 'a'],
       ]);
     });
 
     it('should parse ngContent when it contains WS only', () => {
       expectFromHtml('<ng-content select="a">    \n   </ng-content>').toEqual([
-        ['Content', 1],
+        ['Content', 'a'],
         ['TextAttribute', 'select', 'a'],
       ]);
     });
@@ -128,7 +126,7 @@ describe('R3 template transform', () => {
     it('should parse ngContent regardless the namespace', () => {
       expectFromHtml('<svg><ng-content select="a"></ng-content></svg>').toEqual([
         ['Element', ':svg:svg'],
-        ['Content', 1],
+        ['Content', 'a'],
         ['TextAttribute', 'select', 'a'],
       ]);
     });
@@ -377,30 +375,16 @@ describe('R3 template transform', () => {
   describe('ng-content', () => {
     it('should parse ngContent without selector', () => {
       const res = parse('<ng-content></ng-content>');
-      expect(res.hasNgContent).toEqual(true);
-      expect(res.ngContentSelectors).toEqual([]);
       expectFromR3Nodes(res.nodes).toEqual([
-        ['Content', 0],
-      ]);
-    });
-
-    it('should parse ngContent with a * selector', () => {
-      const res = parse('<ng-content></ng-content>');
-      const selectors = [''];
-      expect(res.hasNgContent).toEqual(true);
-      expect(res.ngContentSelectors).toEqual([]);
-      expectFromR3Nodes(res.nodes).toEqual([
-        ['Content', 0],
+        ['Content', '*'],
       ]);
     });
 
     it('should parse ngContent with a specific selector', () => {
       const res = parse('<ng-content select="tag[attribute]"></ng-content>');
       const selectors = ['', 'tag[attribute]'];
-      expect(res.hasNgContent).toEqual(true);
-      expect(res.ngContentSelectors).toEqual(['tag[attribute]']);
       expectFromR3Nodes(res.nodes).toEqual([
-        ['Content', 1],
+        ['Content', selectors[1]],
         ['TextAttribute', 'select', selectors[1]],
       ]);
     });
@@ -408,24 +392,20 @@ describe('R3 template transform', () => {
     it('should parse ngContent with a selector', () => {
       const res = parse(
           '<ng-content select="a"></ng-content><ng-content></ng-content><ng-content select="b"></ng-content>');
-      const selectors = ['', 'a', 'b'];
-      expect(res.hasNgContent).toEqual(true);
-      expect(res.ngContentSelectors).toEqual(['a', 'b']);
+      const selectors = ['*', 'a', 'b'];
       expectFromR3Nodes(res.nodes).toEqual([
-        ['Content', 1],
+        ['Content', selectors[1]],
         ['TextAttribute', 'select', selectors[1]],
-        ['Content', 0],
-        ['Content', 2],
+        ['Content', selectors[0]],
+        ['Content', selectors[2]],
         ['TextAttribute', 'select', selectors[2]],
       ]);
     });
 
     it('should parse ngProjectAs as an attribute', () => {
       const res = parse('<ng-content ngProjectAs="a"></ng-content>');
-      expect(res.hasNgContent).toEqual(true);
-      expect(res.ngContentSelectors).toEqual([]);
       expectFromR3Nodes(res.nodes).toEqual([
-        ['Content', 0],
+        ['Content', '*'],
         ['TextAttribute', 'ngProjectAs', 'a'],
       ]);
     });


### PR DESCRIPTION
Prior to this change `projectDef` instructions were placed to root templates only, thus the necessary information (selectors) in nested templates was missing. This update adds the logic to insert `projectDef` instructions to all templates where <ng-content> is present.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No