### PR TITLE
test: fix outDir in TS 3.2 integration test

### DIFF
--- a/integration/typings_test_ts32/tsconfig.json
+++ b/integration/typings_test_ts32/tsconfig.json
@@ -4,7 +4,7 @@
     "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "outDir": "../../dist/typings_test_ts31/",
+    "outDir": "../../dist/typings_test_ts32/",
     "rootDir": ".",
     "target": "es5",
     "lib": [


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Integration tests for TS 3.2 outputs in the same directory than integration tests for TS 3.1


## What is the new behavior?

Outputs in their own directory

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No