### PR TITLE
test(ivy): add i18n integration tests via TestBed

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -1347,7 +1347,7 @@ describe('i18n support in the view compiler', () => {
       verify(input, output);
     });
 
-    it('should be able to be child elements inside i18n block', () => {
+    it('should be able to act as child elements inside i18n block', () => {
       const input = `
         <div i18n>
           <ng-template>Template content: {{ valueA | uppercase }}</ng-template>

--- a/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_i18n_spec.ts
@@ -389,7 +389,7 @@ describe('i18n support in the view compiler', () => {
     it('should correctly bind to context in nested template', () => {
       const input = `
         <div *ngFor="let outer of items">
-          <div i18n-title="m|d" title="different scope {{ outer | uppercase }}">
+          <div i18n-title="m|d" title="different scope {{ outer | uppercase }}"></div>
         </div>
       `;
 
@@ -518,7 +518,7 @@ describe('i18n support in the view compiler', () => {
     it('should correctly bind to context in nested template', () => {
       const input = `
         <div *ngFor="let outer of items">
-          <div i18n-title="m|d" title="different scope {{ outer | uppercase }}">
+          <div i18n-title="m|d" title="different scope {{ outer | uppercase }}"></div>
         </div>
       `;
 

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -504,7 +504,7 @@ function appendI18nNode(tNode: TNode, parentTNode: TNode, previousTNode: TNode |
  * @publicAPI
  */
 export function i18nPostprocess(
-    message: string, replacements: {[key: string]: (string | string[])}): string {
+    message: string, replacements: {[key: string]: (string | string[])} = {}): string {
   //
   // Step 1: resolve all multi-value cases (like [�*1:1��#2:1�|�#4:1�|�5�])
   //

--- a/packages/core/test/i18n_integration_spec.ts
+++ b/packages/core/test/i18n_integration_spec.ts
@@ -6,28 +6,61 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
+import {Component, Directive, TemplateRef, ViewContainerRef} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {onlyInIvy, polyfillGoogGetMsg} from '@angular/private/testing';
+
+@Directive({
+  selector: '[tplRef]',
+})
+class DirectiveWithTplRef {
+  constructor(public vcRef: ViewContainerRef, public tplRef: TemplateRef<{}>) {}
+  ngOnInit() { this.vcRef.createEmbeddedView(this.tplRef, {}); }
+}
 
 @Component({selector: 'my-comp', template: ''})
 class MyComp {
   name = 'John Doe';
   items = ['1', '2', '3'];
+  visible = true;
+  age = 20;
+  count = 2;
+  otherLabel = 'other label';
 }
 
+// transform template string into i18n string
 const TRANSFORMS: any = {
-  'Welcome {{ name }}': 'Welcome {$interpolation}',
-  'Welcome {% name %}': 'Welcome {$interpolation}',
+  'Hello {{ name }}': 'Hello {$interpolation}',
+  'Hello {% name %}': 'Hello {$interpolation}',
   'Item {{ id }}': 'Item {$interpolation}'
 };
 
 const TRANSLATIONS: any = {
-  'Welcome': 'Bonjour',
-  'Welcome {$interpolation}': 'Bonjour {$interpolation}',
+  'one': 'un',
+  'two': 'deux',
+  'more than two': 'plus que deux',
+  'ten': 'dix',
+  'twenty': 'vingt',
+  'other': 'autres',
+  'Hello': 'Bonjour',
+  'Hello {$interpolation}': 'Bonjour {$interpolation}',
+  'Bye': 'Au revoir',
   'Item {$interpolation}': 'Article {$interpolation}',
-  '\'Single quotes\' and "Double quotes"': '\'Guillemets simples\' et "Guillemets doubles"'
+  '\'Single quotes\' and "Double quotes"': '\'Guillemets simples\' et "Guillemets doubles"',
+  'My logo': 'Mon logo',
+  '{$startTagSpan}My logo{$tagImg}{$closeTagSpan}':
+      '{$startTagSpan}Mon logo{$tagImg}{$closeTagSpan}',
+  '{$startTagNgTemplate} Hello {$closeTagNgTemplate}{$startTagNgContainer} Bye {$closeTagNgContainer}':
+      '{$startTagNgTemplate} Bonjour {$closeTagNgTemplate}{$startTagNgContainer} Au revoir {$closeTagNgContainer}',
+  '{$startTagNgTemplate}{$startTagSpan}Hello{$closeTagSpan}{$closeTagNgTemplate}{$startTagNgContainer}{$startTagSpan_1}Hello{$closeTagSpan}{$closeTagNgContainer}':
+      '{$startTagNgTemplate}{$startTagSpan}Bonjour{$closeTagSpan}{$closeTagNgTemplate}{$startTagNgContainer}{$startTagSpan_1}Bonjour{$closeTagSpan}{$closeTagNgContainer}',
+  '{VAR_SELECT, select, 10 {ten} 20 {twenty} other {other}}':
+      '{VAR_SELECT, select, 10 {dix} 20 {vingt} other {autres}}',
+  '{VAR_SELECT, select, 10 {10 - {$startBoldText}ten{$closeBoldText}} 20 {20 - {$startItalicText}twenty{$closeItalicText}} other {{$startTagDiv}{$startUnderlinedText}other{$closeUnderlinedText}{$closeTagDiv}}}':
+      '{VAR_SELECT, select, 10 {10 - {$startBoldText}dix{$closeBoldText}} 20 {20 - {$startItalicText}vingt{$closeItalicText}} other {{$startTagDiv}{$startUnderlinedText}autres{$closeUnderlinedText}{$closeTagDiv}}}',
+  '{VAR_SELECT_2, select, 10 {ten - {VAR_SELECT, select, 1 {one} 2 {two} other {more than two}}} 20 {twenty - {VAR_SELECT_1, select, 1 {one} 2 {two} other {more than two}}} other {other}}':
+      '{VAR_SELECT_2, select, 10 {dix - {VAR_SELECT, select, 1 {un} 2 {deux} other {plus que deux}}} 20 {vingt - {VAR_SELECT_1, select, 1 {un} 2 {deux} other {plus que deux}}} other {autres}}'
 };
 
 const translate = (label: string, interpolations: any[] = []): string => {
@@ -45,16 +78,16 @@ const getFixtureWithOverrides = (overrides = {}) => {
   return fixture;
 };
 
-onlyInIvy('Ivy i18n logic').fdescribe('i18n', function() {
+onlyInIvy('Ivy i18n logic').describe('i18n', function() {
 
   beforeEach(() => {
     polyfillGoogGetMsg(TRANSLATIONS);
-    TestBed.configureTestingModule({declarations: [MyComp]});
+    TestBed.configureTestingModule({declarations: [MyComp, DirectiveWithTplRef]});
   });
 
   describe('attributes', () => {
     it('should translate static attributes', () => {
-      const title = 'Welcome';
+      const title = 'Hello';
       const template = `<div i18n-title="m|d" title="${title}"></div>`;
       const fixture = getFixtureWithOverrides({template});
 
@@ -63,7 +96,7 @@ onlyInIvy('Ivy i18n logic').fdescribe('i18n', function() {
     });
 
     it('should support interpolation', () => {
-      const title = 'Welcome {{ name }}';
+      const title = 'Hello {{ name }}';
       const template = `<div i18n-title="m|d" title="${title}"></div>`;
       const fixture = getFixtureWithOverrides({template});
 
@@ -72,7 +105,7 @@ onlyInIvy('Ivy i18n logic').fdescribe('i18n', function() {
     });
 
     it('should support interpolation with custom interpolation config', () => {
-      const title = 'Welcome {% name %}';
+      const title = 'Hello {% name %}';
       const template = `<div i18n-title="m|d" title="${title}"></div>`;
       const interpolation = ['{%', '%}'] as[string, string];
       const fixture = getFixtureWithOverrides({template, interpolation});
@@ -84,7 +117,7 @@ onlyInIvy('Ivy i18n logic').fdescribe('i18n', function() {
     // FW-903: i18n attributes in nested templates throws at runtime
     xit('should correctly bind to context in nested template', () => {
       const title = 'Item {{ id }}';
-      const template = ` 
+      const template = `
         <div *ngFor='let id of items'>
           <div i18n-title='m|d' title='${title}'></div>
         </div>
@@ -98,73 +131,367 @@ onlyInIvy('Ivy i18n logic').fdescribe('i18n', function() {
       }
     });
 
-    describe('nested nodes', () => {
-      it('should handle static content', () => {
-        const content = 'Welcome';
-        const template = `<div i18n>${content}</div>`;
-        const fixture = getFixtureWithOverrides({template});
+    // FW-904: i18n attributes placed on i18n root node don't work
+    xit('should work correctly when placed on i18n root node', () => {
+      const title = 'Hello {{ name }}';
+      const content = 'Hello';
+      const template = `
+        <div i18n i18n-title="m|d" title="${title}">${content}</div>
+      `;
+      const fixture = getFixtureWithOverrides({template});
 
-        const element = fixture.nativeElement.firstChild;
-        expect(element).toHaveText(translate(content));
-      });
+      const element = fixture.nativeElement.firstChild;
+      expect(element.title).toBe(translate(title, [fixture.componentInstance.name]));
+      expect(element).toHaveText(translate(content));
+    });
 
-      it('should support interpolation', () => {
-        const content = 'Welcome {{ name }}';
-        const template = `<div i18n>${content}</div>`;
-        const fixture = getFixtureWithOverrides({template});
+    it('should add i18n attributes on self-closing tags', () => {
+      const title = 'Hello {{ name }}';
+      const template = `<img src="logo.png" i18n-title title="${title}">`;
+      const fixture = getFixtureWithOverrides({template});
 
-        const element = fixture.nativeElement.firstChild;
-        expect(element).toHaveText(translate(content, [fixture.componentInstance.name]));
-      });
+      const element = fixture.nativeElement.firstChild;
+      expect(element.title).toBe(translate(title, [fixture.componentInstance.name]));
+    });
+  });
 
-      it('should support interpolation with custom interpolation config', () => {
-        const content = 'Welcome {% name %}';
-        const template = `<div i18n>${content}</div>`;
-        const interpolation = ['{%', '%}'] as[string, string];
-        const fixture = getFixtureWithOverrides({template, interpolation});
+  describe('nested nodes', () => {
+    it('should handle static content', () => {
+      const content = 'Hello';
+      const template = `<div i18n>${content}</div>`;
+      const fixture = getFixtureWithOverrides({template});
 
-        const element = fixture.nativeElement.firstChild;
-        expect(element).toHaveText(translate(content, [fixture.componentInstance.name]));
-      });
+      const element = fixture.nativeElement.firstChild;
+      expect(element).toHaveText(translate(content));
+    });
 
-      it('should properly escape quotes in content', () => {
-        const content = `'Single quotes' and "Double quotes"`;
-        const template = `<div i18n>${content}</div>`;
-        const fixture = getFixtureWithOverrides({template});
+    it('should support interpolation', () => {
+      const content = 'Hello {{ name }}';
+      const template = `<div i18n>${content}</div>`;
+      const fixture = getFixtureWithOverrides({template});
 
-        const element = fixture.nativeElement.firstChild;
-        expect(element).toHaveText(translate(content));
-      });
+      const element = fixture.nativeElement.firstChild;
+      expect(element).toHaveText(translate(content, [fixture.componentInstance.name]));
+    });
 
-      it('should correctly bind to context in nested template', () => {
-        const content = 'Item {{ id }}';
-        const template = ` 
+    it('should support interpolation with custom interpolation config', () => {
+      const content = 'Hello {% name %}';
+      const template = `<div i18n>${content}</div>`;
+      const interpolation = ['{%', '%}'] as[string, string];
+      const fixture = getFixtureWithOverrides({template, interpolation});
+
+      const element = fixture.nativeElement.firstChild;
+      expect(element).toHaveText(translate(content, [fixture.componentInstance.name]));
+    });
+
+    it('should properly escape quotes in content', () => {
+      const content = `'Single quotes' and "Double quotes"`;
+      const template = `<div i18n>${content}</div>`;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement.firstChild;
+      expect(element).toHaveText(translate(content));
+    });
+
+    it('should correctly bind to context in nested template', () => {
+      const content = 'Item {{ id }}';
+      const template = `
           <div *ngFor='let id of items'>
             <div i18n>${content}</div>
           </div>
         `;
-        const fixture = getFixtureWithOverrides({template});
+      const fixture = getFixtureWithOverrides({template});
 
-        const element = fixture.nativeElement;
-        for (let i = 0; i < element.children.length; i++) {
-          const child = element.children[i];
-          expect(child).toHaveText(translate(content, [i + 1]));
-        }
-      });
+      const element = fixture.nativeElement;
+      for (let i = 0; i < element.children.length; i++) {
+        const child = element.children[i];
+        expect(child).toHaveText(translate(content, [i + 1]));
+      }
+    });
 
-      it('should handle i18n attributes inside i18n section', () => {
-        const title = 'Welcome {{ name }}';
-        const template = `
+    it('should handle i18n attributes inside i18n section', () => {
+      const title = 'Hello {{ name }}';
+      const template = `
           <div i18n>
             <div i18n-title="m|d" title="${title}"></div>
           </div>
         `;
-        const fixture = getFixtureWithOverrides({template});
+      const fixture = getFixtureWithOverrides({template});
 
-        const element = fixture.nativeElement.firstChild;
-        const content = `<div title="${translate(title, [fixture.componentInstance.name])}"></div>`;
-        expect(element.innerHTML).toBe(content);
-      });
+      const element = fixture.nativeElement.firstChild;
+      const content = `<div title="${translate(title, [fixture.componentInstance.name])}"></div>`;
+      expect(element.innerHTML).toBe(content);
+    });
+
+    it('should handle i18n blocks in nested templates', () => {
+      const content = 'Hello {{ name }}';
+      const template = `
+        <div *ngIf="visible">
+          <div i18n>${content}</div>
+        </div>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement.firstChild;
+      expect(element.children[0]).toHaveText(translate(content, [fixture.componentInstance.name]));
+    });
+
+    it('should ignore i18n attributes on self-closing tags', () => {
+      const template = '<img src="logo.png" i18n>';
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement;
+      expect(element.innerHTML).toBe(template.replace(' i18n', ''));
+    });
+
+    it('should handle i18n attribute with directives', () => {
+      const content = 'Hello {{ name }}';
+      const template = `
+        <div *ngIf="visible" i18n>${content}</div>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement.firstChild;
+      expect(element).toHaveText(translate(content, [fixture.componentInstance.name]));
+    });
+  });
+
+  describe('ng-container and ng-template support', () => {
+    it('should handle single translation message within ng-container', () => {
+      const content = 'Hello {{ name }}';
+      const template = `
+        <ng-container i18n>${content}</ng-container>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement.firstChild;
+      expect(element).toHaveText(translate(content, [fixture.componentInstance.name]));
+    });
+
+    it('should handle single translation message within ng-template', () => {
+      const content = 'Hello {{ name }}';
+      const template = `
+        <ng-template i18n tplRef>${content}</ng-template>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement;
+      expect(element).toHaveText(translate(content, [fixture.componentInstance.name]));
+    });
+
+    it('should be able to act as child elements inside i18n block (plain text content)', () => {
+      const hello = 'Hello';
+      const bye = 'Bye';
+      const template = `
+        <div i18n>
+          <ng-template tplRef>
+            ${hello}
+          </ng-template>
+          <ng-container>
+            ${bye}
+          </ng-container>
+        </div>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement.firstChild;
+      expect(element.textContent.replace(/\s+/g, ' ').trim())
+          .toBe(`${translate(hello)} ${translate(bye)}`);
+    });
+
+    // FW-910: Invalid placeholder structure generated when using <ng-template> with content that
+    // contains tags
+    xit('should be able to act as child elements inside i18n block (text + tags)', () => {
+      const content = 'Hello';
+      const template = `
+        <div i18n>
+          <ng-template tplRef>
+            <span>${content}</span>
+          </ng-template>
+          <ng-container>
+            <span>${content}</span>
+          </ng-container>
+        </div>
+       `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement;
+      const spans = element.getElementsByTagName('span');
+      for (let i = 0; i < spans.length; i++) {
+        const child = spans[i];
+        expect((child as any).innerHTML).toBe(translate(content));
+      }
+    });
+
+    it('should handle self-closing tags as content', () => {
+      const label = 'My logo';
+      const content = `${label}<img src="logo.png" title="Logo">`;
+      const template = `
+        <ng-container i18n>
+          <span>${content}</span>
+        </ng-container>
+        <ng-template i18n tplRef>
+          <span>${content}</span>
+        </ng-template>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement;
+      const spans = element.getElementsByTagName('span');
+      for (let i = 0; i < spans.length; i++) {
+        const child = spans[i];
+        expect(child).toHaveText(translate(label));
+      }
+    });
+  });
+
+  describe('ICU logic', () => {
+    it('should handle single ICUs', () => {
+      const template = `
+        <div i18n>{age, select, 10 {ten} 20 {twenty} other {other}}</div>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement;
+      expect(element).toHaveText(translate('twenty'));
+    });
+
+    it('should support ICUs generated outside of i18n blocks', () => {
+      const template = `
+        <div>{age, select, 10 {ten} 20 {twenty} other {other}}</div>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement;
+      expect(element).toHaveText(translate('twenty'));
+    });
+
+    it('should support interpolation', () => {
+      const template = `
+        <div i18n>{age, select, 10 {ten} other {{{ otherLabel }}}}</div>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement;
+      expect(element).toHaveText(fixture.componentInstance.otherLabel);
+    });
+
+    it('should support interpolation with custom interpolation config', () => {
+      const template = `
+        <div i18n>{age, select, 10 {ten} other {{% otherLabel %}}}</div>
+      `;
+      const interpolation = ['{%', '%}'] as[string, string];
+      const fixture = getFixtureWithOverrides({template, interpolation});
+
+      const element = fixture.nativeElement;
+      expect(element).toHaveText(fixture.componentInstance.otherLabel);
+    });
+
+    it('should handle ICUs with HTML tags inside', () => {
+      const template = `
+        <div i18n>
+          {age, select, 10 {10 - <b>ten</b>} 20 {20 - <i>twenty</i>} other {<div class="other"><u>other</u></div>}}
+        </div>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement.firstChild;
+      const italicTags = element.getElementsByTagName('i');
+      expect(italicTags.length).toBe(1);
+      expect(italicTags[0].innerHTML).toBe(translate('twenty'));
+    });
+
+    // FW-905: Multiple ICUs in one i18n block are not processed
+    xit('should handle multiple ICUs in one block', () => {
+      const template = `
+        <div i18n>
+          {age, select, 10 {ten} 20 {twenty} other {other}} - 
+          {count, select, 1 {one} 2 {two} other {more than two}}
+        </div>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement.firstChild;
+      expect(element).toHaveText(`${translate('twenty')} - ${translate('two')}`);
+    });
+
+    // FW-906: Multiple ICUs wrapped in HTML tags in one i18n block throw an error
+    xit('should handle multiple ICUs in one i18n block wrapped in HTML elements', () => {
+      const template = `
+        <div i18n>
+          <span>
+            {age, select, 10 {ten} 20 {twenty} other {other}}
+          </span>
+          <span>
+            {count, select, 1 {one} 2 {two} other {more than two}}
+          </span>
+        </div>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement.firstChild;
+      const spans = element.getElementsByTagName('span');
+      expect(spans.length).toBe(2);
+      expect(spans[0].innerHTML).toBe(translate('twenty'));
+      expect(spans[1].innerHTML).toBe(translate('two'));
+    });
+
+    // FW-907: ICUs in templates are not processed (treated as text)
+    xit('should handle ICUs inside a template in i18n block', () => {
+      const template = `
+        <div i18n>
+          <span *ngIf="visible">
+            {age, select, 10 {ten} 20 {twenty} other {other}}
+          </span>
+        </div>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement.firstChild;
+      const spans = element.getElementsByTagName('span');
+      expect(spans.length).toBe(1);
+      expect(spans[0].innerHTML).toBe(translate('twenty'));
+    });
+
+    it('should handle nested icus', () => {
+      const template = `
+        <div i18n>
+          {age, select,
+            10 {ten - {count, select, 1 {one} 2 {two} other {more than two}}}
+            20 {twenty - {count, select, 1 {one} 2 {two} other {more than two}}}
+            other {other}}
+        </div>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement.firstChild;
+      expect(element).toHaveText(`${translate('twenty')} - ${translate('two')}`);
+    });
+
+    // FW-908: ICUs inside <ng-container>s throw an error at runtime
+    xit('should handle ICUs inside <ng-container>', () => {
+      const template = `
+        <ng-container i18n>
+          {age, select, 10 {ten} 20 {twenty} other {other}}
+        </ng-container>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement;
+      expect(element.innerHTML).toBe(translate('twenty'));
+    });
+
+    // FW-909: ICUs inside <ng-template>s throw errors at runtime
+    xit('should handle ICUs inside <ng-template>', () => {
+      const template = `
+        <ng-template i18n tplRef>
+          {age, select, 10 {ten} 20 {twenty} other {other}}
+        </ng-template>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement;
+      expect(element.innerHTML).toBe(translate('twenty'));
     });
   });
 });

--- a/packages/core/test/i18n_integration_spec.ts
+++ b/packages/core/test/i18n_integration_spec.ts
@@ -1,0 +1,170 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {onlyInIvy, polyfillGoogGetMsg} from '@angular/private/testing';
+
+@Component({selector: 'my-comp', template: ''})
+class MyComp {
+  name = 'John Doe';
+  items = ['1', '2', '3'];
+}
+
+const TRANSFORMS: any = {
+  'Welcome {{ name }}': 'Welcome {$interpolation}',
+  'Welcome {% name %}': 'Welcome {$interpolation}',
+  'Item {{ id }}': 'Item {$interpolation}'
+};
+
+const TRANSLATIONS: any = {
+  'Welcome': 'Bonjour',
+  'Welcome {$interpolation}': 'Bonjour {$interpolation}',
+  'Item {$interpolation}': 'Article {$interpolation}',
+  '\'Single quotes\' and "Double quotes"': '\'Guillemets simples\' et "Guillemets doubles"'
+};
+
+const translate = (label: string, interpolations: any[] = []): string => {
+  const placeholders = interpolations.reduce((acc: any, value: any, idx: number): any => {
+    acc[`interpolation${idx > 0 ? idx : ''}`] = value;
+    return acc;
+  }, {});
+  return goog.getMsg(TRANSFORMS[label] || label, placeholders);
+};
+
+const getFixtureWithOverrides = (overrides = {}) => {
+  TestBed.overrideComponent(MyComp, {set: overrides});
+  const fixture = TestBed.createComponent(MyComp);
+  fixture.detectChanges();
+  return fixture;
+};
+
+onlyInIvy('Ivy i18n logic').fdescribe('i18n', function() {
+
+  beforeEach(() => {
+    polyfillGoogGetMsg(TRANSLATIONS);
+    TestBed.configureTestingModule({declarations: [MyComp]});
+  });
+
+  describe('attributes', () => {
+    it('should translate static attributes', () => {
+      const title = 'Welcome';
+      const template = `<div i18n-title="m|d" title="${title}"></div>`;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement.firstChild;
+      expect(element.title).toBe(translate(title));
+    });
+
+    it('should support interpolation', () => {
+      const title = 'Welcome {{ name }}';
+      const template = `<div i18n-title="m|d" title="${title}"></div>`;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement.firstChild;
+      expect(element.title).toBe(translate(title, [fixture.componentInstance.name]));
+    });
+
+    it('should support interpolation with custom interpolation config', () => {
+      const title = 'Welcome {% name %}';
+      const template = `<div i18n-title="m|d" title="${title}"></div>`;
+      const interpolation = ['{%', '%}'] as[string, string];
+      const fixture = getFixtureWithOverrides({template, interpolation});
+
+      const element = fixture.nativeElement.firstChild;
+      expect(element.title).toBe(translate(title, [fixture.componentInstance.name]));
+    });
+
+    // FW-903: i18n attributes in nested templates throws at runtime
+    xit('should correctly bind to context in nested template', () => {
+      const title = 'Item {{ id }}';
+      const template = ` 
+        <div *ngFor='let id of items'>
+          <div i18n-title='m|d' title='${title}'></div>
+        </div>
+      `;
+      const fixture = getFixtureWithOverrides({template});
+
+      const element = fixture.nativeElement;
+      for (let i = 0; i < element.children.length; i++) {
+        const child = element.children[i];
+        expect((child as any).innerHTML).toBe(`<div title="${translate(title, [i + 1])}"></div>`);
+      }
+    });
+
+    describe('nested nodes', () => {
+      it('should handle static content', () => {
+        const content = 'Welcome';
+        const template = `<div i18n>${content}</div>`;
+        const fixture = getFixtureWithOverrides({template});
+
+        const element = fixture.nativeElement.firstChild;
+        expect(element).toHaveText(translate(content));
+      });
+
+      it('should support interpolation', () => {
+        const content = 'Welcome {{ name }}';
+        const template = `<div i18n>${content}</div>`;
+        const fixture = getFixtureWithOverrides({template});
+
+        const element = fixture.nativeElement.firstChild;
+        expect(element).toHaveText(translate(content, [fixture.componentInstance.name]));
+      });
+
+      it('should support interpolation with custom interpolation config', () => {
+        const content = 'Welcome {% name %}';
+        const template = `<div i18n>${content}</div>`;
+        const interpolation = ['{%', '%}'] as[string, string];
+        const fixture = getFixtureWithOverrides({template, interpolation});
+
+        const element = fixture.nativeElement.firstChild;
+        expect(element).toHaveText(translate(content, [fixture.componentInstance.name]));
+      });
+
+      it('should properly escape quotes in content', () => {
+        const content = `'Single quotes' and "Double quotes"`;
+        const template = `<div i18n>${content}</div>`;
+        const fixture = getFixtureWithOverrides({template});
+
+        const element = fixture.nativeElement.firstChild;
+        expect(element).toHaveText(translate(content));
+      });
+
+      it('should correctly bind to context in nested template', () => {
+        const content = 'Item {{ id }}';
+        const template = ` 
+          <div *ngFor='let id of items'>
+            <div i18n>${content}</div>
+          </div>
+        `;
+        const fixture = getFixtureWithOverrides({template});
+
+        const element = fixture.nativeElement;
+        for (let i = 0; i < element.children.length; i++) {
+          const child = element.children[i];
+          expect(child).toHaveText(translate(content, [i + 1]));
+        }
+      });
+
+      it('should handle i18n attributes inside i18n section', () => {
+        const title = 'Welcome {{ name }}';
+        const template = `
+          <div i18n>
+            <div i18n-title="m|d" title="${title}"></div>
+          </div>
+        `;
+        const fixture = getFixtureWithOverrides({template});
+
+        const element = fixture.nativeElement.firstChild;
+        const content = `<div title="${translate(title, [fixture.componentInstance.name])}"></div>`;
+        expect(element.innerHTML).toBe(content);
+      });
+    });
+  });
+});

--- a/packages/core/test/i18n_integration_spec.ts
+++ b/packages/core/test/i18n_integration_spec.ts
@@ -9,7 +9,7 @@
 import {Component, Directive, TemplateRef, ViewContainerRef} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {onlyInIvy, polyfillGoogGetMsg} from '@angular/private/testing';
+import {fixmeIvy, onlyInIvy, polyfillGoogGetMsg} from '@angular/private/testing';
 
 @Directive({
   selector: '[tplRef]',
@@ -114,36 +114,37 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       expect(element.title).toBe(translate(title, [fixture.componentInstance.name]));
     });
 
-    // FW-903: i18n attributes in nested templates throws at runtime
-    xit('should correctly bind to context in nested template', () => {
-      const title = 'Item {{ id }}';
-      const template = `
-        <div *ngFor='let id of items'>
-          <div i18n-title='m|d' title='${title}'></div>
-        </div>
-      `;
-      const fixture = getFixtureWithOverrides({template});
+    fixmeIvy('FW-903: i18n attributes in nested templates throws at runtime')
+        .it('should correctly bind to context in nested template', () => {
+          const title = 'Item {{ id }}';
+          const template = `
+            <div *ngFor='let id of items'>
+              <div i18n-title='m|d' title='${title}'></div>
+            </div>
+          `;
+          const fixture = getFixtureWithOverrides({template});
 
-      const element = fixture.nativeElement;
-      for (let i = 0; i < element.children.length; i++) {
-        const child = element.children[i];
-        expect((child as any).innerHTML).toBe(`<div title="${translate(title, [i + 1])}"></div>`);
-      }
-    });
+          const element = fixture.nativeElement;
+          for (let i = 0; i < element.children.length; i++) {
+            const child = element.children[i];
+            expect((child as any).innerHTML)
+                .toBe(`<div title="${translate(title, [i + 1])}"></div>`);
+          }
+        });
 
-    // FW-904: i18n attributes placed on i18n root node don't work
-    xit('should work correctly when placed on i18n root node', () => {
-      const title = 'Hello {{ name }}';
-      const content = 'Hello';
-      const template = `
-        <div i18n i18n-title="m|d" title="${title}">${content}</div>
-      `;
-      const fixture = getFixtureWithOverrides({template});
+    fixmeIvy('FW-904: i18n attributes placed on i18n root node don\'t work')
+        .it('should work correctly when placed on i18n root node', () => {
+          const title = 'Hello {{ name }}';
+          const content = 'Hello';
+          const template = `
+            <div i18n i18n-title="m|d" title="${title}">${content}</div>
+          `;
+          const fixture = getFixtureWithOverrides({template});
 
-      const element = fixture.nativeElement.firstChild;
-      expect(element.title).toBe(translate(title, [fixture.componentInstance.name]));
-      expect(element).toHaveText(translate(content));
-    });
+          const element = fixture.nativeElement.firstChild;
+          expect(element.title).toBe(translate(title, [fixture.componentInstance.name]));
+          expect(element).toHaveText(translate(content));
+        });
 
     it('should add i18n attributes on self-closing tags', () => {
       const title = 'Hello {{ name }}';
@@ -299,29 +300,29 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
           .toBe(`${translate(hello)} ${translate(bye)}`);
     });
 
-    // FW-910: Invalid placeholder structure generated when using <ng-template> with content that
-    // contains tags
-    xit('should be able to act as child elements inside i18n block (text + tags)', () => {
-      const content = 'Hello';
-      const template = `
-        <div i18n>
-          <ng-template tplRef>
-            <span>${content}</span>
-          </ng-template>
-          <ng-container>
-            <span>${content}</span>
-          </ng-container>
-        </div>
-       `;
-      const fixture = getFixtureWithOverrides({template});
+    fixmeIvy(
+        'FW-910: Invalid placeholder structure generated when using <ng-template> with content that contains tags')
+        .it('should be able to act as child elements inside i18n block (text + tags)', () => {
+          const content = 'Hello';
+          const template = `
+            <div i18n>
+              <ng-template tplRef>
+                <span>${content}</span>
+              </ng-template>
+              <ng-container>
+                <span>${content}</span>
+              </ng-container>
+            </div>
+          `;
+          const fixture = getFixtureWithOverrides({template});
 
-      const element = fixture.nativeElement;
-      const spans = element.getElementsByTagName('span');
-      for (let i = 0; i < spans.length; i++) {
-        const child = spans[i];
-        expect((child as any).innerHTML).toBe(translate(content));
-      }
-    });
+          const element = fixture.nativeElement;
+          const spans = element.getElementsByTagName('span');
+          for (let i = 0; i < spans.length; i++) {
+            const child = spans[i];
+            expect((child as any).innerHTML).toBe(translate(content));
+          }
+        });
 
     it('should handle self-closing tags as content', () => {
       const label = 'My logo';
@@ -401,57 +402,57 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       expect(italicTags[0].innerHTML).toBe(translate('twenty'));
     });
 
-    // FW-905: Multiple ICUs in one i18n block are not processed
-    xit('should handle multiple ICUs in one block', () => {
-      const template = `
-        <div i18n>
-          {age, select, 10 {ten} 20 {twenty} other {other}} - 
-          {count, select, 1 {one} 2 {two} other {more than two}}
-        </div>
-      `;
-      const fixture = getFixtureWithOverrides({template});
+    fixmeIvy('FW-905: Multiple ICUs in one i18n block are not processed')
+        .it('should handle multiple ICUs in one block', () => {
+          const template = `
+            <div i18n>
+              {age, select, 10 {ten} 20 {twenty} other {other}} - 
+              {count, select, 1 {one} 2 {two} other {more than two}}
+            </div>
+          `;
+          const fixture = getFixtureWithOverrides({template});
 
-      const element = fixture.nativeElement.firstChild;
-      expect(element).toHaveText(`${translate('twenty')} - ${translate('two')}`);
-    });
+          const element = fixture.nativeElement.firstChild;
+          expect(element).toHaveText(`${translate('twenty')} - ${translate('two')}`);
+        });
 
-    // FW-906: Multiple ICUs wrapped in HTML tags in one i18n block throw an error
-    xit('should handle multiple ICUs in one i18n block wrapped in HTML elements', () => {
-      const template = `
-        <div i18n>
-          <span>
-            {age, select, 10 {ten} 20 {twenty} other {other}}
-          </span>
-          <span>
-            {count, select, 1 {one} 2 {two} other {more than two}}
-          </span>
-        </div>
-      `;
-      const fixture = getFixtureWithOverrides({template});
+    fixmeIvy('FW-906: Multiple ICUs wrapped in HTML tags in one i18n block throw an error')
+        .it('should handle multiple ICUs in one i18n block wrapped in HTML elements', () => {
+          const template = `
+            <div i18n>
+              <span>
+                {age, select, 10 {ten} 20 {twenty} other {other}}
+              </span>
+              <span>
+                {count, select, 1 {one} 2 {two} other {more than two}}
+              </span>
+            </div>
+          `;
+          const fixture = getFixtureWithOverrides({template});
 
-      const element = fixture.nativeElement.firstChild;
-      const spans = element.getElementsByTagName('span');
-      expect(spans.length).toBe(2);
-      expect(spans[0].innerHTML).toBe(translate('twenty'));
-      expect(spans[1].innerHTML).toBe(translate('two'));
-    });
+          const element = fixture.nativeElement.firstChild;
+          const spans = element.getElementsByTagName('span');
+          expect(spans.length).toBe(2);
+          expect(spans[0].innerHTML).toBe(translate('twenty'));
+          expect(spans[1].innerHTML).toBe(translate('two'));
+        });
 
-    // FW-907: ICUs in templates are not processed (treated as text)
-    xit('should handle ICUs inside a template in i18n block', () => {
-      const template = `
-        <div i18n>
-          <span *ngIf="visible">
-            {age, select, 10 {ten} 20 {twenty} other {other}}
-          </span>
-        </div>
-      `;
-      const fixture = getFixtureWithOverrides({template});
+    fixmeIvy('FW-907: ICUs in templates are not processed (treated as text)')
+        .it('should handle ICUs inside a template in i18n block', () => {
+          const template = `
+            <div i18n>
+              <span *ngIf="visible">
+                {age, select, 10 {ten} 20 {twenty} other {other}}
+              </span>
+            </div>
+          `;
+          const fixture = getFixtureWithOverrides({template});
 
-      const element = fixture.nativeElement.firstChild;
-      const spans = element.getElementsByTagName('span');
-      expect(spans.length).toBe(1);
-      expect(spans[0]).toHaveText(translate('twenty'));
-    });
+          const element = fixture.nativeElement.firstChild;
+          const spans = element.getElementsByTagName('span');
+          expect(spans.length).toBe(1);
+          expect(spans[0]).toHaveText(translate('twenty'));
+        });
 
     it('should handle nested icus', () => {
       const template = `
@@ -468,30 +469,30 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       expect(element).toHaveText(`${translate('twenty')} - ${translate('two')}`);
     });
 
-    // FW-908: ICUs inside <ng-container>s throw an error at runtime
-    xit('should handle ICUs inside <ng-container>', () => {
-      const template = `
-        <ng-container i18n>
-          {age, select, 10 {ten} 20 {twenty} other {other}}
-        </ng-container>
-      `;
-      const fixture = getFixtureWithOverrides({template});
+    fixmeIvy('FW-908: ICUs inside <ng-container>s throw an error at runtime')
+        .it('should handle ICUs inside <ng-container>', () => {
+          const template = `
+            <ng-container i18n>
+              {age, select, 10 {ten} 20 {twenty} other {other}}
+            </ng-container>
+          `;
+          const fixture = getFixtureWithOverrides({template});
 
-      const element = fixture.nativeElement;
-      expect(element.innerHTML).toBe(translate('twenty'));
-    });
+          const element = fixture.nativeElement;
+          expect(element.innerHTML).toBe(translate('twenty'));
+        });
 
-    // FW-909: ICUs inside <ng-template>s throw errors at runtime
-    xit('should handle ICUs inside <ng-template>', () => {
-      const template = `
-        <ng-template i18n tplRef>
-          {age, select, 10 {ten} 20 {twenty} other {other}}
-        </ng-template>
-      `;
-      const fixture = getFixtureWithOverrides({template});
+    fixmeIvy('FW-909: ICUs inside <ng-template>s throw errors at runtime')
+        .it('should handle ICUs inside <ng-template>', () => {
+          const template = `
+            <ng-template i18n tplRef>
+              {age, select, 10 {ten} 20 {twenty} other {other}}
+            </ng-template>
+          `;
+          const fixture = getFixtureWithOverrides({template});
 
-      const element = fixture.nativeElement;
-      expect(element.innerHTML).toBe(translate('twenty'));
-    });
+          const element = fixture.nativeElement;
+          expect(element.innerHTML).toBe(translate('twenty'));
+        });
   });
 });

