### PR TITLE
 feat(ivy): support property bindings and interpolations in DebugElement

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -10,9 +10,10 @@ import {Injector} from '../di';
 import {getComponent, getContext, getInjectionTokens, getInjector, getListeners, getLocalRefs, isBrowserEvents, loadLContext, loadLContextFromNode} from '../render3/discovery_utils';
 import {TNode} from '../render3/interfaces/node';
 import {StylingIndex} from '../render3/interfaces/styling';
-import {TVIEW} from '../render3/interfaces/view';
+import {LView, TData, TVIEW} from '../render3/interfaces/view';
 import {getProp, getValue, isClassBasedValue} from '../render3/styling/class_and_style_bindings';
 import {getStylingContext} from '../render3/styling/util';
+import {INTERPOLATION_DELIMITER, isPropMetadataString, renderStringify} from '../render3/util';
 import {assertDomNode} from '../util/assert';
 import {DebugContext} from '../view/index';
 
@@ -243,9 +244,9 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
    *  Returns a map of property names to property values for an element.
    *
    *  This map includes:
-   *  - Regular property bindings (e.g. `[id]="id"`) - TODO
+   *  - Regular property bindings (e.g. `[id]="id"`)
    *  - Host property bindings (e.g. `host: { '[id]': "id" }`)
-   *  - Interpolated property bindings (e.g. `id="{{ value }}") - TODO
+   *  - Interpolated property bindings (e.g. `id="{{ value }}")
    *
    *  It should NOT include input property bindings or attribute bindings.
    */
@@ -255,20 +256,8 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
     const tData = lView[TVIEW].data;
     const tNode = tData[context.nodeIndex] as TNode;
 
-    // TODO(kara): include regular property binding values (not just host properties)
-    const properties: {[key: string]: string} = {};
-
-    // Host binding values for a node are stored after directives on that node
-    let index = tNode.directiveEnd;
-    let propertyName = tData[index];
-
-    // When we reach a value in TView.data that is not a string, we know we've
-    // hit the next node's providers and directives and should stop copying data.
-    while (typeof propertyName === 'string') {
-      properties[propertyName] = lView[index];
-      propertyName = tData[++index];
-    }
-    return properties;
+    const properties = collectPropertyBindings(tNode, lView, tData);
+    return collectHostPropertyBindings(tNode, lView, tData, properties);
   }
 
   get attributes(): {[key: string]: string | null;} {
@@ -408,6 +397,88 @@ function _queryNodeChildrenR3(
       }
     });
   }
