### PR TITLE
test(ivy): enable ivy tests for platform-browser/animations

### DIFF
--- a/packages/platform-browser/animations/src/animation_builder.ts
+++ b/packages/platform-browser/animations/src/animation_builder.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AnimationBuilder, AnimationFactory, AnimationMetadata, AnimationOptions, AnimationPlayer, NoopAnimationPlayer, sequence} from '@angular/animations';
+import {AnimationBuilder, AnimationFactory, AnimationMetadata, AnimationOptions, AnimationPlayer, sequence} from '@angular/animations';
 import {Inject, Injectable, RendererFactory2, RendererType2, ViewEncapsulation} from '@angular/core';
 import {DOCUMENT} from '@angular/platform-browser';
 

--- a/packages/platform-browser/animations/src/private_export.ts
+++ b/packages/platform-browser/animations/src/private_export.ts
@@ -7,3 +7,4 @@
  */
 export {BrowserAnimationBuilder as ɵBrowserAnimationBuilder, BrowserAnimationFactory as ɵBrowserAnimationFactory} from './animation_builder';
 export {AnimationRenderer as ɵAnimationRenderer, AnimationRendererFactory as ɵAnimationRendererFactory} from './animation_renderer';
+export {InjectableAnimationEngine as ɵInjectableAnimationEngine} from './providers';

--- a/packages/platform-browser/animations/test/BUILD.bazel
+++ b/packages/platform-browser/animations/test/BUILD.bazel
@@ -17,6 +17,7 @@ ts_library(
         "//packages/platform-browser-dynamic",
         "//packages/platform-browser/animations",
         "//packages/platform-browser/testing",
+        "//packages/private/testing",
         "@rxjs",
     ],
 )
