### PR TITLE
build(docs-infra): pin `nunjucks` to 3.1.4 for `build-local` script

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -165,5 +165,9 @@
     "webpack-cli": "^3.1.2",
     "xregexp": "^4.0.0",
     "yargs": "^7.0.2"
+  },
+  "//resolutions": "Work-around for https://github.com/mozilla/nunjucks/issues/1176 when running `build-local`.",
+  "resolutions": {
+    "nunjucks": "3.1.4"
   }
 }


### PR DESCRIPTION
As part of the `build-local` (or the associated `setup-local`) script we install dependencies ignoring the lockfile (using the `--no-lockfile` flag). The reason is that we want to get latest versions for Angular packages' dependencies and peer dependencies.

This commit works around a problem in nunjucks@3.1.5, by pinning it to 3.1.4 (as a temporary solution).

Related issue: mozilla/nunjucks#1176
