### PR TITLE
test(ivy): all NgModule should be compiled

### DIFF
--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -281,7 +281,6 @@ let verifiedNgModule = new Map<NgModuleType<any>, boolean>();
 export function resetCompiledComponents(): void {
   ownerNgModule = new Map<Type<any>, NgModuleType<any>>();
   verifiedNgModule = new Map<NgModuleType<any>, boolean>();
-  moduleQueue.length = 0;
 }
 
 /**

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -4028,27 +4028,26 @@ describe('Integration', () => {
         });
       });
 
-      fixmeIvy('unknown').it(
-          'should use the injector of the lazily-loaded configuration',
-          fakeAsync(inject(
-              [Router, Location, NgModuleFactoryLoader],
-              (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
-                loader.stubbedModules = {expected: LoadedModule};
+      it('should use the injector of the lazily-loaded configuration',
+         fakeAsync(inject(
+             [Router, Location, NgModuleFactoryLoader],
+             (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+               loader.stubbedModules = {expected: LoadedModule};
 
-                const fixture = createRoot(router, RootCmp);
+               const fixture = createRoot(router, RootCmp);
 
-                router.resetConfig([{
-                  path: 'eager-parent',
-                  component: EagerParentComponent,
-                  children: [{path: 'lazy', loadChildren: 'expected'}]
-                }]);
+               router.resetConfig([{
+                 path: 'eager-parent',
+                 component: EagerParentComponent,
+                 children: [{path: 'lazy', loadChildren: 'expected'}]
+               }]);
 
-                router.navigateByUrl('/eager-parent/lazy/lazy-parent/lazy-child');
-                advance(fixture);
+               router.navigateByUrl('/eager-parent/lazy/lazy-parent/lazy-child');
+               advance(fixture);
 
-                expect(location.path()).toEqual('/eager-parent/lazy/lazy-parent/lazy-child');
-                expect(fixture.nativeElement).toHaveText('eager-parent lazy-parent lazy-child');
-              })));
+               expect(location.path()).toEqual('/eager-parent/lazy/lazy-parent/lazy-child');
+               expect(fixture.nativeElement).toHaveText('eager-parent lazy-parent lazy-child');
+             })));
     });
 
     it('works when given a callback',
@@ -4371,43 +4370,41 @@ describe('Integration', () => {
       class LazyLoadedModule {
       }
 
-      fixmeIvy('unknown').it(
-          'should not ignore empty path when in legacy mode',
-          fakeAsync(inject(
-              [Router, NgModuleFactoryLoader],
-              (router: Router, loader: SpyNgModuleFactoryLoader) => {
-                router.relativeLinkResolution = 'legacy';
-                loader.stubbedModules = {expected: LazyLoadedModule};
+      it('should not ignore empty path when in legacy mode',
+         fakeAsync(inject(
+             [Router, NgModuleFactoryLoader],
+             (router: Router, loader: SpyNgModuleFactoryLoader) => {
+               router.relativeLinkResolution = 'legacy';
+               loader.stubbedModules = {expected: LazyLoadedModule};
 
-                const fixture = createRoot(router, RootCmp);
+               const fixture = createRoot(router, RootCmp);
 
-                router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
+               router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
 
-                router.navigateByUrl('/lazy/foo/bar');
-                advance(fixture);
+               router.navigateByUrl('/lazy/foo/bar');
+               advance(fixture);
 
-                const link = fixture.nativeElement.querySelector('a');
-                expect(link.getAttribute('href')).toEqual('/lazy/foo/bar/simple');
-              })));
+               const link = fixture.nativeElement.querySelector('a');
+               expect(link.getAttribute('href')).toEqual('/lazy/foo/bar/simple');
+             })));
 
-      fixmeIvy('unknown').it(
-          'should ignore empty path when in corrected mode',
-          fakeAsync(inject(
-              [Router, NgModuleFactoryLoader],
-              (router: Router, loader: SpyNgModuleFactoryLoader) => {
-                router.relativeLinkResolution = 'corrected';
-                loader.stubbedModules = {expected: LazyLoadedModule};
+      it('should ignore empty path when in corrected mode',
+         fakeAsync(inject(
+             [Router, NgModuleFactoryLoader],
+             (router: Router, loader: SpyNgModuleFactoryLoader) => {
+               router.relativeLinkResolution = 'corrected';
+               loader.stubbedModules = {expected: LazyLoadedModule};
 
-                const fixture = createRoot(router, RootCmp);
+               const fixture = createRoot(router, RootCmp);
 
-                router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
+               router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
 
-                router.navigateByUrl('/lazy/foo/bar');
-                advance(fixture);
+               router.navigateByUrl('/lazy/foo/bar');
+               advance(fixture);
 
-                const link = fixture.nativeElement.querySelector('a');
-                expect(link.getAttribute('href')).toEqual('/lazy/foo/simple');
-              })));
+               const link = fixture.nativeElement.querySelector('a');
+               expect(link.getAttribute('href')).toEqual('/lazy/foo/simple');
+             })));
     });
   });
 


### PR DESCRIPTION
This PR enables the 3 router tests which were disabled in #27604.
The tests started failing because the NgModule were removed from the queue before being compiled.