### PR TITLE
build: update and unify gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,10 @@
 .DS_STORE
 
 /dist/
-/bazel-out/
+/bazel-out
 /integration/bazel/bazel-*
 e2e_test.*
 node_modules
-bower_components
 tools/gulp-tasks/cldr/cldr-data/
 
 # Include when developing application packages.


### PR DESCRIPTION
After pulling latest master today I've started to see `bazel-out` popping as an untracked. This is due to the fact that `/bazel-out/` would much folders only but it is a symlink (thnx @gkalpak for figuring this out).

I've also removed `bower_components` as bower is gone.