### PR TITLE
build(docs-infra): upgrade cli command docs sources to b87d8a5bc

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -18,7 +18,7 @@
     "build-for": "yarn ~~build --configuration",
     "prebuild-local": "yarn setup-local",
     "build-local": "yarn ~~build --configuration=stable",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 5eef7122c",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js b87d8a5bc",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#master](https://github.com/angular/angular/tree/master) from [cli-builds#master](https://github.com/angular/cli-builds/tree/master).
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/5eef7122c...b87d8a5bc):

**Modified**
- help/build.json
- help/generate.json
- help/serve.json

Closes #27594
Closes #27621