### PR TITLE
build: cleanup compiler-cli unit tests

### DIFF
--- a/packages/compiler-cli/test/BUILD.bazel
+++ b/packages/compiler-cli/test/BUILD.bazel
@@ -7,6 +7,7 @@ ts_library(
     testonly = True,
     srcs = [
         "mocks.ts",
+        "runfile_helpers.ts",
         "test_support.ts",
     ],
     visibility = [

--- a/packages/compiler-cli/test/diagnostics/mocks.ts
+++ b/packages/compiler-cli/test/diagnostics/mocks.ts
@@ -75,11 +75,11 @@ export class MockLanguageServiceHost implements ts.LanguageServiceHost {
   private internalReadFile(fileName: string): string|undefined {
     let basename = path.basename(fileName);
     if (/^lib.*\.d\.ts$/.test(basename)) {
-      let libPath = path.dirname(ts.getDefaultLibFilePath(this.getCompilationSettings()));
-      fileName = path.join(libPath, basename);
+      let libPath = path.posix.dirname(ts.getDefaultLibFilePath(this.getCompilationSettings()));
+      fileName = path.posix.join(libPath, basename);
     }
     if (fileName.startsWith('app/')) {
-      fileName = path.join(this.context.currentDirectory, fileName);
+      fileName = path.posix.join(this.context.currentDirectory, fileName);
     }
     if (this.context.fileExists(fileName)) {
       return this.context.readFile(fileName);

--- a/packages/compiler-cli/test/diagnostics/mocks.ts
+++ b/packages/compiler-cli/test/diagnostics/mocks.ts
@@ -6,27 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AotCompilerHost, AotSummaryResolver, CompileMetadataResolver, CompilerConfig, DEFAULT_INTERPOLATION_CONFIG, DirectiveNormalizer, DirectiveResolver, DomElementSchemaRegistry, HtmlParser, I18NHtmlParser, InterpolationConfig, JitSummaryResolver, Lexer, NgAnalyzedModules, NgModuleResolver, ParseTreeResult, Parser, PipeResolver, ResourceLoader, StaticReflector, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, StaticSymbolResolverHost, SummaryResolver, TemplateParser, analyzeNgModules, createOfflineCompileUrlResolver} from '@angular/compiler';
+import {AotSummaryResolver, CompileMetadataResolver, CompilerConfig, DEFAULT_INTERPOLATION_CONFIG, DirectiveNormalizer, DirectiveResolver, DomElementSchemaRegistry, HtmlParser, I18NHtmlParser, InterpolationConfig, JitSummaryResolver, Lexer, NgAnalyzedModules, NgModuleResolver, ParseTreeResult, Parser, PipeResolver, ResourceLoader, StaticReflector, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, StaticSymbolResolverHost, SummaryResolver, TemplateParser, analyzeNgModules, createOfflineCompileUrlResolver} from '@angular/compiler';
 import {ViewEncapsulation, ɵConsole as Console} from '@angular/core';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 
 import {DiagnosticTemplateInfo} from '../../src/diagnostics/expression_diagnostics';
-import {getClassFromStaticSymbol, getClassMembers, getPipesTable, getSymbolQuery} from '../../src/diagnostics/typescript_symbols';
+import {getClassMembers, getPipesTable, getSymbolQuery} from '../../src/diagnostics/typescript_symbols';
 import {Directory, MockAotContext} from '../mocks';
-import {isInBazel, setup} from '../test_support';
-
-function calculateAngularPath() {
-  if (isInBazel()) {
-    const support = setup();
-    return path.join(support.basePath, 'node_modules/@angular/*');
-  } else {
-    const moduleFilename = module.filename.replace(/\\/g, '/');
-    const distIndex = moduleFilename.indexOf('/dist/all');
-    return moduleFilename.substr(0, distIndex) + '/packages/*';
-  }
-}
+import {setup} from '../test_support';
 
 const realFiles = new Map<string, string>();
 
@@ -36,6 +25,8 @@ export class MockLanguageServiceHost implements ts.LanguageServiceHost {
   private assumedExist = new Set<string>();
 
   constructor(private scripts: string[], files: Directory, currentDirectory: string = '/') {
+    const support = setup();
+
     this.options = {
       target: ts.ScriptTarget.ES5,
       module: ts.ModuleKind.CommonJS,
@@ -49,7 +40,7 @@ export class MockLanguageServiceHost implements ts.LanguageServiceHost {
       strictNullChecks: true,
       baseUrl: currentDirectory,
       lib: ['lib.es2015.d.ts', 'lib.dom.d.ts'],
-      paths: {'@angular/*': [calculateAngularPath()]}
+      paths: {'@angular/*': [path.join(support.basePath, 'node_modules/@angular/*')]}
     };
     this.context = new MockAotContext(currentDirectory, files);
   }

--- a/packages/compiler-cli/test/extract_i18n_spec.ts
+++ b/packages/compiler-cli/test/extract_i18n_spec.ts
@@ -8,17 +8,9 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import * as ts from 'typescript';
 
 import {mainXi18n} from '../src/extract_i18n';
-
-import {isInBazel, makeTempDir, setup} from './test_support';
-
-function getNgRootDir() {
-  const moduleFilename = module.filename.replace(/\\/g, '/');
-  const distIndex = moduleFilename.indexOf('/dist/all');
-  return moduleFilename.substr(0, distIndex);
-}
+import {makeTempDir, setup} from './test_support';
 
 const EXPECTED_XMB = `<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE messagebundle [
@@ -214,31 +206,10 @@ describe('extract_i18n command line', () => {
 
   beforeEach(() => {
     errorSpy = jasmine.createSpy('consoleError').and.callFake(console.error);
-    if (isInBazel()) {
-      const support = setup();
-      write = (fileName: string, content: string) => { support.write(fileName, content); };
-      basePath = support.basePath;
-      outDir = path.join(basePath, 'built');
-    } else {
-      basePath = makeTempDir();
-      write = (fileName: string, content: string) => {
-        const dir = path.dirname(fileName);
-        if (dir !== '.') {
-          const newDir = path.join(basePath, dir);
-          if (!fs.existsSync(newDir)) fs.mkdirSync(newDir);
-        }
-        fs.writeFileSync(path.join(basePath, fileName), content, {encoding: 'utf-8'});
-      };
-      outDir = path.resolve(basePath, 'built');
-      const ngRootDir = getNgRootDir();
-      const nodeModulesPath = path.resolve(basePath, 'node_modules');
-      fs.mkdirSync(nodeModulesPath);
-      fs.symlinkSync(
-          path.resolve(ngRootDir, 'dist', 'all', '@angular'),
-          path.resolve(nodeModulesPath, '@angular'));
-      fs.symlinkSync(
-          path.resolve(ngRootDir, 'node_modules', 'rxjs'), path.resolve(nodeModulesPath, 'rxjs'));
-    }
+    const support = setup();
+    write = (fileName: string, content: string) => { support.write(fileName, content); };
+    basePath = support.basePath;
+    outDir = path.join(basePath, 'built');
     write('tsconfig-base.json', `{
       "compilerOptions": {
         "experimentalDecorators": true,

--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -54,6 +54,7 @@ describe('ngc transformer command-line', () => {
         "baseUrl": ".",
         "declaration": true,
         "target": "es5",
+        "newLine": "lf",
         "module": "es2015",
         "moduleResolution": "node",
         "lib": ["es6", "dom"],
@@ -102,7 +103,7 @@ describe('ngc transformer command-line', () => {
 
       const exitCode = main(['-p', basePath], errorSpy);
       expect(errorSpy).toHaveBeenCalledWith(
-          `error TS6053: File '` + path.join(basePath, 'test.ts') + `' not found.` +
+          `error TS6053: File '` + path.posix.join(basePath, 'test.ts') + `' not found.` +
           '\n');
       expect(exitCode).toEqual(1);
     });

--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -99,6 +99,25 @@ describe('ngc transformer command-line', () => {
     expect(exitCode).toBe(0);
   });
 
+  it('should respect the "newLine" compiler option when printing diagnostics', () => {
+    writeConfig(`{
+      "extends": "./tsconfig-base.json",
+      "compilerOptions": {
+        "newLine": "CRLF",
+      }
+    }`);
+    write('test.ts', 'export NOT_VALID = true;');
+
+    // Stub the error spy because we don't want to call through and print the
+    // expected error diagnostic.
+    errorSpy.and.stub();
+
+    const exitCode = main(['-p', basePath], errorSpy);
+    expect(errorSpy).toHaveBeenCalledWith(
+        `test.ts(1,1): error TS1128: Declaration or statement expected.\r\n`);
+    expect(exitCode).toBe(1);
+  });
+
   describe('errors', () => {
 
     beforeEach(() => { errorSpy.and.stub(); });

--- a/packages/compiler-cli/test/ngc_spec.ts
+++ b/packages/compiler-cli/test/ngc_spec.ts
@@ -11,14 +11,7 @@ import * as path from 'path';
 import * as ts from 'typescript';
 
 import {main, readCommandLineAndConfiguration, watchMode} from '../src/main';
-
-import {isInBazel, makeTempDir, setup} from './test_support';
-
-function getNgRootDir() {
-  const moduleFilename = module.filename.replace(/\\/g, '/');
-  const distIndex = moduleFilename.indexOf('/dist/all');
-  return moduleFilename.substr(0, distIndex);
-}
+import {setup} from './test_support';
 
 describe('ngc transformer command-line', () => {
   let basePath: string;
@@ -44,33 +37,12 @@ describe('ngc transformer command-line', () => {
 
   beforeEach(() => {
     errorSpy = jasmine.createSpy('consoleError').and.callFake(console.error);
-    if (isInBazel) {
-      const support = setup();
-      basePath = support.basePath;
-      outDir = path.join(basePath, 'built');
-      process.chdir(basePath);
-      write = (fileName: string, content: string) => { support.write(fileName, content); };
-    } else {
-      basePath = makeTempDir();
-      process.chdir(basePath);
-      write = (fileName: string, content: string) => {
-        const dir = path.dirname(fileName);
-        if (dir != '.') {
-          const newDir = path.join(basePath, dir);
-          if (!fs.existsSync(newDir)) fs.mkdirSync(newDir);
-        }
-        fs.writeFileSync(path.join(basePath, fileName), content, {encoding: 'utf-8'});
-      };
-      outDir = path.resolve(basePath, 'built');
-      const ngRootDir = getNgRootDir();
-      const nodeModulesPath = path.resolve(basePath, 'node_modules');
-      fs.mkdirSync(nodeModulesPath);
-      fs.symlinkSync(
-          path.resolve(ngRootDir, 'dist', 'all', '@angular'),
-          path.resolve(nodeModulesPath, '@angular'));
-      fs.symlinkSync(
-          path.resolve(ngRootDir, 'node_modules', 'rxjs'), path.resolve(nodeModulesPath, 'rxjs'));
-    }
+    const support = setup();
+    basePath = support.basePath;
+    outDir = path.join(basePath, 'built');
+    process.chdir(basePath);
+    write = (fileName: string, content: string) => { support.write(fileName, content); };
+
     write('tsconfig-base.json', `{
       "compilerOptions": {
         "experimentalDecorators": true,
@@ -269,19 +241,9 @@ describe('ngc transformer command-line', () => {
       expect(exitCode).toEqual(0);
 
       expect(fs.existsSync(path.resolve(outDir, 'mymodule.ngfactory.js'))).toBe(true);
-
-      if (isInBazel()) {
-        // In bazel we use the packaged version so the factory is at the root and we
-        // get the flattened factory.
-        expect(fs.existsSync(
-                   path.resolve(outDir, 'node_modules', '@angular', 'core', 'core.ngfactory.js')))
-            .toBe(true);
-      } else {
-        expect(fs.existsSync(path.resolve(
-                   outDir, 'node_modules', '@angular', 'core', 'src',
-                   'application_module.ngfactory.js')))
-            .toBe(true);
-      }
+      expect(fs.existsSync(
+                 path.resolve(outDir, 'node_modules', '@angular', 'core', 'core.ngfactory.js')))
+          .toBe(true);
     });
 
     describe('comments', () => {
@@ -386,18 +348,9 @@ describe('ngc transformer command-line', () => {
       const exitCode = main(['-p', path.join(basePath, 'tsconfig.json')], errorSpy);
       expect(exitCode).toEqual(0);
       expect(fs.existsSync(path.resolve(outDir, 'mymodule.ngfactory.js'))).toBe(true);
-      if (isInBazel()) {
-        // In bazel we use the packaged version so the factory is at the root and we
-        // get the flattened factory.
-        expect(fs.existsSync(
-                   path.resolve(outDir, 'node_modules', '@angular', 'core', 'core.ngfactory.js')))
-            .toBe(true);
-      } else {
-        expect(fs.existsSync(path.resolve(
-                   outDir, 'node_modules', '@angular', 'core', 'src',
-                   'application_module.ngfactory.js')))
-            .toBe(true);
-      }
+      expect(fs.existsSync(
+                 path.resolve(outDir, 'node_modules', '@angular', 'core', 'core.ngfactory.js')))
+          .toBe(true);
     });
 
     describe(`emit generated files depending on the source file`, () => {
@@ -1217,10 +1170,6 @@ describe('ngc transformer command-line', () => {
           }
         `);
 
-      if (!isInBazel()) {
-        // This is not necessary in bazel as it uses the npm_package
-        expect(main(['-p', path.join(basePath, 'tsconfig-ng.json')], errorSpy)).toBe(0);
-      }
       expect(main(['-p', path.join(basePath, 'lib1', 'tsconfig-lib1.json')], errorSpy)).toBe(0);
       expect(main(['-p', path.join(basePath, 'lib2', 'tsconfig-lib2.json')], errorSpy)).toBe(0);
       expect(main(['-p', path.join(basePath, 'app', 'tsconfig-app.json')], errorSpy)).toBe(0);
@@ -1256,110 +1205,6 @@ describe('ngc transformer command-line', () => {
       outDir = path.resolve(basePath, 'built');
       shouldExist('app/main.js');
     });
-
-    if (!isInBazel()) {
-      // This is an unnecessary test bazel as it always uses flat modules
-      it('should be able to compile libraries with summaries and flat modules', () => {
-        writeFiles();
-        compile();
-
-        // libraries
-        // make `shouldExist` / `shouldNotExist` relative to `node_modules`
-        outDir = path.resolve(basePath, 'node_modules');
-        shouldExist('flat_module/index.ngfactory.js');
-        shouldExist('flat_module/index.ngsummary.json');
-
-        // app
-        // make `shouldExist` / `shouldNotExist` relative to `built`
-        outDir = path.resolve(basePath, 'built');
-        shouldExist('app/main.ngfactory.js');
-
-        const factory = fs.readFileSync(path.resolve(outDir, 'app/main.ngfactory.js')).toString();
-        // reference to the module itself
-        expect(factory).toMatch(/from "flat_module"/);
-        // no reference to a deep file
-        expect(factory).not.toMatch(/from "flat_module\//);
-
-        function writeFiles() {
-          createFlatModuleInNodeModules();
-
-          // Angular + flat module
-          write('tsconfig-lib.json', `{
-            "extends": "./tsconfig-base.json",
-            "angularCompilerOptions": {
-              "generateCodeForLibraries": true
-            },
-            "compilerOptions": {
-              "outDir": "."
-            },
-            "include": ["node_modules/@angular/core/**/*", "node_modules/flat_module/**/*"],
-            "exclude": [
-              "node_modules/@angular/core/test/**",
-              "node_modules/@angular/core/testing/**"
-            ]
-          }`);
-
-          // Application
-          write('app/tsconfig-app.json', `{
-            "extends": "../tsconfig-base.json",
-            "angularCompilerOptions": {
-              "generateCodeForLibraries": false
-            },
-            "compilerOptions": {
-              "rootDir": ".",
-              "outDir": "../built/app"
-            }
-          }`);
-          write('app/main.ts', `
-            import {NgModule} from '@angular/core';
-            import {FlatModule} from 'flat_module';
-
-            @NgModule({
-              imports: [FlatModule]
-            })
-            export class AppModule {}
-          `);
-        }
-
-        function createFlatModuleInNodeModules() {
-          // compile the flat module
-          writeFlatModule('index.js');
-          expect(main(['-p', basePath], errorSpy)).toBe(0);
-
-          // move the flat module output into node_modules
-          const flatModuleNodeModulesPath = path.resolve(basePath, 'node_modules', 'flat_module');
-          fs.renameSync(outDir, flatModuleNodeModulesPath);
-          fs.renameSync(
-              path.resolve(basePath, 'src/flat.component.html'),
-              path.resolve(flatModuleNodeModulesPath, 'src/flat.component.html'));
-          // and remove the sources.
-          fs.renameSync(path.resolve(basePath, 'src'), path.resolve(basePath, 'flat_module_src'));
-          fs.unlinkSync(path.resolve(basePath, 'public-api.ts'));
-
-          // add a flatModuleIndexRedirect
-          write('node_modules/flat_module/redirect.metadata.json', `{
-            "__symbolic": "module",
-            "version": 3,
-            "metadata": {},
-            "exports": [
-              {
-                "from": "./index"
-              }
-            ],
-            "flatModuleIndexRedirect": true,
-            "importAs": "flat_module"
-          }`);
-          write('node_modules/flat_module/redirect.d.ts', `export * from './index';`);
-          // add a package.json to use the redirect
-          write('node_modules/flat_module/package.json', `{"typings": "./redirect.d.ts"}`);
-        }
-
-        function compile() {
-          expect(main(['-p', path.join(basePath, 'tsconfig-lib.json')], errorSpy)).toBe(0);
-          expect(main(['-p', path.join(basePath, 'app', 'tsconfig-app.json')], errorSpy)).toBe(0);
-        }
-      });
-    }
 
     describe('enableResourceInlining', () => {
       it('should inline templateUrl and styleUrl in JS and metadata', () => {

--- a/packages/compiler-cli/test/ngcc/ngcc_spec.ts
+++ b/packages/compiler-cli/test/ngcc/ngcc_spec.ts
@@ -14,11 +14,6 @@ const Module = require('module');
 import {mainNgcc} from '../../src/ngcc/src/main';
 
 describe('ngcc main()', () => {
-  if (!isInBazel()) {
-    // These tests should be excluded from the non-Bazel build.
-    return;
-  }
-
   beforeEach(createMockFileSystem);
   afterEach(restoreRealFileSystem);
 
@@ -98,10 +93,6 @@ function loadDirectory(directoryPath: string): Directory {
 
 interface Directory {
   [pathSegment: string]: string|Directory;
-}
-
-function isInBazel() {
-  return process.env.TEST_SRCDIR != null;
 }
 
 function mockResolve(p: string): string|null {

--- a/packages/compiler-cli/test/ngtools_api_spec.ts
+++ b/packages/compiler-cli/test/ngtools_api_spec.ts
@@ -70,8 +70,8 @@ describe('ngtools_api (deprecated)', () => {
       entryModule: 'src/main#MainModule',
     });
     expect(routes).toEqual({
-      './child#ChildModule': path.resolve(testSupport.basePath, 'src/child.ts'),
-      './child2#ChildModule2': path.resolve(testSupport.basePath, 'src/child2.ts'),
+      './child#ChildModule': path.posix.join(testSupport.basePath, 'src/child.ts'),
+      './child2#ChildModule2': path.posix.join(testSupport.basePath, 'src/child2.ts'),
     });
   });
 

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -14,7 +14,7 @@ import * as ts from 'typescript';
 import {createCompilerHost, createProgram} from '../../ngtools2';
 import {main, mainDiagnosticsForTest, readNgcCommandLineAndConfiguration} from '../../src/main';
 import {LazyRoute} from '../../src/ngtsc/routing';
-import {TestSupport, isInBazel, setup} from '../test_support';
+import {setup, TestSupport} from '../test_support';
 
 function setupFakeCore(support: TestSupport): void {
   if (!process.env.TEST_SRCDIR) {
@@ -42,10 +42,6 @@ export class NgtscTestEnvironment {
    * Set up a new testing environment.
    */
   static setup(): NgtscTestEnvironment {
-    if (!NgtscTestEnvironment.supported) {
-      throw new Error(`Attempting to setup ngtsc tests in an unsupported environment`);
-    }
-
     const support = setup();
     const outDir = path.join(support.basePath, 'built');
     process.chdir(support.basePath);
@@ -135,6 +131,4 @@ export class NgtscTestEnvironment {
     const program = createProgram({rootNames, host, options});
     return program.listLazyRoutes(entryPoint);
   }
-
-  static get supported(): boolean { return isInBazel(); }
 }

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -14,19 +14,21 @@ import * as ts from 'typescript';
 import {createCompilerHost, createProgram} from '../../ngtools2';
 import {main, mainDiagnosticsForTest, readNgcCommandLineAndConfiguration} from '../../src/main';
 import {LazyRoute} from '../../src/ngtsc/routing';
-import {setup, TestSupport} from '../test_support';
+import {resolveNpmTreeArtifact} from '../runfile_helpers';
+import {TestSupport, setup} from '../test_support';
 
 function setupFakeCore(support: TestSupport): void {
   if (!process.env.TEST_SRCDIR) {
     throw new Error('`setupFakeCore` must be run within a Bazel test');
   }
-  const fakeCore = path.join(
-      process.env.TEST_SRCDIR, 'angular/packages/compiler-cli/test/ngtsc/fake_core/npm_package');
+
+  const fakeNpmPackageDir =
+      resolveNpmTreeArtifact('angular/packages/compiler-cli/test/ngtsc/fake_core/npm_package');
 
   const nodeModulesPath = path.join(support.basePath, 'node_modules');
   const angularCoreDirectory = path.join(nodeModulesPath, '@angular/core');
 
-  fs.symlinkSync(fakeCore, angularCoreDirectory);
+  fs.symlinkSync(fakeNpmPackageDir, angularCoreDirectory, 'dir');
 }
 
 /**
@@ -61,6 +63,7 @@ export class NgtscTestEnvironment {
         "baseUrl": ".",
         "declaration": true,
         "target": "es5",
+        "newLine": "lf",
         "module": "es2015",
         "moduleResolution": "node",
         "lib": ["es6", "dom"],

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -13,11 +13,6 @@ import {NgtscTestEnvironment} from './env';
 const trim = (input: string): string => input.replace(/\s+/g, ' ').trim();
 
 describe('ngtsc behavioral tests', () => {
-  if (!NgtscTestEnvironment.supported) {
-    // These tests should be excluded from the non-Bazel build.
-    return;
-  }
-
   let env !: NgtscTestEnvironment;
 
   beforeEach(() => { env = NgtscTestEnvironment.setup(); });

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -42,11 +42,6 @@ export declare class CommonModule {
 }
 
 describe('ngtsc type checking', () => {
-  if (!NgtscTestEnvironment.supported) {
-    // These tests should be excluded from the non-Bazel build.
-    return;
-  }
-
   let env !: NgtscTestEnvironment;
 
   beforeEach(() => {

--- a/packages/compiler-cli/test/perform_watch_spec.ts
+++ b/packages/compiler-cli/test/perform_watch_spec.ts
@@ -71,9 +71,10 @@ describe('perform watch', () => {
       `,
     });
 
-    const mainTsPath = path.resolve(testSupport.basePath, 'src', 'main.ts');
-    const utilTsPath = path.resolve(testSupport.basePath, 'src', 'util.ts');
-    const mainNgFactory = path.resolve(outDir, 'src', 'main.ngfactory.js');
+    const mainTsPath = path.posix.join(testSupport.basePath, 'src', 'main.ts');
+    const utilTsPath = path.posix.join(testSupport.basePath, 'src', 'util.ts');
+    const mainNgFactory = path.posix.join(outDir, 'src', 'main.ngfactory.js');
+
     performWatchCompilation(host);
     expect(fs.existsSync(mainNgFactory)).toBe(true);
     expect(fileExistsSpy !).toHaveBeenCalledWith(mainTsPath);

--- a/packages/compiler-cli/test/runfile_helpers.ts
+++ b/packages/compiler-cli/test/runfile_helpers.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Gets all built Angular NPM package artifacts by querying the Bazel runfiles.
+ * In case there is a runfiles manifest (e.g. on Windows), the packages are resolved
+ * through the manifest because the runfiles are not symlinked and cannot be searched
+ * within the real filesystem.
+ */
+export function getAngularPackagesFromRunfiles() {
+  // Path to the Bazel runfiles manifest if present. This file is present if runfiles are
+  // not symlinked into the runfiles directory.
+  const runfilesManifestPath = process.env.RUNFILES_MANIFEST_FILE;
+
+  if (!runfilesManifestPath) {
+    const packageRunfilesDir = path.join(process.env.RUNFILES !, 'angular/packages');
+
+    return fs.readdirSync(packageRunfilesDir)
+        .map(name => ({name, pkgPath: path.join(packageRunfilesDir, name, 'npm_package/')}))
+        .filter(({pkgPath}) => fs.existsSync(pkgPath));
+  }
+
+  return fs.readFileSync(runfilesManifestPath, 'utf8')
+      .split('\n')
+      .map(mapping => mapping.split(' '))
+      .filter(([runfilePath]) => runfilePath.match(/^angular\/packages\/[\w-]+\/npm_package$/))
+      .map(([runfilePath, realPath]) => ({
+             name: path.relative('angular/packages', runfilePath).split(path.sep)[0],
+             pkgPath: realPath,
+           }));
+}
+
+/**
+ * Resolves a NPM package from the Bazel runfiles. We need to resolve the Bazel tree
+ * artifacts using a "resolve file" because the NodeJS module resolution does not allow
+ * resolving to directory paths.
+ */
+export function resolveNpmTreeArtifact(manifestPath: string, resolveFile = 'package.json') {
+  return path.dirname(require.resolve(path.posix.join(manifestPath, resolveFile)));
+}

--- a/packages/compiler-cli/test/test_support.ts
+++ b/packages/compiler-cli/test/test_support.ts
@@ -10,9 +10,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 import * as ng from '../index';
+import {getAngularPackagesFromRunfiles, resolveNpmTreeArtifact} from './runfile_helpers';
 
 // TEST_TMPDIR is always set by Bazel.
-const tmpdir = process.env.TEST_TMPDIR!;
+const tmpdir = process.env.TEST_TMPDIR !;
 
 export function makeTempDir(): string {
   let dir: string;
@@ -51,6 +52,7 @@ function createTestSupportFor(basePath: string) {
     'baseUrl': basePath,
     'declaration': true,
     'target': ts.ScriptTarget.ES5,
+    'newLine': ts.NewLineKind.LineFeed,
     'module': ts.ModuleKind.ES2015,
     'moduleResolution': ts.ModuleResolutionKind.NodeJs,
     'lib': Object.freeze([
@@ -62,7 +64,16 @@ function createTestSupportFor(basePath: string) {
   };
 
 
-  return {basePath, write, writeFiles, createCompilerOptions, shouldExist, shouldNotExist};
+  return {
+    // We normalize the basePath into a posix path, so that multiple assertions which compare
+    // paths don't need to normalize the path separators each time.
+    basePath: normalizeSeparators(basePath),
+    write,
+    writeFiles,
+    createCompilerOptions,
+    shouldExist,
+    shouldNotExist
+  };
 
   function write(fileName: string, content: string) {
     const dir = path.dirname(fileName);
@@ -95,37 +106,29 @@ function createTestSupportFor(basePath: string) {
   }
 }
 
-export function setupBazelTo(basePath: string) {
-  if (!process.env.TEST_SRCDIR) {
-    throw new Error('`setupBazelTo()` must only be called from in a Bazel job.');
-  }
-  const sources = process.env.TEST_SRCDIR;
-  const packages = path.join(sources, 'angular/packages');
-  const nodeModulesPath = path.join(basePath, 'node_modules');
+export function setupBazelTo(tmpDirPath: string) {
+  const nodeModulesPath = path.join(tmpDirPath, 'node_modules');
   const angularDirectory = path.join(nodeModulesPath, '@angular');
+
   fs.mkdirSync(nodeModulesPath);
-
-  // Link the built angular packages
   fs.mkdirSync(angularDirectory);
-  const packageNames = fs.readdirSync(packages).filter(
-      name => fs.statSync(path.join(packages, name)).isDirectory() &&
-          fs.existsSync(path.join(packages, name, 'npm_package')));
-  for (const pkg of packageNames) {
-    fs.symlinkSync(path.join(packages, `${pkg}/npm_package`), path.join(angularDirectory, pkg));
-  }
 
-  // Link rxjs
-  const rxjsSource = path.join(sources, 'rxjs');
-  const rxjsDest = path.join(nodeModulesPath, 'rxjs');
-  if (fs.existsSync(rxjsSource)) {
-    fs.symlinkSync(rxjsSource, rxjsDest);
-  }
+  getAngularPackagesFromRunfiles().forEach(
+      ({pkgPath, name}) => { fs.symlinkSync(pkgPath, path.join(angularDirectory, name), 'dir'); });
 
   // Link typescript
-  const typescriptSource = path.join(sources, 'ngdeps/node_modules/typescript');
+  const typeScriptSource = resolveNpmTreeArtifact('ngdeps/node_modules/typescript');
   const typescriptDest = path.join(nodeModulesPath, 'typescript');
-  if (fs.existsSync(typescriptSource)) {
-    fs.symlinkSync(typescriptSource, typescriptDest);
+  fs.symlinkSync(typeScriptSource, typescriptDest, 'dir');
+
+  // Link "rxjs" if it has been set up as a runfile. "rxjs" is linked optionally because
+  // not all compiler-cli tests need "rxjs" set up.
+  try {
+    const rxjsSource = resolveNpmTreeArtifact('rxjs', 'index.js');
+    const rxjsDest = path.join(nodeModulesPath, 'rxjs');
+    fs.symlinkSync(rxjsSource, rxjsDest, 'dir');
+  } catch (e) {
+    if (e.code !== 'MODULE_NOT_FOUND') throw e;
   }
 }
 
@@ -147,4 +150,8 @@ export function expectNoDiagnosticsInProgram(options: ng.CompilerOptions, p: ng.
     ...p.getNgStructuralDiagnostics(), ...p.getTsSemanticDiagnostics(),
     ...p.getNgSemanticDiagnostics()
   ]);
+}
+
+export function normalizeSeparators(path: string): string {
+  return path.replace(/\\/g, '/');
 }

--- a/packages/compiler-cli/test/transformers/program_spec.ts
+++ b/packages/compiler-cli/test/transformers/program_spec.ts
@@ -14,8 +14,8 @@ import * as ts from 'typescript';
 import {formatDiagnostics} from '../../src/perform_compile';
 import {CompilerHost, EmitFlags, LazyRoute} from '../../src/transformers/api';
 import {checkVersion, createSrcToOutPathMapper} from '../../src/transformers/program';
-import {GENERATED_FILES, StructureIsReused, tsStructureIsReused} from '../../src/transformers/util';
-import {TestSupport, expectNoDiagnosticsInProgram, isInBazel, setup} from '../test_support';
+import {StructureIsReused, tsStructureIsReused} from '../../src/transformers/util';
+import {TestSupport, expectNoDiagnosticsInProgram, setup} from '../test_support';
 
 describe('ng program', () => {
   let testSupport: TestSupport;
@@ -53,7 +53,7 @@ describe('ng program', () => {
     expectNoDiagnosticsInProgram(options, program);
     fs.symlinkSync(
         path.resolve(testSupport.basePath, 'built', `${libName}_src`),
-        path.resolve(testSupport.basePath, 'node_modules', libName));
+        path.resolve(testSupport.basePath, 'node_modules', libName), 'dir');
     program.emit({emitFlags: ng.EmitFlags.DTS | ng.EmitFlags.JS | ng.EmitFlags.Metadata});
   }
 
@@ -214,9 +214,9 @@ describe('ng program', () => {
 
       // compile without libraries
       const p2 = compile(p1, options, undefined, host).program;
-      expect(written.has(path.resolve(testSupport.basePath, 'built/src/index.js'))).toBe(true);
+      expect(written.has(path.posix.join(testSupport.basePath, 'built/src/index.js'))).toBe(true);
       let ngFactoryContent =
-          written.get(path.resolve(testSupport.basePath, 'built/src/index.ngfactory.js'));
+          written.get(path.posix.join(testSupport.basePath, 'built/src/index.ngfactory.js'));
       expect(ngFactoryContent).toMatch(/Start/);
 
       // no change -> no emit
@@ -226,10 +226,10 @@ describe('ng program', () => {
 
       // change a user file
       written.clear();
-      fileCache.delete(path.resolve(testSupport.basePath, 'src/index.ts'));
+      fileCache.delete(path.posix.join(testSupport.basePath, 'src/index.ts'));
       const p4 = compile(p3, options, undefined, host).program;
       expect(written.size).toBe(1);
-      expect(written.has(path.resolve(testSupport.basePath, 'built/src/index.js'))).toBe(true);
+      expect(written.has(path.posix.join(testSupport.basePath, 'built/src/index.js'))).toBe(true);
 
       // change a file that is input to generated files
       written.clear();
@@ -237,14 +237,14 @@ describe('ng program', () => {
       const p5 = compile(p4, options, undefined, host).program;
       expect(written.size).toBe(1);
       ngFactoryContent =
-          written.get(path.resolve(testSupport.basePath, 'built/src/index.ngfactory.js'));
+          written.get(path.posix.join(testSupport.basePath, 'built/src/index.ngfactory.js'));
       expect(ngFactoryContent).toMatch(/Hello/);
 
       // change a file and create an intermediate program that is not emitted
       written.clear();
-      fileCache.delete(path.resolve(testSupport.basePath, 'src/index.ts'));
+      fileCache.delete(path.posix.join(testSupport.basePath, 'src/index.ts'));
       const p6 = ng.createProgram({
-        rootNames: [path.resolve(testSupport.basePath, 'src/index.ts')],
+        rootNames: [path.posix.join(testSupport.basePath, 'src/index.ts')],
         options: testSupport.createCompilerOptions(options), host,
         oldProgram: p5
       });
@@ -481,10 +481,11 @@ describe('ng program', () => {
     const enum ShouldBe { Empty, EmptyExport, NoneEmpty }
     function assertGenFile(
         fileName: string, checks: {originalFileName: string, shouldBe: ShouldBe}) {
-      const writeData = written.get(path.join(testSupport.basePath, fileName));
+      const writeData = written.get(path.posix.join(testSupport.basePath, fileName));
       expect(writeData).toBeTruthy();
-      expect(writeData !.original !.some(
-                 sf => sf.fileName === path.join(testSupport.basePath, checks.originalFileName)))
+      expect(
+          writeData !.original !.some(
+              sf => sf.fileName === path.posix.join(testSupport.basePath, checks.originalFileName)))
           .toBe(true);
       switch (checks.shouldBe) {
         case ShouldBe.Empty:
@@ -575,29 +576,30 @@ describe('ng program', () => {
 
   describe('createSrcToOutPathMapper', () => {
     it('should return identity mapping if no outDir is present', () => {
-      const mapper = createSrcToOutPathMapper(undefined, undefined, undefined);
+      const mapper = createSrcToOutPathMapper(undefined, undefined, undefined, path.posix);
       expect(mapper('/tmp/b/y.js')).toBe('/tmp/b/y.js');
     });
 
     it('should return identity mapping if first src and out fileName have same dir', () => {
-      const mapper = createSrcToOutPathMapper('/tmp', '/tmp/a/x.ts', '/tmp/a/x.js');
+      const mapper = createSrcToOutPathMapper('/tmp', '/tmp/a/x.ts', '/tmp/a/x.js', path.posix);
       expect(mapper('/tmp/b/y.js')).toBe('/tmp/b/y.js');
     });
 
     it('should adjust the filename if the outDir is inside of the rootDir', () => {
-      const mapper = createSrcToOutPathMapper('/tmp/out', '/tmp/a/x.ts', '/tmp/out/a/x.js');
+      const mapper =
+          createSrcToOutPathMapper('/tmp/out', '/tmp/a/x.ts', '/tmp/out/a/x.js', path.posix);
       expect(mapper('/tmp/b/y.js')).toBe('/tmp/out/b/y.js');
     });
 
     it('should adjust the filename if the outDir is outside of the rootDir', () => {
-      const mapper = createSrcToOutPathMapper('/out', '/tmp/a/x.ts', '/out/a/x.js');
+      const mapper = createSrcToOutPathMapper('/out', '/tmp/a/x.ts', '/out/a/x.js', path.posix);
       expect(mapper('/tmp/b/y.js')).toBe('/out/b/y.js');
     });
 
     it('should adjust the filename if the common prefix of sampleSrc and sampleOut is outside of outDir',
        () => {
-         const mapper =
-             createSrcToOutPathMapper('/dist/common', '/src/common/x.ts', '/dist/common/x.js');
+         const mapper = createSrcToOutPathMapper(
+             '/dist/common', '/src/common/x.ts', '/dist/common/x.js', path.posix);
          expect(mapper('/src/common/y.js')).toBe('/dist/common/y.js');
        });
 
@@ -668,16 +670,23 @@ describe('ng program', () => {
       expectNoDiagnosticsInProgram(options, program);
       expect(normalizeRoutes(program.listLazyRoutes())).toEqual([
         {
-          module: {name: 'MainModule', filePath: path.resolve(testSupport.basePath, 'src/main.ts')},
-          referencedModule:
-              {name: 'ChildModule', filePath: path.resolve(testSupport.basePath, 'src/child.ts')},
+          module:
+              {name: 'MainModule', filePath: path.posix.join(testSupport.basePath, 'src/main.ts')},
+          referencedModule: {
+            name: 'ChildModule',
+            filePath: path.posix.join(testSupport.basePath, 'src/child.ts')
+          },
           route: './child#ChildModule'
         },
         {
-          module:
-              {name: 'ChildModule', filePath: path.resolve(testSupport.basePath, 'src/child.ts')},
-          referencedModule:
-              {name: 'ChildModule2', filePath: path.resolve(testSupport.basePath, 'src/child2.ts')},
+          module: {
+            name: 'ChildModule',
+            filePath: path.posix.join(testSupport.basePath, 'src/child.ts')
+          },
+          referencedModule: {
+            name: 'ChildModule2',
+            filePath: path.posix.join(testSupport.basePath, 'src/child2.ts')
+          },
           route: './child2#ChildModule2'
         },
       ]);
@@ -718,26 +727,37 @@ describe('ng program', () => {
       expectNoDiagnosticsInProgram(options, program);
       expect(normalizeRoutes(program.listLazyRoutes('src/main#MainModule'))).toEqual([
         {
-          module: {name: 'MainModule', filePath: path.resolve(testSupport.basePath, 'src/main.ts')},
-          referencedModule:
-              {name: 'ChildModule', filePath: path.resolve(testSupport.basePath, 'src/child.ts')},
+          module:
+              {name: 'MainModule', filePath: path.posix.join(testSupport.basePath, 'src/main.ts')},
+          referencedModule: {
+            name: 'ChildModule',
+            filePath: path.posix.join(testSupport.basePath, 'src/child.ts')
+          },
           route: './child#ChildModule'
         },
         {
-          module:
-              {name: 'ChildModule', filePath: path.resolve(testSupport.basePath, 'src/child.ts')},
-          referencedModule:
-              {name: 'ChildModule2', filePath: path.resolve(testSupport.basePath, 'src/child2.ts')},
+          module: {
+            name: 'ChildModule',
+            filePath: path.posix.join(testSupport.basePath, 'src/child.ts')
+          },
+          referencedModule: {
+            name: 'ChildModule2',
+            filePath: path.posix.join(testSupport.basePath, 'src/child2.ts')
+          },
           route: './child2#ChildModule2'
         },
       ]);
 
       expect(normalizeRoutes(program.listLazyRoutes('src/child#ChildModule'))).toEqual([
         {
-          module:
-              {name: 'ChildModule', filePath: path.resolve(testSupport.basePath, 'src/child.ts')},
-          referencedModule:
-              {name: 'ChildModule2', filePath: path.resolve(testSupport.basePath, 'src/child2.ts')},
+          module: {
+            name: 'ChildModule',
+            filePath: path.posix.join(testSupport.basePath, 'src/child.ts')
+          },
+          referencedModule: {
+            name: 'ChildModule2',
+            filePath: path.posix.join(testSupport.basePath, 'src/child2.ts')
+          },
           route: './child2#ChildModule2'
         },
       ]);
@@ -764,10 +784,11 @@ describe('ng program', () => {
       const {program, options} = createProgram(['src/main.ts']);
       expect(normalizeRoutes(program.listLazyRoutes('src/main#MainModule'))).toEqual([
         {
-          module: {name: 'MainModule', filePath: path.resolve(testSupport.basePath, 'src/main.ts')},
+          module:
+              {name: 'MainModule', filePath: path.posix.join(testSupport.basePath, 'src/main.ts')},
           referencedModule: {
             name: undefined as any as string,  // TODO: Review use of `any` here (#19904)
-            filePath: path.resolve(testSupport.basePath, 'src/child.ts')
+            filePath: path.posix.join(testSupport.basePath, 'src/child.ts')
           },
           route: './child'
         },
@@ -816,18 +837,21 @@ describe('ng program', () => {
         {
           module: {
             name: 'NestedMainModule',
-            filePath: path.resolve(testSupport.basePath, 'src/nested/main.ts')
+            filePath: path.posix.join(testSupport.basePath, 'src/nested/main.ts')
           },
           referencedModule: {
             name: 'NestedChildModule',
-            filePath: path.resolve(testSupport.basePath, 'src/nested/child.ts')
+            filePath: path.posix.join(testSupport.basePath, 'src/nested/child.ts')
           },
           route: './child#NestedChildModule'
         },
         {
-          module: {name: 'MainModule', filePath: path.resolve(testSupport.basePath, 'src/main.ts')},
-          referencedModule:
-              {name: 'ChildModule', filePath: path.resolve(testSupport.basePath, 'src/child.ts')},
+          module:
+              {name: 'MainModule', filePath: path.posix.join(testSupport.basePath, 'src/main.ts')},
+          referencedModule: {
+            name: 'ChildModule',
+            filePath: path.posix.join(testSupport.basePath, 'src/child.ts')
+          },
           route: './child#ChildModule'
         },
       ]);
@@ -853,16 +877,23 @@ describe('ng program', () => {
       expectNoDiagnosticsInProgram(options, program);
       expect(normalizeRoutes(program.listLazyRoutes('src/main#MainModule'))).toEqual([
         {
-          module: {name: 'MainModule', filePath: path.resolve(testSupport.basePath, 'src/main.ts')},
-          referencedModule:
-              {name: 'ChildModule', filePath: path.resolve(testSupport.basePath, 'src/child.ts')},
+          module:
+              {name: 'MainModule', filePath: path.posix.join(testSupport.basePath, 'src/main.ts')},
+          referencedModule: {
+            name: 'ChildModule',
+            filePath: path.posix.join(testSupport.basePath, 'src/child.ts')
+          },
           route: './child#ChildModule'
         },
         {
-          module:
-              {name: 'ChildModule', filePath: path.resolve(testSupport.basePath, 'src/child.ts')},
-          referencedModule:
-              {name: 'ChildModule2', filePath: path.resolve(testSupport.basePath, 'src/child2.ts')},
+          module: {
+            name: 'ChildModule',
+            filePath: path.posix.join(testSupport.basePath, 'src/child.ts')
+          },
+          referencedModule: {
+            name: 'ChildModule2',
+            filePath: path.posix.join(testSupport.basePath, 'src/child2.ts')
+          },
           route: './child2#ChildModule2'
         },
       ]);
@@ -920,9 +951,10 @@ describe('ng program', () => {
       });
       const program = createProgram(['src/main.ts'], {collectAllErrors: true}).program;
       expect(normalizeRoutes(program.listLazyRoutes('src/main#MainModule'))).toEqual([{
-        module: {name: 'MainModule', filePath: path.resolve(testSupport.basePath, 'src/main.ts')},
+        module:
+            {name: 'MainModule', filePath: path.posix.join(testSupport.basePath, 'src/main.ts')},
         referencedModule:
-            {name: 'ChildModule', filePath: path.resolve(testSupport.basePath, 'src/child.ts')},
+            {name: 'ChildModule', filePath: path.posix.join(testSupport.basePath, 'src/child.ts')},
         route: './child#ChildModule'
       }]);
     });

--- a/packages/language-service/test/test_utils.ts
+++ b/packages/language-service/test/test_utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {isInBazel, setup} from '@angular/compiler-cli/test/test_support';
+import {setup} from '@angular/compiler-cli/test/test_support';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
@@ -76,20 +76,9 @@ export class MockTypescriptHost implements ts.LanguageServiceHost {
   constructor(
       private scriptNames: string[], private data: MockData,
       private node_modules: string = 'node_modules', private myPath: typeof path = path) {
-    const moduleFilename = module.filename.replace(/\\/g, '/');
-    if (isInBazel()) {
-      const support = setup();
-      this.nodeModulesPath = path.join(support.basePath, 'node_modules');
-      this.angularPath = path.join(this.nodeModulesPath, '@angular');
-    } else {
-      const angularIndex = moduleFilename.indexOf('@angular');
-      if (angularIndex >= 0)
-        this.angularPath =
-            moduleFilename.substr(0, angularIndex).replace('/all/', '/all/@angular/');
-      const distIndex = moduleFilename.indexOf('/dist/all');
-      if (distIndex >= 0)
-        this.nodeModulesPath = myPath.join(moduleFilename.substr(0, distIndex), 'node_modules');
-    }
+    const support = setup();
+    this.nodeModulesPath = path.join(support.basePath, 'node_modules');
+    this.angularPath = path.join(this.nodeModulesPath, '@angular');
     this.options = {
       target: ts.ScriptTarget.ES5,
       module: ts.ModuleKind.CommonJS,


### PR DESCRIPTION
See individual commits for description of changes.

**Note**: One could argue that the changes for Windows support are not good yet, due to no CI verifying these changes, but the Windows support is a side-effect (with little efforts) in order to make the tests using Bazel runfile resolution, more Bazel idiomatic. 