### PR TITLE
perf(platform-server): use shared `DomElementSchemaRegistry` instance (#28150)

### DIFF
--- a/packages/platform-server/src/server_renderer.ts
+++ b/packages/platform-server/src/server_renderer.ts
@@ -12,11 +12,13 @@ import {DOCUMENT, EventManager, ɵNAMESPACE_URIS as NAMESPACE_URIS, ɵSharedStyl
 
 const EMPTY_ARRAY: any[] = [];
 
+const DEFAULT_SCHEMA = new DomElementSchemaRegistry();
+
 @Injectable()
 export class ServerRendererFactory2 implements RendererFactory2 {
   private rendererByCompId = new Map<string, Renderer2>();
   private defaultRenderer: Renderer2;
-  private schema = new DomElementSchemaRegistry();
+  private schema = DEFAULT_SCHEMA;
 
   constructor(
       private eventManager: EventManager, private ngZone: NgZone,


### PR DESCRIPTION
Right now the `ServerRendererFactory2` creates a new instance of the `DomElementSchemaRegistry` for each and every request, which is quite costly (for the Tour of Heroes SSR example this takes around **30%** of the overall execution time). Since the schema is never modified, but only used in a read-only fashion, it should be possible to re-use a single instance instead.

Naive performance testing with 100 concurrent connections and 1000 requests in total shows an approximate **33%** improvement in Req/Sec on the Tour of Heroes SSR example (can be found at [bmeurer/angular-tour-of-heroes](https://github.com/bmeurer/angular-tour-of-heroes)).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

A new `DomElementSchemaRegistry` instance is created for each and every `ServerRendererFactory2`.

Issue Number: #28150

## What is the new behavior?

A global `DomElementSchemaRegistry` instance shared by all `ServerRendererFactory2` instances.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No