### PR TITLE
fix(ivy): dedup render3 NodeInjector

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -287,10 +287,12 @@ export function injectAttributeImpl(tNode: TNode, attrNameToInject: string): str
  * Look for the injector providing the token by walking up the node injector tree and then
  * the module injector tree.
  *
- * @param nodeInjector Node injector where the search should start
+ * @param tNode The Node where the search for the injector should start
+ * @param lView The `LView` that contains the `tNode`
  * @param token The token to look for
  * @param flags Injection flags
- * @returns the value from the injector or `null` when not found
+ * @param notFoundValue The value to return when the injection flags is `InjectFlags.Optional`
+ * @returns the value from the injector, `null` when not found, or `notFoundValue` if provided
  */
 export function getOrCreateInjectable<T>(
     tNode: TElementNode | TContainerNode | TElementContainerNode, lView: LView,
@@ -558,22 +560,11 @@ export function injectInjector() {
 }
 
 export class NodeInjector implements Injector {
-  private _injectorIndex: number;
-
   constructor(
-      private _tNode: TElementNode|TContainerNode|TElementContainerNode, private _lView: LView) {
-    this._injectorIndex = getOrCreateNodeInjectorForNode(_tNode, _lView);
-  }
+      private _tNode: TElementNode|TContainerNode|TElementContainerNode, private _lView: LView) {}
 
-  get(token: any): any {
-    const previousTNode = getPreviousOrParentTNode();
-    const previousLView = getLView();
-    setTNodeAndViewData(this._tNode, this._lView);
-    try {
-      return getOrCreateInjectable(this._tNode, this._lView, token);
-    } finally {
-      setTNodeAndViewData(previousTNode, previousLView);
-    }
+  get(token: any, notFoundValue?: any): any {
+    return getOrCreateInjectable(this._tNode, this._lView, token, undefined, notFoundValue);
   }
 }
 

--- a/packages/core/src/render3/discovery_utils.ts
+++ b/packages/core/src/render3/discovery_utils.ts
@@ -5,17 +5,16 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Injector} from '../di/injector';
 
+import {Injector} from '../di/injector';
 import {assertDefined} from './assert';
 import {discoverLocalRefs, getComponentAtNodeIndex, getDirectivesAtNodeIndex, getLContext} from './context_discovery';
+import {NodeInjector} from './di';
 import {LContext} from './interfaces/context';
 import {DirectiveDef} from './interfaces/definition';
-import {INJECTOR_BLOOM_PARENT_SIZE} from './interfaces/injector';
 import {TElementNode, TNode, TNodeProviderIndexes} from './interfaces/node';
 import {CLEANUP, CONTEXT, FLAGS, HOST, LView, LViewFlags, PARENT, RootContext, TVIEW} from './interfaces/view';
 import {readPatchedLView, stringify} from './util';
-import {NodeInjector} from './view_engine_compatibility';
 
 
 /**

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -8,7 +8,6 @@
 
 import {ChangeDetectorRef as ViewEngine_ChangeDetectorRef} from '../change_detection/change_detector_ref';
 import {Injector, NullInjector} from '../di/injector';
-import {InjectFlags} from '../di/injector_compatibility';
 import {ComponentFactory as viewEngine_ComponentFactory, ComponentRef as viewEngine_ComponentRef} from '../linker/component_factory';
 import {ElementRef as ViewEngine_ElementRef} from '../linker/element_ref';
 import {NgModuleRef as viewEngine_NgModuleRef} from '../linker/ng_module_factory';
@@ -16,22 +15,20 @@ import {TemplateRef as ViewEngine_TemplateRef} from '../linker/template_ref';
 import {ViewContainerRef as ViewEngine_ViewContainerRef} from '../linker/view_container_ref';
 import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, ViewRef as viewEngine_ViewRef} from '../linker/view_ref';
 import {Renderer2} from '../render/api';
-
 import {assertDefined, assertGreaterThan, assertLessThan} from './assert';
-import {getOrCreateInjectable, getParentInjectorLocation} from './di';
+import {NodeInjector, getParentInjectorLocation} from './di';
 import {addToViewTree, createEmbeddedViewAndNode, createLContainer, renderEmbeddedTemplate} from './instructions';
 import {ACTIVE_INDEX, LContainer, NATIVE, VIEWS} from './interfaces/container';
 import {RenderFlags} from './interfaces/definition';
-import {TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeFlags, TNodeType, TViewNode} from './interfaces/node';
+import {TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeType, TViewNode} from './interfaces/node';
 import {LQueries} from './interfaces/query';
 import {RComment, RElement, Renderer3, isProceduralRenderer} from './interfaces/renderer';
 import {CONTAINER_INDEX, CONTEXT, HOST_NODE, LView, QUERIES, RENDERER, TView} from './interfaces/view';
-import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
+import {assertNodeOfPossibleTypes} from './node_assert';
 import {addRemoveViewFromContainer, appendChild, detachView, findComponentView, getBeforeNodeForView, insertView, nativeInsertBefore, nativeNextSibling, nativeParentNode, removeView} from './node_manipulation';
 import {getLView, getPreviousOrParentTNode} from './state';
 import {getComponentViewByIndex, getNativeByTNode, getParentInjectorTNode, getParentInjectorView, hasParentInjector, isComponent, isLContainer, isRootView} from './util';
 import {ViewRef} from './view_ref';
-
 
 
 /**
@@ -152,17 +149,6 @@ export function injectViewContainerRef(
   const previousTNode =
       getPreviousOrParentTNode() as TElementNode | TElementContainerNode | TContainerNode;
   return createContainerRef(ViewContainerRefToken, ElementRefToken, previousTNode, getLView());
-}
-
-export class NodeInjector implements Injector {
-  constructor(
-      private _tNode: TElementNode|TContainerNode|TElementContainerNode, private _hostView: LView) {
-  }
-
-  get(token: any, notFoundValue?: any): any {
-    return getOrCreateInjectable(
-        this._tNode, this._hostView, token, InjectFlags.Default, notFoundValue);
-  }
 }
 
 /**

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -141,7 +141,7 @@
     "name": "NgOnChangesFeature"
   },
   {
-    "name": "NodeInjector$1"
+    "name": "NodeInjector"
   },
   {
     "name": "NodeInjectorFactory"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Refactoring (no functional changes, no api changes)


## What is the current behavior?
We have two NodeInjector classes right now, one in `view_compatibility` and one in `di`.


## What is the new behavior?
We replaced the `NodeInjector` class in `di` with the one from `view_compatibility` and reconciled their differences.

## Does this PR introduce a breaking change?

- [x] No