### PR TITLE
fix(ivy): call `hostBindings` function with proper element index

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -198,7 +198,7 @@ export function createRootComponent<T>(
   if (tView.firstTemplatePass && componentDef.hostBindings) {
     const rootTNode = getPreviousOrParentTNode();
     setCurrentDirectiveDef(componentDef);
-    componentDef.hostBindings(RenderFlags.Create, component, rootTNode.index);
+    componentDef.hostBindings(RenderFlags.Create, component, rootTNode.index - HEADER_OFFSET);
     setCurrentDirectiveDef(null);
   }
 

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1538,7 +1538,7 @@ function invokeDirectivesHostBindings(tView: TView, viewData: LView, tNode: TNod
     if (def.hostBindings) {
       const previousExpandoLength = expando.length;
       setCurrentDirectiveDef(def);
-      def.hostBindings !(RenderFlags.Create, directive, tNode.index);
+      def.hostBindings !(RenderFlags.Create, directive, tNode.index - HEADER_OFFSET);
       setCurrentDirectiveDef(null);
       // `hostBindings` function may or may not contain `allocHostVars` call
       // (e.g. it may not if it only contains host listeners), so we need to check whether

--- a/packages/core/test/render3/host_binding_spec.ts
+++ b/packages/core/test/render3/host_binding_spec.ts
@@ -54,7 +54,7 @@ describe('host bindings', () => {
           allocHostVars(1);
         }
         if (rf & RenderFlags.Update) {
-          elementProperty(elementIndex, 'id', bind(ctx.id));
+          elementProperty(elementIndex, 'id', bind(ctx.id), null, true);
         }
       }
     });
@@ -75,7 +75,7 @@ describe('host bindings', () => {
           allocHostVars(1);
         }
         if (rf & RenderFlags.Update) {
-          elementProperty(elIndex, 'id', bind(ctx.id));
+          elementProperty(elIndex, 'id', bind(ctx.id), null, true);
         }
       },
       template: (rf: RenderFlags, ctx: HostBindingComp) => {}
@@ -99,7 +99,7 @@ describe('host bindings', () => {
             allocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
-            elementProperty(elementIndex, 'className', bind(ctx.klass));
+            elementProperty(elementIndex, 'className', bind(ctx.klass), null, true);
           }
         }
       });
@@ -137,7 +137,7 @@ describe('host bindings', () => {
             allocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
-            elementProperty(elIndex, 'id', bind(ctx.id));
+            elementProperty(elIndex, 'id', bind(ctx.id), null, true);
           }
         },
         template: (rf: RenderFlags, ctx: HostBindingComp) => {}
@@ -182,7 +182,7 @@ describe('host bindings', () => {
             allocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
-            elementProperty(elIndex, 'id', bind(ctx.id));
+            elementProperty(elIndex, 'id', bind(ctx.id), null, true);
           }
         },
         template: (rf: RenderFlags, ctx: CompWithProviders) => {},
@@ -218,7 +218,7 @@ describe('host bindings', () => {
             allocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
-            elementProperty(elIndex, 'title', bind(ctx.title));
+            elementProperty(elIndex, 'title', bind(ctx.title), null, true);
           }
         },
         template: (rf: RenderFlags, ctx: HostTitleComp) => {}
@@ -271,7 +271,7 @@ describe('host bindings', () => {
             allocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
-            elementProperty(elIndex, 'id', bind(ctx.id));
+            elementProperty(elIndex, 'id', bind(ctx.id), null, true);
           }
         },
         template: (rf: RenderFlags, ctx: HostBindingComp) => {}
@@ -361,7 +361,7 @@ describe('host bindings', () => {
             allocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
-            elementProperty(elIndex, 'title', bind(ctx.value));
+            elementProperty(elIndex, 'title', bind(ctx.value), null, true);
           }
         },
         inputs: {inputValue: 'inputValue'}
