### PR TITLE
feat(ivy): improve stacktrace for `R3Injector` errors

### DIFF
--- a/packages/core/src/di/interface/injector.ts
+++ b/packages/core/src/di/interface/injector.ts
@@ -15,8 +15,8 @@
 export enum InjectFlags {
   // TODO(alxhub): make this 'const' when ngc no longer writes exports of it into ngfactory files.
 
+  /** Check self and check parent injector if needed */
   Default = 0b0000,
-
   /**
    * Specifies that an injector should retrieve a dependency from any injector until reaching the
    * host element of the current component. (Only used with Element Injector)

--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -16,7 +16,6 @@ import {InternalNgModuleRef, NgModuleFactory as viewEngine_NgModuleFactory, NgMo
 import {NgModuleDef} from '../metadata/ng_module';
 import {assertDefined} from '../util/assert';
 import {stringify} from '../util/stringify';
-
 import {ComponentFactoryResolver} from './component_ref';
 import {getNgModuleDef} from './definition';
 
@@ -52,7 +51,8 @@ export class NgModuleRef<T> extends viewEngine_NgModuleRef<T> implements Interna
       },
       COMPONENT_FACTORY_RESOLVER
     ];
-    this._r3Injector = createInjector(ngModuleType, _parent, additionalProviders) as R3Injector;
+    this._r3Injector = createInjector(
+        ngModuleType, _parent, additionalProviders, stringify(ngModuleType)) as R3Injector;
     this.instance = this.get(ngModuleType);
   }
 

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -6,10 +6,19 @@
     "name": "CIRCULAR"
   },
   {
+    "name": "CIRCULAR"
+  },
+  {
+    "name": "EMPTY"
+  },
+  {
     "name": "EMPTY_ARRAY"
   },
   {
     "name": "EmptyErrorImpl"
+  },
+  {
+    "name": "IDENT"
   },
   {
     "name": "INJECTOR"
@@ -24,13 +33,34 @@
     "name": "InjectionToken"
   },
   {
+    "name": "Injector"
+  },
+  {
+    "name": "MULTI_PROVIDER_FN"
+  },
+  {
+    "name": "NEW_LINE"
+  },
+  {
     "name": "NG_INJECTABLE_DEF"
   },
   {
     "name": "NG_INJECTOR_DEF"
   },
   {
+    "name": "NG_TEMP_TOKEN_PATH"
+  },
+  {
+    "name": "NG_TOKEN_PATH"
+  },
+  {
     "name": "NOT_YET"
+  },
+  {
+    "name": "NO_NEW_LINE"
+  },
+  {
+    "name": "NULL_INJECTOR"
   },
   {
     "name": "NULL_INJECTOR"
@@ -51,6 +81,9 @@
     "name": "R3Injector"
   },
   {
+    "name": "SOURCE"
+  },
+  {
     "name": "ScopedService"
   },
   {
@@ -60,7 +93,7 @@
     "name": "SkipSelf"
   },
   {
-    "name": "THROW_IF_NOT_FOUND"
+    "name": "StaticInjector"
   },
   {
     "name": "USE_VALUE"
@@ -84,6 +117,12 @@
     "name": "_currentInjector"
   },
   {
+    "name": "catchInjectorError"
+  },
+  {
+    "name": "computeDeps"
+  },
+  {
     "name": "couldBeInjectableType"
   },
   {
@@ -97,6 +136,9 @@
   },
   {
     "name": "defineInjector"
+  },
+  {
+    "name": "formatError"
   },
   {
     "name": "forwardRef"
@@ -156,18 +198,36 @@
     "name": "makeRecord"
   },
   {
+    "name": "multiProviderMixError"
+  },
+  {
     "name": "providerToFactory"
   },
   {
     "name": "providerToRecord"
   },
   {
+    "name": "recursivelyProcessProviders"
+  },
+  {
     "name": "resolveForwardRef"
+  },
+  {
+    "name": "resolveProvider"
+  },
+  {
+    "name": "resolveToken"
   },
   {
     "name": "setCurrentInjector"
   },
   {
+    "name": "staticError"
+  },
+  {
     "name": "stringify"
+  },
+  {
+    "name": "tryResolveToken"
   }
 ]

--- a/packages/core/test/di/r3_injector_spec.ts
+++ b/packages/core/test/di/r3_injector_spec.ts
@@ -6,11 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectionToken} from '../../src/di/injection_token';
-import {INJECTOR, Injector} from '../../src/di/injector';
-import {inject} from '../../src/di/injector_compatibility';
-import {defineInjectable, defineInjector} from '../../src/di/interface/defs';
-import {R3Injector, createInjector} from '../../src/di/r3_injector';
+import {INJECTOR, InjectFlags, InjectionToken, Injector, Optional, createInjector, defineInjectable, defineInjector, inject} from '@angular/core';
+import {R3Injector} from '@angular/core/src/di/r3_injector';
+import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 describe('InjectorDef-based createInjector()', () => {
   class CircularA {
@@ -34,6 +32,13 @@ describe('InjectorDef-based createInjector()', () => {
     });
   }
 
+  class OptionalService {
+    static ngInjectableDef = defineInjectable({
+      providedIn: null,
+      factory: () => new OptionalService(),
+    });
+  }
+
   class StaticService {
     constructor(readonly dep: Service) {}
   }
@@ -53,6 +58,24 @@ describe('InjectorDef-based createInjector()', () => {
     static ngInjectableDef = defineInjectable({
       providedIn: null,
       factory: () => new ServiceWithDep(inject(Service)),
+    });
+  }
+
+  class ServiceWithOptionalDep {
+    constructor(@Optional() readonly service: OptionalService|null) {}
+
+    static ngInjectableDef = defineInjectable({
+      providedIn: null,
+      factory: () => new ServiceWithOptionalDep(inject(OptionalService, InjectFlags.Optional)),
+    });
+  }
+
+  class ServiceWithMissingDep {
+    constructor(readonly service: Service) {}
+
+    static ngInjectableDef = defineInjectable({
+      providedIn: null,
+      factory: () => new ServiceWithMissingDep(inject(Service)),
     });
   }
 
@@ -135,6 +158,7 @@ describe('InjectorDef-based createInjector()', () => {
       imports: [IntermediateModule],
       providers: [
         ServiceWithDep,
+        ServiceWithOptionalDep,
         ServiceWithMultiDep,
         {provide: LOCALE, multi: true, useValue: 'en'},
         {provide: LOCALE, multi: true, useValue: 'es'},
@@ -155,6 +179,14 @@ describe('InjectorDef-based createInjector()', () => {
       factory: () => new OtherModule(),
       imports: undefined,
       providers: [],
+    });
+  }
+
+  class ModuleWithMissingDep {
+    static ngInjectorDef = defineInjector({
+      factory: () => new ModuleWithMissingDep(),
+      imports: undefined,
+      providers: [ServiceWithMissingDep],
     });
   }
 
@@ -198,10 +230,39 @@ describe('InjectorDef-based createInjector()', () => {
   it('returns the default value if a provider isn\'t present',
      () => { expect(injector.get(ServiceTwo, null)).toBeNull(); });
 
+  it('should throw when no provider defined', () => {
+    expect(() => injector.get(ServiceTwo))
+        .toThrowError(
+            `R3InjectorError(Module)[ServiceTwo]: \n` +
+            `  NullInjectorError: No provider for ServiceTwo!`);
+  });
+
+  it('should throw without the module name when no module', () => {
+    const injector = createInjector([ServiceTwo]);
+    expect(() => injector.get(ServiceTwo))
+        .toThrowError(
+            `R3InjectorError[ServiceTwo]: \n` +
+            `  NullInjectorError: No provider for ServiceTwo!`);
+  });
+
+  it('should throw with the full path when no provider', () => {
+    const injector = createInjector(ModuleWithMissingDep);
+    expect(() => injector.get(ServiceWithMissingDep))
+        .toThrowError(
+            `R3InjectorError(ModuleWithMissingDep)[ServiceWithMissingDep -> Service]: \n` +
+            `  NullInjectorError: No provider for Service!`);
+  });
+
   it('injects a service with dependencies', () => {
     const instance = injector.get(ServiceWithDep);
     expect(instance instanceof ServiceWithDep);
     expect(instance.service).toBe(injector.get(Service));
+  });
+
+  it('injects a service with optional dependencies', () => {
+    const instance = injector.get(ServiceWithOptionalDep);
+    expect(instance instanceof ServiceWithOptionalDep);
+    expect(instance.service).toBe(null);
   });
 
   it('injects a service with dependencies on multi-providers', () => {

--- a/packages/core/test/di/r3_injector_spec.ts
+++ b/packages/core/test/di/r3_injector_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {INJECTOR, InjectFlags, InjectionToken, Injector, Optional, createInjector, defineInjectable, defineInjector, inject} from '@angular/core';
-import {R3Injector} from '@angular/core/src/di/r3_injector';
+import {INJECTOR, InjectFlags, InjectionToken, Injector, Optional, defineInjectable, defineInjector, inject} from '@angular/core';
+import {R3Injector, createInjector} from '@angular/core/src/di/r3_injector';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 describe('InjectorDef-based createInjector()', () => {

--- a/packages/core/test/di/static_injector_spec.ts
+++ b/packages/core/test/di/static_injector_spec.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, InjectionToken, Injector, Optional, ReflectiveKey, Self, SkipSelf, forwardRef} from '@angular/core';
-import {getOriginalError} from '@angular/core/src/errors';
+import {Inject, InjectionToken, Injector, Optional, Self, SkipSelf, forwardRef} from '@angular/core';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 import {stringify} from '../../src/util/stringify';

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -734,8 +734,11 @@ function declareTests(config?: {useJit: boolean}) {
 
       it('should throw when the aliased provider does not exist', () => {
         const injector = createInjector([{provide: 'car', useExisting: SportsCar}]);
-        const e = `NullInjectorError: No provider for ${stringify(SportsCar)}!`;
-        expect(() => injector.get('car')).toThrowError(e);
+        let errorMsg = `NullInjectorError: No provider for ${stringify(SportsCar)}!`;
+        if (ivyEnabled) {
+          errorMsg = `R3InjectorError(SomeModule)[car -> SportsCar]: \n  ` + errorMsg;
+        }
+        expect(() => injector.get('car')).toThrowError(errorMsg);
       });
 
       it('should handle forwardRef in useExisting', () => {
@@ -930,8 +933,11 @@ function declareTests(config?: {useJit: boolean}) {
 
       it('should throw when no provider defined', () => {
         const injector = createInjector([]);
-        expect(() => injector.get('NonExisting'))
-            .toThrowError('NullInjectorError: No provider for NonExisting!');
+        let errorMsg = 'NullInjectorError: No provider for NonExisting!';
+        if (ivyEnabled) {
+          errorMsg = `R3InjectorError(SomeModule)[NonExisting]: \n  ` + errorMsg;
+        }
+        expect(() => injector.get('NonExisting')).toThrowError(errorMsg);
       });
 
       it('should throw when trying to instantiate a cyclic dependency', () => {

--- a/packages/core/test/view/provider_spec.ts
+++ b/packages/core/test/view/provider_spec.ts
@@ -11,6 +11,7 @@ import {getDebugContext} from '@angular/core/src/errors';
 import {ArgumentType, DepFlags, NodeFlags, Services, anchorDef, asElementData, directiveDef, elementDef, providerDef, textDef} from '@angular/core/src/view/index';
 import {TestBed, withModule} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
+import {ivyEnabled} from '@angular/private/testing';
 
 import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, createRootView, createAndGetRootNodes, compViewDef, compViewDefFactory} from './helper';
 
@@ -147,7 +148,7 @@ import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, createRootView, createAndGetR
 
           expect(() => createAndGetRootNodes(compViewDef(rootElNodes)))
               .toThrowError(
-                  'StaticInjectorError(DynamicTestModule)[SomeService -> Dep]: \n' +
+                  `${ivyEnabled ? 'R3InjectorError' : 'StaticInjectorError'}(DynamicTestModule)[SomeService -> Dep]: \n` +
                   '  StaticInjectorError(Platform: core)[SomeService -> Dep]: \n' +
                   '    NullInjectorError: No provider for Dep!');
 
@@ -161,7 +162,7 @@ import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, createRootView, createAndGetR
 
           expect(() => createAndGetRootNodes(compViewDef(nonRootElNodes)))
               .toThrowError(
-                  'StaticInjectorError(DynamicTestModule)[SomeService -> Dep]: \n' +
+                  `${ivyEnabled ? 'R3InjectorError' : 'StaticInjectorError'}(DynamicTestModule)[SomeService -> Dep]: \n` +
                   '  StaticInjectorError(Platform: core)[SomeService -> Dep]: \n' +
                   '    NullInjectorError: No provider for Dep!');
         });
@@ -186,7 +187,7 @@ import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, createRootView, createAndGetR
                    directiveDef(1, NodeFlags.None, null, 0, SomeService, ['nonExistingDep'])
                  ])))
               .toThrowError(
-                  'StaticInjectorError(DynamicTestModule)[nonExistingDep]: \n' +
+                  `${ivyEnabled ? 'R3InjectorError' : 'StaticInjectorError'}(DynamicTestModule)[nonExistingDep]: \n` +
                   '  StaticInjectorError(Platform: core)[nonExistingDep]: \n' +
                   '    NullInjectorError: No provider for nonExistingDep!');
         });

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -18,7 +18,7 @@ import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {DOCUMENT} from '@angular/platform-browser/src/dom/dom_tokens';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {fixmeIvy, modifiedInIvy, onlyInIvy} from '@angular/private/testing';
+import {ivyEnabled, modifiedInIvy, onlyInIvy} from '@angular/private/testing';
 
 @Component({selector: 'non-existent', template: ''})
 class NonExistentComp {
@@ -205,44 +205,48 @@ function bootstrap(
          });
        }));
 
-    // TODO(misko): can't use `fixmeIvy.it` because the `it` is somehow special here.
-    fixmeIvy('FW-875: The source of the error is missing in the `StaticInjectorError` message')
-            .isEnabled &&
-        it('should throw if no provider',
-           inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-             const logger = new MockConsole();
-             const errorHandler = new ErrorHandler();
-             (errorHandler as any)._console = logger as any;
+    it('should throw if no provider', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+         const logger = new MockConsole();
+         const errorHandler = new ErrorHandler();
+         (errorHandler as any)._console = logger as any;
 
-             class IDontExist {}
+         class IDontExist {}
 
-             @Component({selector: 'cmp', template: 'Cmp'})
-             class CustomCmp {
-               constructor(iDontExist: IDontExist) {}
-             }
+         @Component({selector: 'cmp', template: 'Cmp'})
+         class CustomCmp {
+           constructor(iDontExist: IDontExist) {}
+         }
 
-             @Component({
-               selector: 'hello-app',
-               template: '<cmp></cmp>',
-             })
-             class RootCmp {
-             }
+         @Component({
+           selector: 'hello-app',
+           template: '<cmp></cmp>',
+         })
+         class RootCmp {
+         }
 
-             @NgModule({declarations: [CustomCmp], exports: [CustomCmp]})
-             class CustomModule {
-             }
+         @NgModule({declarations: [CustomCmp], exports: [CustomCmp]})
+         class CustomModule {
+         }
 
-             bootstrap(RootCmp, [{provide: ErrorHandler, useValue: errorHandler}], [], [
-               CustomModule
-             ]).then(null, (e: Error) => {
-               expect(e.message).toContain(
-                   'StaticInjectorError(TestModule)[CustomCmp -> IDontExist]: \n' +
-                   '  StaticInjectorError(Platform: core)[CustomCmp -> IDontExist]: \n' +
-                   '    NullInjectorError: No provider for IDontExist!');
-               async.done();
-               return null;
-             });
-           }));
+         bootstrap(RootCmp, [{provide: ErrorHandler, useValue: errorHandler}], [], [
+           CustomModule
+         ]).then(null, (e: Error) => {
+           let errorMsg: string;
+           if (ivyEnabled) {
+             errorMsg = `R3InjectorError(TestModule)[IDontExist]: \n` +
+                 '  StaticInjectorError(TestModule)[IDontExist]: \n' +
+                 '    StaticInjectorError(Platform: core)[IDontExist]: \n' +
+                 '      NullInjectorError: No provider for IDontExist!';
+           } else {
+             errorMsg = `StaticInjectorError(TestModule)[CustomCmp -> IDontExist]: \n` +
+                 '  StaticInjectorError(Platform: core)[CustomCmp -> IDontExist]: \n' +
+                 '    NullInjectorError: No provider for IDontExist!';
+           }
+           expect(e.message).toContain(errorMsg);
+           async.done();
+           return null;
+         });
+       }));
 
     if (getDOM().supportsDOMEvents()) {
       it('should forward the error to promise when bootstrap fails',


### PR DESCRIPTION
Improve the stacktrace for `R3Injector` errors by adding the source component (or module) that tried to inject the missing provider, as well as the name of the injector which triggered the error (`R3Injector`).

e.g.:
```
R3InjectorError(SomeModule)[car -> SportsCar]:
    NullInjectorError: No provider for SportsCar!
```

PS: I had to change some of the tests because r3 injection works differently sometimes

FW-807 #resolve
FW-875 #resolve