### PR TITLE
fix(bazel): Set module_name and enable ng test

### DIFF
--- a/integration/bazel-schematics/test.sh
+++ b/integration/bazel-schematics/test.sh
@@ -9,15 +9,13 @@ function test() {
   # Create project
   ng new demo --collection=@angular/bazel --defaults --skip-git
   cd demo
-  # TODO(kyliau): Use bazel commands directly for now. Once 7.1.4 is out we can
-  # switch to use builders (ng build and ng test)
   # Run build
+  # TODO(kyliau): Use `bazel build` for now. Running `ng build` requires
+  # node_modules to be available in project directory.
   bazel build //src:bundle
   # Run test
-  bazel test \
-    //src:test \
-    //e2e:devserver_test \
-    //e2e:prodserver_test
+  ng test
+  ng e2e
 }
 
 test

--- a/packages/bazel/src/builders/BUILD.bazel
+++ b/packages/bazel/src/builders/BUILD.bazel
@@ -20,6 +20,7 @@ ts_library(
     data = [
         "schema.json",
     ],
+    module_name = "@angular/bazel/src/builders",
     deps = [
         "@ngdeps//@angular-devkit/architect",
         "@ngdeps//@angular-devkit/core",

--- a/packages/bazel/src/schematics/bazel-workspace/files/e2e/BUILD.bazel.template
+++ b/packages/bazel/src/schematics/bazel-workspace/files/e2e/BUILD.bazel.template
@@ -12,7 +12,10 @@ ts_library(
       "@npm//@types/node",
       "@npm//jasmine",
       "@npm//protractor",
-    ]
+    ],
+    data = [
+      "//:tsconfig.json",
+    ],
 )
 
 protractor_web_test_suite(


### PR DESCRIPTION
Relative imports in Typescript files only work when module_name is
defined in ts_library (when run in Node.js).
See issue https://github.com/bazelbuild/rules_typescript/issues/360

With that fixed, `ng test` now works.

`ng build` requires `node_modules` to be available in the project
directory, so it's not usable yet. Running `yarn` in project directory
does not work because of postinstall version check.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
