### PR TITLE
fix(ivy): restore NG defs after running tests in TestBed

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -163,6 +163,17 @@ export {
 } from './render3/context_discovery';
 
 export {
+  NG_ELEMENT_ID as ɵNG_ELEMENT_ID,
+  NG_COMPONENT_DEF as ɵNG_COMPONENT_DEF,
+  NG_DIRECTIVE_DEF as ɵNG_DIRECTIVE_DEF,
+  NG_INJECTABLE_DEF as ɵNG_INJECTABLE_DEF,
+  NG_INJECTOR_DEF as ɵNG_INJECTOR_DEF,
+  NG_PIPE_DEF as ɵNG_PIPE_DEF,
+  NG_MODULE_DEF as ɵNG_MODULE_DEF,
+  NG_BASE_DEF as ɵNG_BASE_DEF
+} from './render3/fields';
+
+export {
   Player as ɵPlayer,
   PlayerFactory as ɵPlayerFactory,
   PlayState as ɵPlayState,


### PR DESCRIPTION
`R3TestBed` allows consumers to configure a "testing module", declare components, override various metadata, etc. To do this, it implements its own JIT compilation, where components/directives/modules have Ivy definition fields generated based on testing metadata. It results in tests interfering with each other. One test might override something in a component that another test tries to use normally, causing failures.

In order to resolve this problem, we store current components/directives/modules defs before applying overrides and re-compiling. Once the test is complete, we restore initial defs, so the next tests interact with "clean" components.

**Update (12/25): rebased from the latest master.**

This PR resolves FW-872.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
