### PR TITLE
fix(ivy): align NgModuleRef implementation between Ivy and ViewEngine

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -80,10 +80,13 @@ function createChainedInjector(rootViewInjector: Injector, moduleInjector: Injec
     get: <T>(token: Type<T>| InjectionToken<T>, notFoundValue?: T): T => {
       const value = rootViewInjector.get(token, NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR);
 
-      if (value !== NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR) {
+      if (value !== NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR ||
+          notFoundValue === NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR) {
         // Return the value from the root element injector when
         // - it provides it
         //   (value !== NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR)
+        // - the module injector should not be checked
+        //   (notFoundValue === NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR)
         return value;
       }
 

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -34,10 +34,15 @@ import {createElementRef} from './view_engine_compatibility';
 import {RootViewRef, ViewRef} from './view_ref';
 
 export class ComponentFactoryResolver extends viewEngine_ComponentFactoryResolver {
+  /**
+   * @param ngModule The NgModuleRef to which all resolved factories are bound.
+   */
+  constructor(private ngModule?: viewEngine_NgModuleRef<any>) { super(); }
+
   resolveComponentFactory<T>(component: Type<T>): viewEngine_ComponentFactory<T> {
     ngDevMode && assertComponentType(component);
     const componentDef = getComponentDef(component) !;
-    return new ComponentFactory(componentDef);
+    return new ComponentFactory(componentDef, this.ngModule);
   }
 }
 
@@ -103,7 +108,12 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
     return toRefArray(this.componentDef.outputs);
   }
 
-  constructor(private componentDef: ComponentDef<any>) {
+  /**
+   * @param componentDef The component definition.
+   * @param ngModule The NgModuleRef to which the factory is bound.
+   */
+  constructor(
+      private componentDef: ComponentDef<any>, private ngModule?: viewEngine_NgModuleRef<any>) {
     super();
     this.componentType = componentDef.type;
     this.selector = componentDef.selectors[0][0] as string;
@@ -114,6 +124,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
       injector: Injector, projectableNodes?: any[][]|undefined, rootSelectorOrNode?: any,
       ngModule?: viewEngine_NgModuleRef<any>|undefined): viewEngine_ComponentRef<T> {
     const isInternalRootView = rootSelectorOrNode === undefined;
+    ngModule = ngModule || this.ngModule;
 
     const rootViewInjector =
         ngModule ? createChainedInjector(injector, ngModule.injector) : injector;

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -235,7 +235,7 @@ export function createContainerRef(
           injector?: Injector|undefined, projectableNodes?: any[][]|undefined,
           ngModuleRef?: viewEngine_NgModuleRef<any>|undefined): viewEngine_ComponentRef<C> {
         const contextInjector = injector || this.parentInjector;
-        if (!ngModuleRef && contextInjector) {
+        if (!ngModuleRef && (componentFactory as any).ngModule == null && contextInjector) {
           ngModuleRef = contextInjector.get(viewEngine_NgModuleRef, null);
         }
 

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -187,5 +187,87 @@ describe('ComponentFactory', () => {
            expect(mSanitizerFactorySpy).toHaveBeenCalled();
          });
     });
+
+    describe('(when the factory is bound to a `ngModuleRef`)', () => {
+      it('should retrieve `RendererFactory2` from the specified injector first', () => {
+        const injector = Injector.create([
+          {provide: RendererFactory2, useValue: {createRenderer: createRenderer2Spy}},
+        ]);
+        (cf as any).ngModule = {
+          injector: Injector.create([
+            {provide: RendererFactory2, useValue: {createRenderer: createRenderer3Spy}},
+          ])
+        };
+
+        cf.create(injector);
+
+        expect(createRenderer2Spy).toHaveBeenCalled();
+        expect(createRenderer3Spy).not.toHaveBeenCalled();
+      });
+
+      it('should retrieve `RendererFactory2` from the `ngModuleRef` if not provided by the injector',
+         () => {
+           const injector = Injector.create([]);
+           (cf as any).ngModule = {
+             injector: Injector.create([
+               {provide: RendererFactory2, useValue: {createRenderer: createRenderer2Spy}},
+             ])
+           };
+
+           cf.create(injector);
+
+           expect(createRenderer2Spy).toHaveBeenCalled();
+           expect(createRenderer3Spy).not.toHaveBeenCalled();
+         });
+
+      it('should fall back to `domRendererFactory3` if `RendererFactory2` is not provided', () => {
+        const injector = Injector.create([]);
+        (cf as any).ngModule = {injector: Injector.create([])};
+
+        cf.create(injector);
+
+        expect(createRenderer2Spy).not.toHaveBeenCalled();
+        expect(createRenderer3Spy).toHaveBeenCalled();
+      });
+
+      it('should retrieve `Sanitizer` from the specified injector first', () => {
+        const iSanitizerFactorySpy =
+            jasmine.createSpy('Injector#sanitizerFactory').and.returnValue({});
+        const injector = Injector.create([
+          {provide: Sanitizer, useFactory: iSanitizerFactorySpy, deps: []},
+        ]);
+
+        const mSanitizerFactorySpy =
+            jasmine.createSpy('NgModuleRef#sanitizerFactory').and.returnValue({});
+        (cf as any).ngModule = {
+          injector: Injector.create([
+            {provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []},
+          ])
+        };
+
+        cf.create(injector);
+
+        expect(iSanitizerFactorySpy).toHaveBeenCalled();
+        expect(mSanitizerFactorySpy).not.toHaveBeenCalled();
+      });
+
+      it('should retrieve `Sanitizer` from the `ngModuleRef` if not provided by the injector',
+         () => {
+           const injector = Injector.create([]);
+
+           const mSanitizerFactorySpy =
+               jasmine.createSpy('NgModuleRef#sanitizerFactory').and.returnValue({});
+           (cf as any).ngModule = {
+             injector: Injector.create([
+               {provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []},
+             ])
+           };
+
+
+           cf.create(injector);
+
+           expect(mSanitizerFactorySpy).toHaveBeenCalled();
+         });
+    });
   });
 });

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -3561,94 +3561,93 @@ describe('Integration', () => {
              expect(fixture.nativeElement).toHaveText('lazy-loaded-parent [lazy-loaded-child]');
            })));
 