--- a/packages/core/test/i18n_integration_spec.ts
+++ b/packages/core/test/i18n_integration_spec.ts
@@ -420,22 +420,21 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
           expect(spans[1].innerHTML).toBe('deux');
         });
 
-    fixmeIvy('FW-907: ICUs in templates are not processed (treated as text)')
-        .it('should handle ICUs inside a template in i18n block', () => {
-          const template = `
+    it('should handle ICUs inside a template in i18n block', () => {
+      const template = `
             <div i18n>
               <span *ngIf="visible">
                 {age, select, 10 {ten} 20 {twenty} other {other}}
               </span>
             </div>
           `;
-          const fixture = getFixtureWithOverrides({template});
+      const fixture = getFixtureWithOverrides({template});
 
-          const element = fixture.nativeElement.firstChild;
-          const spans = element.getElementsByTagName('span');
-          expect(spans.length).toBe(1);
-          expect(spans[0]).toHaveText('vingt');
-        });
+      const element = fixture.nativeElement.firstChild;
+      const spans = element.getElementsByTagName('span');
+      expect(spans.length).toBe(1);
+      expect(spans[0]).toHaveText('vingt');
+    });
 
     it('should handle nested icus', () => {
       const template = `

--- a/packages/core/test/i18n_integration_spec.ts
+++ b/packages/core/test/i18n_integration_spec.ts
@@ -450,7 +450,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const element = fixture.nativeElement.firstChild;
       const spans = element.getElementsByTagName('span');
       expect(spans.length).toBe(1);
-      expect(spans[0].innerHTML).toBe(translate('twenty'));
+      expect(spans[0]).toHaveText(translate('twenty'));
     });
 
     it('should handle nested icus', () => {

--- a/packages/core/test/i18n_integration_spec.ts
+++ b/packages/core/test/i18n_integration_spec.ts
@@ -21,20 +21,13 @@ class DirectiveWithTplRef {
 
 @Component({selector: 'my-comp', template: ''})
 class MyComp {
-  name = 'John Doe';
+  name = 'John';
   items = ['1', '2', '3'];
   visible = true;
   age = 20;
   count = 2;
   otherLabel = 'other label';
 }
-
-// transform template string into i18n string
-const TRANSFORMS: any = {
-  'Hello {{ name }}': 'Hello {$interpolation}',
-  'Hello {% name %}': 'Hello {$interpolation}',
-  'Item {{ id }}': 'Item {$interpolation}'
-};
 
 const TRANSLATIONS: any = {
   'one': 'un',
@@ -63,14 +56,6 @@ const TRANSLATIONS: any = {
       '{VAR_SELECT_2, select, 10 {dix - {VAR_SELECT, select, 1 {un} 2 {deux} other {plus que deux}}} 20 {vingt - {VAR_SELECT_1, select, 1 {un} 2 {deux} other {plus que deux}}} other {autres}}'
 };
 
-const translate = (label: string, interpolations: any[] = []): string => {
-  const placeholders = interpolations.reduce((acc: any, value: any, idx: number): any => {
-    acc[`interpolation${idx > 0 ? idx : ''}`] = value;
-    return acc;
-  }, {});
-  return goog.getMsg(TRANSFORMS[label] || label, placeholders);
-};
-
 const getFixtureWithOverrides = (overrides = {}) => {
   TestBed.overrideComponent(MyComp, {set: overrides});
   const fixture = TestBed.createComponent(MyComp);
@@ -92,7 +77,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template});
 
       const element = fixture.nativeElement.firstChild;
-      expect(element.title).toBe(translate(title));
+      expect(element.title).toBe('Bonjour');
     });
 
     it('should support interpolation', () => {
@@ -101,7 +86,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template});
 
       const element = fixture.nativeElement.firstChild;
-      expect(element.title).toBe(translate(title, [fixture.componentInstance.name]));
+      expect(element.title).toBe('Bonjour John');
     });
 
     it('should support interpolation with custom interpolation config', () => {
@@ -111,7 +96,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template, interpolation});
 
       const element = fixture.nativeElement.firstChild;
