### PR TITLE
docs(router): fixed a typo in CanLoad title text 

### DIFF
--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -337,7 +337,7 @@ export interface Resolve<T> {
 /**
  * @description
  *
- * Interface that a class can implement to be a guard deciding if a children can be loaded.
+ * Interface that a class can implement to be a guard deciding if children can be loaded.
  *
  * ```
  * class UserToken {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
This sentence for CanLoad's documentation:
"Interface that a class can implement to be a guard deciding if a children can be loaded."
Issue Number: N/A


## What is the new behavior?
"Interface that a class can implement to be a guard deciding if children can be loaded."

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
