### PR TITLE
build: restrict visibility of npm_package targets

### DIFF
--- a/packages/animations/BUILD.bazel
+++ b/packages/animations/BUILD.bazel
@@ -27,6 +27,11 @@ ng_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = [
+        "//packages/compiler/test:__pkg__",
+    ],
     deps = [
         ":animations",
         "//packages/animations/browser",

--- a/packages/bazel/BUILD.bazel
+++ b/packages/bazel/BUILD.bazel
@@ -14,6 +14,9 @@ npm_package(
         "//packages/bazel/docs",
     ],
     tags = ["release-with-framework"],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = ["//visibility:private"],
     deps = [
         "//packages/bazel/src/builders",
         "//packages/bazel/src/ng_package:lib",

--- a/packages/common/BUILD.bazel
+++ b/packages/common/BUILD.bazel
@@ -30,6 +30,17 @@ ng_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = [
+        "//packages/bazel/test/ng_package:__pkg__",
+        "//packages/compiler-cli/test:__pkg__",
+        "//packages/compiler-cli/test/diagnostics:__pkg__",
+        "//packages/compiler-cli/test/ngcc:__pkg__",
+        "//packages/compiler-cli/test/transformers:__pkg__",
+        "//packages/compiler/test:__pkg__",
+        "//packages/language-service/test:__pkg__",
+    ],
     deps = [
         "//packages/common",
         "//packages/common/http",

--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -46,6 +46,9 @@ npm_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = ["//visibility:private"],
     deps = [
         ":compiler-cli",
         "//packages/compiler-cli/src/ngcc",

--- a/packages/compiler/BUILD.bazel
+++ b/packages/compiler/BUILD.bazel
@@ -24,6 +24,11 @@ ng_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = [
+        "//packages/language-service/test:__pkg__",
+    ],
     deps = [
         ":compiler",
         "//packages/compiler/testing",

--- a/packages/core/BUILD.bazel
+++ b/packages/core/BUILD.bazel
@@ -29,6 +29,17 @@ ng_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = [
+        "//packages/bazel/test/ng_package:__pkg__",
+        "//packages/compiler-cli/test:__pkg__",
+        "//packages/compiler-cli/test/diagnostics:__pkg__",
+        "//packages/compiler-cli/test/ngcc:__pkg__",
+        "//packages/compiler-cli/test/transformers:__pkg__",
+        "//packages/compiler/test:__pkg__",
+        "//packages/language-service/test:__pkg__",
+    ],
     deps = [
         ":core",
         "//packages/core/testing",

--- a/packages/elements/BUILD.bazel
+++ b/packages/elements/BUILD.bazel
@@ -31,6 +31,9 @@ ng_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = ["//visibility:private"],
     deps = [
         ":elements",
     ],

--- a/packages/forms/BUILD.bazel
+++ b/packages/forms/BUILD.bazel
@@ -25,6 +25,12 @@ ng_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = [
+        "//packages/compiler-cli/test/diagnostics:__pkg__",
+        "//packages/language-service/test:__pkg__",
+    ],
     deps = [
         ":forms",
     ],

--- a/packages/http/BUILD.bazel
+++ b/packages/http/BUILD.bazel
@@ -28,6 +28,9 @@ ng_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = ["//visibility:private"],
     deps = [
         ":http",
         "//packages/http/testing",

--- a/packages/language-service/BUILD.bazel
+++ b/packages/language-service/BUILD.bazel
@@ -27,6 +27,9 @@ npm_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = ["//visibility:private"],
     deps = [
         ":language-service",
         "//packages/language-service/bundles:language-service",

--- a/packages/platform-browser-dynamic/BUILD.bazel
+++ b/packages/platform-browser-dynamic/BUILD.bazel
@@ -30,6 +30,9 @@ ng_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = ["//visibility:private"],
     deps = [
         ":platform-browser-dynamic",
         "//packages/platform-browser-dynamic/testing",

--- a/packages/platform-browser/BUILD.bazel
+++ b/packages/platform-browser/BUILD.bazel
@@ -31,6 +31,11 @@ ng_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = [
+        "//packages/compiler-cli/test:__pkg__",
+    ],
     deps = [
         ":platform-browser",
         "//packages/platform-browser/animations",

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -37,6 +37,9 @@ ng_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = ["//visibility:private"],
     deps = [
         ":platform-server",
         "//packages/platform-server/testing",

--- a/packages/platform-webworker-dynamic/BUILD.bazel
+++ b/packages/platform-webworker-dynamic/BUILD.bazel
@@ -27,5 +27,8 @@ ng_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = ["//visibility:private"],
     deps = [":platform-webworker-dynamic"],
 )

--- a/packages/platform-webworker/BUILD.bazel
+++ b/packages/platform-webworker/BUILD.bazel
@@ -27,6 +27,9 @@ ng_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = ["//visibility:private"],
     deps = [
         ":platform-webworker",
     ],

--- a/packages/router/BUILD.bazel
+++ b/packages/router/BUILD.bazel
@@ -31,6 +31,12 @@ ng_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = [
+        "//packages/compiler-cli/test:__pkg__",
+        "//packages/compiler-cli/test/transformers:__pkg__",
+    ],
     deps = [
         ":router",
         "//packages/router/testing",

--- a/packages/service-worker/BUILD.bazel
+++ b/packages/service-worker/BUILD.bazel
@@ -51,6 +51,9 @@ ng_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = ["//visibility:private"],
     deps = [
         ":service-worker",
         "//packages/service-worker/config",

--- a/packages/upgrade/BUILD.bazel
+++ b/packages/upgrade/BUILD.bazel
@@ -30,6 +30,9 @@ ng_package(
     tags = [
         "release-with-framework",
     ],
+    # Do not add more to this list.
+    # Dependencies on the full npm_package cause long re-builds.
+    visibility = ["//visibility:private"],
     deps = [
         ":upgrade",
         "//packages/upgrade/static",


### PR DESCRIPTION
dependencies on these cause very long rebuilds which have to re-package angular.
Such tests belong in the integration/ folder - this will probably merit some discussion