### PR TITLE
fix(ivy): queries should register matches from top to bottom

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -500,6 +500,11 @@ export function elementContainerStart(
   appendChild(native, tNode, lView);
   createDirectivesAndLocals(tView, lView, localRefs);
   attachPatchData(native, lView);
+
+  const currentQueries = lView[QUERIES];
+  if (currentQueries) {
+    currentQueries.addNode(tNode);
+  }
 }
 
 /** Mark the end of the <ng-container>. */
@@ -518,7 +523,8 @@ export function elementContainerEnd(): void {
   ngDevMode && assertNodeType(previousOrParentTNode, TNodeType.ElementContainer);
   const currentQueries = lView[QUERIES];
   if (currentQueries) {
-    lView[QUERIES] = currentQueries.addNode(previousOrParentTNode as TElementContainerNode);
+    lView[QUERIES] =
+        isContentQueryHost(previousOrParentTNode) ? currentQueries.parent : currentQueries;
   }
 
   registerPostOrderHooks(tView, previousOrParentTNode);
@@ -591,6 +597,11 @@ export function elementStart(
   // it will take that over for us (this will be removed once #FW-882 is in).
   if (tNode.stylingTemplate && (tNode.flags & TNodeFlags.hasClassInput) === 0) {
     renderInitialStylesAndClasses(native, tNode.stylingTemplate, lView[RENDERER]);
+  }
+
+  const currentQueries = lView[QUERIES];
+  if (currentQueries) {
+    currentQueries.addNode(tNode);
   }
 }
 
@@ -1027,7 +1038,8 @@ export function elementEnd(): void {
   const lView = getLView();
   const currentQueries = lView[QUERIES];
   if (currentQueries) {
-    lView[QUERIES] = currentQueries.addNode(previousOrParentTNode as TElementNode);
+    lView[QUERIES] =
+        isContentQueryHost(previousOrParentTNode) ? currentQueries.parent : currentQueries;
   }
 
   registerPostOrderHooks(getLView()[TVIEW], previousOrParentTNode);

--- a/packages/core/test/linker/query_integration_spec.ts
+++ b/packages/core/test/linker/query_integration_spec.ts
@@ -53,10 +53,8 @@ describe('Query API', () => {
   }));
 
   describe('querying by directive type', () => {
-    fixmeIvy(
-        'FW-781 - Directives invocation sequence on root and nested elements is different in Ivy')
-        .it('should contain all direct child directives in the light dom (constructor)', () => {
-          const template = `
+    it('should contain all direct child directives in the light dom (constructor)', () => {
+      const template = `
             <div text="1"></div>
             <needs-query text="2">
               <div text="3">
@@ -65,10 +63,10 @@ describe('Query API', () => {
             </needs-query>
             <div text="4"></div>
           `;
-          const view = createTestCmpAndDetectChanges(MyComp0, template);
+      const view = createTestCmpAndDetectChanges(MyComp0, template);
 
-          expect(asNativeElements(view.debugElement.children)).toHaveText('2|3|');
-        });
+      expect(asNativeElements(view.debugElement.children)).toHaveText('2|3|');
+    });
 
     it('should contain all direct child directives in the content dom', () => {
       const template = '<needs-content-children #q><div text="foo"></div></needs-content-children>';
@@ -97,7 +95,7 @@ describe('Query API', () => {
     });
 
     fixmeIvy(
-        'FW-781 - Directives invocation sequence on root and nested elements is different in Ivy')
+        'FW-982: For queries, ng-template own directives should be registered before the ones from inside the template')
         .it('should contain the first content child when target is on <ng-template> with embedded view (issue #16568)',
             () => {
               const template =
@@ -168,43 +166,37 @@ describe('Query API', () => {
       expect(q.logs).toEqual([['setter', null], ['check', null]]);
     });
 
-    fixmeIvy(
-        'FW-781 - Directives invocation sequence on root and nested elements is different in Ivy')
-        .it('should contain all directives in the light dom when descendants flag is used', () => {
-          const template = '<div text="1"></div>' +
-              '<needs-query-desc text="2"><div text="3">' +
-              '<div text="4"></div>' +
-              '</div></needs-query-desc>' +
-              '<div text="5"></div>';
-          const view = createTestCmpAndDetectChanges(MyComp0, template);
+    it('should contain all directives in the light dom when descendants flag is used', () => {
+      const template = '<div text="1"></div>' +
+          '<needs-query-desc text="2"><div text="3">' +
+          '<div text="4"></div>' +
+          '</div></needs-query-desc>' +
+          '<div text="5"></div>';
+      const view = createTestCmpAndDetectChanges(MyComp0, template);
 
-          expect(asNativeElements(view.debugElement.children)).toHaveText('2|3|4|');
-        });
+      expect(asNativeElements(view.debugElement.children)).toHaveText('2|3|4|');
+    });
 
-    fixmeIvy(
-        'FW-781 - Directives invocation sequence on root and nested elements is different in Ivy')
-        .it('should contain all directives in the light dom', () => {
-          const template = '<div text="1"></div>' +
-              '<needs-query text="2"><div text="3"></div></needs-query>' +
-              '<div text="4"></div>';
-          const view = createTestCmpAndDetectChanges(MyComp0, template);
+    it('should contain all directives in the light dom', () => {
+      const template = '<div text="1"></div>' +
+          '<needs-query text="2"><div text="3"></div></needs-query>' +
+          '<div text="4"></div>';
+      const view = createTestCmpAndDetectChanges(MyComp0, template);
 
-          expect(asNativeElements(view.debugElement.children)).toHaveText('2|3|');
-        });
+      expect(asNativeElements(view.debugElement.children)).toHaveText('2|3|');
+    });
 
-    fixmeIvy(
-        'FW-781 - Directives invocation sequence on root and nested elements is different in Ivy')
-        .it('should reflect dynamically inserted directives', () => {
-          const template = '<div text="1"></div>' +
-              '<needs-query text="2"><div *ngIf="shouldShow" [text]="\'3\'"></div></needs-query>' +
-              '<div text="4"></div>';
-          const view = createTestCmpAndDetectChanges(MyComp0, template);
-          expect(asNativeElements(view.debugElement.children)).toHaveText('2|');
+    it('should reflect dynamically inserted directives', () => {
+      const template = '<div text="1"></div>' +
+          '<needs-query text="2"><div *ngIf="shouldShow" [text]="\'3\'"></div></needs-query>' +
+          '<div text="4"></div>';
+      const view = createTestCmpAndDetectChanges(MyComp0, template);
+      expect(asNativeElements(view.debugElement.children)).toHaveText('2|');
 
-          view.componentInstance.shouldShow = true;
-          view.detectChanges();
-          expect(asNativeElements(view.debugElement.children)).toHaveText('2|3|');
-        });
+      view.componentInstance.shouldShow = true;
+      view.detectChanges();
+      expect(asNativeElements(view.debugElement.children)).toHaveText('2|3|');
+    });
 
     it('should be cleanly destroyed when a query crosses view boundaries', () => {
       const template = '<div text="1"></div>' +
@@ -217,19 +209,17 @@ describe('Query API', () => {
       view.destroy();
     });
 
-    fixmeIvy(
-        'FW-781 - Directives invocation sequence on root and nested elements is different in Ivy')
-        .it('should reflect moved directives', () => {
-          const template = '<div text="1"></div>' +
-              '<needs-query text="2"><div *ngFor="let  i of list" [text]="i"></div></needs-query>' +
-              '<div text="4"></div>';
-          const view = createTestCmpAndDetectChanges(MyComp0, template);
-          expect(asNativeElements(view.debugElement.children)).toHaveText('2|1d|2d|3d|');
+    it('should reflect moved directives', () => {
+      const template = '<div text="1"></div>' +
+          '<needs-query text="2"><div *ngFor="let  i of list" [text]="i"></div></needs-query>' +
+          '<div text="4"></div>';
+      const view = createTestCmpAndDetectChanges(MyComp0, template);
+      expect(asNativeElements(view.debugElement.children)).toHaveText('2|1d|2d|3d|');
 
-          view.componentInstance.list = ['3d', '2d'];
-          view.detectChanges();
-          expect(asNativeElements(view.debugElement.children)).toHaveText('2|3d|2d|');
-        });
+      view.componentInstance.list = ['3d', '2d'];
+      view.detectChanges();
+      expect(asNativeElements(view.debugElement.children)).toHaveText('2|3d|2d|');
+    });
 
     it('should throw with descriptive error when query selectors are not present', () => {
       TestBed.configureTestingModule({declarations: [MyCompBroken0, HasNullQueryCondition]});
@@ -472,25 +462,19 @@ describe('Query API', () => {
   });
 
   describe('querying in the view', () => {
-    fixmeIvy(
-        'FW-781 - Directives invocation sequence on root and nested elements is different in Ivy')
-        .it('should contain all the elements in the view with that have the given directive',
-            () => {
-              const template =
-                  '<needs-view-query #q><div text="ignoreme"></div></needs-view-query>';
-              const view = createTestCmpAndDetectChanges(MyComp0, template);
-              const q: NeedsViewQuery = view.debugElement.children[0].references !['q'];
-              expect(q.query.map((d: TextDirective) => d.text)).toEqual(['1', '2', '3', '4']);
-            });
+    it('should contain all the elements in the view with that have the given directive', () => {
+      const template = '<needs-view-query #q><div text="ignoreme"></div></needs-view-query>';
+      const view = createTestCmpAndDetectChanges(MyComp0, template);
+      const q: NeedsViewQuery = view.debugElement.children[0].references !['q'];
+      expect(q.query.map((d: TextDirective) => d.text)).toEqual(['1', '2', '3', '4']);
+    });
 
-    fixmeIvy(
-        'FW-781 - Directives invocation sequence on root and nested elements is different in Ivy')
-        .it('should not include directive present on the host element', () => {
-          const template = '<needs-view-query #q text="self"></needs-view-query>';
-          const view = createTestCmpAndDetectChanges(MyComp0, template);
-          const q: NeedsViewQuery = view.debugElement.children[0].references !['q'];
-          expect(q.query.map((d: TextDirective) => d.text)).toEqual(['1', '2', '3', '4']);
-        });
+    it('should not include directive present on the host element', () => {
+      const template = '<needs-view-query #q text="self"></needs-view-query>';
+      const view = createTestCmpAndDetectChanges(MyComp0, template);
+      const q: NeedsViewQuery = view.debugElement.children[0].references !['q'];
+      expect(q.query.map((d: TextDirective) => d.text)).toEqual(['1', '2', '3', '4']);
+    });
 
     it('should reflect changes in the component', () => {
       const template = '<needs-view-query-if #q></needs-view-query-if>';

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -2799,7 +2799,7 @@ describe('query', () => {
           selectors: [['', 'content-query', '']],
           factory: () => contentQueryDirective = new ContentQueryDirective(),
           contentQueries:
-              (dirIndex) => { registerContentQuery(query(null, TextDirective, true), dirIndex); },
+              (dirIndex) => { registerContentQuery(query(TextDirective, true), dirIndex); },
           contentQueriesRefresh: (dirIndex: number, queryStartIdx: number) => {
             let tmp: any;
             const instance = load<ContentQueryDirective>(dirIndex);
@@ -2863,25 +2863,29 @@ describe('query', () => {
           type: ViewQueryComponent,
           selectors: [['view-query']],
           factory: () => new ViewQueryComponent(),
-          template: function(rf: RenderFlags, ctx: any) {
+          template: function(rf: RenderFlags, ctx: ViewQueryComponent) {
             if (rf & RenderFlags.Create) {
-              query(0, TextDirective, true);
-              element(1, 'span', ['text', 'A']);
-              elementStart(2, 'div', ['text', 'B']);
-              elementStart(3, 'span', ['text', 'C']);
-              { element(4, 'span', ['text', 'D']); }
+              element(0, 'span', ['text', 'A']);
+              elementStart(1, 'div', ['text', 'B']);
+              elementStart(2, 'span', ['text', 'C']);
+              { element(3, 'span', ['text', 'D']); }
               elementEnd();
               elementEnd();
-              element(5, 'span', ['text', 'E']);
+              element(4, 'span', ['text', 'E']);
+            }
+          },
+          consts: 5,
+          vars: 0,
+          viewQuery: function(rf: RenderFlags, ctx: ViewQueryComponent) {
+            let tmp: any;
+            if (rf & RenderFlags.Create) {
+              viewQuery(TextDirective, true);
             }
             if (rf & RenderFlags.Update) {
-              let tmp: any;
-              queryRefresh(tmp = load<QueryList<TextDirective>>(0)) &&
+              queryRefresh(tmp = loadViewQuery<QueryList<TextDirective>>()) &&
                   (ctx.texts = tmp as QueryList<TextDirective>);
             }
           },
-          consts: 6,
-          vars: 0,
           directives: [TextDirective]
         });
       }


### PR DESCRIPTION
This PR fixes FW-781.

In order to have the right order in queries' results, the matching is moved from `elementEnd()/elementContainerEnd()` to `elementStart()/elementContainerStart()`.

Edit: both unit tests currently return `['A', 'D', 'C, 'B', 'E'] without this fix.