### PR TITLE
feat(platform-browser): add service to get and set favicon

### DIFF
--- a/packages/platform-browser/src/browser/favicon.ts
+++ b/packages/platform-browser/src/browser/favicon.ts
@@ -34,7 +34,7 @@ export class Favicon {
   /**
    * Get the favicon of the current HTML document.
    */
-  getFavicon() { return getDOM().querySelector(this._doc, 'link[rel*=\'icon\']') }
+  getFavicon() { return getDOM().querySelector(this._doc, 'link[rel*=\'icon\']'); }
 
   /**
    * Set the favicon of the current HTML document.

--- a/packages/platform-browser/src/browser/favicon.ts
+++ b/packages/platform-browser/src/browser/favicon.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Inject, Injectable, inject} from '@angular/core';
+
+import {getDOM} from '../dom/dom_adapter';
+import {DOCUMENT} from '../dom/dom_tokens';
+
+/**
+ * Factory to create Favicon service.
+ */
+export function createFavicon() {
+  return new Favicon(inject(DOCUMENT));
+}
+
+/**
+ * A service that can be used to get and set the favicon of a current HTML document.
+ *
+ * Since an Angular application can't be bootstrapped on the entire HTML document (`<html>` tag)
+ * it is not possible to bind to the `text` property of the `HTMLTitleElement` elements
+ * (representing the `<title>` tag). Instead, this service can be used to set and get the current
+ * title value.
+ *
+ * @publicApi
+ */
+@Injectable({providedIn: 'root', useFactory: createFavicon, deps: []})
+export class Favicon {
+  constructor(@Inject(DOCUMENT) private _doc: any) {}
+  /**
+   * Get the favicon of the current HTML document.
+   */
+  getFavicon() { return getDOM().querySelector(this._doc, 'link[rel*=\'icon\']') }
+
+  /**
+   * Set the favicon of the current HTML document.
+   * @param newFaviconURL
+   */
+  setFavicon(newFaviconURL: string) {
+    const link =
+        getDOM().querySelector(this._doc, 'link[rel*=\'icon\']') || document.createElement('link');
+    link.type = 'image/x-icon';
+    link.rel = 'shortcut icon';
+    link.href = newFaviconURL;
+    getDOM().getElementsByTagName(this._doc, 'head')[0].appendChild(link);
+  }
+}

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -7,6 +7,7 @@
  */
 
 export {BrowserModule, platformBrowser} from './browser';
+export {Favicon} from './browser/favicon';
 export {Meta, MetaDefinition} from './browser/meta';
 export {Title} from './browser/title';
 export {disableDebugTools, enableDebugTools} from './browser/tools/tools';

--- a/packages/platform-browser/test/browser/favicon_spec.ts
+++ b/packages/platform-browser/test/browser/favicon_spec.ts
@@ -33,13 +33,13 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
       getDOM().getElementsByTagName(this._doc, 'head')[0].appendChild(link);
     });
 
-    it('should allow reading initial favicon',
-       () => {
-        if (initialFavicon === null) {
-          expect(faviconService.getFavicon()).toBeNull();
-        } else {
-          expect(faviconService.getFavicon().href).toEqual(initialFavicon.href);
-        } });
+    it('should allow reading initial favicon', () => {
+      if (initialFavicon === null) {
+        expect(faviconService.getFavicon()).toBeNull();
+      } else {
+        expect(faviconService.getFavicon().href).toEqual(initialFavicon.href);
+      }
+    });
 
     it('should set a favicon on the injected document', () => {
       faviconService.setFavicon('test favicon url');

--- a/packages/platform-browser/test/browser/favicon_spec.ts
+++ b/packages/platform-browser/test/browser/favicon_spec.ts
@@ -34,7 +34,12 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
     });
 
     it('should allow reading initial favicon',
-       () => { expect(faviconService.getFavicon().href).toEqual(initialFavicon.href); });
+       () => {
+        if (initialFavicon === null) {
+          expect(faviconService.getFavicon()).toBeNull();
+        } else {
+          expect(faviconService.getFavicon().href).toEqual(initialFavicon.href);
+        } });
 
     it('should set a favicon on the injected document', () => {
       faviconService.setFavicon('test favicon url');
@@ -58,6 +63,6 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
     });
 
     it('should inject Favicon service when using BrowserModule',
-       () => { expect(TestBed.get(DependsOnFavicon).title).toBeAnInstanceOf(Favicon); });
+       () => { expect(TestBed.get(DependsOnFavicon).favicon).toBeAnInstanceOf(Favicon); });
   });
 }

