### PR TITLE
fix(common): escape anchor for some anchors containing characters whi…

### DIFF
--- a/packages/common/src/viewport_scroller.ts
+++ b/packages/common/src/viewport_scroller.ts
@@ -105,6 +105,7 @@ export class BrowserViewportScroller implements ViewportScroller {
    * @param anchor The ID of the anchor element.
    */
   scrollToAnchor(anchor: string): void {
+    anchor = CSS.escape(anchor);
     if (this.supportScrollRestoration()) {
       const elSelectedById = this.document.querySelector(`#${anchor}`);
       if (elSelectedById) {


### PR DESCRIPTION
…ch is used for CSS

If there are some characters('.', ':', '>', etc.)  which are for a part
of CSS selector in the anchor string, document.querySelector() throw
an error like below:

> ERROR DOMException: Failed to execute 'querySelector'
> on 'Document': '#fn:1' is not a valid selector.

So it should be escaped.
Ref: https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape#In_context_uses


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [*] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
