### PR TITLE
fix(bazel): increase node memory limit for ng_module rule to prevent OOM for big modules

### DIFF
--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -285,6 +285,8 @@ _EXTRA_NODE_OPTIONS_FLAGS = [
     "--node_options=--expose-gc",
     # Show ~full stack traces, instead of cutting off after 10 items.
     "--node_options=--stack-trace-limit=100",
+    # Give 2 GB RAM to node to make bigger google3 modules to compile, we should be able to drop this after Ivy/ngtsc is the default in g3
+    "--node_options=--max-old-space-size=2048",
 ]
 
 def ngc_compile_action(


### PR DESCRIPTION
This came up as a request from an internal Google team.

Context:
- http://cl/229881085
- https://groups.google.com/a/google.com/forum/#!topic/nodejs/GLqDEOW0MV4