-      expect(element.title).toBe(translate(title, [fixture.componentInstance.name]));
+      expect(element.title).toBe('Bonjour John');
     });
 
     fixmeIvy('FW-903: i18n attributes in nested templates throws at runtime')
@@ -127,8 +112,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
           const element = fixture.nativeElement;
           for (let i = 0; i < element.children.length; i++) {
             const child = element.children[i];
-            expect((child as any).innerHTML)
-                .toBe(`<div title="${translate(title, [i + 1])}"></div>`);
+            expect((child as any).innerHTML).toBe(`<div title="Article ${i + 1}"></div>`);
           }
         });
 
@@ -142,8 +126,8 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
           const fixture = getFixtureWithOverrides({template});
 
           const element = fixture.nativeElement.firstChild;
-          expect(element.title).toBe(translate(title, [fixture.componentInstance.name]));
-          expect(element).toHaveText(translate(content));
+          expect(element.title).toBe('Bonjour John');
+          expect(element).toHaveText('Bonjour');
         });
 
     it('should add i18n attributes on self-closing tags', () => {
@@ -152,7 +136,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template});
 
       const element = fixture.nativeElement.firstChild;
-      expect(element.title).toBe(translate(title, [fixture.componentInstance.name]));
+      expect(element.title).toBe('Bonjour John');
     });
   });
 