--- a/packages/platform-browser/test/browser/favicon_spec.ts
+++ b/packages/platform-browser/test/browser/favicon_spec.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injectable} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {BrowserModule, Favicon} from '@angular/platform-browser';
+import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
+import {expect} from '@angular/platform-browser/testing/src/matchers';
+
+{
+  describe('favicon service', () => {
+    let doc: Document;
+    let initialFavicon: any;
+    let faviconService: Favicon;
+
+    beforeEach(() => {
+      doc = getDOM().createHtmlDocument();
+      initialFavicon = getDOM().querySelector(doc, 'link[rel*=\'icon\']');
+      faviconService = new Favicon(doc);
+    });
+
+    afterEach(() => {
+      const link = getDOM().querySelector(this._doc, 'link[rel*=\'icon\']') ||
+          document.createElement('link');
+      link.type = 'image/x-icon';
+      link.rel = 'shortcut icon';
+      link.href = initialFavicon.href;
+      getDOM().getElementsByTagName(this._doc, 'head')[0].appendChild(link);
+    });
+
+    it('should allow reading initial favicon',
+       () => { expect(faviconService.getFavicon().href).toEqual(initialFavicon.href); });
+
+    it('should set a favicon on the injected document', () => {
+      faviconService.setFavicon('test favicon url');
+      expect(getDOM().querySelector(doc, 'link[rel*=\'icon\']').href).toEqual('test favicon url');
+      expect(faviconService.getFavicon().href).toEqual('test favicon url');
+    });
+  });
+
+  describe('integration test', () => {
+
+    @Injectable()
+    class DependsOnFavicon {
+      constructor(public favicon: Favicon) {}
+    }
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [BrowserModule],
+        providers: [DependsOnFavicon],
+      });
+    });
+
+    it('should inject Favicon service when using BrowserModule',
+       () => { expect(TestBed.get(DependsOnFavicon).title).toBeAnInstanceOf(Favicon); });
+  });
+}

--- a/packages/platform-browser/test/browser/favicon_spec.ts
+++ b/packages/platform-browser/test/browser/favicon_spec.ts
@@ -24,15 +24,6 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
       faviconService = new Favicon(doc);
     });
 
-    afterEach(() => {
-      const link =
-          getDOM().querySelector(doc, 'link[rel*=\'icon\']') || document.createElement('link');
-      link.type = 'image/x-icon';
-      link.rel = 'shortcut icon';
-      link.href = initialFavicon.href;
-      getDOM().getElementsByTagName(doc, 'head')[0].appendChild(link);
-    });
-
     it('should allow reading initial favicon', () => {
       if (initialFavicon === null) {
         expect(faviconService.getFavicon()).toBeNull();

--- a/packages/platform-browser/test/browser/favicon_spec.ts
+++ b/packages/platform-browser/test/browser/favicon_spec.ts
@@ -25,12 +25,12 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
     });
 
     afterEach(() => {
-      const link = getDOM().querySelector(this._doc, 'link[rel*=\'icon\']') ||
-          document.createElement('link');
+      const link =
+          getDOM().querySelector(doc, 'link[rel*=\'icon\']') || document.createElement('link');
       link.type = 'image/x-icon';
       link.rel = 'shortcut icon';
       link.href = initialFavicon.href;
-      getDOM().getElementsByTagName(this._doc, 'head')[0].appendChild(link);
+      getDOM().getElementsByTagName(doc, 'head')[0].appendChild(link);
     });
 
     it('should allow reading initial favicon', () => {
@@ -43,8 +43,8 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 
     it('should set a favicon on the injected document', () => {
       faviconService.setFavicon('test favicon url');
-      expect(getDOM().querySelector(doc, 'link[rel*=\'icon\']').href).toEqual('test favicon url');
-      expect(faviconService.getFavicon().href).toEqual('test favicon url');
+      expect(getDOM().querySelector(doc, 'link[rel*=\'icon\']').href).toEqual('/test favicon url');
+      expect(faviconService.getFavicon().href).toEqual('/test favicon url');
     });
   });
 


### PR DESCRIPTION
feat(platform-browser): add service to get and set favicon

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Angular does not currently provide an easy way to access and modify the favicon programatically.

Issue Number: N/A


## What is the new behavior?
The new service gets the existing favicon link tag or sets it (will create or update)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
