### PR TITLE
ci: remove required ci status for travis from angular-robot.yaml

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -101,7 +101,6 @@ merge:
 
     # list of PR statuses that need to be successful
     requiredStatuses:
-      - "continuous-integration/travis-ci/pr"
       - "ci/circleci: build"
       - "ci/circleci: lint"
 


### PR DESCRIPTION
we missed this one!! oops

the robot should not expect travis status check on PRs any more.