-    fixmeIvy('FW-646: Directive providers don\'t support primitive types as DI tokens')
-        .it('should have 2 injector trees: module and element',
-            fakeAsync(inject(
-                [Router, Location, NgModuleFactoryLoader],
-                (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-                  @Component({
-                    selector: 'lazy',
-                    template: 'parent[<router-outlet></router-outlet>]',
-                    viewProviders: [
-                      {provide: 'shadow', useValue: 'from parent component'},
-                    ],
-                  })
-                  class Parent {
-                  }
+    it('should have 2 injector trees: module and element',
+       fakeAsync(inject(
+           [Router, Location, NgModuleFactoryLoader],
+           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+             @Component({
+               selector: 'lazy',
+               template: 'parent[<router-outlet></router-outlet>]',
+               viewProviders: [
+                 {provide: 'shadow', useValue: 'from parent component'},
+               ],
+             })
+             class Parent {
+             }
 
-                  @Component({selector: 'lazy', template: 'child'})
-                  class Child {
-                  }
+             @Component({selector: 'lazy', template: 'child'})
+             class Child {
+             }
 
-                  @NgModule({
-                    declarations: [Parent],
-                    imports: [RouterModule.forChild([{
-                      path: 'parent',
-                      component: Parent,
-                      children: [
-                        {path: 'child', loadChildren: 'child'},
-                      ]
-                    }])],
-                    providers: [
-                      {provide: 'moduleName', useValue: 'parent'},
-                      {provide: 'fromParent', useValue: 'from parent'},
-                    ],
-                  })
-                  class ParentModule {
-                  }
+             @NgModule({
+               declarations: [Parent],
+               imports: [RouterModule.forChild([{
+                 path: 'parent',
+                 component: Parent,
+                 children: [
+                   {path: 'child', loadChildren: 'child'},
+                 ]
+               }])],
+               providers: [
+                 {provide: 'moduleName', useValue: 'parent'},
+                 {provide: 'fromParent', useValue: 'from parent'},
+               ],
+             })
+             class ParentModule {
+             }
 
-                  @NgModule({
-                    declarations: [Child],
-                    imports: [RouterModule.forChild([{path: '', component: Child}])],
-                    providers: [
-                      {provide: 'moduleName', useValue: 'child'},
-                      {provide: 'fromChild', useValue: 'from child'},
-                      {provide: 'shadow', useValue: 'from child module'},
-                    ],
-                  })
-                  class ChildModule {
-                  }
+             @NgModule({
+               declarations: [Child],
+               imports: [RouterModule.forChild([{path: '', component: Child}])],
+               providers: [
+                 {provide: 'moduleName', useValue: 'child'},
+                 {provide: 'fromChild', useValue: 'from child'},
+                 {provide: 'shadow', useValue: 'from child module'},
+               ],
+             })
+             class ChildModule {
+             }
 
-                  loader.stubbedModules = {
-                    parent: ParentModule,
-                    child: ChildModule,
-                  };
+             loader.stubbedModules = {
+               parent: ParentModule,
+               child: ChildModule,
+             };
 
-                  const fixture = createRoot(router, RootCmp);
-                  router.resetConfig([{path: 'lazy', loadChildren: 'parent'}]);
-                  router.navigateByUrl('/lazy/parent/child');
-                  advance(fixture);
-                  expect(location.path()).toEqual('/lazy/parent/child');
-                  expect(fixture.nativeElement).toHaveText('parent[child]');
+             const fixture = createRoot(router, RootCmp);
+             router.resetConfig([{path: 'lazy', loadChildren: 'parent'}]);
+             router.navigateByUrl('/lazy/parent/child');
+             advance(fixture);
+             expect(location.path()).toEqual('/lazy/parent/child');
+             expect(fixture.nativeElement).toHaveText('parent[child]');
 
-                  const pInj = fixture.debugElement.query(By.directive(Parent)).injector !;
-                  const cInj = fixture.debugElement.query(By.directive(Child)).injector !;
+             const pInj = fixture.debugElement.query(By.directive(Parent)).injector !;
+             const cInj = fixture.debugElement.query(By.directive(Child)).injector !;
 
-                  expect(pInj.get('moduleName')).toEqual('parent');
-                  expect(pInj.get('fromParent')).toEqual('from parent');
-                  expect(pInj.get(Parent)).toBeAnInstanceOf(Parent);
-                  expect(pInj.get('fromChild', null)).toEqual(null);
-                  expect(pInj.get(Child, null)).toEqual(null);
+             expect(pInj.get('moduleName')).toEqual('parent');
+             expect(pInj.get('fromParent')).toEqual('from parent');
+             expect(pInj.get(Parent)).toBeAnInstanceOf(Parent);
+             expect(pInj.get('fromChild', null)).toEqual(null);
+             expect(pInj.get(Child, null)).toEqual(null);
 
-                  expect(cInj.get('moduleName')).toEqual('child');
-                  expect(cInj.get('fromParent')).toEqual('from parent');
-                  expect(cInj.get('fromChild')).toEqual('from child');
-                  expect(cInj.get(Parent)).toBeAnInstanceOf(Parent);
-                  expect(cInj.get(Child)).toBeAnInstanceOf(Child);
-                  // The child module can not shadow the parent component
-                  expect(cInj.get('shadow')).toEqual('from parent component');
+             expect(cInj.get('moduleName')).toEqual('child');
+             expect(cInj.get('fromParent')).toEqual('from parent');
+             expect(cInj.get('fromChild')).toEqual('from child');
+             expect(cInj.get(Parent)).toBeAnInstanceOf(Parent);
+             expect(cInj.get(Child)).toBeAnInstanceOf(Child);
+             // The child module can not shadow the parent component
+             expect(cInj.get('shadow')).toEqual('from parent component');
 
-                  const pmInj = pInj.get(NgModuleRef).injector;
-                  const cmInj = cInj.get(NgModuleRef).injector;
+             const pmInj = pInj.get(NgModuleRef).injector;
+             const cmInj = cInj.get(NgModuleRef).injector;
 
-                  expect(pmInj.get('moduleName')).toEqual('parent');
-                  expect(cmInj.get('moduleName')).toEqual('child');
+             expect(pmInj.get('moduleName')).toEqual('parent');
+             expect(cmInj.get('moduleName')).toEqual('child');
 
-                  expect(pmInj.get(Parent, '-')).toEqual('-');
-                  expect(cmInj.get(Parent, '-')).toEqual('-');
-                  expect(pmInj.get(Child, '-')).toEqual('-');
-                  expect(cmInj.get(Child, '-')).toEqual('-');
-                })));
+             expect(pmInj.get(Parent, '-')).toEqual('-');
+             expect(cmInj.get(Parent, '-')).toEqual('-');
+             expect(pmInj.get(Child, '-')).toEqual('-');
+             expect(cmInj.get(Child, '-')).toEqual('-');
+           })));
 
     // https://github.com/angular/angular/issues/12889
     it('should create a single instance of lazy-loaded modules',

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -3689,57 +3689,55 @@ describe('Integration', () => {
            })));
 
     // https://github.com/angular/angular/issues/13870
