### PR TITLE
fix(ivy): check semantics of NgModule for consistency

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -128,6 +128,7 @@ export {
   compileNgModule as ɵcompileNgModule,
   compileNgModuleDefs as ɵcompileNgModuleDefs,
   patchComponentDefWithScope as ɵpatchComponentDefWithScope,
+  resetCompiledComponents as ɵresetCompiledComponents,
 } from './render3/jit/module';
 export {
   compilePipe as ɵcompilePipe,
@@ -214,6 +215,8 @@ export {
 export {
   SWITCH_RENDERER2_FACTORY__POST_R3__ as ɵSWITCH_RENDERER2_FACTORY__POST_R3__,
 } from './render/api';
+
+export {getModuleFactory__POST_R3__ as ɵgetModuleFactory__POST_R3__} from './linker/ng_module_factory_loader';
 
 export {
   publishGlobalUtil as ɵpublishGlobalUtil,

--- a/packages/core/src/di/defs.ts
+++ b/packages/core/src/di/defs.ts
@@ -168,7 +168,7 @@ export function defineInjector(options: {factory: () => any, providers?: any[], 
  * @param type type which may have `ngInjectableDef`
  */
 export function getInjectableDef<T>(type: any): InjectableDef<T>|null {
-  return type.hasOwnProperty(NG_INJECTABLE_DEF) ? (type as any)[NG_INJECTABLE_DEF] : null;
+  return type && type.hasOwnProperty(NG_INJECTABLE_DEF) ? (type as any)[NG_INJECTABLE_DEF] : null;
 }
 
 /**
@@ -177,5 +177,5 @@ export function getInjectableDef<T>(type: any): InjectableDef<T>|null {
  * @param type type which may have `ngInjectorDef`
  */
 export function getInjectorDef<T>(type: any): InjectorDef<T>|null {
-  return type.hasOwnProperty(NG_INJECTOR_DEF) ? (type as any)[NG_INJECTOR_DEF] : null;
+  return type && type.hasOwnProperty(NG_INJECTOR_DEF) ? (type as any)[NG_INJECTOR_DEF] : null;
 }

--- a/packages/core/src/linker/ng_module_factory_loader.ts
+++ b/packages/core/src/linker/ng_module_factory_loader.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {NgModuleFactory as R3NgModuleFactory, NgModuleType} from '../render3/ng_module_ref';
+import {Type} from '../type';
+import {stringify} from '../util';
 import {NgModuleFactory} from './ng_module_factory';
 
 /**
@@ -17,23 +20,50 @@ export abstract class NgModuleFactoryLoader {
   abstract load(path: string): Promise<NgModuleFactory<any>>;
 }
 
-let moduleFactories = new Map<string, NgModuleFactory<any>>();
+/**
+ * Map of module-id to the corresponding NgModule.
+ * - In pre Ivy we track NgModuleFactory,
+ * - In post Ivy we track the NgModuleType
+ */
+const modules = new Map<string, NgModuleFactory<any>|NgModuleType>();
 
 /**
  * Registers a loaded module. Should only be called from generated NgModuleFactory code.
  * @publicApi
  */
 export function registerModuleFactory(id: string, factory: NgModuleFactory<any>) {
-  const existing = moduleFactories.get(id);
-  if (existing) {
-    throw new Error(`Duplicate module registered for ${id
-                    } - ${existing.moduleType.name} vs ${factory.moduleType.name}`);
-  }
-  moduleFactories.set(id, factory);
+  const existing = modules.get(id) as NgModuleFactory<any>;
+  assertNotExisting(id, existing && existing.moduleType);
+  modules.set(id, factory);
 }
 
-export function clearModulesForTest() {
-  moduleFactories = new Map<string, NgModuleFactory<any>>();
+function assertNotExisting(id: string, type: Type<any>| null): void {
+  if (type) {
+    throw new Error(
+        `Duplicate module registered for ${id} - ${stringify(type)} vs ${stringify(type.name)}`);
+  }
+}
+
+export function registerNgModuleType(id: string, ngModuleType: NgModuleType) {
+  const existing = modules.get(id) as NgModuleType | null;
+  assertNotExisting(id, existing);
+  modules.set(id, ngModuleType);
+}
+
+export function clearModulesForTest(): void {
+  modules.clear();
+}
+
+export function getModuleFactory__PRE_R3__(id: string): NgModuleFactory<any> {
+  const factory = modules.get(id) as NgModuleFactory<any>| null;
+  if (!factory) throw noModuleError(id);
+  return factory;
+}
+
+export function getModuleFactory__POST_R3__(id: string): NgModuleFactory<any> {
+  const type = modules.get(id) as NgModuleType | null;
+  if (!type) throw noModuleError(id);
+  return new R3NgModuleFactory(type);
 }
 
 /**
@@ -42,8 +72,8 @@ export function clearModulesForTest() {
  * cannot be found.
  * @publicApi
  */
-export function getModuleFactory(id: string): NgModuleFactory<any> {
-  const factory = moduleFactories.get(id);
-  if (!factory) throw new Error(`No module with ID ${id} loaded`);
-  return factory;
+export const getModuleFactory: (id: string) => NgModuleFactory<any> = getModuleFactory__PRE_R3__;
+
+function noModuleError(id: string, ): Error {
+  return new Error(`No module with ID ${id} loaded`);
 }

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -10,6 +10,7 @@ import {ApplicationRef} from '../application_ref';
 import {InjectorType, defineInjector} from '../di/defs';
 import {Provider} from '../di/provider';
 import {convertInjectableProviderToFactory} from '../di/util';
+import {NgModuleType} from '../render3';
 import {compileNgModule as render3CompileNgModule} from '../render3/jit/module';
 import {Type} from '../type';
 import {TypeDecorator, makeDecorator} from '../util/decorators';
@@ -337,7 +338,7 @@ export const NgModule: NgModuleDecorator = makeDecorator(
      * * The `imports` and `exports` options bring in members from other modules, and make
      * this module's members available to others.
      */
-    (type: Type<any>, meta: NgModule) => SWITCH_COMPILE_NGMODULE(type, meta));
+    (type: NgModuleType, meta: NgModule) => SWITCH_COMPILE_NGMODULE(type, meta));
 
 /**
  * @description

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -13,7 +13,7 @@ import {Provider} from '../di/provider';
 import {NgModuleDef} from '../metadata/ng_module';
 import {ViewEncapsulation} from '../metadata/view';
 import {Mutable, Type} from '../type';
-import {noSideEffects} from '../util';
+import {noSideEffects, stringify} from '../util';
 
 import {NG_COMPONENT_DEF, NG_DIRECTIVE_DEF, NG_MODULE_DEF, NG_PIPE_DEF} from './fields';
 import {BaseDef, ComponentDef, ComponentDefFeature, ComponentQuery, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefFeature, DirectiveType, DirectiveTypesOrFactory, HostBindingsFunction, PipeDef, PipeType, PipeTypesOrFactory} from './interfaces/definition';
@@ -651,6 +651,12 @@ export function getPipeDef<T>(type: any): PipeDef<T>|null {
   return (type as any)[NG_PIPE_DEF] || null;
 }
 
-export function getNgModuleDef<T>(type: any): NgModuleDef<T>|null {
-  return (type as any)[NG_MODULE_DEF] || null;
+export function getNgModuleDef<T>(type: any, throwNotFound: true): NgModuleDef<T>;
+export function getNgModuleDef<T>(type: any): NgModuleDef<T>|null;
+export function getNgModuleDef<T>(type: any, throwNotFound?: boolean): NgModuleDef<T>|null {
+  const ngModuleDef = (type as any)[NG_MODULE_DEF] || null;
+  if (!ngModuleDef && throwNotFound === true) {
+    throw new Error(`Type ${stringify(type)} does not have 'ngModuleDef' property.`);
+  }
+  return ngModuleDef;
 }

--- a/packages/core/src/render3/jit/compiler_facade_interface.ts
+++ b/packages/core/src/render3/jit/compiler_facade_interface.ts
@@ -101,8 +101,8 @@ export interface R3InjectorMetadataFacade {
   name: string;
   type: any;
   deps: R3DependencyMetadataFacade[]|null;
-  providers: any;
-  imports: any;
+  providers: any[];
+  imports: any[];
 }
 
 export interface R3DirectiveMetadataFacade {

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -7,12 +7,16 @@
  */
 
 import {resolveForwardRef} from '../../di/forward_ref';
+import {registerNgModuleType} from '../../linker/ng_module_factory_loader';
+import {Component} from '../../metadata';
 import {ModuleWithProviders, NgModule, NgModuleDef, NgModuleTransitiveScopes} from '../../metadata/ng_module';
 import {Type} from '../../type';
 import {assertDefined} from '../assert';
 import {getComponentDef, getDirectiveDef, getNgModuleDef, getPipeDef} from '../definition';
 import {NG_COMPONENT_DEF, NG_DIRECTIVE_DEF, NG_INJECTOR_DEF, NG_MODULE_DEF, NG_PIPE_DEF} from '../fields';
 import {ComponentDef} from '../interfaces/definition';
+import {NgModuleType} from '../ng_module_ref';
+import {stringify} from '../util';
 
 import {R3InjectorMetadataFacade, getCompilerFacade} from './compiler_facade';
 import {angularCoreEnv} from './environment';
@@ -75,7 +79,7 @@ function isResolvedDeclaration(declaration: any[] | Type<any>): boolean {
  * This function automatically gets called when a class has a `@NgModule` decorator.
  */
 export function compileNgModule(moduleType: Type<any>, ngModule: NgModule = {}): void {
-  compileNgModuleDefs(moduleType, ngModule);
+  compileNgModuleDefs(moduleType as NgModuleType, ngModule);
 
   // Because we don't know if all declarations have resolved yet at the moment the
   // NgModule decorator is executing, we're enqueueing the setting of module scope
@@ -87,7 +91,7 @@ export function compileNgModule(moduleType: Type<any>, ngModule: NgModule = {}):
 /**
  * Compiles and adds the `ngModuleDef` and `ngInjectorDef` properties to the module class.
  */
-export function compileNgModuleDefs(moduleType: Type<any>, ngModule: NgModule): void {
+export function compileNgModuleDefs(moduleType: NgModuleType, ngModule: NgModule): void {
   ngDevMode && assertDefined(moduleType, 'Required value moduleType');
   ngDevMode && assertDefined(ngModule, 'Required value ngModule');
   const declarations: Type<any>[] = flatten(ngModule.declarations || EMPTY_ARRAY);
@@ -110,11 +114,15 @@ export function compileNgModuleDefs(moduleType: Type<any>, ngModule: NgModule): 
       return ngModuleDef;
     }
   });
+  if (ngModule.id) {
+    registerNgModuleType(ngModule.id, moduleType);
+  }
 
   let ngInjectorDef: any = null;
   Object.defineProperty(moduleType, NG_INJECTOR_DEF, {
     get: () => {
       if (ngInjectorDef === null) {
+        ngDevMode && verifySemanticsOfNgModuleDef(moduleType as unknown as NgModuleType);
         const meta: R3InjectorMetadataFacade = {
           name: moduleType.name,
           type: moduleType,
@@ -133,6 +141,163 @@ export function compileNgModuleDefs(moduleType: Type<any>, ngModule: NgModule): 
     // Make the property configurable in dev mode to allow overriding in tests
     configurable: !!ngDevMode,
   });
+}
+
+function verifySemanticsOfNgModuleDef(moduleType: NgModuleType): void {
+  if (verifiedNgModule.get(moduleType)) return;
+  verifiedNgModule.set(moduleType, true);
+  moduleType = resolveForwardRef(moduleType);
+  const ngModuleDef = getNgModuleDef(moduleType, true);
+  const errors: string[] = [];
+  ngModuleDef.declarations.forEach(verifyDeclarationsHaveDefinitions);
+  const combinedDeclarations: Type<any>[] = [
+    ...ngModuleDef.declarations,  //
+    ...flatten(ngModuleDef.imports.map(computeCombinedExports)),
+  ];
+  ngModuleDef.exports.forEach(verifyExportsAreDeclaredOrReExported);
+  ngModuleDef.declarations.forEach(verifyDeclarationIsUnique);
+  ngModuleDef.declarations.forEach(verifyComponentEntryComponentsIsPartOfNgModule);
+
+  const ngModule = getAnnotation<NgModule>(moduleType, 'NgModule');
+  if (ngModule) {
+    ngModule.imports &&
+        flatten(ngModule.imports, unwrapModuleWithProvidersImports)
+            .forEach(verifySemanticsOfNgModuleDef);
+    ngModule.bootstrap && ngModule.bootstrap.forEach(verifyComponentIsPartOfNgModule);
+    ngModule.entryComponents && ngModule.entryComponents.forEach(verifyComponentIsPartOfNgModule);
+  }
+
+  // Throw Error if any errors were detected.
+  if (errors.length) {
+    throw new Error(errors.join('\n'));
+  }
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  function verifyDeclarationsHaveDefinitions(type: Type<any>): void {
+    type = resolveForwardRef(type);
+    const def = getComponentDef(type) || getDirectiveDef(type) || getPipeDef(type);
+    if (!def) {
+      errors.push(
+          `Unexpected value '${stringify(type)}' declared by the module '${stringify(moduleType)}'. Please add a @Pipe/@Directive/@Component annotation.`);
+    }
+  }
+
+  function verifyExportsAreDeclaredOrReExported(type: Type<any>) {
+    type = resolveForwardRef(type);
+    const kind = getComponentDef(type) && 'component' || getDirectiveDef(type) && 'directive' ||
+        getPipeDef(type) && 'pipe';
+    if (kind) {
+      // only checked if we are declared as Component, Directive, or Pipe
+      // Modules don't need to be declared or imported.
+      if (combinedDeclarations.lastIndexOf(type) === -1) {
+        // We are exporting something which we don't explicitly declare or import.
+        errors.push(
+            `Can't export ${kind} ${stringify(type)} from ${stringify(moduleType)} as it was neither declared nor imported!`);
+      }
+    }
+  }
+
+  function verifyDeclarationIsUnique(type: Type<any>) {
+    type = resolveForwardRef(type);
+    const existingModule = ownerNgModule.get(type);
+    if (existingModule && existingModule !== moduleType) {
+      const modules = [existingModule, moduleType].map(stringify).sort();
+      errors.push(
+          `Type ${stringify(type)} is part of the declarations of 2 modules: ${modules[0]} and ${modules[1]}! ` +
+          `Please consider moving ${stringify(type)} to a higher module that imports ${modules[0]} and ${modules[1]}. ` +
+          `You can also create a new NgModule that exports and includes ${stringify(type)} then import that NgModule in ${modules[0]} and ${modules[1]}.`);
+    } else {
+      // Mark type as having owner.
+      ownerNgModule.set(type, moduleType);
+    }
+  }
+
+  function verifyComponentIsPartOfNgModule(type: Type<any>) {
+    type = resolveForwardRef(type);
+    const existingModule = ownerNgModule.get(type);
+    if (!existingModule) {
+      errors.push(
+          `Component ${stringify(type)} is not part of any NgModule or the module has not been imported into your module.`);
+    }
+  }
+
+  function verifyComponentEntryComponentsIsPartOfNgModule(type: Type<any>) {
+    type = resolveForwardRef(type);
+    if (getComponentDef(type)) {
+      // We know we are component
+      const component = getAnnotation<Component>(type, 'Component');
+      if (component && component.entryComponents) {
+        component.entryComponents.forEach(verifyComponentIsPartOfNgModule);
+      }
+    }
+  }
+}
+
+function unwrapModuleWithProvidersImports(
+    typeOrWithProviders: NgModuleType<any>| {ngModule: NgModuleType<any>}): NgModuleType<any> {
+  typeOrWithProviders = resolveForwardRef(typeOrWithProviders);
+  return (typeOrWithProviders as any).ngModule || typeOrWithProviders;
+}
+
+function getAnnotation<T>(type: any, name: string): T|null {
+  let annotation: T|null = null;
+  collect(type.__annotations__);
+  collect(type.decorators);
+  return annotation;
+
+  function collect(annotations: any[] | null) {
+    if (annotations) {
+      annotations.forEach(readAnnotation);
+    }
+  }
+
+  function readAnnotation(
+      decorator: {type: {prototype: {ngMetadataName: string}, args: any[]}, args: any}): void {
+    if (!annotation) {
+      const proto = Object.getPrototypeOf(decorator);
+      if (proto.ngMetadataName == name) {
+        annotation = decorator as any;
+      } else if (decorator.type) {
+        const proto = Object.getPrototypeOf(decorator.type);
+        if (proto.ngMetadataName == name) {
+          annotation = decorator.args[0];
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Keep track of compiled components. This is needed because in tests we often want to compile the
+ * same component with more than one NgModule. This would cause an error unless we reset which
+ * NgModule the component belongs to. We keep the list of compiled components here so that the
+ * TestBed can reset it later.
+ */
+let ownerNgModule = new Map<Type<any>, NgModuleType<any>>();
+let verifiedNgModule = new Map<NgModuleType<any>, boolean>();
+
+export function resetCompiledComponents(): void {
+  ownerNgModule = new Map<Type<any>, NgModuleType<any>>();
+  verifiedNgModule = new Map<NgModuleType<any>, boolean>();
+}
+
+/**
+ * Computes the combined declarations of explicit declarations, as well as declarations inherited
+ * by
+ * traversing the exports of imported modules.
+ * @param type
+ */
+function computeCombinedExports(type: Type<any>): Type<any>[] {
+  type = resolveForwardRef(type);
+  const ngModuleDef = getNgModuleDef(type, true);
+  return [...flatten(ngModuleDef.exports.map((type) => {
+    const ngModuleDef = getNgModuleDef(type);
+    if (ngModuleDef) {
+      verifySemanticsOfNgModuleDef(type as unknown as NgModuleType);
+      return computeCombinedExports(type);
+    } else {
+      return type;
+    }
+  }))];
 }
 
 /**
@@ -264,13 +429,13 @@ export function transitiveScopesFor<T>(moduleType: Type<T>): NgModuleTransitiveS
   return scopes;
 }
 
-function flatten<T>(values: any[]): T[] {
-  const out: T[] = [];
+function flatten<T>(values: any[], mapFn?: (value: T) => any): Type<T>[] {
+  const out: Type<T>[] = [];
   values.forEach(value => {
     if (Array.isArray(value)) {
-      out.push(...flatten<T>(value));
+      out.push(...flatten<T>(value, mapFn));
     } else {
-      out.push(value);
+      out.push(mapFn ? mapFn(value) : value);
     }
   });
   return out;

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -48,16 +48,19 @@ let flushingModuleQueue = false;
 export function flushModuleScopingQueueAsMuchAsPossible() {
   if (!flushingModuleQueue) {
     flushingModuleQueue = true;
-    for (let i = moduleQueue.length - 1; i >= 0; i--) {
-      const {moduleType, ngModule} = moduleQueue[i];
+    try {
+      for (let i = moduleQueue.length - 1; i >= 0; i--) {
+        const {moduleType, ngModule} = moduleQueue[i];
 
-      if (ngModule.declarations && ngModule.declarations.every(isResolvedDeclaration)) {
-        // dequeue
-        moduleQueue.splice(i, 1);
-        setScopeOnDeclaredComponents(moduleType, ngModule);
+        if (ngModule.declarations && ngModule.declarations.every(isResolvedDeclaration)) {
+          // dequeue
+          moduleQueue.splice(i, 1);
+          setScopeOnDeclaredComponents(moduleType, ngModule);
+        }
       }
+    } finally {
+      flushingModuleQueue = false;
     }
-    flushingModuleQueue = false;
   }
 }
 
@@ -278,6 +281,7 @@ let verifiedNgModule = new Map<NgModuleType<any>, boolean>();
 export function resetCompiledComponents(): void {
   ownerNgModule = new Map<Type<any>, NgModuleType<any>>();
   verifiedNgModule = new Map<NgModuleType<any>, boolean>();
+  moduleQueue.length = 0;
 }
 
 /**

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -125,7 +125,7 @@ export function compileNgModuleDefs(moduleType: NgModuleType, ngModule: NgModule
   Object.defineProperty(moduleType, NG_INJECTOR_DEF, {
     get: () => {
       if (ngInjectorDef === null) {
-        ngDevMode && verifySemanticsOfNgModuleDef(moduleType as unknown as NgModuleType);
+        ngDevMode && verifySemanticsOfNgModuleDef(moduleType as any as NgModuleType);
         const meta: R3InjectorMetadataFacade = {
           name: moduleType.name,
           type: moduleType,
@@ -296,7 +296,7 @@ function computeCombinedExports(type: Type<any>): Type<any>[] {
   return [...flatten(ngModuleDef.exports.map((type) => {
     const ngModuleDef = getNgModuleDef(type);
     if (ngModuleDef) {
-      verifySemanticsOfNgModuleDef(type as unknown as NgModuleType);
+      verifySemanticsOfNgModuleDef(type as any as NgModuleType);
       return computeCombinedExports(type);
     } else {
       return type;

--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -20,7 +20,7 @@ import {assertDefined} from './assert';
 import {ComponentFactoryResolver} from './component_ref';
 import {getNgModuleDef} from './definition';
 
-export interface NgModuleType { ngModuleDef: NgModuleDef<any>; }
+export interface NgModuleType<T = any> extends Type<T> { ngModuleDef: NgModuleDef<T>; }
 
 const COMPONENT_FACTORY_RESOLVER: StaticProvider = {
   provide: viewEngine_ComponentFactoryResolver,

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -62,7 +62,7 @@ function getPipeDef(name: string, registry: PipeDefList | null): PipeDef<any> {
       }
     }
   }
-  throw new Error(`Pipe with name '${name}' not found!`);
+  throw new Error(`The pipe '${name}' could not be found!`);
 }
 
 /**

--- a/packages/core/test/di/r3_injector_spec.ts
+++ b/packages/core/test/di/r3_injector_spec.ts
@@ -195,9 +195,6 @@ describe('InjectorDef-based createInjector()', () => {
     expect(injector.get(Service)).toBe(instance);
   });
 
-  it('throws an error when a token is not found',
-     () => { expect(() => injector.get(ServiceTwo)).toThrow(); });
-
   it('returns the default value if a provider isn\'t present',
      () => { expect(injector.get(ServiceTwo, null)).toBeNull(); });
 
@@ -239,9 +236,6 @@ describe('InjectorDef-based createInjector()', () => {
     expect(instance instanceof StaticService).toBeTruthy();
     expect(instance.dep).toBe(injector.get(Service));
   });
-
-  it('throws an error on circular deps',
-     () => { expect(() => injector.get(CircularA)).toThrow(); });
 
   it('allows injecting itself via INJECTOR',
      () => { expect(injector.get(INJECTOR)).toBe(injector); });
@@ -286,5 +280,25 @@ describe('InjectorDef-based createInjector()', () => {
   it('should not crash when importing something that has no ngInjectorDef', () => {
     injector = createInjector(ImportsNotAModule);
     expect(injector.get(ImportsNotAModule)).toBeDefined();
+  });
+
+  describe('error handling', () => {
+    it('throws an error when a token is not found',
+       () => { expect(() => injector.get(ServiceTwo)).toThrow(); });
+
+    it('throws an error on circular deps',
+       () => { expect(() => injector.get(CircularA)).toThrow(); });
+
+    it('should throw when it can\'t resolve all arguments', () => {
+      class MissingArgumentType {
+        constructor(missingType: any) {}
+      }
+      class ErrorModule {
+        static ngInjectorDef =
+            defineInjector({factory: () => new ErrorModule(), providers: [MissingArgumentType]});
+      }
+      expect(() => createInjector(ErrorModule).get(MissingArgumentType))
+          .toThrowError('Can\'t resolve all parameters for MissingArgumentType: (?).');
+    });
   });
 });

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -1492,28 +1492,23 @@ function declareTests(config?: {useJit: boolean}) {
     });
 
     describe('error handling', () => {
-      fixmeIvy('FW-682: TestBed: tests assert that compilation produces specific error')
-          .it('should report a meaningful error when a directive is missing annotation', () => {
-            TestBed.configureTestingModule(
-                {declarations: [MyComp, SomeDirectiveMissingAnnotation]});
+      it('should report a meaningful error when a directive is missing annotation', () => {
+        TestBed.configureTestingModule({declarations: [MyComp, SomeDirectiveMissingAnnotation]});
 
-            expect(() => TestBed.createComponent(MyComp))
-                .toThrowError(
-                    `Unexpected value '${stringify(SomeDirectiveMissingAnnotation)}' declared by the module 'DynamicTestModule'. Please add a @Pipe/@Directive/@Component annotation.`);
-          });
+        expect(() => TestBed.createComponent(MyComp))
+            .toThrowError(
+                `Unexpected value '${stringify(SomeDirectiveMissingAnnotation)}' declared by the module 'DynamicTestModule'. Please add a @Pipe/@Directive/@Component annotation.`);
+      });
 
-      fixmeIvy('FW-682: TestBed: tests assert that compilation produces specific error')
-          .it('should report a meaningful error when a component is missing view annotation',
-              () => {
-                TestBed.configureTestingModule({declarations: [MyComp, ComponentWithoutView]});
-                try {
-                  TestBed.createComponent(ComponentWithoutView);
-                  expect(true).toBe(false);
-                } catch (e) {
-                  expect(e.message).toContain(
-                      `No template specified for component ${stringify(ComponentWithoutView)}`);
-                }
-              });
+      it('should report a meaningful error when a component is missing view annotation', () => {
+        TestBed.configureTestingModule({declarations: [MyComp, ComponentWithoutView]});
+        try {
+          TestBed.createComponent(ComponentWithoutView);
+        } catch (e) {
+          expect(e.message).toContain(
+              `No template specified for component ${stringify(ComponentWithoutView)}`);
+        }
+      });
 
       fixmeIvy('FW-722: getDebugContext needs to be replaced / re-implemented')
           .it('should provide an error context when an error happens in DI', () => {

--- a/packages/core/test/linker/query_integration_spec.ts
+++ b/packages/core/test/linker/query_integration_spec.ts
@@ -234,15 +234,14 @@ describe('Query API', () => {
           expect(asNativeElements(view.debugElement.children)).toHaveText('2|3d|2d|');
         });
 
-    fixmeIvy('FW-682 - TestBed: tests assert that compilation produces specific error')
-        .it('should throw with descriptive error when query selectors are not present', () => {
-          TestBed.configureTestingModule({declarations: [MyCompBroken0, HasNullQueryCondition]});
-          const template = '<has-null-query-condition></has-null-query-condition>';
-          TestBed.overrideComponent(MyCompBroken0, {set: {template}});
-          expect(() => TestBed.createComponent(MyCompBroken0))
-              .toThrowError(
-                  `Can't construct a query for the property "errorTrigger" of "${stringify(HasNullQueryCondition)}" since the query selector wasn't defined.`);
-        });
+    it('should throw with descriptive error when query selectors are not present', () => {
+      TestBed.configureTestingModule({declarations: [MyCompBroken0, HasNullQueryCondition]});
+      const template = '<has-null-query-condition></has-null-query-condition>';
+      TestBed.overrideComponent(MyCompBroken0, {set: {template}});
+      expect(() => TestBed.createComponent(MyCompBroken0))
+          .toThrowError(
+              `Can't construct a query for the property "errorTrigger" of "${stringify(HasNullQueryCondition)}" since the query selector wasn't defined.`);
+    });
   });
 
   describe('query for TemplateRef', () => {

--- a/packages/core/test/linker/security_integration_spec.ts
+++ b/packages/core/test/linker/security_integration_spec.ts
@@ -52,27 +52,25 @@ function declareTests(config?: {useJit: boolean}) {
     afterEach(() => { getDOM().log = originalLog; });
 
     describe('events', () => {
-      fixmeIvy('FW-787: Exception in template parsing leaves TestBed in corrupted state')
-          .it('should disallow binding to attr.on*', () => {
-            const template = `<div [attr.onclick]="ctxProp"></div>`;
-            TestBed.overrideComponent(SecuredComponent, {set: {template}});
+      it('should disallow binding to attr.on*', () => {
+        const template = `<div [attr.onclick]="ctxProp"></div>`;
+        TestBed.overrideComponent(SecuredComponent, {set: {template}});
 
-            expect(() => TestBed.createComponent(SecuredComponent))
-                .toThrowError(
-                    /Binding to event attribute 'onclick' is disallowed for security reasons, please use \(click\)=.../);
-          });
+        expect(() => TestBed.createComponent(SecuredComponent))
+            .toThrowError(
+                /Binding to event attribute 'onclick' is disallowed for security reasons, please use \(click\)=.../);
+      });
 
-      fixmeIvy('FW-787: Exception in template parsing leaves TestBed in corrupted state')
-          .it('should disallow binding to on* with NO_ERRORS_SCHEMA', () => {
-            const template = `<div [onclick]="ctxProp"></div>`;
-            TestBed.overrideComponent(SecuredComponent, {set: {template}}).configureTestingModule({
-              schemas: [NO_ERRORS_SCHEMA]
-            });
+      it('should disallow binding to on* with NO_ERRORS_SCHEMA', () => {
+        const template = `<div [onclick]="ctxProp"></div>`;
+        TestBed.overrideComponent(SecuredComponent, {set: {template}}).configureTestingModule({
+          schemas: [NO_ERRORS_SCHEMA]
+        });
 
-            expect(() => TestBed.createComponent(SecuredComponent))
-                .toThrowError(
-                    /Binding to event property 'onclick' is disallowed for security reasons, please use \(click\)=.../);
-          });
+        expect(() => TestBed.createComponent(SecuredComponent))
+            .toThrowError(
+                /Binding to event property 'onclick' is disallowed for security reasons, please use \(click\)=.../);
+      });
 
       fixmeIvy(
           'FW-786: Element properties and directive inputs are not distinguished for sanitisation purposes')
@@ -227,7 +225,7 @@ function declareTests(config?: {useJit: boolean}) {
         expect(getDOM().getStyle(e, 'background')).not.toContain('javascript');
       });
 
-      fixmeIvy('FW-787: Exception in template parsing leaves TestBed in corrupted state')
+      fixmeIvy('FW-850: Should throw on unsafe SVG attributes')
           .it('should escape unsafe SVG attributes', () => {
             const template = `<svg:circle [xlink:href]="ctxProp">Text</svg:circle>`;
             TestBed.overrideComponent(SecuredComponent, {set: {template}});

--- a/packages/core/test/linker/source_map_integration_node_only_spec.ts
+++ b/packages/core/test/linker/source_map_integration_node_only_spec.ts
@@ -12,6 +12,8 @@ import {extractSourceMap, originalPositionFor} from '@angular/compiler/testing/s
 import {MockResourceLoader} from '@angular/compiler/testing/src/resource_loader_mock';
 import {Attribute, Component, Directive, ErrorHandler, ɵglobal} from '@angular/core';
 import {getErrorLogger} from '@angular/core/src/errors';
+import {ivyEnabled} from '@angular/core/src/ivy_switch';
+import {resolveComponentResources} from '@angular/core/src/metadata/resource_loading';
 import {TestBed, fakeAsync, tick} from '@angular/core/testing';
 import {fixmeIvy} from '@angular/private/testing';
 
@@ -102,24 +104,30 @@ import {fixmeIvy} from '@angular/private/testing';
     function declareTests(
         {ngUrl, templateDecorator}:
             {ngUrl: string, templateDecorator: (template: string) => { [key: string]: any }}) {
-      fixmeIvy('FW-682: Compiler error handling')
+      fixmeIvy('FW-223: Generate source maps during template compilation')
           .it('should use the right source url in html parse errors', fakeAsync(() => {
                 @Component({...templateDecorator('<div>\n  </error>')})
                 class MyComp {
                 }
 
-                expect(() => compileAndCreateComponent(MyComp))
+                expect(() => {
+                  ivyEnabled && resolveComponentResources(null !);
+                  compileAndCreateComponent(MyComp);
+                })
                     .toThrowError(new RegExp(
                         `Template parse errors[\\s\\S]*${ngUrl.replace('$', '\\$')}@1:2`));
               }));
 
-      fixmeIvy('FW-682: Compiler error handling')
+      fixmeIvy('FW-223: Generate source maps during template compilation')
           .it('should use the right source url in template parse errors', fakeAsync(() => {
                 @Component({...templateDecorator('<div>\n  <div unknown="{{ctxProp}}"></div>')})
                 class MyComp {
                 }
 
-                expect(() => compileAndCreateComponent(MyComp))
+                expect(() => {
+                  ivyEnabled && resolveComponentResources(null !);
+                  compileAndCreateComponent(MyComp);
+                })
                     .toThrowError(new RegExp(
                         `Template parse errors[\\s\\S]*${ngUrl.replace('$', '\\$')}@1:7`));
               }));

--- a/packages/core/test/render3/pipe_spec.ts
+++ b/packages/core/test/render3/pipe_spec.ts
@@ -69,7 +69,7 @@ describe('pipe', () => {
 
     expect(() => {
       const fixture = new ComponentFixture(App);
-    }).toThrowError(/Pipe with name 'randomPipeName' not found!/);
+    }).toThrowError(/The pipe 'randomPipeName' could not be found!/);
   });
 
   it('should support bindings', () => {

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -617,14 +617,15 @@ class HiddenModule {
            });
          }));
 
-      it('should handle false values on attributes', async(() => {
-           renderModule(FalseAttributesModule, {document: doc}).then(output => {
-             expect(output).toBe(
-                 '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
-                 '<my-child ng-reflect-attr="false">Works!</my-child></app></body></html>');
-             called = true;
-           });
-         }));
+      fixmeIvy('unknown').it(
+          'should handle false values on attributes', async(() => {
+            renderModule(FalseAttributesModule, {document: doc}).then(output => {
+              expect(output).toBe(
+                  '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER">' +
+                  '<my-child ng-reflect-attr="false">Works!</my-child></app></body></html>');
+              called = true;
+            });
+          }));
 
       it('should handle element property "name"', async(() => {
            renderModule(NameModule, {document: doc}).then(output => {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -3991,26 +3991,27 @@ describe('Integration', () => {
         });
       });
 
-      it('should use the injector of the lazily-loaded configuration',
-         fakeAsync(inject(
-             [Router, Location, NgModuleFactoryLoader],
-             (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-               loader.stubbedModules = {expected: LoadedModule};
+      fixmeIvy('unknown').it(
+          'should use the injector of the lazily-loaded configuration',
+          fakeAsync(inject(
+              [Router, Location, NgModuleFactoryLoader],
+              (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+                loader.stubbedModules = {expected: LoadedModule};
 
-               const fixture = createRoot(router, RootCmp);
+                const fixture = createRoot(router, RootCmp);
 
-               router.resetConfig([{
-                 path: 'eager-parent',
-                 component: EagerParentComponent,
-                 children: [{path: 'lazy', loadChildren: 'expected'}]
-               }]);
+                router.resetConfig([{
+                  path: 'eager-parent',
+                  component: EagerParentComponent,
+                  children: [{path: 'lazy', loadChildren: 'expected'}]
+                }]);
 
-               router.navigateByUrl('/eager-parent/lazy/lazy-parent/lazy-child');
-               advance(fixture);
+                router.navigateByUrl('/eager-parent/lazy/lazy-parent/lazy-child');
+                advance(fixture);
 
-               expect(location.path()).toEqual('/eager-parent/lazy/lazy-parent/lazy-child');
-               expect(fixture.nativeElement).toHaveText('eager-parent lazy-parent lazy-child');
-             })));
+                expect(location.path()).toEqual('/eager-parent/lazy/lazy-parent/lazy-child');
+                expect(fixture.nativeElement).toHaveText('eager-parent lazy-parent lazy-child');
+              })));
     });
 
     it('works when given a callback',
@@ -4333,41 +4334,43 @@ describe('Integration', () => {
       class LazyLoadedModule {
       }
 
-      it('should not ignore empty path when in legacy mode',
-         fakeAsync(inject(
-             [Router, NgModuleFactoryLoader],
-             (router: Router, loader: SpyNgModuleFactoryLoader) => {
-               router.relativeLinkResolution = 'legacy';
-               loader.stubbedModules = {expected: LazyLoadedModule};
+      fixmeIvy('unknown').it(
+          'should not ignore empty path when in legacy mode',
+          fakeAsync(inject(
+              [Router, NgModuleFactoryLoader],
+              (router: Router, loader: SpyNgModuleFactoryLoader) => {
+                router.relativeLinkResolution = 'legacy';
+                loader.stubbedModules = {expected: LazyLoadedModule};
 
-               const fixture = createRoot(router, RootCmp);
+                const fixture = createRoot(router, RootCmp);
 
-               router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
+                router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
 
-               router.navigateByUrl('/lazy/foo/bar');
-               advance(fixture);
+                router.navigateByUrl('/lazy/foo/bar');
+                advance(fixture);
 
-               const link = fixture.nativeElement.querySelector('a');
-               expect(link.getAttribute('href')).toEqual('/lazy/foo/bar/simple');
-             })));
+                const link = fixture.nativeElement.querySelector('a');
+                expect(link.getAttribute('href')).toEqual('/lazy/foo/bar/simple');
+              })));
 
-      it('should ignore empty path when in corrected mode',
-         fakeAsync(inject(
-             [Router, NgModuleFactoryLoader],
-             (router: Router, loader: SpyNgModuleFactoryLoader) => {
-               router.relativeLinkResolution = 'corrected';
-               loader.stubbedModules = {expected: LazyLoadedModule};
+      fixmeIvy('unknown').it(
+          'should ignore empty path when in corrected mode',
+          fakeAsync(inject(
+              [Router, NgModuleFactoryLoader],
+              (router: Router, loader: SpyNgModuleFactoryLoader) => {
+                router.relativeLinkResolution = 'corrected';
+                loader.stubbedModules = {expected: LazyLoadedModule};
 
-               const fixture = createRoot(router, RootCmp);
+                const fixture = createRoot(router, RootCmp);
 
-               router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
+                router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
 
-               router.navigateByUrl('/lazy/foo/bar');
-               advance(fixture);
+                router.navigateByUrl('/lazy/foo/bar');
+                advance(fixture);
 
-               const link = fixture.nativeElement.querySelector('a');
-               expect(link.getAttribute('href')).toEqual('/lazy/foo/simple');
-             })));
+                const link = fixture.nativeElement.querySelector('a');
+                expect(link.getAttribute('href')).toEqual('/lazy/foo/simple');
+              })));
     });
   });
 

--- a/packages/upgrade/test/dynamic/upgrade_spec.ts
+++ b/packages/upgrade/test/dynamic/upgrade_spec.ts
@@ -149,30 +149,28 @@ withEachNg1Version(() => {
         adapter = new UpgradeAdapter(Ng2Module);
       });
 
-      fixmeIvy('FW-682: JIT compilation occurs at component definition time rather than bootstrap')
-          .it('should throw an uncaught error', fakeAsync(() => {
-                const resolveSpy = jasmine.createSpy('resolveSpy');
-                spyOn(console, 'error');
+      it('should throw an uncaught error', fakeAsync(() => {
+           const resolveSpy = jasmine.createSpy('resolveSpy');
+           spyOn(console, 'error');
 
-                expect(() => {
-                  adapter.bootstrap(html('<ng2></ng2>'), ['ng1']).ready(resolveSpy);
-                  flushMicrotasks();
-                }).toThrowError();
-                expect(resolveSpy).not.toHaveBeenCalled();
-              }));
+           expect(() => {
+             adapter.bootstrap(html('<ng2></ng2>'), ['ng1']).ready(resolveSpy);
+             flushMicrotasks();
+           }).toThrowError();
+           expect(resolveSpy).not.toHaveBeenCalled();
+         }));
 
-      fixmeIvy('FW-682: JIT compilation occurs at component definition time rather than bootstrap')
-          .it('should output an error message to the console and re-throw', fakeAsync(() => {
-                const consoleErrorSpy: jasmine.Spy = spyOn(console, 'error');
-                expect(() => {
-                  adapter.bootstrap(html('<ng2></ng2>'), ['ng1']);
-                  flushMicrotasks();
-                }).toThrowError();
-                const args: any[] = consoleErrorSpy.calls.mostRecent().args;
-                expect(consoleErrorSpy).toHaveBeenCalled();
-                expect(args.length).toBeGreaterThan(0);
-                expect(args[0]).toEqual(jasmine.any(Error));
-              }));
+      it('should output an error message to the console and re-throw', fakeAsync(() => {
+           const consoleErrorSpy: jasmine.Spy = spyOn(console, 'error');
+           expect(() => {
+             adapter.bootstrap(html('<ng2></ng2>'), ['ng1']);
+             flushMicrotasks();
+           }).toThrowError();
+           const args: any[] = consoleErrorSpy.calls.mostRecent().args;
+           expect(consoleErrorSpy).toHaveBeenCalled();
+           expect(args.length).toBeGreaterThan(0);
+           expect(args[0]).toEqual(jasmine.any(Error));
+         }));
     });
 
     describe('scope/component change-detection', () => {

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -334,7 +334,7 @@ export interface ForwardRefFn {
 
 export declare const getDebugNode: (nativeNode: any) => DebugNode | null;
 
-export declare function getModuleFactory(id: string): NgModuleFactory<any>;
+export declare const getModuleFactory: (id: string) => NgModuleFactory<any>;
 
 export declare function getPlatform(): PlatformRef | null;
 


### PR DESCRIPTION
`NgModule` requires that `Component`s/`Directive`s/`Pipe`s are listed in
declarations, and that each `Component`s/`Directive`s/`Pipe` is declared
in exactly one `NgModule`. This change adds runtime checks to ensure
that these sementics are true at runtime.

There will need to be seperate set of checks for the AoT path of the
codebase to verify that same set of semantics hold. Due to current
design there does not seem to be an easy way to share the two checks
because JIT deal with references where as AoT deals with AST nodes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [n/a] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

