### PR TITLE
build: disable failing optional travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,12 @@ env:
     - CI_MODE=saucelabs_required
     # deactivated, see #19768
     # - CI_MODE=browserstack_required
-    - CI_MODE=saucelabs_optional
-    - CI_MODE=browserstack_optional
+
+    # We disable these optional jobs because those acquire tunnel and browser instances which
+    # could lead to rate limit excess while those are failing most of the time and nobody pays
+    # attention anyway.
+    # - CI_MODE=saucelabs_optional
+    # - CI_MODE=browserstack_optional
 
 matrix:
   fast_finish: true

--- a/scripts/sauce/sauce_connect_setup.sh
+++ b/scripts/sauce/sauce_connect_setup.sh
@@ -22,14 +22,13 @@ CONNECT_URL="https://saucelabs.com/downloads/sc-${SAUCE_CONNECT_VERSION}-linux.t
 CONNECT_DIR="/tmp/sauce-connect-$RANDOM"
 CONNECT_DOWNLOAD="sc-latest-linux.tar.gz"
 
-# logging disabled because it seems to be overwhelming travis and causing flakes
-# when we are cat-ing the log in print-logs.sh
-# CONNECT_LOG="$LOGS_DIR/sauce-connect"
-# CONNECT_STDOUT="$LOGS_DIR/sauce-connect.stdout"
-# CONNECT_STDERR="$LOGS_DIR/sauce-connect.stderr"
+# We don't want to create a log file because sauceconnect always logs in verbose mode. This seems
+# to be overwhelming Travis and causing flakes when we are cat-ing the log in "print-logs.sh"
 CONNECT_LOG="/dev/null"
+
+# Even though the stdout of sauceconnect is not very verbose, we don't want to log this to
+# Travis because it will show up in between different travis log-output groups
 CONNECT_STDOUT="/dev/null"
-CONNECT_STDERR="/dev/null"
 
 # Get Connect and start it
 mkdir -p $CONNECT_DIR
@@ -52,10 +51,7 @@ if [ ! -z "$BROWSER_PROVIDER_READY_FILE" ]; then
 fi
 
 set -v
-echo "Starting Sauce Connect in the background, logging into:"
-echo "  $CONNECT_LOG"
-echo "  $CONNECT_STDOUT"
-echo "  $CONNECT_STDERR"
-sauce-connect/bin/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY $ARGS \
-  --logfile $CONNECT_LOG 2> $CONNECT_STDERR 1> $CONNECT_STDOUT &
+echo "Starting Sauce Connect in the background."
+sauce-connect/bin/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY $ARGS --logfile $CONNECT_LOG \
+  > $CONNECT_STDOUT &
 set +v


### PR DESCRIPTION
**build: disable failing optional travis jobs**

* Disables the failing optional Travis jobs because those just acquire limited resources of Saucelabs and BrowserStack and cause API rate limit problems if the caretaker merges multiple PRs. The rate limit error will spread across multiple repositories because we use the same license in multiple Angular projects (e.g. Angular Material, angular.js etc.)

**build: re-enable saucelabs non-verbose logging**

* Previously the logging to TravisCI has been disabled because the `print-logs.sh` file printed the Sauce-Connect logfile output that is `verbose` by default. See [for example](https://travis-ci.org/angular/angular/jobs/250578973).

  Since the default stderr of sauce-connect is pretty much concise and can alert us if we run into any issues (e.g. rate limit exception), we should stop piping these to `/dev/null`.