@@ -594,10 +594,11 @@ describe('host bindings', () => {
             allocHostVars(8);
           }
           if (rf & RenderFlags.Update) {
-            elementProperty(elIndex, 'id', bind(pureFunction1(3, ff, ctx.id)));
-            elementProperty(elIndex, 'dir', bind(ctx.dir));
+            elementProperty(elIndex, 'id', bind(pureFunction1(3, ff, ctx.id)), null, true);
+            elementProperty(elIndex, 'dir', bind(ctx.dir), null, true);
             elementProperty(
-                elIndex, 'title', bind(pureFunction2(5, ff2, ctx.title, ctx.otherTitle)));
+                elIndex, 'title', bind(pureFunction2(5, ff2, ctx.title, ctx.otherTitle)), null,
+                true);
           }
         },
         template: (rf: RenderFlags, ctx: HostBindingComp) => {}
@@ -672,7 +673,7 @@ describe('host bindings', () => {
             allocHostVars(3);
           }
           if (rf & RenderFlags.Update) {
-            elementProperty(elIndex, 'id', bind(pureFunction1(1, ff, ctx.id)));
+            elementProperty(elIndex, 'id', bind(pureFunction1(1, ff, ctx.id)), null, true);
           }
         },
         template: (rf: RenderFlags, ctx: HostBindingComp) => {}
@@ -703,7 +704,7 @@ describe('host bindings', () => {
             allocHostVars(3);
           }
           if (rf & RenderFlags.Update) {
-            elementProperty(elIndex, 'title', bind(pureFunction1(1, ff1, ctx.title)));
+            elementProperty(elIndex, 'title', bind(pureFunction1(1, ff1, ctx.title)), null, true);
           }
         }
       });
@@ -760,7 +761,7 @@ describe('host bindings', () => {
             allocHostVars(3);
           }
           if (rf & RenderFlags.Update) {
-            elementProperty(elIndex, 'title', bind(pureFunction1(1, ff1, ctx.title)));
+            elementProperty(elIndex, 'title', bind(pureFunction1(1, ff1, ctx.title)), null, true);
           }
         }
       });
@@ -831,10 +832,12 @@ describe('host bindings', () => {
           }
           if (rf & RenderFlags.Update) {
             elementProperty(
-                elIndex, 'id', bind(ctx.condition ? pureFunction1(2, ff, ctx.id) : 'green'));
+                elIndex, 'id', bind(ctx.condition ? pureFunction1(2, ff, ctx.id) : 'green'), null,
+                true);
             elementProperty(
                 elIndex, 'title',
-                bind(ctx.otherCondition ? pureFunction1(4, ff1, ctx.title) : 'other title'));
+                bind(ctx.otherCondition ? pureFunction1(4, ff1, ctx.title) : 'other title'), null,
+                true);
           }
         },
         template: (rf: RenderFlags, ctx: HostBindingComp) => {}
@@ -891,7 +894,7 @@ describe('host bindings', () => {
             allocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
-            elementProperty(elementIndex, 'id', bind(ctx.id));
+            elementProperty(elementIndex, 'id', bind(ctx.id), null, true);
           }
         },
         factory: () => superDir = new SuperDirective(),
@@ -909,7 +912,7 @@ describe('host bindings', () => {
             allocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
-            elementProperty(elementIndex, 'title', bind(ctx.title));
+            elementProperty(elementIndex, 'title', bind(ctx.title), null, true);
           }
         },
         factory: () => subDir = new SubDirective(),
@@ -997,7 +1000,7 @@ describe('host bindings', () => {
             allocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
-            elementProperty(elIndex, 'id', bind(ctx.foos.length));
+            elementProperty(elIndex, 'id', bind(ctx.foos.length), null, true);
           }
         },
         contentQueries: (dirIndex) => { registerContentQuery(query(null, ['foo']), dirIndex); },
@@ -1056,7 +1059,7 @@ describe('host bindings', () => {
             allocHostVars(1);
           }
           if (rf & RenderFlags.Update) {
-            elementProperty(elIndex, 'id', bind(ctx.myValue));
+            elementProperty(elIndex, 'id', bind(ctx.myValue), null, true);
           }
         },
         template: (rf: RenderFlags, cmp: HostBindingWithContentHooks) => {}


### PR DESCRIPTION
We invoked `hostBindings` function in Create and Update modes with different element index due to the fact that we did not subtract HEADER_OFFSET from the index before passing it to `hostBindings` function in Create mode. Now we subtract HEADER_OFFSET value before invoking `hostBindings`, which makes Create and Update calls consistent.

This PR resolves issue FW-847.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No