### PR TITLE
fix(ivy): adding event listeners for global objects (window, document, body)

### DIFF
--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -588,8 +588,11 @@ describe('ngtsc behavioral tests', () => {
           template: 'Test'
         })
         class FooCmp {
+          @HostListener('click')
+          onClick(event: any): void {}
+
           @HostListener('document:click', ['$event.target'])
-          onClick(eventTarget: HTMLElement): void {}
+          onDocumentClick(eventTarget: HTMLElement): void {}
 
           @HostListener('window:scroll')
           onScroll(event: any): void {}
@@ -601,12 +604,33 @@ describe('ngtsc behavioral tests', () => {
     const hostBindingsFn = `
       hostBindings: function FooCmp_HostBindings(rf, ctx, elIndex) {
         if (rf & 1) {
-          i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick($event.target); });
-          i0.ɵlistener("scroll", function FooCmp_scroll_HostBindingHandler($event) { return ctx.onScroll(); });
+          i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick(); });
+          i0.ɵlistener("document:click", function FooCmp_document_click_HostBindingHandler($event) { return ctx.onDocumentClick($event.target); });
+          i0.ɵlistener("window:scroll", function FooCmp_window_scroll_HostBindingHandler($event) { return ctx.onScroll(); });
         }
       }
     `;
     expect(trim(jsContents)).toContain(trim(hostBindingsFn));
+  });
+
+  it('should throw in case unknown global target is provided', () => {
+    env.tsconfig();
+    env.write(`test.ts`, `
+        import {Component, HostListener} from '@angular/core';
+
+        @Component({
+          selector: 'test',
+          template: 'Test'
+        })
+        class FooCmp {
+          @HostListener('UnknownTarget:click')
+          onClick(event: any): void {}
+        }
+    `);
+    const errors = env.driveDiagnostics();
+    expect(trim(errors[0].messageText as string))
+        .toContain(
+            `Unexpected global target 'UnknownTarget' defined for 'click' event. Supported list of global targets: window,document,body.`);
   });
 
   it('should generate host bindings for directives', () => {
@@ -620,6 +644,7 @@ describe('ngtsc behavioral tests', () => {
           host: {
             '[attr.hello]': 'foo',
             '(click)': 'onClick($event)',
+            '(body:click)': 'onBodyClick($event)',
             '[prop]': 'bar',
           },
         })
@@ -641,6 +666,7 @@ describe('ngtsc behavioral tests', () => {
         if (rf & 1) {
           i0.ɵallocHostVars(2);
           i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick($event); });
+          i0.ɵlistener("body:click", function FooCmp_body_click_HostBindingHandler($event) { return ctx.onBodyClick($event); });
           i0.ɵlistener("change", function FooCmp_change_HostBindingHandler($event) { return ctx.onChange(ctx.arg1, ctx.arg2, ctx.arg3); });
           i0.ɵelementStyling(_c0, null, null, ctx);
         }

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -595,7 +595,7 @@ describe('ngtsc behavioral tests', () => {
           onDocumentClick(eventTarget: HTMLElement): void {}
 
           @HostListener('window:scroll')
-          onScroll(event: any): void {}
+          onWindowScroll(event: any): void {}
         }
     `);
 
@@ -605,8 +605,8 @@ describe('ngtsc behavioral tests', () => {
       hostBindings: function FooCmp_HostBindings(rf, ctx, elIndex) {
         if (rf & 1) {
           i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick(); });
-          i0.ɵlistener("document:click", function FooCmp_document_click_HostBindingHandler($event) { return ctx.onDocumentClick($event.target); });
-          i0.ɵlistener("window:scroll", function FooCmp_window_scroll_HostBindingHandler($event) { return ctx.onScroll(); });
+          i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onDocumentClick($event.target); }, false, i0.ɵcreateGlobalTargetGetter("document"));
+          i0.ɵlistener("scroll", function FooCmp_scroll_HostBindingHandler($event) { return ctx.onWindowScroll(); }, false, i0.ɵcreateGlobalTargetGetter("window"));
         }
       }
     `;
@@ -666,7 +666,7 @@ describe('ngtsc behavioral tests', () => {
         if (rf & 1) {
           i0.ɵallocHostVars(2);
           i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick($event); });
-          i0.ɵlistener("body:click", function FooCmp_body_click_HostBindingHandler($event) { return ctx.onBodyClick($event); });
+          i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onBodyClick($event); }, false, i0.ɵcreateGlobalTargetGetter("body"));
           i0.ɵlistener("change", function FooCmp_change_HostBindingHandler($event) { return ctx.onChange(ctx.arg1, ctx.arg2, ctx.arg3); });
           i0.ɵelementStyling(_c0, null, null, ctx);
         }

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -605,8 +605,8 @@ describe('ngtsc behavioral tests', () => {
       hostBindings: function FooCmp_HostBindings(rf, ctx, elIndex) {
         if (rf & 1) {
           i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick(); });
-          i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onDocumentClick($event.target); }, false, i0.ɵcreateGlobalTargetGetter("document"));
-          i0.ɵlistener("scroll", function FooCmp_scroll_HostBindingHandler($event) { return ctx.onWindowScroll(); }, false, i0.ɵcreateGlobalTargetGetter("window"));
+          i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onDocumentClick($event.target); }, false, i0.ɵresolveDocument);
+          i0.ɵlistener("scroll", function FooCmp_scroll_HostBindingHandler($event) { return ctx.onWindowScroll(); }, false, i0.ɵresolveWindow);
         }
       }
     `;
@@ -666,7 +666,7 @@ describe('ngtsc behavioral tests', () => {
         if (rf & 1) {
           i0.ɵallocHostVars(2);
           i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onClick($event); });
-          i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onBodyClick($event); }, false, i0.ɵcreateGlobalTargetGetter("body"));
+          i0.ɵlistener("click", function FooCmp_click_HostBindingHandler($event) { return ctx.onBodyClick($event); }, false, i0.ɵresolveBody);
           i0.ɵlistener("change", function FooCmp_change_HostBindingHandler($event) { return ctx.onChange(ctx.arg1, ctx.arg2, ctx.arg3); });
           i0.ɵelementStyling(_c0, null, null, ctx);
         }

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -131,6 +131,9 @@ export class Identifiers {
   static templateRefExtractor:
       o.ExternalReference = {name: 'ɵtemplateRefExtractor', moduleName: CORE};
 
+  static createGlobalTargetGetter:
+      o.ExternalReference = {name: 'ɵcreateGlobalTargetGetter', moduleName: CORE};
+
   static defineBase: o.ExternalReference = {name: 'ɵdefineBase', moduleName: CORE};
 
   static BaseDef: o.ExternalReference = {

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -131,8 +131,9 @@ export class Identifiers {
   static templateRefExtractor:
       o.ExternalReference = {name: 'ɵtemplateRefExtractor', moduleName: CORE};
 
-  static createGlobalTargetGetter:
-      o.ExternalReference = {name: 'ɵcreateGlobalTargetGetter', moduleName: CORE};
+  static resolveWindow: o.ExternalReference = {name: 'ɵresolveWindow', moduleName: CORE};
+  static resolveDocument: o.ExternalReference = {name: 'ɵresolveDocument', moduleName: CORE};
+  static resolveBody: o.ExternalReference = {name: 'ɵresolveBody', moduleName: CORE};
 
   static defineBase: o.ExternalReference = {name: 'ɵdefineBase', moduleName: CORE};
 

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -828,7 +828,13 @@ function createHostListeners(
     const handler = o.fn(
         [new o.FnParam('$event', o.DYNAMIC_TYPE)], [...bindingExpr.render3Stmts], o.INFERRED_TYPE,
         null, functionName);
-    return o.importExpr(R3.listener).callFn([o.literal(bindingName), handler]).toStmt();
+    const params: o.Expression[] = [o.literal(bindingName), handler];
+    if (target) {
+      params.push(
+          o.literal(false),  // `useCapture` flag, defaults to `false`
+          o.importExpr(R3.createGlobalTargetGetter).callFn([o.literal(target)]));
+    }
+    return o.importExpr(R3.listener).callFn(params).toStmt();
   });
 }
 

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -9,7 +9,7 @@
 import {StaticSymbol} from '../../aot/static_symbol';
 import {CompileDirectiveMetadata, CompileDirectiveSummary, CompileQueryMetadata, CompileTokenMetadata, identifierName, sanitizeIdentifier} from '../../compile_metadata';
 import {CompileReflector} from '../../compile_reflector';
-import {BindingForm, convertActionBinding, convertPropertyBinding} from '../../compiler_util/expression_converter';
+import {BindingForm, convertPropertyBinding} from '../../compiler_util/expression_converter';
 import {ConstantPool, DefinitionKind} from '../../constant_pool';
 import * as core from '../../core';
 import {AST, ParsedEvent, ParsedEventType, ParsedProperty} from '../../expression_parser/ast';
@@ -22,14 +22,15 @@ import {ShadowCss} from '../../shadow_css';
 import {CONTENT_ATTR, HOST_ATTR} from '../../style_compiler';
 import {BindingParser} from '../../template_parser/binding_parser';
 import {OutputContext, error} from '../../util';
+import {BoundEvent} from '../r3_ast';
 import {compileFactoryFunction, dependenciesFromGlobalMetadata} from '../r3_factory';
 import {Identifiers as R3} from '../r3_identifiers';
 import {Render3ParseResult} from '../r3_template_transform';
-import {prepareSyntheticListenerFunctionName, prepareSyntheticListenerName, prepareSyntheticPropertyName, typeWithParameters} from '../util';
+import {prepareSyntheticListenerFunctionName, prepareSyntheticPropertyName, typeWithParameters} from '../util';
 
 import {R3ComponentDef, R3ComponentMetadata, R3DirectiveDef, R3DirectiveMetadata, R3QueryMetadata} from './api';
 import {StylingBuilder, StylingInstruction} from './styling_builder';
-import {BindingScope, TemplateDefinitionBuilder, ValueConverter, renderFlagCheckIfStmt} from './template';
+import {BindingScope, TemplateDefinitionBuilder, ValueConverter, prepareEventListenerParameters, renderFlagCheckIfStmt} from './template';
 import {CONTEXT_NAME, DefinitionMap, RENDER_FLAGS, TEMPORARY_NAME, asLiteral, conditionallyCreateMapObjectLiteral, getQueryPredicate, temporaryAllocator} from './util';
 
 const EMPTY_ARRAY: any[] = [];
@@ -809,31 +810,14 @@ function createHostListeners(
     bindingContext: o.Expression, eventBindings: ParsedEvent[],
     meta: R3DirectiveMetadata): o.Statement[] {
   return eventBindings.map(binding => {
-    const target: string = binding.type === ParsedEventType.Regular ? binding.targetOrPhase : '';
-    if (target && SUPPORTED_GLOBAL_TARGETS.indexOf(target) < 0) {
-      throw new Error(`Unexpected global target '${target}' defined for '${binding.name}' event.
-          Supported list of global targets: ${SUPPORTED_GLOBAL_TARGETS}.`);
-    }
-    const bindingExpr = convertActionBinding(
-        null, bindingContext, binding.handler, 'b', () => error('Unexpected interpolation'));
     let bindingName = binding.name && sanitizeIdentifier(binding.name);
-    let bindingFnName = bindingName;
-    if (binding.type === ParsedEventType.Animation) {
-      bindingFnName = prepareSyntheticListenerFunctionName(bindingName, binding.targetOrPhase);
-      bindingName = prepareSyntheticListenerName(bindingName, binding.targetOrPhase);
-    }
-    const typeName = meta.name;
-    const functionName =
-        typeName && bindingName ? `${typeName}_${bindingFnName}_HostBindingHandler` : null;
-    const handler = o.fn(
-        [new o.FnParam('$event', o.DYNAMIC_TYPE)], [...bindingExpr.render3Stmts], o.INFERRED_TYPE,
-        null, functionName);
-    const params: o.Expression[] = [o.literal(bindingName), handler];
-    if (target) {
-      params.push(
-          o.literal(false),  // `useCapture` flag, defaults to `false`
-          o.importExpr(R3.createGlobalTargetGetter).callFn([o.literal(target)]));
-    }
+    const bindingFnName = binding.type === ParsedEventType.Animation ?
+        prepareSyntheticListenerFunctionName(bindingName, binding.targetOrPhase) :
+        bindingName;
+    const handlerName =
+        meta.name && bindingName ? `${meta.name}_${bindingFnName}_HostBindingHandler` : null;
+    const params = prepareEventListenerParameters(
+        BoundEvent.fromParsedEvent(binding), bindingContext, handlerName);
     return o.importExpr(R3.listener).callFn(params).toStmt();
   });
 }

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -809,6 +809,11 @@ function createHostListeners(
     bindingContext: o.Expression, eventBindings: ParsedEvent[],
     meta: R3DirectiveMetadata): o.Statement[] {
   return eventBindings.map(binding => {
+    const target: string = binding.type === ParsedEventType.Regular ? binding.targetOrPhase : '';
+    if (target && SUPPORTED_GLOBAL_TARGETS.indexOf(target) < 0) {
+      throw new Error(`Unexpected global target '${target}' defined for '${binding.name}' event.
+          Supported list of global targets: ${SUPPORTED_GLOBAL_TARGETS}.`);
+    }
     const bindingExpr = convertActionBinding(
         null, bindingContext, binding.handler, 'b', () => error('Unexpected interpolation'));
     let bindingName = binding.name && sanitizeIdentifier(binding.name);

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -65,6 +65,9 @@ const DEFAULT_NG_CONTENT_SELECTOR = '*';
 // Selector attribute name of `<ng-content>`
 const NG_CONTENT_SELECT_ATTR = 'select';
 
+// List of supported global targets for event listeners
+export const SUPPORTED_GLOBAL_TARGETS = ['window', 'document', 'body'];
+
 export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver {
   private _dataIndex = 0;
   private _bindingContext = 0;
@@ -1077,6 +1080,14 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       bindingFnName = prepareSyntheticListenerFunctionName(eventName, outputAst.phase !);
       eventName = prepareSyntheticListenerName(eventName, outputAst.phase !);
     } else {
+      if (outputAst.target) {
+        if (SUPPORTED_GLOBAL_TARGETS.indexOf(outputAst.target) < 0) {
+          throw new Error(
+              `Unexpected global target '${outputAst.target}' defined for '${outputAst.name}' event.
+            Supported list of global targets: ${SUPPORTED_GLOBAL_TARGETS}.`);
+        }
+        eventName = `${outputAst.target}:${outputAst.name}`;
+      }
       bindingFnName = sanitizeIdentifier(eventName);
     }
 

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1107,10 +1107,17 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
         ...bindingExpr.render3Stmts
       ];
 
-      const handler = o.fn(
+      const handlerFn = o.fn(
           [new o.FnParam('$event', o.DYNAMIC_TYPE)], statements, o.INFERRED_TYPE, null,
           functionName);
-      return [o.literal(eventName), handler];
+
+      const params: o.Expression[] = [o.literal(eventName), handlerFn];
+      if (outputAst.target) {
+        params.push(
+            o.literal(false),  // `useCapture` flag, defaults to `false`
+            o.importExpr(R3.createGlobalTargetGetter).callFn([o.literal(outputAst.target)]));
+      }
+      return params;
     };
   }
 }

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -89,7 +89,7 @@ export function prepareEventListenerParameters(
   statements.push(...bindingExpr.render3Stmts);
 
   const eventName: string =
-      type === ParsedEventType.Animation ? prepareSyntheticListenerName(name, phase) : name;
+      type === ParsedEventType.Animation ? prepareSyntheticListenerName(name, phase !) : name;
   const fnName = handlerName && sanitizeIdentifier(handlerName);
   const fnArgs = [new o.FnParam('$event', o.DYNAMIC_TYPE)];
   const handlerFn = o.fn(fnArgs, statements, o.INFERRED_TYPE, null, fnName);

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -120,6 +120,7 @@ export {
   i18nApply as ɵi18nApply,
   i18nPostprocess as ɵi18nPostprocess,
   setClassMetadata as ɵsetClassMetadata,
+  createGlobalTargetGetter as ɵcreateGlobalTargetGetter,
 } from './render3/index';
 
 

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -120,7 +120,9 @@ export {
   i18nApply as ɵi18nApply,
   i18nPostprocess as ɵi18nPostprocess,
   setClassMetadata as ɵsetClassMetadata,
-  createGlobalTargetGetter as ɵcreateGlobalTargetGetter,
+  resolveWindow as ɵresolveWindow,
+  resolveDocument as ɵresolveDocument,
+  resolveBody as ɵresolveBody,
 } from './render3/index';
 
 

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -145,6 +145,7 @@ export {
 
 export {templateRefExtractor} from './view_engine_compatibility_prebound';
 
+export {createGlobalTargetGetter} from './util';
 
 // clang-format on
 

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -145,7 +145,7 @@ export {
 
 export {templateRefExtractor} from './view_engine_compatibility_prebound';
 
-export {createGlobalTargetGetter} from './util';
+export {resolveWindow, resolveDocument, resolveBody} from './util';
 
 // clang-format on
 

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -823,7 +823,9 @@ export function locateHostElement(
  *
  * @param eventName Name of the event
  * @param listenerFn The function to be called when event emits
- * @param useCapture Whether or not to use capture in event listener.
+ * @param useCapture Whether or not to use capture in event listener
+ * @param globalTargetGetter Function that returns global target information in case this listener
+ * should be attached to a global object like window, document or body
  */
 export function listener(
     eventName: string, listenerFn: (e?: any) => any, useCapture = false,

--- a/packages/core/src/render3/interfaces/renderer.ts
+++ b/packages/core/src/render3/interfaces/renderer.ts
@@ -26,6 +26,8 @@ export enum RendererStyleFlags3 {
 
 export type Renderer3 = ObjectOrientedRenderer3 | ProceduralRenderer3;
 
+export type GlobalTargetSelector = 'document' | 'window' | 'body';
+
 /**
  * Object Oriented style of API needed to create elements and text nodes.
  *
@@ -86,7 +88,9 @@ export interface ProceduralRenderer3 {
   setValue(node: RText|RComment, value: string): void;
 
   // TODO(misko): Deprecate in favor of addEventListener/removeEventListener
-  listen(target: RNode, eventName: string, callback: (event: any) => boolean | void): () => void;
+  listen(
+      target: GlobalTargetSelector|RNode, eventName: string,
+      callback: (event: any) => boolean | void): () => void;
 }
 
 export interface RendererFactory3 {

--- a/packages/core/src/render3/interfaces/renderer.ts
+++ b/packages/core/src/render3/interfaces/renderer.ts
@@ -26,7 +26,11 @@ export enum RendererStyleFlags3 {
 
 export type Renderer3 = ObjectOrientedRenderer3 | ProceduralRenderer3;
 
-export type GlobalTargetSelector = 'document' | 'window' | 'body';
+export type GlobalTargetName = 'document' | 'window' | 'body';
+
+export type GlobalTargetResolver = (element: any) => {
+  name: GlobalTargetName, target: EventTarget
+};
 
 /**
  * Object Oriented style of API needed to create elements and text nodes.
@@ -89,7 +93,7 @@ export interface ProceduralRenderer3 {
 
   // TODO(misko): Deprecate in favor of addEventListener/removeEventListener
   listen(
-      target: GlobalTargetSelector|RNode, eventName: string,
+      target: GlobalTargetName|RNode, eventName: string,
       callback: (event: any) => boolean | void): () => void;
 }
 

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -457,7 +457,11 @@ export interface TView {
    *
    * If it's a native DOM listener or output subscription being stored:
    * 1st index is: event name  `name = tView.cleanup[i+0]`
-   * 2nd index is: index of native element `element = lView[tView.cleanup[i+1]]`
+   * 2nd index is: index of native element or a function that retrieves global target (window,
+   *               document or body) reference based on the native element:
+   *    `typeof idxOrTargetGetter === 'function'`: global target getter function
+   *    `typeof idxOrTargetGetter === 'number'`: index of native element
+   *
    * 3rd index is: index of listener function `listener = lView[CLEANUP][tView.cleanup[i+2]]`
    * 4th index is: `useCaptureOrIndx = tView.cleanup[i+3]`
    *    `typeof useCaptureOrIndx == 'boolean' : useCapture boolean

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -107,7 +107,9 @@ export const angularCoreEnv: {[name: string]: Function} = {
   'ɵi18nEnd': r3.i18nEnd,
   'ɵi18nApply': r3.i18nApply,
   'ɵi18nPostprocess': r3.i18nPostprocess,
-  'ɵcreateGlobalTargetGetter': r3.createGlobalTargetGetter,
+  'ɵresolveWindow': r3.resolveWindow,
+  'ɵresolveDocument': r3.resolveDocument,
+  'ɵresolveBody': r3.resolveBody,
 
   'ɵsanitizeHtml': sanitization.sanitizeHtml,
   'ɵsanitizeStyle': sanitization.sanitizeStyle,

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -107,6 +107,7 @@ export const angularCoreEnv: {[name: string]: Function} = {
   'ɵi18nEnd': r3.i18nEnd,
   'ɵi18nApply': r3.i18nApply,
   'ɵi18nPostprocess': r3.i18nPostprocess,
+  'ɵcreateGlobalTargetGetter': r3.createGlobalTargetGetter,
 
   'ɵsanitizeHtml': sanitization.sanitizeHtml,
   'ɵsanitizeStyle': sanitization.sanitizeStyle,

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -14,7 +14,7 @@ import {unusedValueExportToPlacateAjd as unused3} from './interfaces/projection'
 import {ProceduralRenderer3, RComment, RElement, RNode, RText, Renderer3, isProceduralRenderer, unusedValueExportToPlacateAjd as unused4} from './interfaces/renderer';
 import {CLEANUP, CONTAINER_INDEX, FLAGS, HEADER_OFFSET, HOST_NODE, HookData, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, TVIEW, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
 import {assertNodeType} from './node_assert';
-import {findComponentView, getNativeByTNode, isLContainer, isRootView, readElementValue, stringify} from './util';
+import {extractEventListenerDetails, findComponentView, getNativeByTNode, isLContainer, isRootView, readElementValue, stringify} from './util';
 
 const unusedValueToPlacateAjd = unused1 + unused2 + unused3 + unused4 + unused5;
 
@@ -447,12 +447,13 @@ function removeListeners(lView: LView): void {
       if (typeof tCleanup[i] === 'string') {
         // This is a listener with the native renderer
         const idx = tCleanup[i + 1];
-        const listener = lCleanup[tCleanup[i + 2]];
         const native = readElementValue(lView[idx]);
+        const {eventName, target} = extractEventListenerDetails(tCleanup[i], native);
+        const listener = lCleanup[tCleanup[i + 2]];
         const useCaptureOrSubIdx = tCleanup[i + 3];
         if (typeof useCaptureOrSubIdx === 'boolean') {
           // DOM listener
-          native.removeEventListener(tCleanup[i], listener, useCaptureOrSubIdx);
+          target !.removeEventListener(eventName, listener, useCaptureOrSubIdx);
         } else {
           if (useCaptureOrSubIdx >= 0) {
             // unregister

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -14,7 +14,7 @@ import {unusedValueExportToPlacateAjd as unused3} from './interfaces/projection'
 import {ProceduralRenderer3, RComment, RElement, RNode, RText, Renderer3, isProceduralRenderer, unusedValueExportToPlacateAjd as unused4} from './interfaces/renderer';
 import {CLEANUP, CONTAINER_INDEX, FLAGS, HEADER_OFFSET, HOST_NODE, HookData, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, TVIEW, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
 import {assertNodeType} from './node_assert';
-import {extractEventListenerDetails, findComponentView, getNativeByTNode, isLContainer, isRootView, readElementValue, stringify} from './util';
+import {findComponentView, getNativeByTNode, isLContainer, isRootView, readElementValue, stringify} from './util';
 
 const unusedValueToPlacateAjd = unused1 + unused2 + unused3 + unused4 + unused5;
 
@@ -446,14 +446,15 @@ function removeListeners(lView: LView): void {
     for (let i = 0; i < tCleanup.length - 1; i += 2) {
       if (typeof tCleanup[i] === 'string') {
         // This is a listener with the native renderer
-        const idx = tCleanup[i + 1];
-        const native = readElementValue(lView[idx]);
-        const {eventName, target} = extractEventListenerDetails(tCleanup[i], native);
+        const idxOrTargetGetter = tCleanup[i + 1];
+        const target = typeof idxOrTargetGetter === 'function' ?
+            idxOrTargetGetter(lView) :
+            readElementValue(lView[idxOrTargetGetter]);
         const listener = lCleanup[tCleanup[i + 2]];
         const useCaptureOrSubIdx = tCleanup[i + 3];
         if (typeof useCaptureOrSubIdx === 'boolean') {
           // DOM listener
-          target !.removeEventListener(eventName, listener, useCaptureOrSubIdx);
+          target.removeEventListener(tCleanup[i], listener, useCaptureOrSubIdx);
         } else {
           if (useCaptureOrSubIdx >= 0) {
             // unregister

--- a/packages/core/src/render3/util.ts
+++ b/packages/core/src/render3/util.ts
@@ -99,6 +99,30 @@ export function getNativeByTNode(tNode: TNode, hostView: LView): RElement|RText|
   return readElementValue(hostView[tNode.index]);
 }
 
+export function extractEventListenerDetails(eventName: string, element: RElement):
+    {eventName: string, target: Window | Document | HTMLElement | null, targetName?: string} {
+  if (eventName.indexOf(':') > -1) {
+    const [targetName, evName] = eventName.split(':');
+    const target = getGlobalEventTarget(targetName, element);
+    return {eventName: evName, target: target as HTMLElement, targetName};
+  }
+  return {eventName, target: element as HTMLElement};
+}
+
+export function getGlobalEventTarget(name: string, element: any): EventTarget|null {
+  const doc = element.ownerDocument;
+  if (name === 'document') {
+    return doc;
+  }
+  if (name === 'body') {
+    return doc.body;
+  }
+  if (name === 'window') {
+    return doc.defaultView;
+  }
+  return null;
+}
+
 export function getTNode(index: number, view: LView): TNode {
   ngDevMode && assertGreaterThan(index, -1, 'wrong index for TNode');
   ngDevMode && assertLessThan(index, view[TVIEW].data.length, 'wrong index for TNode');

--- a/packages/core/src/render3/util.ts
+++ b/packages/core/src/render3/util.ts
@@ -14,7 +14,7 @@ import {LContext, MONKEY_PATCH_KEY_NAME} from './interfaces/context';
 import {ComponentDef, DirectiveDef} from './interfaces/definition';
 import {NO_PARENT_INJECTOR, RelativeInjectorLocation, RelativeInjectorLocationFlags} from './interfaces/injector';
 import {TContainerNode, TElementNode, TNode, TNodeFlags, TNodeType} from './interfaces/node';
-import {GlobalTargetSelector, RComment, RElement, RText} from './interfaces/renderer';
+import {GlobalTargetName, GlobalTargetResolver, RComment, RElement, RText} from './interfaces/renderer';
 import {StylingContext} from './interfaces/styling';
 import {CONTEXT, DECLARATION_VIEW, FLAGS, HEADER_OFFSET, HOST, HOST_NODE, LView, LViewFlags, PARENT, RootContext, TData, TVIEW, TView} from './interfaces/view';
 
@@ -97,24 +97,6 @@ export function getNativeByIndex(index: number, lView: LView): RElement {
 
 export function getNativeByTNode(tNode: TNode, hostView: LView): RElement|RText|RComment {
   return readElementValue(hostView[tNode.index]);
-}
-
-export function createGlobalTargetGetter(selector: GlobalTargetSelector): (element: any) => {
-  selector: GlobalTargetSelector, target: EventTarget
-} {
-  const wrap = (target: EventTarget) => ({selector, target});
-  return (element: any) => {
-    if (selector === 'document') {
-      return wrap(element.ownerDocument);
-    }
-    if (selector === 'body') {
-      return wrap(element.ownerDocument.body);
-    }
-    if (selector === 'window') {
-      return wrap(element.ownerDocument.defaultView);
-    }
-    throw new Error(`Unsupported global event target name '${name}' specified`);
-  };
 }
 
 export function getTNode(index: number, view: LView): TNode {
@@ -293,4 +275,16 @@ export function findComponentView(lView: LView): LView {
   }
 
   return lView;
+}
+
+export function resolveWindow(element: RElement & {ownerDocument: Document}) {
+  return {name: 'window', target: element.ownerDocument.defaultView};
+}
+
+export function resolveDocument(element: RElement & {ownerDocument: Document}) {
+  return {name: 'document', target: element.ownerDocument};
+}
+
+export function resolveBody(element: RElement & {ownerDocument: Document}) {
+  return {name: 'body', target: element.ownerDocument.body};
 }

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -845,52 +845,48 @@ function declareTests(config?: {useJit: boolean}) {
            dir.triggerChange('two');
          }));
 
-      fixmeIvy(
-          'FW-743: Registering events on global objects (document, window, body) is not supported')
-          .it('should support render events', () => {
-            TestBed.configureTestingModule({declarations: [MyComp, DirectiveListeningDomEvent]});
-            const template = '<div listener></div>';
-            TestBed.overrideComponent(MyComp, {set: {template}});
-            const fixture = TestBed.createComponent(MyComp);
+      it('should support render events', () => {
+        TestBed.configureTestingModule({declarations: [MyComp, DirectiveListeningDomEvent]});
+        const template = '<div listener></div>';
+        TestBed.overrideComponent(MyComp, {set: {template}});
+        const fixture = TestBed.createComponent(MyComp);
 
-            const tc = fixture.debugElement.children[0];
-            const listener = tc.injector.get(DirectiveListeningDomEvent);
+        const tc = fixture.debugElement.children[0];
+        const listener = tc.injector.get(DirectiveListeningDomEvent);
 
-            dispatchEvent(tc.nativeElement, 'domEvent');
+        dispatchEvent(tc.nativeElement, 'domEvent');
 
-            expect(listener.eventTypes).toEqual([
-              'domEvent', 'body_domEvent', 'document_domEvent', 'window_domEvent'
-            ]);
+        expect(listener.eventTypes).toEqual([
+          'domEvent', 'body_domEvent', 'document_domEvent', 'window_domEvent'
+        ]);
 
-            fixture.destroy();
-            listener.eventTypes = [];
-            dispatchEvent(tc.nativeElement, 'domEvent');
-            expect(listener.eventTypes).toEqual([]);
-          });
+        fixture.destroy();
+        listener.eventTypes = [];
+        dispatchEvent(tc.nativeElement, 'domEvent');
+        expect(listener.eventTypes).toEqual([]);
+      });
 
-      fixmeIvy(
-          'FW-743: Registering events on global objects (document, window, body) is not supported')
-          .it('should support render global events', () => {
-            TestBed.configureTestingModule({declarations: [MyComp, DirectiveListeningDomEvent]});
-            const template = '<div listener></div>';
-            TestBed.overrideComponent(MyComp, {set: {template}});
-            const fixture = TestBed.createComponent(MyComp);
-            const doc = TestBed.get(DOCUMENT);
+      it('should support render global events', () => {
+        TestBed.configureTestingModule({declarations: [MyComp, DirectiveListeningDomEvent]});
+        const template = '<div listener></div>';
+        TestBed.overrideComponent(MyComp, {set: {template}});
+        const fixture = TestBed.createComponent(MyComp);
+        const doc = TestBed.get(DOCUMENT);
 
-            const tc = fixture.debugElement.children[0];
-            const listener = tc.injector.get(DirectiveListeningDomEvent);
-            dispatchEvent(getDOM().getGlobalEventTarget(doc, 'window'), 'domEvent');
-            expect(listener.eventTypes).toEqual(['window_domEvent']);
+        const tc = fixture.debugElement.children[0];
+        const listener = tc.injector.get(DirectiveListeningDomEvent);
+        dispatchEvent(getDOM().getGlobalEventTarget(doc, 'window'), 'domEvent');
+        expect(listener.eventTypes).toEqual(['window_domEvent']);
 
-            listener.eventTypes = [];
-            dispatchEvent(getDOM().getGlobalEventTarget(doc, 'document'), 'domEvent');
-            expect(listener.eventTypes).toEqual(['document_domEvent', 'window_domEvent']);
+        listener.eventTypes = [];
+        dispatchEvent(getDOM().getGlobalEventTarget(doc, 'document'), 'domEvent');
+        expect(listener.eventTypes).toEqual(['document_domEvent', 'window_domEvent']);
 
-            fixture.destroy();
-            listener.eventTypes = [];
-            dispatchEvent(getDOM().getGlobalEventTarget(doc, 'body'), 'domEvent');
-            expect(listener.eventTypes).toEqual([]);
-          });
+        fixture.destroy();
+        listener.eventTypes = [];
+        dispatchEvent(getDOM().getGlobalEventTarget(doc, 'body'), 'domEvent');
+        expect(listener.eventTypes).toEqual([]);
+      });
 
       it('should support updating host element via hostAttributes on root elements', () => {
         @Component({host: {'role': 'button'}, template: ''})
@@ -1027,44 +1023,41 @@ function declareTests(config?: {useJit: boolean}) {
         });
       }
 
-      fixmeIvy(
-          'FW-743: Registering events on global objects (document, window, body) is not supported')
-          .it('should support render global events from multiple directives', () => {
-            TestBed.configureTestingModule({
-              declarations: [MyComp, DirectiveListeningDomEvent, DirectiveListeningDomEventOther]
-            });
-            const template = '<div *ngIf="ctxBoolProp" listener listenerother></div>';
-            TestBed.overrideComponent(MyComp, {set: {template}});
-            const fixture = TestBed.createComponent(MyComp);
-            const doc = TestBed.get(DOCUMENT);
+      it('should support render global events from multiple directives', () => {
+        TestBed.configureTestingModule(
+            {declarations: [MyComp, DirectiveListeningDomEvent, DirectiveListeningDomEventOther]});
+        const template = '<div *ngIf="ctxBoolProp" listener listenerother></div>';
+        TestBed.overrideComponent(MyComp, {set: {template}});
+        const fixture = TestBed.createComponent(MyComp);
+        const doc = TestBed.get(DOCUMENT);
 
-            globalCounter = 0;
-            fixture.componentInstance.ctxBoolProp = true;
-            fixture.detectChanges();
+        globalCounter = 0;
+        fixture.componentInstance.ctxBoolProp = true;
+        fixture.detectChanges();
 
-            const tc = fixture.debugElement.children[0];
+        const tc = fixture.debugElement.children[0];
 
-            const listener = tc.injector.get(DirectiveListeningDomEvent);
-            const listenerother = tc.injector.get(DirectiveListeningDomEventOther);
-            dispatchEvent(getDOM().getGlobalEventTarget(doc, 'window'), 'domEvent');
-            expect(listener.eventTypes).toEqual(['window_domEvent']);
-            expect(listenerother.eventType).toEqual('other_domEvent');
-            expect(globalCounter).toEqual(1);
+        const listener = tc.injector.get(DirectiveListeningDomEvent);
+        const listenerother = tc.injector.get(DirectiveListeningDomEventOther);
+        dispatchEvent(getDOM().getGlobalEventTarget(doc, 'window'), 'domEvent');
+        expect(listener.eventTypes).toEqual(['window_domEvent']);
+        expect(listenerother.eventType).toEqual('other_domEvent');
+        expect(globalCounter).toEqual(1);
 
 
-            fixture.componentInstance.ctxBoolProp = false;
-            fixture.detectChanges();
-            dispatchEvent(getDOM().getGlobalEventTarget(doc, 'window'), 'domEvent');
-            expect(globalCounter).toEqual(1);
+        fixture.componentInstance.ctxBoolProp = false;
+        fixture.detectChanges();
+        dispatchEvent(getDOM().getGlobalEventTarget(doc, 'window'), 'domEvent');
+        expect(globalCounter).toEqual(1);
 
-            fixture.componentInstance.ctxBoolProp = true;
-            fixture.detectChanges();
-            dispatchEvent(getDOM().getGlobalEventTarget(doc, 'window'), 'domEvent');
-            expect(globalCounter).toEqual(2);
+        fixture.componentInstance.ctxBoolProp = true;
+        fixture.detectChanges();
+        dispatchEvent(getDOM().getGlobalEventTarget(doc, 'window'), 'domEvent');
+        expect(globalCounter).toEqual(2);
 
-            // need to destroy to release all remaining global event listeners
-            fixture.destroy();
-          });
+        // need to destroy to release all remaining global event listeners
+        fixture.destroy();
+      });
 
       describe('ViewContainerRef', () => {
         beforeEach(() => {

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {bind, createGlobalTargetGetter, defineComponent, defineDirective, markDirty, reference, textBinding} from '../../src/render3/index';
+import {bind, defineComponent, defineDirective, markDirty, reference, resolveBody, textBinding} from '../../src/render3/index';
 import {container, containerRefreshEnd, containerRefreshStart, element, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, getCurrentView, listener, text} from '../../src/render3/instructions';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
+import {GlobalTargetResolver} from '../../src/render3/interfaces/renderer';
 import {restoreView} from '../../src/render3/state';
 
 import {getRendererFactory2} from './imported_renderer2';
@@ -475,7 +476,7 @@ describe('event listeners', () => {
             listener('click', function() { return ctx.onClick(); });
             listener('click', function() {
               return ctx.onBodyClick();
-            }, false, createGlobalTargetGetter('body'));
+            }, false, resolveBody as GlobalTargetResolver);
           }
         }
       });
@@ -515,7 +516,7 @@ describe('event listeners', () => {
             listener('click', function() { return ctx.onClick(); });
             listener('click', function() {
               return ctx.onBodyClick();
-            }, false, createGlobalTargetGetter('body'));
+            }, false, resolveBody as GlobalTargetResolver);
           }
         }
       });

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util';
+
 import {bind, defineComponent, defineDirective, markDirty, reference, resolveBody, resolveDocument, textBinding} from '../../src/render3/index';
 import {container, containerRefreshEnd, containerRefreshStart, element, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, getCurrentView, listener, text} from '../../src/render3/instructions';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
@@ -555,10 +557,10 @@ describe('event listeners', () => {
     const fixture = new ComponentFixture(MyCompWithGlobalListeners);
     const doc = fixture.hostElement.ownerDocument !;
 
-    doc.dispatchEvent(new CustomEvent('custom'));
+    dispatchEvent(doc, 'custom');
     expect(events).toEqual(['component - document:custom']);
 
-    doc.body.click();
+    dispatchEvent(doc.body, 'click');
     expect(events).toEqual(['component - document:custom', 'component - body:click']);
 
     // invoke destroy for this fixture to cleanup all listeners setup for global objects
@@ -607,10 +609,10 @@ describe('event listeners', () => {
 
     const doc = fixture.hostElement.ownerDocument !;
 
-    doc.dispatchEvent(new CustomEvent('custom'));
+    dispatchEvent(doc, 'custom');
     expect(events).toEqual(['directive - document:custom']);
 
-    doc.body.click();
+    dispatchEvent(doc.body, 'click');
     expect(events).toEqual(['directive - document:custom', 'directive - body:click']);
 
     // invoke destroy for this fixture to cleanup all listeners setup for global objects

--- a/packages/core/test/render3/listeners_spec.ts
+++ b/packages/core/test/render3/listeners_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {bind, defineComponent, defineDirective, markDirty, reference, textBinding} from '../../src/render3/index';
+import {bind, createGlobalTargetGetter, defineComponent, defineDirective, markDirty, reference, textBinding} from '../../src/render3/index';
 import {container, containerRefreshEnd, containerRefreshStart, element, elementEnd, elementStart, embeddedViewEnd, embeddedViewStart, getCurrentView, listener, text} from '../../src/render3/instructions';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {restoreView} from '../../src/render3/state';
@@ -473,7 +473,9 @@ describe('event listeners', () => {
             rf: RenderFlags, ctx: any, elIndex: number) {
           if (rf & RenderFlags.Create) {
             listener('click', function() { return ctx.onClick(); });
-            listener('body:click', function() { return ctx.onBodyClick(); });
+            listener('click', function() {
+              return ctx.onBodyClick();
+            }, false, createGlobalTargetGetter('body'));
           }
         }
       });
@@ -511,7 +513,9 @@ describe('event listeners', () => {
             rf: RenderFlags, ctx: any, elIndex: number) {
           if (rf & RenderFlags.Create) {
             listener('click', function() { return ctx.onClick(); });
-            listener('body:click', function() { return ctx.onBodyClick(); });
+            listener('click', function() {
+              return ctx.onBodyClick();
+            }, false, createGlobalTargetGetter('body'));
           }
         }
       });

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -31,6 +31,8 @@ import {DirectiveDefList, DirectiveTypesOrFactory, PipeDef, PipeDefList, PipeTyp
 import {PlayerHandler} from '../../src/render3/interfaces/player';
 import {ProceduralRenderer3, RComment, RElement, RNode, RText, Renderer3, RendererFactory3, RendererStyleFlags3, domRendererFactory3} from '../../src/render3/interfaces/renderer';
 import {HEADER_OFFSET, LView} from '../../src/render3/interfaces/view';
+import {destroyLView} from '../../src/render3/node_manipulation';
+import {getRootView} from '../../src/render3/util';
 import {Sanitizer} from '../../src/sanitization/security';
 import {Type} from '../../src/type';
 
@@ -130,6 +132,11 @@ export class TemplateFixture extends BaseFixture {
         this.hostElement, updateBlock || this.updateBlock, 0, this.vars, null !,
         this._rendererFactory, this.hostView, this._directiveDefs, this._pipeDefs, this._sanitizer);
   }
+
+  destroy(): void {
+    this.hostElement.remove();
+    destroyLView(this.hostView);
+  }
 }
 
 
@@ -170,6 +177,11 @@ export class ComponentFixture<T> extends BaseFixture {
   update(): void {
     tick(this.component);
     this.requestAnimationFrame.flush();
+  }
+
+  destroy(): void {
+    this.hostElement.remove();
+    destroyLView(getRootView(this.component));
   }
 }
 

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -134,7 +134,7 @@ export class TemplateFixture extends BaseFixture {
   }
 
   destroy(): void {
-    this.hostElement.remove();
+    this.containerElement.removeChild(this.hostElement);
     destroyLView(this.hostView);
   }
 }
@@ -180,7 +180,7 @@ export class ComponentFixture<T> extends BaseFixture {
   }
 
   destroy(): void {
-    this.hostElement.remove();
+    this.containerElement.removeChild(this.hostElement);
     destroyLView(getRootView(this.component));
   }
 }


### PR DESCRIPTION
This update introduces support for global object (window, document, body) listeners, that can be defined via host listeners on Components and Directives.

PR resolves issue FW-743.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No