### PR TITLE
test(ivy): turn on platform-browser-dynamic tests on CI

### DIFF
--- a/packages/platform-browser-dynamic/test/BUILD.bazel
+++ b/packages/platform-browser-dynamic/test/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
         "//packages/platform-browser-dynamic",
         "//packages/platform-browser-dynamic/testing",
         "//packages/platform-browser/testing",
+        "//packages/private/testing",
     ],
 )
 
@@ -29,9 +30,6 @@ ts_web_test_suite(
     static_files = [
         "//packages/platform-browser/test:static_assets/test.html",
         "//packages/platform-browser/test:browser/static_assets/200.html",
-    ],
-    tags = [
-        "fixme-ivy-aot",
     ],
     deps = [
         ":test_lib",

--- a/packages/platform-browser-dynamic/test/resource_loader/resource_loader_cache_spec.ts
+++ b/packages/platform-browser-dynamic/test/resource_loader/resource_loader_cache_spec.ts
@@ -9,11 +9,10 @@
 import {ResourceLoader, UrlResolver} from '@angular/compiler';
 import {Component} from '@angular/core';
 import {TestBed, async, fakeAsync, tick} from '@angular/core/testing';
+import {CachedResourceLoader} from '@angular/platform-browser-dynamic/src/resource_loader/resource_loader_cache';
+import {setTemplateCache} from '@angular/platform-browser-dynamic/test/resource_loader/resource_loader_cache_setter';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-
-import {CachedResourceLoader} from '../../src/resource_loader/resource_loader_cache';
-
-import {setTemplateCache} from './resource_loader_cache_setter';
+import {fixmeIvy} from '@angular/private/testing';
 
 if (isBrowser) {
   describe('CachedResourceLoader', () => {
@@ -55,19 +54,20 @@ if (isBrowser) {
              .catch((error) => {/** success */});
        }));
 
-    it('should allow fakeAsync Tests to load components with templateUrl synchronously',
-       fakeAsync(() => {
-         TestBed.configureTestingModule({declarations: [TestComponent]});
-         TestBed.compileComponents();
-         tick();
+    fixmeIvy('FW-553: TestBed is unaware of async compilation')
+        .it('should allow fakeAsync Tests to load components with templateUrl synchronously',
+            fakeAsync(() => {
+              TestBed.configureTestingModule({declarations: [TestComponent]});
+              TestBed.compileComponents();
+              tick();
 
-         const fixture = TestBed.createComponent(TestComponent);
+              const fixture = TestBed.createComponent(TestComponent);
 
-         // This should initialize the fixture.
-         tick();
+              // This should initialize the fixture.
+              tick();
 
-         expect(fixture.debugElement.children[0].nativeElement).toHaveText('Hello');
-       }));
+              expect(fixture.debugElement.children[0].nativeElement).toHaveText('Hello');
+            }));
   });
 }
 

