### PR TITLE
fix(router): Change segment expansion to allow route matching with named outlets and lazy loading

### DIFF
--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -176,7 +176,7 @@ class ApplyRedirects {
   private expandSegmentAgainstRoute(
       ngModule: NgModuleRef<any>, segmentGroup: UrlSegmentGroup, routes: Route[], route: Route,
       paths: UrlSegment[], outlet: string, allowRedirects: boolean): Observable<UrlSegmentGroup> {
-    if (getOutlet(route) !== outlet) {
+    if (getOutlet(route) !== outlet && !route.loadChildren) {
       return noMatch(segmentGroup);
     }
 

--- a/packages/router/test/apply_redirects.spec.ts
+++ b/packages/router/test/apply_redirects.spec.ts
@@ -423,6 +423,25 @@ describe('applyRedirects', () => {
       applyRedirects(testModule.injector, <any>loader, serializer, tree('xyz'), config)
           .forEach(r => { expect((config[0] as any)._loadedConfig).toBe(loadedConfig); });
     });
+
+    it('should load config with named router outlet', () => {
+      const loadedConfig = new LoadedRouterConfig([{path: 'b', component: ComponentB}], testModule);
+      const loader = {
+        load: (injector: any, p: any) => {
+          if (injector !== testModule.injector) throw 'Invalid Injector';
+          return of (loadedConfig);
+        }
+      };
+      const config: Routes = [{path: 'a', outlet: 'outlet', loadChildren: 'children'}];
+
+      applyRedirects(testModule.injector, <any>loader, serializer, tree('a/b'), config)
+          .subscribe(
+              (r) => {
+                expectTreeToBe(r, '/a/b');
+                expect((config[0] as any)._loadedConfig).toBe(loadedConfig);
+              },
+              () => { throw 'Should not reach'; });
+    });
   });
 
   describe('empty paths', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently during segment expansion, if there is a lazy loaded route targeting a named router outlet,
the segment is regarded as having no match even though the resolved lazy load configuration may actually have a matching segment after it's creation. 

Issue Number: #14243


## What is the new behavior?

This fix adds a check to expandSegmentAgainstRoute for the existence of loadChildren on a route and lets the route expansion proceed as normal.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
