### PR TITLE
fix(docs-infra): removal of the use of the ChildNode.remove() method …

### DIFF
--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.ts
@@ -100,9 +100,9 @@ export class DocViewerComponent implements OnDestroy {
     if (needsToc && !embeddedToc) {
       // Add an embedded ToC if it's needed and there isn't one in the content already.
       titleEl!.insertAdjacentHTML('afterend', '<aio-toc class="embedded"></aio-toc>');
-    } else if (!needsToc && embeddedToc) {
+    } else if (!needsToc && embeddedToc && embeddedToc.parentNode !== null) {
       // Remove the embedded Toc if it's there and not needed.
-      embeddedToc.remove();
+      embeddedToc.parentNode.removeChild(embeddedToc);
     }
 
     return () => {

--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.ts
@@ -102,6 +102,7 @@ export class DocViewerComponent implements OnDestroy {
       titleEl!.insertAdjacentHTML('afterend', '<aio-toc class="embedded"></aio-toc>');
     } else if (!needsToc && embeddedToc && embeddedToc.parentNode !== null) {
       // Remove the embedded Toc if it's there and not needed.
+      // We cannot use ChildNode.remove() because of IE11
       embeddedToc.parentNode.removeChild(embeddedToc);
     }
 

--- a/aio/src/app/shared/toc.service.ts
+++ b/aio/src/app/shared/toc.service.ts
@@ -68,7 +68,9 @@ export class TocService {
         }
       }
       // now remove the anchor
-      anchorLink.remove();
+      if (anchorLink.parentNode !== null) {
+        anchorLink.parentNode.removeChild(anchorLink);
+      }
     }
     // security: the document element which provides this heading content
     // is always authored by the documentation team and is considered to be safe

--- a/aio/src/app/shared/toc.service.ts
+++ b/aio/src/app/shared/toc.service.ts
@@ -69,6 +69,7 @@ export class TocService {
       }
       // now remove the anchor
       if (anchorLink.parentNode !== null) {
+        // We cannot use ChildNode.remove() because of IE11
         anchorLink.parentNode.removeChild(anchorLink);
       }
     }


### PR DESCRIPTION
…that it isn't supported by IE

fixes #28177

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Removing the use of ChildNode.remove() that it isn't supported by IE.

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

angular.io doesn't work with IE 

Issue Number: #28177


## What is the new behavior?

angular.io works with IE ?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


@gkalpak , can you call Mary Poppins for me ? I can't test it at home.