@@ -163,7 +147,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template});
 
       const element = fixture.nativeElement.firstChild;
-      expect(element).toHaveText(translate(content));
+      expect(element).toHaveText('Bonjour');
     });
 
     it('should support interpolation', () => {
@@ -172,7 +156,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template});
 
       const element = fixture.nativeElement.firstChild;
-      expect(element).toHaveText(translate(content, [fixture.componentInstance.name]));
+      expect(element).toHaveText('Bonjour John');
     });
 
     it('should support interpolation with custom interpolation config', () => {
@@ -182,7 +166,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template, interpolation});
 
       const element = fixture.nativeElement.firstChild;
-      expect(element).toHaveText(translate(content, [fixture.componentInstance.name]));
+      expect(element).toHaveText('Bonjour John');
     });
 
     it('should properly escape quotes in content', () => {
@@ -191,7 +175,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template});
 
       const element = fixture.nativeElement.firstChild;
-      expect(element).toHaveText(translate(content));
+      expect(element).toHaveText('\'Guillemets simples\' et "Guillemets doubles"');
     });
 
     it('should correctly bind to context in nested template', () => {
@@ -206,7 +190,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const element = fixture.nativeElement;
       for (let i = 0; i < element.children.length; i++) {
         const child = element.children[i];
-        expect(child).toHaveText(translate(content, [i + 1]));
+        expect(child).toHaveText(`Article ${i + 1}`);
       }
     });
 
