### PR TITLE
ci: make `integration_test` job logs less verbose

### DIFF
--- a/integration/bazel-schematics/angular.json.original
+++ b/integration/bazel-schematics/angular.json.original
@@ -62,6 +62,9 @@
           "configurations": {
             "production": {
               "browserTarget": "demo:build:production"
+            },
+            "ci": {
+              "progress": false
             }
           }
         },
@@ -116,6 +119,9 @@
           "configurations": {
             "production": {
               "devServerTarget": "demo:serve:production"
+            },
+            "ci": {
+              "devServerTarget": "demo:serve:ci"
             }
           }
         },

--- a/integration/bazel-schematics/test.sh
+++ b/integration/bazel-schematics/test.sh
@@ -28,9 +28,9 @@ function testNonBazel() {
   rm -rf dist src/main.dev.ts src/main.prod.ts
   # Just make a symlink instead of full yarn install to expose node_modules
   ln -s $(bazel info output_base)/external/npm/node_modules node_modules
-  ng build
-  ng test --watch=false
-  ng e2e
+  ng build --progress=false
+  ng test --progress=false --watch=false
+  ng e2e --configuration=ci
 }
 
 testBazel


### PR DESCRIPTION
The build and test progress logs make the CI log output so long that it can't be displayed in the UI and one has to download and view the file locally instead. This makes it harder to get to the interesting lines, such as error messages.

Similar to #26869, but for the `bazel-schematics` integration project.
