### PR TITLE
docs: fix Redundant "See also:" link in ContentChild

### DIFF
--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -175,8 +175,6 @@ export interface ContentChildDecorator {
 /**
  * Type of the ContentChild metadata.
  *
- * @see `ContentChild`.
- *
  * @publicApi
  */
 export type ContentChild = Query;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
This changes removed Redundant "See also:" link in ContentChild Page. Which will re render the same page on click, 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently if the "See also:" link in ContentChild page will re render the ContentChild page again. 

Issue Number: #28318


## What is the new behavior?
The See Also link has been removed from the ContentChild Page.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
