### PR TITLE
fix(animations): remove spread operator on NodeList object

### DIFF
--- a/packages/animations/browser/src/render/shared.ts
+++ b/packages/animations/browser/src/render/shared.ts
@@ -172,7 +172,10 @@ if (_isNode || typeof Element !== 'undefined') {
   _query = (element: any, selector: string, multi: boolean): any[] => {
     let results: any[] = [];
     if (multi) {
-      results.push(...element.querySelectorAll(selector));
+      const nodeList = element.querySelectorAll(selector);
+      for (let i = 0; i < nodeList.length; i++) {
+        results.push(nodeList[i]);
+      }
     } else {
       const elm = element.querySelector(selector);
       if (elm) {


### PR DESCRIPTION
Prior to this when querying multiple elements the function would sometimes return an array with with a single NodeList instead of an array of the found elements in IE11.

PR for #27887

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #27887


## What is the new behavior?
Loops over NodeList as per spec.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
