### PR TITLE
build: create dist/bin symlink with Bazel outputs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,12 +22,18 @@ test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test
 # Filesystem interactions     #
 ###############################
 
-# Don't create symlinks like bazel-out in the project.
-# These cause VSCode to traverse a massive tree, opening file handles and
+# Create symlinks in the project:
+# - dist/bin for outputs
+# - dist/testlogs, dist/genfiles
+# - bazel-out
+# NB: bazel-out should be excluded from the editor configuration.
+# The checked-in /.vscode/settings.json does this for VSCode.
+# Other editors may require manual config to ignore this directory.
+# In the past, we say a problem where VSCode traversed a massive tree, opening file handles and
 # eventually a surprising failure with auto-discovery of the C++ toolchain in
 # MacOS High Sierra.
 # See https://github.com/bazelbuild/bazel/issues/4603
-build --symlink_prefix=/
+build --symlink_prefix=dist/
 
 # Performance: avoid stat'ing input files
 build --watchfs

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_STORE
 
 /dist/
-/bazel-*
+/bazel-out/
 /integration/bazel/bazel-*
 e2e_test.*
 node_modules
@@ -15,7 +15,6 @@ pubspec.lock
 .settings/
 *.swo
 modules/.settings
-.vscode
 modules/.vscode
 
 # Don't check in secret files

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true,
+    "**/node_modules/**": true,
+    "**/bazel-out/**": true,
+    "**/dist/**": true,
+  },
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/bower_components": true,
+    "**/bazel-out": true,
+    "**/dist": true,
+  },
+}

--- a/integration/bazel/.bazelrc
+++ b/integration/bazel/.bazelrc
@@ -13,3 +13,6 @@ build --local_resources=14336,8.0,1.0
 
 # Use the Angular 6 compiler
 build --define=compile=legacy
+
+# Don't create symlinks
+build --symlink_prefix=/


### PR DESCRIPTION
Note that we had nasty problems in the past when this was enabled, but those have supposedly been fixed.
