### PR TITLE
fix(bazel): protractor utils cannot start server on windows

### DIFF
--- a/packages/bazel/test/protractor-utils/BUILD.bazel
+++ b/packages/bazel/test/protractor-utils/BUILD.bazel
@@ -1,0 +1,29 @@
+load("//tools:defaults.bzl", "jasmine_node_test", "nodejs_binary", "ts_library")
+
+ts_library(
+    name = "protractor_utils_tests_lib",
+    testonly = True,
+    srcs = ["index_test.ts"],
+    deps = [
+        "//packages/bazel/src/protractor/utils",
+    ],
+)
+
+nodejs_binary(
+    name = "fake-devserver",
+    testonly = True,
+    data = [
+        "fake-devserver.js",
+        "@ngdeps//minimist",
+    ],
+    entry_point = "angular/packages/bazel/test/protractor-utils/fake-devserver.js",
+)
+
+jasmine_node_test(
+    name = "protractor_utils_tests",
+    size = "small",
+    srcs = [":protractor_utils_tests_lib"],
+    data = [
+        ":fake-devserver",
+    ],
+)

--- a/packages/bazel/test/protractor-utils/fake-devserver.js
+++ b/packages/bazel/test/protractor-utils/fake-devserver.js
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+const http = require('http');
+const minimist = require('minimist');
+
+const {port} = minimist(process.argv);
+const server = new http.Server();
+
+// Basic request handler so that it could respond to fake requests.
+server.on('request', (req, res) => {
+  res.writeHead(200, {'Content-Type': 'text/plain'});
+  res.end('Running');
+});
+
+server.listen(port);
+
+console.info('Server running on port:', port);

--- a/packages/bazel/test/protractor-utils/index_test.ts
+++ b/packages/bazel/test/protractor-utils/index_test.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {runServer} from '../../src/protractor/utils';
+
+describe('Bazel protractor utils', () => {
+
+  it('should be able to start devserver', async() => {
+    // Test will automatically time out if the server couldn't be launched as expected.
+    await runServer('angular', 'packages/bazel/test/protractor-utils/fake-devserver', '--port', []);
+  });
+});


### PR DESCRIPTION
* Currently the protractor utils assume that the specified Bazel server runfile can be resolved by just using the real file system. This is not the case on Windows because the runfiles are not symlinked into the working directory and need to be resolved through the runfile manifest.