### PR TITLE
fix(ivy): adding TestBed.overrideProvider support

### DIFF
--- a/packages/core/src/render3/features/providers_feature.ts
+++ b/packages/core/src/render3/features/providers_feature.ts
@@ -7,7 +7,7 @@
  */
 import {Provider} from '../../di/provider';
 import {providersResolver} from '../di_setup';
-import {DirectiveDef} from '../interfaces/definition';
+import {DirectiveDef, ProvidersResolverFunction} from '../interfaces/definition';
 
 /**
  * This feature resolves the providers of a directive (or component),
@@ -39,7 +39,8 @@ import {DirectiveDef} from '../interfaces/definition';
  */
 export function ProvidersFeature<T>(providers: Provider[], viewProviders: Provider[] = []) {
   return (definition: DirectiveDef<T>) => {
-    definition.providersResolver = (def: DirectiveDef<T>) =>
-        providersResolver(def, providers, viewProviders);
+    definition.providersResolver =
+        (def: DirectiveDef<T>, resolver: ProvidersResolverFunction<T> = providersResolver) =>
+            resolver(def, providers, viewProviders);
   };
 }

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -9,9 +9,7 @@
 import {ViewEncapsulation} from '../../core';
 import {Provider} from '../../di/provider';
 import {Type} from '../../type';
-
 import {CssSelectorList} from './projection';
-
 
 
 /**

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -7,8 +7,11 @@
  */
 
 import {ViewEncapsulation} from '../../core';
+import {Provider} from '../../di/provider';
 import {Type} from '../../type';
+
 import {CssSelectorList} from './projection';
+
 
 
 /**
@@ -113,7 +116,7 @@ export interface DirectiveDef<T> extends BaseDef<T> {
   type: Type<T>;
 
   /** Function that resolves providers and publishes them into the DI system. */
-  providersResolver: ((def: DirectiveDef<T>) => void)|null;
+  providersResolver: ((def: DirectiveDef<T>, resolver?: ProvidersResolverFunction<T>) => any)|null;
 
   /** The selectors that will be used to match nodes to this directive. */
   readonly selectors: CssSelectorList;
@@ -326,6 +329,9 @@ export type DirectiveTypeList =
      Type<any>/* Type as workaround for: Microsoft/TypeScript/issues/4881 */)[];
 
 export type HostBindingsFunction<T> = (rf: RenderFlags, ctx: T, elementIndex: number) => void;
