### PR TITLE
fix(ivy): TestBed should use annotation for the last match rather tha…

### DIFF
--- a/packages/core/src/render3/metadata.ts
+++ b/packages/core/src/render3/metadata.ts
@@ -28,7 +28,7 @@ export function setClassMetadata(
     propDecorators: {[field: string]: any} | null): void {
   const clazz = type as TypeWithMetadata;
   if (decorators !== null) {
-    if (clazz.decorators !== undefined) {
+    if (clazz.hasOwnProperty('decorators') && clazz.decorators !== undefined) {
       clazz.decorators.push(...decorators);
     } else {
       clazz.decorators = decorators;

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -48,8 +48,19 @@ export class SimpleCmp {
 export class WithRefsCmp {
 }
 
+// This is not used directly in tests, but it's necessary to keep it in the
+// HelloWorldModule so we can properly test resolution of components that
+// are extended (e.g. SimpleCmp should not throw if it's extended).
+@Component({selector: 'inherited-cmp', template: ''})
+export class InheritedCmp extends SimpleCmp {
+}
+
+@Component({selector: 'simple-app', template: '<simple-cmp></simple-cmp>'})
+export class SimpleApp {
+}
+
 @NgModule({
-  declarations: [HelloWorld, SimpleCmp, WithRefsCmp],
+  declarations: [HelloWorld, SimpleCmp, WithRefsCmp, InheritedCmp, SimpleApp],
   imports: [GreetingModule],
   providers: [
     {provide: NAME, useValue: 'World!'},
@@ -172,6 +183,12 @@ describe('TestBed', () => {
     const hello = TestBed.createComponent(HelloWorld);
     hello.detectChanges();
     expect(hello.nativeElement).toHaveText('Hello injected World !');
+  });
+
+  it('should properly resolve components that inherit from other components', () => {
+    const simpleApp = TestBed.createComponent(SimpleApp);
+    simpleApp.detectChanges();
+    expect(simpleApp.nativeElement).toHaveText('simple');
   });
 
   onlyInIvy('patched ng defs should be removed after resetting TestingModule')

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -185,7 +185,8 @@ describe('TestBed', () => {
     expect(hello.nativeElement).toHaveText('Hello injected World !');
   });
 
-  it('should properly resolve components that inherit from other components', () => {
+  it('should resolve components that are extended by other components', () => {
+    // SimpleApp uses SimpleCmp in its template, which is extended by InheritedCmp
     const simpleApp = TestBed.createComponent(SimpleApp);
     simpleApp.detectChanges();
     expect(simpleApp.nativeElement).toHaveText('simple');

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -48,14 +48,16 @@ export class SimpleCmp {
 export class WithRefsCmp {
 }
 
-// This is not used directly in tests, but it's necessary to keep it in the
-// HelloWorldModule so we can properly test resolution of components that
-// are extended (e.g. SimpleCmp should not throw if it's extended).
-@Component({selector: 'inherited-cmp', template: ''})
+@Component({selector: 'inherited-cmp', template: 'inherited'})
 export class InheritedCmp extends SimpleCmp {
 }
 
-@Component({selector: 'simple-app', template: '<simple-cmp></simple-cmp>'})
+@Component({
+  selector: 'simple-app',
+  template: `
+    <simple-cmp></simple-cmp> - <inherited-cmp></inherited-cmp>
+  `
+})
 export class SimpleApp {
 }
 
@@ -189,7 +191,7 @@ describe('TestBed', () => {
     // SimpleApp uses SimpleCmp in its template, which is extended by InheritedCmp
     const simpleApp = TestBed.createComponent(SimpleApp);
     simpleApp.detectChanges();
-    expect(simpleApp.nativeElement).toHaveText('simple');
+    expect(simpleApp.nativeElement).toHaveText('simple - inherited');
   });
 
   onlyInIvy('patched ng defs should be removed after resetting TestingModule')

--- a/packages/core/testing/src/resolvers.ts
+++ b/packages/core/testing/src/resolvers.ts
@@ -37,6 +37,8 @@ abstract class OverrideResolver<T> implements Resolver<T> {
   }
 
   getAnnotation(type: Type<any>): T|null {
+    // We should always return the last match from filter(), or we may return superclass data by
+    // mistake.
     return reflection.annotations(type).filter(a => a instanceof this.type).pop() || null;
   }
 

--- a/packages/core/testing/src/resolvers.ts
+++ b/packages/core/testing/src/resolvers.ts
@@ -37,7 +37,7 @@ abstract class OverrideResolver<T> implements Resolver<T> {
   }
 
   getAnnotation(type: Type<any>): T|null {
-    return reflection.annotations(type).find(a => a instanceof this.type) || null;
+    return reflection.annotations(type).filter(a => a instanceof this.type).pop() || null;
   }
 
   resolve(type: Type<any>): T|null {


### PR DESCRIPTION
…n the first

When we look for matching annotations in TestBed, we should always take the last
matching annotation. Otherwise, we will return superclass data for subclasses,
which would have unintended consequences like directives matching the wrong selectors.