+}
+
+/**
+ * Iterates through the property bindings for a given node and generates
+ * a map of property names to values. This map only contains property bindings
+ * defined in templates, not in host bindings.
+ */
+function collectPropertyBindings(
+    tNode: TNode, lView: LView, tData: TData): {[key: string]: string} {
+  const properties: {[key: string]: string} = {};
+  let bindingIndex = getFirstBindingIndex(tNode.propertyMetadataStartIndex, tData);
+
+  while (bindingIndex < tNode.propertyMetadataEndIndex) {
+    let value = '';
+    let propMetadata = tData[bindingIndex] as string;
+    while (!isPropMetadataString(propMetadata)) {
+      // This is the first value for an interpolation. We need to build up
+      // the full interpolation by combining runtime values in LView with
+      // the static interstitial values stored in TData.
+      value += renderStringify(lView[bindingIndex]) + tData[bindingIndex];
+      propMetadata = tData[++bindingIndex] as string;
+    }
+    value += lView[bindingIndex];
+    // Property metadata string has 3 parts: property name, prefix, and suffix
+    const metadataParts = propMetadata.split(INTERPOLATION_DELIMITER);
+    const propertyName = metadataParts[0];
+    // Attr bindings don't have property names and should be skipped
+    if (propertyName) {
+      // Wrap value with prefix and suffix (will be '' for normal bindings)
+      properties[propertyName] = metadataParts[1] + value + metadataParts[2];
+    }
+    bindingIndex++;
+  }
+  return properties;
+}
+
+/**
+ * Retrieves the first binding index that holds values for this property
+ * binding.
+ *
+ * For normal bindings (e.g. `[id]="id"`), the binding index is the
+ * same as the metadata index. For interpolations (e.g. `id="{{id}}-{{name}}"`),
+ * there can be multiple binding values, so we might have to loop backwards
+ * from the metadata index until we find the first one.
+ *
+ * @param metadataIndex The index of the first property metadata string for
+ * this node.
+ * @param tData The data array for the current TView
+ * @returns The first binding index for this binding
+ */
+function getFirstBindingIndex(metadataIndex: number, tData: TData): number {
+  let currentBindingIndex = metadataIndex - 1;
+
+  // If the slot before the metadata holds a string, we know that this
+  // metadata applies to an interpolation with at least 2 bindings, and
+  // we need to search further to access the first binding value.
+  let currentValue = tData[currentBindingIndex];
+
+  // We need to iterate until we hit either a:
+  // - TNode (it is an element slot marking the end of `consts` section), OR a
+  // - metadata string (slot is attribute metadata or a previous node's property metadata)
+  while (typeof currentValue === 'string' && !isPropMetadataString(currentValue)) {
+    currentValue = tData[--currentBindingIndex];
+  }
+  return currentBindingIndex + 1;
+}
+
+function collectHostPropertyBindings(
+    tNode: TNode, lView: LView, tData: TData,
+    properties: {[key: string]: string}): {[key: string]: string} {
+  // Host binding values for a node are stored after directives on that node
+  let hostPropIndex = tNode.directiveEnd;
+  let propMetadata = tData[hostPropIndex] as any;
+
+  // When we reach a value in TView.data that is not a string, we know we've
+  // hit the next node's providers and directives and should stop copying data.
+  while (typeof propMetadata === 'string') {
+    const propertyName = propMetadata.split(INTERPOLATION_DELIMITER)[0];
+    properties[propertyName] = lView[hostPropIndex];
+    propMetadata = tData[++hostPropIndex];
+  }
+  return properties;
 }
 
 

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -257,7 +257,8 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
     const tNode = tData[context.nodeIndex] as TNode;
 
     const properties = collectPropertyBindings(tNode, lView, tData);
