### PR TITLE
ci: use buildifier binary release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,21 +53,19 @@ version: 2
 jobs:
   lint:
     <<: *job_defaults
-    resource_class: xlarge
     steps:
       - checkout:
           <<: *post_checkout
       - restore_cache:
           key: *cache_key
       - *define_env_vars
-      - *setup_circleci_bazel_config
       - *yarn_install
 
-      - run: 'yarn buildifier -mode=check ||
-              (echo "BUILD files not formatted. Please run ''yarn buildifier''" ; exit 1)'
+      - run: 'yarn bazel:format -mode=check ||
+              (echo "BUILD files not formatted. Please run ''yarn bazel:format''" ; exit 1)'
       # Run the skylark linter to check our Bazel rules
-      - run: 'yarn skylint ||
-              (echo -e "\n.bzl files have lint errors. Please run ''yarn skylint''"; exit 1)'
+      - run: 'yarn bazel:lint ||
+              (echo -e "\n.bzl files have lint errors. Please run ''yarn bazel:lint-fix''"; exit 1)'
 
       - run: ./node_modules/.bin/gulp lint
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,15 +19,18 @@ load(
 
 # Angular Bazel users will call this function
 rules_angular_dependencies()
+
 # These are the dependencies only for us
 rules_angular_dev_dependencies()
 
 # Install transitive deps of rules_typescript
 load("@build_bazel_rules_typescript//:package.bzl", "rules_typescript_dependencies")
+
 rules_typescript_dependencies()
 
 # Install transitive deps of rules_nodejs
 load("@build_bazel_rules_nodejs//:package.bzl", "rules_nodejs_dependencies")
+
 rules_nodejs_dependencies()
 
 #
@@ -35,9 +38,9 @@ rules_nodejs_dependencies()
 #
 http_archive(
     name = "rxjs",
-    url = "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz",
-    strip_prefix = "package/src",
     sha256 = "72b0b4e517f43358f554c125e40e39f67688cd2738a8998b4a266981ed32f403",
+    strip_prefix = "package/src",
+    url = "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz",
 )
 
 # Point to the integration test workspace just so that Bazel doesn't descend into it
@@ -70,7 +73,7 @@ local_repository(
     path = "tools/npm_workspace",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,6 @@
 workspace(name = "angular")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(
     "//packages/bazel:package.bzl",
     "rules_angular_dependencies",

--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -11,9 +11,9 @@ local_repository(
 
 http_archive(
     name = "rxjs",
-    url = "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz",
-    strip_prefix = "package/src",
     sha256 = "72b0b4e517f43358f554c125e40e39f67688cd2738a8998b4a266981ed32f403",
+    strip_prefix = "package/src",
+    url = "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz",
 )
 
 load("@angular//packages/bazel:package.bzl", "rules_angular_dependencies")
@@ -42,6 +42,7 @@ http_archive(
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories", "yarn_install")
 
 check_bazel_version("0.17.0")
+
 node_repositories(
     node_version = "10.9.0",
     yarn_version = "1.12.1",
@@ -53,14 +54,16 @@ yarn_install(
     yarn_lock = "//src:yarn.lock",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
+
 go_register_toolchains()
 
 load("@io_bazel_rules_webtesting//web:repositories.bzl", "browser_repositories", "web_test_repositories")
 
 web_test_repositories()
+
 browser_repositories(
     chromium = True,
     firefox = True,

--- a/package.json
+++ b/package.json
@@ -16,11 +16,9 @@
     "url": "https://github.com/angular/angular.git"
   },
   "scripts": {
-    "preskylint": "bazel build --noshow_progress @io_bazel//src/tools/skylark/java/com/google/devtools/skylark/skylint:Skylint",
-    "//": "deprecated-api is disabled because we use actions.new_file(genfiles_dir) which has no replacement, see https://github.com/bazelbuild/bazel/issues/4858",
-    "skylint": "find . -type f -name \"*.bzl\" ! -path \"*/node_modules/*\" ! -path \"./dist/*\" | xargs $(bazel info bazel-bin)/external/io_bazel/src/tools/skylark/java/com/google/devtools/skylark/skylint/Skylint --disable-checks=deprecated-api",
-    "prebuildifier": "bazel build --noshow_progress @com_github_bazelbuild_buildtools//buildifier",
-    "buildifier": "find . -type f \\( -name \"*.bzl\" -or -name BUILD -or -name BUILD.bazel \\) ! -path \"*/node_modules/*\" | xargs $(bazel info bazel-bin)/external/com_github_bazelbuild_buildtools/buildifier/*/buildifier",
+    "bazel:format": "find . -type f \\( -name \"*.bzl\" -or -name BUILD -or -name BUILD.bazel -or -name WORKSPACE \\) ! -path \"*/node_modules/*\" | xargs buildifier -v",
+    "bazel:lint": "yarn bazel:format --lint=warn",
+    "bazel:lint-fix": "yarn bazel:format --lint=fix",
     "preinstall": "node tools/yarn/check-yarn.js",
     "postinstall": "yarn update-webdriver && node ./tools/postinstall-patches.js",
     "update-webdriver": "webdriver-manager update --gecko false $CHROMEDRIVER_VERSION_ARG",
@@ -91,6 +89,7 @@
   "// 2": "devDependencies are not used under Bazel. Many can be removed after test.sh is deleted.",
   "devDependencies": {
     "@bazel/bazel": "^0.18.1",
+    "@bazel/buildifier": "^0.19.2",
     "@bazel/ibazel": "~0.8.2",
     "@types/angular": "^1.6.47",
     "@types/base64-js": "1.2.5",

--- a/packages/bazel/package.bzl
+++ b/packages/bazel/package.bzl
@@ -74,21 +74,6 @@ def rules_angular_dev_dependencies():
         url = "https://github.com/google/brotli/archive/v1.0.5.zip",
     )
 
-    # Fetching the Bazel source code allows us to compile the Skylark linter
-    http_archive(
-        name = "io_bazel",
-        sha256 = "978f7e0440dd82182563877e2e0b7c013b26b3368888b57837e9a0ae206fd396",
-        strip_prefix = "bazel-0.18.0",
-        url = "https://github.com/bazelbuild/bazel/archive/0.18.0.zip",
-    )
-
-    http_archive(
-        name = "com_github_bazelbuild_buildtools",
-        sha256 = "a82d4b353942b10c1535528b02bff261d020827c9c57e112569eddcb1c93d7f6",
-        strip_prefix = "buildtools-0.17.2",
-        url = "https://github.com/bazelbuild/buildtools/archive/0.17.2.zip",
-    )
-
     #############################################
     # Dependencies for generating documentation #
     #############################################

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,6 +64,24 @@
     "@bazel/bazel-linux_x64" "0.18.0"
     "@bazel/bazel-win32_x64" "0.18.0"
 
+"@bazel/buildifier-darwin_x64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@bazel/buildifier-darwin_x64/-/buildifier-darwin_x64-0.19.2.tgz#1182862b4a3578fb9367ab42e807131187a61702"
+  integrity sha512-f6CITRj8jFhhZFrQkIao3IgJjZAXGYwUkW/QBSeAu0HIltBerJ0FTt/Nmu9ji1QZYT2aO4RpZ8oJksG6xv1dcQ==
+
+"@bazel/buildifier-linux_x64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@bazel/buildifier-linux_x64/-/buildifier-linux_x64-0.19.2.tgz#8b26eaf1f091cd3846a7dd7ea94008b55498401e"
+  integrity sha512-kJjzbrjuAW4yVms5mbTWSHpJF6ogDLkuq4MjVP6a03umQ7E15o9YoxbDoiN+CzAj9ZMWPWfc5/N5TouiwXkGzA==
+
+"@bazel/buildifier@^0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@bazel/buildifier/-/buildifier-0.19.2.tgz#3e077de346ad98561cee703297aa8db50cfb3c76"
+  integrity sha512-MwkuoQdOdZ/VYKJvZe3qVCn3/20pLJyJpzNl3cBmaccWeUtdDKhtOm8YlLU08lxrt0VcKNcTYt4uiA62e/315A==
+  optionalDependencies:
+    "@bazel/buildifier-darwin_x64" "0.19.2"
+    "@bazel/buildifier-linux_x64" "0.19.2"
+
 "@bazel/ibazel@~0.8.2":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.8.2.tgz#a837d93922c0d273361ed4f141c792384c0e10bb"


### PR DESCRIPTION
Switch from Skylint to buildifier --lint - this is required for the Bazel 0.20 upgrade since Bazel no longer lets us use the embedded JDK to build and run Java programs, and Skylint is a Java program
