### PR TITLE
fix(ivy): deps are actually supported

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -109,9 +109,6 @@ function extractInjectableMetadata(
             ErrorCode.VALUE_NOT_LITERAL, depsExpr,
             `In Ivy, deps metadata must be an inline array.`);
       }
-      if (depsExpr.elements.length > 0) {
-        throw new Error(`deps not yet supported`);
-      }
       userDeps = depsExpr.elements.map(dep => getDep(dep, reflector));
     }
 


### PR DESCRIPTION
This code was throwing if the `deps` array of a provider has several elements, but at the next line it resolves them... With this check `ngtsc` couldn’t compile `ng-bootstrap` for example.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The `deps` resolution is working but the guard stayed in place. The `ngcc` compilation of a module like `ng-bootstrap` fails with `7.2.0`.

Quoting @alxhub on Slack (back in November when I first spotted the issue): `Yeah, I think I wrote `getDep` later on when working on the same PR, and just forgot to remove the guard.`. 

## What is the new behavior?

The `ngcc` compilation of a module like `ng-bootstrap` succeeds.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
