### PR TITLE
fix(router): explicitly use pathname of host page to make external URL

### DIFF
--- a/packages/common/src/location/hash_location_strategy.ts
+++ b/packages/common/src/location/hash_location_strategy.ts
@@ -35,14 +35,15 @@ import {LocationChangeListener, PlatformLocation} from './platform_location';
  */
 @Injectable()
 export class HashLocationStrategy extends LocationStrategy {
-  private _baseHref: string = '';
+  private _baseHref: string;
+  private _hashFragmentPrefix: string;
   constructor(
       private _platformLocation: PlatformLocation,
       @Optional() @Inject(APP_BASE_HREF) _baseHref?: string) {
     super();
-    if (_baseHref != null) {
-      this._baseHref = _baseHref;
-    }
+    const fragmentPrefix = Location.stripTrailingSlash(_baseHref || '');
+    this._baseHref = _platformLocation.pathname;
+    this._hashFragmentPrefix = '#' + fragmentPrefix;
   }
 
   onPopState(fn: LocationChangeListener): void {
@@ -50,20 +51,28 @@ export class HashLocationStrategy extends LocationStrategy {
     this._platformLocation.onHashChange(fn);
   }
 
-  getBaseHref(): string { return this._baseHref; }
+  getBaseHref(): string { return this._baseHref + this._hashFragmentPrefix; }
 
   path(includeHash: boolean = false): string {
     // the hash value is always prefixed with a `#`
     // and if it is empty then it will stay empty
     let path = this._platformLocation.hash;
-    if (path == null) path = '#';
-
+    if (path == null) {
+      path = this._hashFragmentPrefix;
+    }
+    if (path.startsWith(this._hashFragmentPrefix)) {
+      return path.substring(this._hashFragmentPrefix.length);
+    }
     return path.length > 0 ? path.substring(1) : path;
   }
 
   prepareExternalUrl(internal: string): string {
-    const url = Location.joinWithSlash(this._baseHref, internal);
-    return url.length > 0 ? ('#' + url) : url;
+    if (internal.length === 0) {
+      return this._baseHref + this._hashFragmentPrefix + '/';
+    }
+    const mark =
+        internal.startsWith('/') ? this._hashFragmentPrefix : (this._hashFragmentPrefix + '/');
+    return this._baseHref + mark + internal;
   }
 
   pushState(state: any, title: string, path: string, queryParams: string) {


### PR DESCRIPTION
This PR attempts to solve same problem with #26936 but treat `APP_BASE_HREF` as fragment prefix (same as current implementation do).

The pros of this approach is existed application using `APP_BASE_HREF` will not break.

The cons is the `APP_BASE_HREF` works differently for `HashLocationStrategy` (fragment prefix) and `PathLocationStrategy` (base path).

--------

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number:  #13482, #20033

For routing with `HashLocationStrategy`:

If dist files (`main.*.js`, `runtime.*.js`, `asset/*` ...) and host page (`index.html`) have different deploy path, (eg. `/static-content/my-app/` for dist files and `/my/app` for host page), a base-href tag is required for loading resources correctly.

The expected routed URL for component is based on host page's URL path (eg. `/my/app#/ui/component`).

However the routed URL is based on path provided by base-href tag (eg. `/static-content/my-app/#/ui/component`) with current implementation.

An example reproduces this issue is [aio/contents/examples/upgrade-phonecat-3-final](/angular/angular/tree/master/aio/content/examples/upgrade-phonecat-3-final) (in test_docs_examples_1) - User cannot visit the application page with routed URL (ie: http://127.0.0.1:8080/app/#!/phones). Instead of application page, the content of app/ folder will be shown.

I made an experiment to reproduce and explore this issue: [angular-hashlocationstrategy-experiments](https://github.com/yinyin/angular-hashlocationstrategy-experiments)

In summary, for an application serving its host page from http://example.com/my/app and serving other files from http://example.com/static-content/my-app/ (base-href=`/static-content/my-app/`), the flow with current implementation is:

1. User open app URL: http://example.com/my/app
2. User click on router link to navigate to a component with route link `/ui/component`
3. `HashLocationStrategy` generates external URL `#/ui/component`
4. The external URL `#/ui/component` pushed to history API
5. Browser resolves URL with path from base-href tag (`http://example.com/static-content/my-app/`) and `#/ui/component` to form a new URL http://example.com/static-content/my-app/#/ui/component
6. The new URL is placed on browser's address bar: http://example.com/static-content/my-app/#/ui/component.


## What is the new behavior?

Makes HashLocationStrategy to generate external URL with pathname of
host page (index.html)'s location.

Based on previous example, for an application serving its host page from http://example.com/my/app and serving other files from http://example.com/static-content/my-app/ (base-href=`/static-content/my-app/`), the flow with current implementation is:

1. User open app URL: http://example.com/my/app
2. User click on router link to navigate to a component with route link `/ui/component`
3. `HashLocationStrategy` generates external URL `/my/app#/ui/component` by concatenating pathname-of-host-page (`index.html`), hash-mark (`#`), `APP_BASE_HREF` (if given) and route link
4. The external URL `/my/app#/ui/component` pushed to history API
5. Browser resolves URL with base-href tag (`http://example.com/static-content/my-app/`) and `/my/app#/ui/component` to form a new URL http://example.com/my/app#/ui/component
6. The new URL is placed on browser's address bar: http://example.com/my/app#/ui/component.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
