### PR TITLE
fix(ivy): don't throw in `i18nAttributes` when a component is re-rendered

### DIFF
--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -834,9 +834,6 @@ export function i18n(index: number, message: string, subTemplateIndex?: number):
 export function i18nAttributes(index: number, values: string[]): void {
   const tView = getLView()[TVIEW];
   ngDevMode && assertDefined(tView, `tView should be defined`);
-  ngDevMode &&
-      assertEqual(
-          tView.firstTemplatePass, true, `You should only call i18nEnd on first template pass`);
   if (tView.firstTemplatePass && tView.data[index + HEADER_OFFSET] === null) {
     i18nAttributesFirstPass(tView, index, values);
   }

--- a/packages/core/test/render3/i18n_spec.ts
+++ b/packages/core/test/render3/i18n_spec.ts
@@ -1274,6 +1274,23 @@ describe('Runtime i18n', () => {
         expect(fixture.html)
             .toEqual(
                 '<div><child><p><any></any><b title="Enfant de Parent">Je suis projeté depuis Parent</b><any></any></p></child></div>');
+
+        // it should be able to render a new component with the same template code
+        const fixture2 = new ComponentFixture(Parent);
+        expect(fixture2.html).toEqual(fixture.html);
+
+        // Updating the fixture should work
+        fixture2.component.name = 'Parent 2';
+        fixture.update();
+        fixture2.update();
+        expect(fixture2.html)
+            .toEqual(
+                '<div><child><p><any></any><b title="Enfant de Parent 2">Je suis projeté depuis Parent 2</b><any></any></p></child></div>');
+
+        // The first fixture should not have changed
+        expect(fixture.html)
+            .toEqual(
+                '<div><child><p><any></any><b title="Enfant de Parent">Je suis projeté depuis Parent</b><any></any></p></child></div>');
       });
 
       it('should re-project translations when multiple projections', () => {


### PR DESCRIPTION
`i18nAttributes` was throwing an error when it was called multiple times in the create part of the template function with the same index, for example when we create multiple components with the same template. It shouldn't throw in this case, and just use the cache when available.

FW-903 #resolve