### PR TITLE
fix(core): Remove unsafe type assertion from destroyNode

### DIFF
--- a/packages/core/src/view/services.ts
+++ b/packages/core/src/view/services.ts
@@ -688,10 +688,12 @@ export class DebugRenderer2 implements Renderer2 {
   constructor(private delegate: Renderer2) { this.data = this.delegate.data; }
 
   destroyNode(node: any) {
-    const debugNode = getDebugNode(node) !;
-    removeDebugNodeFromIndex(debugNode);
-    if (debugNode instanceof DebugNode__PRE_R3__) {
-      debugNode.listeners.length = 0;
+    const debugNode = getDebugNode(node);
+    if (debugNode) {
+      removeDebugNodeFromIndex(debugNode);
+      if (debugNode instanceof DebugNode__PRE_R3__) {
+        debugNode.listeners.length = 0;
+      }
     }
     if (this.delegate.destroyNode) {
       this.delegate.destroyNode(node);


### PR DESCRIPTION
This type assertion was unsafe when using an angular element
within an angular component.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Introduce a check to see if a debug node exists before destroying it.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
