### PR TITLE
fix(ivy): ignore empty bindings

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -120,6 +120,23 @@ describe('compiler compliance: bindings', () => {
       const result = compile(files, angularFiles);
       expectEmit(result.source, template, 'Incorrect interpolated property binding');
     });
+
+    it('should ignore empty bindings', () => {
+      const files: MockDirectory = {
+        app: {
+          'example.ts': `
+            import {Component} from '@angular/core';
+            @Component({
+              selector: 'test',
+              template: '<div [someProp]></div>'
+            })
+            class FooCmp {}
+          `
+        }
+      };
+      const result = compile(files, angularFiles);
+      expect(result.source).not.toContain('i0.ɵelementProperty');
+    });
   });
 
   describe('host bindings', () => {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -887,6 +887,21 @@ describe('ngtsc behavioral tests', () => {
             'changeDetection must be a member of ChangeDetectionStrategy enum from @angular/core');
   });
 
+  it('should ignore empty bindings', () => {
+    env.tsconfig();
+    env.write(`test.ts`, `
+      import {Component} from '@angular/core';
+       @Component({
+        selector: 'test',
+        template: '<div [someProp]></div>'
+      })
+      class FooCmp {}
+    `);
+    env.driveMain();
+    const jsContents = env.getContents('test.js');
+    expect(jsContents).not.toContain('i0.ɵelementProperty');
+  });
+
   it('should correctly recognize local symbols', () => {
     env.tsconfig();
     env.write('module.ts', `

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -709,21 +709,20 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
           });
         }
       } else if (instruction) {
-        const params: any[] = [];
-        const isAttributeBinding = input.type === BindingType.Attribute;
-        const sanitizationRef = resolveSanitizationFn(input.securityContext, isAttributeBinding);
-        if (sanitizationRef) params.push(sanitizationRef);
-
-        // TODO(chuckj): runtime: security context
         const value = input.value.visit(this._valueConverter);
-        this.allocateBindingSlots(value);
-
-        this.updateInstruction(input.sourceSpan, instruction, () => {
-          return [
-            o.literal(elementIndex), o.literal(input.name),
-            this.convertPropertyBinding(implicit, value), ...params
-          ];
-        });
+        if (value !== undefined) {
+          const params: any[] = [];
+          const isAttributeBinding = input.type === BindingType.Attribute;
+          const sanitizationRef = resolveSanitizationFn(input.securityContext, isAttributeBinding);
+          if (sanitizationRef) params.push(sanitizationRef);
+          this.allocateBindingSlots(value);
+          this.updateInstruction(input.sourceSpan, instruction, () => {
+            return [
+              o.literal(elementIndex), o.literal(input.name),
+              this.convertPropertyBinding(implicit, value), ...params
+            ];
+          });
+        }
       } else {
         this._unsupported(`binding type ${input.type}`);
       }

--- a/packages/core/test/linker/change_detection_integration_spec.ts
+++ b/packages/core/test/linker/change_detection_integration_spec.ts
@@ -444,14 +444,13 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
          }));
 
 
-      fixmeIvy('FW-814: Bindings with an empty value should be ignored in the compiler')
-          .it('should ignore empty bindings', fakeAsync(() => {
-                const ctx = _bindSimpleProp('[someProp]', TestData);
-                ctx.componentInstance.a = 'value';
-                ctx.detectChanges(false);
+      it('should ignore empty bindings', fakeAsync(() => {
+           const ctx = _bindSimpleProp('[someProp]', TestData);
+           ctx.componentInstance.a = 'value';
+           ctx.detectChanges(false);
 
-                expect(renderLog.log).toEqual([]);
-              }));
+           expect(renderLog.log).toEqual([]);
+         }));
 
       it('should support interpolation', fakeAsync(() => {
            const ctx = _bindSimpleProp('someProp="B{{a}}A"', TestData);


### PR DESCRIPTION
This update aligns Ivy behavior with ViewEngine related to empty bindings (for example <div [someProp]></div>): empty bindings are ignored.

As a part of this PR I also removed this TODO (since I had to move some code): `TODO(chuckj): runtime: security context`. It looks like this TODO is obsolete, since we have sanitization mechanisms invoked at runtime as needed.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No