### PR TITLE
test: remove extranious fixme from packages/bazel/test/ngc-wrapped

### DIFF
--- a/packages/bazel/test/ngc-wrapped/index_test.ts
+++ b/packages/bazel/test/ngc-wrapped/index_test.ts
@@ -6,16 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {fixmeIvy} from '@angular/private/testing';
-import * as fs from 'fs';
 import * as path from 'path';
 
 import {setup} from './test_support';
 
 describe('ngc_wrapped', () => {
-
-  // fixmeIvy placeholder to prevent jasmine from erroring out because there are no specs
-  it('should be removed once the fixmeIvy below is resolved', () => {});
 
   it('should work', () => {
     const {read, write, runOneBuild, writeConfig, shouldExist, basePath} = setup();


### PR DESCRIPTION
we forgot to remove this when the last fixme was removed.
