### PR TITLE
test(ivy): NodeInjector should know how to get itself (INJECTOR)

### DIFF
--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/test/app_spec.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/test/app_spec.ts
@@ -9,7 +9,6 @@
 import {Component, INJECTOR, Injectable, NgModule} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {renderModuleFactory} from '@angular/platform-server';
-import {fixmeIvy} from '@angular/private/testing';
 import {BasicAppModuleNgFactory} from 'app_built/src/basic.ngfactory';
 import {DepAppModuleNgFactory} from 'app_built/src/dep.ngfactory';
 import {HierarchyAppModuleNgFactory} from 'app_built/src/hierarchy.ngfactory';
@@ -168,21 +167,20 @@ describe('ngInjectableDef Bazel Integration', () => {
     expect(TestBed.get(INJECTOR).get('foo')).toEqual('bar');
   });
 
-  fixmeIvy('FW-854: NodeInjector does not know how to get itself (INJECTOR)')
-      .it('Component injector understands requests for INJECTABLE', () => {
-        @Component({
-          selector: 'test-cmp',
-          template: 'test',
-          providers: [{provide: 'foo', useValue: 'bar'}],
-        })
-        class TestCmp {
-        }
+  it('Component injector understands requests for INJECTABLE', () => {
+    @Component({
+      selector: 'test-cmp',
+      template: 'test',
+      providers: [{provide: 'foo', useValue: 'bar'}],
+    })
+    class TestCmp {
+    }
 
-        TestBed.configureTestingModule({
-          declarations: [TestCmp],
-        });
+    TestBed.configureTestingModule({
+      declarations: [TestCmp],
+    });
 
-        const fixture = TestBed.createComponent(TestCmp);
-        expect(fixture.componentRef.injector.get(INJECTOR).get('foo')).toEqual('bar');
-      });
+    const fixture = TestBed.createComponent(TestCmp);
+    expect(fixture.componentRef.injector.get(INJECTOR).get('foo')).toEqual('bar');
+  });
 });

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Attribute, ChangeDetectorRef, ElementRef, Host, Inject, InjectFlags, Injector, Optional, Renderer2, Self, SkipSelf, TemplateRef, ViewContainerRef, createInjector, defineInjectable, defineInjector} from '@angular/core';
+import {Attribute, ChangeDetectorRef, ElementRef, Host, INJECTOR, Inject, InjectFlags, Injector, Optional, Renderer2, Self, SkipSelf, TemplateRef, ViewContainerRef, createInjector, defineInjectable, defineInjector} from '@angular/core';
 import {ComponentType, RenderFlags} from '@angular/core/src/render3/interfaces/definition';
 
 import {defineComponent} from '../../src/render3/definition';
@@ -1458,6 +1458,36 @@ describe('di', () => {
         expect(otherInjectorDir.injector.get(ElementRef).nativeElement).toBe(divElement);
         expect(otherInjectorDir.injector.get(InjectorDir)).toBe(injectorDir);
         expect(injectorDir.injector).not.toBe(otherInjectorDir.injector);
+      });
+
+      it('should inject INJECTOR', () => {
+        let injectorDir !: INJECTORDir;
+        let divElement !: HTMLElement;
+
+        class INJECTORDir {
+          constructor(public injector: Injector) {}
+
+          static ngDirectiveDef = defineDirective({
+            type: INJECTORDir,
+            selectors: [['', 'injectorDir', '']],
+            factory: () => injectorDir = new INJECTORDir(directiveInject(INJECTOR as any))
+          });
+        }
+
+
+        /** <div injectorDir otherInjectorDir></div> */
+        const App = createComponent('app', (rf: RenderFlags, ctx: any) => {
+          if (rf & RenderFlags.Create) {
+            element(0, 'div', ['injectorDir', '']);
+          }
+          // testing only
+          divElement = load(0);
+        }, 1, 0, [INJECTORDir]);
+
+        const fixture = new ComponentFixture(App);
+        expect(injectorDir.injector.get(ElementRef).nativeElement).toBe(divElement);
+        expect(injectorDir.injector.get(Injector).get(ElementRef).nativeElement).toBe(divElement);
+        expect(injectorDir.injector.get(INJECTOR).get(ElementRef).nativeElement).toBe(divElement);
       });
 
     });


### PR DESCRIPTION
This PR fixes FW-854.

My first approach was to add a special case for `INJECTOR` in `NodeInjector.get()`, but this solution feels better.