### PR TITLE
test(ivy): add compiler.getModuleId support in R3TestBed

### DIFF
--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -573,7 +573,7 @@ export class TestBedRender3 implements Injector, TestBed {
   /**
    * @internal
    */
-  _getModuleResolver() { return this._resolvers.module; };
+  _getModuleResolver() { return this._resolvers.module; }
 
   /**
    * @internal

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -573,6 +573,11 @@ export class TestBedRender3 implements Injector, TestBed {
   /**
    * @internal
    */
+  _getModuleResolver() { return this._resolvers.module; };
+
+  /**
+   * @internal
+   */
   _compileNgModule(moduleType: NgModuleType): void {
     const ngModule = this._resolvers.module.resolve(moduleType);
 
@@ -713,5 +718,8 @@ class R3TestCompiler implements Compiler {
 
   clearCacheFor(type: Type<any>): void {}
 
-  getModuleId(moduleType: Type<any>): string|undefined { return undefined; }
+  getModuleId(moduleType: Type<any>): string|undefined {
+    const meta = this.testBed._getModuleResolver().resolve(moduleType);
+    return meta && meta.id || undefined;
+  }
 }

--- a/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
+++ b/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
@@ -80,20 +80,19 @@ if (isBrowser) {
     });
 
     describe('Compiler', () => {
-      fixmeIvy('FW-855: TestBed.get(Compiler) should return TestBed-specific Compiler instance')
-          .it('should return NgModule id when asked', () => {
-            @NgModule({
-              id: 'test-module',
-            })
-            class TestModule {
-            }
+      it('should return NgModule id when asked', () => {
+        @NgModule({
+          id: 'test-module',
+        })
+        class TestModule {
+        }
 
-            TestBed.configureTestingModule({
-              imports: [TestModule],
-            });
-            const compiler = TestBed.get(Compiler) as Compiler;
-            expect(compiler.getModuleId(TestModule)).toBe('test-module');
-          });
+        TestBed.configureTestingModule({
+          imports: [TestModule],
+        });
+        const compiler = TestBed.get(Compiler) as Compiler;
+        expect(compiler.getModuleId(TestModule)).toBe('test-module');
+      });
     });
 
     describe('errors', () => {

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -458,28 +458,25 @@ class CompWithUrlTemplate {
             expect(TestBed.get('a')).toBe('mockA: depValue');
           });
 
-          fixmeIvy('FW-855: TestBed.get(Compiler) should return TestBed-specific Compiler instance')
-              .it('should support SkipSelf', () => {
-                @NgModule({
-                  providers: [
-                    {provide: 'a', useValue: 'aValue'},
-                    {provide: 'dep', useValue: 'depValue'},
-                  ]
-                })
-                class MyModule {
-                }
+          it('should support SkipSelf', () => {
+            @NgModule({
+              providers: [
+                {provide: 'a', useValue: 'aValue'},
+                {provide: 'dep', useValue: 'depValue'},
+              ]
+            })
+            class MyModule {
+            }
 
-                TestBed.overrideProvider(
-                    'a',
-                    {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new SkipSelf(), 'dep']]});
-                TestBed.configureTestingModule(
-                    {providers: [{provide: 'dep', useValue: 'parentDepValue'}]});
+            TestBed.overrideProvider(
+                'a', {useFactory: (dep: any) => `mockA: ${dep}`, deps: [[new SkipSelf(), 'dep']]});
+            TestBed.configureTestingModule(
+                {providers: [{provide: 'dep', useValue: 'parentDepValue'}]});
 
-                const compiler = TestBed.get(Compiler) as Compiler;
-                const modFactory = compiler.compileModuleSync(MyModule);
-                expect(modFactory.create(getTestBed()).injector.get('a'))
-                    .toBe('mockA: parentDepValue');
-              });
+            const compiler = TestBed.get(Compiler) as Compiler;
+            const modFactory = compiler.compileModuleSync(MyModule);
+            expect(modFactory.create(getTestBed()).injector.get('a')).toBe('mockA: parentDepValue');
+          });
 
           it('should keep imported NgModules eager', () => {
             let someModule: SomeModule|undefined;


### PR DESCRIPTION
This update brings `getModuleId` function support to R3TestBed-specific Compiler instance.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No