### PR TITLE
refactor: couple of fixes to have valid types when using dts bundler (DON'T MERGE)

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -124,6 +124,13 @@ export {
   resolveBody as ɵresolveBody,
 } from './render3/index';
 
+export {
+  injectChangeDetectorRef as erender3InjectChangeDetectorRef,
+  injectElementRef as erender3InjectElementRef,
+  injectTemplateRef as erender3InjectTemplateRef,
+  injectViewContainerRef as erender3InjectViewContainerRef,
+  injectRenderer2 as erender3InjectRenderer2,
+} from './render3/view_engine_compatibility';
 
 export {
   compileComponent as ɵcompileComponent,
@@ -219,6 +226,9 @@ export {
 export {
   getDebugNode__POST_R3__ as ɵgetDebugNode__POST_R3__,
 } from './debug/debug_node';
+export {
+  compileInjectable as erender3CompileInjectable
+} from './di/jit/injectable';
 export {
   SWITCH_COMPILE_INJECTABLE__POST_R3__ as ɵSWITCH_COMPILE_INJECTABLE__POST_R3__,
 } from './di/injectable';

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -18,7 +18,8 @@ import {stringify} from '../util/stringify';
 import {EMPTY_ARRAY, EMPTY_OBJ} from './empty';
 import {NG_COMPONENT_DEF, NG_DIRECTIVE_DEF, NG_MODULE_DEF, NG_PIPE_DEF} from './fields';
 import {BaseDef, ComponentDef, ComponentDefFeature, ComponentQuery, ComponentTemplate, ComponentType, DirectiveDef, DirectiveDefFeature, DirectiveType, DirectiveTypesOrFactory, HostBindingsFunction, PipeDef, PipeType, PipeTypesOrFactory} from './interfaces/definition';
-import {CssSelectorList} from './interfaces/projection';
+// while SelectorFlags is unused here, it's required so that types don't get resolved lazily
+import {CssSelectorList, SelectorFlags} from './interfaces/projection';
 
 let _renderCompCount = 0;
 


### PR DESCRIPTION
Workarounds for https://github.com/Microsoft/web-build-tools/issues/1048 and https://github.com/Microsoft/web-build-tools/issues/1050

Ref: TOOL-611

ATM, this is for testing purposes.
