### PR TITLE
fix(ivy): support complex type nodes in ModuleWithProviders

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
 import {Decorator, ReflectionHost} from '../../host';
-import {Reference, ResolvedReference, ResolvedValue, reflectObjectLiteral, staticallyResolve} from '../../metadata';
+import {Reference, ResolvedReference, ResolvedValue, reflectObjectLiteral, staticallyResolve, typeNodeToValueExpr} from '../../metadata';
 import {AnalysisOutput, CompileResult, DecoratorHandler} from '../../transform';
 
 import {generateSetClassMetadataCall} from './metadata';
@@ -223,12 +223,7 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
 
     const arg = type.typeArguments[0];
 
-    // If the argument isn't an Identifier, bail.
-    if (!ts.isTypeReferenceNode(arg) || !ts.isIdentifier(arg.typeName)) {
-      return null;
-    }
-
-    return arg.typeName;
+    return typeNodeToValueExpr(arg);
   }
 
   /**

--- a/packages/compiler-cli/src/ngtsc/metadata/index.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/index.ts
@@ -8,5 +8,5 @@
 
 /// <reference types="node" />
 
-export {TypeScriptReflectionHost, filterToMembersWithDecorator, findMember, reflectObjectLiteral, reflectTypeEntityToDeclaration} from './src/reflector';
+export {TypeScriptReflectionHost, filterToMembersWithDecorator, findMember, reflectObjectLiteral, reflectTypeEntityToDeclaration, typeNodeToValueExpr} from './src/reflector';
 export {AbsoluteReference, EnumValue, ImportMode, Reference, ResolvedReference, ResolvedValue, isDynamicValue, staticallyResolve} from './src/resolver';

--- a/packages/compiler-cli/src/ngtsc/metadata/src/reflector.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/reflector.ts
@@ -418,7 +418,7 @@ function parameterName(name: ts.BindingName): string|null {
   }
 }
 
-function typeNodeToValueExpr(node: ts.TypeNode): ts.Expression|null {
+export function typeNodeToValueExpr(node: ts.TypeNode): ts.Expression|null {
   if (ts.isTypeReferenceNode(node)) {
     return entityNameToValue(node.typeName);
   } else {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -387,10 +387,15 @@ describe('ngtsc behavioral tests', () => {
 
     env.write('node_modules/router/index.d.ts', `
         import {ModuleWithProviders} from '@angular/core';
+        import * as internal from './internal';
 
         declare class RouterModule {
-          static forRoot(): ModuleWithProviders<RouterModule>;
+          static forRoot(): ModuleWithProviders<internal.InternalRouterModule>;
         }
+    `);
+
+    env.write('node_modules/router/internal.d.ts', `
+        export declare class InternalRouterModule {}
     `);
 
     env.driveMain();
@@ -401,7 +406,8 @@ describe('ngtsc behavioral tests', () => {
     const dtsContents = env.getContents('test.d.ts');
     expect(dtsContents).toContain(`import * as i1 from 'router';`);
     expect(dtsContents)
-        .toContain('i0.ɵNgModuleDefWithMeta<TestModule, never, [typeof i1.RouterModule], never>');
+        .toContain(
+            'i0.ɵNgModuleDefWithMeta<TestModule, never, [typeof i1.InternalRouterModule], never>');
   });
 
   it('should inject special types according to the metadata', () => {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -375,9 +375,10 @@ describe('ngtsc behavioral tests', () => {
             'i0.ɵNgModuleDefWithMeta<TestModule, [typeof TestPipe, typeof TestCmp], never, never>');
   });
 
-  it('should unwrap a ModuleWithProviders function if a generic type is provided for it', () => {
-    env.tsconfig();
-    env.write(`test.ts`, `
+  describe('unwrapping ModuleWithProviders functions', () => {
+    it('should extract the generic type and include it in the module\'s declaration', () => {
+      env.tsconfig();
+      env.write(`test.ts`, `
         import {NgModule} from '@angular/core';
         import {RouterModule} from 'router';
 
@@ -385,7 +386,36 @@ describe('ngtsc behavioral tests', () => {
         export class TestModule {}
     `);
 
-    env.write('node_modules/router/index.d.ts', `
+      env.write('node_modules/router/index.d.ts', `
+        import {ModuleWithProviders} from '@angular/core';
+
+        declare class RouterModule {
+          static forRoot(): ModuleWithProviders<RouterModule>;
+        }
+    `);
+
+      env.driveMain();
+
+      const jsContents = env.getContents('test.js');
+      expect(jsContents).toContain('imports: [[RouterModule.forRoot()]]');
+
+      const dtsContents = env.getContents('test.d.ts');
+      expect(dtsContents).toContain(`import * as i1 from 'router';`);
+      expect(dtsContents)
+          .toContain('i0.ɵNgModuleDefWithMeta<TestModule, never, [typeof i1.RouterModule], never>');
+    });
+
+    it('should extract the generic type if it is provided as qualified type name', () => {
+      env.tsconfig();
+      env.write(`test.ts`, `
+        import {NgModule} from '@angular/core';
+        import {RouterModule} from 'router';
+
+        @NgModule({imports: [RouterModule.forRoot()]})
+        export class TestModule {}
+    `);
+
+      env.write('node_modules/router/index.d.ts', `
         import {ModuleWithProviders} from '@angular/core';
         import * as internal from './internal';
 
@@ -394,20 +424,21 @@ describe('ngtsc behavioral tests', () => {
         }
     `);
 
-    env.write('node_modules/router/internal.d.ts', `
+      env.write('node_modules/router/internal.d.ts', `
         export declare class InternalRouterModule {}
     `);
 
-    env.driveMain();
+      env.driveMain();
 
-    const jsContents = env.getContents('test.js');
-    expect(jsContents).toContain('imports: [[RouterModule.forRoot()]]');
+      const jsContents = env.getContents('test.js');
+      expect(jsContents).toContain('imports: [[RouterModule.forRoot()]]');
 
-    const dtsContents = env.getContents('test.d.ts');
-    expect(dtsContents).toContain(`import * as i1 from 'router';`);
-    expect(dtsContents)
-        .toContain(
-            'i0.ɵNgModuleDefWithMeta<TestModule, never, [typeof i1.InternalRouterModule], never>');
+      const dtsContents = env.getContents('test.d.ts');
+      expect(dtsContents).toContain(`import * as i1 from 'router';`);
+      expect(dtsContents)
+          .toContain(
+              'i0.ɵNgModuleDefWithMeta<TestModule, never, [typeof i1.InternalRouterModule], never>');
+    });
   });
 
   it('should inject special types according to the metadata', () => {


### PR DESCRIPTION
With ngcc's ability to fixup pre-Ivy `ModuleWithProviders` such that they
include a reference to the NgModule type, the type may become a qualified
name:

```
import {ModuleWithProviders} from '@angular/core';
import * as ngcc0 from './module';

export declare provide(): ModuleWithProviders<ngcc0.Module>;
```

ngtsc now takes this situation into account when reflecting a
`ModuleWithProvider`'s type argument.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:
