### PR TITLE
feat(ivy): implement `compileComponents` method for `TestBedRender3`

### DIFF
--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -19,7 +19,7 @@ export {APP_ROOT as ɵAPP_ROOT} from './di/scope';
 export {ivyEnabled as ɵivyEnabled} from './ivy_switch';
 export {ComponentFactory as ɵComponentFactory} from './linker/component_factory';
 export {CodegenComponentFactoryResolver as ɵCodegenComponentFactoryResolver} from './linker/component_factory_resolver';
-export {resolveComponentResources as ɵresolveComponentResources} from './metadata/resource_loading';
+export {clearResolutionOfComponentResourcesQueue as ɵclearResolutionOfComponentResourcesQueue, resolveComponentResources as ɵresolveComponentResources} from './metadata/resource_loading';
 export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/reflection_capabilities';
 export {GetterFn as ɵGetterFn, MethodFn as ɵMethodFn, SetterFn as ɵSetterFn} from './reflection/types';
 export {DirectRenderer as ɵDirectRenderer, RenderDebugInfo as ɵRenderDebugInfo} from './render/api';

--- a/packages/core/src/metadata/resource_loading.ts
+++ b/packages/core/src/metadata/resource_loading.ts
@@ -79,7 +79,7 @@ export function resolveComponentResources(
       });
     });
   });
-  componentResourceResolutionQueue.clear();
+  clearResolutionOfComponentResourcesQueue();
   return Promise.all(urlFetches).then(() => null);
 }
 

--- a/packages/core/testing/BUILD.bazel
+++ b/packages/core/testing/BUILD.bazel
@@ -12,6 +12,7 @@ ng_module(
     module_name = "@angular/core/testing",
     deps = [
         "//packages:types",
+        "//packages/compiler",
         "//packages/core",
         "@ngdeps//@types/jasmine",
         "@ngdeps//zone.js",

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -49,6 +49,7 @@ import {
   ɵtransitiveScopesFor as transitiveScopesFor,
   CompilerOptions,
   StaticProvider,
+  COMPILER_OPTIONS,
 } from '@angular/core';
 // clang-format on
 import {ResourceLoader} from '@angular/compiler';
@@ -594,7 +595,14 @@ export class TestBedRender3 implements Injector, TestBed {
       return;
     }
 
-    const providers = this._compilerProviders;
+    const providers = [];
+    const compilerOptions = this.platform.injector.get(COMPILER_OPTIONS);
+    compilerOptions.forEach(opts => {
+      if (opts.providers) {
+        providers.push(opts.providers);
+      }
+    });
+    providers.push(...this._compilerProviders);
 
     @NgModule({providers})
     class CompilerModule {

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -382,12 +382,11 @@ export class TestBedRender3 implements Injector, TestBed {
       }
     });
 
-    this._createCompilerInjector();
     let resourceLoader: ResourceLoader;
 
     return resolveComponentResources(url => {
              if (!resourceLoader) {
-               resourceLoader = this._compilerInjector.get(ResourceLoader);
+               resourceLoader = this.compilerInjector.get(ResourceLoader);
              }
              return Promise.resolve(resourceLoader.get(url));
            })
@@ -590,9 +589,9 @@ export class TestBedRender3 implements Injector, TestBed {
     return DynamicTestModule as NgModuleType;
   }
 
-  private _createCompilerInjector() {
-    if (this._compilerInjector) {
-      return;
+  get compilerInjector(): Injector {
+    if (this._compilerInjector !== undefined) {
+      this._compilerInjector;
     }
 
     const providers = [];
@@ -604,12 +603,14 @@ export class TestBedRender3 implements Injector, TestBed {
     });
     providers.push(...this._compilerProviders);
 
+    // TODO(ocombe): make this work with an Injector directly instead of creating a module for it
     @NgModule({providers})
     class CompilerModule {
     }
 
     const CompilerModuleFactory = new R3NgModuleFactory(CompilerModule);
     this._compilerInjector = CompilerModuleFactory.create(this.platform.injector).injector;
+    return this._compilerInjector;
   }
 
   private _getMetaWithOverrides(meta: Component|Directive|NgModule, type?: Type<any>) {

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -594,7 +594,7 @@ export class TestBedRender3 implements Injector, TestBed {
       this._compilerInjector;
     }
 
-    const providers = [];
+    const providers: StaticProvider[] = [];
     const compilerOptions = this.platform.injector.get(COMPILER_OPTIONS);
     compilerOptions.forEach(opts => {
       if (opts.providers) {

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -161,7 +161,9 @@ function bootstrap(
     afterEach(destroyPlatform);
 
     // TODO(misko): can't use `fixmeIvy.it` because the `it` is somehow special here.
-    fixmeIvy('FW-553: TestBed is unaware of async compilation').isEnabled &&
+    fixmeIvy(
+        'FW-876: Bootstrap factory method should throw if bootstrapped Directive is not a Component')
+            .isEnabled &&
         it('should throw if bootstrapped Directive is not a Component',
            inject([AsyncTestCompleter], (done: AsyncTestCompleter) => {
              const logger = new MockConsole();
@@ -190,7 +192,8 @@ function bootstrap(
        }));
 
     // TODO(misko): can't use `fixmeIvy.it` because the `it` is somehow special here.
-    fixmeIvy('FW-553: TestBed is unaware of async compilation').isEnabled &&
+    fixmeIvy('FW-875: The source of the error is missing in the `StaticInjectorError` message')
+            .isEnabled &&
         it('should throw if no provider',
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
              const logger = new MockConsole();

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -10,7 +10,7 @@ import {CompilerConfig, ResourceLoader} from '@angular/compiler';
 import {CUSTOM_ELEMENTS_SCHEMA, Compiler, Component, Directive, Inject, Injectable, Injector, Input, NgModule, Optional, Pipe, SkipSelf, ɵstringify as stringify} from '@angular/core';
 import {TestBed, async, fakeAsync, getTestBed, inject, tick, withModule} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {fixmeIvy, obsoleteInIvy} from '@angular/private/testing';
+import {fixmeIvy, ivyEnabled, obsoleteInIvy} from '@angular/private/testing';
 
 // Services, and components for the tests.
 
@@ -311,12 +311,11 @@ class CompWithUrlTemplate {
         }));
 
         isBrowser &&
-            fixmeIvy('FW-553: TestBed is unaware of async compilation')
-                .it('should allow to createSync components with templateUrl after explicit async compilation',
-                    () => {
-                      const fixture = TestBed.createComponent(CompWithUrlTemplate);
-                      expect(fixture.nativeElement).toHaveText('from external template');
-                    });
+            it('should allow to createSync components with templateUrl after explicit async compilation',
+               () => {
+                 const fixture = TestBed.createComponent(CompWithUrlTemplate);
+                 expect(fixture.nativeElement).toHaveText('from external template');
+               });
       });
 
       describe('overwriting metadata', () => {
@@ -792,13 +791,12 @@ class CompWithUrlTemplate {
                 {providers: [{provide: ResourceLoader, useValue: {get: resourceLoaderGet}}]});
           });
 
-          fixmeIvy('FW-553: TestBed is unaware of async compilation')
-              .it('should use set up providers', fakeAsync(() => {
-                    TestBed.compileComponents();
-                    tick();
-                    const compFixture = TestBed.createComponent(CompWithUrlTemplate);
-                    expect(compFixture.nativeElement).toHaveText('Hello world!');
-                  }));
+          it('should use set up providers', fakeAsync(() => {
+               TestBed.compileComponents();
+               tick();
+               const compFixture = TestBed.createComponent(CompWithUrlTemplate);
+               expect(compFixture.nativeElement).toHaveText('Hello world!');
+             }));
         });
 
         describe('useJit true', () => {
@@ -904,22 +902,25 @@ class CompWithUrlTemplate {
               {providers: [{provide: ResourceLoader, useValue: {get: resourceLoaderGet}}]});
         });
 
-        fixmeIvy('FW-553: TestBed is unaware of async compilation')
-            .it('should report an error for declared components with templateUrl which never call TestBed.compileComponents',
-                () => {
-                  const itPromise = patchJasmineIt();
+        it('should report an error for declared components with templateUrl which never call TestBed.compileComponents',
+           () => {
+             const itPromise = patchJasmineIt();
 
-                  expect(
-                      () => it(
-                          'should fail', withModule(
-                                             {declarations: [CompWithUrlTemplate]},
-                                             () => TestBed.createComponent(CompWithUrlTemplate))))
-                      .toThrowError(
-                          `This test module uses the component ${stringify(CompWithUrlTemplate)} which is using a "templateUrl" or "styleUrls", but they were never compiled. ` +
-                          `Please call "TestBed.compileComponents" before your test.`);
+             expect(
+                 () =>
+                     it('should fail', withModule(
+                                           {declarations: [CompWithUrlTemplate]},
+                                           () => TestBed.createComponent(CompWithUrlTemplate))))
+                 .toThrowError(
+                     ivyEnabled ?
+                         `Component 'CompWithUrlTemplate' is not resolved:
+ - templateUrl: /base/angular/packages/platform-browser/test/static_assets/test.html
+Did you run and wait for 'resolveComponentResources()'?` :
+                         `This test module uses the component ${stringify(CompWithUrlTemplate)} which is using a "templateUrl" or "styleUrls", but they were never compiled. ` +
+                             `Please call "TestBed.compileComponents" before your test.`);
 
-                  restoreJasmineIt();
-                });
+             restoreJasmineIt();
+           });
 
       });
 
@@ -1015,7 +1016,6 @@ class CompWithUrlTemplate {
       });
 
       it('should override component dependencies', async(() => {
-
            const componentFixture = TestBed.createComponent(ParentComp);
            componentFixture.detectChanges();
            expect(componentFixture.nativeElement).toHaveText('Parent(Mock)');


### PR DESCRIPTION
The implementation of the `compileComponents` method for `TestBedRender3` was missing.
We now pass each component through `resolveComponentResources` when `TestBed.compileComponents` is called so that `templateUrl` and `styleUrls` can be resolved asynchronously and used once `TestBed.createComponent` is called.
The component's metadata are overriden in `TestBed` instead of mutating the original metadata like this is the case outside of TestBed. The reason for that is that we need to ensure that we didn't mutate anything so that the following tests can run with the same original metadata, otherwise we it could trigger or hide some errors.

FW-553 #resolve