### PR TITLE
ci: fix public api rule in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -732,14 +732,6 @@ testing/**                                                      @angular/fw-test
 
 
 # ================================================
-#  Public API
-# ================================================
-
-/tools/public_api_guard/**                                      @angular/fw-public-api
-
-
-
-# ================================================
 #  Build & CI Owners
 # ================================================
 
@@ -752,6 +744,14 @@ testing/**                                                      @angular/fw-test
 /third_party/**                                                 @angular/fw-dev-infra
 /tools/**                                                       @angular/fw-dev-infra
 *.bzl                                                           @angular/fw-dev-infra
+
+
+
+# ================================================
+#  Public API
+# ================================================
+
+/tools/public_api_guard/**                                      @angular/fw-public-api
 
 
 


### PR DESCRIPTION
@alxhub spotted that the public api rule in codeowners is being overridden by the Build & CI Owners rule.

swapping the two sections fixes the problem.
