### PR TITLE
build: update `version` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "7.2.0-rc.0",
+  "version": "7.2.0",
   "private": true,
   "branchPattern": "2.0.*",
   "description": "Angular - a web framework for modern web apps",


### PR DESCRIPTION
The version was updated on master (with 0efbb3738), but the commit was not backported to 7.2.x. As a result, the version on angular.io appears as `7.2.0-rc.0` (instead of 7.2.0).
