### PR TITLE
build: improve error message for upgrade test helper

### DIFF
--- a/packages/upgrade/test/common/test_helpers.ts
+++ b/packages/upgrade/test/common/test_helpers.ts
@@ -69,7 +69,18 @@ export function createWithEachNg1VersionFn(setNg1: typeof setAngularJSGlobal) {
                 (prev, file) => prev.then(() => new Promise<void>((resolve, reject) => {
                                             const script = document.createElement('script');
                                             script.async = true;
-                                            script.onerror = reject;
+                                            script.onerror = () => {
+                                              // Whenever the script failed loading, browsers will
+                                              // just pass an "ErrorEvent" which does not contain
+                                              // useful information on most browsers we run tests
+                                              // against. In order to avoid writing logic to convert
+                                              // the event into a readable error and since just
+                                              // passing the event might cause people to spend
+                                              // unnecessary time debugging the "ErrorEvent", we
+                                              // create a simple error that doesn't imply that there
+                                              // is a lot of information within the "ErrorEvent".
+                                              reject(`An error occurred while loading: "${file}".`);
+                                            };
                                             script.onload = () => {
                                               document.body.removeChild(script);
                                               resolve();


### PR DESCRIPTION
Currently whenever the upgrade test helper fails to load a given AngularJS version, the error that will be rejected is technically not an error because the `onerror` callback is not returning an error, but an "ErrorEvent".

Since that `ErrorEvent` is basically just rejected, browsers will print the error as followed:

```
Failed: [object Event]
```

This is not helpful at all and also implies that there _might_ be more information hidden within the `Event` instance. Unfortunately that's not the case (at least on browsers we test against) and the logic to extract the data from the event would be not worth the effort, we just return a simple custom `Error` that won't imply that there is more information hidden.