### PR TITLE
fix(docs-infra): fix top menu item clickable area

### DIFF
--- a/aio/src/styles/1-layouts/_top-menu.scss
+++ b/aio/src/styles/1-layouts/_top-menu.scss
@@ -147,14 +147,13 @@ aio-top-menu {
 
   a.nav-link {
     margin: 0;
-    padding: 24px 16px;
+    padding: 8px 16px;
     cursor: pointer;
-
+    border-radius: 4px;
+      
     &:focus {
       background: rgba($white, 0.15);
-      border-radius: 4px;
       outline: none;
-      padding: 8px 16px;
     }
   }
 }


### PR DESCRIPTION
fixes #27618

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The menu items of the top nav bar in angular.io have a large clickable area, but the click has no effect if clicking outside of the region corresponding to the focused region.

Issue Number: #27618


## What is the new behavior?
The clickable region is reduced to the focused area, so no cursor pointer is shown outside the clickable area.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
