### PR TITLE
refactor(ivy): expose resolving URLs in the `ResourceLoader`

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/api.ts
@@ -6,7 +6,50 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/**
+ * Resolves and loads resource files that are referenced in Angular metadata.
+ *
+ * Note that `preload()` and `load()` take a `resolvedUrl`, which can be found
+ * by calling `resolve()`. These two steps are separated because sometimes the
+ * resolved URL to the resource is needed as well as its contents.
+ */
 export interface ResourceLoader {
-  preload?(url: string, containingFile: string): Promise<void>|undefined;
-  load(url: string, containingFile: string): string;
+  /**
+   * True if this resource loader can preload resources.
+   *
+   * Sometimes a `ResourceLoader` is not able to do asynchronous pre-loading of resources.
+   */
+  canPreload: boolean;
+
+  /**
+   * Resolve the url of a resource relative to the file that contains the reference to it.
+   * The return value of this method can be used in the `load()` and `preload()` methods.
+   *
+   * @param url The, possibly relative, url of the resource.
+   * @param fromFile The path to the file that contains the URL of the resource.
+   * @returns A resolved url of resource.
+   * @throws An error if the resource cannot be resolved.
+   */
+  resolve(file: string, basePath: string): string;
+
+  /**
+   * Preload the specified resource, asynchronously. Once the resource is loaded, its value
+   * should be cached so it can be accessed synchronously via the `load()` method.
+   *
+   * @param resolvedUrl The url (resolved by a call to `resolve()`) of the resource to preload.
+   * @returns A Promise that is resolved once the resource has been loaded or `undefined`
+   * if the file has already been loaded.
+   * @throws An Error if pre-loading is not available.
+   */
+  preload(resolvedUrl: string): Promise<void>|undefined;
+
+  /**
+   * Load the resource at the given url, synchronously.
+   *
+   * The contents of the resource may have been cached by a previous call to `preload()`.
+   *
+   * @param resolvedUrl The url (resolved by a call to `resolve()`) of the resource to load.
+   * @returns The contents of the resource.
+   */
+  load(resolvedUrl: string): string;
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
@@ -18,7 +18,10 @@ import {ComponentDecoratorHandler} from '../src/component';
 import {SelectorScopeRegistry} from '../src/selector_scope';
 
 export class NoopResourceLoader implements ResourceLoader {
-  load(url: string): string { throw new Error('Not implemented'); }
+  resolve(): string { throw new Error('Not implemented.'); }
+  canPreload = false;
+  load(): string { throw new Error('Not implemented'); }
+  preload(): Promise<void>|undefined { throw new Error('Not implemented'); }
 }
 
 describe('ComponentDecoratorHandler', () => {

--- a/packages/compiler-cli/src/ngtsc/resource_loader.ts
+++ b/packages/compiler-cli/src/ngtsc/resource_loader.ts
@@ -8,8 +8,8 @@
 
 import * as fs from 'fs';
 import * as ts from 'typescript';
-
-import {ResourceLoader} from './annotations';
+import {CompilerHost} from '../transformers/api';
+import {ResourceLoader} from './annotations/src/api';
 
 /**
  * `ResourceLoader` which delegates to a `CompilerHost` resource loading method.
@@ -18,107 +18,141 @@ export class HostResourceLoader implements ResourceLoader {
   private cache = new Map<string, string>();
   private fetching = new Map<string, Promise<void>>();
 
-  constructor(
-      private resolver: (file: string, basePath: string) => string | null,
-      private loader: (url: string) => string | Promise<string>) {}
+  canPreload = !!this.host.readResource;
 
-  preload(file: string, containingFile: string): Promise<void>|undefined {
-    const resolved = this.resolver(file, containingFile);
-    if (resolved === null) {
+  constructor(private host: CompilerHost, private options: ts.CompilerOptions) {}
+
+  /**
+   * Resolve the url of a resource relative to the file that contains the reference to it.
+   * The return value of this method can be used in the `load()` and `preload()` methods.
+   *
+   * Uses the provided CompilerHost if it supports mapping resources to filenames.
+   * Otherwise, uses a fallback mechanism that searches the module resolution candidates.
+   *
+   * @param url The, possibly relative, url of the resource.
+   * @param fromFile The path to the file that contains the URL of the resource.
+   * @returns A resolved url of resource.
+   * @throws An error if the resource cannot be resolved.
+   */
+  resolve(url: string, fromFile: string): string {
+    let resolvedUrl: string|null = null;
+    if (this.host.resourceNameToFileName) {
+      resolvedUrl = this.host.resourceNameToFileName(url, fromFile);
+    } else {
+      resolvedUrl = this.fallbackResolve(url, fromFile);
+    }
+    if (resolvedUrl === null) {
+      throw new Error(`HostResourceResolver: could not resolve ${url} in context of ${fromFile})`);
+    }
+    return resolvedUrl;
+  }
+
+  /**
+   * Preload the specified resource, asynchronously.
+   *
+   * Once the resource is loaded, its value is cached so it can be accessed synchronously via the
+   * `load()` method.
+   *
+   * @param resolvedUrl The url (resolved by a call to `resolve()`) of the resource to preload.
+   * @returns A Promise that is resolved once the resource has been loaded or `undefined` if the
+   * file has already been loaded.
+   * @throws An Error if pre-loading is not available.
+   */
+  preload(resolvedUrl: string): Promise<void>|undefined {
+    if (!this.host.readResource) {
+      throw new Error(
+          'HostResourceLoader: the CompilerHost provided does not support pre-loading resources.');
+    }
+    if (this.cache.has(resolvedUrl)) {
       return undefined;
+    } else if (this.fetching.has(resolvedUrl)) {
+      return this.fetching.get(resolvedUrl);
     }
 
-    if (this.cache.has(resolved)) {
-      return undefined;
-    } else if (this.fetching.has(resolved)) {
-      return this.fetching.get(resolved);
-    }
-
-    const result = this.loader(resolved);
+    const result = this.host.readResource(resolvedUrl);
     if (typeof result === 'string') {
-      this.cache.set(resolved, result);
+      this.cache.set(resolvedUrl, result);
       return undefined;
     } else {
       const fetchCompletion = result.then(str => {
-        this.fetching.delete(resolved);
-        this.cache.set(resolved, str);
+        this.fetching.delete(resolvedUrl);
+        this.cache.set(resolvedUrl, str);
       });
-      this.fetching.set(resolved, fetchCompletion);
+      this.fetching.set(resolvedUrl, fetchCompletion);
       return fetchCompletion;
     }
   }
 
-  load(file: string, containingFile: string): string {
-    const resolved = this.resolver(file, containingFile);
-    if (resolved === null) {
-      throw new Error(
-          `HostResourceLoader: could not resolve ${file} in context of ${containingFile})`);
+  /**
+   * Load the resource at the given url, synchronously.
+   *
+   * The contents of the resource may have been cached by a previous call to `preload()`.
+   *
+   * @param resolvedUrl The url (resolved by a call to `resolve()`) of the resource to load.
+   * @returns The contents of the resource.
+   */
+  load(resolvedUrl: string): string {
+    if (this.cache.has(resolvedUrl)) {
+      return this.cache.get(resolvedUrl) !;
     }
 
-    if (this.cache.has(resolved)) {
-      return this.cache.get(resolved) !;
-    }
-
-    const result = this.loader(resolved);
+    const result = this.host.readResource ? this.host.readResource(resolvedUrl) :
+                                            fs.readFileSync(resolvedUrl, 'utf8');
     if (typeof result !== 'string') {
-      throw new Error(`HostResourceLoader: loader(${resolved}) returned a Promise`);
+      throw new Error(`HostResourceLoader: loader(${resolvedUrl}) returned a Promise`);
     }
-    this.cache.set(resolved, result);
+    this.cache.set(resolvedUrl, result);
     return result;
   }
-}
 
-
-
-// `failedLookupLocations` is in the name of the type ts.ResolvedModuleWithFailedLookupLocations
-// but is marked @internal in TypeScript. See https://github.com/Microsoft/TypeScript/issues/28770.
-type ResolvedModuleWithFailedLookupLocations =
-    ts.ResolvedModuleWithFailedLookupLocations & {failedLookupLocations: ReadonlyArray<string>};
-
-/**
- * `ResourceLoader` which directly uses the filesystem to resolve resources synchronously.
- */
-export class FileResourceLoader implements ResourceLoader {
-  constructor(private host: ts.CompilerHost, private options: ts.CompilerOptions) {}
-
-  load(file: string, containingFile: string): string {
-    // Attempt to resolve `file` in the context of `containingFile`, while respecting the rootDirs
-    // option from the tsconfig. First, normalize the file name.
-
+  /**
+   * Attempt to resolve `url` in the context of `fromFile`, while respecting the rootDirs
+   * option from the tsconfig. First, normalize the file name.
+   */
+  private fallbackResolve(url: string, fromFile: string): string|null {
     // Strip a leading '/' if one is present.
-    if (file.startsWith('/')) {
-      file = file.substr(1);
+    if (url.startsWith('/')) {
+      url = url.substr(1);
     }
     // Turn absolute paths into relative paths.
-    if (!file.startsWith('.')) {
-      file = `./${file}`;
+    if (!url.startsWith('.')) {
+      url = `./${url}`;
     }
 
-    // TypeScript provides utilities to resolve module names, but not resource files (which aren't
-    // a part of the ts.Program). However, TypeScript's module resolution can be used creatively
-    // to locate where resource files should be expected to exist. Since module resolution returns
-    // a list of file names that were considered, the loader can enumerate the possible locations
-    // for the file by setting up a module resolution for it that will fail.
-    file += '.$ngresource$';
+    const candidateLocations = this.getCandidateLocations(url, fromFile);
+    for (const candidate of candidateLocations) {
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+
+  /**
+   * TypeScript provides utilities to resolve module names, but not resource files (which aren't
+   * a part of the ts.Program). However, TypeScript's module resolution can be used creatively
+   * to locate where resource files should be expected to exist. Since module resolution returns
+   * a list of file names that were considered, the loader can enumerate the possible locations
+   * for the file by setting up a module resolution for it that will fail.
+   */
+  private getCandidateLocations(url: string, fromFile: string): string[] {
+    // `failedLookupLocations` is in the name of the type ts.ResolvedModuleWithFailedLookupLocations
+    // but is marked @internal in TypeScript. See
+    // https://github.com/Microsoft/TypeScript/issues/28770.
+    type ResolvedModuleWithFailedLookupLocations =
+        ts.ResolvedModuleWithFailedLookupLocations & {failedLookupLocations: ReadonlyArray<string>};
 
     // clang-format off
-    const failedLookup = ts.resolveModuleName(file, containingFile, this.options, this.host) as ResolvedModuleWithFailedLookupLocations;
+    const failedLookup = ts.resolveModuleName(url + '.$ngresource$', fromFile, this.options, this.host) as ResolvedModuleWithFailedLookupLocations;
     // clang-format on
     if (failedLookup.failedLookupLocations === undefined) {
       throw new Error(
-          `Internal error: expected to find failedLookupLocations during resolution of resource '${file}' in context of ${containingFile}`);
+          `Internal error: expected to find failedLookupLocations during resolution of resource '${url}' in context of ${fromFile}`);
     }
 
-    const candidateLocations =
-        failedLookup.failedLookupLocations
-            .filter(candidate => candidate.endsWith('.$ngresource$.ts'))
-            .map(candidate => candidate.replace(/\.\$ngresource\$\.ts$/, ''));
-
-    for (const candidate of candidateLocations) {
-      if (fs.existsSync(candidate)) {
-        return fs.readFileSync(candidate, 'utf8');
-      }
-    }
-    throw new Error(`Could not find resource ${file} in context of ${containingFile}`);
+    return failedLookup.failedLookupLocations
+        .filter(candidate => candidate.endsWith('.$ngresource$.ts'))
+        .map(candidate => candidate.replace(/\.\$ngresource\$\.ts$/, ''));
   }
 }


### PR DESCRIPTION
Resources can be loaded in the context of another file, which
means that the path to the resource file must be resolved
before it can be loaded.

Previously the API of this interface did not allow the client
code to get access to the resolved URL which is used to load
the resource.

Now this API has been refactored so that you must do the
resource URL resolving first and the loading expects a
resolved URL.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current `ResourceLoader` interface does not expose the `resolvedUrl`.


## What is the new behavior?

The current `ResourceLoader` interface exposes the `resolvedUrl` via a new `resolve()` method.

## Does this PR introduce a breaking change?

- [] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
