### PR TITLE
fix(compiler-cli): ngtsc shim files not being generated on case-insensitive platforms

### DIFF
--- a/packages/compiler-cli/src/ngtsc/shims/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/host.ts
@@ -48,10 +48,9 @@ export class GeneratedShimsHostWrapper implements ts.CompilerHost {
       fileName: string, languageVersion: ts.ScriptTarget,
       onError?: ((message: string) => void)|undefined,
       shouldCreateNewSourceFile?: boolean|undefined): ts.SourceFile|undefined {
-    const canonical = this.getCanonicalFileName(fileName);
     for (let i = 0; i < this.shimGenerators.length; i++) {
       const generator = this.shimGenerators[i];
-      const originalFile = generator.getOriginalSourceOfShim(canonical);
+      const originalFile = generator.getOriginalSourceOfShim(fileName);
       if (originalFile !== null) {
         // This shim generator has recognized the filename being requested, and is now responsible
         // for generating its contents, based on the contents of the original file it has requested.


### PR DESCRIPTION
Common insensitive platforms are `win32/win64` (see: [here](https://github.com/Microsoft/TypeScript/blob/3e4c5c95abd515eb9713b881d27ab3a93cc00461/src/compiler/sys.ts#L681-L682))


Currently when running `bazel build packages/core --define=compile=aot`, the `compiler-cli` will throw because it cannot find the `index.ngfactory.ts` file in the compiler host. This is because the shim host wrapper is not properly generating the requested `ngfactory` file.

```
 Error: ENOENT: no such file or directory, open 'C:/users/paul/_bazel_paul/lm3s4mgv/execroot/angular/packages/core/index.ngfactory.ts'
    at Object.openSync (fs.js:434:3)
    at Object.readFileSync (fs.js:339:35)
    at CachedFileLoader.loadFile (C:\users\paul\_bazel_paul\lm3s4mgv\external\internal\tsc_wrapped\cache.ts:366:29)
    at C:\users\paul\_bazel_paul\lm3s4mgv\external\internal\tsc_wrapped\compiler_host.ts:413:34
    at Object.wrap (C:\users\paul\_bazel_paul\lm3s4mgv\external\internal\tsc_wrapped\perf_trace.ts:54:12)
    at CompilerHost.getSourceFile (C:\users\paul\_bazel_paul\lm3s4mgv\external\internal\tsc_wrapped\compiler_host.ts:412:22)
    at GeneratedShimsHostWrapper.getSourceFile (C:\users\paul\_bazel_paul\lm3s4mgv\execroot\angular\packages\compiler-cli\src\ngtsc\shims\src\host.ts:66:26)

```

This happens because we call `getCanonicalFileName` that returns a path that is different to the actual `rootNames` (passed to `NgtscProgram`) which are used to construct a map of generated files.

Since the generators always use the paths which are not normalized and TypeScript seems to pass "non"-canonical paths to the host `getSourceFile`, we should be able to stop manually calling `getCanonicalFileName` (this would then follow typescript internal semantics apparently)

--- 

Example: 
```js

// Generator Map:

'C:/users/paul/_bazel_paul/lm3s4mgv/execroot/angular/packages/core/index.ngfactory.ts' =>
'C:/users/paul/_bazel_paul/lm3s4mgv/execroot/angular/packages/core/index.ts',

// getSourceFile fileName
C:/users/paul/_bazel_paul/lm3s4mgv/execroot/angular/packages/core/index.ngfactory.ts

// after getCanonicalFileName (notice the lower-case drive name)
c:/users/paul/_bazel_paul/lm3s4mgv/execroot/angular/packages/core/index.ngfactory.ts
```

See [source code of getCanonicalFileName](https://github.com/Microsoft/TypeScript/blob/3e4c5c95abd515eb9713b881d27ab3a93cc00461/src/compiler/program.ts#L76-L79).