@@ -220,7 +204,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template});
 
       const element = fixture.nativeElement.firstChild;
-      const content = `<div title="${translate(title, [fixture.componentInstance.name])}"></div>`;
+      const content = `<div title="Bonjour John"></div>`;
       expect(element.innerHTML).toBe(content);
     });
 
@@ -234,7 +218,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template});
 
       const element = fixture.nativeElement.firstChild;
-      expect(element.children[0]).toHaveText(translate(content, [fixture.componentInstance.name]));
+      expect(element.children[0]).toHaveText('Bonjour John');
     });
 
     it('should ignore i18n attributes on self-closing tags', () => {
@@ -253,7 +237,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template});
 
       const element = fixture.nativeElement.firstChild;
-      expect(element).toHaveText(translate(content, [fixture.componentInstance.name]));
+      expect(element).toHaveText('Bonjour John');
     });
   });
 
@@ -266,7 +250,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template});
 
       const element = fixture.nativeElement.firstChild;
-      expect(element).toHaveText(translate(content, [fixture.componentInstance.name]));
+      expect(element).toHaveText('Bonjour John');
     });
 
     it('should handle single translation message within ng-template', () => {
@@ -277,7 +261,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template});
 
       const element = fixture.nativeElement;
-      expect(element).toHaveText(translate(content, [fixture.componentInstance.name]));
+      expect(element).toHaveText('Bonjour John');
     });
 
     it('should be able to act as child elements inside i18n block (plain text content)', () => {
@@ -296,8 +280,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template});
 
       const element = fixture.nativeElement.firstChild;
