### PR TITLE
docs: clarify when polyfills are included with JIT compilation in browser support

### DIFF
--- a/aio/content/guide/browser-support.md
+++ b/aio/content/guide/browser-support.md
@@ -187,7 +187,7 @@ These are the polyfills required to run an Angular application on each supported
 
     <td>
 
-      [ES7/reflect](guide/browser-support#core-es7-reflect) (JIT only)
+      [ES7/reflect](guide/browser-support#core-es7-reflect) (JIT only, automatically included by @angular/cli if AOT is off)
 
     </td>
 
@@ -268,7 +268,7 @@ Here are the features which may require additional polyfills:
     </td>
 
     <td>
-      All current browsers. Enabled by default.
+      All current browsers. Included automactically by @angular/cli if AOT is off.
       Can remove if you always use AOT and only use Angular decorators.
     </td>
 


### PR DESCRIPTION
Since https://github.com/angular/angular-cli/commit/30f8352ca2b3cccd72f5fcff8e09a543f9c70a8d
disabling AOT will automatically include the required polyfills. This should be clarified
in the documentation

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Documentation states that you need to import `es7/reflect` polyfill to use JIT compilation. Since `@angular/cli@7.0`, this is untrue.

## What is the new behavior?

Try to shortly explain this

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
