### PR TITLE
fix(bazel): Load http_archive and rules_nodejs dependencies

### DIFF
--- a/packages/bazel/src/schematics/bazel-workspace/files/WORKSPACE.template
+++ b/packages/bazel/src/schematics/bazel-workspace/files/WORKSPACE.template
@@ -10,6 +10,8 @@
 # imports also make sense when referencing the published package.
 workspace(name = "<%= utils.underscore(name) %>")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # The @angular repo contains rule for building Angular applications
 # Provides "build_bazel_rules_typescript"
 ANGULAR_VERSION = "<%= ANGULAR_VERSION %>"
@@ -44,6 +46,9 @@ rules_angular_dependencies()
 load("@build_bazel_rules_typescript//:package.bzl", "rules_typescript_dependencies")
 rules_typescript_dependencies()
 # build_bazel_rules_nodejs is loaded transitively through rules_typescript_dependencies.
+
+load("@build_bazel_rules_nodejs//:package.bzl", "rules_nodejs_dependencies")
+rules_nodejs_dependencies()
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories", "yarn_install")
 # 0.18.0 is needed for .bazelignore


### PR DESCRIPTION
Bazel 0.20 requires loading http_archive explicitly.
rules_nodejs dependencies must now be installed explicity as well.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
