### PR TITLE
test(docs-infra): increase timeout for all redirection tests

### DIFF
--- a/aio/tests/deployment/e2e/redirection.e2e-spec.ts
+++ b/aio/tests/deployment/e2e/redirection.e2e-spec.ts
@@ -27,16 +27,14 @@ describe(browser.baseUrl, () => {
 
   describe('(with legacy URLs)', () => {
     page.legacyUrls.forEach(([fromUrl, toUrl], i) => {
-      const isExternalUrl = /^https?:/.test(toUrl);
-
       it(`should redirect '${fromUrl}' to '${toUrl}' (${i + 1}/${page.legacyUrls.length})`, async () => {
         await page.goTo(fromUrl);
 
-        const expectedUrl = stripTrailingSlash(isExternalUrl ? toUrl : page.baseUrl + toUrl);
+        const expectedUrl = stripTrailingSlash(/^https?:/.test(toUrl) ? toUrl : page.baseUrl + toUrl);
         const actualUrl = await getCurrentUrl();
 
         expect(actualUrl).toBe(expectedUrl);
-      }, isExternalUrl ? 60000 : undefined);
+      }, 60000);
     });
   });
 


### PR DESCRIPTION
Occasionally, URLs take longer to load, which causes CI flakes.
In #27903, the timeout for external URLs was increased, but internal URLs turned out to be affected as well.
