### PR TITLE
test(ivy): add root cause on tree shakable providers test

### DIFF
--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -1335,7 +1335,7 @@ function declareTests(config?: {useJit: boolean}) {
       });
 
       describe('tree shakable providers', () => {
-        fixmeIvy('unknown') &&
+        fixmeIvy('FW-794: NgModuleDefinition not exposed on NgModuleData') &&
             it('definition should not persist across NgModuleRef instances', () => {
               @NgModule()
               class SomeModule {


### PR DESCRIPTION
Adds the root cause on one of the failing NgModule tests.
