### PR TITLE
Add repository.directory field to package.jsons

### DIFF
--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/animations"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -47,7 +47,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/bazel"
   },
   "builders": "./src/builders/builders.json",
   "schematics": "./src/schematics/collection.json",

--- a/packages/benchpress/package.json
+++ b/packages/benchpress/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/benchpress"
   },
   "keywords": [
     "angular",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/common"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -33,7 +33,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/compiler-cli"
   },
   "keywords": [
     "angular",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -17,7 +17,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/compiler"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/core"
   },
   "ng-update": {
     "migrations": "./schematics/migrations.json",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/elements"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -21,7 +21,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/forms"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "repository": "packages/http"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/language-service"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"

--- a/packages/platform-browser-dynamic/package.json
+++ b/packages/platform-browser-dynamic/package.json
@@ -21,7 +21,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/platform-browser-dynamic"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -19,7 +19,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/platform-browser"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -27,7 +27,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/platform-server"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"

--- a/packages/platform-webworker-dynamic/package.json
+++ b/packages/platform-webworker-dynamic/package.json
@@ -22,7 +22,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/platform-webworker-dynamic"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"

--- a/packages/platform-webworker/package.json
+++ b/packages/platform-webworker/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/platform-webworker"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -16,7 +16,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/angular/angular.git"
+    "url": "git+https://github.com/angular/angular.git",
+    "directory": "packages/router"
   },
   "author": "angular",
   "license": "MIT",

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -19,7 +19,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/service-worker"
   },
   "bin": {
     "ngsw-config": "./ngsw-config.js"

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -21,7 +21,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/angular/angular.git"
+    "url": "https://github.com/angular/angular.git",
+    "directory": "packages/upgrade"
   },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe:

This adds a `directory` field to the `repository` objects in package.json. This is a new field for monorepos specced in this npm RFC: https://github.com/npm/rfcs/blob/d39184cdedc000aa8e60b4d63878b834aa5f0ff0/accepted/0000-monorepo-subdirectory-declaration.md

It enables cross-repository go-to-definition on [Sourcegraph](https://sourcegraph.com) for angular, as Sourcegraph can resolve packages to a specific directory in the angular monorepo.
Clients that don't know this field will ignore it (as with any other arbitrary field in package.json).

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