-      expect(element.textContent.replace(/\s+/g, ' ').trim())
-          .toBe(`${translate(hello)} ${translate(bye)}`);
+      expect(element.textContent.replace(/\s+/g, ' ').trim()).toBe('Bonjour Au revoir');
     });
 
     fixmeIvy(
@@ -320,7 +303,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
           const spans = element.getElementsByTagName('span');
           for (let i = 0; i < spans.length; i++) {
             const child = spans[i];
-            expect((child as any).innerHTML).toBe(translate(content));
+            expect((child as any).innerHTML).toBe('Bonjour');
           }
         });
 
@@ -341,7 +324,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const spans = element.getElementsByTagName('span');
       for (let i = 0; i < spans.length; i++) {
         const child = spans[i];
-        expect(child).toHaveText(translate(label));
+        expect(child).toHaveText('Mon logo');
       }
     });
   });
@@ -354,7 +337,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template});
 
       const element = fixture.nativeElement;
-      expect(element).toHaveText(translate('twenty'));
+      expect(element).toHaveText('vingt');
     });
 
     it('should support ICUs generated outside of i18n blocks', () => {
@@ -364,7 +347,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template});
 
       const element = fixture.nativeElement;
-      expect(element).toHaveText(translate('twenty'));
+      expect(element).toHaveText('vingt');
     });
 
     it('should support interpolation', () => {
@@ -399,7 +382,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const element = fixture.nativeElement.firstChild;
       const italicTags = element.getElementsByTagName('i');
       expect(italicTags.length).toBe(1);
-      expect(italicTags[0].innerHTML).toBe(translate('twenty'));
+      expect(italicTags[0].innerHTML).toBe('vingt');
     });
 
     fixmeIvy('FW-905: Multiple ICUs in one i18n block are not processed')
