### PR TITLE
fix(bazel): flat module misses AMD module name on windows

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -199,25 +199,27 @@ export function compile({allDepsCompiledWithBazel = true, compilerOpts, tsHost, 
   };
   const origBazelHostShouldNameModule = bazelHost.shouldNameModule.bind(bazelHost);
   bazelHost.shouldNameModule = (fileName: string) => {
+    const flatModuleOutPath =
+        path.posix.join(bazelOpts.package, compilerOpts.flatModuleOutFile + '.ts');
+
     // The bundle index file is synthesized in bundle_index_host so it's not in the
     // compilationTargetSrc.
     // However we still want to give it an AMD module name for devmode.
     // We can't easily tell which file is the synthetic one, so we build up the path we expect
     // it to have and compare against that.
-    if (fileName ===
-        path.join(compilerOpts.baseUrl, bazelOpts.package, compilerOpts.flatModuleOutFile + '.ts'))
-      return true;
+    if (fileName === path.posix.join(compilerOpts.baseUrl, flatModuleOutPath)) return true;
+
     // Also handle the case the target is in an external repository.
     // Pull the workspace name from the target which is formatted as `@wksp//package:target`
     // if it the target is from an external workspace. If the target is from the local
     // workspace then it will be formatted as `//package:target`.
     const targetWorkspace = bazelOpts.target.split('/')[0].replace(/^@/, '');
+
     if (targetWorkspace &&
         fileName ===
-            path.join(
-                compilerOpts.baseUrl, 'external', targetWorkspace, bazelOpts.package,
-                compilerOpts.flatModuleOutFile + '.ts'))
+            path.posix.join(compilerOpts.baseUrl, 'external', targetWorkspace, flatModuleOutPath))
       return true;
+
     return origBazelHostShouldNameModule(fileName) || NGC_GEN_FILES.test(fileName);
   };
 

--- a/packages/bazel/test/ngc-wrapped/BUILD.bazel
+++ b/packages/bazel/test/ngc-wrapped/BUILD.bazel
@@ -35,3 +35,19 @@ jasmine_node_test(
         "@build_bazel_rules_typescript//third_party/github.com/bazelbuild/bazel/src/main/protobuf:worker_protocol.proto",
     ],
 )
+
+ts_library(
+    name = "flat_module_test_lib",
+    testonly = True,
+    srcs = ["flat_module_test.ts"],
+    tsconfig = ":tsconfig.json",
+    deps = [
+        "//packages/private/testing",
+    ],
+)
+
+jasmine_node_test(
+    name = "flat_module_test",
+    srcs = [":flat_module_test_lib"],
+    data = ["//packages/bazel/test/ngc-wrapped/flat_module"],
+)

--- a/packages/bazel/test/ngc-wrapped/flat_module/BUILD.bazel
+++ b/packages/bazel/test/ngc-wrapped/flat_module/BUILD.bazel
@@ -1,0 +1,16 @@
+load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//packages/bazel/test:__subpackages__"])
+
+ng_module(
+    name = "flat_module",
+    srcs = [
+        "export.ts",
+        "index.ts",
+    ],
+    module_name = "flat_module",
+    tsconfig = ":tsconfig.json",
+    deps = [
+        "//packages/core",
+    ],
+)

--- a/packages/bazel/test/ngc-wrapped/flat_module/export.ts
+++ b/packages/bazel/test/ngc-wrapped/flat_module/export.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export const Test = 'This is a test export';

--- a/packages/bazel/test/ngc-wrapped/flat_module/index.ts
+++ b/packages/bazel/test/ngc-wrapped/flat_module/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './export';

--- a/packages/bazel/test/ngc-wrapped/flat_module/tsconfig.json
+++ b/packages/bazel/test/ngc-wrapped/flat_module/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "types": []
+  }
+}

--- a/packages/bazel/test/ngc-wrapped/flat_module_test.ts
+++ b/packages/bazel/test/ngc-wrapped/flat_module_test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {obsoleteInIvy, onlyInIvy} from '@angular/private/testing';
+import {existsSync, readFileSync} from 'fs';
+import {dirname, join} from 'path';
+
+describe('flat_module ng_module', () => {
+
+  let packageOutput: string;
+  let flatModuleOutFile: string;
+
+  beforeAll(() => {
+    packageOutput =
+        dirname(require.resolve('angular/packages/bazel/test/ngc-wrapped/flat_module/index.js'));
+    flatModuleOutFile = join(packageOutput, 'flat_module.js');
+  });
+
+  it('should have a flat module out file',
+     () => { expect(existsSync(flatModuleOutFile)).toBe(true); });
+
+  describe('flat module out file', () => {
+
+    obsoleteInIvy('Ngtsc computes the AMD module name differently than NGC')
+        .it('should have a proper AMD module name', () => {
+          expect(readFileSync(flatModuleOutFile, 'utf8'))
+              .toContain(`define("flat_module/flat_module"`);
+        });
+
+    onlyInIvy('Ngtsc computes the AMD module name differently than NGC')
+        .it('should have a proper AMD module name', () => {
+          expect(readFileSync(flatModuleOutFile, 'utf8')).toContain(`define("flat_module"`);
+        });
+  });
+});


### PR DESCRIPTION
Fixes that flat module out files do not have a proper AMD module name on Windows.

This is currently blocking serving a `ng_module` using the Bazel TypeScript `devserver` on Windows.

This is how it currently looks on Windows (note that there is no module name for the `define()`)

```js
/**
 * Generated bundle index. Do not edit.
 */
(function (factory) {
    if (typeof module === "object" && typeof module.exports === "object") {
        var v = factory(require, exports);
        if (v !== undefined) module.exports = v;
    }
    else if (typeof define === "function" && define.amd) {
        define(["require", "exports", "tslib", "@angular/forms", "@angular/forms/src/directives", "@angular/forms/src/directives/checkbox_value_accessor", "@angular/forms/src/directives/default_value_accessor", "@angular/forms/src/directives/ng_control_status", "@angular/forms/src/directives/ng_form", "@angular/forms/src/directives/ng_form_selector_warning", "@angular/forms/src/directives/ng_model", "@angular/forms/src/directives/ng_model_group", "@angular/forms/src/directives/ng_no_validate_directive", "@angular/forms/src/directives/number_value_accessor", "@angular/forms/src/directives/radio_control_value_accessor", "@angular/forms/src/directives/range_value_accessor", "@angular/forms/src/directives/reactive_directives/form_control_directive", "@angular/forms/src/directives/reactive_directives/form_control_name", "@angular/forms/src/directives/reactive_directives/form_group_directive", "@angular/forms/src/directives/reactive_directives/form_group_name", "@angular/forms/src/directives/select_control_value_accessor", "@angular/forms/src/directives/select_multiple_control_value_accessor", "@angular/forms/src/directives/validators"], factory);
    }
})(function (require, exports) {
```