### PR TITLE
test(ivy): enable i18n test for nested templates

### DIFF
--- a/packages/core/test/i18n_integration_spec.ts
+++ b/packages/core/test/i18n_integration_spec.ts
@@ -99,22 +99,21 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       expect(element.title).toBe('Bonjour John');
     });
 
-    fixmeIvy('FW-903: i18n attributes in nested templates throws at runtime')
-        .it('should correctly bind to context in nested template', () => {
-          const title = 'Item {{ id }}';
-          const template = `
-            <div *ngFor='let id of items'>
-              <div i18n-title='m|d' title='${title}'></div>
-            </div>
-          `;
-          const fixture = getFixtureWithOverrides({template});
+    it('should correctly bind to context in nested template', () => {
+      const title = 'Item {{ id }}';
+      const template = `
+        <div *ngFor='let id of items'>
+          <div i18n-title='m|d' title='${title}'></div>
+        </div>
+      `;
+      const fixture = getFixtureWithOverrides({template});
 
-          const element = fixture.nativeElement;
-          for (let i = 0; i < element.children.length; i++) {
-            const child = element.children[i];
-            expect((child as any).innerHTML).toBe(`<div title="Article ${i + 1}"></div>`);
-          }
-        });
+      const element = fixture.nativeElement;
+      for (let i = 0; i < element.children.length; i++) {
+        const child = element.children[i];
+        expect((child as any).innerHTML).toBe(`<div title="Article ${i + 1}"></div>`);
+      }
+    });
 
     fixmeIvy('FW-904: i18n attributes placed on i18n root node don\'t work')
         .it('should work correctly when placed on i18n root node', () => {


### PR DESCRIPTION
Follow up on PR #27911.

The bug that was causing this test to fail has been resolved (see FW-903). The test now runs correctly.