-    fixmeIvy(
-        'FW-767: Lazy loaded modules are not used when resolving dependencies in one of their components')
-        .it('should create a single instance of guards for lazy-loaded modules',
-            fakeAsync(inject(
-                [Router, Location, NgModuleFactoryLoader],
-                (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-                  @Injectable()
-                  class Service {
-                  }
+    it('should create a single instance of guards for lazy-loaded modules',
+       fakeAsync(inject(
+           [Router, Location, NgModuleFactoryLoader],
+           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+             @Injectable()
+             class Service {
+             }
 
-                  @Injectable()
-                  class Resolver implements Resolve<Service> {
-                    constructor(public service: Service) {}
-                    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-                      return this.service;
-                    }
-                  }
+             @Injectable()
+             class Resolver implements Resolve<Service> {
+               constructor(public service: Service) {}
+               resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+                 return this.service;
+               }
+             }
 
-                  @Component({selector: 'lazy', template: 'lazy'})
-                  class LazyLoadedComponent {
-                    resolvedService: Service;
-                    constructor(public injectedService: Service, route: ActivatedRoute) {
-                      this.resolvedService = route.snapshot.data['service'];
-                    }
-                  }
+             @Component({selector: 'lazy', template: 'lazy'})
+             class LazyLoadedComponent {
+               resolvedService: Service;
+               constructor(public injectedService: Service, route: ActivatedRoute) {
+                 this.resolvedService = route.snapshot.data['service'];
+               }
+             }
 
-                  @NgModule({
-                    declarations: [LazyLoadedComponent],
-                    providers: [Service, Resolver],
-                    imports: [
-                      RouterModule.forChild([{
-                        path: 'loaded',
-                        component: LazyLoadedComponent,
-                        resolve: {'service': Resolver},
-                      }]),
-                    ]
-                  })
-                  class LoadedModule {
-                  }
+             @NgModule({
+               declarations: [LazyLoadedComponent],
+               providers: [Service, Resolver],
+               imports: [
+                 RouterModule.forChild([{
+                   path: 'loaded',
+                   component: LazyLoadedComponent,
+                   resolve: {'service': Resolver},
+                 }]),
+               ]
+             })
+             class LoadedModule {
+             }
 
-                  loader.stubbedModules = {expected: LoadedModule};
-                  const fixture = createRoot(router, RootCmp);
-                  router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
-                  router.navigateByUrl('/lazy/loaded');
-                  advance(fixture);
+             loader.stubbedModules = {expected: LoadedModule};
+             const fixture = createRoot(router, RootCmp);
+             router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
+             router.navigateByUrl('/lazy/loaded');
+             advance(fixture);
 
-                  expect(fixture.nativeElement).toHaveText('lazy');
-                  const lzc = fixture.debugElement.query(By.directive(LazyLoadedComponent))
-                                  .componentInstance;
-                  expect(lzc.injectedService).toBe(lzc.resolvedService);
-                })));
+             expect(fixture.nativeElement).toHaveText('lazy');
+             const lzc =
+                 fixture.debugElement.query(By.directive(LazyLoadedComponent)).componentInstance;
+             expect(lzc.injectedService).toBe(lzc.resolvedService);
+           })));
 
 
     it('should emit RouteConfigLoadStart and RouteConfigLoadEnd event when route is lazy loaded',
@@ -3990,28 +3988,26 @@ describe('Integration', () => {
         });
       });
 
