### PR TITLE
fix(docs-infra): change the key used to find out the cli section

### DIFF
--- a/aio/tools/transforms/cli-docs-package/processors/processCliCommands.js
+++ b/aio/tools/transforms/cli-docs-package/processors/processCliCommands.js
@@ -1,10 +1,14 @@
-module.exports = function processCliCommands() {
+module.exports = function processCliCommands(createDocMessage) {
   return {
     $runAfter: ['extra-docs-added'],
     $runBefore: ['rendering-docs'],
     $process(docs) {
       const navigationDoc = docs.find(doc => doc.docType === 'navigation-json');
-      const navigationNode = navigationDoc && navigationDoc.data['SideNav'].find(node => node.title === 'CLI Commands');
+      const navigationNode = navigationDoc && navigationDoc.data['SideNav'].find(node => node.children && node.children.length && node.children[0].url === 'cli');
+
+      if (!navigationNode) {
+        throw new Error(createDocMessage('Missing `cli` url - CLI Commands must include a first child node with url set at `cli`', navigationDoc));
+      }
 
       docs.forEach(doc => {
         if (doc.docType === 'cli-command') {
@@ -14,9 +18,7 @@ module.exports = function processCliCommands() {
           processOptions(doc, doc.options);
 
           // Add to navigation doc
-          if (navigationNode) {
-            navigationNode.children.push({ url: doc.path, title: `ng ${doc.name}` });
-          }
+          navigationNode.children.push({ url: doc.path, title: `ng ${doc.name}` });
         }
       });
     }


### PR DESCRIPTION
closes #28185

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, it isn't possible to translate 'CLI COMMANDS'  in https://angular.jp or other localized versions because it's a key of the internal process of generation.  

Issue Number: #28185


## What is the new behavior?
Now, we use the key `url` which is  deemed stable.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
