### PR TITLE
fix(animations): error when setting position before starting animation

### DIFF
--- a/packages/animations/browser/src/render/web_animations/web_animations_player.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_player.ts
@@ -156,6 +156,9 @@ export class WebAnimationsPlayer implements AnimationPlayer {
   }
 
   setPosition(p: number): void {
+    if (this.domPlayer === undefined) {
+      this.init();
+    }
     this.domPlayer.currentTime = p * this.time;
   }
 

--- a/packages/animations/browser/test/render/web_animations/web_animations_player_spec.ts
+++ b/packages/animations/browser/test/render/web_animations/web_animations_player_spec.ts
@@ -67,6 +67,27 @@ import {WebAnimationsPlayer} from '../../../src/render/web_animations/web_animat
       player.finish();
       expect(log).toEqual(['started', 'done']);
     });
+
+    it('should allow setting position before animation is started', () => {
+      const player = new WebAnimationsPlayer(element, [], {duration: 1000});
+
+      player.setPosition(0.5);
+      const p = innerPlayer!;
+      expect(p.log).toEqual(['pause']);
+      expect(p.currentTime).toEqual(500);
+    });
+
+    it('should continue playing animations from setPosition', () => {
+      const player = new WebAnimationsPlayer(element, [], {duration: 1000});
+
+      player.play();
+      const p = innerPlayer!;
+      expect(p.log).toEqual(['play']);
+
+      player.setPosition(0.5);
+      expect(p.currentTime).toEqual(500);
+      expect(p.log).toEqual(['play']);
+    });
   });
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Calling `player.setPosition(value)` before `player.play()` causes an error "undefined is not an object" [stackblitz](https://stackblitz.com/edit/angular-getposition-bug?file=src%2Fapp%2Fapp.component.ts)
Issue Number: N/A


## What is the new behavior?
calling `setPosition` before `play` will set the position without playing the animation. Calling `setPosition` after `play` will behave as before (set the position, and play the animation starting from the new position)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
To prevent problems like this, maybe `domPlayer` should either become nullable, or have a getter that checks for undefined.