### PR TITLE
ci: update payload size for cli-hello-world

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1497,
-        "main": 185238,
+        "main": 187112,
         "polyfills": 59608
       }
     }


### PR DESCRIPTION
A recent PR seemed to push us over the limit. Will look into this, but submitting this to get master green in the meantime.