-      fixmeIvy(
-          'FW-767: Lazy loaded modules are not used when resolving dependencies in one of their components')
-          .it('should use the injector of the lazily-loaded configuration',
-              fakeAsync(inject(
-                  [Router, Location, NgModuleFactoryLoader],
-                  (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-                    loader.stubbedModules = {expected: LoadedModule};
+      it('should use the injector of the lazily-loaded configuration',
+         fakeAsync(inject(
+             [Router, Location, NgModuleFactoryLoader],
+             (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+               loader.stubbedModules = {expected: LoadedModule};
 
-                    const fixture = createRoot(router, RootCmp);
+               const fixture = createRoot(router, RootCmp);
 
-                    router.resetConfig([{
-                      path: 'eager-parent',
-                      component: EagerParentComponent,
-                      children: [{path: 'lazy', loadChildren: 'expected'}]
-                    }]);
+               router.resetConfig([{
+                 path: 'eager-parent',
+                 component: EagerParentComponent,
+                 children: [{path: 'lazy', loadChildren: 'expected'}]
+               }]);
 
-                    router.navigateByUrl('/eager-parent/lazy/lazy-parent/lazy-child');
-                    advance(fixture);
+               router.navigateByUrl('/eager-parent/lazy/lazy-parent/lazy-child');
+               advance(fixture);
 
-                    expect(location.path()).toEqual('/eager-parent/lazy/lazy-parent/lazy-child');
-                    expect(fixture.nativeElement).toHaveText('eager-parent lazy-parent lazy-child');
-                  })));
+               expect(location.path()).toEqual('/eager-parent/lazy/lazy-parent/lazy-child');
+               expect(fixture.nativeElement).toHaveText('eager-parent lazy-parent lazy-child');
+             })));
     });
 
     it('works when given a callback',


### PR DESCRIPTION
Between Ivy and the View Engine, there are some discrepancies in the implementation of `NgModuleRef` which are causing 4 tests to fail in the router.
Currently in the View Engine:
1) `NgModuleRef` is an `Injector`
2) `NgModuleRef` has a public parent property named `_public`
3) `NgModuleRef` has a dependency on `CodegenComponentFactoryResolver` which basically produces `ComponentFactory` which are bound to a module