### PR TITLE
build(bazel): fix postinstall-patches.js script run during yarn postinstall when running yarn_install

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bazel:lint": "yarn bazel:format --lint=warn",
     "bazel:lint-fix": "yarn bazel:format --lint=fix",
     "preinstall": "node tools/yarn/check-yarn.js",
-    "postinstall": "yarn update-webdriver && node ./tools/postinstall-patches.js",
+    "postinstall": "yarn update-webdriver && node --preserve-symlinks --preserve-symlinks-main ./tools/postinstall-patches.js",
     "update-webdriver": "webdriver-manager update --gecko false $CHROMEDRIVER_VERSION_ARG",
     "check-env": "gulp check-env",
     "commitmsg": "node ./scripts/git/commit-msg.js",

--- a/tools/postinstall-patches.js
+++ b/tools/postinstall-patches.js
@@ -15,7 +15,8 @@ try {
   // This can be fixed using the --preserve-symlinks-main flag which
   // is introduced in node 10.2.0
   console.warn(
-      'Running postinstall-patches.js script in an external repository requires --preserve-symlinks-main node flag introduced in node 10.2.0');
+      `Running postinstall-patches.js script in an external repository requires --preserve-symlinks-main node flag introduced in node 10.2.0. ` +
+      `Current node version is ${process.version}. Node called with '${process.argv.join(" ")}'.`);
   process.exit(0);
 }
 


### PR DESCRIPTION
`postinstall-patches.js` is a no-op at the moment but if there are ever post-install steps then this is needed or the steps won't run under yarn_install().