### PR TITLE
fix(ivy): fix "fixmeIvy" invocations in "platform-browser" tests

### DIFF
--- a/packages/platform-browser/animations/test/animation_renderer_spec.ts
+++ b/packages/platform-browser/animations/test/animation_renderer_spec.ts
@@ -121,8 +121,8 @@ import {el} from '../../testing/src/browser_util';
       if (isNode) return;
 
       fixmeIvy(
-          `FW-643: Components with animations throw with "Failed to execute 'setAttribute' on 'Element'`) &&
-          it('should flush and fire callbacks when the zone becomes stable', (async) => {
+          `FW-643: Components with animations throw with "Failed to execute 'setAttribute' on 'Element'`)
+          .it('should flush and fire callbacks when the zone becomes stable', (async) => {
             @Component({
               selector: 'my-cmp',
               template: '<div [@myAnimation]="exp" (@myAnimation.start)="onStart($event)"></div>',
@@ -198,76 +198,76 @@ import {el} from '../../testing/src/browser_util';
          });
 
       fixmeIvy(
-          `FW-643: Components with animations throw with "Failed to execute 'setAttribute' on 'Element'`) &&
-          it('should only queue up dom removals if the element itself contains a valid leave animation',
-             () => {
-               @Component({
-                 selector: 'my-cmp',
-                 template: `
+          `FW-643: Components with animations throw with "Failed to execute 'setAttribute' on 'Element'`)
+          .it('should only queue up dom removals if the element itself contains a valid leave animation',
+              () => {
+                @Component({
+                  selector: 'my-cmp',
+                  template: `
                <div #elm1 *ngIf="exp1"></div>
                <div #elm2 @animation1 *ngIf="exp2"></div>
                <div #elm3 @animation2 *ngIf="exp3"></div>
             `,
-                 animations: [
-                   trigger('animation1', [transition('a => b', [])]),
-                   trigger('animation2', [transition(':leave', [])]),
-                 ]
-               })
-               class Cmp {
-                 exp1: any = true;
-                 exp2: any = true;
-                 exp3: any = true;
+                  animations: [
+                    trigger('animation1', [transition('a => b', [])]),
+                    trigger('animation2', [transition(':leave', [])]),
+                  ]
+                })
+                class Cmp {
+                  exp1: any = true;
+                  exp2: any = true;
+                  exp3: any = true;
 
-                 @ViewChild('elm1') public elm1: any;
+                  @ViewChild('elm1') public elm1: any;
 
-                 @ViewChild('elm2') public elm2: any;
+                  @ViewChild('elm2') public elm2: any;
 
-                 @ViewChild('elm3') public elm3: any;
-               }
+                  @ViewChild('elm3') public elm3: any;
+                }
 
-               TestBed.configureTestingModule({
-                 providers: [{provide: AnimationEngine, useClass: InjectableAnimationEngine}],
-                 declarations: [Cmp]
-               });
+                TestBed.configureTestingModule({
+                  providers: [{provide: AnimationEngine, useClass: InjectableAnimationEngine}],
+                  declarations: [Cmp]
+                });
 
-               const engine = TestBed.get(AnimationEngine);
-               const fixture = TestBed.createComponent(Cmp);
-               const cmp = fixture.componentInstance;
+                const engine = TestBed.get(AnimationEngine);
+                const fixture = TestBed.createComponent(Cmp);
+                const cmp = fixture.componentInstance;
 
-               fixture.detectChanges();
-               const elm1 = cmp.elm1;
-               const elm2 = cmp.elm2;
-               const elm3 = cmp.elm3;
-               assertHasParent(elm1);
-               assertHasParent(elm2);
-               assertHasParent(elm3);
-               engine.flush();
-               finishPlayers(engine.players);
+                fixture.detectChanges();
+                const elm1 = cmp.elm1;
+                const elm2 = cmp.elm2;
+                const elm3 = cmp.elm3;
+                assertHasParent(elm1);
+                assertHasParent(elm2);
+                assertHasParent(elm3);
+                engine.flush();
+                finishPlayers(engine.players);
 
-               cmp.exp1 = false;
-               fixture.detectChanges();
-               assertHasParent(elm1, false);
-               assertHasParent(elm2);
-               assertHasParent(elm3);
-               engine.flush();
-               expect(engine.players.length).toEqual(0);
+                cmp.exp1 = false;
+                fixture.detectChanges();
+                assertHasParent(elm1, false);
+                assertHasParent(elm2);
+                assertHasParent(elm3);
+                engine.flush();
+                expect(engine.players.length).toEqual(0);
 
-               cmp.exp2 = false;
-               fixture.detectChanges();
-               assertHasParent(elm1, false);
-               assertHasParent(elm2, false);
-               assertHasParent(elm3);
-               engine.flush();
-               expect(engine.players.length).toEqual(0);
+                cmp.exp2 = false;
+                fixture.detectChanges();
+                assertHasParent(elm1, false);
+                assertHasParent(elm2, false);
+                assertHasParent(elm3);
+                engine.flush();
+                expect(engine.players.length).toEqual(0);
 
-               cmp.exp3 = false;
-               fixture.detectChanges();
-               assertHasParent(elm1, false);
-               assertHasParent(elm2, false);
-               assertHasParent(elm3);
-               engine.flush();
-               expect(engine.players.length).toEqual(1);
-             });
+                cmp.exp3 = false;
+                fixture.detectChanges();
+                assertHasParent(elm1, false);
+                assertHasParent(elm2, false);
+                assertHasParent(elm3);
+                engine.flush();
+                expect(engine.players.length).toEqual(1);
+              });
     });
   });
 
