### PR TITLE
docs: update SAVED_REPLIES and CONTRIBUTING with new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -4,7 +4,7 @@ about: Report a bug in the Angular Framework
 ---
 <!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅
 
-Oh hi there! 😄 
+Oh hi there! 😄
 
 To expedite issue processing please search open and closed issues before submitting a new one.
 Existing issues often contain information about workarounds, resolution, or progress updates.
@@ -38,6 +38,10 @@ Please create and share minimal reproduction of the issue starting with this tem
 
 <!--
 If StackBlitz is not suitable for reproduction of your issue, please create a minimal GitHub repository with the reproduction of the issue. Share the link to the repo below along with step-by-step instructions to reproduce the problem, as well as expected and actual behavior.
+
+Issues that don't have enough info and can't be reproduced will be closed.
+
+You can read more about issue submission guidelines here: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-submitting-an-issue
 -->
 
 ## 🔥 Exception or Error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,19 +51,15 @@ and help you to craft the change so that it is successfully accepted into the pr
 
 Before you submit an issue, please search the issue tracker, maybe an issue for your problem already exists and the discussion might inform you of workarounds readily available.
 
-We want to fix all the issues as soon as possible, but before fixing a bug we need to reproduce and confirm it. In order to reproduce bugs, we will systematically ask you to provide a minimal reproduction scenario using http://plnkr.co. Having a live, reproducible scenario gives us a wealth of important information without going back & forth to you with additional questions like:
+We want to fix all the issues as soon as possible, but before fixing a bug we need to reproduce and confirm it. In order to reproduce bugs, we will systematically ask you to provide a minimal reproduction. Having a minimal reproducible scenario gives us a wealth of important information without going back & forth to you with additional questions.
 
-- version of Angular used
-- 3rd-party libraries and their versions
-- and most importantly - a use-case that fails
+A minimal reproduction allows us to quickly confirm a bug (or point out a coding problem) as well as confirm that we are fixing the right problem.
 
-A minimal reproduce scenario using http://plnkr.co/ allows us to quickly confirm a bug (or point out coding problem) as well as confirm that we are fixing the right problem. If plunker is not a suitable way to demonstrate the problem (for example for issues related to our npm packaging), please create a standalone git repository demonstrating the problem.
-
-We will be insisting on a minimal reproduce scenario in order to save maintainers time and ultimately be able to fix more bugs. Interestingly, from our experience users often find coding problems themselves while preparing a minimal plunk. We understand that sometimes it might be hard to extract essentials bits of code from a larger code-base but we really need to isolate the problem before we can fix it.
+We will be insisting on a minimal reproduction scenario in order to save maintainers time and ultimately be able to fix more bugs. Interestingly, from our experience users often find coding problems themselves while preparing a minimal reproduction. We understand that sometimes it might be hard to extract essential bits of code from a larger code-base but we really need to isolate the problem before we can fix it.
 
 Unfortunately, we are not able to investigate / fix bugs without a minimal reproduction, so if we don't hear back from you we are going to close an issue that doesn't have enough info to be reproduced.
 
