### PR TITLE
fix(bazel): incorrectly always uses ngc-wrapped from "npm" workspace

### DIFF
--- a/packages/bazel/src/esm5.bzl
+++ b/packages/bazel/src/esm5.bzl
@@ -96,9 +96,9 @@ def _esm5_outputs_aspect(target, ctx):
         compiler = ctx.executable._ngc_wrapped
 
         # BEGIN-INTERNAL
-        # If the "replay_compiler" path refers does not refer to "ngc_wrapped" from the "@npm"
-        # workspace, we use "ngc_wrapped" from within the Angular workspace. This is necessary
-        # because we don't have a "npm" workspace with the "@angular/bazel" NPM package installed.
+        # If the "replay_compiler" path does not refer to "ngc_wrapped" from the "@npm" workspace,
+        # we use "ngc_wrapped" from within the Angular workspace. This is necessary because we
+        # don't have a "npm" workspace with the "@angular/bazel" NPM package installed.
         if replay_compiler_path != ctx.executable._ngc_wrapped.short_path:
             compiler = ctx.executable._internal_ngc_wrapped
 

--- a/packages/bazel/src/esm5.bzl
+++ b/packages/bazel/src/esm5.bzl
@@ -96,10 +96,10 @@ def _esm5_outputs_aspect(target, ctx):
         compiler = ctx.executable._ngc_wrapped
 
         # BEGIN-INTERNAL
-        # If the "replay_compiler" path refers to "ngc_wrapped" from within the Angular workspace,
-        # we need to use "ngc_wrapped" from source. This is necessary because we don't have
-        # a "npm" workspace with the "@angular/bazel" NPM package installed.
-        if not replay_compiler_path.startswith("../"):
+        # If the "replay_compiler" path refers does not refer to "ngc_wrapped" from the "@npm"
+        # workspace, we use "ngc_wrapped" from within the Angular workspace. This is necessary
+        # because we don't have a "npm" workspace with the "@angular/bazel" NPM package installed.
+        if replay_compiler_path != ctx.executable._ngc_wrapped.short_path:
             compiler = ctx.executable._internal_ngc_wrapped
 
         # END-INTERNAL


### PR DESCRIPTION
This is a follow-up to cd04513 which fixes that "ngc-wrapped" from the "npm" workspace is used to build the Angular ESM5 output when `angular` is an external repository. 