### PR TITLE
test(bazel): fix `bazel-workspace` schematics test

### DIFF
--- a/packages/bazel/src/schematics/bazel-workspace/index_spec.ts
+++ b/packages/bazel/src/schematics/bazel-workspace/index_spec.ts
@@ -48,7 +48,7 @@ describe('Bazel-workspace Schematic', () => {
     const {files} = host;
     expect(files).toContain('/demo-app/src/BUILD.bazel');
     const content = host.readContent('/demo-app/src/BUILD.bazel');
-    expect(content).toContain('entry_module = "demo_app/src/main.dev"');
+    expect(content).toContain('entry_module = "demo_app/src/main"');
   });
 
   describe('WORKSPACE', () => {


### PR DESCRIPTION
The test was cherry-picked from #27719 into 7.1.x, where entry module path ended in `/main`, not `/main.dev`. It was changed to `/main.dev` in #27277, which was not backported to 7.1.x.
