### PR TITLE
docs: `multi: true` usage clarification

### DIFF
--- a/aio/content/guide/dependency-injection-providers.md
+++ b/aio/content/guide/dependency-injection-providers.md
@@ -270,7 +270,7 @@ A provider object can associate any of these injection tokens with one or more c
 
 * [APP_INITIALIZER](api/core/APP_INITIALIZER): Callback is invoked before an app is initialized. All registered initializers can optionally return a Promise. All initializer functions that return Promises must be resolved before the application is bootstrapped. If one of the initializers fails to resolves, the application is not bootstrapped.
 
-The provider object can have a third option, `multi: true`, which you can use with `APP_INITIALIZER`
+The provider object can have a third option, `multi: true`, which you can use with the above injection tokens
 to register multiple handlers for the provide event.
 
 For example, when bootstrapping an application, you can register many initializers using the same token.


### PR DESCRIPTION
All three injection tokens can accept the `multi: true` parameter, not only `APP_INITIALIZER`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
