### PR TITLE
fix(ivy): apply all overrides from TestBed, not the last one only

### DIFF
--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -388,12 +388,11 @@ class CompWithUrlTemplate {
                 .overridePipe(SomePipe, {set: {name: 'somePipe'}})
                 .overridePipe(SomePipe, {add: {pure: false}});
           });
-          fixmeIvy('FW-788: Support metadata override in TestBed (for AOT-compiled components)')
-              .it('should work', () => {
-                const compFixture = TestBed.createComponent(SomeComponent);
-                compFixture.detectChanges();
-                expect(compFixture.nativeElement).toHaveText('transformed hello');
-              });
+          it('should work', () => {
+            const compFixture = TestBed.createComponent(SomeComponent);
+            compFixture.detectChanges();
+            expect(compFixture.nativeElement).toHaveText('transformed hello');
+          });
         });
 
         describe('template', () => {


### PR DESCRIPTION
In some cases in our tests we can define multiple overrides for a given class. As a result, only the last override is actually applied due to the fact that we store overrides in a `Type<->Override` map. This update changes the logic to keep all overrides defined in a given test for a Type (i.e. `Type<->Override[]` map) and applies them one by one at resolution phase. This behavior is more inline with the previous TestBed.

An example test case (from `packages/platform-browser/test/testing_public_spec.ts`) that was failing is:

```
    TestBed
        .overridePipe(SomePipe, {set: {name: 'somePipe'}})
        .overridePipe(SomePipe, {add: {pure: false}});
```

As a result, the `pure` flag was changed, but the `name` remained the same, because the name-related override was replaced by the second one that sets the `pure` flag.

This PR resolves FW-852.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No