### PR TITLE
feat(core): introduce local scope & make NgModules optional in ivy

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -50,6 +50,7 @@ export class DirectiveDecoratorHandler implements
       this.scopeRegistry.registerDirective(node, {
         ref,
         directive: ref,
+        deps: [],
         name: node.name !.text,
         selector: analysis.selector,
         exportAs: analysis.exportAs,

--- a/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
@@ -38,9 +38,10 @@ describe('ComponentDecoratorHandler', () => {
     ]);
     const checker = program.getTypeChecker();
     const host = new TypeScriptReflectionHost(checker);
+    const selectorRegistry = new SelectorScopeRegistry(checker, host);
+    const noopLoader = new NoopResourceLoader();
     const handler = new ComponentDecoratorHandler(
-        checker, host, new SelectorScopeRegistry(checker, host), false, new NoopResourceLoader(),
-        [''], false, true);
+        checker, host, selectorRegistry, false, noopLoader, [''], false, true);
     const TestCmp = getDeclaration(program, 'entry.ts', 'TestCmp', ts.isClassDeclaration);
     const detected = handler.detect(TestCmp, host.getDecoratorsOfDeclaration(TestCmp));
     if (detected === undefined) {

--- a/packages/compiler-cli/src/ngtsc/annotations/test/selector_scope_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/selector_scope_spec.ts
@@ -9,9 +9,8 @@
 import * as ts from 'typescript';
 
 import {TypeScriptReflectionHost} from '../../metadata';
-import {AbsoluteReference, ResolvedReference} from '../../metadata/src/resolver';
+import {AbsoluteReference, NodeReference, ResolvedReference} from '../../metadata/src/resolver';
 import {getDeclaration, makeProgram} from '../../testing/in_memory_typescript';
-import {NgModuleDecoratorHandler} from '../src/ng_module';
 import {SelectorScopeRegistry} from '../src/selector_scope';
 
 describe('SelectorScopeRegistry', () => {
@@ -73,7 +72,6 @@ describe('SelectorScopeRegistry', () => {
       imports: [new AbsoluteReference(SomeModule, SomeModule.name !, 'some_library', 'SomeModule')],
     });
 
-    const ref = new ResolvedReference(ProgramCmp, ProgramCmp.name !);
     registry.registerDirective(ProgramCmp, {
       name: 'ProgramCmp',
       ref: ProgramCmpRef,
@@ -84,6 +82,7 @@ describe('SelectorScopeRegistry', () => {
       inputs: {},
       outputs: {},
       queries: [],
+      deps: [],
       hasNgTemplateContextGuard: false,
       ngTemplateGuards: [],
     });
@@ -155,6 +154,7 @@ describe('SelectorScopeRegistry', () => {
       inputs: {},
       outputs: {},
       queries: [],
+      deps: [],
       hasNgTemplateContextGuard: false,
       ngTemplateGuards: [],
     });
@@ -163,5 +163,117 @@ describe('SelectorScopeRegistry', () => {
     expect(scope).toBeDefined();
     expect(scope.directives).toBeDefined();
     expect(scope.directives.length).toBe(2);
+  });
+
+  it('local dependencies', () => {
+    const {program} = makeProgram([
+      {
+        name: 'node_modules/@angular/core/index.ts',
+        contents: `
+        export interface NgComponentDefWithMeta<A, B, C, D, E, F> {}
+        export interface NgModuleDef<A, B, C, D> {}
+      `
+      },
+      {
+        name: 'node_modules/some_library/index.d.ts',
+        contents: `
+        import {NgModuleDef} from '@angular/core';
+        import * as i0 from './component';
+        
+        export declare class SomeModule {
+          static ngModuleDef: NgModuleDef<SomeModule, [typeof i0.SomeCmp], never, [typeof i0.SomeCmp]>;
+        }
+      `
+      },
+      {
+        name: 'node_modules/some_library/component.d.ts',
+        contents: `
+        import {NgComponentDefWithMeta} from '@angular/core';
+
+        export declare class SomeCmp {
+          static ngComponentDef: NgComponentDefWithMeta<SomeCmp, 'some-cmp', never, {}, {}, never>;
+        }
+      `
+      },
+      {
+        name: 'entry.ts',
+        contents: `
+          export class ProgramCmp {}
+          export class ProgramModule {}
+      `
+      },
+      {
+        name: 'local.ts',
+        contents: `
+          export class Dir {}
+          export class Pipe {}
+      `
+      },
+    ]);
+    const checker = program.getTypeChecker();
+    const host = new TypeScriptReflectionHost(checker);
+    const ProgramModule =
+        getDeclaration(program, 'entry.ts', 'ProgramModule', ts.isClassDeclaration);
+    const ProgramCmp = getDeclaration(program, 'entry.ts', 'ProgramCmp', ts.isClassDeclaration);
+    const Dir = getDeclaration(program, 'local.ts', 'Dir', ts.isClassDeclaration);
+    const Pipe = getDeclaration(program, 'local.ts', 'Pipe', ts.isClassDeclaration);
+    const SomeModule = getDeclaration(
+        program, 'node_modules/some_library/index.d.ts', 'SomeModule', ts.isClassDeclaration);
+
+    expect(ProgramModule).toBeDefined();
+    expect(SomeModule).toBeDefined();
+
+    const ProgramCmpRef = new ResolvedReference(ProgramCmp, ProgramCmp.name !);
+    const DirRef = new ResolvedReference(Dir, Dir.name !);
+
+    const registry = new SelectorScopeRegistry(checker, host);
+
+    registry.registerModule(ProgramModule, {
+      declarations: [new ResolvedReference(ProgramCmp, ProgramCmp.name !)],
+      exports: [],
+      imports: [new AbsoluteReference(SomeModule, SomeModule.name !, 'some_library', 'SomeModule')],
+    });
+
+    registry.registerDirective(ProgramCmp, {
+      name: 'ProgramCmp',
+      ref: ProgramCmpRef,
+      directive: ProgramCmpRef,
+      selector: 'program-cmp',
+      isComponent: true,
+      exportAs: null,
+      inputs: {},
+      outputs: {},
+      queries: [],
+      deps: [
+        new AbsoluteReference(Dir, Dir.name !, 'local.ts', 'Dir'),
+        new AbsoluteReference(Pipe, Pipe.name !, 'local.ts', 'Pipe')
+      ],
+      hasNgTemplateContextGuard: false,
+      ngTemplateGuards: [],
+    });
+
+    registry.registerDirective(Dir, {
+      name: 'Dir',
+      ref: DirRef,
+      directive: DirRef,
+      selector: '[dir]',
+      isComponent: false,
+      exportAs: null,
+      inputs: {},
+      outputs: {},
+      queries: [],
+      deps: [],
+      hasNgTemplateContextGuard: false,
+      ngTemplateGuards: [],
+    });
+
+    registry.registerPipe(Pipe, 'pipe');
+
+    const scope = registry.lookupCompilationScope(ProgramCmp) !;
+    expect(scope).toBeDefined();
+    expect(scope.directives).toBeDefined();
+    expect(scope.directives.length).toBe(3);
+    expect(scope.pipes).toBeDefined();
+    expect(scope.pipes.size).toBe(1);
   });
 });

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/api.ts
@@ -17,6 +17,7 @@ import {Reference} from '../../metadata';
  */
 export interface TypeCheckableDirectiveMeta extends DirectiveMeta {
   ref: Reference<ts.ClassDeclaration>;
+  deps: Reference<ts.Declaration>[];
   queries: string[];
   ngTemplateGuards: string[];
   hasNgTemplateContextGuard: boolean;

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -969,6 +969,48 @@ describe('ngtsc behavioral tests', () => {
     expect(jsContents).toMatch(/directives: \[DirA,\s+DirB\]/);
   });
 
+  describe('local scope', () => {
+    it('should compile a component considering the directives in the local scope', () => {
+      env.tsconfig();
+      env.write('test.ts', `
+        import {Component, Directive} from '@angular/core';
+  
+        @Directive({selector: '[test]'})
+        class DirA {}
+  
+        @Component({
+          template: '<div test></div>',
+          deps: [DirA]
+        })
+        class SampleCmp {}
+      `);
+
+      env.driveMain();
+      const jsContents = env.getContents('test.js');
+      expect(jsContents).toContain('directives: [DirA]');
+    });
+
+    it('should compile a component considering the pipes in the local scope', () => {
+      env.tsconfig();
+      env.write('test.ts', `
+        import {Component, Pipe} from '@angular/core';
+  
+        @Pipe({name: 'test'})
+        class TestPipe {}
+  
+        @Component({
+          template: '<div>{{ "text" | test }}</div>',
+          deps: [TestPipe]
+        })
+        class SampleCmp1 {}
+      `);
+
+      env.driveMain();
+      const jsContents = env.getContents('test.js');
+      expect(jsContents).toContain('pipes: [TestPipe]');
+    });
+  });
+
   describe('duplicate local refs', () => {
     const getComponentScript = (template: string): string => `
       import {Component, Directive, NgModule} from '@angular/core';

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -13,6 +13,7 @@ import {ParseSourceSpan} from '../../parse_util';
 import * as t from '../r3_ast';
 import {R3DependencyMetadata} from '../r3_factory';
 
+
 /**
  * Information needed to compile a directive for the render3 runtime.
  */

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -552,6 +552,11 @@ export interface Component extends Directive {
    * overridden in compiler options.
    */
   preserveWhitespaces?: boolean;
+
+  /**
+   * A set of directives, components and pipes used in the component's template.
+   */
+  deps?: Array<Type<any>>;
 }
 
 /**

--- a/packages/core/test/render3/BUILD.bazel
+++ b/packages/core/test/render3/BUILD.bazel
@@ -8,6 +8,8 @@ ts_library(
     srcs = glob(
         ["**/*.ts"],
         exclude = [
+            "render_util.ts",
+            "imported_renderer2.ts",
             "**/*_perf.ts",
             "domino.d.ts",
             "load_domino.ts",
@@ -15,6 +17,7 @@ ts_library(
         ],
     ),
     deps = [
+        ":render3_util",
         "//packages:types",
         "//packages/animations",
         "//packages/animations/browser",
@@ -27,6 +30,22 @@ ts_library(
         "//packages/platform-browser/animations",
         "//packages/platform-browser/testing",
         "//packages/private/testing",
+    ],
+)
+
+ts_library(
+    name = "render3_util",
+    testonly = True,
+    srcs = [
+        "imported_renderer2.ts",
+        "render_util.ts",
+    ],
+    deps = [
+        "//packages:types",
+        "//packages/animations/browser/testing",
+        "//packages/core/testing",
+        "//packages/platform-browser",
+        "//packages/platform-browser/testing",
     ],
 )
 

--- a/packages/core/test/render3/ivy/BUILD.bazel
+++ b/packages/core/test/render3/ivy/BUILD.bazel
@@ -23,5 +23,6 @@ jasmine_node_test(
     deps = [
         ":ivy_lib",
         "//packages/core/test/render3:domino",
+        "//packages/core/test/render3:render3_util",
     ],
 )

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -15,7 +15,10 @@ import {ivyEnabled} from '@angular/core/src/ivy_switch';
 import {ContentChild, ContentChildren, ViewChild, ViewChildren} from '@angular/core/src/metadata/di';
 import {Component, Directive, HostBinding, HostListener, Input, Output, Pipe} from '@angular/core/src/metadata/directives';
 import {NgModule, NgModuleDef} from '@angular/core/src/metadata/ng_module';
+import {getHostElement} from '@angular/core/src/render3';
 import {ComponentDef, PipeDef} from '@angular/core/src/render3/interfaces/definition';
+
+import {renderComponent} from '../render_util';
 
 
 ivyEnabled && describe('render3 jit', () => {
@@ -377,6 +380,32 @@ ivyEnabled && describe('render3 jit', () => {
 
     expect((TestComponent as any).ngComponentDef.viewQuery).not.toBeNull();
   });
+
+  it('should respect the "deps" property in the component metadata', () => {
+    @Component({selector: 'child', template: 'child'})
+    class ChildComponent {
+    }
+
+    @Pipe({name: 'customPipe'})
+    class MyPipe {
+      transform(val: string) { return val.toUpperCase(); }
+    }
+
+    @Component({
+      selector: 'test',
+      template: '<div>{{ "test" | customPipe }}</div><child></child>',
+      deps: [ChildComponent, MyPipe],
+    })
+    class TestComponent {
+    }
+
+    const def = (TestComponent as any).ngComponentDef;
+    expect(def).not.toBeNull();
+    const myComp = renderComponent(TestComponent as any);
+    const result = getHostElement(myComp).innerHTML;
+    expect(result).toBe('<div>TEST</div><child>child</child>');
+  });
+
 });
 
 it('ensure at least one spec exists', () => {});

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -102,6 +102,7 @@ export declare type CompilerOptions = {
 export interface Component extends Directive {
     animations?: any[];
     changeDetection?: ChangeDetectionStrategy;
+    deps?: Array<Type<any>>;
     encapsulation?: ViewEncapsulation;
     entryComponents?: Array<Type<any> | any[]>;
     interpolation?: [string, string];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The templates of a component are compiled based on the NgModule transitive scope, without accepting local component scope.

Issue Number: N/A


## What is the new behavior?

The templates of the component could be only compiled using the local component scope, which makes NgModules optional.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
