### PR TITLE
fix(ivy): proper slot allocation for pure functions in `hostBindings` function

### DIFF
--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -666,11 +666,11 @@ function createHostBindingsFunction(
     return convertPropertyBinding(
         null, implicit, value, 'b', BindingForm.TrySimple, () => error('Unexpected interpolation'));
   };
-
   if (bindings) {
     const hostVarsCountFn = (numSlots: number): number => {
+      const originalVarsCount = totalHostVarsCount;
       totalHostVarsCount += numSlots;
-      return hostVarsCount;
+      return originalVarsCount;
     };
     const valueConverter = new ValueConverter(
         constantPool,


### PR DESCRIPTION
Prior to this update, we always returned the number of host vars defined in @Component definition as a value for `allocatePureFunctionsSlot` callback in ValueConverter. As a result, pure function arguments were not accounted for, thus leasing to incorrect slot offsets in `pureFunction` calls. Now we update and return total # of host vars, so the offsets are defined correctly.

This PR resolves issue FW-817.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No