### PR TITLE
ci: build clean windows cache image on master

### DIFF
--- a/.buildkite/dockerfiles/docker-compose.yml
+++ b/.buildkite/dockerfiles/docker-compose.yml
@@ -4,7 +4,14 @@ services:
     build:
       context: ../../
       dockerfile: ./.buildkite/dockerfiles/windows-env.Dockerfile
-  windows-test:
+  windows-test-cached:
+    build:
+      context: ../../
+      dockerfile: ./.buildkite/dockerfiles/windows-test.Dockerfile
+      args:
+        COMMIT_SHA: "${BUILDKITE_COMMIT}"
+        FROM_IMG: "gcr.io/internal-200822/angular-windows:master"
+  windows-test-clean:
     build:
       context: ../../
       dockerfile: ./.buildkite/dockerfiles/windows-test.Dockerfile

--- a/.buildkite/dockerfiles/windows-test.Dockerfile
+++ b/.buildkite/dockerfiles/windows-test.Dockerfile
@@ -1,15 +1,20 @@
-# Use the a previous image as source.
+# Use a cached image base if provided, otherwise use the base environment.
 # gcr.io/internal-200822 is the Google Cloud container registry for Angular tooling.
-FROM gcr.io/internal-200822/angular-windows:master
+# angular-windows-env is the base Windows environment image.
+ARG FROM_IMG=gcr.io/internal-200822/angular-windows-env
+FROM $FROM_IMG
 WORKDIR /src
 
-# Copy package.json and yarn.lock before the other files.
+# Copy node_modules install files before the other files.
 # This allows docker to cache these steps even if source files change.
 COPY ./package.json /src/package.json
 COPY ./yarn.lock /src/yarn.lock
+COPY ./tools/yarn/check-yarn.js /src/tools/yarn/check-yarn.js
+COPY ./tools/postinstall-patches.js /src/tools/postinstall-patches.js
 RUN yarn install --frozen-lockfile --non-interactive --network-timeout 100000
 
-# Update image git repo.
+# Copy remaining files and update to commit.
+COPY ./ /src
 ARG COMMIT_SHA
 RUN git fetch -v origin %COMMIT_SHA%
 RUN git checkout -f %COMMIT_SHA%

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,17 +1,17 @@
 steps:
-  - label: windows-test
+  - label: windows-test-cached
+    branches: "!master"
     plugins:
       - docker-compose#v2.6.0:
-          build: windows-test
+          build: windows-test-cached
           config: .buildkite/dockerfiles/docker-compose.yml
     agents:
       windows: true
-  - wait
-  - label: windows-update-image
+  - label: windows-test-clean
     branches: master
     plugins:
       - docker-compose#v2.6.0:
-          push: windows-test:gcr.io/internal-200822/angular-windows:master
+          push: windows-test-clean:gcr.io/internal-200822/angular-windows:master
           config: .buildkite/dockerfiles/docker-compose.yml
     agents:
       windows: true


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Shortly after https://github.com/angular/angular/pull/27990 the Windows CI started failing with `Service 'windows-test' failed to build: max depth exceeded`.

Looking up this error shows that docker images have a maximum of 127 layers. The current setup adds more and more layers over time, reaching this limit.

This PR addresses the problem by always creating the cache image clean base environment, without reusing the previous one. This only happens on master.

Related to https://github.com/angular/angular/issues/27508


## What is the new behavior?
Cache image will only have a limited number of layers.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
