### PR TITLE
docs: Replace old command line flags with new ones for CLI running

### DIFF
--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -126,7 +126,7 @@ jobs:
           key: my-project-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
             - "node_modules"
-      - run: npm run test -- --single-run --no-progress --browser=ChromeHeadlessCI
+      - run: npm run test -- --watch=false --no-progress --browsers=ChromeHeadlessCI
       - run: npm run e2e -- --no-progress --config=protractor-ci.conf.js
 ```
 
@@ -167,7 +167,7 @@ install:
   - npm install
 
 script:
-  - npm run test -- --single-run --no-progress --browser=ChromeHeadlessCI
+  - npm run test -- --watch=false --no-progress --browsers=ChromeHeadlessCI
   - npm run e2e -- --no-progress --config=protractor-ci.conf.js
 ```
 
@@ -218,7 +218,7 @@ exports.config = config;
 Now you can run the following commands to use the `--no-sandbox` flag:
 
 <code-example language="sh" class="code-shell">
-  ng test --single-run --no-progress --browser=ChromeHeadlessCI
+  ng test --watch=false --no-progress --browsers=ChromeHeadlessCI
   ng e2e --no-progress --config=protractor-ci.conf.js
 </code-example>
 


### PR DESCRIPTION
The --single-run and --browser (singular) flags don't exist with the 6+ versions of Angular CLI. This updates them to the --watch=false and --browsers flags.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The current documentation for running on CI servers is using old command line flags that do not exist.

Issue Number: N/A


## What is the new behavior?
Updated the documentation to use the new flags.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
