### PR TITLE
build(docs-infra): upgrade cli command docs sources to 771c22899

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -18,7 +18,7 @@
     "build-for": "yarn ~~build --configuration",
     "prebuild-local": "yarn setup-local",
     "build-local": "yarn ~~build --configuration=stable",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 02524ab82",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 771c22899",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#7.1.x](https://github.com/angular/angular/tree/7.1.x) from [cli-builds#7.2.x](https://github.com/angular/cli-builds/tree/7.2.x).
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/02524ab82...771c22899):

**Modified**
- help/build.json
- help/generate.json
- help/run.json
- help/serve.json
- help/test.json
- help/update.json