### PR TITLE
docs(core/service-worker): document `isStable` traps

### DIFF
--- a/aio/content/guide/service-worker-communications.md
+++ b/aio/content/guide/service-worker-communications.md
@@ -51,7 +51,7 @@ You can avoid that by waiting for the app to stabilize first, before starting to
 (as shown in the example above).
 
 Note that this is true for any kind of polling done by your application!
-Check the {@link ApplicationRef#isStable} documentation for more information. 
+Check the {@link ApplicationRef#isStable isStable} documentation for more information. 
 
 </div>
 

--- a/aio/content/guide/service-worker-communications.md
+++ b/aio/content/guide/service-worker-communications.md
@@ -51,10 +51,7 @@ You can avoid that by waiting for the app to stabilize first, before starting to
 (as shown in the example above).
 
 Note that this is true for any kind of polling done by your application!
-The `isStable` observable will never emit `true` if, for example, a `setInterval` is running when your application starts.
-You will have to first wait for the application to be stable, then start the polling for updates 
-and your other polling tasks.
-Check the `isStable` documentation for more information. 
+Check the {@link ApplicationRef#isStable} documentation for more information. 
 
 </div>
 

--- a/aio/content/guide/service-worker-communications.md
+++ b/aio/content/guide/service-worker-communications.md
@@ -50,7 +50,7 @@ script will never be registered with the browser.
 You can avoid that by waiting for the app to stabilize first, before starting to poll for updates
 (as shown in the example above).
 
-Note that this is true for any kind of polling done by your application!
+Note that this is true for any kind of polling done by your application.
 Check the {@link ApplicationRef#isStable isStable} documentation for more information. 
 
 </div>

--- a/aio/content/guide/service-worker-communications.md
+++ b/aio/content/guide/service-worker-communications.md
@@ -50,6 +50,12 @@ script will never be registered with the browser.
 You can avoid that by waiting for the app to stabilize first, before starting to poll for updates
 (as shown in the example above).
 
+Note that this is true for any kind of polling done by your application!
+The `isStable` observable will never emit `true` if, for example, a `setInterval` is running when your application starts.
+You will have to first wait for the application to be stable, then start the polling for updates 
+and your other polling tasks.
+Check the `isStable` documentation for more information. 
+
 </div>
 
 ### Forcing update activation

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -373,10 +373,12 @@ export class ApplicationRef {
 
   /**
    * Returns an Observable that indicates when the application is stable or unstable.
+   *
    * Note two important points, demonstrated in the examples below:
-   * - the application will never be stable if you start a `setInterval`
-   * or use RxJS operator `interval` when the application starts
-   * (for example for a polling process);
+   * - the application will never be stable if you start any kind
+   * of asynchronous task when the application starts
+   * (for example for a polling process, started with a `setInterval`, a `setTimeout`
+   * or using RxJS operators like `interval`);
    * - the `isStable` Observable runs outside of the Angular zone.
    *
    * Let's imagine that you start a recurrent task
@@ -401,8 +403,7 @@ export class ApplicationRef {
    * ```
    * constructor(appRef: ApplicationRef) {
    *   appRef.isStable.pipe(
-   *     filter(stable => stable),
-   *     first(),
+   *     first(stable => stable),
    *     tap(stable => console.log('App is stable now')),
    *     switchMap(() => interval(1000))
    *   ).subscribe(counter => console.log(counter));
@@ -422,8 +423,7 @@ export class ApplicationRef {
    * ```
    * constructor(appRef: ApplicationRef) {
    *   appRef.isStable.pipe(
-   *     filter(stable => stable),
-   *     first(),
+   *     first(stable => stable),
    *     switchMap(() => interval(1000))
    *   ).subscribe(counter => this.value = counter);
    * }
@@ -437,8 +437,7 @@ export class ApplicationRef {
    * ```
    * constructor(appRef: ApplicationRef, cd: ChangeDetectorRef) {
    *   appRef.isStable.pipe(
-   *     filter(stable => stable),
-   *     first(),
+   *     first(stable => stable),
    *     switchMap(() => interval(1000))
    *   ).subscribe(counter => {
    *     this.value = counter;
@@ -452,10 +451,9 @@ export class ApplicationRef {
    * ```
    * constructor(appRef: ApplicationRef, zone: NgZone) {
    *   appRef.isStable.pipe(
-   *     filter(stable => stable),
-   *     first(),
+   *     first(stable => stable),
    *     switchMap(() => interval(1000))
-   *   ).subscribe(counter => zone.run(this.value = counter));
+   *   ).subscribe(counter => zone.run(() => this.value = counter));
    * }
    * ```
    */

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -350,6 +350,7 @@ function optionsReducer<T extends Object>(dst: any, objs: T | T[]): T {
  *
  * @usageNotes
  *
+ * {@a is-stable-examples}
  * ### isStable examples and caveats
  *
  * Note two important points about `isStable`, demonstrated in the examples below:
@@ -461,7 +462,7 @@ export class ApplicationRef {
   /**
    * Returns an Observable that indicates when the application is stable or unstable.
    *
-   * @see  [Usage notes](#usage-notes) for examples and caveats when using this API.
+   * @see  [Usage notes](#is-stable-examples) for examples and caveats when using this API.
    */
   // TODO(issue/24571): remove '!'.
   public readonly isStable !: Observable<boolean>;

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -348,6 +348,93 @@ function optionsReducer<T extends Object>(dst: any, objs: T | T[]): T {
 /**
  * A reference to an Angular application running on a page.
  *
+ * @usageNotes
+ *
+ * ### isStable examples and caveats
+ *
+ * Note two important points about `isStable`, demonstrated in the examples below:
+ * - the application will never be stable if you start any kind
+ * of recurrent asynchronous task when the application starts
+ * (for example for a polling process, started with a `setInterval`, a `setTimeout`
+ * or using RxJS operators like `interval`);
+ * - the `isStable` Observable runs outside of the Angular zone.
+ *
+ * Let's imagine that you start a recurrent task
+ * (here incrementing a counter, using RxJS `interval`),
+ * and at the same time subscribe to `isStable`.
+ *
+ * ```
+ * constructor(appRef: ApplicationRef) {
+ *   appRef.isStable.pipe(
+ *      filter(stable => stable)
+ *   ).subscribe(() => console.log('App is stable now');
+ *   interval(1000).subscribe(counter => console.log(counter));
+ * }
+ * ```
+ * In this example, `isStable` will never emit `true`,
+ * and the trace "App is stable now" will never get logged.
+ *
+ * If you want to execute something when the app is stable,
+ * you have to wait for the application to be stable
+ * before starting your polling process.
+ *
+ * ```
+ * constructor(appRef: ApplicationRef) {
+ *   appRef.isStable.pipe(
+ *     first(stable => stable),
+ *     tap(stable => console.log('App is stable now')),
+ *     switchMap(() => interval(1000))
+ *   ).subscribe(counter => console.log(counter));
+ * }
+ * ```
+ * In this example, the trace "App is stable now" will be logged
+ * and then the counter starts incrementing every second.
+ *
+ * Note also that this Observable runs outside of the Angular zone,
+ * which means that the code in the subscription
+ * to this Observable will not trigger the change detection.
+ *
+ * Let's imagine that instead of logging the counter value,
+ * you update a field of your component
+ * and display it in its template.
+ *
+ * ```
+ * constructor(appRef: ApplicationRef) {
+ *   appRef.isStable.pipe(
+ *     first(stable => stable),
+ *     switchMap(() => interval(1000))
+ *   ).subscribe(counter => this.value = counter);
+ * }
+ * ```
+ * As the `isStable` Observable runs outside the zone,
+ * the `value` field will be updated properly,
+ * but the template will not be refreshed!
+ *
+ * You'll have to manually trigger the change detection to update the template.
+ *
+ * ```
+ * constructor(appRef: ApplicationRef, cd: ChangeDetectorRef) {
+ *   appRef.isStable.pipe(
+ *     first(stable => stable),
+ *     switchMap(() => interval(1000))
+ *   ).subscribe(counter => {
+ *     this.value = counter;
+ *     cd.detectChanges();
+ *   });
+ * }
+ * ```
+ *
+ * Or make the subscription callback run inside the zone.
+ *
+ * ```
+ * constructor(appRef: ApplicationRef, zone: NgZone) {
+ *   appRef.isStable.pipe(
+ *     first(stable => stable),
+ *     switchMap(() => interval(1000))
+ *   ).subscribe(counter => zone.run(() => this.value = counter));
+ * }
+ * ```
+ *
  * @publicApi
  */
 @Injectable()
@@ -374,88 +461,7 @@ export class ApplicationRef {
   /**
    * Returns an Observable that indicates when the application is stable or unstable.
    *
-   * Note two important points, demonstrated in the examples below:
-   * - the application will never be stable if you start any kind
-   * of recurrent asynchronous task when the application starts
-   * (for example for a polling process, started with a `setInterval`, a `setTimeout`
-   * or using RxJS operators like `interval`);
-   * - the `isStable` Observable runs outside of the Angular zone.
-   *
-   * Let's imagine that you start a recurrent task
-   * (here incrementing a counter, using RxJS `interval`),
-   * and at the same time subscribe to `isStable`.
-   *
-   * ```
-   * constructor(appRef: ApplicationRef) {
-   *   appRef.isStable.pipe(
-   *      filter(stable => stable)
-   *   ).subscribe(() => console.log('App is stable now');
-   *   interval(1000).subscribe(counter => console.log(counter));
-   * }
-   * ```
-   * In this example, `isStable` will never emit `true`,
-   * and the trace "App is stable now" will never get logged.
-   *
-   * If you want to execute something when the app is stable,
-   * you have to wait for the application to be stable
-   * before starting your polling process.
-   *
-   * ```
-   * constructor(appRef: ApplicationRef) {
-   *   appRef.isStable.pipe(
-   *     first(stable => stable),
-   *     tap(stable => console.log('App is stable now')),
-   *     switchMap(() => interval(1000))
-   *   ).subscribe(counter => console.log(counter));
-   * }
-   * ```
-   * In this example, the trace "App is stable now" will be logged
-   * and then the counter starts incrementing every second.
-   *
-   * Note also that this Observable runs outside of the Angular zone,
-   * which means that the code in the subscription
-   * to this Observable will not trigger the change detection.
-   *
-   * Let's imagine that instead of logging the counter value,
-   * you update a field of your component
-   * and display it in its template.
-   *
-   * ```
-   * constructor(appRef: ApplicationRef) {
-   *   appRef.isStable.pipe(
-   *     first(stable => stable),
-   *     switchMap(() => interval(1000))
-   *   ).subscribe(counter => this.value = counter);
-   * }
-   * ```
-   * As the `isStable` Observable runs outside the zone,
-   * the `value` field will be updated properly,
-   * but the template will not be refreshed!
-   *
-   * You'll have to manually trigger the change detection to update the template.
-   *
-   * ```
-   * constructor(appRef: ApplicationRef, cd: ChangeDetectorRef) {
-   *   appRef.isStable.pipe(
-   *     first(stable => stable),
-   *     switchMap(() => interval(1000))
-   *   ).subscribe(counter => {
-   *     this.value = counter;
-   *     cd.detectChanges();
-   *   });
-   * }
-   * ```
-   *
-   * Or make the subscription callback run inside the zone.
-   *
-   * ```
-   * constructor(appRef: ApplicationRef, zone: NgZone) {
-   *   appRef.isStable.pipe(
-   *     first(stable => stable),
-   *     switchMap(() => interval(1000))
-   *   ).subscribe(counter => zone.run(() => this.value = counter));
-   * }
-   * ```
+   * @see  [Usage notes](#usage-notes) for examples and caveats when using this API.
    */
   // TODO(issue/24571): remove '!'.
   public readonly isStable !: Observable<boolean>;

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -376,29 +376,29 @@ export class ApplicationRef {
    *
    * Note two important points, demonstrated in the examples below:
    * - the application will never be stable if you start any kind
-   * of asynchronous task when the application starts
+   * of recurrent asynchronous task when the application starts
    * (for example for a polling process, started with a `setInterval`, a `setTimeout`
    * or using RxJS operators like `interval`);
    * - the `isStable` Observable runs outside of the Angular zone.
    *
    * Let's imagine that you start a recurrent task
    * (here incrementing a counter, using RxJS `interval`),
-   * and then subscribe to `isStable`.
+   * and at the same time subscribe to `isStable`.
    *
    * ```
    * constructor(appRef: ApplicationRef) {
-   *   interval(1000).subscribe(counter => console.log(counter));
    *   appRef.isStable.pipe(
    *      filter(stable => stable)
    *   ).subscribe(() => console.log('App is stable now');
+   *   interval(1000).subscribe(counter => console.log(counter));
    * }
    * ```
    * In this example, `isStable` will never emit `true`,
    * and the trace "App is stable now" will never get logged.
    *
    * If you want to execute something when the app is stable,
-   * you'll have to delay your polling process,
-   * or wait for the application to be stable before starting it.
+   * you have to wait for the application to be stable
+   * before starting your polling process.
    *
    * ```
    * constructor(appRef: ApplicationRef) {


### PR DESCRIPTION
The docs don't mention that the app will never be stable if a `setInterval` is running somewhere, and that it will prevent the servcie worker to be registered too.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

Add an extra note about `setInterval` and `isStable` after #28020 fix.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No