### PR TITLE
fix(ivy): make ViewRef.detectChanges work with embedded views (FW-749)

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -2509,7 +2509,7 @@ export function checkNoChangesInRootView(lView: LView): void {
 }
 
 /** Checks the view of the component provided. Does not gate on dirty checks or execute doCheck. */
-function detectChangesInternal<T>(hostView: LView, component: T, rf: RenderFlags | null) {
+export function detectChangesInternal<T>(hostView: LView, component: T, rf: RenderFlags | null) {
   const hostTView = hostView[TVIEW];
   const oldView = enterView(hostView, hostView[HOST_NODE]);
   const templateFn = hostTView.template !;

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -11,7 +11,7 @@ import {ChangeDetectorRef as viewEngine_ChangeDetectorRef} from '../change_detec
 import {ViewContainerRef as viewEngine_ViewContainerRef} from '../linker/view_container_ref';
 import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, InternalViewRef as viewEngine_InternalViewRef} from '../linker/view_ref';
 
-import {checkNoChanges, checkNoChangesInRootView, detectChanges, detectChangesInRootView, markViewDirty, storeCleanupFn, viewAttached} from './instructions';
+import {checkNoChanges, checkNoChangesInRootView, detectChangesInRootView, detectChangesInternal, markViewDirty, storeCleanupFn, viewAttached} from './instructions';
 import {TNode, TNodeType, TViewNode} from './interfaces/node';
 import {FLAGS, HOST, HOST_NODE, LView, LViewFlags, PARENT, RENDERER_FACTORY} from './interfaces/view';
 import {destroyLView} from './node_manipulation';
@@ -244,7 +244,7 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
     if (rendererFactory.begin) {
       rendererFactory.begin();
     }
-    detectChanges(this.context);
+    detectChangesInternal(this._lView, this.context, null);
     if (rendererFactory.end) {
       rendererFactory.end();
     }

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {TemplateRef, ViewContainerRef} from '@angular/core';
+import {EmbeddedViewRef, TemplateRef, ViewContainerRef} from '@angular/core';
 import {withBody} from '@angular/private/testing';
 
 import {ChangeDetectionStrategy, ChangeDetectorRef, DoCheck, RendererType2} from '../../src/core';
@@ -97,7 +97,7 @@ describe('change detection', () => {
 
         constructor(public vcr: ViewContainerRef) {}
 
-        create() { this.vcr.createEmbeddedView(this.tmp); }
+        create() { return this.vcr.createEmbeddedView(this.tmp); }
 
         static ngComponentDef = defineComponent({
           type: StructuralComp,
@@ -145,8 +145,11 @@ describe('change detection', () => {
       fixture.update();
       expect(fixture.html).toEqual('<structural-comp>one</structural-comp>');
 
-      structuralComp.create();
+      const viewRef: EmbeddedViewRef<any> = structuralComp.create();
       fixture.update();
+      expect(fixture.html).toEqual('<structural-comp>one</structural-comp>Temp content');
+
+      viewRef.detectChanges();
       expect(fixture.html).toEqual('<structural-comp>one</structural-comp>Temp content');
 
       structuralComp.value = 'two';

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -150,8 +150,8 @@ describe('change detection', () => {
 
       // check root view update
       structuralComp.value = 'three';
-      detectChanges(structuralComp);
-      expect(fixture.html).toEqual('<structural-comp>three</structural-comp>two');
+      fixture.update();
+      expect(fixture.html).toEqual('<structural-comp>three</structural-comp>three');
     });
 
   });

--- a/packages/core/test/render3/change_detection_spec.ts
+++ b/packages/core/test/render3/change_detection_spec.ts
@@ -92,7 +92,6 @@ describe('change detection', () => {
       let structuralComp !: StructuralComp;
 
       function FooTemplate(rf: RenderFlags, ctx: any) {
-        debugger;
         if (rf & RenderFlags.Create) {
           text(0);
         }


### PR DESCRIPTION
In `ViewRef.detectChanges`, we are passing `ViewRef.context` into `detectChanges` to trigger change detection. This only makes sense for component `ViewRefs` (i.e. injected `ChangeDetectorRefs`) because with embedded views, `context` is not a component instance where the view has been monkey-patched. It's a just a normal object, so the view will be undefined.

In order to resolve this problem, we now invoke `detectChangesInternal` and also pass `LView` (to make sure we always have a view available).

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No