### PR TITLE
Declaration transform

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -292,6 +292,7 @@ export function compile({allDepsCompiledWithBazel = true, compilerOpts, tsHost, 
           cancellationToken, emitOnlyDtsFiles, {
             beforeTs: customTransformers.before,
             afterTs: customTransformers.after,
+            afterDeclarations: customTransformers.afterDeclarations,
           });
 
   if (!gatherDiagnostics) {

--- a/packages/compiler-cli/src/ngcc/src/rendering/renderer.ts
+++ b/packages/compiler-cli/src/ngcc/src/rendering/renderer.ts
@@ -169,6 +169,7 @@ export abstract class Renderer {
   renderDtsFile(dtsFile: ts.SourceFile, renderInfo: DtsRenderInfo): FileInfo[] {
     const input = this.extractSourceMap(dtsFile);
     const outputText = new MagicString(input.source);
+    const printer = ts.createPrinter();
     const importManager = new ImportManager(
         this.getImportRewriter(this.bundle.dts !.r3SymbolsFile, false), IMPORT_PREFIX);
 
@@ -176,7 +177,8 @@ export abstract class Renderer {
       const endOfClass = dtsClass.dtsDeclaration.getEnd();
       dtsClass.compilation.forEach(declaration => {
         const type = translateType(declaration.type, importManager);
-        const newStatement = `    static ${declaration.name}: ${type};\n`;
+        const typeStr = printer.printNode(ts.EmitHint.Unspecified, type, dtsFile);
+        const newStatement = `    static ${declaration.name}: ${typeStr};\n`;
         outputText.appendRight(endOfClass - 1, newStatement);
       });
     });

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -22,7 +22,7 @@ import {TypeScriptReflectionHost} from './reflection';
 import {HostResourceLoader} from './resource_loader';
 import {FactoryGenerator, FactoryInfo, GeneratedShimsHostWrapper, ShimGenerator, SummaryGenerator, generatedFactoryTransform} from './shims';
 import {ivySwitchTransform} from './switch';
-import {IvyCompilation, ivyTransformFactory} from './transform';
+import {IvyCompilation, declarationTransformFactory, ivyTransformFactory} from './transform';
 import {TypeCheckContext, TypeCheckProgramHost} from './typecheck';
 import {isDtsPath} from './util/src/typescript';
 
@@ -213,17 +213,13 @@ export class NgtscProgram implements api.Program {
   }): ts.EmitResult {
     const emitCallback = opts && opts.emitCallback || defaultEmitCallback;
 
-    this.ensureAnalyzed();
+    const compilation = this.ensureAnalyzed();
 
-    // Since there is no .d.ts transformation API, .d.ts files are transformed during write.
     const writeFile: ts.WriteFileCallback =
         (fileName: string, data: string, writeByteOrderMark: boolean,
          onError: ((message: string) => void) | undefined,
          sourceFiles: ReadonlyArray<ts.SourceFile>) => {
-          if (fileName.endsWith('.d.ts')) {
-            data = sourceFiles.reduce(
-                (data, sf) => this.compilation !.transformedDtsFor(sf.fileName, data), data);
-          } else if (this.closureCompilerEnabled && fileName.endsWith('.js')) {
+          if (this.closureCompilerEnabled && fileName.endsWith('.js')) {
             data = nocollapseHack(data);
           }
           this.host.writeFile(fileName, data, writeByteOrderMark, onError, sourceFiles);
@@ -231,7 +227,8 @@ export class NgtscProgram implements api.Program {
 
     const customTransforms = opts && opts.customTransformers;
     const beforeTransforms =
-        [ivyTransformFactory(this.compilation !, this.reflector, this.importRewriter, this.isCore)];
+        [ivyTransformFactory(compilation, this.reflector, this.importRewriter, this.isCore)];
+    const afterDeclarationsTransforms = [declarationTransformFactory(compilation)];
 
     if (this.factoryToSourceInfo !== null) {
       beforeTransforms.push(
@@ -253,6 +250,7 @@ export class NgtscProgram implements api.Program {
       customTransformers: {
         before: beforeTransforms,
         after: customTransforms && customTransforms.afterTs,
+        afterDeclarations: afterDeclarationsTransforms,
       },
     });
     return emitResult;

--- a/packages/compiler-cli/src/ngtsc/transform/index.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/index.ts
@@ -8,5 +8,5 @@
 
 export * from './src/api';
 export {IvyCompilation} from './src/compilation';
-export {DtsFileTransformer} from './src/declaration';
+export {DtsFileTransformer, declarationTransformFactory} from './src/declaration';
 export {ivyTransformFactory} from './src/transform';

--- a/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
@@ -212,17 +212,21 @@ export class IvyCompilation {
   }
 
   /**
-   * Process a .d.ts source string and return a transformed version that incorporates the changes
+   * Process a declaration file and return a transformed version that incorporates the changes
    * made to the source file.
    */
-  transformedDtsFor(tsFileName: string, dtsOriginalSource: string): string {
-    // No need to transform if no changes have been requested to the input file.
-    if (!this.dtsMap.has(tsFileName)) {
-      return dtsOriginalSource;
+  transformedDtsFor(file: ts.SourceFile, context: ts.TransformationContext): ts.SourceFile {
+    // No need to transform if it's not a declarations file, or if no changes have been requested
+    // to the input file.
+    // Due to the way TypeScript afterDeclarations transformers work, the SourceFile path is the
+    // same as the original .ts.
+    // The only way we know it's actually a declaration file is via the isDeclarationFile property.
+    if (!file.isDeclarationFile || !this.dtsMap.has(file.fileName)) {
+      return file;
     }
 
-    // Return the transformed .d.ts source.
-    return this.dtsMap.get(tsFileName) !.transform(dtsOriginalSource, tsFileName);
+    // Return the transformed source.
+    return this.dtsMap.get(file.fileName) !.transform(file, context);
   }
 
   get diagnostics(): ReadonlyArray<ts.Diagnostic> { return this._diagnostics; }

--- a/packages/compiler-cli/src/ngtsc/transform/src/declaration.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/declaration.ts
@@ -12,8 +12,23 @@ import {ImportRewriter} from '../../imports';
 import {ImportManager, translateType} from '../../translator';
 
 import {CompileResult} from './api';
+import {IvyCompilation} from './compilation';
+import {addImports} from './utils';
 
 
+
+export function declarationTransformFactory(compilation: IvyCompilation):
+    ts.TransformerFactory<ts.Bundle|ts.SourceFile> {
+  return (context: ts.TransformationContext) => {
+    return (fileOrBundle) => {
+      if (ts.isBundle(fileOrBundle)) {
+        // Only attempt to transform source files.
+        return fileOrBundle;
+      }
+      return compilation.transformedDtsFor(fileOrBundle, context);
+    };
+  };
+}
 
 /**
  * Processes .d.ts file text and adds static field declarations, with types.
@@ -32,36 +47,34 @@ export class DtsFileTransformer {
   recordStaticField(name: string, decls: CompileResult[]): void { this.ivyFields.set(name, decls); }
 
   /**
-   * Process the .d.ts text for a file and add any declarations which were recorded.
+   * Transform the declaration file and add any declarations which were recorded.
    */
-  transform(dts: string, tsPath: string): string {
-    const dtsFile =
-        ts.createSourceFile('out.d.ts', dts, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);
+  transform(file: ts.SourceFile, context: ts.TransformationContext): ts.SourceFile {
+    const visitor: ts.Visitor = (node: ts.Node): ts.VisitResult<ts.Node> => {
+      // This class declaration needs to have fields added to it.
+      if (ts.isClassDeclaration(node) && node.name !== undefined &&
+          this.ivyFields.has(node.name.text)) {
+        const decls = this.ivyFields.get(node.name.text) !;
+        const newMembers = decls.map(decl => {
+          const modifiers = [ts.createModifier(ts.SyntaxKind.StaticKeyword)];
+          const type = translateType(decl.type, this.imports);
+          const typeRef = ts.createTypeReferenceNode(ts.createIdentifier(type), undefined);
+          return ts.createProperty(undefined, modifiers, decl.name, undefined, typeRef, undefined);
+        });
 
-    for (let i = dtsFile.statements.length - 1; i >= 0; i--) {
-      const stmt = dtsFile.statements[i];
-      if (ts.isClassDeclaration(stmt) && stmt.name !== undefined &&
-          this.ivyFields.has(stmt.name.text)) {
-        const decls = this.ivyFields.get(stmt.name.text) !;
-        const before = dts.substring(0, stmt.end - 1);
-        const after = dts.substring(stmt.end - 1);
-
-        dts = before +
-            decls
-                .map(decl => {
-                  const type = translateType(decl.type, this.imports);
-                  return `    static ${decl.name}: ${type};\n`;
-                })
-                .join('') +
-            after;
+        return ts.updateClassDeclaration(
+            node, node.decorators, node.modifiers, node.name, node.typeParameters,
+            node.heritageClauses, [...node.members, ...newMembers]);
       }
-    }
 
-    const imports = this.imports.getAllImports(tsPath);
-    if (imports.length !== 0) {
-      dts = imports.map(i => `import * as ${i.as} from '${i.name}';\n`).join('') + dts;
-    }
+      // Otherwise return node as is.
+      return ts.visitEachChild(node, visitor, context);
+    };
 
-    return dts;
+    // Recursively scan through the AST and add all class members needed.
+    const sf = ts.visitNode(file, visitor);
+
+    // Add new imports for this file.
+    return addImports(this.imports, sf);
   }
 }

--- a/packages/compiler-cli/src/ngtsc/transform/src/declaration.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/declaration.ts
@@ -57,8 +57,7 @@ export class DtsFileTransformer {
         const decls = this.ivyFields.get(node.name.text) !;
         const newMembers = decls.map(decl => {
           const modifiers = [ts.createModifier(ts.SyntaxKind.StaticKeyword)];
-          const type = translateType(decl.type, this.imports);
-          const typeRef = ts.createTypeReferenceNode(ts.createIdentifier(type), undefined);
+          const typeRef = translateType(decl.type, this.imports);
           return ts.createProperty(undefined, modifiers, decl.name, undefined, typeRef, undefined);
         });
 

--- a/packages/compiler-cli/src/ngtsc/transform/src/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/utils.ts
@@ -7,22 +7,22 @@
  */
 import * as ts from 'typescript';
 
-import { ImportManager } from '../../translator';
+import {ImportManager} from '../../translator';
 
 /**
  * Adds extra imports in the import manage for this source file, after the existing imports
  * and before the module body.
  * Can optionally add extra statements (e.g. new constants) before the body as well.
  */
-export function addImports(importManager: ImportManager, sf: ts.SourceFile,
+export function addImports(
+    importManager: ImportManager, sf: ts.SourceFile,
     extraStatements: ts.Statement[] = []): ts.SourceFile {
-
   // Generate the import statements to prepend.
   const addedImports = importManager.getAllImports(sf.fileName).map(i => {
     return ts.createImportDeclaration(
-      undefined, undefined,
-      ts.createImportClause(undefined, ts.createNamespaceImport(ts.createIdentifier(i.as))),
-      ts.createLiteral(i.name));
+        undefined, undefined,
+        ts.createImportClause(undefined, ts.createNamespaceImport(ts.createIdentifier(i.as))),
+        ts.createLiteral(i.name));
   });
 
   // Filter out the existing imports and the source file body. All new statements
@@ -32,7 +32,7 @@ export function addImports(importManager: ImportManager, sf: ts.SourceFile,
   // Prepend imports if needed.
   if (addedImports.length > 0) {
     sf.statements =
-      ts.createNodeArray([...existingImports, ...addedImports, ...extraStatements, ...body]);
+        ts.createNodeArray([...existingImports, ...addedImports, ...extraStatements, ...body]);
   }
 
   return sf;
@@ -40,5 +40,5 @@ export function addImports(importManager: ImportManager, sf: ts.SourceFile,
 
 function isImportStatement(stmt: ts.Statement): boolean {
   return ts.isImportDeclaration(stmt) || ts.isImportEqualsDeclaration(stmt) ||
-    ts.isNamespaceImport(stmt);
+      ts.isNamespaceImport(stmt);
 }

--- a/packages/compiler-cli/src/ngtsc/transform/src/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/utils.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+
+import { ImportManager } from '../../translator';
+
+/**
+ * Adds extra imports in the import manage for this source file, after the existing imports
+ * and before the module body.
+ * Can optionally add extra statements (e.g. new constants) before the body as well.
+ */
+export function addImports(importManager: ImportManager, sf: ts.SourceFile,
+    extraStatements: ts.Statement[] = []): ts.SourceFile {
+
+  // Generate the import statements to prepend.
+  const addedImports = importManager.getAllImports(sf.fileName).map(i => {
+    return ts.createImportDeclaration(
+      undefined, undefined,
+      ts.createImportClause(undefined, ts.createNamespaceImport(ts.createIdentifier(i.as))),
+      ts.createLiteral(i.name));
+  });
+
+  // Filter out the existing imports and the source file body. All new statements
+  // will be inserted between them.
+  const existingImports = sf.statements.filter(stmt => isImportStatement(stmt));
+  const body = sf.statements.filter(stmt => !isImportStatement(stmt));
+  // Prepend imports if needed.
+  if (addedImports.length > 0) {
+    sf.statements =
+      ts.createNodeArray([...existingImports, ...addedImports, ...extraStatements, ...body]);
+  }
+
+  return sf;
+}
+
+function isImportStatement(stmt: ts.Statement): boolean {
+  return ts.isImportDeclaration(stmt) || ts.isImportEqualsDeclaration(stmt) ||
+    ts.isNamespaceImport(stmt);
+}

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -437,8 +437,8 @@ describe('ngtsc behavioral tests', () => {
     const dtsContents = env.getContents('test.d.ts');
 
     expect(jsContents).toContain('import { Foo } from \'./foo\';');
-    expect(jsContents).not.toMatch(/as i[0-9] from '.\/foo'/);
-    expect(dtsContents).toContain('as i1 from \'./foo\';');
+    expect(jsContents).not.toMatch(/as i[0-9] from ".\/foo"/);
+    expect(dtsContents).toContain('as i1 from "./foo";');
   });
 
   it('should compile NgModules with references to absolute components', () => {
@@ -465,8 +465,8 @@ describe('ngtsc behavioral tests', () => {
     const dtsContents = env.getContents('test.d.ts');
 
     expect(jsContents).toContain('import { Foo } from \'foo\';');
-    expect(jsContents).not.toMatch(/as i[0-9] from 'foo'/);
-    expect(dtsContents).toContain('as i1 from \'foo\';');
+    expect(jsContents).not.toMatch(/as i[0-9] from "foo"/);
+    expect(dtsContents).toContain('as i1 from "foo";');
   });
 
   it('should compile Pipes without errors', () => {
@@ -591,7 +591,7 @@ describe('ngtsc behavioral tests', () => {
       expect(jsContents).toContain('imports: [[RouterModule.forRoot()]]');
 
       const dtsContents = env.getContents('test.d.ts');
-      expect(dtsContents).toContain(`import * as i1 from 'router';`);
+      expect(dtsContents).toContain(`import * as i1 from "router";`);
       expect(dtsContents)
           .toContain('i0.ɵNgModuleDefWithMeta<TestModule, never, [typeof i1.RouterModule], never>');
     });
@@ -627,7 +627,7 @@ describe('ngtsc behavioral tests', () => {
       expect(jsContents).toContain('imports: [[RouterModule.forRoot()]]');
 
       const dtsContents = env.getContents('test.d.ts');
-      expect(dtsContents).toContain(`import * as i1 from 'router';`);
+      expect(dtsContents).toContain(`import * as i1 from "router";`);
       expect(dtsContents)
           .toContain(
               'i0.ɵNgModuleDefWithMeta<TestModule, never, [typeof i1.InternalRouterModule], never>');
@@ -661,7 +661,7 @@ describe('ngtsc behavioral tests', () => {
        expect(jsContents).toContain('imports: [[RouterModule.forRoot()]]');
 
        const dtsContents = env.getContents('test.d.ts');
-       expect(dtsContents).toContain(`import * as i1 from 'router';`);
+       expect(dtsContents).toContain(`import * as i1 from "router";`);
        expect(dtsContents)
            .toContain(
                'i0.ɵNgModuleDefWithMeta<TestModule, never, [typeof i1.RouterModule], never>');

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -169,7 +169,7 @@ describe('ngtsc behavioral tests', () => {
     const dtsContents = env.getContents('test.d.ts');
     expect(dtsContents)
         .toContain(
-            'static ngComponentDef: i0.ɵComponentDefWithMeta<TestCmp, \'test-cmp\', never, {}, {}, never>');
+            'static ngComponentDef: i0.ɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never>');
   });
 
   it('should compile Components without errors', () => {
@@ -280,7 +280,7 @@ describe('ngtsc behavioral tests', () => {
     const dtsContents = env.getContents('test.d.ts');
     expect(dtsContents)
         .toContain(
-            'static ngComponentDef: i0.ɵComponentDefWithMeta<TestCmp, \'test-cmp\', never, {}, {}, never>');
+            'static ngComponentDef: i0.ɵComponentDefWithMeta<TestCmp, "test-cmp", never, {}, {}, never>');
     expect(dtsContents)
         .toContain(
             'static ngModuleDef: i0.ɵNgModuleDefWithMeta<TestModule, [typeof TestCmp], never, never>');
@@ -490,8 +490,7 @@ describe('ngtsc behavioral tests', () => {
         .toContain(
             'TestPipe.ngPipeDef = i0.ɵdefinePipe({ name: "test-pipe", type: TestPipe, ' +
             'factory: function TestPipe_Factory(t) { return new (t || TestPipe)(); }, pure: false })');
-    expect(dtsContents)
-        .toContain('static ngPipeDef: i0.ɵPipeDefWithMeta<TestPipe, \'test-pipe\'>;');
+    expect(dtsContents).toContain('static ngPipeDef: i0.ɵPipeDefWithMeta<TestPipe, "test-pipe">;');
   });
 
   it('should compile pure Pipes without errors', () => {
@@ -514,8 +513,7 @@ describe('ngtsc behavioral tests', () => {
         .toContain(
             'TestPipe.ngPipeDef = i0.ɵdefinePipe({ name: "test-pipe", type: TestPipe, ' +
             'factory: function TestPipe_Factory(t) { return new (t || TestPipe)(); }, pure: true })');
-    expect(dtsContents)
-        .toContain('static ngPipeDef: i0.ɵPipeDefWithMeta<TestPipe, \'test-pipe\'>;');
+    expect(dtsContents).toContain('static ngPipeDef: i0.ɵPipeDefWithMeta<TestPipe, "test-pipe">;');
   });
 
   it('should compile Pipes with dependencies', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
```
fix(bazel): also pass afterDeclarations transformers to emitWithTsickle

    Tsickle supports afterDeclarations transformers, but these were not being passed in.

refactor(compiler-cli): refactor import adding logic into helper

    This logic will be common to transforms that add imports. Using it as a helper helps reduce duplication

refactor(compiler-cli): use a transformer for dts files

    The current DtsFileTransformer works by intercepting file writes and editing the source string directly.

    This PR refactors it as a afterDeclaration transform in order to fit better in the TypeScript API.

    This is part of a greater effort of converting ngtsc to be usable as a TS transform plugin.

refactor(compiler-cli): return TS nodes from TypeTranslatorVisitor

    The TypeTranslatorVisitor visitor returned strings because before it wasn't possible to transform declaration files directly through the TypeScript custom transformer API.

    Now that's possible though, so it should return nodes instead.
```
## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
