### PR TITLE
fix(ivy): error when encountering an empty class attribute

### DIFF
--- a/packages/core/src/render3/styling/class_and_style_bindings.ts
+++ b/packages/core/src/render3/styling/class_and_style_bindings.ts
@@ -982,14 +982,17 @@ function setClass(
     if (playerBuilder) {
       playerBuilder.setValue(className, add);
     }
-  } else if (add) {
-    ngDevMode && ngDevMode.rendererAddClass++;
-    isProceduralRenderer(renderer) ? renderer.addClass(native, className) :
-                                     native['classList'].add(className);
-  } else {
-    ngDevMode && ngDevMode.rendererRemoveClass++;
-    isProceduralRenderer(renderer) ? renderer.removeClass(native, className) :
-                                     native['classList'].remove(className);
+    // DOMTokenList will throw if we try to add or remove an empty string.
+  } else if (className !== '') {
+    if (add) {
+      ngDevMode && ngDevMode.rendererAddClass++;
+      isProceduralRenderer(renderer) ? renderer.addClass(native, className) :
+                                       native['classList'].add(className);
+    } else {
+      ngDevMode && ngDevMode.rendererRemoveClass++;
+      isProceduralRenderer(renderer) ? renderer.removeClass(native, className) :
+                                       native['classList'].remove(className);
+    }
   }
 }
 

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -317,6 +317,13 @@ function declareTests(config?: {useJit: boolean}) {
       expect(ctx.componentInstance.viewContainers.first).toBe(vc);
     });
 
+    it('should not throw when encountering an empty class attribute', () => {
+      const template = '<div class=""></div>';
+      TestBed.overrideComponent(MyComp1, {set: {template}});
+
+      expect(() => TestBed.createComponent(MyComp1)).not.toThrow();
+    });
+
     describe('empty templates - #15143', () => {
       it('should allow empty components', () => {
         @Component({template: ''})


### PR DESCRIPTION
Fixes Ivy throwing an error if it encounters an empty class attribute in a template (`class=""`).

This PR resolves FW-972.
