### PR TITLE
build(packaging): Use natives v1.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,5 +143,8 @@
     "vlq": "0.2.2",
     "vrsource-tslint-rules": "5.1.1",
     "webpack": "1.12.9"
+  },
+  "resolutions": {
+    "natives": "1.1.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5640,10 +5640,10 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-natives@^1.1.0:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.4.tgz#2f0f224fc9a7dd53407c7667c84cf8dbe773de58"
-  integrity sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==
+natives@1.1.6, natives@^1.1.0:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
+  integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
 needle@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
Add manual resolution for natives v1.1.6 because the current resolved
version 1.1.4 does not work with Node v10.14.2

Error: ReferenceError: internalBinding is not defined

See issue https://github.com/gulpjs/gulp/issues/2246

```
$ yarn why natives
yarn why v1.12.3
[1/4] Why do we have the module "natives"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "natives@1.1.6"
info Reasons this module exists
   - "gulp#vinyl-fs#graceful-fs" depends on it
   - Hoisted from "gulp#vinyl-fs#graceful-fs#natives"
   - Hoisted from "browserstacktunnel-wrapper#unzip#fstream#graceful-fs#natives"
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
