### PR TITLE
feat(service-worker): add JSON schema for service worker config

### DIFF
--- a/integration/service-worker-schema/package.json
+++ b/integration/service-worker-schema/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "service-worker-schema",
+  "version": "0.0.0",
+  "scripts": {
+    "//test": "Ensure that `config/schema.json` is published to npm.",
+    "test": "node --eval \"require('@angular/service-worker/config/schema.json')\""
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/common": "file:../../dist/packages-dist/common",
+    "@angular/core": "file:../../dist/packages-dist/core",
+    "@angular/service-worker": "file:../../dist/packages-dist/service-worker",
+    "rxjs": "file:../../node_modules/rxjs",
+    "zone.js": "file:../../node_modules/zone.js"
+  }
+}

--- a/packages/service-worker/BUILD.bazel
+++ b/packages/service-worker/BUILD.bazel
@@ -38,13 +38,14 @@ ng_package(
     name = "npm_package",
     srcs = [
         "package.json",
-        "safety-worker.js",
         "//packages/service-worker/config:package.json",
     ],
     data = [
+        "safety-worker.js",
         ":ngsw_config_binary",
         ":ngsw_worker_renamed",
         "//packages/service-worker/config",
+        "//packages/service-worker/config:schema.json",
     ],
     entry_point = "packages/service-worker/index.js",
     tags = [

--- a/packages/service-worker/config/BUILD.bazel
+++ b/packages/service-worker/config/BUILD.bazel
@@ -2,7 +2,10 @@ load("//tools:defaults.bzl", "ng_module")
 
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["package.json"])
+exports_files([
+    "package.json",
+    "schema.json",
+])
 
 ng_module(
     name = "config",

--- a/packages/service-worker/config/schema.json
+++ b/packages/service-worker/config/schema.json
@@ -1,5 +1,10 @@
 {
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "appData": {
       "type": "object",
       "description": "This section enables you to pass any data you want that describes this particular version of the app. The SwUpdate service includes that data in the update notifications. Many apps use this section to provide additional information for the display of UI popups, notifying users of the available update."
@@ -42,17 +47,21 @@
                 "description": "Lists patterns that match files in the distribution directory. These can be single files or glob-like patterns that match a number of files.",
                 "items": {
                   "type": "string"
-                }
+                },
+                "uniqueItems": true
               },
               "urls": {
                 "type": "array",
                 "description": "Includes both URLs and URL patterns that will be matched at runtime. These resources are not fetched directly and do not have content hashes, but they will be cached according to their HTTP headers. This is most useful for CDNs such as the Google Fonts service. (Negative glob patterns are not supported and '?' will be matched literally; i.e. it will not match any character other than '?'.)",
                 "items": {
                   "type": "string"
-                }
-              }
+                },
+                "uniqueItems": true
+              },
+              "additionalProperties": false
             }
-          }
+          },
+          "additionalProperties": false
         },
         "required": [
           "name",
@@ -75,7 +84,8 @@
             "description": "A list of URL patterns. URLs that match these patterns will be cached according to this data group's policy. (Negative glob patterns are not supported and '?' will be matched literally; i.e. it will not match any character other than '?'.)",
             "items": {
               "type": "string"
-            }
+            },
+            "uniqueItems": true
           },
           "version": {
             "type": "integer",
@@ -105,13 +115,15 @@
                 ],
                 "default": "performance",
                 "description": "The Angular service worker can use either of two caching strategies for data resources. 'performance', the default, optimizes for responses that are as fast as possible. If a resource exists in the cache, the cached version is used. This allows for some staleness, depending on the 'maxAge', in exchange for better performance. This is suitable for resources that don't change often; for example, user avatar images. 'freshness' optimizes for currency of data, preferentially fetching requested data from the network. Only if the network times out, according to 'timeout', does the request fall back to the cache. This is useful for resources that change frequently; for example, account balances."
-              }
+              },
+              "additionalProperties": false
             },
             "required": [
               "maxSize",
               "maxAge"
             ]
-          }
+          },
+          "additionalProperties": false
         },
         "required": [
           "name",
@@ -125,10 +137,12 @@
       "description": "This optional section enables you to specify a custom list of URLs or URL patterns that will be redirected to the 'index' file.",
       "items": {
         "type": "string"
-      }
+      },
+      "uniqueItems": true
     }
   },
   "required": [
     "index"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/packages/service-worker/config/schema.json
+++ b/packages/service-worker/config/schema.json
@@ -31,7 +31,7 @@
               "prefetch",
               "lazy"
             ],
