### PR TITLE
 fix(docs-infra): align property names to the top

### DIFF
--- a/aio/src/styles/2-modules/_api-pages.scss
+++ b/aio/src/styles/2-modules/_api-pages.scss
@@ -74,6 +74,12 @@
           vertical-align: top;
         }
       }
+
+      &.property-table {
+        td {
+          vertical-align: top;
+        }
+      }
   }
 
   .class-overview {

--- a/aio/src/styles/2-modules/_api-pages.scss
+++ b/aio/src/styles/2-modules/_api-pages.scss
@@ -87,19 +87,6 @@
   .short-description {
     margin: 6px 0 0 10px;
   }
-
-  .properties-table {
-    font-size: 14px;
-
-    thead th {
-      &:nth-child(1) {
-        width: 20%;
-      }
-      &:nth-child(2) {
-        width: 20%;
-      }
-    }
-  }
 }
 
 .breadcrumb-container {


### PR DESCRIPTION
This looks better when the property descriptions span multiple lines; especially when scrolling to a specific property (e.g.
[AbstractControl#status][1]).

**Before**
![props-before](https://user-images.githubusercontent.com/8604205/51075999-a2e26a00-169b-11e9-8fbf-1e4818c7e331.png)

**After**
![props-after](https://user-images.githubusercontent.com/8604205/51076002-aece2c00-169b-11e9-881d-d723faa3880d.png)


[1]: https://next.angular.io/api/forms/AbstractControl#status