### PR TITLE
build: remove remaining travis leftovers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,7 @@ If the commit reverts a previous commit, it should begin with `revert: `, follow
 Must be one of the following:
 
 * **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-* **ci**: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
+* **ci**: Changes to our CI configuration files and scripts (example scopes: Circle, BrowserStack, SauceLabs)
 * **docs**: Documentation only changes
 * **feat**: A new feature
 * **fix**: A bug fix

--- a/aio/content/examples/upgrade-phonecat-2-hybrid/karma.conf.js
+++ b/aio/content/examples/upgrade-phonecat-2-hybrid/karma.conf.js
@@ -23,15 +23,6 @@ module.exports = function(config) {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
 
-    customLaunchers: {
-      // From the CLI. Not used here but interesting
-      // chrome setup for travis CI using chromium
-      Chrome_travis_ci: {
-        base: 'Chrome',
-        flags: ['--no-sandbox']
-      }
-    },
-
     files: [
       // System.js for module loading
       'node_modules/systemjs/dist/system.src.js',

--- a/aio/content/examples/upgrade-phonecat-3-final/karma.conf.js
+++ b/aio/content/examples/upgrade-phonecat-3-final/karma.conf.js
@@ -23,15 +23,6 @@ module.exports = function(config) {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
 
-    customLaunchers: {
-      // From the CLI. Not used here but interesting
-      // chrome setup for travis CI using chromium
-      Chrome_travis_ci: {
-        base: 'Chrome',
-        flags: ['--no-sandbox']
-      }
-    },
-
     files: [
       // System.js for module loading
       'node_modules/systemjs/dist/system.src.js',

--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -99,7 +99,7 @@ Continuous integration (CI) servers let you set up your project repository so th
 There are paid CI services like Circle CI and Travis CI, and you can also host your own for free using Jenkins and others. 
 Although Circle CI and Travis CI are paid services, they are provided free for open source projects. 
 You can create a public project on GitHub and add these services without paying. 
-Contributions to the Angular repo are automatically run through a whole suite of Circle CI and Travis CI tests.
+Contributions to the Angular repo are automatically run through a whole suite of Circle CI tests.
 
 This article explains how to configure your project to run Circle CI and Travis CI, and also update your test configuration to be able to run tests in the Chrome browser in either environment.
 

--- a/aio/scripts/test-pwa-score.js
+++ b/aio/scripts/test-pwa-score.js
@@ -23,13 +23,6 @@ const LIGHTHOUSE_FLAGS = {logLevel: 'info'};
 const SKIPPED_HTTPS_AUDITS = ['redirects-http'];
 const VIEWER_URL = 'https://googlechrome.github.io/lighthouse/viewer/';
 
-
-// Specify the path and flags for Chrome on Travis.
-if (process.env.TRAVIS) {
-  process.env.LIGHTHOUSE_CHROMIUM_PATH = process.env.CHROME_BIN;
-  CHROME_LAUNCH_OPTS.chromeFlags = ['--no-sandbox'];
-}
-
 // Be less verbose on CI.
 if (process.env.CI) {
   LIGHTHOUSE_FLAGS.logLevel = 'error';

--- a/aio/src/karma.conf.js
+++ b/aio/src/karma.conf.js
@@ -25,14 +25,8 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['CustomChrome'],
+    browsers: ['Chrome'],
     browserNoActivityTimeout: 60000,
     singleRun: false,
-    customLaunchers: {
-      CustomChrome: {
-        base: 'Chrome',
-        flags: process.env.TRAVIS && ['--no-sandbox']
-      }
-    }
   });
 };

--- a/aio/tests/deployment/e2e/protractor.conf.js
+++ b/aio/tests/deployment/e2e/protractor.conf.js
@@ -10,11 +10,6 @@ exports.config = {
   suite: 'full',
   capabilities: {
     browserName: 'chrome',
-    // For Travis
-    chromeOptions: {
-      binary: process.env.CHROME_BIN,
-      args: ['--no-sandbox']
-    }
   },
   directConnect: true,
   framework: 'jasmine',

--- a/aio/tests/e2e/protractor.conf.js
+++ b/aio/tests/e2e/protractor.conf.js
@@ -10,11 +10,6 @@ exports.config = {
   ],
   capabilities: {
     browserName: 'chrome',
-    // For Travis
-    chromeOptions: {
-      binary: process.env.CHROME_BIN,
-      args: ['--no-sandbox']
-    }
   },
   directConnect: true,
   baseUrl: 'http://localhost:4200/',

--- a/aio/tools/README.md
+++ b/aio/tools/README.md
@@ -21,7 +21,7 @@ See the [README.md](cli-patches/README.md) for more details.
 Many of the documentation pages contain snippets of code examples. We extract these snippets from real
 working example applications, which are stored in subfolders of the `/aio/content/examples` folder. Each
 example can be built and run independently. Each example also provides e2e specs, which are run as part
-of our Travis build tasks, to verify that the examples continue to work as expected, as changes are made
+of our CI build tasks, to verify that the examples continue to work as expected, as changes are made
 to the core Angular libraries.
 
 In order to build, run and test these examples independently we need to install dependencies into their

--- a/aio/tools/examples/shared/boilerplate/cli/e2e/protractor.conf.js
+++ b/aio/tools/examples/shared/boilerplate/cli/e2e/protractor.conf.js
@@ -10,11 +10,6 @@ exports.config = {
   ],
   capabilities: {
     'browserName': 'chrome',
-    // For Travis CI only
-    chromeOptions: {
-      binary: process.env.CHROME_BIN,
-      args: ['--no-sandbox']
-    }
   },
   directConnect: true,
   baseUrl: 'http://localhost:4200/',

--- a/aio/tools/examples/shared/protractor.config.js
+++ b/aio/tools/examples/shared/protractor.config.js
@@ -21,11 +21,6 @@ exports.config = {
   // Capabilities to be passed to the webdriver instance.
   capabilities: {
     'browserName': 'chrome',
-    // For Travis
-    chromeOptions: {
-      binary: process.env.CHROME_BIN,
-      args: ['--no-sandbox']
-    }
   },
 
   // Framework to use. Jasmine is recommended.

--- a/browser-providers.conf.js
+++ b/browser-providers.conf.js
@@ -10,7 +10,7 @@
 // and BrowserStack (BS).
 // If the target is set to null, then the browser is not run anywhere during CI.
 // If a category becomes empty (e.g. BS and required), then the corresponding job must be commented
-// out in Travis configuration.
+// out in the CI configuration.
 var CIconfiguration = {
   'Chrome': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
   'Firefox': {unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -136,13 +136,13 @@ http://github.com/angular/core-builds.
 
 You may find that your un-merged change needs some validation from external participants.
 Rather than requiring them to pull your Pull Request and build Angular locally, you can
-publish the `*-builds` snapshots just like our Travis build does.
+publish the `*-builds` snapshots just like our CircleCI build does.
 
 First time, you need to create the github repositories:
 
 ``` shell
 $ export TOKEN=[get one from https://github.com/settings/tokens]
-$ CREATE_REPOS=1 TRAVIS= ./scripts/ci/publish-build-artifacts.sh [github username]
+$ CREATE_REPOS=1 ./scripts/ci/publish-build-artifacts.sh [github username]
 ```
 
 For subsequent snapshots, just run

--- a/modules/benchmarks/src/largetable/render3/index.ts
+++ b/modules/benchmarks/src/largetable/render3/index.ts
@@ -27,10 +27,4 @@ export function main() {
   }
 }
 
-const isBazel = location.pathname.indexOf('/all/') !== 0;
-// isBazel needed while 'scripts/ci/test-e2e.sh test.e2e.protractor-e2e' is run
-// on Travis
-// TODO: port remaining protractor e2e tests to bazel protractor_web_test_suite rule
-if (isBazel) {
-  main();
-}
+main();

--- a/modules/playground/e2e_test/key_events/key_events_spec.ts
+++ b/modules/playground/e2e_test/key_events/key_events_spec.ts
@@ -13,7 +13,7 @@ const Key = protractor.Key;
 
 describe('key_events', function() {
 
-  const URL = 'all/playground/src/key_events/index.html?bundles=false';
+  const URL = 'all/playground/src/key_events/index.html';
 
   afterEach(verifyNoBrowserErrors);
   beforeEach(() => { browser.get(URL); });

--- a/protractor-e2e.conf.js
+++ b/protractor-e2e.conf.js
@@ -14,11 +14,7 @@ exports.config = {
   onPrepare: function() { beforeEach(function() { browser.ignoreSynchronization = false; }); },
   allScriptsTimeout: 11000,
   specs: ['dist/all/**/e2e_test/**/*_spec.js'],
-  exclude: [
-    'dist/all/@angular/examples/**',
-    '**/key_events/**',  // can't tell why this is failing
-    '**/sourcemap/**'    // fails only on travis
-  ],
+  exclude: ['dist/all/@angular/examples/**'],
   capabilities: {
     'browserName': 'chrome',
     // Enables concurrent testing. Currently runs four e2e files in parallel.

--- a/protractor-e2e.conf.js
+++ b/protractor-e2e.conf.js
@@ -10,23 +10,6 @@
 // as this could exit node if the help script should be printed.
 require('./dist/all/e2e_util/e2e_util').readCommandLine();
 
-var BROWSER_OPTIONS = {
-  LocalChrome: {
-    'browserName': 'chrome',
-
-    // Enables concurrent testing. Currently runs four e2e files in parallel.
-    shardTestFiles: true,
-    maxInstances: 4,
-  },
-  ChromeOnTravis: {
-    browserName: 'chrome',
-    chromeOptions: {
-      'args': ['--no-sandbox'],
-      'binary': process.env.CHROME_BIN,
-    }
-  }
-};
-
 exports.config = {
   onPrepare: function() { beforeEach(function() { browser.ignoreSynchronization = false; }); },
   allScriptsTimeout: 11000,
@@ -36,7 +19,12 @@ exports.config = {
     '**/key_events/**',  // can't tell why this is failing
     '**/sourcemap/**'    // fails only on travis
   ],
-  capabilities: process.env.TRAVIS ? BROWSER_OPTIONS.ChromeOnTravis : BROWSER_OPTIONS.LocalChrome,
+  capabilities: {
+    'browserName': 'chrome',
+    // Enables concurrent testing. Currently runs four e2e files in parallel.
+    shardTestFiles: true,
+    maxInstances: 4,
+  },
   directConnect: true,
   baseUrl: 'http://localhost:8000/',
   framework: 'jasmine2',

--- a/protractor-examples-e2e.conf.js
+++ b/protractor-examples-e2e.conf.js
@@ -13,28 +13,16 @@ require('reflect-metadata');
 
 Error.stackTraceLimit = 9999;
 
-var BROWSER_OPTIONS = {
-  LocalChrome: {
-    'browserName': 'chrome',
-
-    // Enables concurrent testing. Currently runs four e2e files in parallel.
-    shardTestFiles: true,
-    maxInstances: 4,
-  },
-  ChromeOnTravis: {
-    browserName: 'chrome',
-    chromeOptions: {
-      'args': ['--no-sandbox'],
-      'binary': process.env.CHROME_BIN,
-    }
-  },
-};
-
 exports.config = {
   onPrepare: function() { beforeEach(function() { browser.ignoreSynchronization = false; }); },
   allScriptsTimeout: 11000,
   specs: ['dist/examples/**/e2e_test/*_spec.js'],
-  capabilities: process.env.TRAVIS ? BROWSER_OPTIONS.ChromeOnTravis : BROWSER_OPTIONS.LocalChrome,
+  capabilities: {
+    'browserName': 'chrome',
+    // Enables concurrent testing. Currently runs four e2e files in parallel.
+    shardTestFiles: true,
+    maxInstances: 4,
+  },
   directConnect: true,
   baseUrl: 'http://localhost:8001/',
   framework: 'jasmine2',

--- a/protractor-perf.conf.js
+++ b/protractor-perf.conf.js
@@ -17,7 +17,7 @@ const isBazel = !!process.env.RUNFILES;
 const BASE = isBazel ? 'angular/modules' : 'dist/all';
 require(`./${BASE}/e2e_util/perf_util`).readCommandLine();
 
-var CHROME_OPTIONS = {
+const CHROME_OPTIONS = {
   'args': ['--js-flags=--expose-gc', '--no-sandbox', '--headless', '--disable-dev-shm-usage'],
   'perfLoggingPrefs': {
     'traceCategories':
@@ -25,8 +25,11 @@ var CHROME_OPTIONS = {
   }
 };
 
-var BROWSER_CAPS = {
-  LocalChrome: {
+const config = {
+  onPrepare: function() { beforeEach(function() { browser.ignoreSynchronization = false; }); },
+  restartBrowserBetweenTests: true,
+  allScriptsTimeout: 11000,
+  capabilities: {
     'browserName': 'chrome',
     chromeOptions: CHROME_OPTIONS,
     loggingPrefs: {
@@ -34,30 +37,6 @@ var BROWSER_CAPS = {
       browser: 'ALL',
     }
   },
-  ChromeOnTravis: {
-    browserName: 'chrome',
-    chromeOptions: mergeInto(CHROME_OPTIONS, {
-      'binary': process.env.CHROME_BIN,
-    }),
-    loggingPrefs: {
-      performance: 'ALL',
-      browser: 'ALL',
-    }
-  }
-};
-
-function mergeInto(src, target) {
-  for (var prop in src) {
-    target[prop] = src[prop];
-  }
-  return target;
-}
-
-const config = {
-  onPrepare: function() { beforeEach(function() { browser.ignoreSynchronization = false; }); },
-  restartBrowserBetweenTests: true,
-  allScriptsTimeout: 11000,
-  capabilities: process.env.TRAVIS ? BROWSER_CAPS.ChromeOnTravis : BROWSER_CAPS.LocalChrome,
   directConnect: true,
   framework: 'jasmine2',
   jasmineNodeOpts: {

--- a/scripts/ci/payload-size.sh
+++ b/scripts/ci/payload-size.sh
@@ -51,7 +51,7 @@ addTimestamp() {
   payloadData="$payloadData\"timestamp\": $timestamp, "
 }
 
-# Write travis commit message to global variable `$payloadData`.
+# Write the commit message for the current CI commit range to global variable `$payloadData`.
 #   $1: string - The commit range for this build (in `<SHA-1>...<SHA-2>` format).
 addMessage() {
   commitRange="$1"

--- a/yarn.lock.readme.md
+++ b/yarn.lock.readme.md
@@ -2,7 +2,7 @@ All of our npm dependencies are locked via the `yarn.lock` file for the followin
 
 - our project has lots of dependencies which update at unpredictable times, so it's important that
   we update them explicitly once in a while rather than implicitly when any of us runs `yarn install`
-- locked dependencies allow us to reuse yarn cache on travis, significantly speeding up our builds
+- locked dependencies allow us to reuse yarn cache on CircleCI, significantly speeding up our builds
   (by 5 minutes or more)
 - locked dependencies allow us to detect when node_modules folder is out of date after a branch switch
   which allows us to build the project with the correct dependencies every time


### PR DESCRIPTION
* There still seem to be a few TravisCI leftovers which can be removed now.
* Also fixes that a few e2e tests aren't running. These have been disabled a long time ago, but can be re-enabled now.