### PR TITLE
build: ts-api-guardian tsconfig warning with bazel

### DIFF
--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -30,5 +30,8 @@
     "typings-test",
     "public_api_guard",
     "docs"
-  ]
+  ],
+  "bazelOptions": {
+    "suppressTsconfigOverrideWarnings": true
+  }
 }


### PR DESCRIPTION
* Suppresses the warning from the Bazel TypeScript rules about overwritten options from the `tools/tsconfig.json` file. This is the only remaining warning that makes our Bazel build on Angular Material "dirty"