### PR TITLE
fix(core): proper @internal and @nocollapse combined usage fix

### DIFF
--- a/packages/core/src/change_detection/change_detector_ref.ts
+++ b/packages/core/src/change_detection/change_detector_ref.ts
@@ -107,8 +107,10 @@ export abstract class ChangeDetectorRef {
    */
   abstract reattach(): void;
 
-  /** @internal */
-  /** @nocollapse */
+  /**
+   * @internal
+   * @nocollapse
+   */
   static __NG_ELEMENT_ID__: () => ChangeDetectorRef = () => SWITCH_CHANGE_DETECTOR_REF_FACTORY();
 }
 

--- a/packages/core/src/linker/element_ref.ts
+++ b/packages/core/src/linker/element_ref.ts
@@ -50,8 +50,10 @@ export class ElementRef<T = any> {
 
   constructor(nativeElement: T) { this.nativeElement = nativeElement; }
 
-  /** @internal */
-  /** @nocollapse */
+  /**
+   * @internal
+   * @nocollapse
+   */
   static __NG_ELEMENT_ID__: () => ElementRef = () => SWITCH_ELEMENT_REF_FACTORY(ElementRef);
 }
 

--- a/packages/core/src/linker/template_ref.ts
+++ b/packages/core/src/linker/template_ref.ts
@@ -53,8 +53,10 @@ export abstract class TemplateRef<C> {
    */
   abstract createEmbeddedView(context: C): EmbeddedViewRef<C>;
 
-  /** @internal */
-  /** @nocollapse */
+  /**
+   * @internal
+   * @nocollapse
+   */
   static __NG_ELEMENT_ID__:
       () => TemplateRef<any>| null = () => SWITCH_TEMPLATE_REF_FACTORY(TemplateRef, ElementRef)
 }

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -144,8 +144,10 @@ export abstract class ViewContainerRef {
    */
   abstract detach(index?: number): ViewRef|null;
 
-  /** @internal */
-  /** @nocollapse */
+  /**
+   * @internal
+   * @nocollapse
+   */
   static __NG_ELEMENT_ID__:
       () => ViewContainerRef = () => SWITCH_VIEW_CONTAINER_REF_FACTORY(ViewContainerRef, ElementRef)
 }

--- a/packages/core/src/render/api.ts
+++ b/packages/core/src/render/api.ts
@@ -374,8 +374,10 @@ export abstract class Renderer2 {
       target: 'window'|'document'|'body'|any, eventName: string,
       callback: (event: any) => boolean | void): () => void;
 
-  /** @internal */
-  /** @nocollapse */
+  /**
+   * @internal
+   * @nocollapse
+   */
   static __NG_ELEMENT_ID__: () => Renderer2 = () => SWITCH_RENDERER2_FACTORY();
 }
 


### PR DESCRIPTION
This update fixes the way the @internal and @nocollapse annotations are used together, which produced errors while running it with Closure compiler. Now two annotations are a part of the same comment block.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No