### PR TITLE
fix(bazel): tsickle dependency not working with typescript 3.1.x

### DIFF
--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -19,7 +19,7 @@
     "@schematics/angular": "^7.0.4",
     "@types/node": "6.0.84",
     "shelljs": "0.8.2",
-    "tsickle": "0.32.1"
+    "tsickle": "0.34.0"
   },
   "peerDependencies": {
     "@angular/compiler-cli": "0.0.0-PLACEHOLDER",


### PR DESCRIPTION
`@angular/bazel` currently requires TypeScript 3.1.x as a peer dependency, but comes with `tsickle` as dependency. The current version of `tsickle` that is specified by `@angular/bazel` does not support TypeScript 3.1.x (which is a peer dependency) and therefore we need to make sure that `tsickle` works with the required TypeScript versions.

This change updates `tsickle` to the latest version that comes with angular/tsickle@b10fb6d in order to work with TypeScript 3.1.x.