### PR TITLE
fix(ivy): ngtsc program emit ignoring custom transformers

### DIFF
--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -22,7 +22,7 @@ import {performWatchCompilation, createPerformWatchHost} from './perform_watch'
 
 export function main(
     args: string[], consoleError: (s: string) => void = console.error,
-    config?: NgcParsedConfiguration): number {
+    config?: NgcParsedConfiguration, customTransformers?: api.CustomTransformers): number {
   let {project, rootNames, options, errors: configErrors, watch, emitFlags} =
       config || readNgcCommandLineAndConfiguration(args);
   if (configErrors.length) {
@@ -32,8 +32,12 @@ export function main(
     const result = watchMode(project, options, consoleError);
     return reportErrorsAndExit(result.firstCompileResult, options, consoleError);
   }
-  const {diagnostics: compileDiags} = performCompilation(
-      {rootNames, options, emitFlags, emitCallback: createEmitCallback(options)});
+  const {diagnostics: compileDiags} = performCompilation({
+    rootNames,
+    options,
+    emitFlags,
+    emitCallback: createEmitCallback(options), customTransformers
+  });
   return reportErrorsAndExit(compileDiags, options, consoleError);
 }
 

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {CustomTransformers} from '@angular/compiler-cli';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
@@ -111,9 +112,9 @@ export class NgtscTestEnvironment {
   /**
    * Run the compiler to completion, and assert that no errors occurred.
    */
-  driveMain(): void {
+  driveMain(customTransformers?: CustomTransformers): void {
     const errorSpy = jasmine.createSpy('consoleError').and.callFake(console.error);
-    const exitCode = main(['-p', this.basePath], errorSpy);
+    const exitCode = main(['-p', this.basePath], errorSpy, undefined, customTransformers);
     expect(errorSpy).not.toHaveBeenCalled();
     expect(exitCode).toBe(0);
   }

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1227,4 +1227,32 @@ describe('ngtsc behavioral tests', () => {
       expect(dtsContents).toContain('/// <amd-module name="@mymodule" />');
     });
   });
+
+  it('should execute custom transformers', () => {
+    let beforeCount = 0;
+    let afterCount = 0;
+
+    env.tsconfig();
+    env.write('test.ts', `
+      import {NgModule} from '@angular/core';
+
+      @NgModule({})
+      class Module {}
+    `);
+
+    env.driveMain({
+      beforeTs: [() => sourceFile => {
+        beforeCount++;
+        return sourceFile;
+      }],
+      afterTs: [() => sourceFile => {
+        afterCount++;
+        return sourceFile;
+      }],
+    });
+
+    expect(beforeCount).toBe(1);
+    expect(afterCount).toBe(1);
+  });
+
 });


### PR DESCRIPTION
Fixes the `customTransformers` that are passed to the `NgtscProgram.emit` not being passed along to the emit callback.
