### PR TITLE
test(ivy): correct attribute marker in broken test

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_spec.ts
@@ -173,7 +173,7 @@ describe('r3_view_compiler', () => {
       };
 
       const template = `
-      const _c0 = [1, "mySelector"];
+      const _c0 = [3, "mySelector"];
       // ...
       template: function MyApp_Template(rf, ctx) {
         if (rf & 1) {


### PR DESCRIPTION
Test incorrectly marks the attribute as a 'Class', when it should be 'SelectOnly'
