### PR TITLE
fix(ivy): avoid counting style/class bindings in Component/Directive `hostBindings` (FW-761)

### DIFF
--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -512,7 +512,7 @@ describe('ngtsc behavioral tests', () => {
     const hostBindingsFn = `
       hostBindings: function FooCmp_HostBindings(rf, ctx, elIndex) {
         if (rf & 1) {
-          i0.ɵallocHostVars(3);
+          i0.ɵallocHostVars(2);
           i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick($event); });
           i0.ɵlistener("change", function FooCmp_change_HostBindingHandler($event) { return ctx.onChange(ctx.arg1, ctx.arg2, ctx.arg3); });
           i0.ɵelementStyling(_c0, null, null, ctx);

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1515,7 +1515,8 @@ function invokeDirectivesHostBindings(tView: TView, viewData: LView, previousOrP
       setCurrentDirectiveDef(null);
       // `hostBindings` function may or may not contain `allocHostVars` call
       // (e.g. it may not if it only contains host listeners), so we need to check whether
-      // `expandoInstructions` has changed and if not - we push `null` to keep indices in sync
+      // `expandoInstructions` has changed and if not - we still push `hostBindings` to
+      // expando block, to make sure we execute it for DI cycle
       if (previousExpandoLength === expando.length && firstTemplatePass) {
         expando.push(def.hostBindings);
       }

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1517,7 +1517,7 @@ function invokeDirectivesHostBindings(tView: TView, viewData: LView, previousOrP
       // (e.g. it may not if it only contains host listeners), so we need to check whether
       // `expandoInstructions` has changed and if not - we push `null` to keep indices in sync
       if (previousExpandoLength === expando.length && firstTemplatePass) {
-        expando.push(null);
+        expando.push(def.hostBindings);
       }
     } else if (firstTemplatePass) {
       expando.push(null);

--- a/packages/core/test/render3/host_binding_spec.ts
+++ b/packages/core/test/render3/host_binding_spec.ts
@@ -999,7 +999,6 @@ describe('host bindings', () => {
           vars: 0,
           hostBindings: (rf: RenderFlags, ctx: HostBindingToStyles, elIndex: number) => {
             if (rf & RenderFlags.Create) {
-              allocHostVars(0);  // this is wrong, but necessary until FW-761 gets in
               elementStyling(null, ['width'], null, ctx);
             }
             if (rf & RenderFlags.Update) {
@@ -1043,7 +1042,6 @@ describe('host bindings', () => {
           vars: 0,
           hostBindings: (rf: RenderFlags, ctx: StaticHostClass, elIndex: number) => {
             if (rf & RenderFlags.Create) {
-              allocHostVars(0);  // this is wrong, but necessary until FW-761 gets in
               elementStyling(
                   ['mat-toolbar', InitialStylingFlags.VALUES_MODE, 'mat-toolbar', true], null, null,
                   ctx);


### PR DESCRIPTION
The goal of this PR is to avoid counting of style/class bindings for host bindings sections. Motivation: there can't be any slots allocated because styling can be added to elements dynamically at any point.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
