### PR TITLE
fix(ivy): throw meaningful error for uninitialized output

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -14,6 +14,7 @@ import {validateAttribute, validateProperty} from '../sanitization/sanitization'
 import {Sanitizer} from '../sanitization/security';
 import {StyleSanitizeFn} from '../sanitization/style_sanitizer';
 import {assertDataInRange, assertDefined, assertEqual, assertLessThan, assertNotEqual} from '../util/assert';
+import {isObservable} from '../util/lang';
 import {normalizeDebugBindingName, normalizeDebugBindingValue} from '../util/ng_reflect';
 
 import {assertHasParent, assertPreviousIsParent} from './assert';
@@ -898,7 +899,14 @@ export function listener(
         const declaredName = props[i++] as string;
         ngDevMode && assertDataInRange(lView, directiveIndex as number);
         const directive = unwrapOnChangesDirectiveWrapper(lView[directiveIndex]);
-        const subscription = directive[minifiedName].subscribe(listenerFn);
+        const output = directive[minifiedName];
+
+        if (ngDevMode && !isObservable(output)) {
+          throw new Error(
+              `@Output ${minifiedName} not initialized in '${directive.constructor.name}'.`);
+        }
+
+        const subscription = output.subscribe(listenerFn);
         const idx = lCleanup.length;
         lCleanup.push(listenerFn, subscription);
         tCleanup && tCleanup.push(eventName, tNode.index, idx, -(idx + 1));

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -347,22 +347,20 @@ function declareTests(config?: {useJit: boolean}) {
         expect(tc.injector.get(EventDir)).not.toBeNull();
       });
 
-      fixmeIvy('FW-680: Throw meaningful error for uninitialized @Output')
-          .it('should display correct error message for uninitialized @Output', () => {
-            @Component({selector: 'my-uninitialized-output', template: '<p>It works!</p>'})
-            class UninitializedOutputComp {
-              @Output() customEvent !: EventEmitter<any>;
-            }
+      it('should display correct error message for uninitialized @Output', () => {
+        @Component({selector: 'my-uninitialized-output', template: '<p>It works!</p>'})
+        class UninitializedOutputComp {
+          @Output() customEvent !: EventEmitter<any>;
+        }
 
-            const template =
-                '<my-uninitialized-output (customEvent)="doNothing()"></my-uninitialized-output>';
-            TestBed.overrideComponent(MyComp, {set: {template}});
+        const template =
+            '<my-uninitialized-output (customEvent)="doNothing()"></my-uninitialized-output>';
+        TestBed.overrideComponent(MyComp, {set: {template}});
 
-            TestBed.configureTestingModule({declarations: [MyComp, UninitializedOutputComp]});
-            expect(() => TestBed.createComponent(MyComp))
-                .toThrowError(
-                    '@Output customEvent not initialized in \'UninitializedOutputComp\'.');
-          });
+        TestBed.configureTestingModule({declarations: [MyComp, UninitializedOutputComp]});
+        expect(() => TestBed.createComponent(MyComp))
+            .toThrowError('@Output customEvent not initialized in \'UninitializedOutputComp\'.');
+      });
 
       it('should read directives metadata from their binding token', () => {
         TestBed.configureTestingModule({declarations: [MyComp, PrivateImpl, NeedsPublicApi]});


### PR DESCRIPTION
Throws a similar error to ViewEngine when encountering an `@Output` that hasn't been initialized to an `Observable`.

These changes resolve FW-680.
