### PR TITLE
feat(core): Make TestBed.get() type safe.

### DIFF
--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -775,14 +775,16 @@ describe('AppComponent', () => {
 
       describe('showing search results', () => {
         it('should not display search results when query is empty', () => {
-          const searchService: MockSearchService = TestBed.get(SearchService);
+          // tslint:disable-next-line:no-any forcing assignment of incompatible type
+          const searchService: MockSearchService = TestBed.get(SearchService) as any;
           searchService.searchResults.next({ query: '', results: [] });
           fixture.detectChanges();
           expect(component.showSearchResults).toBe(false);
         });
 
         it('should hide the results when a search result is selected', () => {
-          const searchService: MockSearchService = TestBed.get(SearchService);
+          // tslint:disable-next-line:no-any forcing assignment of incompatible type
+          const searchService: MockSearchService = TestBed.get(SearchService) as any;
 
           const results = [
             { path: 'news', title: 'News', type: 'marketing', keywords: '', titleWords: '', deprecated: false }

--- a/aio/src/app/custom-elements/announcement-bar/announcement-bar.component.spec.ts
+++ b/aio/src/app/custom-elements/announcement-bar/announcement-bar.component.spec.ts
@@ -19,14 +19,15 @@ describe('AnnouncementBarComponent', () => {
   let mockLogger: MockLogger;
 
   beforeEach(() => {
-    const injector = TestBed.configureTestingModule({
+    TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       declarations: [AnnouncementBarComponent],
       providers: [{ provide: Logger, useClass: MockLogger }]
     });
 
-    httpMock = injector.get(HttpTestingController);
-    mockLogger = injector.get(Logger);
+    httpMock = TestBed.get(HttpTestingController);
+    // tslint:disable-next-line:no-any forcing assignment of incompatible type
+    mockLogger = TestBed.get(Logger) as any;
     fixture = TestBed.createComponent(AnnouncementBarComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement;

--- a/aio/src/app/custom-elements/code/code.component.spec.ts
+++ b/aio/src/app/custom-elements/code/code.component.spec.ts
@@ -254,7 +254,8 @@ describe('CodeComponent', () => {
     it('should display an error when copy fails', () => {
       const snackBar: MatSnackBar = TestBed.get(MatSnackBar);
       const copierService: CopierService = TestBed.get(CopierService);
-      const logger: TestLogger = TestBed.get(Logger);
+      // tslint:disable-next-line:no-any forcing assignment of incompatible type
+      const logger: TestLogger = TestBed.get(Logger) as any;
       spyOn(snackBar, 'open');
       spyOn(copierService, 'copyText').and.returnValue(false);
       getButton().click();

--- a/aio/src/app/custom-elements/lazy-custom-element.component.spec.ts
+++ b/aio/src/app/custom-elements/lazy-custom-element.component.spec.ts
@@ -23,7 +23,8 @@ describe('LazyCustomElementComponent', () => {
       ],
     });
 
-    mockLogger = injector.get(Logger);
+    // tslint:disable-next-line:no-any forcing assignment of incompatible type
+    mockLogger = injector.get(Logger) as any;
     fixture = TestBed.createComponent(LazyCustomElementComponent);
   });
 

--- a/aio/src/app/custom-elements/toc/toc.component.spec.ts
+++ b/aio/src/app/custom-elements/toc/toc.component.spec.ts
@@ -48,7 +48,8 @@ describe('TocComponent', () => {
       fixture = TestBed.createComponent(HostEmbeddedTocComponent);
       tocComponentDe = fixture.debugElement.children[0];
       tocComponent = tocComponentDe.componentInstance;
-      tocService = TestBed.get(TocService);
+      // tslint:disable-next-line:no-any forcing assignment of incompatible type
+      tocService = TestBed.get(TocService) as any;
     });
 
     it('should create tocComponent', () => {
@@ -134,7 +135,8 @@ describe('TocComponent', () => {
       beforeEach(() => {
         fixture.detectChanges();
         page = setPage();
-        scrollToTopSpy = TestBed.get(ScrollService).scrollToTop;
+        // tslint:disable-next-line:no-any forcing assignment of incompatible type
+        scrollToTopSpy = TestBed.get(ScrollService).scrollToTop as any;
       });
 
       it('should have more than 4 displayed items', () => {
@@ -248,7 +250,8 @@ describe('TocComponent', () => {
 
       tocComponentDe = fixture.debugElement.children[0];
       tocComponent = tocComponentDe.componentInstance;
-      tocService = TestBed.get(TocService);
+      // tslint:disable-next-line:no-any forcing assignment of incompatible type
+      tocService = TestBed.get(TocService) as any;
 
       fixture.detectChanges();
       page = setPage();

--- a/aio/src/app/documents/document.service.spec.ts
+++ b/aio/src/app/documents/document.service.spec.ts
@@ -32,9 +32,11 @@ describe('DocumentService', () => {
     const injector = createInjector(initialUrl);
     httpMock = injector.get(HttpTestingController) as HttpTestingController;
     return {
-      locationService: injector.get(LocationService) as MockLocationService,
+      // tslint:disable-next-line:no-any forcing assignment of incompatible type
+      locationService: injector.get(LocationService) as any as MockLocationService,
       docService: injector.get(DocumentService) as DocumentService,
-      logger: injector.get(Logger) as MockLogger
+      // tslint:disable-next-line:no-any forcing assignment of incompatible type
+      logger: injector.get(Logger) as any as MockLogger
     };
   }
 

--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
@@ -128,8 +128,10 @@ describe('DocViewerComponent', () => {
     };
 
     beforeEach(() => {
-      titleService = TestBed.get(Title);
-      tocService = TestBed.get(TocService);
+      // tslint:disable-next-line:no-any forcing assignment of incompatible type
+      titleService = TestBed.get(Title) as any;
+      // tslint:disable-next-line:no-any forcing assignment of incompatible type
+      tocService = TestBed.get(TocService) as any;
 
       targetEl = document.createElement('div');
       document.body.appendChild(targetEl);  // Required for `innerText` to work as expected.
@@ -299,7 +301,8 @@ describe('DocViewerComponent', () => {
       docViewer.render({contents, id}).toPromise();
 
     beforeEach(() => {
-      const elementsLoader = TestBed.get(ElementsLoader) as MockElementsLoader;
+      // tslint:disable-next-line:no-any forcing assignment of incompatible type
+      const elementsLoader: MockElementsLoader = TestBed.get(ElementsLoader) as any;
       loadElementsSpy = elementsLoader.loadContainedCustomElements.and.returnValue(of(undefined));
       prepareTitleAndTocSpy = spyOn(docViewer, 'prepareTitleAndToc');
       swapViewsSpy = spyOn(docViewer, 'swapViews').and.returnValue(of(undefined));
@@ -454,7 +457,10 @@ describe('DocViewerComponent', () => {
     describe('(on error) should clean up, log the error and recover', () => {
       let logger: MockLogger;
 
-      beforeEach(() => logger = TestBed.get(Logger));
+      beforeEach(() => {
+        // tslint:disable-next-line:no-any forcing assignment of incompatible type
+        logger = TestBed.get(Logger) as any;
+      });
 
       it('when `prepareTitleAndTocSpy()` fails', async () => {
         const error = Error('Typical `prepareTitleAndToc()` error');

--- a/aio/src/app/layout/notification/notification.component.spec.ts
+++ b/aio/src/app/layout/notification/notification.component.spec.ts
@@ -92,7 +92,7 @@ describe('NotificationComponent', () => {
   it('should update localStorage key when dismiss is called', () => {
     configTestingModule();
     createComponent();
-    const setItemSpy: jasmine.Spy = TestBed.get(WindowToken).localStorage.setItem;
+    const setItemSpy = TestBed.get(WindowToken).localStorage.setItem as jasmine.Spy;
     component.dismiss();
     expect(setItemSpy).toHaveBeenCalledWith('aio-notification/survey-january-2018', 'hide');
   });
@@ -105,7 +105,7 @@ describe('NotificationComponent', () => {
 
   it('should not show the notification if the there is a "hide" flag in localStorage', () => {
     configTestingModule();
-    const getItemSpy: jasmine.Spy = TestBed.get(WindowToken).localStorage.getItem;
+    const getItemSpy = TestBed.get(WindowToken).localStorage.getItem as jasmine.Spy;
     getItemSpy.and.returnValue('hide');
     createComponent();
     expect(getItemSpy).toHaveBeenCalledWith('aio-notification/survey-january-2018');

--- a/aio/src/app/shared/reporting-error-handler.spec.ts
+++ b/aio/src/app/shared/reporting-error-handler.spec.ts
@@ -22,7 +22,8 @@ describe('ReportingErrorHandler service', () => {
   });
 
   it('should be registered on the AppModule', () => {
-    handler = TestBed.configureTestingModule({ imports: [AppModule] }).get(ErrorHandler);
+    // tslint:disable-next-line:no-any forcing assignment of incompatible type
+    handler = TestBed.configureTestingModule({ imports: [AppModule] }).get(ErrorHandler) as any;
     expect(handler).toEqual(jasmine.any(ReportingErrorHandler));
   });
 

--- a/aio/src/app/shared/window.ts
+++ b/aio/src/app/shared/window.ts
@@ -1,4 +1,4 @@
 import { InjectionToken } from '@angular/core';
 
-export const WindowToken = new InjectionToken('Window');
+export const WindowToken = new InjectionToken<Window>('Window');
 export function windowProvider() { return window; }

--- a/packages/core/src/interface/type.ts
+++ b/packages/core/src/interface/type.ts
@@ -24,6 +24,8 @@ export function isType(v: any): v is Type<any> {
 
 export interface Type<T> extends Function { new (...args: any[]): T; }
 
+export type AbstractType<T> = T extends{prototype: infer U} ? Exclude<U, Type<any>>: never;
+
 export type Mutable<T extends{[x: string]: any}, K extends string> = {
   [P in K]: T[P];
 };

--- a/packages/core/test/animation/animation_integration_spec.ts
+++ b/packages/core/test/animation/animation_integration_spec.ts
@@ -1444,7 +1444,7 @@ const DEFAULT_COMPONENT_ID = '1';
         fixture.detectChanges();
         engine.flush();
 
-        const player = engine.players.pop();
+        const player = engine.players.pop() !;
         player.finish();
 
         expect(getDOM().hasStyle(cmp.element.nativeElement, 'background-color', 'green'))
@@ -2510,7 +2510,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
            expect(cmp.event).toBeFalsy();
 
-           const player = engine.players.pop();
+           const player = engine.players.pop() !;
            player.finish();
            flushMicrotasks();
 

--- a/packages/core/test/animation/animation_query_integration_spec.ts
+++ b/packages/core/test/animation/animation_query_integration_spec.ts
@@ -2733,7 +2733,8 @@ import {HostListener} from '../../src/metadata/directives';
         expect(players.length).toEqual(2);
         expect(engine.players.length).toEqual(1);
 
-        expect(engine.players[0].getRealPlayer()).toBe(players[1]);
+        // tslint:disable-next-line:no-any testing private method
+        expect((engine.players[0] as any).getRealPlayer()).toBe(players[1]);
       });
 
       it('should fire and synchronize the start/done callbacks on sub triggers even if they are not allowed to animate within the animation',
@@ -2972,7 +2973,8 @@ import {HostListener} from '../../src/metadata/directives';
            engine.flush();
 
            expect(engine.players.length).toEqual(1);  // child player, parent cover, parent player
-           const groupPlayer = engine.players[0].getRealPlayer() as AnimationGroupPlayer;
+           // tslint:disable-next-line:no-any testing private method
+           const groupPlayer = (engine.players[0] as any).getRealPlayer() as AnimationGroupPlayer;
            const childPlayer = groupPlayer.players.find(player => {
              if (player instanceof MockAnimationPlayer) {
                return matchesElement(player.element, '.child');

--- a/packages/core/test/animation/animation_router_integration_spec.ts
+++ b/packages/core/test/animation/animation_router_integration_spec.ts
@@ -131,7 +131,8 @@ import {RouterTestingModule} from '@angular/router/testing';
          engine.flush();
 
          const player = engine.players[0] !;
-         const groupPlayer = player.getRealPlayer() as AnimationGroupPlayer;
+         // tslint:disable-next-line:no-any testing private method
+         const groupPlayer = (player as any).getRealPlayer() as AnimationGroupPlayer;
          const players = groupPlayer.players as MockAnimationPlayer[];
 
          expect(players.length).toEqual(2);
@@ -238,7 +239,8 @@ import {RouterTestingModule} from '@angular/router/testing';
          engine.flush();
 
          const player = engine.players[0] !;
-         const groupPlayer = player.getRealPlayer() as AnimationGroupPlayer;
+         // tslint:disable-next-line:no-any testing private method
+         const groupPlayer = (player as any).getRealPlayer() as AnimationGroupPlayer;
          const players = groupPlayer.players as MockAnimationPlayer[];
 
          expect(players.length).toEqual(2);
@@ -342,7 +344,8 @@ import {RouterTestingModule} from '@angular/router/testing';
          engine.flush();
 
          const player = engine.players[0] !;
-         const groupPlayer = player.getRealPlayer() as AnimationGroupPlayer;
+         // tslint:disable-next-line:no-any testing private method
+         const groupPlayer = (player as any).getRealPlayer() as AnimationGroupPlayer;
          const players = groupPlayer.players as MockAnimationPlayer[];
 
          expect(players.length).toEqual(2);
@@ -438,7 +441,8 @@ import {RouterTestingModule} from '@angular/router/testing';
          expect(players.length).toEqual(1);
          const [p1] = players;
 
-         const innerPlayers = p1.getRealPlayer().players;
+         // tslint:disable-next-line:no-any testing private method
+         const innerPlayers = (p1 as any).getRealPlayer().players;
          expect(innerPlayers.length).toEqual(2);
 
          const [ip1, ip2] = innerPlayers;

--- a/packages/core/test/animation/animations_with_css_keyframes_animations_integration_spec.ts
+++ b/packages/core/test/animation/animations_with_css_keyframes_animations_integration_spec.ts
@@ -303,7 +303,7 @@ import {TestBed} from '../../testing';
 
          expect(foo.style.getPropertyValue('max-height')).toEqual('0px');
 
-         const player = engine.players.pop();
+         const player = engine.players.pop() !;
          player.finish();
 
          expect(foo.style.getPropertyValue('max-height')).toBeFalsy();

--- a/packages/core/test/animation/animations_with_web_animations_integration_spec.ts
+++ b/packages/core/test/animation/animations_with_web_animations_integration_spec.ts
@@ -62,7 +62,8 @@ import {fixmeIvy} from '@angular/private/testing';
       fixture.detectChanges();
 
       expect(engine.players.length).toEqual(1);
-      let webPlayer = engine.players[0].getRealPlayer() as ɵWebAnimationsPlayer;
+      // tslint:disable-next-line:no-any testing private method
+      let webPlayer = (engine.players[0] as any).getRealPlayer() as ɵWebAnimationsPlayer;
 
       expect(webPlayer.keyframes).toEqual([
         {height: '0px', offset: 0}, {height: '100px', offset: 1}
@@ -76,7 +77,8 @@ import {fixmeIvy} from '@angular/private/testing';
         engine.flush();
 
         expect(engine.players.length).toEqual(1);
-        webPlayer = engine.players[0].getRealPlayer() as ɵWebAnimationsPlayer;
+        // tslint:disable-next-line:no-any testing private method
+        webPlayer = (engine.players[0] as any).getRealPlayer() as ɵWebAnimationsPlayer;
 
         expect(webPlayer.keyframes).toEqual([
           {height: '100px', offset: 0}, {height: '0px', offset: 1}
@@ -116,7 +118,8 @@ import {fixmeIvy} from '@angular/private/testing';
       engine.flush();
 
       expect(engine.players.length).toEqual(1);
-      let webPlayer = engine.players[0].getRealPlayer() as ɵWebAnimationsPlayer;
+      // tslint:disable-next-line:no-any testing private method
+      let webPlayer = (engine.players[0] as any).getRealPlayer() as ɵWebAnimationsPlayer;
 
       expect(webPlayer.keyframes).toEqual([
         {height: '100px', offset: 0}, {height: '120px', offset: 1}
@@ -155,7 +158,8 @@ import {fixmeIvy} from '@angular/private/testing';
 
       expect(engine.players.length).toEqual(1);
       let player = engine.players[0];
-      let webPlayer = player.getRealPlayer() as ɵWebAnimationsPlayer;
+      // tslint:disable-next-line:no-any testing private method
+      let webPlayer = (player as any).getRealPlayer() as ɵWebAnimationsPlayer;
 
       expect(webPlayer.keyframes).toEqual([
         {height: '0px', offset: 0}, {height: '100px', offset: 1}
@@ -173,7 +177,8 @@ import {fixmeIvy} from '@angular/private/testing';
 
       expect(engine.players.length).toEqual(1);
       player = engine.players[0];
-      webPlayer = player.getRealPlayer() as ɵWebAnimationsPlayer;
+      // tslint:disable-next-line:no-any testing private method
+      webPlayer = (player as any).getRealPlayer() as ɵWebAnimationsPlayer;
 
       expect(webPlayer.keyframes).toEqual([
         {height: '100px', offset: 0}, {height: '80px', offset: 1}
@@ -224,7 +229,8 @@ import {fixmeIvy} from '@angular/private/testing';
       fixture.detectChanges();
 
       let player = engine.players[0] !;
-      let webPlayer = player.getRealPlayer() as ɵWebAnimationsPlayer;
+      // tslint:disable-next-line:no-any testing private method
+      let webPlayer = (player as any).getRealPlayer() as ɵWebAnimationsPlayer;
       expect(webPlayer.keyframes).toEqual([
         {height: '0px', offset: 0},
         {height: '300px', offset: 1},
@@ -235,7 +241,8 @@ import {fixmeIvy} from '@angular/private/testing';
       fixture.detectChanges();
 
       player = engine.players[0] !;
-      webPlayer = player.getRealPlayer() as ɵWebAnimationsPlayer;
+      // tslint:disable-next-line:no-any testing private method
+      webPlayer = (player as any).getRealPlayer() as ɵWebAnimationsPlayer;
       expect(webPlayer.keyframes).toEqual([
         {height: '300px', offset: 0},
         {height: '0px', offset: 1},
@@ -245,8 +252,8 @@ import {fixmeIvy} from '@angular/private/testing';
     it('should treat * styles as ! for queried items that are collected in a container that is being removed',
        () => {
          @Component({
-            selector: 'my-app',
-            styles: [`
+          selector: 'my-app',
+          styles: [`
               .list .outer {
                 overflow:hidden;
               }
@@ -254,7 +261,7 @@ import {fixmeIvy} from '@angular/private/testing';
                 line-height:50px;
               }
             `],
-            template: `
+          template: `
               <button (click)="empty()">Empty</button>
               <button (click)="middle()">Middle</button>
               <button (click)="full()">Full</button>
@@ -267,22 +274,22 @@ import {fixmeIvy} from '@angular/private/testing';
                 </div>
               </div>
             `,
-            animations: [
-              trigger('list', [
-                transition(':enter', []),
-                transition('* => empty', [
-                  query(':leave', [
-                    animate(500, style({ height: '0px' }))
-                  ])
-                ]),
-                transition('* => full', [
-                  query(':enter', [
-                    style({ height: '0px' }),
-                    animate(500, style({ height: '*' }))
-                  ])
-                ]),
-              ])
-            ]
+          animations: [
+            trigger('list', [
+              transition(':enter', []),
+              transition('* => empty', [
+                query(':leave', [
+                  animate(500, style({ height: '0px' }))
+                ])
+              ]),
+              transition('* => full', [
+                query(':enter', [
+                  style({ height: '0px' }),
+                  animate(500, style({ height: '*' }))
+                ])
+              ]),
+            ])
+          ]
         })
         class Cmp {
            items: any[] = [];
@@ -373,14 +380,16 @@ import {fixmeIvy} from '@angular/private/testing';
       fixture.detectChanges();
 
       let player = engine.players[0] !;
-      let webPlayer = player.getRealPlayer() as ɵWebAnimationsPlayer;
+      // tslint:disable-next-line:no-any testing private method
+      let webPlayer = (player as any).getRealPlayer() as ɵWebAnimationsPlayer;
       webPlayer.setPosition(0.5);
 
       cmp.exp = 'b';
       fixture.detectChanges();
 
       player = engine.players[0] !;
-      webPlayer = player.getRealPlayer() as ɵWebAnimationsPlayer;
+      // tslint:disable-next-line:no-any testing private method
+      webPlayer = (player as any).getRealPlayer() as ɵWebAnimationsPlayer;
       expect(approximate(parseFloat(webPlayer.keyframes[0]['width'] as string), 150))
           .toBeLessThan(0.05);
       expect(approximate(parseFloat(webPlayer.keyframes[0]['height'] as string), 300))
@@ -429,7 +438,8 @@ import {fixmeIvy} from '@angular/private/testing';
          fixture.detectChanges();
 
          let player = engine.players[0] !;
-         let groupPlayer = player.getRealPlayer() as AnimationGroupPlayer;
+         // tslint:disable-next-line:no-any testing private method
+         let groupPlayer = (player as any).getRealPlayer() as AnimationGroupPlayer;
          let players = groupPlayer.players;
          expect(players.length).toEqual(5);
 
@@ -443,7 +453,8 @@ import {fixmeIvy} from '@angular/private/testing';
          fixture.detectChanges();
 
          player = engine.players[0];
-         groupPlayer = player.getRealPlayer() as AnimationGroupPlayer;
+         // tslint:disable-next-line:no-any testing private method
+         groupPlayer = (player as any).getRealPlayer() as AnimationGroupPlayer;
          players = groupPlayer.players;
 
          expect(players.length).toEqual(5);

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -26,7 +26,7 @@ import {modifiedInIvy, obsoleteInIvy, onlyInIvy} from '@angular/private/testing'
 
 import {stringify} from '../../src/util/stringify';
 
-const ANCHOR_ELEMENT = new InjectionToken('AnchorElement');
+const ANCHOR_ELEMENT = new InjectionToken<HTMLAnchorElement>('AnchorElement');
 
 if (ivyEnabled) {
   describe('ivy', () => { declareTests(); });
@@ -1157,7 +1157,8 @@ function declareTests(config?: {useJit: boolean}) {
             const compFixture =
                 TestBed.configureTestingModule({imports: [RootModule]}).createComponent(RootComp);
             const compiler = <Compiler>TestBed.get(Compiler);
-            const myModule = compiler.compileModuleSync(MyModule).create(TestBed.get(NgModuleRef));
+            const myModule =
+                compiler.compileModuleSync(MyModule).create(TestBed.get(NgModuleRef).injector);
             const myCompFactory = (<ComponentFactoryResolver>TestBed.get(ComponentFactoryResolver))
                                       .resolveComponentFactory(MyComp);
 
@@ -1200,7 +1201,7 @@ function declareTests(config?: {useJit: boolean}) {
                                        .createComponent(RootComp);
                const compiler = <Compiler>TestBed.get(Compiler);
                const myModule =
-                   compiler.compileModuleSync(MyModule).create(TestBed.get(NgModuleRef));
+                   compiler.compileModuleSync(MyModule).create(TestBed.get(NgModuleRef).injector);
                const myCompFactory =
                    myModule.componentFactoryResolver.resolveComponentFactory(MyComp);
 

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -8,9 +8,15 @@
 
 import {Component, Directive, InjectionToken, NgModule, Pipe, PlatformRef, SchemaMetadata, Type} from '@angular/core';
 
+import {AbstractType} from '../../src/interface/type';
+
 import {ComponentFixture} from './component_fixture';
 import {MetadataOverride} from './metadata_override';
 import {TestBed} from './test_bed';
+
+type InjectorReturnValue<T> = T extends InjectionToken<infer U>?
+    U :
+    T extends Type<any>? InstanceType<T>: T extends string ? unknown : AbstractType<T>;
 
 /**
  * An abstract class for inserting the root test component element in a platform independent way.
@@ -130,7 +136,8 @@ export interface TestBedStatic {
     deps?: any[],
   }): TestBedStatic;
 
-  get(token: any, notFoundValue?: any): any;
+  get<T>(token: T): InjectorReturnValue<T>;
+  get<T1, T2>(token: T1, notFoundValue: T2): InjectorReturnValue<T1>|T2;
 
   createComponent<T>(component: Type<T>): ComponentFixture<T>;
 }

--- a/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
+++ b/packages/platform-webworker/test/web_workers/worker/renderer_v2_integration_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ComponentRef, Renderer2, RendererFactory2, RendererType2, destroyPlatform} from '@angular/core';
+import {Component, ComponentRef, Renderer2, RendererFactory2, RendererType2, Type, destroyPlatform} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {platformBrowserDynamicTesting} from '@angular/platform-browser-dynamic/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
@@ -70,9 +70,9 @@ let lastCreatedRenderer: Renderer2;
           {provide: RenderStore, useValue: wwRenderStore},
           {
             provide: RendererFactory2,
-            useFactory:
-                (wwSerializer: Serializer) => createWebWorkerRendererFactory2(
-                    wwSerializer, uiSerializer, domRendererFactory, uiRenderStore, wwRenderStore),
+            useFactory: (wwSerializer: Serializer) => createWebWorkerRendererFactory2(
+                            wwSerializer, uiSerializer, domRendererFactory as DomRendererFactory2,
+                            uiRenderStore, wwRenderStore),
             deps: [Serializer],
           },
         ],

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1100,7 +1100,7 @@ describe('Integration', () => {
   ['deferred', 'eager'].forEach((strat: any) => {
     it('should dispatch NavigationError after the url has been reset back', fakeAsync(() => {
          const router: Router = TestBed.get(Router);
-         const location: SpyLocation = TestBed.get(Location);
+         const location = TestBed.get(Location) as SpyLocation;
          const fixture = createRoot(router, RootCmp);
 
          router.resetConfig(
@@ -1127,7 +1127,7 @@ describe('Integration', () => {
 
     it('should reset the url with the right state when navigation errors', fakeAsync(() => {
          const router: Router = TestBed.get(Router);
-         const location: SpyLocation = TestBed.get(Location);
+         const location = TestBed.get(Location) as SpyLocation;
          const fixture = createRoot(router, RootCmp);
 
          router.resetConfig([
@@ -1194,7 +1194,7 @@ describe('Integration', () => {
            {providers: [{provide: 'returnsFalse', useValue: () => false}]});
 
        const router: Router = TestBed.get(Router);
-       const location: SpyLocation = TestBed.get(Location);
+       const location = TestBed.get(Location) as SpyLocation;
 
        const fixture = createRoot(router, RootCmp);
 

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -62,15 +62,16 @@ export interface TestBed {
         useValue?: any;
         deps?: any[];
     }): void;
+    deprecatedOverrideProvider(token: any, provider: {
+        useValue: any;
+    }): void;
     /** @deprecated */ deprecatedOverrideProvider(token: any, provider: {
         useFactory: Function;
         deps: any[];
     }): void;
-    deprecatedOverrideProvider(token: any, provider: {
-        useValue: any;
-    }): void;
     execute(tokens: any[], fn: Function, context?: any): any;
-    get(token: any, notFoundValue?: any): any;
+    get<T>(token: T): InjectorReturnValue<T>;
+    get<T1, T2>(token: T1, notFoundValue: T2): InjectorReturnValue<T1> | T2;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): void;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): void;
     overrideDirective(directive: Type<any>, override: MetadataOverride<Directive>): void;
@@ -82,11 +83,11 @@ export interface TestBed {
         deps?: any[];
     }): void;
     overrideProvider(token: any, provider: {
-        useFactory: Function;
-        deps: any[];
+        useValue: any;
     }): void;
     overrideProvider(token: any, provider: {
-        useValue: any;
+        useFactory: Function;
+        deps: any[];
     }): void;
     overrideTemplateUsingTestingModule(component: Type<any>, template: string): void;
     resetTestEnvironment(): void;
@@ -116,7 +117,8 @@ export interface TestBedStatic {
         useFactory: Function;
         deps: any[];
     }): void;
-    get(token: any, notFoundValue?: any): any;
+    get<T1, T2>(token: T1, notFoundValue: T2): InjectorReturnValue<T1> | T2;
+    get<T>(token: T): InjectorReturnValue<T>;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): TestBedStatic;
     overrideDirective(directive: Type<any>, override: MetadataOverride<Directive>): TestBedStatic;


### PR DESCRIPTION
Added stronger type declarations to TestBed (for both pre-Ivy and Ivy)
using conditional types from TS2.8. The TestBed injector should now
infer the correct type given the InjectionToken or the class.
Future work is needed to make the Injector class just as type-safe.

Fixes #26491

BREAKING CHANGE: TestBed.get() used to return `any`, which allowed for
bugs to creep into tests because of potential abuse of the lack of
types. Because TestBed.get() is now stronger-typed, incorrect uses of
the return value will now cause a compilation error.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
```ts
get(x: any, y?: any): any;
```

Issue Number: 26491


## What is the new behavior?
```ts
type InjectorReturnValue<T> = T extends InjectionToken<infer U>? U: T extends Type<any>? InstanceType<T> : T extends string ? unknown : AbstractType<T>;
get<T>(x: T): InjectorReturnValue<T>;
get<T1, T2>(x: T1, y?: T2): InjectorReturnValue<T1>|T2;
```

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Abuse of the lack of type safety will now cause a compilation error and force users to explicitly cast to `any` if they want to keep abusing the return values' type.
Incorrect use due to the lack of type safety will now cause a compilation error and users will notice this problem and fix their tests.

## Other information

I plan to go ahead and do the same for Injector.