### PR TITLE
fix(ivy): save queries at the correct indices

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -2930,6 +2930,7 @@ export function store<T>(index: number, value: T): void {
   const adjustedIndex = index + HEADER_OFFSET;
   if (adjustedIndex >= tView.data.length) {
     tView.data[adjustedIndex] = null;
+    tView.blueprint[adjustedIndex] = null;
   }
   lView[adjustedIndex] = value;
 }

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -23,7 +23,7 @@ import {unusedValueExportToPlacateAjd as unused1} from './interfaces/definition'
 import {unusedValueExportToPlacateAjd as unused2} from './interfaces/injector';
 import {TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeType, unusedValueExportToPlacateAjd as unused3} from './interfaces/node';
 import {LQueries, unusedValueExportToPlacateAjd as unused4} from './interfaces/query';
-import {LView, TVIEW} from './interfaces/view';
+import {HEADER_OFFSET, LView, TVIEW} from './interfaces/view';
 import {getCurrentViewQueryIndex, getIsParent, getLView, getOrCreateCurrentQueries, setCurrentViewQueryIndex} from './state';
 import {isContentQueryHost} from './util';
 import {createElementRef, createTemplateRef} from './view_engine_compatibility';
@@ -407,7 +407,7 @@ export function viewQuery<T>(
   }
   const index = getCurrentViewQueryIndex();
   const viewQuery: QueryList<T> = query<T>(predicate, descend, read);
-  store(index, viewQuery);
+  store(index - HEADER_OFFSET, viewQuery);
   setCurrentViewQueryIndex(index + 1);
   return viewQuery;
 }
@@ -418,5 +418,5 @@ export function viewQuery<T>(
 export function loadViewQuery<T>(): T {
   const index = getCurrentViewQueryIndex();
   setCurrentViewQueryIndex(index + 1);
-  return load<T>(index);
+  return load<T>(index - HEADER_OFFSET);
 }

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -1305,14 +1305,14 @@ describe('query', () => {
                     0, Cmpt_Template_1, 2, 0, 'ng-template', null, ['foo', ''],
                     templateRefExtractor);
                 template(
-                    1, Cmpt_Template_1, 2, 0, 'ng-template', null, ['bar', ''],
+                    2, Cmpt_Template_1, 2, 0, 'ng-template', null, ['bar', ''],
                     templateRefExtractor);
                 template(
-                    2, Cmpt_Template_1, 2, 0, 'ng-template', null, ['baz', ''],
+                    4, Cmpt_Template_1, 2, 0, 'ng-template', null, ['baz', ''],
                     templateRefExtractor);
               }
             },
-            3, 0, [], [],
+            6, 0, [], [],
             function(rf: RenderFlags, ctx: any) {
               if (rf & RenderFlags.Create) {
                 viewQuery(TemplateRef as any, false);
@@ -2160,7 +2160,7 @@ describe('query', () => {
               element(0, 'div', null, ['foo', '']);
             }
           },
-          1, 0, [], [],
+          2, 0, [], [],
           function(rf: RenderFlags, ctx: any) {
             if (rf & RenderFlags.Create) {
               viewQuery(['foo'], false);

--- a/packages/core/test/render3/styling/players_spec.ts
+++ b/packages/core/test/render3/styling/players_spec.ts
@@ -279,8 +279,8 @@ class SuperComp {
     vars: 0,
     template: (rf: RenderFlags, ctx: SuperComp) => {
       if (rf & RenderFlags.Create) {
-        elementStart(1, 'div');
-        element(2, 'child-comp', ['child', ''], ['child', 'child']);
+        elementStart(0, 'div');
+        element(1, 'child-comp', ['child', ''], ['child', 'child']);
         elementEnd();
       }
     },

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -2060,10 +2060,10 @@ describe('ViewContainerRef', () => {
           vars: 0,
           template: (rf: RenderFlags, ctx: DynamicCompWithViewQueries) => {
             if (rf & RenderFlags.Create) {
-              element(1, 'div', ['bar', ''], ['foo', '']);
+              element(0, 'div', ['bar', ''], ['foo', '']);
             }
             // testing only
-            fooEl = getNativeByIndex(1, getLView());
+            fooEl = getNativeByIndex(0, getLView());
           },
           viewQuery: function(rf: RenderFlags, ctx: any) {
             if (rf & RenderFlags.Create) {


### PR DESCRIPTION
Previous to this change, we were storing view queries at the
wrong index. This is because we were passing a raw index to the
store() instruction instead of an adjusted index (i.e. an
index that does not include the HEADER_OFFSET). We had an
additional issue where TView.blueprint was not backfilled
when TView.data was backfilled, so new component instances
created from the blueprint would end up having a shorter LView.
Both of these problems together led to the Material demo app
failing with Ivy. This commit fixes those discrepancies.