### PR TITLE
fix(bazel): devserver entry_module should have underscore name

### DIFF
--- a/packages/bazel/src/schematics/bazel-workspace/files/src/BUILD.bazel.template
+++ b/packages/bazel/src/schematics/bazel-workspace/files/src/BUILD.bazel.template
@@ -58,7 +58,7 @@ ts_devserver(
         "npm/node_modules/zone.js/dist",
         "npm/node_modules/tslib",
     ],
-    entry_module = "<%= name %>/src/main.dev",
+    entry_module = "<%= utils.underscore(name) %>/src/main.dev",
     serving_path = "/bundle.min.js",
     static_files = [
         "@npm//node_modules/zone.js:dist/zone.min.js",

--- a/packages/bazel/src/schematics/bazel-workspace/index_spec.ts
+++ b/packages/bazel/src/schematics/bazel-workspace/index_spec.ts
@@ -42,6 +42,15 @@ describe('Bazel-workspace Schematic', () => {
     expect(workspace).toMatch('ANGULAR_VERSION = "6.6.6"');
   });
 
+  it('should have the correct entry_module for devserver', () => {
+    const options = {...defaultOptions, name: 'demo-app'};
+    const host = schematicRunner.runSchematic('bazel-workspace', options);
+    const {files} = host;
+    expect(files).toContain('/demo-app/src/BUILD.bazel');
+    const content = host.readContent('/demo-app/src/BUILD.bazel');
+    expect(content).toContain('entry_module = "demo_app/src/main.dev"');
+  });
+
   describe('WORKSPACE', () => {
     it('should contain project name', () => {
       const options = {...defaultOptions};


### PR DESCRIPTION
This commit fixes a bug whereby the path of the entry_module is not
consistent with the workspace name, which does not permit dashes
in the name.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
