### PR TITLE
ci: rebase check in merge-pr script

### DIFF
--- a/scripts/github/merge-pr
+++ b/scripts/github/merge-pr
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-set -u -e -o pipefail
+# https://www.tldp.org/LDP/abs/html/options.html#AEN19601
+# https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
+set -u -e -E -o pipefail
+
 
 BASEDIR=$(dirname "$0")
 BASEDIR=`(cd $BASEDIR; pwd)`
@@ -107,11 +110,26 @@ REWRITE_MESSAGE="git filter-branch -f --msg-filter \"$BASEDIR/utils/github_close
 PUSH_BRANCHES="git push git@github.com:angular/angular.git merge_pr_master:$MASTER_BRANCH merge_pr_patch:$PATCH_BRANCH"
 CHERRY_PICK_PR="git cherry-pick merge_pr_base..merge_pr"
 
+# Checks that each PR branch to be merged upstream contains SHAs of commits that significantly changed our CI infrastructure.
+#
+# This check is used to enforce that we don't merge PRs that have not been rebased recently and could result in merging
+# of non-approved or otherwise bad changes.
+REQUIRED_BASE_SHA_MASTER="3fba6eff79a9b50909199eaa4ebf754c1c4adba6" # pullapprove => CODEOWNERS migration
+REQUIRED_BASE_SHA_PATCH="e3853e842ea5c10fafbc310a76a4a7f47ed8c65e"  # pullapprove => CODEOWNERS migration
+if [[ $MERGE_MASTER == 1 ]]; then
+  REQUIRED_BASE_SHA="$REQUIRED_BASE_SHA_MASTER"
+# check patch only if patch-only PR
+elif [[ $MERGE_PATCH == 1 ]]; then
+  REQUIRED_BASE_SHA="$REQUIRED_BASE_SHA_PATCH"
+fi
+CHECK_IF_PR_REBASED="git branch --quiet merge_pr --contains $REQUIRED_BASE_SHA"
+
 echo "======================"
 echo "GitHub Merge PR Steps"
 echo "======================"
 echo "   $FETCH_PR"
 echo "   $BASE_PR"
+echo "   $CHECK_IF_PR_REBASED"
 echo "   $SQUASH_PR"
 echo "   $REWRITE_MESSAGE"
 if [[ $MERGE_MASTER == 1 ]]; then
@@ -127,6 +145,19 @@ echo ">>> Fetch PR: $FETCH_PR"
 $FETCH_PR
 echo ">>> Mark base: $BASE_PR"
 $BASE_PR
+echo ">>> Check if PR rebased: $CHECK_IF_PR_REBASED"
+if [[ $($CHECK_IF_PR_REBASED) != "" ]]; then
+  echo "The PR is sufficiently rebased!"
+else
+  echo ""
+  echo ""
+  echo "Failed to merge pull request #${PR_NUMBER} because it hasn't been rebased recently and could be bypassing new or updated CI checks!"
+  echo ""
+  echo "Please rebase the PR and try again."
+  echo ""
+  $RESTORE_BRANCH
+  exit 1
+fi
 echo ">>> Autosquash: $SQUASH_PR"
 GIT_EDITOR=echo $SQUASH_PR
 echo ">>> Rewrite message: $REWRITE_MESSAGE"
@@ -153,4 +184,3 @@ if [[ $PUSH_UPSTREAM == 1 ]]; then
 fi
 echo
 echo ">>>>>> SUCCESS <<<<<< PR#$PR_NUMBER merged."
-


### PR DESCRIPTION
Adds a check to verify that each PR branch to be merged upstream contains SHAs of commits that significantly changed our CI infrastructure.

This check is used to enforce that we don't merge PRs that have not been rebased recently and could result in merging of non-approved or otherwise bad changes.