### PR TITLE
refactor: remove unused return statement in logsToObject method

### DIFF
--- a/tools/build/logging.js
+++ b/tools/build/logging.js
@@ -28,7 +28,6 @@ function logsToObject(logstr) {
     if (key.length > 0) obj[key] = true;
     return obj;
   }, Object.create(null));
-  return logs;
 }
 
 function camelize(str) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is a `return` statement after another one.

Issue Number: N/A


## What is the new behavior?

The unused `return` statement is removed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
