### PR TITLE
fix(ivy): TestBed.get should be able to retrieve tokens from Compiler's injector

### DIFF
--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -65,6 +65,8 @@ let _nextRootElementId = 0;
 
 const EMPTY_ARRAY: Type<any>[] = [];
 
+const UNDEFINED: Symbol = Symbol('UNDEFINED');
+
 // Resolvers for Angular decorators
 type Resolvers = {
   module: Resolver<NgModule>,
@@ -311,6 +313,7 @@ export class TestBedRender3 implements Injector, TestBed {
     // reset test module config
     this._providers = [];
     this._compilerOptions = [];
+    this._compilerProviders = [];
     this._declarations = [];
     this._imports = [];
     this._schemas = [];
@@ -405,7 +408,8 @@ export class TestBedRender3 implements Injector, TestBed {
     if (token === TestBedRender3) {
       return this;
     }
-    return this._moduleRef.injector.get(token, notFoundValue);
+    const result = this._moduleRef.injector.get(token, UNDEFINED);
+    return result === UNDEFINED ? this.compilerInjector.get(token, notFoundValue) : result;
   }
 
   execute(tokens: any[], fn: Function, context?: any): any {
@@ -590,8 +594,8 @@ export class TestBedRender3 implements Injector, TestBed {
   }
 
   get compilerInjector(): Injector {
-    if (this._compilerInjector !== undefined) {
-      this._compilerInjector;
+    if (this._compilerInjector !== null) {
+      return this._compilerInjector;
     }
 
     const providers: StaticProvider[] = [];

--- a/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
+++ b/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
@@ -63,11 +63,10 @@ if (isBrowser) {
               {providers: [{provide: FancyService, useValue: new FancyService()}]});
         });
 
-        fixmeIvy('FW-919: TestBed.get should be able to retrieve tokens from Compiler\'s injector')
-            .it('provides a real ResourceLoader instance',
-                inject([ResourceLoader], (resourceLoader: ResourceLoader) => {
-                  expect(resourceLoader instanceof ResourceLoaderImpl).toBeTruthy();
-                }));
+        it('provides a real ResourceLoader instance',
+           inject([ResourceLoader], (resourceLoader: ResourceLoader) => {
+             expect(resourceLoader instanceof ResourceLoaderImpl).toBeTruthy();
+           }));
 
         it('should allow the use of fakeAsync',
            fakeAsync(inject([FancyService], (service: any /** TODO #9100 */) => {


### PR DESCRIPTION
This changes restores parity between VE TestBed and R3TestBed logic related to retrieving tokens using TestBed.get function. Now R3TestBed also tries to retrieve tokens from Compiler Injector.

This PR also contains a couple additional minor fixes:

- `_compilerProviders` were not cleared between test runs, thus sharing state between tests which led to random test failures
- `compilerInjector` getter didn't return previously created injector (typo).

This PR resolves FW-919.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No