### PR TITLE
fix(common): make more restrictive the supportScrollRestoration method

### DIFF
--- a/aio/src/app/shared/scroll.service.ts
+++ b/aio/src/app/shared/scroll.service.ts
@@ -24,7 +24,7 @@ export class ScrollService implements OnDestroy {
   poppedStateScrollPosition: ScrollPosition|null = null;
   // Whether the browser supports the necessary features for manual scroll restoration.
   supportManualScrollRestoration: boolean = !!window && ('scrollTo' in window) &&
-      ('scrollX' in window) && ('scrollY' in window) && isScrollRestorationWritable();
+      ('pageXOffset' in window) && isScrollRestorationWritable();
 
   // Offset from the top of the document to bottom of any static elements
   // at the top (e.g. toolbar) + some margin

--- a/packages/common/src/viewport_scroller.ts
+++ b/packages/common/src/viewport_scroller.ts
@@ -89,7 +89,7 @@ export class BrowserViewportScroller implements ViewportScroller {
    */
   getScrollPosition(): [number, number] {
     if (this.supportsScrolling()) {
-      return [this.window.scrollX, this.window.scrollY];
+      return [this.window.pageXOffset, this.window.pageYOffset];
     } else {
       return [0, 0];
     }
@@ -149,7 +149,7 @@ export class BrowserViewportScroller implements ViewportScroller {
    */
   private supportScrollRestoration(): boolean {
     try {
-      if (!this.window || !this.window.scrollTo) {
+      if (!this.supportsScrolling()) {
         return false;
       }
       // The `scrollRestoration` property could be on the `history` instance or its prototype.
@@ -166,7 +166,7 @@ export class BrowserViewportScroller implements ViewportScroller {
 
   private supportsScrolling(): boolean {
     try {
-      return !!this.window.scrollTo;
+      return !!this.window && !!this.window.scrollTo && 'pageXOffset' in this.window;
     } catch {
       return false;
     }

--- a/packages/common/test/viewport_scroller_spec.ts
+++ b/packages/common/test/viewport_scroller_spec.ts
@@ -15,7 +15,8 @@ describe('BrowserViewportScroller', () => {
   let windowSpy: any;
 
   beforeEach(() => {
-    windowSpy = jasmine.createSpyObj('window', ['history', 'scrollTo']);
+    windowSpy =
+        jasmine.createSpyObj('window', ['history', 'scrollTo', 'pageXOffset', 'pageYOffset']);
     windowSpy.history.scrollRestoration = 'auto';
     documentSpy = jasmine.createSpyObj('document', ['getElementById', 'getElementsByName']);
     scroller = new BrowserViewportScroller(documentSpy, windowSpy, null!);

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -349,7 +349,8 @@ describe('bootstrap', () => {
     window.scrollTo(0, 5000);
 
     // IE 11 uses non-standard pageYOffset instead of scrollY
-    const getScrollY = () => window.scrollY !== undefined ? window.scrollY : window.pageYOffset;
+    // For cross-browser compatibility, prefer window.pageYOffset instead of window.scrollY
+    const getScrollY = () => window.pageYOffset;
 
     await router.navigateByUrl('/fail');
     expect(getScrollY()).toEqual(5000);

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -348,28 +348,24 @@ describe('bootstrap', () => {
     await router.navigateByUrl('/aa');
     window.scrollTo(0, 5000);
 
-    // IE 11 uses non-standard pageYOffset instead of scrollY
-    // For cross-browser compatibility, prefer window.pageYOffset instead of window.scrollY
-    const getScrollY = () => window.pageYOffset;
-
     await router.navigateByUrl('/fail');
-    expect(getScrollY()).toEqual(5000);
+    expect(window.pageYOffset).toEqual(5000);
 
     await router.navigateByUrl('/bb');
     window.scrollTo(0, 3000);
 
-    expect(getScrollY()).toEqual(3000);
+    expect(window.pageYOffset).toEqual(3000);
 
     await router.navigateByUrl('/cc');
-    expect(getScrollY()).toEqual(0);
+    expect(window.pageYOffset).toEqual(0);
 
     await router.navigateByUrl('/aa#marker2');
-    expect(getScrollY()).toBeGreaterThanOrEqual(5900);
-    expect(getScrollY()).toBeLessThan(6000);  // offset
+    expect(window.pageYOffset).toBeGreaterThanOrEqual(5900);
+    expect(window.pageYOffset).toBeLessThan(6000);  // offset
 
     await router.navigateByUrl('/aa#marker3');
-    expect(getScrollY()).toBeGreaterThanOrEqual(8900);
-    expect(getScrollY()).toBeLessThan(9000);
+    expect(window.pageYOffset).toBeGreaterThanOrEqual(8900);
+    expect(window.pageYOffset).toBeLessThan(9000);
     done();
   });
 


### PR DESCRIPTION
closes #27957

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, ViewportScroller does not work in Internet Explorer because of the use of scrollX and scrollY. Neither of which are supported by Internet Explorer.

Issue Number: #27957


## What is the new behavior?
We check these properties with the supportScrollRestoration method  before calling them in getScrollPosition()

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
