### PR TITLE
fix(ivy): temporary hack to set host styles and static classes

### DIFF
--- a/packages/core/src/render3/styling/class_and_style_bindings.ts
+++ b/packages/core/src/render3/styling/class_and_style_bindings.ts
@@ -594,7 +594,7 @@ export function renderStyleAndClassBindings(
  * @param renderer
  * @param store an optional key/value map that will be used as a context to render styles on
  */
-function setStyle(
+export function setStyle(
     native: any, prop: string, value: string | null, renderer: Renderer3,
     sanitizer: StyleSanitizeFn | null, store?: BindingStore | null,
     playerBuilder?: ClassAndStylePlayerBuilder<any>| null) {

--- a/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animation_world/bundle.golden_symbols.json
@@ -786,6 +786,9 @@
     "name": "hackImplementationOfElementStylingMap"
   },
   {
+    "name": "hackSetStaticClasses"
+  },
+  {
     "name": "hackSquashDeclaration"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -819,6 +819,9 @@
     "name": "hackImplementationOfElementStylingApply"
   },
   {
+    "name": "hackSetStaticClasses"
+  },
+  {
     "name": "hackSquashDeclaration"
   },
   {

--- a/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo_r2/bundle.golden_symbols.json
@@ -2001,6 +2001,9 @@
     "name": "hackImplementationOfElementStylingApply"
   },
   {
+    "name": "hackSetStaticClasses"
+  },
+  {
     "name": "hackSquashDeclaration"
   },
   {


### PR DESCRIPTION
This PR adds another temporary hack so host style instructions don't throw in the Material demo app. It should be replaced when @matsko implements real host bindings for styles.