### PR TITLE
docs: update rxjs example and change fromPromise to from 

### DIFF
--- a/aio/content/examples/rx-library/src/simple-creation.ts
+++ b/aio/content/examples/rx-library/src/simple-creation.ts
@@ -1,10 +1,10 @@
 
 // #docregion promise
 
-import { fromPromise } from 'rxjs';
+import { from } from 'rxjs';
 
 // Create an Observable out of a promise
-const data = fromPromise(fetch('/api/endpoint'));
+const data = from(fetch('/api/endpoint'));
 // Subscribe to begin listening for async result
 data.subscribe({
  next(response) { console.log(response); },


### PR DESCRIPTION
the first example at https://angular.io/guide/rx-library, `fromPromise` is outdated
https://github.com/ReactiveX/rxjs-tslint/issues/7

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
in rxjs, `fromPromise` is outdated    
just a tiny change

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
