### PR TITLE
fix(ivy): ensure animation component host listeners are rendered in the sub component

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_styling_spec.ts
@@ -341,8 +341,8 @@ describe('compiler compliance: styling', () => {
           hostBindings: function MyAnimDir_HostBindings(rf, ctx, elIndex) {
             if (rf & 1) {
               $r3$.ɵallocHostVars(1);
-              $r3$.ɵlistener("@myAnim.start", function MyAnimDir_animation_myAnim_start_HostBindingHandler($event) { return ctx.onStart(); });
-              $r3$.ɵlistener("@myAnim.done", function MyAnimDir_animation_myAnim_done_HostBindingHandler($event) { return ctx.onDone(); });
+              $r3$.ɵcomponentHostSyntheticListener("@myAnim.start", function MyAnimDir_animation_myAnim_start_HostBindingHandler($event) { return ctx.onStart(); });
+              $r3$.ɵcomponentHostSyntheticListener("@myAnim.done", function MyAnimDir_animation_myAnim_done_HostBindingHandler($event) { return ctx.onDone(); });
             } if (rf & 2) {
               $r3$.ɵcomponentHostSyntheticProperty(elIndex, "@myAnim", $r3$.ɵbind(ctx.myAnimState), null, true);
             }

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -34,6 +34,9 @@ export class Identifiers {
   static componentHostSyntheticProperty:
       o.ExternalReference = {name: 'ɵcomponentHostSyntheticProperty', moduleName: CORE};
 
+  static componentHostSyntheticListener:
+      o.ExternalReference = {name: 'ɵcomponentHostSyntheticListener', moduleName: CORE};
+
   static elementAttribute: o.ExternalReference = {name: 'ɵelementAttribute', moduleName: CORE};
 
   static elementClassProp: o.ExternalReference = {name: 'ɵelementClassProp', moduleName: CORE};

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -839,7 +839,9 @@ function createHostListeners(
         meta.name && bindingName ? `${meta.name}_${bindingFnName}_HostBindingHandler` : null;
     const params = prepareEventListenerParameters(
         BoundEvent.fromParsedEvent(binding), bindingContext, handlerName);
-    return o.importExpr(R3.listener).callFn(params).toStmt();
+    const instruction =
+        binding.type == ParsedEventType.Animation ? R3.componentHostSyntheticListener : R3.listener;
+    return o.importExpr(instruction).callFn(params).toStmt();
   });
 }
 

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -83,6 +83,7 @@ export {
   elementEnd as ɵelementEnd,
   elementProperty as ɵelementProperty,
   componentHostSyntheticProperty as ɵcomponentHostSyntheticProperty,
+  componentHostSyntheticListener as ɵcomponentHostSyntheticListener,
   projectionDef as ɵprojectionDef,
   reference as ɵreference,
   enableBindings as ɵenableBindings,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -44,6 +44,7 @@ export {
   elementEnd,
   elementProperty,
   componentHostSyntheticProperty,
+  componentHostSyntheticListener,
   elementStart,
 
   elementContainerStart,

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -78,6 +78,7 @@ export const angularCoreEnv: {[name: string]: Function} = {
   'ɵprojection': r3.projection,
   'ɵelementProperty': r3.elementProperty,
   'ɵcomponentHostSyntheticProperty': r3.componentHostSyntheticProperty,
+  'ɵcomponentHostSyntheticListener': r3.componentHostSyntheticListener,
   'ɵpipeBind1': r3.pipeBind1,
   'ɵpipeBind2': r3.pipeBind2,
   'ɵpipeBind3': r3.pipeBind3,

--- a/packages/core/test/animation/animation_query_integration_spec.ts
+++ b/packages/core/test/animation/animation_query_integration_spec.ts
@@ -2238,84 +2238,82 @@ import {HostListener} from '../../src/metadata/directives';
         expect(p3.element.classList.contains('parent1')).toBeTruthy();
       });
 
-      fixmeIvy(
-          'FW-943 - Fix final `unknown` issue in `animation_query_integration_spec.ts` once #28162 lands')
-          .it('should emulate a leave animation on the nearest sub host elements when a parent is removed',
-              fakeAsync(() => {
-                @Component({
-                  selector: 'ani-cmp',
-                  template: `
+      it('should emulate a leave animation on the nearest sub host elements when a parent is removed',
+         fakeAsync(() => {
+           @Component({
+             selector: 'ani-cmp',
+             template: `
             <div @parent *ngIf="exp" class="parent1" #parent>
               <child-cmp #child @leave (@leave.start)="animateStart($event)"></child-cmp>
             </div>
           `,
-                  animations: [
-                    trigger(
-                        'leave',
-                        [
-                          transition(':leave', [animate(1000, style({color: 'gold'}))]),
-                        ]),
-                    trigger(
-                        'parent',
-                        [
-                          transition(':leave', [query(':leave', animateChild())]),
-                        ]),
-                  ]
-                })
-                class ParentCmp {
-                  public exp: boolean = true;
-                  @ViewChild('child') public childElm: any;
+             animations: [
+               trigger(
+                   'leave',
+                   [
+                     transition(':leave', [animate(1000, style({color: 'gold'}))]),
+                   ]),
+               trigger(
+                   'parent',
+                   [
+                     transition(':leave', [query(':leave', animateChild())]),
+                   ]),
+             ]
+           })
+           class ParentCmp {
+             public exp: boolean = true;
+             @ViewChild('child') public childElm: any;
 
-                  public childEvent: any;
+             public childEvent: any;
 
-                  animateStart(event: any) {
-                    if (event.toState == 'void') {
-                      this.childEvent = event;
-                    }
-                  }
-                }
+             animateStart(event: any) {
+               if (event.toState == 'void') {
+                 this.childEvent = event;
+               }
+             }
+           }
 
-                @Component({
-                  selector: 'child-cmp',
-                  template: '...',
-                  animations: [
-                    trigger(
-                        'child',
-                        [
-                          transition(':leave', [animate(1000, style({color: 'gold'}))]),
-                        ]),
-                  ]
-                })
-                class ChildCmp {
-                  public childEvent: any;
+           @Component({
+             selector: 'child-cmp',
+             template: '...',
+             animations: [
+               trigger(
+                   'child',
+                   [
+                     transition(':leave', [animate(1000, style({color: 'gold'}))]),
+                   ]),
+             ]
+           })
+           class ChildCmp {
+             public childEvent: any;
 
-                  @HostBinding('@child') public animate = true;
+             @HostBinding('@child') public animate = true;
 
-                  @HostListener('@child.start', ['$event'])
-                  animateStart(event: any) {
-                    if (event.toState == 'void') {
-                      this.childEvent = event;
-                    }
-                  }
-                }
+             @HostListener('@child.start', ['$event'])
+             animateStart(event: any) {
+               if (event.toState == 'void') {
+                 this.childEvent = event;
+               }
+             }
+           }
 
-                TestBed.configureTestingModule({declarations: [ParentCmp, ChildCmp]});
-                const fixture = TestBed.createComponent(ParentCmp);
-                const cmp = fixture.componentInstance;
+           TestBed.configureTestingModule({declarations: [ParentCmp, ChildCmp]});
+           const fixture = TestBed.createComponent(ParentCmp);
+           const cmp = fixture.componentInstance;
 
-                fixture.detectChanges();
+           fixture.detectChanges();
 
-                const childCmp = cmp.childElm;
+           const childCmp = cmp.childElm;
 
-                cmp.exp = false;
-                fixture.detectChanges();
-                flushMicrotasks();
+           cmp.exp = false;
+           fixture.detectChanges();
+           flushMicrotasks();
 
-                expect(cmp.childEvent.toState).toEqual('void');
-                expect(cmp.childEvent.totalTime).toEqual(1000);
-                expect(childCmp.childEvent.toState).toEqual('void');
-                expect(childCmp.childEvent.totalTime).toEqual(1000);
-              }));
+           expect(cmp.childEvent.toState).toEqual('void');
+           expect(cmp.childEvent.totalTime).toEqual(1000);
+           expect(childCmp.childEvent.toState).toEqual('void');
+           expect(childCmp.childEvent.totalTime).toEqual(1000);
+         }));
 
       it('should emulate a leave animation on a sub component\'s inner elements when a parent leave animation occurs with animateChild',
          () => {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -951,6 +951,9 @@
     "name": "listener"
   },
   {
+    "name": "listenerInternal"
+  },
+  {
     "name": "loadInternal"
   },
   {


### PR DESCRIPTION
Due to the fact that animations in Angular are defined in the component metadata, all animation trigger definitions are localized to the component and are inaccessible outside of it. Animation host listeners in Ivy are rendered in the context of the parent component, but the VE renders them differently. This patch ensures that animation host listeners are always registered in the sub component's renderer

Jira issue: FW-943
Jira issue: FW-958