### PR TITLE
wip: build(compiler-cli): move offline_compiler_test.sh under bazel

### DIFF
--- a/packages/compiler-cli/integrationtest/test/BUILD.bazel
+++ b/packages/compiler-cli/integrationtest/test/BUILD.bazel
@@ -1,0 +1,27 @@
+load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
+
+ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob(["**/*.ts"]),
+    deps = [
+        "//packages/core",
+        "//packages/core/testing",
+        "//packages/compiler-cli",
+        "//packages/platform-browser",
+        "//packages/platform-server/testing",
+        "@ngdeps//typescript",
+    ],
+)
+
+jasmine_node_test(
+    name = "test",
+    bootstrap = ["angular/tools/testing/init_node_spec.js"],
+    deps = [
+        ":test_lib",
+        "//packages/platform-server",
+        "//packages/platform-server/testing",
+        "//packages/private/testing",
+        "//tools/testing:node",
+    ],
+)


### PR DESCRIPTION
This tests is currently disabled and broken, additionally it also needs to run under bazel.

