### PR TITLE
fix(ivy): content projection with Shadow DOM not working

### DIFF
--- a/packages/core/test/linker/projection_integration_spec.ts
+++ b/packages/core/test/linker/projection_integration_spec.ts
@@ -381,22 +381,21 @@ describe('projection', () => {
   });
 
   if (getDOM().supportsNativeShadowDOM()) {
-    fixmeIvy('FW-841: Content projection with ShadovDom v0 doesn\'t work')
-        .it('should support native content projection and isolate styles per component', () => {
-          TestBed.configureTestingModule({declarations: [SimpleNative1, SimpleNative2]});
-          TestBed.overrideComponent(MainComp, {
-            set: {
-              template: '<simple-native1><div>A</div></simple-native1>' +
-                  '<simple-native2><div>B</div></simple-native2>'
-            }
-          });
-          const main = TestBed.createComponent(MainComp);
+    it('should support native content projection and isolate styles per component', () => {
+      TestBed.configureTestingModule({declarations: [SimpleNative1, SimpleNative2]});
+      TestBed.overrideComponent(MainComp, {
+        set: {
+          template: '<simple-native1><div>A</div></simple-native1>' +
+              '<simple-native2><div>B</div></simple-native2>'
+        }
+      });
+      const main = TestBed.createComponent(MainComp);
 
-          const childNodes = getDOM().childNodes(main.nativeElement);
-          expect(childNodes[0]).toHaveText('div {color: red}SIMPLE1(A)');
-          expect(childNodes[1]).toHaveText('div {color: blue}SIMPLE2(B)');
-          main.destroy();
-        });
+      const childNodes = getDOM().childNodes(main.nativeElement);
+      expect(childNodes[0]).toHaveText('div {color: red}SIMPLE1(A)');
+      expect(childNodes[1]).toHaveText('div {color: blue}SIMPLE2(B)');
+      main.destroy();
+    });
   }
 
   if (getDOM().supportsDOMEvents()) {


### PR DESCRIPTION
Fixes components with native content projection (using `<content>` or `<slot>`) not working under Ivy.

The issue comes from the fact that when creating elements inside a component, we sometimes don't append the element immediately, but we leave it to projection to move it into its final destination. This ends up breaking the native projection, because the slots have to be in place from the beginning. The following changes switch to appending the element immediately when inside a component with Shadow DOM encapsulation.

This PR resolves FW-841.