### PR TITLE
fix(ivy): attempting to remove detached view on destroy

### DIFF
--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -61,7 +61,12 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
     if (this._appRef) {
       this._appRef.detachView(this);
     } else if (this._viewContainerRef && viewAttached(this._lView)) {
-      this._viewContainerRef.detach(this._viewContainerRef.indexOf(this));
+      const index = this._viewContainerRef.indexOf(this);
+
+      if (index > -1) {
+        this._viewContainerRef.detach(index);
+      }
+
       this._viewContainerRef = null;
     }
     destroyLView(this._lView);

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -60,7 +60,7 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
   destroy(): void {
     if (this._appRef) {
       this._appRef.detachView(this);
-    } else if (this._viewContainerRef && viewAttached(this._lView)) {
+    } else if (this._viewContainerRef) {
       const index = this._viewContainerRef.indexOf(this);
 
       if (index > -1) {

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -1107,7 +1107,6 @@ describe('ViewContainerRef', () => {
           fixture.update();
 
           fixture.component.vcr.detach(fixture.component.vcr.indexOf(ref.hostView));
-          ref.hostView.reattach();
 
           expect(() => { ref.destroy(); }).not.toThrow();
 

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -19,7 +19,6 @@ import {pipe, pipeBind1} from '../../src/render3/pipe';
 import {getLView} from '../../src/render3/state';
 import {getNativeByIndex} from '../../src/render3/util';
 import {NgForOf} from '../../test/render3/common_with_def';
-import {fixmeIvy} from '@angular/private/testing';
 
 import {getRendererFactory2} from './imported_renderer2';
 import {ComponentFixture, TemplateFixture, createComponent, getDirectiveOnNode} from './render_util';
@@ -1099,6 +1098,20 @@ describe('ViewContainerRef', () => {
              expect(dynamicComp.doCheckCount).toEqual(1);
              expect(changeDetector.context).toEqual(dynamicComp);
            });
+
+        it('should not throw when destroying a reattached component', () => {
+          const fixture = new ComponentFixture(AppComp);
+
+          const dynamicCompFactory = fixture.component.cfr.resolveComponentFactory(DynamicComp);
+          const ref = fixture.component.vcr.createComponent(dynamicCompFactory);
+          fixture.update();
+
+          fixture.component.vcr.detach(fixture.component.vcr.indexOf(ref.hostView));
+          ref.hostView.reattach();
+
+          expect(() => { ref.destroy(); }).not.toThrow();
+
+        });
       });
 
       class EmbeddedComponentWithNgContent {


### PR DESCRIPTION
Currently the `ViewRef.destroy` method assumes that its index inside the view container will always be valid, however if it has been removed already, it'll be -1 which will throw an error.

The error manifested itself in one of the unit tests where a view had been detached during the test and then `TestBed` attempted to destroy its `ComponentRef` which ended up throwing an `Error during cleanup of component`.