### PR TITLE
fix(ivy): proper accounting of host vars in case of inherited Directives

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1624,11 +1624,18 @@ function queueHostBindingForCheck(
   ngDevMode &&
       assertEqual(getFirstTemplatePass(), true, 'Should only be called in first template pass.');
   const expando = tView.expandoInstructions !;
+  const length = expando.length;
   // check whether a given `hostBindings` function already exists in expandoInstructions,
   // which can happen in case directive definition was extended from base definition (as a part of
   // the `InheritDefinitionFeature` logic)
-  if (expando.length < 2 || expando[expando.length - 2] !== def.hostBindings) {
+  if (length < 2 || expando[length - 2] !== def.hostBindings) {
     expando.push(def.hostBindings !, hostVars);
+  } else {
+    // if we found the same `hostBindings` function in the list, we just increase the number of
+    // host vars associated with that function, but do not add it into the list again
+    if (length >= 2 && expando[length - 2] === def.hostBindings) {
+      expando[length - 1] = (expando[length - 1] as number) + hostVars;
+    }
   }
 }
 

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1625,17 +1625,15 @@ function queueHostBindingForCheck(
       assertEqual(getFirstTemplatePass(), true, 'Should only be called in first template pass.');
   const expando = tView.expandoInstructions !;
   const length = expando.length;
-  // check whether a given `hostBindings` function already exists in expandoInstructions,
+  // Check whether a given `hostBindings` function already exists in expandoInstructions,
   // which can happen in case directive definition was extended from base definition (as a part of
-  // the `InheritDefinitionFeature` logic)
-  if (length < 2 || expando[length - 2] !== def.hostBindings) {
-    expando.push(def.hostBindings !, hostVars);
+  // the `InheritDefinitionFeature` logic). If we found the same `hostBindings` function in the
+  // list, we just increase the number of host vars associated with that function, but do not add it
+  // into the list again.
+  if (length >= 2 && expando[length - 2] === def.hostBindings) {
+    expando[length - 1] = (expando[length - 1] as number) + hostVars;
   } else {
-    // if we found the same `hostBindings` function in the list, we just increase the number of
-    // host vars associated with that function, but do not add it into the list again
-    if (length >= 2 && expando[length - 2] === def.hostBindings) {
-      expando[length - 1] = (expando[length - 1] as number) + hostVars;
-    }
+    expando.push(def.hostBindings !, hostVars);
   }
 }
 


### PR DESCRIPTION
Prior to this change, the number of host vars stored for directives with `hostBindings` in expando block was incorrect for inherited directives (in case both parent and child directive have `hostBindings` defined). Now if we identify that we already added a `hostBinding` into expando block, we just increase the corresponding number of host binding vars

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
