### PR TITLE
feat(common): inject CURRENCY_ID in number_pipe constructor

### DIFF
--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, LOCALE_ID, Pipe, PipeTransform} from '@angular/core';
+import {Inject, LOCALE_ID, CURRENCY_ID, Pipe, PipeTransform} from '@angular/core';
 import {formatCurrency, formatNumber, formatPercent} from '../i18n/format_number';
 import {getCurrencySymbol} from '../i18n/locale_data_api';
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
@@ -155,13 +155,14 @@ export class PercentPipe implements PipeTransform {
  */
 @Pipe({name: 'currency'})
 export class CurrencyPipe implements PipeTransform {
-  constructor(@Inject(LOCALE_ID) private _locale: string) {}
+  constructor(@Inject(LOCALE_ID) private _locale: string, @Inject(CURRENCY_ID) private _currencyCode?: string) {}
 
   /**
    *
    * @param value The number to be formatted as currency.
    * @param currencyCode The [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code,
-   * such as `USD` for the US dollar and `EUR` for the euro.
+   * such as `USD` for the US dollar and `EUR` for the euro. If not provided, it will use injected CURRENCY_ID,
+   * and if no value was injected, it will default to 'USD'.
    * @param display The format for the currency indicator. One of the following:
    *   - `code`: Show the code (such as `USD`).
    *   - `symbol`(default): Show the symbol (such as `$`).
@@ -205,7 +206,7 @@ export class CurrencyPipe implements PipeTransform {
       display = display ? 'symbol' : 'code';
     }
 
-    let currency: string = currencyCode || 'USD';
+    let currency: string = currencyCode || this._currencyCode || 'USD';
     if (display !== 'code') {
       if (display === 'symbol' || display === 'symbol-narrow') {
         currency = getCurrencySymbol(currency, display === 'symbol' ? 'wide' : 'narrow', locale);

--- a/packages/common/test/pipes/number_pipe_spec.ts
+++ b/packages/common/test/pipes/number_pipe_spec.ts
@@ -79,12 +79,31 @@ import {beforeEach, describe, expect, it} from '@angular/core/testing/src/testin
       });
     });
 
+
     describe('CurrencyPipe', () => {
       let pipe: CurrencyPipe;
 
-      beforeEach(() => { pipe = new CurrencyPipe('en-US'); });
+      describe('Constructor', ()=>{
+        it('should show EUR symbol', ()=>{
+          const pipe = new CurrencyPipe('en-US', 'EUR');
+          expect(pipe.transform(12, undefined, 'code', '.1')).toEqual('EUR12.0');
+        }),
+          it('should show CAD symbol', ()=>{
+            const pipe = new CurrencyPipe('en-US', 'EUR');
+            expect(pipe.transform(5.1234, 'CAD', 'symbol')).toEqual('CA$5.12');
+          }),
+          it('should show $ symbol', ()=>{
+            const pipe = new CurrencyPipe('en-US');
+            expect(pipe.transform(123)).toEqual('$123.00');
+          }),
+          it('should show CAD symbol', ()=>{
+            const pipe = new CurrencyPipe('en-US');
+            expect(pipe.transform(5.1234, 'CAD', 'symbol')).toEqual('CA$5.12');
+          })
+      })
 
       describe('transform', () => {
+        beforeEach(() => { pipe = new CurrencyPipe('en-US'); });
         it('should return correct value for numbers', () => {
           expect(pipe.transform(123)).toEqual('$123.00');
           expect(pipe.transform(12, 'EUR', 'code', '.1')).toEqual('EUR12.0');

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -26,7 +26,7 @@ export {DebugElement, DebugNode, asNativeElements, getDebugNode, Predicate} from
 export {GetTestability, Testability, TestabilityRegistry, setTestabilityGetter} from './testability/testability';
 export * from './change_detection';
 export * from './platform_core_providers';
-export {TRANSLATIONS, TRANSLATIONS_FORMAT, LOCALE_ID, MissingTranslationStrategy} from './i18n/tokens';
+export {TRANSLATIONS, TRANSLATIONS_FORMAT, LOCALE_ID, CURRENCY_ID, MissingTranslationStrategy} from './i18n/tokens';
 export {ApplicationModule} from './application_module';
 export {wtfCreateScope, wtfLeave, wtfStartTimeRange, wtfEndTimeRange, WtfScopeFn} from './profile/profile';
 export {Type} from './type';

--- a/packages/core/src/i18n/tokens.ts
+++ b/packages/core/src/i18n/tokens.ts
@@ -33,6 +33,28 @@ import {InjectionToken} from '../di/injection_token';
 export const LOCALE_ID = new InjectionToken<string>('LocaleId');
 
 /**
+ * Provide this token to set the default currency of your application.
+ * It is used  by CurrencyPipe to show a default currency symbol without expliciting in every template use.
+ *
+ *
+ * @usageNotes
+ * ### Example
+ *
+ * ```typescript
+ * import { CURRENCY_ID } from '@angular/core';
+ * import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+ * import { AppModule } from './app/app.module';
+ *
+ * platformBrowserDynamic().bootstrapModule(AppModule, {
+ *   providers: [{provide: CURRENCY_ID, useValue: 'GBP' }]
+ * });
+ * ```
+ *
+ * @publicApi
+ */
+export const CURRENCY_ID = new InjectionToken<string>('CurrencyId');
+
+/**
  * Use this token at bootstrap to provide the content of your translation file (`xtb`,
  * `xlf` or `xlf2`) when you want to translate your application in another language.
  *


### PR DESCRIPTION
change constructor to accept an injected CURRENCY_ID(similar to LOCALE_ID) and use it as a default when no currencyCode is provided, before 'USD' fallback.

Now currency code still is by default 'USD', but can be changed in a provider using provide and useValue:
```
  providers: [
      { provide: CURRENCY_ID, useValue: "EUR" },
  ],
```

Closes #25461, #22519

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

 #25461, #22519

## What is the new behavior?

Currency code still is by default 'USD', but can be changed in a provider using provide and useValue:
```
  providers: [
      { provide: CURRENCY_ID, useValue: "EUR" },
  ],
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
