### PR TITLE
fix(bazel): do not throw if ts compile action does not create esm5 outputs

### DIFF
--- a/packages/bazel/src/esm5.bzl
+++ b/packages/bazel/src/esm5.bzl
@@ -51,6 +51,10 @@ def _esm5_outputs_aspect(target, ctx):
     if not hasattr(target.typescript, "replay_params"):
         print("WARNING: no esm5 output from target %s//%s:%s available" % (target.label.workspace_root, target.label.package, target.label.name))
         return []
+    elif not target.typescript.replay_params:
+        # In case there are "replay_params" specified but the compile action didn't generate any
+        # outputs (e.g. only "d.ts" files), we cannot create ESM5 outputs for this target either.
+        return []
 
     # We create a new tsconfig.json file that will have our compilation settings
     tsconfig = ctx.actions.declare_file("%s_esm5.tsconfig.json" % target.label.name)


### PR DESCRIPTION
In some applications, developers define a `ts_library` that just consists of `d.ts` files (e.g. to type `module.id` - see [material](https://github.com/angular/material2/blob/master/src/module-typings.d.ts)), and expect the `esm5.bzl` file to not throw an error like:

```
  target.typescript.replay_params.outputs
struct' object has no attribute 'outputs'
```

The "replay_parameters" property will exist in that case, but is set to "None" because there is no action that should be replayed in favor of producing ES5 outputs. See: https://github.com/bazelbuild/rules_typescript/pull/326. 

Notice that this right now breaks similarly because a;empt:  is returned that does not have a property called `outputs`. [#326](https://github.com/bazelbuild/rules_typescript/pull/326) fixes that by being explicit and stating that there is no _action_ at all.