### PR TITLE
fix(http): add listener on the abort event to all XMLHttpRequsts

### DIFF
--- a/packages/common/http/src/jsonp.ts
+++ b/packages/common/http/src/jsonp.ts
@@ -192,6 +192,7 @@ export class JsonpClientBackend implements HttpBackend {
       // and add it to the page.
       node.addEventListener('load', onLoad);
       node.addEventListener('error', onError);
+      node.addEventListener('abort', onError);
       this.document.body.appendChild(node);
 
       // The request has now been successfully sent.
@@ -205,6 +206,7 @@ export class JsonpClientBackend implements HttpBackend {
         // Remove the event listeners so they won't run if the events later fire.
         node.removeEventListener('load', onLoad);
         node.removeEventListener('error', onError);
+        node.removeEventListener('abort', onError);
 
         // And finally, clean up the page.
         cleanup();

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -309,6 +309,7 @@ export class HttpXhrBackend implements HttpBackend {
       // By default, register for load and error events.
       xhr.addEventListener('load', onLoad);
       xhr.addEventListener('error', onError);
+      xhr.addEventListener('abort', onError);
 
       // Progress events are only enabled if requested.
       if (req.reportProgress) {
@@ -331,6 +332,7 @@ export class HttpXhrBackend implements HttpBackend {
         // On a cancellation, remove all registered event listeners.
         xhr.removeEventListener('error', onError);
         xhr.removeEventListener('load', onLoad);
+        xhr.removeEventListener('abort', onLoad);
         if (req.reportProgress) {
           xhr.removeEventListener('progress', onDownProgress);
           if (reqBody !== null && xhr.upload) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe: add listener on the abort event to all XMLHttpRequsts

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/22324


## What is the new behavior?

Now, when request is canceled or aborted Angular will handle it and return an error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains  #a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Abort event handles in the same way as all other XMLHttpRequest errors. If request is canceled or aborted an appropriate Observable will be completed with an error.