### PR TITLE
fix(docs-infra): render `deprecated` markers for CLI command options

### DIFF
--- a/aio/src/styles/2-modules/_cli-pages.scss
+++ b/aio/src/styles/2-modules/_cli-pages.scss
@@ -8,3 +8,8 @@
   white-space: pre;
 }
 
+.cli-deprecated {
+  background-color: $brightred;;
+  padding: 2px 10px;
+  margin-right: 10px;
+}

--- a/aio/src/styles/2-modules/_cli-pages.scss
+++ b/aio/src/styles/2-modules/_cli-pages.scss
@@ -7,9 +7,3 @@
 .cli-option-syntax {
   white-space: pre;
 }
-
-.cli-deprecated {
-  background-color: $brightred;;
-  padding: 2px 10px;
-  margin-right: 10px;
-}

--- a/aio/tools/transforms/templates/cli/lib/cli.html
+++ b/aio/tools/transforms/templates/cli/lib/cli.html
@@ -56,6 +56,7 @@
         <code class="cli-option-syntax no-auto-link">{$ renderOption(option.name, option.type, option.default, option.enum) $}</code>
       </td>
       <td>
+        {% if option.deprecated !== undefined and option.deprecated !== false %}<label class="raised cli-deprecated">deprecated</label> {% if option.deprecated !== true %} {$ option.deprecated | marked $} {% endif %}{% endif %}
         {$ option.description | marked $}
         {% if option.default !== undefined %}<p><span class="cli-default">Default:</span> <code class="no-auto-link">{$ option.default $}</code></p>{% endif %}
         {% if option.aliases.length %}<p><span class="cli-aliases">Aliases:</span> {% for alias in option.aliases %}{$ renderOptionName(alias) $}{% if not loop.last %}, {% endif %}{% endfor %}</p>{% endif %}

--- a/aio/tools/transforms/templates/cli/lib/cli.html
+++ b/aio/tools/transforms/templates/cli/lib/cli.html
@@ -53,15 +53,14 @@
   {% for option in options %}
     <tr class="cli-option">
       <td>
-        <code class="cli-option-syntax no-auto-link">{$ renderOption(option.name, option.type, option.default, option.enum) $}</code>
+        <code class="cli-option-syntax no-auto-link{% if option.deprecated %} deprecated-api-item{% endif %}">{$ renderOption(option.name, option.type, option.default, option.enum) $}</code>
       </td>
       <td>
         {% if option.deprecated %}
-          {% if option.deprecated !== true %}
-            {$ ('**Deprecated:** ' + option.deprecated) | marked $}
-          {% endif %}
           {% if option.deprecated === true %}
-            {$ ('**Deprecated**') | marked $}
+            <p><strong>Deprecated</strong></p>
+          {% else %}
+            {$ ('**Deprecated:** ' + option.deprecated) | marked $}
           {% endif %}
         {% endif %}
         {$ option.description | marked $}

--- a/aio/tools/transforms/templates/cli/lib/cli.html
+++ b/aio/tools/transforms/templates/cli/lib/cli.html
@@ -56,7 +56,14 @@
         <code class="cli-option-syntax no-auto-link">{$ renderOption(option.name, option.type, option.default, option.enum) $}</code>
       </td>
       <td>
-        {% if option.deprecated !== undefined and option.deprecated !== false %}<label class="raised cli-deprecated">deprecated</label> {% if option.deprecated !== true %} {$ option.deprecated | marked $} {% endif %}{% endif %}
+        {% if option.deprecated %}
+          {% if option.deprecated !== true %}
+            {$ ('**Deprecated:** ' + option.deprecated) | marked $}
+          {% endif %}
+          {% if option.deprecated === true %}
+            {$ ('**Deprecated**') | marked $}
+          {% endif %}
+        {% endif %}
         {$ option.description | marked $}
         {% if option.default !== undefined %}<p><span class="cli-default">Default:</span> <code class="no-auto-link">{$ option.default $}</code></p>{% endif %}
         {% if option.aliases.length %}<p><span class="cli-aliases">Aliases:</span> {% for alias in option.aliases %}{$ renderOptionName(alias) $}{% if not loop.last %}, {% endif %}{% endfor %}</p>{% endif %}


### PR DESCRIPTION
fixes #27563
fixes #27423

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Show a deprecated label near option cli deprecated 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #27563 #27423

No deprecated information near cli options that were deprecated. The information exists however in build.json file.

```json
{
      "name": "vendorSourceMap",
      "description": "Resolve vendor packages sourcemaps.",
      "type": "boolean",
      "default": false,
      "required": false,
      "aliases": [],
      "hidden": false,
      "deprecated": true
    },
```

## What is the new behavior?

We have a deprecated label and we can add a message below whether we change `true`by a text:

```json
{
      "name": "vendorSourceMap",
      "description": "Resolve vendor packages sourcemaps.",
      "type": "boolean",
      "default": false,
      "required": false,
      "aliases": [],
      "hidden": false,
      "deprecated": "lorem ipsum ..."
    },
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
