### PR TITLE
Add Renovate to Ivy Integration tests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,49 @@
+{
+	"pinVersions": false,
+	"semanticCommits": true,
+	"semanticPrefix": "build",
+	"commitMessage": "{{semanticPrefix}} update {{depName}} to version {{newVersion}}",
+	"separateMajorMinor": false,
+	"labels": [
+		"PR target: master-only",
+		"comp: build & ci"
+	],
+	"baseBranches": [
+		"master"
+	],
+	"ignoreDeps": [
+		"source-map",
+		"@types/node"
+	],
+	"packageFiles": [
+		"integration/cli-hello-world-ivy/package.json",
+		"integration/cli-hello-world/package.json"
+	],
+	"major": {
+		"devDependencies": {
+			"enabled": false
+		}
+	},
+	"packageRules": [
+		{
+			"packagePatterns": [
+				"^@angular.*"
+			],
+			"groupName": "angular",
+			"pinVersions": false
+		},
+		{
+			"packagePatterns": [
+				"^@bazel\/.*"
+			],
+			"groupName": "bazel",
+			"pinVersions": false
+		},
+		{
+			"packageNames": [
+				"typescript"
+			],
+			"updateTypes": "patch"
+		}
+	]
+}


### PR DESCRIPTION
This will be important to keep the CLI / Framework changes in sync and not to have size regressions.

TOOL-582 