### PR TITLE
fix(bazel): Respect existing angular version

### DIFF
--- a/packages/bazel/src/schematics/bazel-workspace/index_spec.ts
+++ b/packages/bazel/src/schematics/bazel-workspace/index_spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
 
 describe('Bazel-workspace Schematic', () => {
   const schematicRunner =
@@ -25,6 +26,19 @@ describe('Bazel-workspace Schematic', () => {
     expect(files).toContain('/demo/src/BUILD.bazel');
     expect(files).toContain('/demo/WORKSPACE');
     expect(files).toContain('/demo/yarn.lock');
+  });
+
+  it('should find existing Angular version', () => {
+    let host = new UnitTestTree(new HostTree);
+    host.create('/demo/node_modules/@angular/core/package.json', JSON.stringify({
+      name: '@angular/core',
+      version: '6.6.6',
+    }));
+    const options = {...defaultOptions};
+    host = schematicRunner.runSchematic('bazel-workspace', options, host);
+    expect(host.files).toContain('/demo/WORKSPACE');
+    const workspace = host.readContent('/demo/WORKSPACE');
+    expect(workspace).toMatch('ANGULAR_VERSION = "6.6.6"');
   });
 
   describe('WORKSPACE', () => {


### PR DESCRIPTION
If user has already installed Angular, Bazel should fetch the same
version. Otherwise, user will see an error in the post-install step
that performs version check.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