@@ -24,9 +25,6 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
-    tags = [
-        "fixme-ivy-aot",
-    ],
     deps = [
         ":test_lib",
         "//tools/testing:node",
@@ -35,9 +33,6 @@ jasmine_node_test(
 
 ts_web_test_suite(
     name = "test_web",
-    tags = [
-        "fixme-ivy-aot",
-    ],
     deps = [
         ":test_lib",
     ],

--- a/packages/platform-browser/animations/test/browser_animation_builder_spec.ts
+++ b/packages/platform-browser/animations/test/browser_animation_builder_spec.ts
@@ -10,10 +10,9 @@ import {AnimationDriver} from '@angular/animations/browser';
 import {MockAnimationDriver} from '@angular/animations/browser/testing';
 import {Component, ViewChild} from '@angular/core';
 import {TestBed, fakeAsync, flushMicrotasks} from '@angular/core/testing';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {NoopAnimationsModule, ɵBrowserAnimationBuilder as BrowserAnimationBuilder} from '@angular/platform-browser/animations';
 
 import {el} from '../../testing/src/browser_util';
-import {BrowserAnimationBuilder} from '../src/animation_builder';
 
 {
   describe('BrowserAnimationBuilder', () => {

--- a/packages/platform-browser/animations/test/noop_animations_module_spec.ts
+++ b/packages/platform-browser/animations/test/noop_animations_module_spec.ts
@@ -9,88 +9,94 @@ import {animate, style, transition, trigger} from '@angular/animations';
 import {ɵAnimationEngine} from '@angular/animations/browser';
 import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-
-import {NoopAnimationsModule} from '../src/module';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {fixmeIvy} from '@angular/private/testing';
 
 {
   describe('NoopAnimationsModule', () => {
     beforeEach(() => { TestBed.configureTestingModule({imports: [NoopAnimationsModule]}); });
 
-    it('should flush and fire callbacks when the zone becomes stable', (async) => {
-      @Component({
-        selector: 'my-cmp',
-        template:
-            '<div [@myAnimation]="exp" (@myAnimation.start)="onStart($event)" (@myAnimation.done)="onDone($event)"></div>',
-        animations: [trigger(
-            'myAnimation',
-            [transition(
-                '* => state', [style({'opacity': '0'}), animate(500, style({'opacity': '1'}))])])],
-      })
-      class Cmp {
-        exp: any;
-        startEvent: any;
-        doneEvent: any;
-        onStart(event: any) { this.startEvent = event; }
-        onDone(event: any) { this.doneEvent = event; }
-      }
+    fixmeIvy(
+        `FW-643: Components with animations throw with "Failed to execute 'setAttribute' on 'Element'`) &&
+        it('should flush and fire callbacks when the zone becomes stable', (async) => {
+          @Component({
+            selector: 'my-cmp',
+            template:
+                '<div [@myAnimation]="exp" (@myAnimation.start)="onStart($event)" (@myAnimation.done)="onDone($event)"></div>',
+            animations: [trigger(
+                'myAnimation',
+                [transition(
+                    '* => state',
+                    [style({'opacity': '0'}), animate(500, style({'opacity': '1'}))])])],
+          })
+          class Cmp {
+            exp: any;
+            startEvent: any;
+            doneEvent: any;
+            onStart(event: any) { this.startEvent = event; }
+            onDone(event: any) { this.doneEvent = event; }
+          }
 
-      TestBed.configureTestingModule({declarations: [Cmp]});
+          TestBed.configureTestingModule({declarations: [Cmp]});
 
-      const fixture = TestBed.createComponent(Cmp);
-      const cmp = fixture.componentInstance;
-      cmp.exp = 'state';
-      fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        expect(cmp.startEvent.triggerName).toEqual('myAnimation');
-        expect(cmp.startEvent.phaseName).toEqual('start');
-        expect(cmp.doneEvent.triggerName).toEqual('myAnimation');
-        expect(cmp.doneEvent.phaseName).toEqual('done');
-        async();
-      });
-    });
+          const fixture = TestBed.createComponent(Cmp);
+          const cmp = fixture.componentInstance;
+          cmp.exp = 'state';
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            expect(cmp.startEvent.triggerName).toEqual('myAnimation');
+            expect(cmp.startEvent.phaseName).toEqual('start');
+            expect(cmp.doneEvent.triggerName).toEqual('myAnimation');
+            expect(cmp.doneEvent.phaseName).toEqual('done');
+            async();
+          });
+        });
 
-    it('should handle leave animation callbacks even if the element is destroyed in the process',
-       (async) => {
-         @Component({
-           selector: 'my-cmp',
-           template:
-               '<div *ngIf="exp" @myAnimation (@myAnimation.start)="onStart($event)" (@myAnimation.done)="onDone($event)"></div>',
-           animations: [trigger(
-               'myAnimation',
-               [transition(
-                   ':leave', [style({'opacity': '0'}), animate(500, style({'opacity': '1'}))])])],
-         })
-         class Cmp {
-           exp: any;
-           startEvent: any;
-           doneEvent: any;
-           onStart(event: any) { this.startEvent = event; }
-           onDone(event: any) { this.doneEvent = event; }
-         }
+    fixmeIvy(
+        `FW-643: Components with animations throw with "Failed to execute 'setAttribute' on 'Element'`) &&
+        it('should handle leave animation callbacks even if the element is destroyed in the process',
+           (async) => {
+             @Component({
+               selector: 'my-cmp',
+               template:
+                   '<div *ngIf="exp" @myAnimation (@myAnimation.start)="onStart($event)" (@myAnimation.done)="onDone($event)"></div>',
+               animations: [trigger(
+                   'myAnimation',
+                   [transition(
+                       ':leave',
+                       [style({'opacity': '0'}), animate(500, style({'opacity': '1'}))])])],
+             })
+             class Cmp {
+               exp: any;
+               startEvent: any;
+               doneEvent: any;
+               onStart(event: any) { this.startEvent = event; }
+               onDone(event: any) { this.doneEvent = event; }
+             }
 
-         TestBed.configureTestingModule({declarations: [Cmp]});
-         const engine = TestBed.get(ɵAnimationEngine);
-         const fixture = TestBed.createComponent(Cmp);
-         const cmp = fixture.componentInstance;
+             TestBed.configureTestingModule({declarations: [Cmp]});
+             const engine = TestBed.get(ɵAnimationEngine);
+             const fixture = TestBed.createComponent(Cmp);
+             const cmp = fixture.componentInstance;
 
-         cmp.exp = true;
-         fixture.detectChanges();
-         fixture.whenStable().then(() => {
-           cmp.startEvent = null;
-           cmp.doneEvent = null;
+             cmp.exp = true;
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
+               cmp.startEvent = null;
+               cmp.doneEvent = null;
 
-           cmp.exp = false;
-           fixture.detectChanges();
-           fixture.whenStable().then(() => {
-             expect(cmp.startEvent.triggerName).toEqual('myAnimation');
-             expect(cmp.startEvent.phaseName).toEqual('start');
-             expect(cmp.startEvent.toState).toEqual('void');
-             expect(cmp.doneEvent.triggerName).toEqual('myAnimation');
-             expect(cmp.doneEvent.phaseName).toEqual('done');
-             expect(cmp.doneEvent.toState).toEqual('void');
-             async();
+               cmp.exp = false;
+               fixture.detectChanges();
+               fixture.whenStable().then(() => {
+                 expect(cmp.startEvent.triggerName).toEqual('myAnimation');
+                 expect(cmp.startEvent.phaseName).toEqual('start');
+                 expect(cmp.startEvent.toState).toEqual('void');
+                 expect(cmp.doneEvent.triggerName).toEqual('myAnimation');
+                 expect(cmp.doneEvent.phaseName).toEqual('done');
+                 expect(cmp.doneEvent.toState).toEqual('void');
+                 async();
+               });
+             });
            });
-         });
-       });
   });
 }

--- a/packages/platform-browser/animations/test/noop_animations_module_spec.ts
+++ b/packages/platform-browser/animations/test/noop_animations_module_spec.ts
@@ -16,6 +16,9 @@ import {fixmeIvy} from '@angular/private/testing';
   describe('NoopAnimationsModule', () => {
     beforeEach(() => { TestBed.configureTestingModule({imports: [NoopAnimationsModule]}); });
 
+    it('should be removed once FW-643 is fixed', () => { expect(true).toBeTruthy(); });
+
+    // TODO: remove the dummy test above ^ once the bug FW-643 has been fixed
     fixmeIvy(
         `FW-643: Components with animations throw with "Failed to execute 'setAttribute' on 'Element'`) &&
         it('should flush and fire callbacks when the zone becomes stable', (async) => {


### PR DESCRIPTION
Enable ivy tests for platform-browser/animations + root cause analysis. It's the same bug that's making all the tests fail. We might have other bugs but we'll know more once we've fixed this one.