--- a/packages/platform-browser-dynamic/test/resource_loader/resource_loader_impl_spec.ts
+++ b/packages/platform-browser-dynamic/test/resource_loader/resource_loader_impl_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {AsyncTestCompleter, beforeEach, describe, expect, inject, it} from '@angular/core/testing/src/testing_internal';
-import {ResourceLoaderImpl} from '../../src/resource_loader/resource_loader_impl';
+import {ResourceLoaderImpl} from '@angular/platform-browser-dynamic/src/resource_loader/resource_loader_impl';
 
 if (isBrowser) {
   describe('ResourceLoaderImpl', () => {

--- a/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
+++ b/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
@@ -10,7 +10,8 @@ import {ResourceLoader} from '@angular/compiler';
 import {Compiler, Component, NgModule} from '@angular/core';
 import {TestBed, async, fakeAsync, inject, tick} from '@angular/core/testing';
 
-import {ResourceLoaderImpl} from '../src/resource_loader/resource_loader_impl';
+import {ResourceLoaderImpl} from '@angular/platform-browser-dynamic/src/resource_loader/resource_loader_impl';
+import {fixmeIvy} from '@angular/private/testing';
 
 
 
@@ -62,10 +63,11 @@ if (isBrowser) {
               {providers: [{provide: FancyService, useValue: new FancyService()}]});
         });
 
-        it('provides a real ResourceLoader instance',
-           inject([ResourceLoader], (resourceLoader: ResourceLoader) => {
-             expect(resourceLoader instanceof ResourceLoaderImpl).toBeTruthy();
-           }));
+        fixmeIvy('unknown').it(
+            'provides a real ResourceLoader instance',
+            inject([ResourceLoader], (resourceLoader: ResourceLoader) => {
+              expect(resourceLoader instanceof ResourceLoaderImpl).toBeTruthy();
+            }));
 
         it('should allow the use of fakeAsync',
            fakeAsync(inject([FancyService], (service: any /** TODO #9100 */) => {
@@ -78,7 +80,7 @@ if (isBrowser) {
     });
 
     describe('Compiler', () => {
-      it('should return NgModule id when asked', () => {
+      fixmeIvy('unknown').it('should return NgModule id when asked', () => {
         @NgModule({
           id: 'test-module',
         })
@@ -115,37 +117,41 @@ if (isBrowser) {
 
       const restoreJasmineIt = () => { jasmine.getEnv().it = originalJasmineIt; };
 
-      it('should fail when an ResourceLoader fails', done => {
-        const itPromise = patchJasmineIt();
+      fixmeIvy('FW-553: TestBed is unaware of async compilation')
+          .it('should fail when an ResourceLoader fails', done => {
+            const itPromise = patchJasmineIt();
 
-        it('should fail with an error from a promise', async(() => {
-             TestBed.configureTestingModule({declarations: [BadTemplateUrl]});
-             TestBed.compileComponents();
-           }));
+            it('should fail with an error from a promise', async(() => {
+                 TestBed.configureTestingModule({declarations: [BadTemplateUrl]});
+                 TestBed.compileComponents();
+               }));
 
-        itPromise.then(
-            () => { done.fail('Expected test to fail, but it did not'); },
-            (err: any) => {
-              expect(err.message)
-                  .toEqual('Uncaught (in promise): Failed to load non-existent.html');
-              done();
-            });
-        restoreJasmineIt();
-      }, 10000);
+            itPromise.then(
+                () => { done.fail('Expected test to fail, but it did not'); },
+                (err: any) => {
+                  expect(err.message)
+                      .toEqual('Uncaught (in promise): Failed to load non-existent.html');
+                  done();
+                });
+            restoreJasmineIt();
+          }, 10000);
     });
 
     describe('TestBed createComponent', function() {
-      it('should allow an external templateUrl', async(() => {
-           TestBed.configureTestingModule({declarations: [ExternalTemplateComp]});
-           TestBed.compileComponents().then(() => {
-             const componentFixture = TestBed.createComponent(ExternalTemplateComp);
-             componentFixture.detectChanges();
-             expect(componentFixture.nativeElement.textContent).toEqual('from external template');
-           });
-         }),
-         10000);  // Long timeout here because this test makes an actual ResourceLoader request, and
-                  // is slow
-                  // on Edge.
+      fixmeIvy('FW-553: TestBed is unaware of async compilation')
+          .it('should allow an external templateUrl', async(() => {
+                TestBed.configureTestingModule({declarations: [ExternalTemplateComp]});
+                TestBed.compileComponents().then(() => {
+                  const componentFixture = TestBed.createComponent(ExternalTemplateComp);
+                  componentFixture.detectChanges();
+                  expect(componentFixture.nativeElement.textContent)
+                      .toEqual('from external template');
+                });
+              }),
+              10000);  // Long timeout here because this test makes an actual ResourceLoader
+                       // request, and
+                       // is slow
+                       // on Edge.
     });
   });
 }


### PR DESCRIPTION
We missed a `fixme-ivy-aot` tag, so we weren't running the `//packages/platform-browser-dynamic/test:test_web_chromium-local` test target on CI. This PR turns on the tests and adds root causes where known.