+
+export type ProvidersResolverFunction<T> =
+    (def: DirectiveDef<T>, providers: Provider[], viewProviders: Provider[]) => any;
 
 /**
  * Type used for PipeDefs on component definition.

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -503,7 +503,9 @@ function setProvidersOverride(
     getProviderOverride?: (token: any) => Provider | undefined) {
   if (!getProviderOverride) return;
 
-  const token = (provider: any) => typeof provider === 'function' ? provider : provider.provide;
+  const token = (provider: any) =>
+      typeof provider === 'object' && provider.hasOwnProperty('provide') ? provider.provide :
+                                                                           provider;
   const setOverridesFor = (resolver: any, def: any) => {
     if (!def) return;
     const current = getProvidersFromDef(def);

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -16,7 +16,6 @@ import {ComponentResolver, DirectiveResolver, NgModuleResolver, PipeResolver, Re
 import {TestBed} from './test_bed';
 import {ComponentFixtureAutoDetect, ComponentFixtureNoNgZone, TestBedStatic, TestComponentRenderer, TestModuleMetadata} from './test_bed_common';
 
-
 let _nextRootElementId = 0;
 
 type DefsStore = Map<Type<any>, [string, PropertyDescriptor]>;
@@ -259,7 +258,7 @@ export class TestBedRender3 implements Injector, TestBed {
     });
     this._activeFixtures = [];
 
-    // restore component/directive/pipe defs generated initially
+    // restore component/directive/pipe defs generated previously
     this._initialDefsStore.forEach(
         (value: [string, PropertyDescriptor], type: Type<any>) =>
             Object.defineProperty(type, value[0], value[1]));

--- a/packages/core/testing/src/resolvers.ts
+++ b/packages/core/testing/src/resolvers.ts
@@ -27,9 +27,13 @@ abstract class OverrideResolver<T> implements Resolver<T> {
 
   abstract get type(): any;
 
+  addOverrides(overrides: Array<[Type<any>, MetadataOverride<T>]>) {
+    overrides.forEach(([type, override]) => this.overrides.set(type, override));
+  }
+
   setOverrides(overrides: Array<[Type<any>, MetadataOverride<T>]>) {
     this.overrides.clear();
-    overrides.forEach(([type, override]) => this.overrides.set(type, override));
+    this.addOverrides(overrides);
   }
 
   getAnnotation(type: Type<any>): T|null {

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -388,7 +388,7 @@ class CompWithUrlTemplate {
                 .overridePipe(SomePipe, {set: {name: 'somePipe'}})
                 .overridePipe(SomePipe, {add: {pure: false}});
           });
-          fixmeIvy('FW-788: Support metadata override in TestBed (for AOT-compiled components)')
+          fixmeIvy('FW-852: Pipe not found in TestBed.overridePipe-related test')
               .it('should work', () => {
                 const compFixture = TestBed.createComponent(SomeComponent);
                 compFixture.detectChanges();
@@ -459,28 +459,25 @@ class CompWithUrlTemplate {
             expect(TestBed.get('a')).toBe('mockA: depValue');
           });
 
-          fixmeIvy('FW-788: Support metadata override in TestBed (for AOT-compiled components)')
-              .it('should support SkipSelf', () => {
-                @NgModule({
-                  providers: [
-                    {provide: 'a', useValue: 'aValue'},
-                    {provide: 'dep', useValue: 'depValue'},
-                  ]
-                })
-                class MyModule {
-                }
+          fixmeIvy('unknown').it('should support SkipSelf', () => {
+            @NgModule({
+              providers: [
+                {provide: 'a', useValue: 'aValue'},
+                {provide: 'dep', useValue: 'depValue'},
+              ]
+            })
+            class MyModule {
+            }
 
-                TestBed.overrideProvider(
-                    'a',
-                    {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new SkipSelf(), 'dep']]});
-                TestBed.configureTestingModule(
-                    {providers: [{provide: 'dep', useValue: 'parentDepValue'}]});
+            TestBed.overrideProvider(
+                'a', {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new SkipSelf(), 'dep']]});
+            TestBed.configureTestingModule(
+                {providers: [{provide: 'dep', useValue: 'parentDepValue'}]});
 
-                const compiler = TestBed.get(Compiler) as Compiler;
-                const modFactory = compiler.compileModuleSync(MyModule);
-                expect(modFactory.create(getTestBed()).injector.get('a'))
-                    .toBe('mockA: parentDepValue');
-              });
+            const compiler = TestBed.get(Compiler) as Compiler;
+            const modFactory = compiler.compileModuleSync(MyModule);
+            expect(modFactory.create(getTestBed()).injector.get('a')).toBe('mockA: parentDepValue');
+          });
 
           it('should keep imported NgModules eager', () => {
             let someModule: SomeModule|undefined;
@@ -554,147 +551,137 @@ class CompWithUrlTemplate {
         });
 
         describe('in Components', () => {
-          fixmeIvy('FW-788: Support metadata override in TestBed (for AOT-compiled components)')
-              .it('should support useValue', () => {
-                @Component({
-                  template: '',
-                  providers: [
-                    {provide: 'a', useValue: 'aValue'},
-                  ]
-                })
-                class MComp {
-                }
+          it('should support useValue', () => {
+            @Component({
+              template: '',
+              providers: [
+                {provide: 'a', useValue: 'aValue'},
+              ]
+            })
+            class MComp {
+            }
 
-                TestBed.overrideProvider('a', {useValue: 'mockValue'});
-                const ctx =
-                    TestBed.configureTestingModule({declarations: [MComp]}).createComponent(MComp);
+            TestBed.overrideProvider('a', {useValue: 'mockValue'});
+            const ctx =
+                TestBed.configureTestingModule({declarations: [MComp]}).createComponent(MComp);
 
-                expect(ctx.debugElement.injector.get('a')).toBe('mockValue');
-              });
+            expect(ctx.debugElement.injector.get('a')).toBe('mockValue');
+          });
 
-          fixmeIvy('FW-788: Support metadata override in TestBed (for AOT-compiled components)')
-              .it('should support useFactory', () => {
-                @Component({
-                  template: '',
-                  providers: [
-                    {provide: 'dep', useValue: 'depValue'},
-                    {provide: 'a', useValue: 'aValue'},
-                  ]
-                })
-                class MyComp {
-                }
+          it('should support useFactory', () => {
+            @Component({
+              template: '',
+              providers: [
+                {provide: 'dep', useValue: 'depValue'},
+                {provide: 'a', useValue: 'aValue'},
+              ]
+            })
+            class MyComp {
+            }
 
-                TestBed.overrideProvider(
-                    'a', {useFactory: (dep: any) => `mockA: ${dep}`, deps: ['dep']});
-                const ctx = TestBed.configureTestingModule({declarations: [MyComp]})
-                                .createComponent(MyComp);
+            TestBed.overrideProvider(
+                'a', {useFactory: (dep: any) => `mockA: ${dep}`, deps: ['dep']});
+            const ctx =
+                TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
 
-                expect(ctx.debugElement.injector.get('a')).toBe('mockA: depValue');
-              });
+            expect(ctx.debugElement.injector.get('a')).toBe('mockA: depValue');
+          });
 
-          fixmeIvy('FW-788: Support metadata override in TestBed (for AOT-compiled components)')
-              .it('should support @Optional without matches', () => {
-                @Component({
-                  template: '',
-                  providers: [
-                    {provide: 'a', useValue: 'aValue'},
-                  ]
-                })
-                class MyComp {
-                }
+          it('should support @Optional without matches', () => {
+            @Component({
+              template: '',
+              providers: [
+                {provide: 'a', useValue: 'aValue'},
+              ]
+            })
+            class MyComp {
+            }
 
-                TestBed.overrideProvider(
-                    'a',
-                    {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new Optional(), 'dep']]});
-                const ctx = TestBed.configureTestingModule({declarations: [MyComp]})
-                                .createComponent(MyComp);
+            TestBed.overrideProvider(
+                'a', {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new Optional(), 'dep']]});
+            const ctx =
+                TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
 
-                expect(ctx.debugElement.injector.get('a')).toBe('mockA: null');
-              });
+            expect(ctx.debugElement.injector.get('a')).toBe('mockA: null');
+          });
 
-          fixmeIvy('FW-788: Support metadata override in TestBed (for AOT-compiled components)')
-              .it('should support Optional with matches', () => {
-                @Component({
-                  template: '',
-                  providers: [
-                    {provide: 'dep', useValue: 'depValue'},
-                    {provide: 'a', useValue: 'aValue'},
-                  ]
-                })
-                class MyComp {
-                }
+          it('should support Optional with matches', () => {
+            @Component({
+              template: '',
+              providers: [
+                {provide: 'dep', useValue: 'depValue'},
+                {provide: 'a', useValue: 'aValue'},
+              ]
+            })
+            class MyComp {
+            }
 
-                TestBed.overrideProvider(
-                    'a',
-                    {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new Optional(), 'dep']]});
-                const ctx = TestBed.configureTestingModule({declarations: [MyComp]})
-                                .createComponent(MyComp);
+            TestBed.overrideProvider(
+                'a', {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new Optional(), 'dep']]});
+            const ctx =
+                TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
 
-                expect(ctx.debugElement.injector.get('a')).toBe('mockA: depValue');
-              });
+            expect(ctx.debugElement.injector.get('a')).toBe('mockA: depValue');
+          });
 
-          fixmeIvy('FW-788: Support metadata override in TestBed (for AOT-compiled components)')
-              .it('should support SkipSelf', () => {
-                @Directive({
-                  selector: '[myDir]',
-                  providers: [
-                    {provide: 'a', useValue: 'aValue'},
-                    {provide: 'dep', useValue: 'depValue'},
-                  ]
-                })
-                class MyDir {
-                }
+          it('should support SkipSelf', () => {
+            @Directive({
+              selector: '[myDir]',
+              providers: [
+                {provide: 'a', useValue: 'aValue'},
+                {provide: 'dep', useValue: 'depValue'},
+              ]
+            })
+            class MyDir {
+            }
 
-                @Component({
-                  template: '<div myDir></div>',
-                  providers: [
-                    {provide: 'dep', useValue: 'parentDepValue'},
-                  ]
-                })
-                class MyComp {
-                }
+            @Component({
+              template: '<div myDir></div>',
+              providers: [
+                {provide: 'dep', useValue: 'parentDepValue'},
+              ]
+            })
+            class MyComp {
+            }
 
-                TestBed.overrideProvider(
-                    'a',
-                    {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new SkipSelf(), 'dep']]});
-                const ctx = TestBed.configureTestingModule({declarations: [MyComp, MyDir]})
-                                .createComponent(MyComp);
-                expect(ctx.debugElement.children[0].injector.get('a'))
-                    .toBe('mockA: parentDepValue');
-              });
+            TestBed.overrideProvider(
+                'a', {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new SkipSelf(), 'dep']]});
+            const ctx = TestBed.configureTestingModule({declarations: [MyComp, MyDir]})
+                            .createComponent(MyComp);
+            expect(ctx.debugElement.children[0].injector.get('a')).toBe('mockA: parentDepValue');
+          });
 
-          fixmeIvy('FW-788: Support metadata override in TestBed (for AOT-compiled components)')
-              .it('should support multiple providers in a template', () => {
-                @Directive({
-                  selector: '[myDir1]',
-                  providers: [
-                    {provide: 'a', useValue: 'aValue1'},
-                  ]
-                })
-                class MyDir1 {
-                }
+          it('should support multiple providers in a template', () => {
+            @Directive({
+              selector: '[myDir1]',
+              providers: [
+                {provide: 'a', useValue: 'aValue1'},
+              ]
+            })
+            class MyDir1 {
+            }
 
-                @Directive({
-                  selector: '[myDir2]',
-                  providers: [
-                    {provide: 'a', useValue: 'aValue2'},
-                  ]
-                })
-                class MyDir2 {
-                }
+            @Directive({
+              selector: '[myDir2]',
+              providers: [
+                {provide: 'a', useValue: 'aValue2'},
+              ]
+            })
+            class MyDir2 {
+            }
 
-                @Component({
-                  template: '<div myDir1></div><div myDir2></div>',
-                })
-                class MyComp {
-                }
+            @Component({
+              template: '<div myDir1></div><div myDir2></div>',
+            })
+            class MyComp {
+            }
 
-                TestBed.overrideProvider('a', {useValue: 'mockA'});
-                const ctx = TestBed.configureTestingModule({declarations: [MyComp, MyDir1, MyDir2]})
-                                .createComponent(MyComp);
-                expect(ctx.debugElement.children[0].injector.get('a')).toBe('mockA');
-                expect(ctx.debugElement.children[1].injector.get('a')).toBe('mockA');
-              });
+            TestBed.overrideProvider('a', {useValue: 'mockA'});
+            const ctx = TestBed.configureTestingModule({declarations: [MyComp, MyDir1, MyDir2]})
+                            .createComponent(MyComp);
+            expect(ctx.debugElement.children[0].injector.get('a')).toBe('mockA');
+            expect(ctx.debugElement.children[1].injector.get('a')).toBe('mockA');
+          });
 
           describe('injecting eager providers into an eager overwritten provider', () => {
             @Component({
@@ -709,25 +696,24 @@ class CompWithUrlTemplate {
               constructor(@Inject('a') a: any, @Inject('b') b: any) {}
             }
 
-            fixmeIvy('FW-788: Support metadata override in TestBed (for AOT-compiled components)')
-                .it('should inject providers that were declared before it', () => {
-                  TestBed.overrideProvider(
-                      'b', {useFactory: (a: string) => `mockB: ${a}`, deps: ['a']});
-                  const ctx = TestBed.configureTestingModule({declarations: [MyComp]})
-                                  .createComponent(MyComp);
+            // akushnir
+            it('should inject providers that were declared before it', () => {
+              TestBed.overrideProvider(
+                  'b', {useFactory: (a: string) => `mockB: ${a}`, deps: ['a']});
+              const ctx =
+                  TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
 
-                  expect(ctx.debugElement.injector.get('b')).toBe('mockB: aValue');
-                });
+              expect(ctx.debugElement.injector.get('b')).toBe('mockB: aValue');
+            });
 
-            fixmeIvy('FW-788: Support metadata override in TestBed (for AOT-compiled components)')
-                .it('should inject providers that were declared after it', () => {
-                  TestBed.overrideProvider(
-                      'a', {useFactory: (b: string) => `mockA: ${b}`, deps: ['b']});
-                  const ctx = TestBed.configureTestingModule({declarations: [MyComp]})
-                                  .createComponent(MyComp);
+            it('should inject providers that were declared after it', () => {
+              TestBed.overrideProvider(
+                  'a', {useFactory: (b: string) => `mockA: ${b}`, deps: ['b']});
+              const ctx =
+                  TestBed.configureTestingModule({declarations: [MyComp]}).createComponent(MyComp);
 
-                  expect(ctx.debugElement.injector.get('a')).toBe('mockA: bValue');
-                });
+              expect(ctx.debugElement.injector.get('a')).toBe('mockA: bValue');
+            });
           });
         });
 
@@ -740,7 +726,7 @@ class CompWithUrlTemplate {
       });
 
       describe('overrideTemplateUsingTestingModule', () => {
-        fixmeIvy('FW-788: Support metadata override in TestBed (for AOT-compiled components)')
+        fixmeIvy('FW-851: TestBed.overrideTemplateUsingTestingModule is not implemented')
             .it('should compile the template in the context of the testing module', () => {
               @Component({selector: 'comp', template: 'a'})
               class MyComponent {
@@ -769,7 +755,7 @@ class CompWithUrlTemplate {
               expect(testDir !.test).toBe('some prop');
             });
 
-        fixmeIvy('FW-788: Support metadata override in TestBed (for AOT-compiled components)')
+        fixmeIvy('FW-851: TestBed.overrideTemplateUsingTestingModule is not implemented')
             .it('should throw if the TestBed is already created', () => {
               @Component({selector: 'comp', template: 'a'})
               class MyComponent {
@@ -782,7 +768,7 @@ class CompWithUrlTemplate {
                       /Cannot override template when the test module has already been instantiated/);
             });
 
-        fixmeIvy('FW-788: Support metadata override in TestBed (for AOT-compiled components)')
+        fixmeIvy('FW-851: TestBed.overrideTemplateUsingTestingModule is not implemented')
             .it('should reset overrides when the testing module is resetted', () => {
               @Component({selector: 'comp', template: 'a'})
               class MyComponent {

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -696,7 +696,6 @@ class CompWithUrlTemplate {
               constructor(@Inject('a') a: any, @Inject('b') b: any) {}
             }
 
-            // akushnir
             it('should inject providers that were declared before it', () => {
               TestBed.overrideProvider(
                   'b', {useFactory: (a: string) => `mockB: ${a}`, deps: ['a']});


### PR DESCRIPTION
Prior to this change, provider overrides defined via TestBed.overrideProvider were not applied to Components/Directives. Now providers are taken into account while compiling Components/Directives.

Also due to the fact that ngComponentDef/ngDirectiveDef/ngPipeDef were overwritten during subsequent compilations, additional logic was added to keep existing def and restore it once a test is completed.

This PR resolves issue FW-788.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No