### PR TITLE
refactor(ivy): simplify signature of appendChild / removeChild

### DIFF
--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -782,7 +782,10 @@ function readUpdateOpCodes(
 function removeNode(index: number, viewData: LView) {
   const removedPhTNode = getTNode(index, viewData);
   const removedPhRNode = getNativeByIndex(index, viewData);
-  removeChild(removedPhTNode, removedPhRNode || null, viewData);
+  if (removedPhRNode) {
+    removeChild(removedPhTNode, removedPhRNode, viewData);
+  }
+
   removedPhTNode.detached = true;
   ngDevMode && ngDevMode.rendererRemoveNode++;
 
@@ -790,7 +793,7 @@ function removeNode(index: number, viewData: LView) {
   if (isLContainer(slotValue)) {
     const lContainer = slotValue as LContainer;
     if (removedPhTNode.type !== TNodeType.Container) {
-      removeChild(removedPhTNode, lContainer[NATIVE] || null, viewData);
+      removeChild(removedPhTNode, lContainer[NATIVE], viewData);
     }
     lContainer[RENDER_PARENT] = null;
   }

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -629,9 +629,8 @@ export function nativeNextSibling(renderer: Renderer3, node: RNode): RNode|null 
  * @param currentView The current LView
  * @returns Whether or not the child was appended
  */
-export function appendChild(
-    childEl: RNode | null = null, childTNode: TNode, currentView: LView): boolean {
-  if (childEl !== null && canInsertNativeNode(childTNode, currentView)) {
+export function appendChild(childEl: RNode, childTNode: TNode, currentView: LView): boolean {
+  if (canInsertNativeNode(childTNode, currentView)) {
     const renderer = currentView[RENDERER];
     const renderParent = getRenderParent(childTNode, currentView) !;
     const parentTNode: TNode = childTNode.parent || currentView[HOST_NODE] !;
@@ -688,9 +687,9 @@ export function getBeforeNodeForView(index: number, views: LView[], containerNat
  * @param currentView The current LView
  * @returns Whether or not the child was removed
  */
-export function removeChild(childTNode: TNode, childEl: RNode | null, currentView: LView): boolean {
+export function removeChild(childTNode: TNode, childEl: RNode, currentView: LView): boolean {
   // We only remove the element if not in View or not projected.
-  if (childEl !== null && canInsertNativeNode(childTNode, currentView)) {
+  if (canInsertNativeNode(childTNode, currentView)) {
     const parentNative = getRenderParent(childTNode, currentView) !;
     nativeRemoveChild(currentView[RENDERER], parentNative, childEl);
     return true;


### PR DESCRIPTION
Previously the appendChild / removeChild could take null as an argument for
a child to be added / removed. This is difficult to understand since the
mentioned methods are noop if a child is null.

This commit clarifies the appendChild / removeChild signature to systematically
require a child node to be added removed. It turns out that null could be passed
only for a very specific i18n cases so now we guard a call to removeChild with
an explicit check on the i18n side.
