### PR TITLE
build: support external angular in ng_rollup_bundle

### DIFF
--- a/packages/bazel/src/ng_rollup_bundle.bzl
+++ b/packages/bazel/src/ng_rollup_bundle.bzl
@@ -27,7 +27,19 @@ load(
 load("@build_bazel_rules_nodejs//internal:collect_es6_sources.bzl", collect_es2015_sources = "collect_es6_sources")
 load(":esm5.bzl", "esm5_outputs_aspect", "esm5_root_dir", "flatten_esm5")
 
-PACKAGES = ["packages/core/src", "packages/common/src", "packages/compiler/src", "external/rxjs"]
+PACKAGES = [
+    # Generated paths when using ng_rollup_bundle outside this monorepo.
+    "external/angular/packages/core/src",
+    "external/angular/packages/common/src",
+    "external/angular/packages/compiler/src",
+    "external/angular/packages/platform-browser/src",
+    "external/rxjs",
+    # Generated paths when using ng_rollup_bundle inside this monorepo.
+    "packages/core/src",
+    "packages/common/src",
+    "packages/compiler/src",
+    "packages/platform-browser/src",
+]
 PLUGIN_CONFIG = "{sideEffectFreeModules: [\n%s]}" % ",\n".join(
     ["        '.esm5/{0}'".format(p) for p in PACKAGES],
 )


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
ng_rollup_bundle only produces the smallest bundles when used in the Angular monorepo.

Issue Number: N/A


## What is the new behavior?
Supports existing ng_rollup_bundle optimizations outside the Angular monorepo.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
