### PR TITLE
test(upgrade): clean up global state after test

### DIFF
--- a/packages/upgrade/test/static/integration/downgrade_module_spec.ts
+++ b/packages/upgrade/test/static/integration/downgrade_module_spec.ts
@@ -16,6 +16,7 @@ import {UpgradeComponent, downgradeComponent, downgradeModule} from '@angular/up
 import * as angular from '@angular/upgrade/static/src/common/angular1';
 import {$EXCEPTION_HANDLER, $ROOT_SCOPE, INJECTOR_KEY, LAZY_MODULE_REF} from '@angular/upgrade/static/src/common/constants';
 import {LazyModuleRef} from '@angular/upgrade/static/src/common/util';
+import {setTempInjectorRef} from '@angular/upgrade/static/src/static/angular1_providers';
 
 import {html, multiTrim, withEachNg1Version} from '../test_helpers';
 
@@ -1295,6 +1296,12 @@ withEachNg1Version(() => {
           downModB = doDowngradeModule(Ng2ModuleB);
           errorSpy = jasmine.createSpy($EXCEPTION_HANDLER);
         });
+
+        // In the tests below, some of the components' bootstrap process is interrupted by an error.
+        // If the bootstrap process for other components/modules is not completed in time, there is
+        // a chance that some global state is retained, possibly messing subsequent tests.
+        // Explicitly clean up after each test to prevent that.
+        afterEach(() => setTempInjectorRef(null !));
 
         it('should throw if no downgraded module is included', async(() => {
              const ng1Module = angular.module('ng1', [])


### PR DESCRIPTION
In ngUpgradeLite, when a downgraded component [requests its downgraded module][1], the AngularJS injector is [temporarily stored][2] with the intention of grabbing it [once the module has been bootstrapped][3] (which also cleans up the [temporary injector reference][4]).

In [some tests][5], bootstrapping a component might throw an error, which causes the test to fail immediatelly and move on to the next test. In slow browsers (e.g. on CI/Saucelabs), the (successful) bootstrapping of another downgraded module might not have been completed in time and thus the temporary injector reference not cleaned up.

In such a case, if the following test (in our randomized test suite) happens to rely on the temporary injector reference's being initially unset (such as [this test][6]), it will fail. This might appear as a flake on CI, because it depends on a race condition and specific order of tests, so it usually goes away after a rerun.

This commit fixes it by ensuring the temporary injector reference is manually cleaned up, when necessary.

Jira issue: [FW-939]

[1]: https://github.com/angular/angular/blob/f983e99fb245532b41125672447a7d6756e9da06/packages/upgrade/src/common/downgrade_component.ts#L120
[2]: https://github.com/angular/angular/blob/f983e99fb245532b41125672447a7d6756e9da06/packages/upgrade/src/static/downgrade_module.ts#L165
[3]: https://github.com/angular/angular/blob/f983e99fb245532b41125672447a7d6756e9da06/packages/upgrade/src/static/downgrade_module.ts#L169
[4]: https://github.com/angular/angular/blob/f983e99fb245532b41125672447a7d6756e9da06/packages/upgrade/src/static/angular1_providers.ts#L25
[5]: https://github.com/angular/angular/blob/f983e99fb245532b41125672447a7d6756e9da06/packages/upgrade/test/static/integration/downgrade_module_spec.ts#L1331-L1381
[6]: https://github.com/angular/angular/blob/f983e99fb245532b41125672447a7d6756e9da06/packages/upgrade/test/static/angular1_providers_spec.ts#L31-L45
[FW-939]: https://angular-team.atlassian.net/browse/FW-939?filter=-1