### PR TITLE
fix(bazel): Bazel schematics should add router package

### DIFF
--- a/packages/bazel/src/schematics/bazel-workspace/files/src/BUILD.bazel.template
+++ b/packages/bazel/src/schematics/bazel-workspace/files/src/BUILD.bazel.template
@@ -23,7 +23,8 @@ ng_module(
     ]),
     deps = [
         "@angular//packages/core",
-        "@angular//packages/platform-browser",
+        "@angular//packages/platform-browser",<% if (routing) { %>
+        "@angular//packages/router",<% } %>
         "@npm//@types",
     ],
 )

--- a/packages/bazel/src/schematics/bazel-workspace/index.ts
+++ b/packages/bazel/src/schematics/bazel-workspace/index.ts
@@ -51,6 +51,15 @@ export function clean(version: string): string|null {
   return matches && matches.pop() || null;
 }
 
+/**
+ * Returns true if project contains routing module, false otherwise.
+ */
+function hasRoutingModule(host: Tree) {
+  let hasRouting = false;
+  host.visit((file: string) => { hasRouting = hasRouting || file.endsWith('-routing.module.ts'); });
+  return hasRouting;
+}
+
 export default function(options: BazelWorkspaceOptions): Rule {
   return (host: Tree, context: SchematicContext) => {
     if (!options.name) {
@@ -93,6 +102,7 @@ export default function(options: BazelWorkspaceOptions): Rule {
         utils: strings,
         ...options,
         'dot': '.', ...workspaceVersions,
+        routing: hasRoutingModule(host),
       }),
       move(appDir),
     ]));

--- a/packages/bazel/src/schematics/bazel-workspace/index_spec.ts
+++ b/packages/bazel/src/schematics/bazel-workspace/index_spec.ts
@@ -51,6 +51,17 @@ describe('Bazel-workspace Schematic', () => {
     expect(content).toContain('entry_module = "demo_app/src/main.dev"');
   });
 
+  it('should add router if project contains routing module', () => {
+    let host = new UnitTestTree(new HostTree);
+    host.create('/demo/src/app/app-routing.module.ts', '');
+    expect(host.files).toContain('/demo/src/app/app-routing.module.ts');
+    const options = {...defaultOptions};
+    host = schematicRunner.runSchematic('bazel-workspace', options, host);
+    expect(host.files).toContain('/demo/src/BUILD.bazel');
+    const content = host.readContent('/demo/src/BUILD.bazel');
+    expect(content).toContain('@angular//packages/router');
+  });
+
   describe('WORKSPACE', () => {
     it('should contain project name', () => {
       const options = {...defaultOptions};


### PR DESCRIPTION
This commit fixes a bug whereby a Bazel project created by the
schematics would not compiled if project contains routing module.

It is missing a dependency on the router package.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
