### PR TITLE
fix(docs-infra): fix top menu item clickable area

### DIFF
--- a/aio/src/app/layout/top-menu/top-menu.component.ts
+++ b/aio/src/app/layout/top-menu/top-menu.component.ts
@@ -5,7 +5,11 @@ import { NavigationNode } from 'app/navigation/navigation.service';
   selector: 'aio-top-menu',
   template: `
     <ul role="navigation">
-      <li *ngFor="let node of nodes"><a class="nav-link" [href]="node.url" [title]="node.title">{{ node.title }}</a></li>
+      <li *ngFor="let node of nodes">
+        <a class="nav-link" [href]="node.url" [title]="node.title">
+          <span class="nav-link-inner">{{ node.title }}</span>
+        </a>
+      </li>
     </ul>`
 })
 export class TopMenuComponent {

--- a/aio/src/styles/1-layouts/_top-menu.scss
+++ b/aio/src/styles/1-layouts/_top-menu.scss
@@ -147,13 +147,17 @@ aio-top-menu {
 
   a.nav-link {
     margin: 0;
-    padding: 8px 16px;
+    padding: 24px 0px;
     cursor: pointer;
-    border-radius: 4px;
-      
+    .nav-link-inner {
+      padding: 8px 16px;
+    }
     &:focus {
-      background: rgba($white, 0.15);
       outline: none;
+      .nav-link-inner {
+        background: rgba($white, 0.15);
+        border-radius: 4px;
+      }
     }
   }
 }

--- a/aio/src/styles/1-layouts/_top-menu.scss
+++ b/aio/src/styles/1-layouts/_top-menu.scss
@@ -149,11 +149,14 @@ aio-top-menu {
     margin: 0;
     padding: 24px 0px;
     cursor: pointer;
+
     .nav-link-inner {
       padding: 8px 16px;
     }
+
     &:focus {
       outline: none;
+
       .nav-link-inner {
         background: rgba($white, 0.15);
         border-radius: 4px;


### PR DESCRIPTION
the clickable region of the top menu item is expanded beyond the focused area, so the clickable area is spans the entire height of the navigation

fixes #27618 

follow-up of #27620

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, only the area with visible hover state of a menu top item is clickable.

Issue Number: #27618


## What is the new behavior?
The clickable area of the menu top item fits the entire height of the navigation bar.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



## Other information
