### PR TITLE
test(upgrade): properly clean up after tests to avoid errors in unrelated tests

### DIFF
--- a/packages/upgrade/test/static/integration/downgrade_module_spec.ts
+++ b/packages/upgrade/test/static/integration/downgrade_module_spec.ts
@@ -25,6 +25,7 @@ withEachNg1Version(() => {
     describe(`lazy-load ng2 module (propagateDigest: ${propagateDigest})`, () => {
 
       beforeEach(() => destroyPlatform());
+      afterEach(() => destroyPlatform());
 
       it('should support multiple downgraded modules', async(() => {
            @Component({selector: 'ng2A', template: 'a'})


### PR DESCRIPTION
Many `ngUpgrade` tests need to manually [bootstrap modules][1] (instead of using `TestBed` which automatically cleans up) and thus need to also manually clean up afterwards (e.g. by calling [destroyPlatform()][2] after each test).

Failing to destroy the platform is usually not a problem, unless the next test tries to manually destroy it (as a precaution), as happens [here][3] (among other places).

More specifically, the problem happens, because (as part of the clean-up happening on platform destruction) upgraded components will try to [call a method][4] on `angular.element` after `angular` has been [set to `undefined`][5] (assuming the last test was using the [withEachNg1Version()][6] helper).

Because the test order is pseudo-random and thus different on each run, these errors did not always come up and - when they did- they would go away after a couple of reruns, making them appear as flakes on CI.

(For reference, the issue was introduced in 43c33d566.)

This commit eliminates the issue by always destroying the platform after each `ngUpgrade` test.

Jira issue: FW-924

[1]: https://github.com/angular/angular/blob/c3aa24c3f9699242331ca014b1616e968c1a7f8c/packages/upgrade/test/static/test_helpers.ts#L21
[2]: https://github.com/angular/angular/blob/c3aa24c3f9699242331ca014b1616e968c1a7f8c/packages/upgrade/test/static/integration/upgrade_component_spec.ts#L24
[3]: https://github.com/angular/angular/blob/c3aa24c3f9699242331ca014b1616e968c1a7f8c/packages/elements/test/create-custom-element_spec.ts#L31
[4]: https://github.com/angular/angular/blob/c3aa24c3f9699242331ca014b1616e968c1a7f8c/packages/upgrade/src/common/upgrade_helper.ts#L134-L135
[5]: https://github.com/angular/angular/blob/c3aa24c3f9699242331ca014b1616e968c1a7f8c/packages/upgrade/test/common/test_helpers.ts#L115
[6]: https://github.com/angular/angular/blob/c3aa24c3f9699242331ca014b1616e968c1a7f8c/packages/upgrade/test/common/test_helpers.ts#L31
