### PR TITLE
docs: remove AngularDart from the version picker

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -741,7 +741,6 @@
     { "title": "v6", "url": "https://v6.angular.io" },
     { "title": "v5", "url": "https://v5.angular.io" },
     { "title": "v4", "url": "https://v4.angular.io" },
-    { "title": "v2", "url": "https://v2.angular.io" },
-    { "title": "AngularDart", "url": "https://webdev.dartlang.org/angular" }
+    { "title": "v2", "url": "https://v2.angular.io" }
   ]
 }


### PR DESCRIPTION
At this point it's only confusing people.