### PR TITLE
docs: remove deprecated `fromPromise` from RxJS guide

### DIFF
--- a/aio/content/guide/rx-library.md
+++ b/aio/content/guide/rx-library.md
@@ -53,7 +53,7 @@ RxJS provides many operators, but only a handful are used frequently. For a list
 
 | Area | Operators |
 | :------------| :----------|
-| Creation |  `from`, `fromPromise`,`fromEvent`, `of` |
+| Creation |  `from`,`fromEvent`, `of` |
 | Combination | `combineLatest`, `concat`, `merge`, `startWith` , `withLatestFrom`, `zip` |
 | Filtering | `debounceTime`, `distinctUntilChanged`, `filter`, `take`, `takeUntil` |
 | Transformation | `bufferTime`, `concatMap`, `map`, `mergeMap`, `scan`, `switchMap` |


### PR DESCRIPTION
Follow-up to #27443.
