### PR TITLE
fix(bazel): replay compilation uses wrong compiler for building esm5

### DIFF
--- a/packages/bazel/src/esm5.bzl
+++ b/packages/bazel/src/esm5.bzl
@@ -101,6 +101,7 @@ def _esm5_outputs_aspect(target, ctx):
         # a "npm" workspace with the "@angular/bazel" NPM package installed.
         if not replay_compiler_path.startswith("../"):
             compiler = ctx.executable._internal_ngc_wrapped
+
         # END-INTERNAL
     else:
         fail("Unknown replay compiler", target.typescript.replay_params.compiler.path)

--- a/packages/bazel/src/esm5.bzl
+++ b/packages/bazel/src/esm5.bzl
@@ -12,6 +12,8 @@ However we need to publish this flavor on NPM, so it's necessary to be able
 to produce it.
 """
 
+load(":external.bzl", "DEFAULT_NG_COMPILER")
+
 # The provider downstream rules use to access the outputs
 ESM5Info = provider(
     doc = "Typescript compilation outputs in ES5 syntax with ES Modules",
@@ -142,7 +144,7 @@ esm5_outputs_aspect = aspect(
             cfg = "host",
         ),
         "_ngc_wrapped": attr.label(
-            default = Label("//packages/bazel/src/ngc-wrapped"),
+            default = Label(DEFAULT_NG_COMPILER),
             executable = True,
             cfg = "host",
         ),


### PR DESCRIPTION
**What's the issue?**

With the update to TypeScript 3.2.x, a big issue seems to have appeared for downstream Bazel users. If the downstream user still uses a lower TypeScript version, normal Bazel targets using the `ng_module` rule are still compiled with the expected TypeScript version (assuming they set the `node_modules` attribute properly).

But, if they build the previous Bazel targets by specifying them within a `ng_package` rule, the TypeScript version from the Angular `workspace` is being used for the replayed ESM5 compilation. 

**Why is this?** 

This is because we resolve the replay compiler to `ngc_wrapped` or `tsc_wrapped` Bazel executables which are defined as part of the `angular` workspace. This means that the compilers are different if the downstream user uses `ngc-wrapped` from the `@npm` repository because the replayed compilation would use the compiler with `@ngdeps//typescript`.

**How can we fix it**

In order to fix this, we should just use the compiler that is defined in the `@angular//BUILD.bazel` file. This target by defaults to the "@npm" workspace which is working for downstream users. This is similar to how it is handled for `tsc-wrapped`. `tsc-wrapped` works as expected for downstream users.

**Future things to explore**
Note that in general the way we use the "replay_compiler" is not perfect because ideally we would completely respect the `compiler` option from the base `ng_module`, but this is not possible in a hermetic way, unless we somehow accept the `compiler` as an attribute that builds all transitive deps. This is something we should explore in the future. For now, we just fix this in a reasonable way that is also used for `tsc_wrapped` from the TypeScript rules (as mentioned above)