### PR TITLE
test(docs-infra): reduce flakiness

### DIFF
--- a/aio/tests/deployment/e2e/redirection.e2e-spec.ts
+++ b/aio/tests/deployment/e2e/redirection.e2e-spec.ts
@@ -38,7 +38,7 @@ describe(browser.baseUrl, () => {
         const actualUrl = await getCurrentUrl();
 
         expect(actualUrl).toBe(expectedUrl);
-      }, 60000);
+      }, 120000);
     });
   });
 

--- a/aio/tests/deployment/e2e/redirection.e2e-spec.ts
+++ b/aio/tests/deployment/e2e/redirection.e2e-spec.ts
@@ -7,7 +7,7 @@ describe(browser.baseUrl, () => {
   const stripQuery = (url: string) => url.replace(/\?.*$/, '');
   const stripTrailingSlash = (url: string) => url.replace(/\/$/, '');
 
-  beforeAll(done => page.init().then(done));
+  beforeAll(() => page.init());
 
   beforeEach(() => browser.waitForAngularEnabled(false));
   afterEach(() => browser.waitForAngularEnabled(true));

--- a/aio/tests/deployment/e2e/redirection.e2e-spec.ts
+++ b/aio/tests/deployment/e2e/redirection.e2e-spec.ts
@@ -10,7 +10,11 @@ describe(browser.baseUrl, () => {
   beforeAll(() => page.init());
 
   beforeEach(() => browser.waitForAngularEnabled(false));
-  afterEach(() => browser.waitForAngularEnabled(true));
+
+  afterEach(async () => {
+    await page.unregisterSw();
+    await browser.waitForAngularEnabled(true);
+  });
 
   describe('(with sitemap URLs)', () => {
     page.sitemapUrls.forEach((path, i) => {

--- a/aio/tests/deployment/e2e/site.po.ts
+++ b/aio/tests/deployment/e2e/site.po.ts
@@ -42,15 +42,10 @@ export class SitePage {
    * (The SW is unregistered to ensure that subsequent requests are passed through to the server.)
    */
   async goTo(url: string) {
-    const unregisterServiceWorker = (cb: () => void) => navigator.serviceWorker
-        .getRegistrations()
-        .then(regs => Promise.all(regs.map(reg => reg.unregister())))
-        .then(cb);
-
     await browser.get(url || this.baseUrl);
     await browser.executeScript('document.body.classList.add(\'no-animations\')');
     await browser.waitForAngular();
-    await browser.executeAsyncScript(unregisterServiceWorker);
+    await this.unregisterSw();
   };
 
   /**
@@ -59,5 +54,17 @@ export class SitePage {
   async init() {
     // Make an initial request to unregister the ServiceWorker.
     await this.goTo('');
+  }
+
+  /**
+   * Unregister the ServiceWorker (if registered).
+   */
+  async unregisterSw() {
+    const unregisterSwFn = (cb: () => void) => navigator.serviceWorker
+        .getRegistrations()
+        .then(regs => Promise.all(regs.map(reg => reg.unregister())))
+        .then(cb);
+
+    await browser.executeAsyncScript(unregisterSwFn);
   }
 }

--- a/aio/tests/deployment/e2e/site.po.ts
+++ b/aio/tests/deployment/e2e/site.po.ts
@@ -38,7 +38,7 @@ export class SitePage {
   }
 
   /**
-   * Navigate to a URL, disable animations, unregister the ServiceWorker, and wait for Angular.
+   * Navigate to a URL, disable animations, wait for Angular and unregister the ServiceWorker.
    * (The SW is unregistered to ensure that subsequent requests are passed through to the server.)
    */
   async goTo(url: string) {
@@ -49,8 +49,8 @@ export class SitePage {
 
     await browser.get(url || this.baseUrl);
     await browser.executeScript('document.body.classList.add(\'no-animations\')');
-    await browser.executeAsyncScript(unregisterServiceWorker);
     await browser.waitForAngular();
+    await browser.executeAsyncScript(unregisterServiceWorker);
   };
 
   /**

--- a/aio/tests/deployment/e2e/smoke-tests.e2e-spec.ts
+++ b/aio/tests/deployment/e2e/smoke-tests.e2e-spec.ts
@@ -7,7 +7,11 @@ describe(browser.baseUrl, () => {
   beforeAll(() => page.init());
 
   beforeEach(() => browser.waitForAngularEnabled(false));
-  afterEach(() => browser.waitForAngularEnabled(true));
+
+  afterEach(async () => {
+    await page.unregisterSw();
+    await browser.waitForAngularEnabled(true);
+  });
 
   describe('(smoke tests)', () => {
     it('should show the home page', () => {

--- a/aio/tests/deployment/e2e/smoke-tests.e2e-spec.ts
+++ b/aio/tests/deployment/e2e/smoke-tests.e2e-spec.ts
@@ -4,7 +4,7 @@ import { SitePage } from './site.po';
 describe(browser.baseUrl, () => {
   const page = new SitePage();
 
-  beforeAll(done => page.init().then(done));
+  beforeAll(() => page.init());
 
   beforeEach(() => browser.waitForAngularEnabled(false));
   afterEach(() => browser.waitForAngularEnabled(true));


### PR DESCRIPTION
In the redirection e2e tests, we mostly care about the URL, which does not depend on Angular (since it comes from the server-side). Thus, we do not need to wait for Angular on every navigation, which could also cause Protractor to fail when Angular could not be found on the redirected page (e.g. `/news` being redirected to blog.angular.io).

This commit disables waiting for Angular on navigation (for the redirection tests), but `waitForAngular()` can be manually called in a test, if needed.