@@ -413,7 +396,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
           const fixture = getFixtureWithOverrides({template});
 
           const element = fixture.nativeElement.firstChild;
-          expect(element).toHaveText(`${translate('twenty')} - ${translate('two')}`);
+          expect(element).toHaveText('vingt - deux');
         });
 
     fixmeIvy('FW-906: Multiple ICUs wrapped in HTML tags in one i18n block throw an error')
@@ -433,8 +416,8 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
           const element = fixture.nativeElement.firstChild;
           const spans = element.getElementsByTagName('span');
           expect(spans.length).toBe(2);
-          expect(spans[0].innerHTML).toBe(translate('twenty'));
-          expect(spans[1].innerHTML).toBe(translate('two'));
+          expect(spans[0].innerHTML).toBe('vingt');
+          expect(spans[1].innerHTML).toBe('deux');
         });
 
     fixmeIvy('FW-907: ICUs in templates are not processed (treated as text)')
@@ -451,7 +434,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
           const element = fixture.nativeElement.firstChild;
           const spans = element.getElementsByTagName('span');
           expect(spans.length).toBe(1);
-          expect(spans[0]).toHaveText(translate('twenty'));
+          expect(spans[0]).toHaveText('vingt');
         });
 
     it('should handle nested icus', () => {
@@ -466,7 +449,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const fixture = getFixtureWithOverrides({template});
 
       const element = fixture.nativeElement.firstChild;
-      expect(element).toHaveText(`${translate('twenty')} - ${translate('two')}`);
+      expect(element).toHaveText('vingt - deux');
     });
 
     fixmeIvy('FW-908: ICUs inside <ng-container>s throw an error at runtime')
