### PR TITLE
ci: onlyInIvy tests should not be triggered for FIND_PASSING_TESTS mode

### DIFF
--- a/packages/private/testing/src/ivy_test_selectors.ts
+++ b/packages/private/testing/src/ivy_test_selectors.ts
@@ -94,7 +94,7 @@ export function obsoleteInIvy(reason: string): JasmineMethods {
  * ```
  */
 export function onlyInIvy(reason: string): JasmineMethods {
-  return ivyEnabled ? PASSTHROUGH : IGNORE;
+  return ivyEnabled && !FIND_PASSING_TESTS ? PASSTHROUGH : IGNORE;
 }
 
 /**


### PR DESCRIPTION
Previous to this change, there was a lot of noise when
trying to find tests in FIND_PASSING_TESTS mode because
tests marked "onlyInIvy" were also listed as "already
passing". Since these tests are not "fixmes" that need
to be enabled, it is not useful to have them listed.

This commit removes "onlyInIvy" tests from consideration
when running in this manual mode. The tests should still
run on CI by default (since FIND_PASSING_TESTS mode will
be false).
