### PR TITLE
fix(ivy): debug node references not returning template ref

### DIFF
--- a/packages/core/src/render3/context_discovery.ts
+++ b/packages/core/src/render3/context_discovery.ts
@@ -300,14 +300,9 @@ export function discoverLocalRefs(lView: LView, nodeIndex: number): {[key: strin
   if (tNode && tNode.localNames) {
     const result: {[key: string]: any} = {};
     let localIndex = tNode.index + 1;
-    for (let i = 0; i < tNode.localNames.length; i += 2, localIndex++) {
-      const localRefName = tNode.localNames[i];
-      const directiveIndex = tNode.localNames[i + 1] as number;
-      if (directiveIndex === -1) {
-        result[localRefName] = lView[localIndex] || getNativeByTNode(tNode, lView);
-      } else {
-        result[localRefName] = lView[directiveIndex];
-      }
+    for (let i = 0; i < tNode.localNames.length; i += 2) {
+      result[tNode.localNames[i]] = lView[localIndex];
+      localIndex++;
     }
     return result;
   }

--- a/packages/core/src/render3/context_discovery.ts
+++ b/packages/core/src/render3/context_discovery.ts
@@ -299,11 +299,15 @@ export function discoverLocalRefs(lView: LView, nodeIndex: number): {[key: strin
   const tNode = lView[TVIEW].data[nodeIndex] as TNode;
   if (tNode && tNode.localNames) {
     const result: {[key: string]: any} = {};
-    for (let i = 0; i < tNode.localNames.length; i += 2) {
+    let localIndex = tNode.index + 1;
+    for (let i = 0; i < tNode.localNames.length; i += 2, localIndex++) {
       const localRefName = tNode.localNames[i];
       const directiveIndex = tNode.localNames[i + 1] as number;
-      result[localRefName] =
-          directiveIndex === -1 ? getNativeByTNode(tNode, lView) ! : lView[directiveIndex];
+      if (directiveIndex === -1) {
+        result[localRefName] = lView[localIndex] || getNativeByTNode(tNode, lView);
+      } else {
+        result[localRefName] = lView[directiveIndex];
+      }
     }
     return result;
   }

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -541,18 +541,16 @@ function declareTests(config?: {useJit: boolean}) {
           expect(value.tagName.toLowerCase()).toEqual('div');
         });
 
-        fixmeIvy(
-            'FW-870: DebugNode.references gets comment node instead of TemplateRef for template nodes')
-            .it('should assign the TemplateRef to a user-defined variable', () => {
-              const fixture =
-                  TestBed.configureTestingModule({declarations: [MyComp]})
-                      .overrideComponent(
-                          MyComp, {set: {template: '<ng-template ref-alice></ng-template>'}})
-                      .createComponent(MyComp);
+        it('should assign the TemplateRef to a user-defined variable', () => {
+          const fixture =
+              TestBed.configureTestingModule({declarations: [MyComp]})
+                  .overrideComponent(
+                      MyComp, {set: {template: '<ng-template ref-alice></ng-template>'}})
+                  .createComponent(MyComp);
 
-              const value = fixture.debugElement.childNodes[0].references !['alice'];
-              expect(value.createEmbeddedView).toBeTruthy();
-            });
+          const value = fixture.debugElement.childNodes[0].references !['alice'];
+          expect(value.createEmbeddedView).toBeTruthy();
+        });
 
         it('should preserve case', () => {
           TestBed.configureTestingModule({declarations: [MyComp, ChildComp]});


### PR DESCRIPTION
Fixes the `DebugNode.references` returning a reference to the underlying comment node, rather than the `TemplateRef` that the reference is pointing to. The issue comes from the fact that `discoverLocalRefs` falls back directly to returning the native node, if the ref isn't pointing to a directive, rather than looking through the locals.

These changes resolve FW-870.
