### PR TITLE
test(ivy): fix query compliance spec

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_compiler_compliance_spec.ts
@@ -1182,7 +1182,7 @@ describe('compiler compliance', () => {
           app: {
             ...directive,
             'view_query.component.ts': `
-            import {Component, NgModule, ViewChild} from '@angular/core';
+            import {Component, NgModule, ViewChild, ViewChildren} from '@angular/core';
             import {SomeDirective} from './some.directive';
 
             @Component({
@@ -1212,17 +1212,19 @@ describe('compiler compliance', () => {
             viewQuery: function ViewQueryComponent_Query(rf, ctx) {
               if (rf & 1) {
                 $r3$.ɵquery(0, SomeDirective, true);
+                $r3$.ɵquery(1, SomeDirective, true);
               }
               if (rf & 2) {
                 var $tmp$;
                 ($r3$.ɵqueryRefresh(($tmp$ = $r3$.ɵload(0))) && (ctx.someDir = $tmp$.first));
+                ($r3$.ɵqueryRefresh(($tmp$ = $r3$.ɵload(1))) && (ctx.someDirs = $tmp$));
               }
             },
-            consts: 2,
+            consts: 3,
             vars: 0,
             template:  function ViewQueryComponent_Template(rf, ctx) {
               if (rf & 1) {
-                $r3$.ɵelement(1, "div", $e0_attrs$);
+                $r3$.ɵelement(2, "div", $e0_attrs$);
               }
             },
             directives: function () { return [SomeDirective]; },


### PR DESCRIPTION
This PR fixes the query compliance spec. It was broken because the `ViewChildren` import was missing, so the test never actually ran properly.

Will look into causing missing imports to throw to avoid this in the future.