### PR TITLE
fix(bazel): fix TS errors in the `schematics/bazel-workspace` files

### DIFF
--- a/packages/bazel/src/schematics/bazel-workspace/index.ts
+++ b/packages/bazel/src/schematics/bazel-workspace/index.ts
@@ -48,7 +48,7 @@ function findVersion(projectName: string, packageName: string, host: Tree): stri
  */
 export function clean(version: string): string|null {
   const matches = version.match(/(\d+\.\d+\.\d+)/);
-  return matches ? matches.pop() : null;
+  return matches && matches.pop() || null;
 }
 
 export default function(options: BazelWorkspaceOptions): Rule {
@@ -72,12 +72,12 @@ export default function(options: BazelWorkspaceOptions): Rule {
       RxJs: findVersion(options.name, 'rxjs', host),
     };
 
-    for (const name of Object.keys(existingVersions)) {
-      const version = existingVersions[name];
+    Object.keys(existingVersions).forEach((name: 'Angular' | 'RxJs') => {
+      const version = existingVersions[name] as string;
       if (version) {
         context.logger.info(`Bazel will reuse existing version for ${name}: ${version}`);
       }
-    }
+    });
 
     const workspaceVersions = {
       'ANGULAR_VERSION': existingVersions.Angular || clean(latestVersions.Angular),

--- a/packages/bazel/src/schematics/bazel-workspace/index_spec.ts
+++ b/packages/bazel/src/schematics/bazel-workspace/index_spec.ts
@@ -64,7 +64,7 @@ describe('Bazel-workspace Schematic', () => {
 describe('clean', () => {
   [['1.2.3', '1.2.3'], ['  1.2.3', '1.2.3'], ['1.2.3  ', '1.2.3'], ['~1.2.3', '1.2.3'],
    ['^1.2.3', '1.2.3'], ['v1.2.3', '1.2.3'], ['1.2', null], ['a.b.c', null],
-  ].forEach(([version, want]) => {
+  ].forEach(([version, want]: [string, string]) => {
     it(`should match ${version} with ${want}`, () => {
       const got = clean(version);
       expect(got).toBe(want);


### PR DESCRIPTION
Upgrading to the new `ts_library` rule uncovered TS errors in these
files. This commit fixes the code to pass TS checking.
