### PR TITLE
fix(ivy): add missing getDirectives export

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -74,6 +74,7 @@ export {
   pureFunction8 as ɵpureFunction8,
   pureFunctionV as ɵpureFunctionV,
   getCurrentView as ɵgetCurrentView,
+  getDirectives as ɵgetDirectives,
   getHostElement as ɵgetHostElement,
   restoreView as ɵrestoreView,
   containerRefreshStart as ɵcontainerRefreshStart,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -7,7 +7,7 @@
  */
 import {LifecycleHooksFeature, renderComponent, whenRendered} from './component';
 import {defineBase, defineComponent, defineDirective, defineNgModule, definePipe} from './definition';
-import {getComponent, getHostElement, getRenderedText} from './discovery_utils';
+import {getComponent, getDirectives, getHostElement, getRenderedText} from './discovery_utils';
 import {InheritDefinitionFeature} from './features/inherit_definition_feature';
 import {ProvidersFeature} from './features/providers_feature';
 import {BaseDef, ComponentDef, ComponentDefWithMeta, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefFlags, DirectiveDefWithMeta, DirectiveType, PipeDef, PipeDefWithMeta} from './interfaces/definition';
@@ -170,6 +170,7 @@ export {
   definePipe,
   getHostElement,
   getComponent,
+  getDirectives,
   getRenderedText,
   renderComponent,
   whenRendered,


### PR DESCRIPTION

## PR Type
This PR adds the getDirectives to the render3 export, as it was not exported before

<!-- Please check the one that applies to this PR using "x". -->

- [ x] Bugfix
