### PR TITLE
ci: remove packages/bazel from compiler-cli group

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -254,7 +254,6 @@ groups:
       files:
         include:
           - "packages/compiler-cli/*"
-          - "packages/bazel/*"
         exclude:
           - "packages/compiler-cli/src/ngtools*"
     users:


### PR DESCRIPTION
it doesn't make sense require approvals from compiler-cli group for most @angular/bazel changes.
