### PR TITLE
build(bazel): List explicit dependencies in WORKSPACE

### DIFF
--- a/packages/bazel/src/schematics/bazel-workspace/files/WORKSPACE.template
+++ b/packages/bazel/src/schematics/bazel-workspace/files/WORKSPACE.template
@@ -12,8 +12,21 @@ workspace(name = "<%= utils.underscore(name) %>")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+RULES_NODEJS_VERSION = "<%= RULES_NODEJS_VERSION %>"
+http_archive(
+    name = "build_bazel_rules_nodejs",
+    url = "https://github.com/bazelbuild/rules_nodejs/archive/%s.zip" % RULES_NODEJS_VERSION,
+    strip_prefix = "rules_nodejs-%s" % RULES_NODEJS_VERSION,
+)
+
+RULES_TYPESCRIPT_VERSION = "<%= RULES_TYPESCRIPT_VERSION %>"
+http_archive(
+    name = "build_bazel_rules_typescript",
+    url = "https://github.com/bazelbuild/rules_typescript/archive/%s.zip" % RULES_TYPESCRIPT_VERSION,
+    strip_prefix = "rules_typescript-%s" % RULES_TYPESCRIPT_VERSION,
+)
+
 # The @angular repo contains rule for building Angular applications
-# Provides "build_bazel_rules_typescript"
 ANGULAR_VERSION = "<%= ANGULAR_VERSION %>"
 http_archive(
     name = "angular",
@@ -45,7 +58,6 @@ rules_angular_dependencies()
 
 load("@build_bazel_rules_typescript//:package.bzl", "rules_typescript_dependencies")
 rules_typescript_dependencies()
-# build_bazel_rules_nodejs is loaded transitively through rules_typescript_dependencies.
 
 load("@build_bazel_rules_nodejs//:package.bzl", "rules_nodejs_dependencies")
 rules_nodejs_dependencies()
@@ -71,7 +83,7 @@ browser_repositories(
     firefox = True,
 )
 
-load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace", "check_rules_typescript_version")
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_setup_workspace")
 ts_setup_workspace()
 
 load("@io_bazel_rules_sass//sass:sass_repositories.bzl", "sass_repositories")

--- a/packages/bazel/src/schematics/bazel-workspace/index.ts
+++ b/packages/bazel/src/schematics/bazel-workspace/index.ts
@@ -80,6 +80,8 @@ export default function(options: BazelWorkspaceOptions): Rule {
     });
 
     const workspaceVersions = {
+      'RULES_NODEJS_VERSION': '0.16.5',
+      'RULES_TYPESCRIPT_VERSION': '0.22.0',
       'ANGULAR_VERSION': existingVersions.Angular || clean(latestVersions.Angular),
       'RXJS_VERSION': existingVersions.RxJs || clean(latestVersions.RxJs),
       // TODO(kyliau): Consider moving this to latest-versions.ts


### PR DESCRIPTION
Instead of relying on implicit dependencies through Angular, the WORKSPACE
of the project should explicitly add `rules_nodejs` and `rules_typescript` so
it can better control the versions.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
