### PR TITLE
test(router): add test verifying guards re-run when parent path segments change

### DIFF
--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -2381,31 +2381,29 @@ describe('Integration', () => {
            })));
 
         it('should rerun when a parent segment changes',
-            fakeAsync(inject([Router], (router: Router) => {
-              const fixture = configureRouter(router, 'pathParamsChange');
+           fakeAsync(inject([Router], (router: Router) => {
+             const fixture = configureRouter(router, 'pathParamsChange');
 
-              const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
-              const recordedData: any[] = [];
-              cmp.route.data.subscribe((data: any) => recordedData.push(data));
+             const cmp: RouteCmp = fixture.debugElement.children[1].componentInstance;
 
-              // Land on an inital page
-              router.navigateByUrl('/d/1;dd=11/e/2;dd=22');
-              advance(fixture);
+             // Land on an inital page
+             router.navigateByUrl('/d/1;dd=11/e/2;dd=22');
+             advance(fixture);
 
-              expect(guardRunCount).toEqual(2);
+             expect(guardRunCount).toEqual(2);
 
-              // Changes cause re-run on the config with the guard
-              router.navigateByUrl('/d/1;dd=11/e/3;ee=22');
-              advance(fixture);
+             // Changes cause re-run on the config with the guard
+             router.navigateByUrl('/d/1;dd=11/e/3;ee=22');
+             advance(fixture);
 
-              expect(guardRunCount).toEqual(3);
+             expect(guardRunCount).toEqual(3);
 
-              // Changes to the parent also cause re-run
-              router.navigateByUrl('/d/2;dd=11/e/3;ee=22');
-              advance(fixture);
+             // Changes to the parent also cause re-run
+             router.navigateByUrl('/d/2;dd=11/e/3;ee=22');
+             advance(fixture);
 
-              expect(guardRunCount).toEqual(4);
-            })));
+             expect(guardRunCount).toEqual(4);
+           })));
       });
 
       describe('should wait for parent to complete', () => {


### PR DESCRIPTION
Related to #26861

This PR is just adding a test. I noticed other modes ensure parents cause a re-run and I wanted to guarantee this behavior going forward.