### PR TITLE
refactor: remove obsolete font-smoothing property

### DIFF
--- a/modules/playground/src/todo/css/base.css
+++ b/modules/playground/src/todo/css/base.css
@@ -13,10 +13,6 @@ button {
   -webkit-appearance: none;
   -ms-appearance: none;
   appearance: none;
-  -webkit-font-smoothing: antialiased;
-  -moz-font-smoothing: antialiased;
-  -ms-font-smoothing: antialiased;
-  font-smoothing: antialiased;
 }
 
 button,
@@ -89,10 +85,6 @@ input[type="checkbox"] {
   box-shadow: inset 0 -1px 5px 0 rgba(0, 0, 0, 0.2);
   -ms-box-sizing: border-box;
   box-sizing: border-box;
-  -webkit-font-smoothing: antialiased;
-  -moz-font-smoothing: antialiased;
-  -ms-font-smoothing: antialiased;
-  font-smoothing: antialiased;
 }
 
 #new-todo {

--- a/modules/playground/src/todo/css/main.css
+++ b/modules/playground/src/todo/css/main.css
@@ -11,9 +11,4 @@ body {
   color: #4d4d4d;
   width: 550px;
   margin: 0 auto;
-  -webkit-font-smoothing: antialiased;
-  -moz-font-smoothing: antialiased;
-  -ms-font-smoothing: antialiased;
-  -o-font-smoothing: antialiased;
-  font-smoothing: antialiased;
 }

--- a/modules/playground/src/web_workers/todo/css/main.css
+++ b/modules/playground/src/web_workers/todo/css/main.css
@@ -13,11 +13,6 @@ body {
   color: #4d4d4d;
   width: 550px;
   margin: 0 auto;
-  -webkit-font-smoothing: antialiased;
-  -moz-font-smoothing: antialiased;
-  -ms-font-smoothing: antialiased;
-  -o-font-smoothing: antialiased;
-  font-smoothing: antialiased;
 }
 
 button {
@@ -33,10 +28,6 @@ button {
   -webkit-appearance: none;
   -ms-appearance: none;
   appearance: none;
-  -webkit-font-smoothing: antialiased;
-  -moz-font-smoothing: antialiased;
-  -ms-font-smoothing: antialiased;
-  font-smoothing: antialiased;
 }
 
 button,
@@ -109,10 +100,6 @@ input[type="checkbox"] {
   box-shadow: inset 0 -1px 5px 0 rgba(0, 0, 0, 0.2);
   -ms-box-sizing: border-box;
   box-sizing: border-box;
-  -webkit-font-smoothing: antialiased;
-  -moz-font-smoothing: antialiased;
-  -ms-font-smoothing: antialiased;
-  font-smoothing: antialiased;
 }
 
 #new-todo {

--- a/packages/core/test/bundling/todo/todo.css
+++ b/packages/core/test/bundling/todo/todo.css
@@ -16,9 +16,6 @@ button {
 	color: inherit;
 	-webkit-appearance: none;
 	appearance: none;
-	-webkit-font-smoothing: antialiased;
-	-moz-font-smoothing: antialiased;
-	font-smoothing: antialiased;
 }
 
 body {
@@ -29,9 +26,6 @@ body {
 	min-width: 230px;
 	max-width: 550px;
 	margin: 0 auto;
-	-webkit-font-smoothing: antialiased;
-	-moz-font-smoothing: antialiased;
-	font-smoothing: antialiased;
 	font-weight: 300;
 }
 
@@ -99,9 +93,6 @@ input[type="checkbox"] {
 	border: 1px solid #999;
 	box-shadow: inset 0 -1px 5px 0 rgba(0, 0, 0, 0.2);
 	box-sizing: border-box;
-	-webkit-font-smoothing: antialiased;
-	-moz-font-smoothing: antialiased;
-	font-smoothing: antialiased;
 }
 
 .new-todo {

--- a/packages/core/test/bundling/todo_i18n/todo.css
+++ b/packages/core/test/bundling/todo_i18n/todo.css
@@ -16,9 +16,6 @@ button {
 	color: inherit;
 	-webkit-appearance: none;
 	appearance: none;
-	-webkit-font-smoothing: antialiased;
-	-moz-font-smoothing: antialiased;
-	font-smoothing: antialiased;
 }
 
 body {
@@ -29,9 +26,6 @@ body {
 	min-width: 230px;
 	max-width: 550px;
 	margin: 0 auto;
-	-webkit-font-smoothing: antialiased;
-	-moz-font-smoothing: antialiased;
-	font-smoothing: antialiased;
 	font-weight: 300;
 }
 
@@ -100,9 +94,6 @@ input[type="checkbox"] {
 	border: 1px solid #999;
 	box-shadow: inset 0 -1px 5px 0 rgba(0, 0, 0, 0.2);
 	box-sizing: border-box;
-	-webkit-font-smoothing: antialiased;
-	-moz-font-smoothing: antialiased;
-	font-smoothing: antialiased;
 }
 
 .new-todo {

--- a/packages/core/test/bundling/todo_r2/todo.css
+++ b/packages/core/test/bundling/todo_r2/todo.css
@@ -16,9 +16,6 @@ button {
 	color: inherit;
 	-webkit-appearance: none;
 	appearance: none;
-	-webkit-font-smoothing: antialiased;
-	-moz-font-smoothing: antialiased;
-	font-smoothing: antialiased;
 }
 
 body {
@@ -29,9 +26,6 @@ body {
 	min-width: 230px;
 	max-width: 550px;
 	margin: 0 auto;
-	-webkit-font-smoothing: antialiased;
-	-moz-font-smoothing: antialiased;
-	font-smoothing: antialiased;
 	font-weight: 300;
 }
 
@@ -99,9 +93,6 @@ input[type="checkbox"] {
 	border: 1px solid #999;
 	box-shadow: inset 0 -1px 5px 0 rgba(0, 0, 0, 0.2);
 	box-sizing: border-box;
-	-webkit-font-smoothing: antialiased;
-	-moz-font-smoothing: antialiased;
-	font-smoothing: antialiased;
 }
 
 .new-todo {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently there is `font-smoothing` used but these are non-standard and we should not do this with CSS but let the client decide about antialiasing.

Also see http://usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/ and https://caniuse.com/#feat=font-smooth

![bildschirmfoto 2019-01-16 um 08 45 06](https://user-images.githubusercontent.com/827205/51233787-22f22380-196b-11e9-91e2-cfcec00228bc.png)


Issue Number: N/A


## What is the new behavior?
Should be still the same.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
