### PR TITLE
test(ivy): update root causes for @angular/core TestBed failures

### DIFF
--- a/packages/core/test/linker/change_detection_integration_spec.ts
+++ b/packages/core/test/linker/change_detection_integration_spec.ts
@@ -1445,26 +1445,28 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
           expect(log).toEqual(['inner-start', 'main-tpl', 'outer-tpl']);
         });
 
-        fixmeIvy('unknown').it(
-            'should dirty check projected views if the declaration place is dirty checked', () => {
-              ctx.detectChanges(false);
-              log = [];
-              innerComp.cdRef.detach();
-              mainComp.cdRef.detectChanges();
+        fixmeIvy(
+            'FW-842: View engine dirty-checks projected views when the declaration place is checked')
+            .it('should dirty check projected views if the declaration place is dirty checked',
+                () => {
+                  ctx.detectChanges(false);
+                  log = [];
+                  innerComp.cdRef.detach();
+                  mainComp.cdRef.detectChanges();
 
-              expect(log).toEqual(['main-start', 'outer-start', 'main-tpl', 'outer-tpl']);
+                  expect(log).toEqual(['main-start', 'outer-start', 'main-tpl', 'outer-tpl']);
 
-              log = [];
-              outerComp.cdRef.detectChanges();
+                  log = [];
+                  outerComp.cdRef.detectChanges();
 
-              expect(log).toEqual(['outer-start', 'outer-tpl']);
+                  expect(log).toEqual(['outer-start', 'outer-tpl']);
 
-              log = [];
-              outerComp.cdRef.detach();
-              mainComp.cdRef.detectChanges();
+                  log = [];
+                  outerComp.cdRef.detach();
+                  mainComp.cdRef.detectChanges();
 
-              expect(log).toEqual(['main-start', 'main-tpl']);
-            });
+                  expect(log).toEqual(['main-start', 'main-tpl']);
+                });
       });
     });
 

