### PR TITLE
docs(animations): fix group and sequence function usage examples

### DIFF
--- a/packages/animations/src/animation_metadata.ts
+++ b/packages/animations/src/animation_metadata.ts
@@ -671,8 +671,8 @@ export function animate(
  *
  * ```typescript
  * group([
- *   animate("1s", { background: "black" }))
- *   animate("2s", { color: "white" }))
+ *   animate("1s", style({ background: "black" })),
+ *   animate("2s", style({ color: "white" }))
  * ])
  * ```
  *
@@ -708,7 +708,7 @@ export function group(
  * ```typescript
  * sequence([
  *   style({ opacity: 0 })),
- *   animate("1s", { opacity: 1 }))
+ *   animate("1s", style({ opacity: 1 }))
  * ])
  * ```
  *


### PR DESCRIPTION
animate functions now contain style functions instead of plain objects
e.g. `animate("1s", { background: "black" }))`
to   `animate("1s", style({ background: "black" }))`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The `sequence` and `group` function comments display the example in the function comment in the following way

```
animate("2s", { color: "white" }))
```

where the `style(` is missing.

## What is the new behavior?

The function comment for `group` function will display the usage example

```
group([
  animate("1s", style({ background: "black" })),
  animate("2s", style({ color: "white" }))
])
```

and the comment for `sequence` function will display the example

```
sequence([
  style({ opacity: 0 })),
  animate("1s", style({ opacity: 1 }))
])
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
