### PR TITLE
build(docs-infra): upgrade cli command docs sources to fd4e960d6

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -17,7 +17,7 @@
     "build": "yarn ~~build",
     "prebuild-local": "yarn setup-local",
     "build-local": "yarn ~~build",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 4ae713b5a",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js fd4e960d6",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#master](https://github.com/angular/angular/tree/master) from [cli-builds#master](https://github.com/angular/cli-builds/tree/master).
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/4ae713b5a...fd4e960d6):

**Modified**
- help/generate.json
- help/new.json

Closes #28260