### PR TITLE
fix(ivy): resolve `forwardRefs` correctly in TestBed

### DIFF
--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -66,8 +66,7 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
           pipes: new Map(),
           encapsulation: metadata.encapsulation || ViewEncapsulation.Emulated,
           interpolation: metadata.interpolation,
-          viewProviders: metadata.viewProviders ? metadata.viewProviders.map(resolveForwardRef) :
-                                                  null,
+          viewProviders: metadata.viewProviders || null,
         };
         ngComponentDef = compiler.compileComponent(
             angularCoreEnv, `ng://${stringify(type)}/template.html`, meta);
@@ -151,7 +150,7 @@ function directiveMetadata(type: Type<any>, metadata: Directive): R3DirectiveMet
     typeSourceSpan: null !,
     usesInheritance: !extendsDirectlyFromObject(type),
     exportAs: metadata.exportAs || null,
-    providers: metadata.providers ? metadata.providers.map(resolveForwardRef) : null,
+    providers: metadata.providers || null,
   };
 }
 

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -133,6 +133,7 @@ export function extendsDirectlyFromObject(type: Type<any>): boolean {
 function directiveMetadata(type: Type<any>, metadata: Directive): R3DirectiveMetadataFacade {
   // Reflect inputs and outputs.
   const propMetadata = getReflect().propMetadata(type);
+
   return {
     name: type.name,
     type: type,

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -7,6 +7,7 @@
  */
 
 import {ComponentType} from '..';
+import {resolveForwardRef} from '../../di/forward_ref';
 import {Query} from '../../metadata/di';
 import {Component, Directive} from '../../metadata/directives';
 import {componentNeedsResolution, maybeQueueResolutionOfComponentResources} from '../../metadata/resource_loading';
@@ -65,7 +66,8 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
           pipes: new Map(),
           encapsulation: metadata.encapsulation || ViewEncapsulation.Emulated,
           interpolation: metadata.interpolation,
-          viewProviders: metadata.viewProviders || null,
+          viewProviders: metadata.viewProviders ? metadata.viewProviders.map(resolveForwardRef) :
+                                                  null,
         };
         ngComponentDef = compiler.compileComponent(
             angularCoreEnv, `ng://${stringify(type)}/template.html`, meta);
@@ -132,7 +134,6 @@ export function extendsDirectlyFromObject(type: Type<any>): boolean {
 function directiveMetadata(type: Type<any>, metadata: Directive): R3DirectiveMetadataFacade {
   // Reflect inputs and outputs.
   const propMetadata = getReflect().propMetadata(type);
-
   return {
     name: type.name,
     type: type,
@@ -150,12 +151,12 @@ function directiveMetadata(type: Type<any>, metadata: Directive): R3DirectiveMet
     typeSourceSpan: null !,
     usesInheritance: !extendsDirectlyFromObject(type),
     exportAs: metadata.exportAs || null,
-    providers: metadata.providers || null,
+    providers: metadata.providers ? metadata.providers.map(resolveForwardRef) : null,
   };
 }
 
 function convertToR3QueryPredicate(selector: any): any|string[] {
-  return typeof selector === 'string' ? splitByComma(selector) : selector;
+  return typeof selector === 'string' ? splitByComma(selector) : resolveForwardRef(selector);
 }
 
 export function convertToR3QueryMetadata(propertyName: string, ann: Query): R3QueryMetadataFacade {

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -107,10 +107,12 @@ export function compileNgModuleDefs(moduleType: NgModuleType, ngModule: NgModule
         ngModuleDef = getCompilerFacade().compileNgModule(
             angularCoreEnv, `ng://${moduleType.name}/ngModuleDef.js`, {
               type: moduleType,
-              bootstrap: flatten(ngModule.bootstrap || EMPTY_ARRAY),
-              declarations: declarations,
-              imports: flatten(ngModule.imports || EMPTY_ARRAY).map(expandModuleWithProviders),
-              exports: flatten(ngModule.exports || EMPTY_ARRAY).map(expandModuleWithProviders),
+              bootstrap: flatten(ngModule.bootstrap || EMPTY_ARRAY, resolveForwardRef),
+              declarations: declarations.map(resolveForwardRef),
+              imports: flatten(ngModule.imports || EMPTY_ARRAY, resolveForwardRef)
+                           .map(expandModuleWithProviders),
+              exports: flatten(ngModule.exports || EMPTY_ARRAY, resolveForwardRef)
+                           .map(expandModuleWithProviders),
               emitInline: true,
             });
       }
@@ -130,10 +132,10 @@ export function compileNgModuleDefs(moduleType: NgModuleType, ngModule: NgModule
           name: moduleType.name,
           type: moduleType,
           deps: reflectDependencies(moduleType),
-          providers: ngModule.providers || EMPTY_ARRAY,
+          providers: (ngModule.providers || EMPTY_ARRAY).map(resolveForwardRef),
           imports: [
-            ngModule.imports || EMPTY_ARRAY,
-            ngModule.exports || EMPTY_ARRAY,
+            (ngModule.imports || EMPTY_ARRAY).map(resolveForwardRef),
+            (ngModule.exports || EMPTY_ARRAY).map(resolveForwardRef),
           ],
         };
         ngInjectorDef = getCompilerFacade().compileInjector(
@@ -154,8 +156,8 @@ function verifySemanticsOfNgModuleDef(moduleType: NgModuleType): void {
   const errors: string[] = [];
   ngModuleDef.declarations.forEach(verifyDeclarationsHaveDefinitions);
   const combinedDeclarations: Type<any>[] = [
-    ...ngModuleDef.declarations,  //
-    ...flatten(ngModuleDef.imports.map(computeCombinedExports)),
+    ...ngModuleDef.declarations.map(resolveForwardRef),  //
+    ...flatten(ngModuleDef.imports.map(computeCombinedExports), resolveForwardRef),
   ];
   ngModuleDef.exports.forEach(verifyExportsAreDeclaredOrReExported);
   ngModuleDef.declarations.forEach(verifyDeclarationIsUnique);

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -132,7 +132,7 @@ export function compileNgModuleDefs(moduleType: NgModuleType, ngModule: NgModule
           name: moduleType.name,
           type: moduleType,
           deps: reflectDependencies(moduleType),
-          providers: (ngModule.providers || EMPTY_ARRAY).map(resolveForwardRef),
+          providers: ngModule.providers || EMPTY_ARRAY,
           imports: [
             (ngModule.imports || EMPTY_ARRAY).map(resolveForwardRef),
             (ngModule.exports || EMPTY_ARRAY).map(resolveForwardRef),

--- a/packages/core/test/forward_ref_integration_spec.ts
+++ b/packages/core/test/forward_ref_integration_spec.ts
@@ -10,19 +10,16 @@ import {CommonModule} from '@angular/common';
 import {Component, ContentChildren, Directive, Inject, NO_ERRORS_SCHEMA, NgModule, QueryList, asNativeElements, forwardRef} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {fixmeIvy} from '@angular/private/testing';
 
 describe('forwardRef integration', function() {
   beforeEach(() => { TestBed.configureTestingModule({imports: [Module], declarations: [App]}); });
 
-  fixmeIvy('FW-756: Pipes and directives from imported modules are not taken into account')
-      .it('should instantiate components which are declared using forwardRef', () => {
-        const a =
-            TestBed.configureTestingModule({schemas: [NO_ERRORS_SCHEMA]}).createComponent(App);
-        a.detectChanges();
-        expect(asNativeElements(a.debugElement.children)).toHaveText('frame(lock)');
-        expect(TestBed.get(ModuleFrame)).toBeDefined();
-      });
+  it('should instantiate components which are declared using forwardRef', () => {
+    const a = TestBed.configureTestingModule({schemas: [NO_ERRORS_SCHEMA]}).createComponent(App);
+    a.detectChanges();
+    expect(asNativeElements(a.debugElement.children)).toHaveText('frame(lock)');
+    expect(TestBed.get(ModuleFrame)).toBeDefined();
+  });
 });
 
 @NgModule({

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -486,8 +486,7 @@ function declareTests(config?: {useJit: boolean}) {
 
       describe('import/export', () => {
 
-        fixmeIvy(
-            'FW-681: TestBed: not possible to retrieve host property bindings for DebugElement')
+        fixmeIvy('FW-756: Pipes and directives from imported modules are not taken into account')
             .it('should support exported directives and pipes', () => {
               @NgModule(
                   {declarations: [SomeDirective, SomePipe], exports: [SomeDirective, SomePipe]})
@@ -509,8 +508,7 @@ function declareTests(config?: {useJit: boolean}) {
                   .toBe('transformed someValue');
             });
 
-        fixmeIvy(
-            'FW-681: TestBed: not possible to retrieve host property bindings for DebugElement')
+        fixmeIvy('FW-756: Pipes and directives from imported modules are not taken into account')
             .it('should support exported directives and pipes if the module is wrapped into an `ModuleWithProviders`',
                 () => {
                   @NgModule(
@@ -533,8 +531,7 @@ function declareTests(config?: {useJit: boolean}) {
                       .toBe('transformed someValue');
                 });
 
-        fixmeIvy(
-            'FW-681: TestBed: not possible to retrieve host property bindings for DebugElement')
+        fixmeIvy('FW-756: Pipes and directives from imported modules are not taken into account')
             .it('should support reexported modules', () => {
               @NgModule(
                   {declarations: [SomeDirective, SomePipe], exports: [SomeDirective, SomePipe]})
@@ -559,8 +556,7 @@ function declareTests(config?: {useJit: boolean}) {
                   .toBe('transformed someValue');
             });
 
-        fixmeIvy(
-            'FW-681: TestBed: not possible to retrieve host property bindings for DebugElement')
+        fixmeIvy('FW-756: Pipes and directives from imported modules are not taken into account')
             .it('should support exporting individual directives of an imported module', () => {
               @NgModule(
                   {declarations: [SomeDirective, SomePipe], exports: [SomeDirective, SomePipe]})

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -486,7 +486,8 @@ function declareTests(config?: {useJit: boolean}) {
 
       describe('import/export', () => {
 
-        fixmeIvy('FW-756: Pipes and directives from imported modules are not taken into account')
+        fixmeIvy(
+            'FW-681: TestBed: not possible to retrieve host property bindings for DebugElement')
             .it('should support exported directives and pipes', () => {
               @NgModule(
                   {declarations: [SomeDirective, SomePipe], exports: [SomeDirective, SomePipe]})
@@ -508,7 +509,8 @@ function declareTests(config?: {useJit: boolean}) {
                   .toBe('transformed someValue');
             });
 
-        fixmeIvy('FW-756: Pipes and directives from imported modules are not taken into account')
+        fixmeIvy(
+            'FW-681: TestBed: not possible to retrieve host property bindings for DebugElement')
             .it('should support exported directives and pipes if the module is wrapped into an `ModuleWithProviders`',
                 () => {
                   @NgModule(
@@ -531,7 +533,8 @@ function declareTests(config?: {useJit: boolean}) {
                       .toBe('transformed someValue');
                 });
 
-        fixmeIvy('FW-756: Pipes and directives from imported modules are not taken into account')
+        fixmeIvy(
+            'FW-681: TestBed: not possible to retrieve host property bindings for DebugElement')
             .it('should support reexported modules', () => {
               @NgModule(
                   {declarations: [SomeDirective, SomePipe], exports: [SomeDirective, SomePipe]})
@@ -556,7 +559,8 @@ function declareTests(config?: {useJit: boolean}) {
                   .toBe('transformed someValue');
             });
 
-        fixmeIvy('FW-756: Pipes and directives from imported modules are not taken into account')
+        fixmeIvy(
+            'FW-681: TestBed: not possible to retrieve host property bindings for DebugElement')
             .it('should support exporting individual directives of an imported module', () => {
               @NgModule(
                   {declarations: [SomeDirective, SomePipe], exports: [SomeDirective, SomePipe]})

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationInitStatus, Component, Directive, Injector, NgModule, NgZone, Pipe, PlatformRef, Provider, SchemaMetadata, Type, ɵInjectableDef as InjectableDef, ɵNgModuleDef as NgModuleDef, ɵNgModuleTransitiveScopes as NgModuleTransitiveScopes, ɵNgModuleType as NgModuleType, ɵRender3ComponentFactory as ComponentFactory, ɵRender3NgModuleRef as NgModuleRef, ɵcompileComponent as compileComponent, ɵcompileDirective as compileDirective, ɵcompileNgModuleDefs as compileNgModuleDefs, ɵcompilePipe as compilePipe, ɵgetInjectableDef as getInjectableDef, ɵpatchComponentDefWithScope as patchComponentDefWithScope, ɵresetCompiledComponents as resetCompiledComponents, ɵstringify as stringify} from '@angular/core';
+import {ApplicationInitStatus, Component, Directive, Injector, NgModule, NgZone, Pipe, PlatformRef, Provider, SchemaMetadata, Type, resolveForwardRef, ɵInjectableDef as InjectableDef, ɵNgModuleDef as NgModuleDef, ɵNgModuleTransitiveScopes as NgModuleTransitiveScopes, ɵNgModuleType as NgModuleType, ɵRender3ComponentFactory as ComponentFactory, ɵRender3NgModuleRef as NgModuleRef, ɵcompileComponent as compileComponent, ɵcompileDirective as compileDirective, ɵcompileNgModuleDefs as compileNgModuleDefs, ɵcompilePipe as compilePipe, ɵgetInjectableDef as getInjectableDef, ɵpatchComponentDefWithScope as patchComponentDefWithScope, ɵresetCompiledComponents as resetCompiledComponents, ɵstringify as stringify} from '@angular/core';
 
-import {resolveForwardRef} from '../../src/di/forward_ref';
 import {ComponentFixture} from './component_fixture';
 import {MetadataOverride} from './metadata_override';
 import {ComponentResolver, DirectiveResolver, NgModuleResolver, PipeResolver, Resolver} from './resolvers';

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -8,6 +8,7 @@
 
 import {ApplicationInitStatus, Component, Directive, Injector, NgModule, NgZone, Pipe, PlatformRef, Provider, SchemaMetadata, Type, ɵInjectableDef as InjectableDef, ɵNgModuleDef as NgModuleDef, ɵNgModuleTransitiveScopes as NgModuleTransitiveScopes, ɵNgModuleType as NgModuleType, ɵRender3ComponentFactory as ComponentFactory, ɵRender3NgModuleRef as NgModuleRef, ɵcompileComponent as compileComponent, ɵcompileDirective as compileDirective, ɵcompileNgModuleDefs as compileNgModuleDefs, ɵcompilePipe as compilePipe, ɵgetInjectableDef as getInjectableDef, ɵpatchComponentDefWithScope as patchComponentDefWithScope, ɵresetCompiledComponents as resetCompiledComponents, ɵstringify as stringify} from '@angular/core';
 
+import {resolveForwardRef} from '../../src/di/forward_ref';
 import {ComponentFixture} from './component_fixture';
 import {MetadataOverride} from './metadata_override';
 import {ComponentResolver, DirectiveResolver, NgModuleResolver, PipeResolver, Resolver} from './resolvers';
@@ -493,7 +494,8 @@ export class TestBedRender3 implements Injector, TestBed {
     const metadata = this._getMetaWithOverrides(ngModule);
     compileNgModuleDefs(moduleType, metadata);
 
-    const declarations: Type<any>[] = flatten(ngModule.declarations || EMPTY_ARRAY);
+    const declarations: Type<any>[] =
+        flatten(ngModule.declarations || EMPTY_ARRAY, resolveForwardRef);
     const compiledComponents: Type<any>[] = [];
 
     // Compile the components, directives and pipes declared by this module


### PR DESCRIPTION
Forward refs in some places (like imports/export/providers/viewProviders/queries) were not resolved before passing to compilation phase. Now we resolve missing refs before invoking compile function.

I also updated root causes for some tests from `FW-756: Pipes and directives from imported modules are not taken into account` to `FW-681: TestBed: not possible to retrieve host property bindings for DebugElement`, since the problem described in FW-756 seems to be resolved.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No