### PR TITLE
fix(bazel): protractor rule does not run spec files with underscore

### DIFF
--- a/packages/bazel/src/protractor/protractor.conf.js
+++ b/packages/bazel/src/protractor/protractor.conf.js
@@ -88,7 +88,8 @@ if (onPreparePath) {
 // ts_web_test_suite & rules_webtesting WEB_TEST_METADATA attributes
 setConf(conf, 'framework', 'jasmine2', 'is set to jasmine2');
 
-const specs = [TMPL_specs].map(s => require.resolve(s)).filter(s => /\b(spec|test)\.js$/.test(s));
+const specs =
+    [TMPL_specs].map(s => require.resolve(s)).filter(s => /(\b|_)(spec|test)\.js$/.test(s));
 
 setConf(conf, 'specs', specs, 'are determined by the srcs and deps attribute');
 


### PR DESCRIPTION
There are various e2e tests with the `_spec.ts` suffix in the Angular project. Currently the protractor Bazel rule does not pick up these files and just ignores them. Since underscore is commonly used, we should support this.