-            "description": "For resources already in the cache, determines the caching behavior when a new version of the app is discovered. Any resources in the group that have changed since the previous version are updated in accordance with 'updateMode'. 'prefetch' tells the service worker to download and cache the changed resources immediately. 'lazy' tells the service worker to not cache those resources. Instead, it treats them as unrequested and waits until they're requested again before updating them. An 'updateMode' of lazy is only valid if the 'installMode' is also lazy. Defaults to the same value as 'installMode'."
+            "description": "For resources already in the cache, determines the caching behavior when a new version of the app is discovered. Any resources in the group that have changed since the previous version are updated in accordance with 'updateMode'. 'prefetch' tells the service worker to download and cache the changed resources immediately. 'lazy' tells the service worker to not cache those resources. Instead, it treats them as unrequested and waits until they're requested again before updating them. An 'updateMode' of lazy is only valid if the 'installMode' is also lazy. Defaults to the value `installMode` is set to."
           },
           "resources": {
             "type": "object",

--- a/packages/service-worker/config/schema.json
+++ b/packages/service-worker/config/schema.json
@@ -1,0 +1,134 @@
+{
+  "properties": {
+    "appData": {
+      "type": "object",
+      "description": "This section enables you to pass any data you want that describes this particular version of the app. The SwUpdate service includes that data in the update notifications. Many apps use this section to provide additional information for the display of UI popups, notifying users of the available update."
+    },
+    "index": {
+      "type": "string",
+      "description": "Specifies the file that serves as the index page to satisfy navigation requests. Usually this is '/index.html'."
+    },
+    "assetGroups": {
+      "type": "array",
+      "description": "Assets are resources that are part of the app version that update along with the app. They can include resources loaded from the page's origin as well as third-party resources loaded from CDNs and other external URLs. As not all such external URLs may be known at build time, URL patterns can be matched.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "It identifies this particular group of assets between versions of the configuration."
+          },
+          "installMode": {
+            "enum": [
+              "prefetch",
+              "lazy"
+            ],
+            "default": "prefetch",
+            "description": "Determines how the resources are initially cached. 'prefetch' tells the Angular service worker to fetch every single listed resource while it's caching the current version of the app. This is bandwidth-intensive but ensures resources are available whenever they're requested, even if the browser is currently offline. 'lazy' does not cache any of the resources up front. Instead, the Angular service worker only caches resources for which it receives requests. This is an on-demand caching mode. Resources that are never requested will not be cached. This is useful for things like images at different resolutions, so the service worker only caches the correct assets for the particular screen and orientation."
+          },
+          "updateMode": {
+            "enum": [
+              "prefetch",
+              "lazy"
+            ],
+            "description": "For resources already in the cache, determines the caching behavior when a new version of the app is discovered. Any resources in the group that have changed since the previous version are updated in accordance with 'updateMode'. 'prefetch' tells the service worker to download and cache the changed resources immediately. 'lazy' tells the service worker to not cache those resources. Instead, it treats them as unrequested and waits until they're requested again before updating them. An 'updateMode' of lazy is only valid if the 'installMode' is also lazy. Defaults to the same value as 'installMode'."
+          },
+          "resources": {
+            "type": "object",
+            "description": "This section describes the resources to cache.",
+            "properties": {
+              "files": {
+                "type": "array",
+                "description": "Lists patterns that match files in the distribution directory. These can be single files or glob-like patterns that match a number of files.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "urls": {
+                "type": "array",
+                "description": "Includes both URLs and URL patterns that will be matched at runtime. These resources are not fetched directly and do not have content hashes, but they will be cached according to their HTTP headers. This is most useful for CDNs such as the Google Fonts service. (Negative glob patterns are not supported and '?' will be matched literally; i.e. it will not match any character other than '?'.)",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "name",
+          "resources"
+        ]
+      }
+    },
+    "dataGroups": {
+      "type": "array",
+      "description": "Policies for caching data requests, such as API requests and other data dependencies. Unlike asset resources, data requests are not versioned along with the app.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "It identifies this particular group of data between versions of the configuration."
+          },
+          "urls": {
+            "type": "array",
+            "description": "A list of URL patterns. URLs that match these patterns will be cached according to this data group's policy. (Negative glob patterns are not supported and '?' will be matched literally; i.e. it will not match any character other than '?'.)",
+            "items": {
+              "type": "string"
+            }
+          },
+          "version": {
+            "type": "integer",
+            "default": 1,
+            "description": "Occasionally APIs change formats in a way that is not backward-compatible. A new version of the app may not be compatible with the old API format and thus may not be compatible with existing cached resources from that API. 'version' provides a mechanism to indicate that the resources being cached have been updated in a backwards-incompatible way, and that the old cache entries—those from previous versions—should be discarded."
+          },
+          "cacheConfig": {
+            "type": "object",
+            "description": "This section defines the policy by which matching requests will be cached.",
+            "properties": {
+              "maxSize": {
+                "type": "integer",
+                "description": "The maximum number of entries, or responses, in the cache. Open-ended caches can grow in unbounded ways and eventually exceed storage quotas, calling for eviction."
+              },
+              "maxAge": {
+                "type": "string",
+                "description": "Indicates how long responses are allowed to remain in the cache before being considered invalid and evicted. 'maxAge' is a duration string, using the following unit suffixes: d= days, h= hours, m= minutes, s= seconds, u= milliseconds. For example, the string '3d12h' will cache content for up to three and a half days."
+              },
+              "timeout": {
+                "type": "string",
+                "description": "This duration string specifies the network timeout. The network timeout is how long the Angular service worker will wait for the network to respond before using a cached response, if configured to do so. 'timeout' is a duration string, using the following unit suffixes: d= days, h= hours, m= minutes, s= seconds, u= milliseconds. For example, the string '5s30u' will translate to five seconds and 30 milliseconds of network timeout."
+              },
+              "strategy": {
+                "enum": [
+                  "freshness",
+                  "performance"
+                ],
+                "default": "performance",
+                "description": "The Angular service worker can use either of two caching strategies for data resources. 'performance', the default, optimizes for responses that are as fast as possible. If a resource exists in the cache, the cached version is used. This allows for some staleness, depending on the 'maxAge', in exchange for better performance. This is suitable for resources that don't change often; for example, user avatar images. 'freshness' optimizes for currency of data, preferentially fetching requested data from the network. Only if the network times out, according to 'timeout', does the request fall back to the cache. This is useful for resources that change frequently; for example, account balances."
+              }
+            },
+            "required": [
+              "maxSize",
+              "maxAge"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "urls",
+          "cacheConfig"
+        ]
+      }
+    },
+    "navigationUrls": {
+      "type": "array",
+      "description": "This optional section enables you to specify a custom list of URLs or URL patterns that will be redirected to the 'index' file.",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "index"
+  ]
+}

--- a/packages/service-worker/config/schema.json
+++ b/packages/service-worker/config/schema.json
@@ -57,16 +57,16 @@
                   "type": "string"
                 },
                 "uniqueItems": true
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
         },
         "required": [
           "name",
           "resources"
-        ]
+        ],
+        "additionalProperties": false
       }
     },
     "dataGroups": {
@@ -115,21 +115,21 @@
                 ],
                 "default": "performance",
                 "description": "The Angular service worker can use either of two caching strategies for data resources. 'performance', the default, optimizes for responses that are as fast as possible. If a resource exists in the cache, the cached version is used. This allows for some staleness, depending on the 'maxAge', in exchange for better performance. This is suitable for resources that don't change often; for example, user avatar images. 'freshness' optimizes for currency of data, preferentially fetching requested data from the network. Only if the network times out, according to 'timeout', does the request fall back to the cache. This is useful for resources that change frequently; for example, account balances."
