### PR TITLE
fix(ivy): normalize summary and factory shim files paths

### DIFF
--- a/packages/compiler-cli/src/ngtsc/shims/src/factory_generator.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/factory_generator.ts
@@ -89,8 +89,8 @@ export class FactoryGenerator implements ShimGenerator {
 
   static forRootFiles(files: ReadonlyArray<string>): FactoryGenerator {
     const map = new Map<string, string>();
-    files.map(sourceFile => normalizeSeparators(sourceFile))
-        .filter(sourceFile => isNonDeclarationTsPath(sourceFile))
+    files.filter(sourceFile => isNonDeclarationTsPath(sourceFile))
+        .map(sourceFile => normalizeSeparators(sourceFile))
         .forEach(sourceFile => map.set(sourceFile.replace(/\.ts$/, '.ngfactory.ts'), sourceFile));
     return new FactoryGenerator(map);
   }

--- a/packages/compiler-cli/src/ngtsc/shims/src/factory_generator.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/factory_generator.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import * as ts from 'typescript';
 
 import {ImportRewriter} from '../../imports';
+import {normalizeSeparators} from '../../util/src/path';
 import {isNonDeclarationTsPath} from '../../util/src/typescript';
 
 import {ShimGenerator} from './host';
@@ -88,7 +89,8 @@ export class FactoryGenerator implements ShimGenerator {
 
   static forRootFiles(files: ReadonlyArray<string>): FactoryGenerator {
     const map = new Map<string, string>();
-    files.filter(sourceFile => isNonDeclarationTsPath(sourceFile))
+    files.map(sourceFile => normalizeSeparators(sourceFile))
+        .filter(sourceFile => isNonDeclarationTsPath(sourceFile))
         .forEach(sourceFile => map.set(sourceFile.replace(/\.ts$/, '.ngfactory.ts'), sourceFile));
     return new FactoryGenerator(map);
   }

--- a/packages/compiler-cli/src/ngtsc/shims/src/summary_generator.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/summary_generator.ts
@@ -8,6 +8,7 @@
 
 import * as ts from 'typescript';
 
+import {normalizeSeparators} from '../../util/src/path';
 import {isNonDeclarationTsPath} from '../../util/src/typescript';
 
 import {ShimGenerator} from './host';
@@ -63,7 +64,8 @@ export class SummaryGenerator implements ShimGenerator {
 
   static forRootFiles(files: ReadonlyArray<string>): SummaryGenerator {
     const map = new Map<string, string>();
-    files.filter(sourceFile => isNonDeclarationTsPath(sourceFile))
+    files.map(sourceFile => normalizeSeparators(sourceFile))
+        .filter(sourceFile => isNonDeclarationTsPath(sourceFile))
         .forEach(sourceFile => map.set(sourceFile.replace(/\.ts$/, '.ngsummary.ts'), sourceFile));
     return new SummaryGenerator(map);
   }

--- a/packages/compiler-cli/src/ngtsc/shims/src/summary_generator.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/summary_generator.ts
@@ -64,8 +64,8 @@ export class SummaryGenerator implements ShimGenerator {
 
   static forRootFiles(files: ReadonlyArray<string>): SummaryGenerator {
     const map = new Map<string, string>();
-    files.map(sourceFile => normalizeSeparators(sourceFile))
-        .filter(sourceFile => isNonDeclarationTsPath(sourceFile))
+    files.filter(sourceFile => isNonDeclarationTsPath(sourceFile))
+        .map(sourceFile => normalizeSeparators(sourceFile))
         .forEach(sourceFile => map.set(sourceFile.replace(/\.ts$/, '.ngsummary.ts'), sourceFile));
     return new SummaryGenerator(map);
   }

--- a/packages/compiler-cli/src/ngtsc/util/src/path.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/path.ts
@@ -26,3 +26,7 @@ export function relativePathBetween(from: string, to: string): string|null {
 
   return relative;
 }
+
+export function normalizeSeparators(path: string): string {
+  return path.replace(/\\/g, '/');
+}

--- a/packages/compiler-cli/src/ngtsc/util/src/path.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/path.ts
@@ -28,5 +28,6 @@ export function relativePathBetween(from: string, to: string): string|null {
 }
 
 export function normalizeSeparators(path: string): string {
+  // TODO: normalize path only for OS that need it.
   return path.replace(/\\/g, '/');
 }


### PR DESCRIPTION
At the moment, paths stored in `maps` are not normalized and in Windows is causing files not to be found when enabling factory shimming.

For example, the map contents will be
```
Map {
  'C:\\git\\cli-repos\\ng-factory-shims\\index.ngfactory.ts' => 'C:\\git\\cli-repos\\ng-factory-shims\\index.ts' }
```

However, ts compiler normalized the paths and is causing;
```
error TS6053: File 'C:/git/cli-repos/ng-factory-shims/index.ngfactory.ts' not found.
error TS6053: File 'C:/git/cli-repos/ng-factory-shims/index.ngsummary.ts' not found.
```

The changes normalized the paths that are stored within the factory and summary maps.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
