### PR TITLE
test(ivy): remove state fixme from packages/compiler-cli/test:ngtools_api

### DIFF
--- a/packages/compiler-cli/test/BUILD.bazel
+++ b/packages/compiler-cli/test/BUILD.bazel
@@ -118,9 +118,6 @@ jasmine_node_test(
         "//packages/core:npm_package",
         "//packages/router:npm_package",
     ],
-    tags = [
-        "fixme-ivy-aot",
-    ],
     deps = [
         ":ngtools_api_lib",
         "//packages/core",


### PR DESCRIPTION
it seems that we forgot to remove it in the recent refactoring.

the tests compile and only subset is disabled via runtime fixmes.