-You can file new issues by selecting from our [new issue templates](https://github.com/angular/angular/issues/new/choose) and filling out the form.
+You can file new issues by selecting from our [new issue templates](https://github.com/angular/angular/issues/new/choose) and filling out the issue template.
 
 
 ### <a name="submit-pr"></a> Submitting a Pull Request (PR)

--- a/docs/SAVED_REPLIES.md
+++ b/docs/SAVED_REPLIES.md
@@ -54,7 +54,7 @@ It appears this behaves as expected. If you still feel there is an issue, please
 ```
 I'm sorry but we can't reproduce the problem following the instructions you provided.
 
-If the problem still still exists in your application please [open a new issue](https://github.com/angular/angular/issues/new/choose) and follow the instructions in the issue template.
+If the problem still exists in your application please [open a new issue](https://github.com/angular/angular/issues/new/choose) and follow the instructions in the issue template.
 ```
 
 ## Angular: Obsolete (v2)

--- a/docs/SAVED_REPLIES.md
+++ b/docs/SAVED_REPLIES.md
@@ -5,43 +5,44 @@ The following are canned responses that the Angular team should use to close iss
 Since GitHub currently doesn't allow us to have a repository-wide or organization-wide list of [saved replies](https://help.github.com/articles/working-with-saved-replies/), these replies need to be maintained by individual team members. Since the responses can be modified in the future, all responses are versioned to simplify the process of keeping the responses up to date.
 
 
-## Angular: Already Fixed (v2)
+## Angular: Already Fixed (v3)
 ```
 Thanks for reporting this issue. Luckily it has already been fixed in one of the recent releases. Please update to the most recent version to resolve the problem.
 
-If after upgrade the problem still exists in your application please open a new issue and provide a StackBlitz reproducing the problem and describing the difference between the expected and current behavior. You can use this StackBlitz template: https://stackblitz.com/fork/angular-gitter
+If after upgrade the problem still exists in your application please [open a new issue](https://github.com/angular/angular/issues/new/choose) and follow the instructions in the issue template.
 ```
 
-## Angular: Don't Understand (v2)
+## Angular: Don't Understand (v3)
 ```
 I'm sorry but we don't understand the problem you are reporting.
 
-If the problem still exists please open a new issue and provide a StackBlitz reproducing the problem and describing the difference between the expected and current behavior. You can use this StackBlitz template: https://stackblitz.com/fork/angular-gitter
+If the problem still exists in your application, please [open a new issue](https://github.com/angular/angular/issues/new/choose) and follow the instructions in the issue template.
 ```
 
-## Angular: StackBlitz Needed (v1)
+## Angular: StackBlitz Needed (v2)
 ```
 I'm sorry but reported issues require a StackBlitz reproducing the problem.
 
-If this issue persists, please create a StackBlitz using this template and describe the difference between the expected and current behavior and create a new issue: https://stackblitz.com/fork/angular-gitter
+If the problem still exists in your application, please [open a new issue](https://github.com/angular/angular/issues/new/choose) and follow the instructions in the issue template.
 ```
 
-## Angular: Duplicate (v1)
+## Angular: Duplicate (v2)
 ```
-Thanks for reporting this issue. However this issue is a duplicate of an existing issue #<ISSUE_NUMBER>. Please subscribe to that issue for future updates.
+Thanks for reporting this issue. However this issue is a duplicate of an existing issue #ISSUE_NUMBER. Please subscribe to that issue for future updates.
 ```
 
 
-## Angular: Insufficient Information Provided (v1)
+## Angular: Insufficient Information Provided (v2)
 ```
 Thanks for reporting this issue. However, you didn't provide sufficient information for us to understand and reproduce the problem. Please check out [our submission guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-submitting-an-issue) to understand why we can't act on issues that are lacking important information.
 
-If the problem still persists, please file a new issue and ensure you provide all of the required information when filling out the issue template.
+If the problem still exists in your application, please [open a new issue](https://github.com/angular/angular/issues/new/choose) and follow the instructions in the issue template.
+
 ```
 
-## Angular: Issue Outside of Angular (v1)
+## Angular: Issue Outside of Angular (v2)
 ```
-I'm sorry but this issue is not caused by Angular. Please contact the author(s) of project <PROJECT NAME> or file issue on their issue tracker.
+I'm sorry but this issue is not caused by Angular. Please contact the author(s) of project PROJECT_NAME or file issue on their issue tracker.
 ```
 
 ## Angular: Behaving as Expected (v1)
@@ -49,18 +50,18 @@ I'm sorry but this issue is not caused by Angular. Please contact the author(s) 
 It appears this behaves as expected. If you still feel there is an issue, please provide further details in a new issue.
 ```
 
-## Angular: Non-reproducible (v1)
+## Angular: Non-reproducible (v2)
 ```
 I'm sorry but we can't reproduce the problem following the instructions you provided.
 
-If the problem still exists please open a new issue following [our submission guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-submitting-an-issue).
+If the problem still still exists in your application please [open a new issue](https://github.com/angular/angular/issues/new/choose) and follow the instructions in the issue template.
 ```
 
-## Angular: Obsolete (v1)
+## Angular: Obsolete (v2)
 ```
 Thanks for reporting this issue. This issue is now obsolete due to changes in the recent releases. Please update to the most recent Angular version.
 
-If the problem still persists, please file a new issue and ensure you provide the version of Angular affected and include the steps to reproduce the problem when filling out the issue template.
+If the problem still exists in your application, please [open a new issue](https://github.com/angular/angular/issues/new/choose) and follow the instructions in the issue template.
 ```
 
 

--- a/docs/SAVED_REPLIES.md
+++ b/docs/SAVED_REPLIES.md
@@ -19,11 +19,11 @@ I'm sorry but we don't understand the problem you are reporting.
 If the problem still exists in your application, please [open a new issue](https://github.com/angular/angular/issues/new/choose) and follow the instructions in the issue template.
 ```
 
-## Angular: StackBlitz Needed (v2)
+## Angular: Can't reproduce (v2)
 ```
-I'm sorry but reported issues require a StackBlitz reproducing the problem.
+I'm sorry but we can't reproduce the problem you are reporting. We require that reported issues have a minimal reproduction that showcases the problem.
 
-If the problem still exists in your application, please [open a new issue](https://github.com/angular/angular/issues/new/choose) and follow the instructions in the issue template.
+If the problem still exists in your application, please [open a new issue](https://github.com/angular/angular/issues/new/choose) and follow the instructions in the issue template that include info on how to create a reproduction using our template.
 ```
 
 ## Angular: Duplicate (v2)


### PR DESCRIPTION
When we launched the new issue templates (.github/ISSUE_TEMPLATE/*), we forgot to update these
docs which got stale and needed a refresh.
