### PR TITLE
fix(docs-infra): log the successful creation of previews

### DIFF
--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/preview-server/preview-server-factory.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/preview-server/preview-server-factory.ts
@@ -7,7 +7,7 @@ import {CircleCiApi} from '../common/circle-ci-api';
 import {GithubApi} from '../common/github-api';
 import {GithubPullRequests} from '../common/github-pull-requests';
 import {GithubTeams} from '../common/github-teams';
-import {assert, assertNotMissingOrEmpty, Logger} from '../common/utils';
+import {assert, assertNotMissingOrEmpty, computeShortSha, Logger} from '../common/utils';
 import {BuildCreator} from './build-creator';
 import {ChangedPrVisibilityEvent, CreatedBuildEvent} from './build-events';
 import {BuildRetriever} from './build-retriever';
@@ -144,7 +144,10 @@ export class PreviewServerFactory {
         const artifactPath = await buildRetriever.downloadBuildArtifact(buildNum, pr, sha, cfg.buildArtifactPath);
         const isPublic = await buildVerifier.getPrIsTrusted(pr);
         await buildCreator.create(pr, sha, artifactPath, isPublic);
+
         res.sendStatus(isPublic ? 201 : 202);
+        logger.log(`PR:${pr}, SHA:${computeShortSha(sha)}, Build:${buildNum} - ` +
+                   `Successfully created ${isPublic ? 'public' : 'non-public'} preview.`);
       } catch (err) {
         logger.error('CircleCI webhook error', err);
         respondWithError(res, err);


### PR DESCRIPTION
This can help with debugging issues, e.g. with the communication between the preview server and CI, as it gives a better idea of exactly when was the preview made available and how long it took.
