### PR TITLE
fix(ivy): Forward refs now supported

### DIFF
--- a/packages/compiler-cli/integrationtest/bazel/injector_def/ivy_build/app/test/BUILD.bazel
+++ b/packages/compiler-cli/integrationtest/bazel/injector_def/ivy_build/app/test/BUILD.bazel
@@ -24,7 +24,6 @@ jasmine_node_test(
     name = "test",
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
     tags = [
-        "fixme-ivy-aot",
         "ivy-only",
     ],
     deps = [

--- a/packages/compiler-cli/integrationtest/bazel/injector_def/ivy_build/app/test/module_spec.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injector_def/ivy_build/app/test/module_spec.ts
@@ -7,7 +7,6 @@
  */
 
 import {Injectable, InjectionToken, Injector, NgModule, createInjector, forwardRef} from '@angular/core';
-import {fixmeIvy} from '@angular/private/testing';
 import {AOT_TOKEN, AotModule, AotService} from 'app_built/src/module';
 
 describe('Ivy NgModule', () => {
@@ -41,24 +40,23 @@ describe('Ivy NgModule', () => {
 
     it('works', () => { createInjector(JitAppModule); });
 
-    fixmeIvy('FW-645: jit doesn\'t support forwardRefs')
-        .it('throws an error on circular module dependencies', () => {
-          @NgModule({
-            imports: [forwardRef(() => BModule)],
-          })
-          class AModule {
-          }
+    it('throws an error on circular module dependencies', () => {
+      @NgModule({
+        imports: [forwardRef(() => BModule)],
+      })
+      class AModule {
+      }
 
-          @NgModule({
-            imports: [AModule],
-          })
-          class BModule {
-          }
+      @NgModule({
+        imports: [AModule],
+      })
+      class BModule {
+      }
 
-          expect(() => createInjector(AModule))
-              .toThrowError(
-                  'Circular dependency in DI detected for type AModule. Dependency path: AModule > BModule > AModule.');
-        });
+      expect(() => createInjector(AModule))
+          .toThrowError(
+              'Circular dependency in DI detected for type AModule. Dependency path: AModule > BModule > AModule.');
+    });
 
     it('merges imports and exports', () => {
       const TOKEN = new InjectionToken<string>('TOKEN');

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -205,8 +205,8 @@ ivyEnabled && describe('render3 jit', () => {
     }
 
     const moduleDef: NgModuleDef<Module> = (Module as any).ngModuleDef;
-    expect(cmpDef.directiveDefs instanceof Function).toBe(true);
-    expect((cmpDef.directiveDefs as Function)()).toEqual([cmpDef]);
+    // directive defs are still null, since no directives were in that component
+    expect(cmpDef.directiveDefs).toBeNull();
   });
 
   it('should add hostbindings and hostlisteners', () => {


### PR DESCRIPTION
Adds deferred execution of scope setting for modules such that forward refs can be supported in ivy. Design docs can be found at https://docs.google.com/document/d/11KTbybis9rt0cZgMKd1wo_IKb6y1PMU-RoTDVLTXK4Y/edit#
