### PR TITLE
fix(ivy): fix styling context resolution for host bindings on containers

### DIFF
--- a/packages/core/src/render3/styling/util.ts
+++ b/packages/core/src/render3/styling/util.ts
@@ -9,7 +9,7 @@ import '../../util/ng_dev_mode';
 
 import {StyleSanitizeFn} from '../../sanitization/style_sanitizer';
 import {getLContext} from '../context_discovery';
-import {LContainer} from '../interfaces/container';
+import {LCONTAINER_LENGTH, LContainer} from '../interfaces/container';
 import {LContext} from '../interfaces/context';
 import {AttributeMarker, TAttributes, TNode, TNodeFlags} from '../interfaces/node';
 import {PlayState, Player, PlayerContext, PlayerIndex} from '../interfaces/player';
@@ -96,7 +96,7 @@ export function getStylingContext(index: number, viewData: LView): StylingContex
 export function isStylingContext(value: any): value is StylingContext {
   // Not an LView or an LContainer
   return Array.isArray(value) && typeof value[StylingIndex.MasterFlagPosition] === 'number' &&
-      Array.isArray(value[StylingIndex.InitialStyleValuesPosition]);
+      value.length !== LCONTAINER_LENGTH;
 }
 
 export function isAnimationProp(name: string): boolean {


### PR DESCRIPTION
Previous to this change, the isStylingContext() function was improperly returning true
for LContainers because it used the presence of an array at index 2 to determine
whether it was a styling context. Unfortunately, LContainers also contain arrays at
index 2, so this would return a false positive. This led to other errors down the line
because we would treat nodes with containers as if they already had styling contexts
(even if they did not), so the proper initialization logic for styling contexts
was not run.

This commit fixes the isStylingContext() function to use LCONTAINER_LENGTH as a marker
rather than the presence of an array, which in turn fixes host bindings to styles on
nodes with containers.
