### PR TITLE
build: update source-map-support to get rid of Node's DeprecationWarning

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "selenium-webdriver": "3.5.0",
     "shelljs": "^0.8.1",
     "source-map": "^0.6.1",
-    "source-map-support": "0.4.18",
+    "source-map-support": "0.5.9",
     "tsickle": "0.32.1",
     "tslib": "^1.7.1",
     "typescript": "~3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7567,13 +7567,6 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@0.4.18, source-map-support@~0.4.0:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
-  integrity sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
-  dependencies:
-    source-map "^0.5.6"
-
 source-map-support@0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.3.tgz#693c8383d4389a4569486987c219744dfc601685"
@@ -7596,6 +7589,13 @@ source-map-support@^0.5.0:
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
+
+source-map-support@~0.4.0:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+  integrity sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
+  dependencies:
+    source-map "^0.5.6"
 
 source-map-url@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Removes the following when bazel runs any of our jasmine_node_tests:
```
(node:85494) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

I was able to find the source of the warning by running the target with the following tags:

```
bazel test packages/language-service/... --test_arg=--node_options=--throw-deprecation
```