### PR TITLE
build(docs-infra): upgrade cli command docs sources to 02524ab82

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -18,7 +18,7 @@
     "build-for": "yarn ~~build --configuration",
     "prebuild-local": "yarn setup-local",
     "build-local": "yarn ~~build --configuration=stable",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js a176d127a",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 02524ab82",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/a176d127a...02524ab82):

**Modified**
- help/build.json
- help/serve.json
- help/test.json