@@ -284,8 +284,8 @@ import {el} from '../../testing/src/browser_util';
     });
 
     fixmeIvy(
-        `FW-643: Components with animations throw with "Failed to execute 'setAttribute' on 'Element'`) &&
-        it('should provide hooks at the start and end of change detection', () => {
+        `FW-643: Components with animations throw with "Failed to execute 'setAttribute' on 'Element'`)
+        .it('should provide hooks at the start and end of change detection', () => {
           @Component({
             selector: 'my-cmp',
             template: `

--- a/packages/platform-browser/animations/test/noop_animations_module_spec.ts
+++ b/packages/platform-browser/animations/test/noop_animations_module_spec.ts
@@ -20,8 +20,8 @@ import {fixmeIvy} from '@angular/private/testing';
 
     // TODO: remove the dummy test above ^ once the bug FW-643 has been fixed
     fixmeIvy(
-        `FW-643: Components with animations throw with "Failed to execute 'setAttribute' on 'Element'`) &&
-        it('should flush and fire callbacks when the zone becomes stable', (async) => {
+        `FW-643: Components with animations throw with "Failed to execute 'setAttribute' on 'Element'`)
+        .it('should flush and fire callbacks when the zone becomes stable', (async) => {
           @Component({
             selector: 'my-cmp',
             template:
@@ -56,50 +56,50 @@ import {fixmeIvy} from '@angular/private/testing';
         });
 
     fixmeIvy(
-        `FW-643: Components with animations throw with "Failed to execute 'setAttribute' on 'Element'`) &&
-        it('should handle leave animation callbacks even if the element is destroyed in the process',
-           (async) => {
-             @Component({
-               selector: 'my-cmp',
-               template:
-                   '<div *ngIf="exp" @myAnimation (@myAnimation.start)="onStart($event)" (@myAnimation.done)="onDone($event)"></div>',
-               animations: [trigger(
-                   'myAnimation',
-                   [transition(
-                       ':leave',
-                       [style({'opacity': '0'}), animate(500, style({'opacity': '1'}))])])],
-             })
-             class Cmp {
-               exp: any;
-               startEvent: any;
-               doneEvent: any;
-               onStart(event: any) { this.startEvent = event; }
-               onDone(event: any) { this.doneEvent = event; }
-             }
+        `FW-643: Components with animations throw with "Failed to execute 'setAttribute' on 'Element'`)
+        .it('should handle leave animation callbacks even if the element is destroyed in the process',
+            (async) => {
+              @Component({
+                selector: 'my-cmp',
+                template:
+                    '<div *ngIf="exp" @myAnimation (@myAnimation.start)="onStart($event)" (@myAnimation.done)="onDone($event)"></div>',
+                animations: [trigger(
+                    'myAnimation',
+                    [transition(
+                        ':leave',
+                        [style({'opacity': '0'}), animate(500, style({'opacity': '1'}))])])],
+              })
+              class Cmp {
+                exp: any;
+                startEvent: any;
+                doneEvent: any;
+                onStart(event: any) { this.startEvent = event; }
+                onDone(event: any) { this.doneEvent = event; }
+              }
 
-             TestBed.configureTestingModule({declarations: [Cmp]});
-             const engine = TestBed.get(ɵAnimationEngine);
-             const fixture = TestBed.createComponent(Cmp);
-             const cmp = fixture.componentInstance;
+              TestBed.configureTestingModule({declarations: [Cmp]});
+              const engine = TestBed.get(ɵAnimationEngine);
+              const fixture = TestBed.createComponent(Cmp);
+              const cmp = fixture.componentInstance;
 
-             cmp.exp = true;
-             fixture.detectChanges();
-             fixture.whenStable().then(() => {
-               cmp.startEvent = null;
-               cmp.doneEvent = null;
+              cmp.exp = true;
+              fixture.detectChanges();
+              fixture.whenStable().then(() => {
+                cmp.startEvent = null;
+                cmp.doneEvent = null;
 
-               cmp.exp = false;
-               fixture.detectChanges();
-               fixture.whenStable().then(() => {
-                 expect(cmp.startEvent.triggerName).toEqual('myAnimation');
-                 expect(cmp.startEvent.phaseName).toEqual('start');
-                 expect(cmp.startEvent.toState).toEqual('void');
-                 expect(cmp.doneEvent.triggerName).toEqual('myAnimation');
-                 expect(cmp.doneEvent.phaseName).toEqual('done');
-                 expect(cmp.doneEvent.toState).toEqual('void');
-                 async();
-               });
-             });
-           });
+                cmp.exp = false;
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                  expect(cmp.startEvent.triggerName).toEqual('myAnimation');
+                  expect(cmp.startEvent.phaseName).toEqual('start');
+                  expect(cmp.startEvent.toState).toEqual('void');
+                  expect(cmp.doneEvent.triggerName).toEqual('myAnimation');
+                  expect(cmp.doneEvent.phaseName).toEqual('done');
+                  expect(cmp.doneEvent.toState).toEqual('void');
+                  async();
+                });
+              });
+            });
   });
 }


### PR DESCRIPTION
Some "platform-browser" tests were updated before `fixmeIvy` function contract was changed to `fixmeIvy(...).it(...)`, thus triggering failed tests to run on CI. This commit updates these cases to invoke `fixmeIvy` correctly.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No