@@ -479,7 +462,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
           const fixture = getFixtureWithOverrides({template});
 
           const element = fixture.nativeElement;
-          expect(element.innerHTML).toBe(translate('twenty'));
+          expect(element.innerHTML).toBe('vingt');
         });
 
     fixmeIvy('FW-909: ICUs inside <ng-template>s throw errors at runtime')
@@ -492,7 +475,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
           const fixture = getFixtureWithOverrides({template});
 
           const element = fixture.nativeElement;
-          expect(element.innerHTML).toBe(translate('twenty'));
+          expect(element.innerHTML).toBe('vingt');
         });
   });
 });

--- a/packages/private/testing/src/goog_get_msg.ts
+++ b/packages/private/testing/src/goog_get_msg.ts
@@ -16,13 +16,12 @@
 export function polyfillGoogGetMsg(translations: {[key: string]: string} = {}): void {
   const glob = (global as any);
   glob.goog = glob.goog || {};
-  glob.goog.getMsg =
-      glob.goog.getMsg || function(input: string, placeholders: {[key: string]: string} = {}) {
-        if (typeof translations[input] !== 'undefined') {  // to account for empty string
-          input = translations[input];
-        }
-        return Object.keys(placeholders).length ?
-            input.replace(/\{\$(.*?)\}/g, (match, key) => placeholders[key] || '') :
-            input;
-      };
+  glob.goog.getMsg = function(input: string, placeholders: {[key: string]: string} = {}) {
+    if (typeof translations[input] !== 'undefined') {  // to account for empty string
+      input = translations[input];
+    }
+    return Object.keys(placeholders).length ?
+        input.replace(/\{\$(.*?)\}/g, (match, key) => placeholders[key] || '') :
+        input;
+  };
 }


### PR DESCRIPTION
This PR adds i18n tests powered by TestBed. Most of the tests cases are taken from the `r3_view_compiler_i18n_spec.ts` script (i18n compiler tests).

Note: several tests are disabled with `xit` due to some issues that require further investigation.

Corresponding ticket: FW-627.

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: integration tests for i18n functionality in Ivy


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No