### PR TITLE
build: bump @bazel/ibazel to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   "devDependencies": {
     "@bazel/bazel": "~0.20.0",
     "@bazel/buildifier": "^0.19.2",
-    "@bazel/ibazel": "~0.8.2",
+    "@bazel/ibazel": "~0.9.0",
     "@types/angular": "^1.6.47",
     "@types/base64-js": "1.2.5",
     "@types/jasminewd2": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,10 +82,10 @@
     "@bazel/buildifier-darwin_x64" "0.19.2"
     "@bazel/buildifier-linux_x64" "0.19.2"
 
-"@bazel/ibazel@~0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.8.2.tgz#a837d93922c0d273361ed4f141c792384c0e10bb"
-  integrity sha512-5lbqeoqv2sIRybV9s4CIRNBR68wdv22wfpNY1qmO3AsPrLx4zICPXyW8YOiLaLvYPzvezPznfhD7Is13jU/jsQ==
+"@bazel/ibazel@~0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.9.0.tgz#fd60023acd36313d304cc2f8c2e181b88b5445cd"
+  integrity sha512-E31cefDcdJsx/oii6p/gqKZXSVw0kEg1O73DD2McFcSvnf/p1GYWcQtVgdRQmlviBEytJkJgdX8rtThitRvcow==
 
 "@bazel/karma@~0.22.0":
   version "0.22.0"


### PR DESCRIPTION
This should fix the problem with ibazel crashing on bzl/BUILD file syntax errors. bazelbuild/bazel-watcher/issues/194

https://github.com/bazelbuild/bazel-watcher/blob/master/CHANGELOG.md#v090-2018-12-07
