### PR TITLE
Root cause analysis for the remaining projection tests

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -2398,8 +2398,8 @@ export function projectionDef(selectors?: CssSelectorList[], textSelectors?: str
         tails[bucketIndex] !.next = componentChild;
       } else {
         pData[bucketIndex] = componentChild;
-        componentChild.next = null;
       }
+      componentChild.next = null;
       tails[bucketIndex] = componentChild;
 
       componentChild = nextNode;

--- a/packages/core/test/linker/projection_integration_spec.ts
+++ b/packages/core/test/linker/projection_integration_spec.ts
@@ -543,48 +543,74 @@ describe('projection', () => {
     expect(main.nativeElement).toHaveText('B(A)');
   });
 
-  fixmeIvy('unknown').it('should project filled view containers into a view container', () => {
+  it('should project view containers', () => {
     TestBed.configureTestingModule(
-        {declarations: [ConditionalContentComponent, ManualViewportDirective]});
+        {declarations: [SingleContentTagComponent, ManualViewportDirective]});
     TestBed.overrideComponent(MainComp, {
       set: {
-        template: '<conditional-content>' +
-            '<div class="left">A</div>' +
-            '<ng-template manual class="left">B</ng-template>' +
-            '<div class="left">C</div>' +
-            '<div>D</div>' +
-            '</conditional-content>'
+        template: '<single-content-tag>' +
+            '<div class="target">A</div>' +
+            '<ng-template manual class="target">B</ng-template>' +
+            '<div class="target">C</div>' +
+            '</single-content-tag>'
       }
     });
+
     const main = TestBed.createComponent(MainComp);
-
-    const conditionalComp = main.debugElement.query(By.directive(ConditionalContentComponent));
-
-    const viewViewportDir =
-        conditionalComp.queryAllNodes(By.directive(ManualViewportDirective))[0].injector.get(
+    const manualDirective =
+        main.debugElement.queryAllNodes(By.directive(ManualViewportDirective))[0].injector.get(
             ManualViewportDirective);
 
-    expect(main.nativeElement).toHaveText('(, D)');
-    expect(main.nativeElement).toHaveText('(, D)');
+    expect(main.nativeElement).toHaveText('AC');
 
-    viewViewportDir.show();
+    manualDirective.show();
     main.detectChanges();
-    expect(main.nativeElement).toHaveText('(AC, D)');
-
-    const contentViewportDir =
-        conditionalComp.queryAllNodes(By.directive(ManualViewportDirective))[1].injector.get(
-            ManualViewportDirective);
-
-    contentViewportDir.show();
-    main.detectChanges();
-    expect(main.nativeElement).toHaveText('(ABC, D)');
-
-    // hide view viewport, and test that it also hides
-    // the content viewport's views
-    viewViewportDir.hide();
-    main.detectChanges();
-    expect(main.nativeElement).toHaveText('(, D)');
+    expect(main.nativeElement).toHaveText('ABC');
   });
+
+  fixmeIvy('FW-869: debugElement.queryAllNodes returns nodes in the wrong order')
+      .it('should project filled view containers into a view container', () => {
+        TestBed.configureTestingModule(
+            {declarations: [ConditionalContentComponent, ManualViewportDirective]});
+        TestBed.overrideComponent(MainComp, {
+          set: {
+            template: '<conditional-content>' +
+                '<div class="left">A</div>' +
+                '<ng-template manual class="left">B</ng-template>' +
+                '<div class="left">C</div>' +
+                '<div>D</div>' +
+                '</conditional-content>'
+          }
+        });
+        const main = TestBed.createComponent(MainComp);
+
+        const conditionalComp = main.debugElement.query(By.directive(ConditionalContentComponent));
+
+        const viewViewportDir =
+            conditionalComp.queryAllNodes(By.directive(ManualViewportDirective))[0].injector.get(
+                ManualViewportDirective);
+
+        expect(main.nativeElement).toHaveText('(, D)');
+        expect(main.nativeElement).toHaveText('(, D)');
+
+        viewViewportDir.show();
+        main.detectChanges();
+        expect(main.nativeElement).toHaveText('(AC, D)');
+
+        const contentViewportDir =
+            conditionalComp.queryAllNodes(By.directive(ManualViewportDirective))[1].injector.get(
+                ManualViewportDirective);
+
+        contentViewportDir.show();
+        main.detectChanges();
+        expect(main.nativeElement).toHaveText('(ABC, D)');
+
+        // hide view viewport, and test that it also hides
+        // the content viewport's views
+        viewViewportDir.hide();
+        main.detectChanges();
+        expect(main.nativeElement).toHaveText('(, D)');
+      });
 });
 
 @Component({selector: 'main', template: ''})

--- a/packages/core/test/linker/projection_integration_spec.ts
+++ b/packages/core/test/linker/projection_integration_spec.ts
@@ -95,7 +95,7 @@ describe('projection', () => {
     expect(main.nativeElement).toHaveText('I AM PROJECTED');
   });
 
-  fixmeIvy('unknown').it('should support multiple content tags', () => {
+  it('should support multiple content tags', () => {
     TestBed.configureTestingModule({declarations: [MultipleContentTagsComponent]});
     TestBed.overrideComponent(MainComp, {
       set: {
@@ -195,7 +195,7 @@ describe('projection', () => {
     expect(main.nativeElement).toHaveText('OUTER(INNER(INNERINNER(A,BC)))');
   });
 
-  fixmeIvy('unknown').it('should redistribute when the shadow dom changes', () => {
+  it('should redistribute when the shadow dom changes', () => {
     TestBed.configureTestingModule(
         {declarations: [ConditionalContentComponent, ManualViewportDirective]});
     TestBed.overrideComponent(MainComp, {
@@ -302,7 +302,7 @@ describe('projection', () => {
     expect(main.nativeElement).toHaveText('SIMPLE()START(A)END');
   });
 
-  fixmeIvy('unknown').it('should support moving ng-content around', () => {
+  it('should support moving ng-content around', () => {
     TestBed.configureTestingModule(
         {declarations: [ConditionalContentComponent, ProjectDirective, ManualViewportDirective]});
     TestBed.overrideComponent(MainComp, {


### PR DESCRIPTION
There are 2 commits in this PR:
- fix that make sure that we _unlink_ nodes (`.next` property) when we re-distribute those nodes amongst different projection buckets - this fixes 3 existing tests;
- a root cause analysis for the one remaining test (see commit message for more details).