### PR TITLE
fix(ivy): support finding the import of namespace-imported identifiers

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -286,12 +286,19 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
    */
   private _reflectModuleFromTypeParam(type: ts.TypeNode): ts.Expression|null {
     // Examine the type of the function to see if it's a ModuleWithProviders reference.
-    if (!ts.isTypeReferenceNode(type) || !ts.isIdentifier(type.typeName)) {
+    if (!ts.isTypeReferenceNode(type)) {
+      return null;
+    }
+
+    const typeName = type && (ts.isIdentifier(type.typeName) && type.typeName ||
+                              ts.isQualifiedName(type.typeName) && type.typeName.right) ||
+        null;
+    if (typeName === null) {
       return null;
     }
 
     // Look at the type itself to see where it comes from.
-    const id = this.reflector.getImportOfIdentifier(type.typeName);
+    const id = this.reflector.getImportOfIdentifier(typeName);
 
     // If it's not named ModuleWithProviders, bail.
     if (id === null || id.name !== 'ModuleWithProviders') {


### PR DESCRIPTION
Currently there is no support in ngtsc for imports of the form:

```
import * as core from `@angular/core`

export function forRoot(): core.ModuleWithProviders;
```

This commit modifies the `ReflectionHost.getImportOfIdentifier(id)`
method, so that it supports this kind of return type.
