### PR TITLE
fix(ivy): deduplicate directives in component scopes

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -266,8 +266,9 @@ export class ComponentDecoratorHandler implements
     const scope = this.scopeRegistry.lookupCompilationScopeAsRefs(node);
     const matcher = new SelectorMatcher<ScopeDirective<any>>();
     if (scope !== null) {
-      scope.directives.forEach(
-          ({selector, meta}) => { matcher.addSelectables(CssSelector.parse(selector), meta); });
+      for (const meta of scope.directives) {
+        matcher.addSelectables(CssSelector.parse(meta.selector), meta);
+      }
       ctx.addTemplate(node as ts.ClassDeclaration, meta.parsedTemplate, matcher);
     }
   }
@@ -284,8 +285,10 @@ export class ComponentDecoratorHandler implements
       // fully analyzed.
       const {pipes, containsForwardDecls} = scope;
       const directives: {selector: string, expression: Expression}[] = [];
-      scope.directives.forEach(
-          ({selector, meta}) => directives.push({selector, expression: meta.directive}));
+
+      for (const meta of scope.directives) {
+        directives.push({selector: meta.selector, expression: meta.directive});
+      }
       const wrapDirectivesAndPipesInClosure: boolean = !!containsForwardDecls;
       metadata = {...metadata, directives, pipes, wrapDirectivesAndPipesInClosure};
     }

--- a/packages/compiler-cli/test/ngtsc/fake_core/index.ts
+++ b/packages/compiler-cli/test/ngtsc/fake_core/index.ts
@@ -61,3 +61,6 @@ export function forwardRef<T>(fn: () => T): T {
 }
 
 export interface SimpleChanges { [propName: string]: any; }
+
+export type ɵNgModuleDefWithMeta<ModuleT, DeclarationsT, ImportsT, ExportsT> = any;
+export type ɵDirectiveDefWithMeta<DirT, SelectorT, ExportAsT, InputsT, OutputsT, QueriesT> = any;


### PR DESCRIPTION
A previous fix to ngtsc opened the door for duplicate directives in
the 'directives' array of a component. This would happen if the directive
was declared in a module which was imported more than once within the
component's module.

This commit adds deduplication when the component's scope is materialized,
so declarations which arrive via more than one module import are coalesced.
