### PR TITLE
fix(bazel): Fix integration test after v8 bump

### DIFF
--- a/integration/bazel-schematics/package.json.replace
+++ b/integration/bazel-schematics/package.json.replace
@@ -1,0 +1,53 @@
+{
+  "name": "demo",
+  "version": "0.0.0",
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "test": "ng test",
+    "lint": "ng lint",
+    "e2e": "ng e2e"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/animations": "file:../angular/dist/packages-dist/animations",
+    "@angular/common": "file:../angular/dist/packages-dist/common",
+    "@angular/compiler": "file:../angular/dist/packages-dist/compiler",
+    "@angular/core": "file:../angular/dist/packages-dist/core",
+    "@angular/forms": "file:../angular/dist/packages-dist/forms",
+    "@angular/platform-browser": "file:../angular/dist/packages-dist/platform-browser",
+    "@angular/platform-browser-dynamic": "file:../angular/dist/packages-dist/platform-browser-dynamic",
+    "@angular/router": "file:../angular/dist/packages-dist/router",
+    "core-js": "^2.5.4",
+    "rxjs": "~6.3.3",
+    "tslib": "^1.9.0",
+    "zone.js": "~0.8.26"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "~0.12.0",
+    "@angular/bazel": "file:../angular/dist/packages-dist/bazel",
+    "@angular/cli": "~7.2.1",
+    "@angular/compiler-cli": "file:../angular/dist/packages-dist/compiler-cli",
+    "@angular/language-service": "file:../angular/dist/packages-dist/language-service",
+    "@bazel/bazel": "^0.21.0",
+    "@bazel/ibazel": "^0.9.0",
+    "@bazel/karma": "^0.22.1",
+    "@bazel/typescript": "^0.22.1",
+    "@types/node": "~8.9.4",
+    "@types/jasmine": "~2.8.8",
+    "@types/jasminewd2": "~2.0.3",
+    "codelyzer": "~4.5.0",
+    "jasmine-core": "~2.99.1",
+    "jasmine-spec-reporter": "~4.2.1",
+    "karma": "~3.1.1",
+    "karma-chrome-launcher": "~2.2.0",
+    "karma-coverage-istanbul-reporter": "~2.0.1",
+    "karma-jasmine": "~1.1.2",
+    "karma-jasmine-html-reporter": "^0.2.2",
+    "protractor": "~5.4.0",
+    "ts-node": "~7.0.0",
+    "tslint": "~5.11.0",
+    "typescript": "~3.2.2"
+  }
+}

--- a/integration/bazel-schematics/test.sh
+++ b/integration/bazel-schematics/test.sh
@@ -13,6 +13,7 @@ function testBazel() {
   # TODO(kyliau) Remove this once the type annotations are added to AppPage
   # https://github.com/angular/angular-cli/pull/13406
   cp ../app.po.ts ./e2e/src/
+  cp ../package.json.replace ./package.json
   # Run build
   # TODO(kyliau): Use `bazel build` for now. Running `ng build` requires
   # node_modules to be available in project directory.

--- a/integration/bazel-schematics/yarn.lock
+++ b/integration/bazel-schematics/yarn.lock
@@ -73,7 +73,7 @@
     "@angular-devkit/architect" "^0.10.6"
     "@angular-devkit/core" "^7.0.4"
     "@angular-devkit/schematics" "^7.0.4"
-    "@bazel/typescript" "^0.21.0"
+    "@bazel/typescript" "^0.22.1"
     "@schematics/angular" "^7.0.4"
     "@types/node" "6.0.84"
     semver "^5.6.0"
@@ -115,12 +115,13 @@
     "@bazel/bazel-linux_x64" "0.21.0"
     "@bazel/bazel-win32_x64" "0.21.0"
 
-"@bazel/typescript@^0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.21.0.tgz#41c304f77a42c6a016280d0f4c20e0749c3f4b2a"
-  integrity sha512-ASXj0RFybmqoa3LwqkTU3gNkX9bY9wL/VDNo5hlp9pynYWl4RMpe9V3m/qDIdtSuLJ+qD+Z3FKT/OcpWQHMlYA==
+"@bazel/typescript@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.22.1.tgz#b52c00e8560019e2f9d273d45c04785e0ec9d9bd"
+  integrity sha512-88DaCCnNg8rPlKP0eAQEZuoiJkEPeiItpUS3oBR1sFQNBRJb56D25ahK8+N6LJk4qaH+ZQ1/AHOPDhfEEWvDzA==
   dependencies:
     protobufjs "5.0.3"
+    semver "5.6.0"
     source-map-support "0.5.9"
     tsutils "2.27.2"
 
@@ -1907,7 +1908,7 @@ semver-intersect@1.4.0:
   dependencies:
     semver "^5.0.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@5.6.0, semver@^5.0.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==


### PR DESCRIPTION
The integration test for bazel-schematics installs Angular in
two different locations:

1. Bazel workspace
2. package.json -> fetched from npm

Pull request #28142 changes the test to always install (1) from
source. This breaks (2) when there's a major version bump since the
local version and the version in package.json no longer match.

This change updates package.json to fetch @angular/* packages
from source (packages-dist) as well.

Note: This is just a temporary solution. The version skew will be fixed
once and for all when Greg's upcoming changes to yarn_install rule is
rolled out.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
