### PR TITLE
fix(ivy): support ICU messages inside `<ng-container>`

### DIFF
--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -202,13 +202,9 @@ function executeNodeAction(
     action: WalkTNodeTreeAction, renderer: Renderer3, parent: RElement | null,
     node: RComment | RElement | RText, beforeNode?: RNode | null) {
   if (action === WalkTNodeTreeAction.Insert) {
-    isProceduralRenderer(renderer !) ?
-        (renderer as ProceduralRenderer3).insertBefore(parent !, node, beforeNode as RNode | null) :
-        parent !.insertBefore(node, beforeNode as RNode | null, true);
+    nativeInsertBefore(renderer, parent !, node, beforeNode || null);
   } else if (action === WalkTNodeTreeAction.Detach) {
-    isProceduralRenderer(renderer !) ?
-        (renderer as ProceduralRenderer3).removeChild(parent !, node) :
-        parent !.removeChild(node);
+    nativeRemoveChild(renderer, parent !, node);
   } else if (action === WalkTNodeTreeAction.Destroy) {
     ngDevMode && ngDevMode.rendererDestroyNode++;
     (renderer as ProceduralRenderer3).destroyNode !(node);
@@ -634,6 +630,14 @@ export function nativeInsertBefore(
 }
 
 /**
+ * Removes a native child node from a given native parent node.
+ */
+export function nativeRemoveChild(renderer: Renderer3, parent: RElement, child: RNode): void {
+  isProceduralRenderer(renderer) ? renderer.removeChild(parent as RElement, child) :
+                                   parent !.removeChild(child);
+}
+
+/**
  * Returns a native parent of a given native node.
  */
 export function nativeParentNode(renderer: Renderer3, node: RNode): RElement|null {
@@ -721,9 +725,7 @@ export function removeChild(childTNode: TNode, childEl: RNode | null, currentVie
   // We only remove the element if not in View or not projected.
   if (childEl !== null && canInsertNativeNode(childTNode, currentView)) {
     const parentNative = getParentNative(childTNode, currentView) !as RElement;
-    const renderer = currentView[RENDERER];
-    isProceduralRenderer(renderer) ? renderer.removeChild(parentNative as RElement, childEl) :
-                                     parentNative !.removeChild(childEl);
+    nativeRemoveChild(currentView[RENDERER], parentNative, childEl);
     return true;
   }
   return false;

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {assertDefined} from './assert';
 import {attachPatchData} from './context_discovery';
 import {callHooks} from './hooks';
 import {LContainer, NATIVE, RENDER_PARENT, VIEWS, unusedValueExportToPlacateAjd as unused1} from './interfaces/container';
@@ -19,12 +18,12 @@ import {findComponentView, getNativeByTNode, isLContainer, isRootView, readEleme
 
 const unusedValueToPlacateAjd = unused1 + unused2 + unused3 + unused4 + unused5;
 
-/** Retrieves the parent element of a given node. */
+/** Retrieves the native node (element or a comment) for the parent of a given node. */
 export function getParentNative(tNode: TNode, currentView: LView): RElement|RComment|null {
   if (tNode.parent == null) {
     return getHostNative(currentView);
   } else {
-    const parentTNode = getFirstParentNative(tNode);
+    const parentTNode = getFirstNonICUParent(tNode);
     return getNativeByTNode(parentTNode, currentView);
   }
 }
@@ -32,7 +31,7 @@ export function getParentNative(tNode: TNode, currentView: LView): RElement|RCom
 /**
  * Get the first parent of a node that isn't an IcuContainer TNode
  */
-function getFirstParentNative(tNode: TNode): TNode {
+function getFirstNonICUParent(tNode: TNode): TNode {
   let parent = tNode.parent;
   while (parent && parent.type === TNodeType.IcuContainer) {
     parent = parent.parent;
@@ -606,7 +605,7 @@ export function canInsertNativeNode(tNode: TNode, currentView: LView): boolean {
       currentNode = getHighestElementContainer(tNode);
       parent = currentNode.parent;
     } else if (tNode.parent.type === TNodeType.IcuContainer) {
-      currentNode = getFirstParentNative(currentNode);
+      currentNode = getFirstNonICUParent(currentNode);
       parent = currentNode.parent;
     }
   }

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -518,13 +518,12 @@ export function getRenderParent(tNode: TNode, currentView: LView): RElement|null
       return nativeParentNode(currentView[RENDERER], getNativeByTNode(tNode, currentView));
     }
 
-    const hostTNode = currentView[HOST_NODE];
-
-    const tNodeParent = tNode.parent;
+    const tNodeParent = getFirstNonICUParent(tNode);
     if (tNodeParent != null && tNodeParent.type === TNodeType.ElementContainer) {
       tNode = getHighestElementContainer(tNodeParent);
     }
 
+    const hostTNode = currentView[HOST_NODE];
     return tNode.parent == null && hostTNode !.type === TNodeType.View ?
         getContainerRenderParent(hostTNode as TViewNode, currentView) :
         getParentNative(tNode, currentView) as RElement;
@@ -677,10 +676,12 @@ export function appendChild(
           getBeforeNodeForView(index, views, lContainer[NATIVE]));
     } else if (parentTNode.type === TNodeType.ElementContainer) {
       const renderParent = getRenderParent(childTNode, currentView) !;
-      nativeInsertBefore(renderer, renderParent, childEl, parentEl);
+      const ngContainerAnchorNode = getNativeByTNode(parentTNode, currentView);
+      nativeInsertBefore(renderer, renderParent, childEl, ngContainerAnchorNode);
     } else if (parentTNode.type === TNodeType.IcuContainer) {
-      const icuAnchorNode = getNativeByTNode(childTNode.parent !, currentView) !as RElement;
-      nativeInsertBefore(renderer, parentEl as RElement, childEl, icuAnchorNode);
+      const renderParent = getRenderParent(childTNode, currentView) !;
+      const icuAnchorNode = getNativeByTNode(parentTNode, currentView);
+      nativeInsertBefore(renderer, renderParent, childEl, icuAnchorNode);
     } else {
       isProceduralRenderer(renderer) ? renderer.appendChild(parentEl !as RElement, childEl) :
                                        parentEl !.appendChild(childEl);

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -258,7 +258,7 @@
     "name": "getDirectiveDef"
   },
   {
-    "name": "getFirstParentNative"
+    "name": "getFirstNonICUParent"
   },
   {
     "name": "getHighestElementContainer"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -258,10 +258,7 @@
     "name": "getDirectiveDef"
   },
   {
-    "name": "getFirstNonICUParent"
-  },
-  {
-    "name": "getHighestElementContainer"
+    "name": "getHighestElementOrICUContainer"
   },
   {
     "name": "getHostNative"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -675,13 +675,10 @@
     "name": "getElementDepthCount"
   },
   {
-    "name": "getFirstNonICUParent"
-  },
-  {
     "name": "getFirstTemplatePass"
   },
   {
-    "name": "getHighestElementContainer"
+    "name": "getHighestElementOrICUContainer"
   },
   {
     "name": "getHostNative"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -675,7 +675,7 @@
     "name": "getElementDepthCount"
   },
   {
-    "name": "getFirstParentNative"
+    "name": "getFirstNonICUParent"
   },
   {
     "name": "getFirstTemplatePass"
@@ -1003,6 +1003,9 @@
   },
   {
     "name": "nativeParentNode"
+  },
+  {
+    "name": "nativeRemoveChild"
   },
   {
     "name": "nextContext"

--- a/packages/core/test/render3/i18n_spec.ts
+++ b/packages/core/test/render3/i18n_spec.ts
@@ -713,7 +713,7 @@ describe('Runtime i18n', () => {
       expect(fixture.html)
           .toEqual(
               '<div><span>3 <span title="emails label">emails</span><!--ICU 4--></span></div>');
-            });
+    });
 
     it('for ICU expressions inside <ng-container>', () => {
       const MSG_DIV = `{�0�, plural, 
@@ -721,20 +721,24 @@ describe('Runtime i18n', () => {
         =1 {one <i>email</i>} 
         other {�0� <span title="�1�">emails</span>}
       }`;
-      const fixture = prepareFixture(() => {
-        elementStart(0, 'div'); {
-          elementContainerStart(1); {
-            i18n(2, MSG_DIV);
-          }
-          elementContainerEnd();
-        }
-        elementEnd();
-      }, () => {
-        i18nExp(bind(0));
-        i18nApply(2);
-      }, 3, 1);
+      const fixture = prepareFixture(
+          () => {
+            elementStart(0, 'div');
+            {
+              elementContainerStart(1);
+              { i18n(2, MSG_DIV); }
+              elementContainerEnd();
+            }
+            elementEnd();
+          },
+          () => {
+            i18nExp(bind(0));
+            i18nExp(bind('more than one'));
+            i18nApply(2);
+          },
+          3, 2);
 
-      expect(fixture.html).toEqual('<div>no <b title="none">emails</b>!<!--ICU 4--></div>');
+      expect(fixture.html).toEqual('<div>no <b title="none">emails</b>!<!--ICU 5--></div>');
     });
 
     it('for nested ICU expressions', () => {

--- a/packages/core/test/render3/i18n_spec.ts
+++ b/packages/core/test/render3/i18n_spec.ts
@@ -15,7 +15,7 @@ import {getNativeByIndex} from '../../src/render3/util';
 
 import {NgIf} from './common_with_def';
 
-import {element, elementEnd, elementStart, template, text, nextContext, bind, elementProperty, projectionDef, projection} from '../../src/render3/instructions';
+import {element, elementEnd, elementStart, template, text, nextContext, bind, elementProperty, projectionDef, projection, elementContainerStart, elementContainerEnd} from '../../src/render3/instructions';
 import {COMMENT_MARKER, ELEMENT_MARKER, I18nMutateOpCode, I18nUpdateOpCode, I18nUpdateOpCodes, TI18n} from '../../src/render3/interfaces/i18n';
 import {HEADER_OFFSET, LView, TVIEW} from '../../src/render3/interfaces/view';
 import {ComponentFixture, TemplateFixture} from './render_util';
@@ -713,6 +713,28 @@ describe('Runtime i18n', () => {
       expect(fixture.html)
           .toEqual(
               '<div><span>3 <span title="emails label">emails</span><!--ICU 4--></span></div>');
+            });
+
+    it('for ICU expressions inside <ng-container>', () => {
+      const MSG_DIV = `{�0�, plural, 
+        =0 {no <b title="none">emails</b>!} 
+        =1 {one <i>email</i>} 
+        other {�0� <span title="�1�">emails</span>}
+      }`;
+      const fixture = prepareFixture(() => {
+        elementStart(0, 'div'); {
+          elementContainerStart(1); {
+            i18n(2, MSG_DIV);
+          }
+          elementContainerEnd();
+        }
+        elementEnd();
+      }, () => {
+        i18nExp(bind(0));
+        i18nApply(2);
+      }, 3, 1);
+
+      expect(fixture.html).toEqual('<div>no <b title="none">emails</b>!<!--ICU 4--></div>');
     });
 
     it('for nested ICU expressions', () => {


### PR DESCRIPTION
This PR has a fix that enables ICU messages inside `<ng-container>` (FW-908). This bug and a fix was discovered while working on a different refactoring hence this PR has also refactor commits.

Best to review on the commit-by-commit basis to see how things progressed to the final state