--- a/packages/core/test/linker/projection_integration_spec.ts
+++ b/packages/core/test/linker/projection_integration_spec.ts
@@ -371,8 +371,8 @@ describe('projection', () => {
   });
 
   if (getDOM().supportsNativeShadowDOM()) {
-    fixmeIvy('unknown').it(
-        'should support native content projection and isolate styles per component', () => {
+    fixmeIvy('FW-841: Content projection with ShadovDom v0 doesn\'t work')
+        .it('should support native content projection and isolate styles per component', () => {
           TestBed.configureTestingModule({declarations: [SimpleNative1, SimpleNative2]});
           TestBed.overrideComponent(MainComp, {
             set: {

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -428,83 +428,84 @@ function declareTestsUsingBootstrap() {
     if (getDOM().supportsDOMEvents()) {
       // This test needs a real DOM....
 
-      fixmeIvy('unknown').it('should keep change detecting if there was an error', (done) => {
-        @Component({
-          selector: COMP_SELECTOR,
-          template:
-              '<button (click)="next()"></button><button (click)="nextAndThrow()"></button><button (dirClick)="nextAndThrow()"></button><span>Value:{{value}}</span><span>{{throwIfNeeded()}}</span>'
-        })
-        class ErrorComp {
-          value = 0;
-          thrownValue = 0;
-          next() { this.value++; }
-          nextAndThrow() {
-            this.value++;
-            this.throwIfNeeded();
-          }
-          throwIfNeeded() {
-            NgZone.assertInAngularZone();
-            if (this.thrownValue !== this.value) {
-              this.thrownValue = this.value;
-              throw new Error(`Error: ${this.value}`);
+      fixmeIvy('FW-840: Exceptions thrown in event handlers are not reported to ErrorHandler')
+          .it('should keep change detecting if there was an error', (done) => {
+            @Component({
+              selector: COMP_SELECTOR,
+              template:
+                  '<button (click)="next()"></button><button (click)="nextAndThrow()"></button><button (dirClick)="nextAndThrow()"></button><span>Value:{{value}}</span><span>{{throwIfNeeded()}}</span>'
+            })
+            class ErrorComp {
+              value = 0;
+              thrownValue = 0;
+              next() { this.value++; }
+              nextAndThrow() {
+                this.value++;
+                this.throwIfNeeded();
+              }
+              throwIfNeeded() {
+                NgZone.assertInAngularZone();
+                if (this.thrownValue !== this.value) {
+                  this.thrownValue = this.value;
+                  throw new Error(`Error: ${this.value}`);
+                }
+              }
             }
-          }
-        }
 
-        @Directive({selector: '[dirClick]'})
-        class EventDir {
-          @Output()
-          dirClick = new EventEmitter();
+            @Directive({selector: '[dirClick]'})
+            class EventDir {
+              @Output()
+              dirClick = new EventEmitter();
 
-          @HostListener('click', ['$event'])
-          onClick(event: any) { this.dirClick.next(event); }
-        }
+              @HostListener('click', ['$event'])
+              onClick(event: any) { this.dirClick.next(event); }
+            }
 
-        @NgModule({
-          imports: [BrowserModule],
-          declarations: [ErrorComp, EventDir],
-          bootstrap: [ErrorComp],
-          providers: [{provide: ErrorHandler, useValue: errorHandler}],
-        })
-        class TestModule {
-        }
+            @NgModule({
+              imports: [BrowserModule],
+              declarations: [ErrorComp, EventDir],
+              bootstrap: [ErrorComp],
+              providers: [{provide: ErrorHandler, useValue: errorHandler}],
+            })
+            class TestModule {
+            }
 
-        platformBrowserDynamic().bootstrapModule(TestModule).then((ref) => {
-          NgZone.assertNotInAngularZone();
-          const appRef = ref.injector.get(ApplicationRef) as ApplicationRef;
-          const compRef = appRef.components[0] as ComponentRef<ErrorComp>;
-          const compEl = compRef.location.nativeElement;
-          const nextBtn = compEl.children[0];
-          const nextAndThrowBtn = compEl.children[1];
-          const nextAndThrowDirBtn = compEl.children[2];
+            platformBrowserDynamic().bootstrapModule(TestModule).then((ref) => {
+              NgZone.assertNotInAngularZone();
+              const appRef = ref.injector.get(ApplicationRef) as ApplicationRef;
+              const compRef = appRef.components[0] as ComponentRef<ErrorComp>;
+              const compEl = compRef.location.nativeElement;
+              const nextBtn = compEl.children[0];
+              const nextAndThrowBtn = compEl.children[1];
+              const nextAndThrowDirBtn = compEl.children[2];
 
-          nextBtn.click();
-          assertValueAndErrors(compEl, 1, 0);
-          nextBtn.click();
-          assertValueAndErrors(compEl, 2, 2);
+              nextBtn.click();
+              assertValueAndErrors(compEl, 1, 0);
+              nextBtn.click();
+              assertValueAndErrors(compEl, 2, 2);
 
-          nextAndThrowBtn.click();
-          assertValueAndErrors(compEl, 3, 4);
-          nextAndThrowBtn.click();
-          assertValueAndErrors(compEl, 4, 6);
+              nextAndThrowBtn.click();
+              assertValueAndErrors(compEl, 3, 4);
+              nextAndThrowBtn.click();
+              assertValueAndErrors(compEl, 4, 6);
 
-          nextAndThrowDirBtn.click();
-          assertValueAndErrors(compEl, 5, 8);
-          nextAndThrowDirBtn.click();
-          assertValueAndErrors(compEl, 6, 10);
+              nextAndThrowDirBtn.click();
+              assertValueAndErrors(compEl, 5, 8);
+              nextAndThrowDirBtn.click();
+              assertValueAndErrors(compEl, 6, 10);
 
-          // Assert that there were no more errors
-          expect(logger.errors.length).toBe(12);
-          done();
-        });
+              // Assert that there were no more errors
+              expect(logger.errors.length).toBe(12);
+              done();
+            });
 
-        function assertValueAndErrors(compEl: any, value: number, errorIndex: number) {
-          expect(compEl).toHaveText(`Value:${value}`);
-          expect(logger.errors[errorIndex][0]).toBe('ERROR');
-          expect(logger.errors[errorIndex][1].message).toBe(`Error: ${value}`);
-          expect(logger.errors[errorIndex + 1][0]).toBe('ERROR CONTEXT');
-        }
-      });
+            function assertValueAndErrors(compEl: any, value: number, errorIndex: number) {
+              expect(compEl).toHaveText(`Value:${value}`);
+              expect(logger.errors[errorIndex][0]).toBe('ERROR');
+              expect(logger.errors[errorIndex][1].message).toBe(`Error: ${value}`);
+              expect(logger.errors[errorIndex + 1][0]).toBe('ERROR CONTEXT');
+            }
+          });
     }
   });
 }


### PR DESCRIPTION
This PR concludes the root-causes analysis for `@angular/core` for all parts but animations and view providers.