### PR TITLE
fix(core): make injector.get() return default value with InjectFlags.…

### DIFF
--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -342,6 +342,10 @@ function resolveToken(
     }
   } else if (!(flags & InjectFlags.Self)) {
     value = parent.get(token, notFoundValue, InjectFlags.Default);
+  } else if (!(flags & InjectFlags.Optional)) {
+    value = Injector.NULL.get(token, notFoundValue);
+  } else {
+    value = Injector.NULL.get(token, typeof notFoundValue !== 'undefined' ? notFoundValue : null);
   }
   return value;
 }

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -197,7 +197,12 @@ export class R3Injector {
       // Select the next injector based on the Self flag - if self is set, the next injector is
       // the NullInjector, otherwise it's the parent.
       const nextInjector = !(flags & InjectFlags.Self) ? this.parent : getNullInjector();
-      return nextInjector.get(token, flags & InjectFlags.Optional ? null : notFoundValue);
+      // Set the notFoundValue based on the Optional flag - if optional is set and notFoundValue
+      // is undefined, the value is null, otherwise it's the notFoundValue.
+      notFoundValue = (flags & InjectFlags.Optional) && notFoundValue === THROW_IF_NOT_FOUND ?
+          null :
+          notFoundValue;
+      return nextInjector.get(token, notFoundValue);
     } catch (e) {
       if (e.name === 'NullInjectorError') {
         const path: any[] = e[NG_TEMP_TOKEN_PATH] = e[NG_TEMP_TOKEN_PATH] || [];

--- a/packages/core/test/di/static_injector_spec.ts
+++ b/packages/core/test/di/static_injector_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, InjectionToken, Injector, Optional, Self, SkipSelf, forwardRef} from '@angular/core';
+import {Inject, InjectFlags, InjectionToken, Injector, Optional, Self, SkipSelf, forwardRef} from '@angular/core';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {ivyEnabled, modifiedInIvy} from '@angular/private/testing';
 
@@ -420,6 +420,35 @@ function factoryFn(a: any){}
             .toThrowError(
                 `${injectorName}Error[${stringify(Car)} -> ${stringify(Engine)}]: \n` +
                 '  NullInjectorError: No provider for Engine!');
+      });
+
+      it('should return a default value when not requested provider on self', () => {
+        const car = new SportsCar(new Engine());
+        const injector = Injector.create([]);
+        expect(injector.get<Car|null>(Car, null, InjectFlags.Self)).toBeNull();
+        expect(injector.get<Car>(Car, car, InjectFlags.Self)).toBe(car);
+      });
+
+      it('should return a default value when not requested provider on self and optional', () => {
+        const flags = InjectFlags.Self | InjectFlags.Optional;
+        const injector = Injector.create([]);
+        expect(injector.get<Car|null>(Car, null, InjectFlags.Self)).toBeNull();
+        expect(injector.get<Car|number>(Car, 0, flags)).toBe(0);
+      });
+
+      it(`should return null when not requested provider on self and optional`, () => {
+        const flags = InjectFlags.Self | InjectFlags.Optional;
+        const injector = Injector.create([]);
+        expect(injector.get<Car|null>(Car, undefined, flags)).toBeNull();
+      });
+
+      it('should throw error when not requested provider on self', () => {
+        const injector = Injector.create([]);
+        const injectorName = ivyEnabled ? `R3Injector` : `StaticInjector`;
+        expect(() => injector.get(Car, undefined, InjectFlags.Self))
+            .toThrowError(
+                `${injectorName}Error[${stringify(Car)}]: \n` +
+                `  NullInjectorError: No provider for ${stringify(Car)}!`);
       });
     });
 


### PR DESCRIPTION
…Self flag on

Fixes #27729

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #27729 


## What is the new behavior?

injector.get() return default value with InjectFlags.Self flag on

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
**injector.get()** will return default value with **InjectFlags.Self** flag on instead of **undefined**

## Other information