-    return collectHostPropertyBindings(tNode, lView, tData, properties);
+    const hostProperties = collectHostPropertyBindings(tNode, lView, tData);
+    return {...properties, ...hostProperties};
   }
 
   get attributes(): {[key: string]: string | null;} {
@@ -465,8 +466,9 @@ function getFirstBindingIndex(metadataIndex: number, tData: TData): number {
 }
 
 function collectHostPropertyBindings(
-    tNode: TNode, lView: LView, tData: TData,
-    properties: {[key: string]: string}): {[key: string]: string} {
+    tNode: TNode, lView: LView, tData: TData): {[key: string]: string} {
+  const properties: {[key: string]: string} = {};
+
   // Host binding values for a node are stored after directives on that node
   let hostPropIndex = tNode.directiveEnd;
   let propMetadata = tData[hostPropIndex] as any;

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -241,14 +241,16 @@ class DebugElement__POST_R3__ extends DebugNode__POST_R3__ implements DebugEleme
   get name(): string { return this.nativeElement !.nodeName; }
 
   /**
-   *  Returns a map of property names to property values for an element.
+   *  Gets a map of property names to property values for an element.
    *
    *  This map includes:
    *  - Regular property bindings (e.g. `[id]="id"`)
    *  - Host property bindings (e.g. `host: { '[id]': "id" }`)
    *  - Interpolated property bindings (e.g. `id="{{ value }}")
    *
-   *  It should NOT include input property bindings or attribute bindings.
+   *  It does not include:
+   *  - input property bindings (e.g. `[myCustomInput]="value"`)
+   *  - attribute bindings (e.g. `[attr.role]="menu"`)
    */
   get properties(): {[key: string]: any;} {
     const context = loadLContext(this.nativeNode) !;

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1154,6 +1154,14 @@ function elementPropertyInternal<T>(
       validateProperty(propName);
       ngDevMode.rendererSetProperty++;
     }
+    const tView = lView[TVIEW];
+    const lastBindingIndex = lView[BINDING_INDEX] - 1;
+    if (nativeOnly && tView.data[lastBindingIndex] == null) {
+      // We need to store the host property name so it can be accessed by DebugElement.properties.
+      // Host properties cannot have interpolations, so using the last binding index is
+      // sufficient.
+      tView.data[lastBindingIndex] = propName;
+    }
     const renderer = loadRendererFn ? loadRendererFn(tNode, lView) : lView[RENDERER];
     // It is assumed that the sanitizer is only added when the compiler determines that the property
     // is risky, so sanitization can be done without further checks.

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -170,6 +170,18 @@ export interface TNode {
   directiveEnd: number;
 
   /**
+   * Stores the first index where property binding metadata is stored for
+   * this node.
+   */
+  propertyMetadataStartIndex: number;
+
+  /**
+   * Stores the exclusive final index where property binding metadata is
+   * stored for this node.
+   */
+  propertyMetadataEndIndex: number;
+
+  /**
    * Stores if Node isComponent, isProjected, hasContentQuery and hasClassInput
    */
   flags: TNodeFlags;
@@ -475,7 +487,6 @@ export type PropertyAliases = {
  * e.g. [0, 'change', 'change-minified']
  */
 export type PropertyAliasValue = (number | string)[];
-
 
 /**
  * This array contains information about input properties that

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -559,6 +559,18 @@ export type HookData = (number | (() => void))[];
  * Each host property's name is stored here at the same index as its value in the
  * data array.
  *
+ * Each property binding name is stored here at the same index as its value in
+ * the data array. If the binding is an interpolation, the static string values
+ * are stored parallel to the dynamic values. Example:
+ *
+ * id="prefix {{ v0 }} a {{ v1 }} b {{ v2 }} suffix"
+ *
+ * LView       |   TView.data
+ *------------------------
+ *  v0 value   |   'a'
+ *  v1 value   |   'b'
+ *  v2 value   |   id � prefix � suffix
+ *
  * Injector bloom filters are also stored here.
  */
 export type TData =

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -556,11 +556,14 @@ export type HookData = (number | (() => void))[];
  * Each pipe's definition is stored here at the same index as its pipe instance in
  * the data array.
  *
+ * Each host property's name is stored here at the same index as its value in the
+ * data array.
+ *
  * Injector bloom filters are also stored here.
  */
 export type TData =
     (TNode | PipeDef<any>| DirectiveDef<any>| ComponentDef<any>| number | Type<any>|
-     InjectionToken<any>| TI18n | I18nUpdateOpCodes | null)[];
+     InjectionToken<any>| TI18n | I18nUpdateOpCodes | null | string)[];
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency
 // failure based on types.

--- a/packages/core/src/render3/util.ts
+++ b/packages/core/src/render3/util.ts
@@ -292,3 +292,17 @@ export function resolveDocument(element: RElement & {ownerDocument: Document}) {
 export function resolveBody(element: RElement & {ownerDocument: Document}) {
   return {name: 'body', target: element.ownerDocument.body};
 }
+
+/**
+ * The special delimiter we use to separate property names, prefixes, and suffixes
+ * in property binding metadata. See storeBindingMetadata().
+ */
+export const INTERPOLATION_DELIMITER = `�`;
+
+/**
+ * Returns whether or not the given string is a property metadata string.
+ * See storeBindingMetadata().
+ */
+export function isPropMetadataString(str: string): boolean {
+  return new RegExp(/�/).test(str);
+}

--- a/packages/core/src/render3/util.ts
+++ b/packages/core/src/render3/util.ts
@@ -304,5 +304,5 @@ export const INTERPOLATION_DELIMITER = `�`;
  * See storeBindingMetadata().
  */
 export function isPropMetadataString(str: string): boolean {
-  return new RegExp(/�/).test(str);
+  return str.indexOf(INTERPOLATION_DELIMITER) >= 0;
 }

--- a/packages/core/src/render3/util.ts
+++ b/packages/core/src/render3/util.ts
@@ -296,11 +296,21 @@ export function resolveBody(element: RElement & {ownerDocument: Document}) {
 /**
  * The special delimiter we use to separate property names, prefixes, and suffixes
  * in property binding metadata. See storeBindingMetadata().
+ *
+ * We intentionally use the Unicode "REPLACEMENT CHARACTER" (U+FFFD) as a delimiter
+ * because it is a very uncommon character that is unlikely to be part of a user's
+ * property names or interpolation strings. If it is in fact used in a property
+ * binding, DebugElement.properties will not return the correct value for that
+ * binding. However, there should be no runtime effect for real applications.
+ *
+ * This character is typically rendered as a question mark inside of a diamond.
+ * See https://en.wikipedia.org/wiki/Specials_(Unicode_block)
+ *
  */
 export const INTERPOLATION_DELIMITER = `�`;
 
 /**
- * Returns whether or not the given string is a property metadata string.
+ * Determines whether or not the given string is a property metadata string.
  * See storeBindingMetadata().
  */
 export function isPropMetadataString(str: string): boolean {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -78,6 +78,9 @@
     "name": "INJECTOR_BLOOM_PARENT_SIZE"
   },
   {
+    "name": "INTERPOLATION_DELIMITER"
+  },
+  {
     "name": "InjectFlags"
   },
   {
@@ -1101,6 +1104,9 @@
     "name": "saveNameToExportMap"
   },
   {
+    "name": "savePropertyDebugData"
+  },
+  {
     "name": "saveResolvedLocalsInData"
   },
   {
@@ -1189,6 +1195,9 @@
   },
   {
     "name": "shouldSearchParent"
+  },
+  {
+    "name": "storeBindingMetadata"
   },
   {
     "name": "storeCleanupFn"

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -924,26 +924,24 @@ function declareTests(config?: {useJit: boolean}) {
         expect(getDOM().getProperty(tc.nativeElement, 'id')).toEqual('newId');
       });
 
-      fixmeIvy('FW-681: not possible to retrieve host property bindings from TView')
-          .it('should not use template variables for expressions in hostProperties', () => {
-            @Directive(
-                {selector: '[host-properties]', host: {'[id]': 'id', '[title]': 'unknownProp'}})
-            class DirectiveWithHostProps {
-              id = 'one';
-            }
+      it('should not use template variables for expressions in hostProperties', () => {
+        @Directive({selector: '[host-properties]', host: {'[id]': 'id', '[title]': 'unknownProp'}})
+        class DirectiveWithHostProps {
+          id = 'one';
+        }
 
-            const fixture =
-                TestBed.configureTestingModule({declarations: [MyComp, DirectiveWithHostProps]})
-                    .overrideComponent(MyComp, {
-                      set: {template: `<div *ngFor="let id of ['forId']" host-properties></div>`}
-                    })
-                    .createComponent(MyComp);
-            fixture.detectChanges();
+        const fixture =
+            TestBed.configureTestingModule({declarations: [MyComp, DirectiveWithHostProps]})
+                .overrideComponent(
+                    MyComp,
+                    {set: {template: `<div *ngFor="let id of ['forId']" host-properties></div>`}})
+                .createComponent(MyComp);
+        fixture.detectChanges();
 
-            const tc = fixture.debugElement.children[0];
-            expect(tc.properties['id']).toBe('one');
-            expect(tc.properties['title']).toBe(undefined);
-          });
+        const tc = fixture.debugElement.children[0];
+        expect(tc.properties['id']).toBe('one');
+        expect(tc.properties['title']).toBe(undefined);
+      });
 
       fixmeIvy('FW-725: Pipes in host bindings fail with a cryptic error')
           .it('should not allow pipes in hostProperties', () => {

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -423,163 +423,155 @@ function declareTests(config?: {useJit: boolean}) {
     });
 
     describe('directives and pipes', () => {
-      fixmeIvy('FW-681: not possible to retrieve host property bindings from TView')
-          .describe('declarations', () => {
-            it('should be supported in root modules', () => {
-              @NgModule({
-                declarations: [CompUsingModuleDirectiveAndPipe, SomeDirective, SomePipe],
-                entryComponents: [CompUsingModuleDirectiveAndPipe]
-              })
-              class SomeModule {
-              }
+      describe('declarations', () => {
+        it('should be supported in root modules', () => {
+          @NgModule({
+            declarations: [CompUsingModuleDirectiveAndPipe, SomeDirective, SomePipe],
+            entryComponents: [CompUsingModuleDirectiveAndPipe]
+          })
+          class SomeModule {
+          }
 
-              const compFixture = createComp(CompUsingModuleDirectiveAndPipe, SomeModule);
+          const compFixture = createComp(CompUsingModuleDirectiveAndPipe, SomeModule);
 
-              compFixture.detectChanges();
-              expect(compFixture.debugElement.children[0].properties['title'])
-                  .toBe('transformed someValue');
-            });
+          compFixture.detectChanges();
+          expect(compFixture.debugElement.children[0].properties['title'])
+              .toBe('transformed someValue');
+        });
 
-            it('should be supported in imported modules', () => {
-              @NgModule({
-                declarations: [CompUsingModuleDirectiveAndPipe, SomeDirective, SomePipe],
-                entryComponents: [CompUsingModuleDirectiveAndPipe]
-              })
-              class SomeImportedModule {
-              }
+        it('should be supported in imported modules', () => {
+          @NgModule({
+            declarations: [CompUsingModuleDirectiveAndPipe, SomeDirective, SomePipe],
+            entryComponents: [CompUsingModuleDirectiveAndPipe]
+          })
+          class SomeImportedModule {
+          }
 
-              @NgModule({imports: [SomeImportedModule]})
-              class SomeModule {
-              }
+          @NgModule({imports: [SomeImportedModule]})
+          class SomeModule {
+          }
 
-              const compFixture = createComp(CompUsingModuleDirectiveAndPipe, SomeModule);
-              compFixture.detectChanges();
-              expect(compFixture.debugElement.children[0].properties['title'])
-                  .toBe('transformed someValue');
-            });
+          const compFixture = createComp(CompUsingModuleDirectiveAndPipe, SomeModule);
+          compFixture.detectChanges();
+          expect(compFixture.debugElement.children[0].properties['title'])
+              .toBe('transformed someValue');
+        });
 
 
-            it('should be supported in nested components', () => {
-              @Component({
-                selector: 'parent',
-                template: '<comp></comp>',
-              })
-              class ParentCompUsingModuleDirectiveAndPipe {
-              }
+        it('should be supported in nested components', () => {
+          @Component({
+            selector: 'parent',
+            template: '<comp></comp>',
+          })
+          class ParentCompUsingModuleDirectiveAndPipe {
+          }
 
-              @NgModule({
-                declarations: [
-                  ParentCompUsingModuleDirectiveAndPipe, CompUsingModuleDirectiveAndPipe,
-                  SomeDirective, SomePipe
-                ],
-                entryComponents: [ParentCompUsingModuleDirectiveAndPipe]
-              })
-              class SomeModule {
-              }
+          @NgModule({
+            declarations: [
+              ParentCompUsingModuleDirectiveAndPipe, CompUsingModuleDirectiveAndPipe, SomeDirective,
+              SomePipe
+            ],
+            entryComponents: [ParentCompUsingModuleDirectiveAndPipe]
+          })
+          class SomeModule {
+          }
 
-              const compFixture = createComp(ParentCompUsingModuleDirectiveAndPipe, SomeModule);
-              compFixture.detectChanges();
-              expect(compFixture.debugElement.children[0].children[0].properties['title'])
-                  .toBe('transformed someValue');
-            });
-          });
+          const compFixture = createComp(ParentCompUsingModuleDirectiveAndPipe, SomeModule);
+          compFixture.detectChanges();
+          expect(compFixture.debugElement.children[0].children[0].properties['title'])
+              .toBe('transformed someValue');
+        });
+      });
 
       describe('import/export', () => {
 
-        fixmeIvy('FW-681: not possible to retrieve host property bindings from TView')
-            .it('should support exported directives and pipes', () => {
-              @NgModule(
-                  {declarations: [SomeDirective, SomePipe], exports: [SomeDirective, SomePipe]})
-              class SomeImportedModule {
-              }
+        it('should support exported directives and pipes', () => {
+          @NgModule({declarations: [SomeDirective, SomePipe], exports: [SomeDirective, SomePipe]})
+          class SomeImportedModule {
+          }
 
-              @NgModule({
-                declarations: [CompUsingModuleDirectiveAndPipe],
-                imports: [SomeImportedModule],
-                entryComponents: [CompUsingModuleDirectiveAndPipe]
-              })
-              class SomeModule {
-              }
+          @NgModule({
+            declarations: [CompUsingModuleDirectiveAndPipe],
+            imports: [SomeImportedModule],
+            entryComponents: [CompUsingModuleDirectiveAndPipe]
+          })
+          class SomeModule {
+          }
 
 
-              const compFixture = createComp(CompUsingModuleDirectiveAndPipe, SomeModule);
-              compFixture.detectChanges();
-              expect(compFixture.debugElement.children[0].properties['title'])
-                  .toBe('transformed someValue');
-            });
+          const compFixture = createComp(CompUsingModuleDirectiveAndPipe, SomeModule);
+          compFixture.detectChanges();
+          expect(compFixture.debugElement.children[0].properties['title'])
+              .toBe('transformed someValue');
+        });
 
-        fixmeIvy('FW-681: not possible to retrieve host property bindings from TView')
-            .it('should support exported directives and pipes if the module is wrapped into an `ModuleWithProviders`',
-                () => {
-                  @NgModule(
-                      {declarations: [SomeDirective, SomePipe], exports: [SomeDirective, SomePipe]})
-                  class SomeImportedModule {
-                  }
+        it('should support exported directives and pipes if the module is wrapped into an `ModuleWithProviders`',
+           () => {
+             @NgModule(
+                 {declarations: [SomeDirective, SomePipe], exports: [SomeDirective, SomePipe]})
+             class SomeImportedModule {
+             }
 
-                  @NgModule({
-                    declarations: [CompUsingModuleDirectiveAndPipe],
-                    imports: [{ngModule: SomeImportedModule}],
-                    entryComponents: [CompUsingModuleDirectiveAndPipe]
-                  })
-                  class SomeModule {
-                  }
+             @NgModule({
+               declarations: [CompUsingModuleDirectiveAndPipe],
+               imports: [{ngModule: SomeImportedModule}],
+               entryComponents: [CompUsingModuleDirectiveAndPipe]
+             })
+             class SomeModule {
+             }
 
 
-                  const compFixture = createComp(CompUsingModuleDirectiveAndPipe, SomeModule);
-                  compFixture.detectChanges();
-                  expect(compFixture.debugElement.children[0].properties['title'])
-                      .toBe('transformed someValue');
-                });
+             const compFixture = createComp(CompUsingModuleDirectiveAndPipe, SomeModule);
+             compFixture.detectChanges();
+             expect(compFixture.debugElement.children[0].properties['title'])
+                 .toBe('transformed someValue');
+           });
 
-        fixmeIvy('FW-681: not possible to retrieve host property bindings from TView')
-            .it('should support reexported modules', () => {
-              @NgModule(
-                  {declarations: [SomeDirective, SomePipe], exports: [SomeDirective, SomePipe]})
-              class SomeReexportedModule {
-              }
+        it('should support reexported modules', () => {
+          @NgModule({declarations: [SomeDirective, SomePipe], exports: [SomeDirective, SomePipe]})
+          class SomeReexportedModule {
+          }
 
-              @NgModule({exports: [SomeReexportedModule]})
-              class SomeImportedModule {
-              }
+          @NgModule({exports: [SomeReexportedModule]})
+          class SomeImportedModule {
+          }
 
-              @NgModule({
-                declarations: [CompUsingModuleDirectiveAndPipe],
-                imports: [SomeImportedModule],
-                entryComponents: [CompUsingModuleDirectiveAndPipe]
-              })
-              class SomeModule {
-              }
+          @NgModule({
+            declarations: [CompUsingModuleDirectiveAndPipe],
+            imports: [SomeImportedModule],
+            entryComponents: [CompUsingModuleDirectiveAndPipe]
+          })
+          class SomeModule {
+          }
 
-              const compFixture = createComp(CompUsingModuleDirectiveAndPipe, SomeModule);
-              compFixture.detectChanges();
-              expect(compFixture.debugElement.children[0].properties['title'])
-                  .toBe('transformed someValue');
-            });
+          const compFixture = createComp(CompUsingModuleDirectiveAndPipe, SomeModule);
+          compFixture.detectChanges();
+          expect(compFixture.debugElement.children[0].properties['title'])
+              .toBe('transformed someValue');
+        });
 
-        fixmeIvy('FW-681: not possible to retrieve host property bindings from TView')
-            .it('should support exporting individual directives of an imported module', () => {
-              @NgModule(
-                  {declarations: [SomeDirective, SomePipe], exports: [SomeDirective, SomePipe]})
-              class SomeReexportedModule {
-              }
+        it('should support exporting individual directives of an imported module', () => {
+          @NgModule({declarations: [SomeDirective, SomePipe], exports: [SomeDirective, SomePipe]})
+          class SomeReexportedModule {
+          }
 
-              @NgModule({imports: [SomeReexportedModule], exports: [SomeDirective, SomePipe]})
-              class SomeImportedModule {
-              }
+          @NgModule({imports: [SomeReexportedModule], exports: [SomeDirective, SomePipe]})
+          class SomeImportedModule {
+          }
 
-              @NgModule({
-                declarations: [CompUsingModuleDirectiveAndPipe],
-                imports: [SomeImportedModule],
-                entryComponents: [CompUsingModuleDirectiveAndPipe]
-              })
-              class SomeModule {
-              }
+          @NgModule({
+            declarations: [CompUsingModuleDirectiveAndPipe],
+            imports: [SomeImportedModule],
+            entryComponents: [CompUsingModuleDirectiveAndPipe]
+          })
+          class SomeModule {
+          }
 
-              const compFixture = createComp(CompUsingModuleDirectiveAndPipe, SomeModule);
-              compFixture.detectChanges();
-              expect(compFixture.debugElement.children[0].properties['title'])
-                  .toBe('transformed someValue');
-            });
+          const compFixture = createComp(CompUsingModuleDirectiveAndPipe, SomeModule);
+          compFixture.detectChanges();
+          expect(compFixture.debugElement.children[0].properties['title'])
+              .toBe('transformed someValue');
+        });
 
         it('should not use non exported pipes of an imported module', () => {
           @NgModule({

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -52,13 +52,22 @@ export class WithRefsCmp {
 export class InheritedCmp extends SimpleCmp {
 }
 
-@Directive({selector: '[dir]', host: {'[id]': 'id'}})
+@Directive({selector: '[hostBindingDir]', host: {'[id]': 'id'}})
 export class HostBindingDir {
   id = 'one';
 }
 
-@Component({selector: 'host-binding-parent', template: '<div dir></div>'})
-export class HostBindingParent {
+@Component({
+  selector: 'component-with-prop-bindings',
+  template: `
+    <div hostBindingDir [title]="title" [attr.aria-label]="label"></div>
+    <p title="( {{ label }} - {{ title }} )" [attr.aria-label]="label" id="[ {{ label }} ] [ {{ title }} ]">
+    </p>
+  `
+})
+export class ComponentWithPropBindings {
+  title = 'some title';
+  label = 'some label';
 }
 
 @Component({
@@ -72,7 +81,8 @@ export class SimpleApp {
 
 @NgModule({
   declarations: [
-    HelloWorld, SimpleCmp, WithRefsCmp, InheritedCmp, SimpleApp, HostBindingParent, HostBindingDir
+    HelloWorld, SimpleCmp, WithRefsCmp, InheritedCmp, SimpleApp, ComponentWithPropBindings,
+    HostBindingDir
   ],
   imports: [GreetingModule],
   providers: [
@@ -123,12 +133,21 @@ describe('TestBed', () => {
     expect(greetingByCss.nativeElement).toHaveText('Hello TestBed!');
   });
 
-  it('should give the ability to access host properties', () => {
-    const fixture = TestBed.createComponent(HostBindingParent);
+  it('should give the ability to access property bindings on a node', () => {
+    const fixture = TestBed.createComponent(ComponentWithPropBindings);
     fixture.detectChanges();
 
-    const divElement = fixture.debugElement.children[0];
-    expect(divElement.properties).toEqual({id: 'one'});
+    const divElement = fixture.debugElement.query(By.css('div'));
+    expect(divElement.properties).toEqual({id: 'one', title: 'some title'});
+  });
+
+  it('should give the ability to access interpolated properties on a node', () => {
+    const fixture = TestBed.createComponent(ComponentWithPropBindings);
+    fixture.detectChanges();
+
+    const paragraphEl = fixture.debugElement.query(By.css('p'));
+    expect(paragraphEl.properties)
+        .toEqual({title: '( some label - some title )', id: '[ some label ] [ some title ]'});
   });
 
   it('should give access to the node injector', () => {

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -52,6 +52,15 @@ export class WithRefsCmp {
 export class InheritedCmp extends SimpleCmp {
 }
 
+@Directive({selector: '[dir]', host: {'[id]': 'id'}})
+export class HostBindingDir {
+  id = 'one';
+}
+
+@Component({selector: 'host-binding-parent', template: '<div dir></div>'})
+export class HostBindingParent {
+}
+
 @Component({
   selector: 'simple-app',
   template: `
@@ -62,7 +71,9 @@ export class SimpleApp {
 }
 
 @NgModule({
-  declarations: [HelloWorld, SimpleCmp, WithRefsCmp, InheritedCmp, SimpleApp],
+  declarations: [
+    HelloWorld, SimpleCmp, WithRefsCmp, InheritedCmp, SimpleApp, HostBindingParent, HostBindingDir
+  ],
   imports: [GreetingModule],
   providers: [
     {provide: NAME, useValue: 'World!'},
@@ -110,6 +121,14 @@ describe('TestBed', () => {
     greetingByCss.componentInstance.name = 'TestBed!';
     hello.detectChanges();
     expect(greetingByCss.nativeElement).toHaveText('Hello TestBed!');
+  });
+
+  it('should give the ability to access host properties', () => {
+    const fixture = TestBed.createComponent(HostBindingParent);
+    fixture.detectChanges();
+
+    const divElement = fixture.debugElement.children[0];
+    expect(divElement.properties).toEqual({id: 'one'});
   });
 
   it('should give access to the node injector', () => {

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -251,14 +251,13 @@ class CompWithUrlTemplate {
           expect(compFixture.componentInstance).toBeAnInstanceOf(CompUsingModuleDirectiveAndPipe);
         });
 
-        fixmeIvy('FW-681: not possible to retrieve host property bindings from TView')
-            .it('should use set up directives and pipes', () => {
-              const compFixture = TestBed.createComponent(CompUsingModuleDirectiveAndPipe);
-              const el = compFixture.debugElement;
+        it('should use set up directives and pipes', () => {
+          const compFixture = TestBed.createComponent(CompUsingModuleDirectiveAndPipe);
+          const el = compFixture.debugElement;
 
-              compFixture.detectChanges();
-              expect(el.children[0].properties['title']).toBe('transformed someValue');
-            });
+          compFixture.detectChanges();
+          expect(el.children[0].properties['title']).toBe('transformed someValue');
+        });
 
         it('should use set up imported modules',
            inject([SomeLibModule], (libModule: SomeLibModule) => {
@@ -289,14 +288,13 @@ class CompWithUrlTemplate {
              expect(service.value).toEqual('real value');
            }));
 
-        fixmeIvy('FW-681: not possible to retrieve host property bindings from TView')
-            .it('should use set up directives and pipes', withModule(moduleConfig, () => {
-                  const compFixture = TestBed.createComponent(CompUsingModuleDirectiveAndPipe);
-                  const el = compFixture.debugElement;
+        it('should use set up directives and pipes', withModule(moduleConfig, () => {
+             const compFixture = TestBed.createComponent(CompUsingModuleDirectiveAndPipe);
+             const el = compFixture.debugElement;
 
-                  compFixture.detectChanges();
-                  expect(el.children[0].properties['title']).toBe('transformed someValue');
-                }));
+             compFixture.detectChanges();
+             expect(el.children[0].properties['title']).toBe('transformed someValue');
+           }));
 
         it('should use set up library modules',
            withModule(moduleConfig).inject([SomeLibModule], (libModule: SomeLibModule) => {
@@ -371,12 +369,11 @@ class CompWithUrlTemplate {
                 .overrideDirective(
                     SomeDirective, {set: {selector: '[someDir]', host: {'[title]': 'someProp'}}});
           });
-          fixmeIvy('FW-681: not possible to retrieve host property bindings from TView')
-              .it('should work', () => {
-                const compFixture = TestBed.createComponent(SomeComponent);
-                compFixture.detectChanges();
-                expect(compFixture.debugElement.children[0].properties['title']).toEqual('hello');
-              });
+          it('should work', () => {
+            const compFixture = TestBed.createComponent(SomeComponent);
+            compFixture.detectChanges();
+            expect(compFixture.debugElement.children[0].properties['title']).toEqual('hello');
+          });
         });
 
         describe('pipe', () => {


### PR DESCRIPTION
DebugElement.properties should contain a map of element
property names to element property values, with entries
for both normal property bindings and host bindings.
Many Angular core tests depend on this map being present.

This PR adds support for host property bindings, normal property
bindings, and interpolations in DebugElement.properties, which 
fixes the Angular core tests.