### PR TITLE
fix(router): redirect to root url when returned as UrlTree from guard

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -717,6 +717,11 @@ export class Router {
                 if (isNavigationCancelingError(e)) {
                   const redirecting = isUrlTree(e.url);
                   if (!redirecting) {
+                    // Set property only if we're not redirecting. If we landed on a page and
+                    // redirect to `/` route, the new navigation is going to see the `/` isn't
+                    // a change from the default currentUrlTree and won't navigate. This is
+                    // only applicable with initial navigation, so setting `navigated` only when
+                    // not redirecting resolves this scenario.
                     this.navigated = true;
                     this.resetStateAndUrl(t.currentRouterState, t.currentUrlTree, t.rawUrl);
                   }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -715,9 +715,9 @@ export class Router {
                 /* This error type is issued during Redirect, and is handled as a cancellation
                  * rather than an error. */
                 if (isNavigationCancelingError(e)) {
-                  this.navigated = true;
                   const redirecting = isUrlTree(e.url);
                   if (!redirecting) {
+                    this.navigated = true;
                     this.resetStateAndUrl(t.currentRouterState, t.currentUrlTree, t.rawUrl);
                   }
                   const navCancel =


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature

## What is the current behavior?
When returning the root url as UrlTree from a guard, to be [handled as a redirection](https://github.com/angular/angular/commit/4e9f2e58957b65d08ff97bbc6374673597c65fa5), the navigation is not processed. 

Issue Number: #27845

## What is the new behavior?
The redirection to the root url is properly processed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The issue came from the error handler which incorrectly marked the router as already navigated *in any case*.
> [_line 706_](https://github.com/angular/angular/blob/eea2b0f288eec889d56afb07dad21f75e77f1241/packages/router/src/router.ts#L706) `this.navigated = true;`

When the new navigation was handled afterwards, it would not be marked as to be processed. It was considered to be a navigation to the same path which had already been navigated to.

> [_line 463_](https://github.com/angular/angular/blob/eea2b0f288eec889d56afb07dad21f75e77f1241/packages/router/src/router.ts#L463) `const urlTransition = !this.navigated ||
t.extractedUrl.toString() !== this.currentUrlTree.toString();`

It was working for urls other than root because a url comparison would mark the navigation as new, as seen above.