### PR TITLE
build: hide vscode settings e.g. debug launch config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ pubspec.lock
 .c9
 .idea/
 .settings/
+.vscode/launch.json
 *.swo
 modules/.settings
 modules/.vscode


### PR DESCRIPTION
`.vscode/launch.json` is used to be ignored because `.vscode` folder was ignored. PR #27781 changed this. Launch configs differ by platform and environment, so shouldn't be committed to the repo.