-              },
-              "additionalProperties": false
+              }
             },
             "required": [
               "maxSize",
               "maxAge"
-            ]
-          },
-          "additionalProperties": false
+            ],
+            "additionalProperties": false
+          }
         },
         "required": [
           "name",
           "urls",
           "cacheConfig"
-        ]
+        ],
+        "additionalProperties": false
       }
     },
     "navigationUrls": {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features) > not relevant
- [x] Docs have been added / updated (for bug fixes / features) (not relevant here) > not relevant


## PR Type
What kind of change does this PR introduce?

- [x] Feature


## What is the current behavior?
No assistance/validation in editor for service worker config.

Issue Number: Fixes #19847 

With angular/angular-cli#13325, it will also fix angular/angular-cli#13324

## What is the new behavior?
Assistance/validation in editor for service worker config.

## Does this PR introduce a breaking change?
- [X] No

## Other information

The schema follows `@angular/service-worker` interfaces ([here](https://github.com/angular/angular/blob/master/packages/service-worker/config/src/in.ts)).

Descriptions come from the official documentation on angular.io ([here](https://angular.io/guide/service-worker-config)).

Default values have been verified in `@angular/service-worker` code ([here](https://github.com/angular/angular/blob/f8096d499324cf0961f092944bbaedd05364eea1/packages/service-worker/config/src/generator.ts)).

I don't understand how the build works. When following the contributing guidelines, I can't see the static files that should be copied (like `safety-worker.js` and `schema.json`) in `dist` builds. **So this part have to be checked.**

As this is just an helper for development, this could be added in a patch version.

@gkalpak 