### PR TITLE
build: load angular.js minified output in upgrade tests

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -23,8 +23,13 @@ filegroup(
 filegroup(
     name = "angularjs_scripts",
     srcs = [
+        # We also declare the unminfied AngularJS files since these can be used for
+        # local debugging (e.g. see: packages/upgrade/test/common/test_helpers.ts)
+        "@ngdeps//node_modules/angular:angular.js",
         "@ngdeps//node_modules/angular:angular.min.js",
+        "@ngdeps//node_modules/angular-1.5:angular.js",
         "@ngdeps//node_modules/angular-1.5:angular.min.js",
+        "@ngdeps//node_modules/angular-1.6:angular.js",
         "@ngdeps//node_modules/angular-1.6:angular.min.js",
         "@ngdeps//node_modules/angular-mocks:angular-mocks.js",
         "@ngdeps//node_modules/angular-mocks-1.5:angular-mocks.js",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -23,9 +23,9 @@ filegroup(
 filegroup(
     name = "angularjs_scripts",
     srcs = [
-        "@ngdeps//node_modules/angular:angular.js",
-        "@ngdeps//node_modules/angular-1.5:angular.js",
-        "@ngdeps//node_modules/angular-1.6:angular.js",
+        "@ngdeps//node_modules/angular:angular.min.js",
+        "@ngdeps//node_modules/angular-1.5:angular.min.js",
+        "@ngdeps//node_modules/angular-1.6:angular.min.js",
         "@ngdeps//node_modules/angular-mocks:angular-mocks.js",
         "@ngdeps//node_modules/angular-mocks-1.5:angular-mocks.js",
         "@ngdeps//node_modules/angular-mocks-1.6:angular-mocks.js",

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -29,11 +29,11 @@ module.exports = function(config) {
       {pattern: 'dist/all/@angular/**/*.js', included: false, watched: true},
 
       // Serve AngularJS for `ngUpgrade` testing.
-      {pattern: 'node_modules/angular-1.5/angular.min.js', included: false, watched: false},
+      {pattern: 'node_modules/angular-1.5/angular?(.min).js', included: false, watched: false},
       {pattern: 'node_modules/angular-mocks-1.5/angular-mocks.js', included: false, watched: false},
-      {pattern: 'node_modules/angular-1.6/angular.min.js', included: false, watched: false},
+      {pattern: 'node_modules/angular-1.6/angular?(.min).js', included: false, watched: false},
       {pattern: 'node_modules/angular-mocks-1.6/angular-mocks.js', included: false, watched: false},
-      {pattern: 'node_modules/angular/angular.min.js', included: false, watched: false},
+      {pattern: 'node_modules/angular/angular?(.min).js', included: false, watched: false},
       {pattern: 'node_modules/angular-mocks/angular-mocks.js', included: false, watched: false},
 
       'node_modules/core-js/client/core.js',

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -29,11 +29,11 @@ module.exports = function(config) {
       {pattern: 'dist/all/@angular/**/*.js', included: false, watched: true},
 
       // Serve AngularJS for `ngUpgrade` testing.
-      {pattern: 'node_modules/angular-1.5/angular.js', included: false, watched: false},
+      {pattern: 'node_modules/angular-1.5/angular.min.js', included: false, watched: false},
       {pattern: 'node_modules/angular-mocks-1.5/angular-mocks.js', included: false, watched: false},
-      {pattern: 'node_modules/angular-1.6/angular.js', included: false, watched: false},
+      {pattern: 'node_modules/angular-1.6/angular.min.js', included: false, watched: false},
       {pattern: 'node_modules/angular-mocks-1.6/angular-mocks.js', included: false, watched: false},
-      {pattern: 'node_modules/angular/angular.js', included: false, watched: false},
+      {pattern: 'node_modules/angular/angular.min.js', included: false, watched: false},
       {pattern: 'node_modules/angular-mocks/angular-mocks.js', included: false, watched: false},
 
       'node_modules/core-js/client/core.js',

--- a/packages/upgrade/test/common/test_helpers.ts
+++ b/packages/upgrade/test/common/test_helpers.ts
@@ -11,15 +11,15 @@ import {setAngularJSGlobal} from '@angular/upgrade/src/common/angular1';
 const ng1Versions = [
   {
     label: '1.5',
-    files: ['angular-1.5/angular.js', 'angular-mocks-1.5/angular-mocks.js'],
+    files: ['angular-1.5/angular.min.js', 'angular-mocks-1.5/angular-mocks.js'],
   },
   {
     label: '1.6',
-    files: ['angular-1.6/angular.js', 'angular-mocks-1.6/angular-mocks.js'],
+    files: ['angular-1.6/angular.min.js', 'angular-mocks-1.6/angular-mocks.js'],
   },
   {
     label: '1.7',
-    files: ['angular/angular.js', 'angular-mocks/angular-mocks.js'],
+    files: ['angular/angular.min.js', 'angular-mocks/angular-mocks.js'],
   },
 ];
 

--- a/packages/upgrade/test/common/test_helpers.ts
+++ b/packages/upgrade/test/common/test_helpers.ts
@@ -7,19 +7,23 @@
  */
 import {setAngularJSGlobal} from '@angular/upgrade/src/common/angular1';
 
+// Whether the upgrade tests should run against AngularJS minified or not. This can be
+// temporarily switched to "false" in order to make it easy to debug AngularJS locally.
+const TEST_MINIFIED = true;
+const ANGULARJS_FILENAME = TEST_MINIFIED ? 'angular.min.js' : 'angular.js';
 
 const ng1Versions = [
   {
     label: '1.5',
-    files: ['angular-1.5/angular.min.js', 'angular-mocks-1.5/angular-mocks.js'],
+    files: [`angular-1.5/${ANGULARJS_FILENAME}`, 'angular-mocks-1.5/angular-mocks.js'],
   },
   {
     label: '1.6',
-    files: ['angular-1.6/angular.min.js', 'angular-mocks-1.6/angular-mocks.js'],
+    files: [`angular-1.6/${ANGULARJS_FILENAME}`, 'angular-mocks-1.6/angular-mocks.js'],
   },
   {
     label: '1.7',
-    files: ['angular/angular.min.js', 'angular-mocks/angular-mocks.js'],
+    files: [`angular/${ANGULARJS_FILENAME}`, 'angular-mocks/angular-mocks.js'],
   },
 ];
 


### PR DESCRIPTION
We should try loading Angular.JS for the upgrade tests in their minfied output. 

There seems to be a lot flakiness in regards to loading `AngularJS` within Travis, and the `onerror` messages aren't really too helpful. In order to reduce the payload that will be passed through the Saucelabs tunnel, we should try to load the minfied output files.