### PR TITLE
ci: add brandonroberts to @angular/framework-global-approvers-for-docs-only-changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -93,6 +93,7 @@
 #  Used for approving minor documentation-only changes that don't require engineering review.
 #  (secret team to avoid review requests, it also doesn't inherit from @angular/framework because nested teams can't be secret)
 #
+#   - brandonroberts
 #   - gkalpak
 #   - jenniferfell
 #   - petebacondarwin


### PR DESCRIPTION
I’ve observed that Brandon reviews many docs-only PRs and then we still need me or Jeniffer to approve them. In most cases, Brandon is perfectly qualified to approve these, so I’m proposing that Brandon is added to the framework-global-approvers-for-docs-only-changes group.

@brandonroberts are you ok with this? this change will make you more "dangerous" because will mean that you will need to be much more careful when approving PRs because you could accidentally approve changes that impact also code and not only docs. If you are willing to be more careful, we trust you to not approve code changes for areas outside of your other areas of code ownership (currently only stuff owned by @angular/fw-docs-intro).

*Please note that this change is for documentation purposes only, once this PR is approved and merged the actual change needs to be made in the github team settings by an admin*