### PR TITLE
fix(bazel): fix major/minor semver check between @angular/bazel npm p…

### DIFF
--- a/packages/bazel/check_version.js
+++ b/packages/bazel/check_version.js
@@ -57,7 +57,8 @@ if (isBazelManagedDeps()) {
   }
   // Be tolerant of versions such as "0.17.0-7-g76dc057"
   const angularPackageVersion = contents.version.split('-')[0];
-  const range = `~${angularPackageVersion}`;  // should match patch version
+  // Should match only the major and minor versions
+  const range = `${semver.major(angularPackageVersion)}.${semver.minor(angularPackageVersion)}.x`;
   if (!semver.satisfies(npmPackageVersion, range)) {
     throw new Error(
         `Expected angular npm version ${npmPackageVersion} to satisfy ${range}. ` +


### PR DESCRIPTION
…ackage version and angular bazel repo version

Was updating rules_typescript with the semver check (https://github.com/bazelbuild/rules_typescript/pull/352) and noticed the logic error in the check where using `~major.minor.patch` as the condition means the version being checked must be`>= major.minor.patch` whereas using `major.minor.x` as the condition means the version being checked must only match on major and minor and can have any patch version.