### PR TITLE
ci: update ngbot config to add merge linked labels

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -59,6 +59,10 @@ merge:
   # label to monitor
   mergeLabel: "PR action: merge"
 
+  # adding any of these labels will also add the merge label
+  mergeLinkedLabels:
+    - "PR action: merge-assistance"
+
   # list of checks that will determine if the merge label can be added
   checks:
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] CI related changes


## What is the new behavior?
Adding the `merge-assistance` label will also add the `merge` label automatically

Issue Number: #27494


## Does this PR introduce a breaking change?

- [x] No