### PR TITLE
build(docs-infra): upgrade cli command docs sources to 699743282

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -17,7 +17,7 @@
     "build": "yarn ~~build",
     "prebuild-local": "yarn setup-local",
     "build-local": "yarn ~~build",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 02d2ec250",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 699743282",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#7.2.x](https://github.com/angular/angular/tree/7.2.x) from [cli-builds#7.2.x](https://github.com/angular/cli-builds/tree/7.2.x).
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/02d2ec250...699743282):

**Modified**
- help/generate.json
- help/new.json