### PR TITLE
test(ivy): enable all test for @angular/common

### DIFF
--- a/packages/common/test/BUILD.bazel
+++ b/packages/common/test/BUILD.bazel
@@ -15,7 +15,6 @@ ts_library(
         "//packages/platform-browser",
         "//packages/platform-browser-dynamic",
         "//packages/platform-browser/testing",
-        "//packages/private/testing",
     ],
 )
 

--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -11,7 +11,6 @@ import {NgComponentOutlet} from '@angular/common/src/directives/ng_component_out
 import {Compiler, Component, ComponentRef, Inject, InjectionToken, Injector, NO_ERRORS_SCHEMA, NgModule, NgModuleFactory, Optional, QueryList, TemplateRef, Type, ViewChild, ViewChildren, ViewContainerRef} from '@angular/core';
 import {TestBed, async} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {fixmeIvy} from '@angular/private/testing';
 
 describe('insert/remove', () => {
 
@@ -157,22 +156,21 @@ describe('insert/remove', () => {
        expect(fixture.nativeElement).toHaveText('baz');
      }));
 
-  fixmeIvy('FW-739: destroy on NgModuleRef is not being called')
-      .it('should clean up moduleRef, if supplied', async(() => {
-            let destroyed = false;
-            const compiler = TestBed.get(Compiler) as Compiler;
-            const fixture = TestBed.createComponent(TestComponent);
-            fixture.componentInstance.module = compiler.compileModuleSync(TestModule2);
-            fixture.componentInstance.currentComponent = Module2InjectedComponent;
-            fixture.detectChanges();
+  it('should clean up moduleRef, if supplied', async(() => {
+       let destroyed = false;
+       const compiler = TestBed.get(Compiler) as Compiler;
+       const fixture = TestBed.createComponent(TestComponent);
+       fixture.componentInstance.module = compiler.compileModuleSync(TestModule2);
+       fixture.componentInstance.currentComponent = Module2InjectedComponent;
+       fixture.detectChanges();
 
-            const moduleRef = fixture.componentInstance.ngComponentOutlet['_moduleRef'] !;
-            spyOn(moduleRef, 'destroy').and.callThrough();
+       const moduleRef = fixture.componentInstance.ngComponentOutlet['_moduleRef'] !;
+       spyOn(moduleRef, 'destroy').and.callThrough();
 
-            expect(moduleRef.destroy).not.toHaveBeenCalled();
-            fixture.destroy();
-            expect(moduleRef.destroy).toHaveBeenCalled();
-          }));
+       expect(moduleRef.destroy).not.toHaveBeenCalled();
+       fixture.destroy();
+       expect(moduleRef.destroy).toHaveBeenCalled();
+     }));
 
   it('should not re-create moduleRef when it didn\'t actually change', async(() => {
        const compiler = TestBed.get(Compiler) as Compiler;


### PR DESCRIPTION
It turns out that #27676 fixed the last remaining test in the `@angular/common` package - 100% tests are passing now!