### PR TITLE
fix(ivy): verify Host Bindings and Host Listeners before compiling them

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -439,7 +439,8 @@ function extractHostBindings(
 
   const bindings = parseHostBindings(hostMetadata);
 
-  const errors = verifyHostBindings(bindings);
+  // Create and provide proper sourceSpan to make error message more descriptive (FW-995)
+  const errors = verifyHostBindings(bindings, null !);
   if (errors.length) {
     throw new FatalDiagnosticError(
         ErrorCode.HOST_BINDING_PARSE_ERROR, metadata.get('host') !,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/directive.ts
@@ -439,10 +439,12 @@ function extractHostBindings(
 
   const bindings = parseHostBindings(hostMetadata);
 
-  // Create and provide proper sourceSpan to make error message more descriptive (FW-995)
-  const errors = verifyHostBindings(bindings, null !);
-  if (errors.length) {
+  // TODO: create and provide proper sourceSpan to make error message more descriptive (FW-995)
+  const errors = verifyHostBindings(bindings, /* sourceSpan */ null !);
+  if (errors.length > 0) {
     throw new FatalDiagnosticError(
+        // TODO: provide more granular diagnostic and output specific host expression that triggered
+        // an error instead of the whole host object
         ErrorCode.HOST_BINDING_PARSE_ERROR, metadata.get('host') !,
         errors.map((error: ParseError) => error.msg).join('\n'));
   }

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
@@ -25,6 +25,10 @@ export enum ErrorCode {
 
   CONFIG_FLAT_MODULE_NO_INDEX = 4001,
 
+  /**
+   * Raised when a host expression has a parse error, such as a host listener or host binding
+   * expression containing a pipe.
+   */
   HOST_BINDING_PARSE_ERROR = 5001,
 }
 

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/code.ts
@@ -24,6 +24,8 @@ export enum ErrorCode {
   SYMBOL_EXPORTED_UNDER_DIFFERENT_NAME = 3002,
 
   CONFIG_FLAT_MODULE_NO_INDEX = 4001,
+
+  HOST_BINDING_PARSE_ERROR = 5001,
 }
 
 export function ngErrorCode(code: ErrorCode): number {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -836,6 +836,45 @@ describe('ngtsc behavioral tests', () => {
             `Unexpected global target 'UnknownTarget' defined for 'click' event. Supported list of global targets: window,document,body.`);
   });
 
+  it('should throw in case pipes are used in host listeners', () => {
+    env.tsconfig();
+    env.write(`test.ts`, `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test',
+          template: '...',
+          host: {
+            '(click)': 'doSmth() | myPipe'
+          }
+        })
+        class FooCmp {}
+    `);
+    const errors = env.driveDiagnostics();
+    debugger;
+    expect(trim(errors[0].messageText as string))
+        .toContain('Cannot have a pipe in an action expression');
+  });
+
+  it('should throw in case pipes are used in host listeners', () => {
+    env.tsconfig();
+    env.write(`test.ts`, `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test',
+          template: '...',
+          host: {
+            '[id]': 'id | myPipe'
+          }
+        })
+        class FooCmp {}
+    `);
+    const errors = env.driveDiagnostics();
+    expect(trim(errors[0].messageText as string))
+        .toContain('Host binding expression cannot contain pipes');
+  });
+
   it('should generate host bindings for directives', () => {
     env.tsconfig();
     env.write(`test.ts`, `

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -851,7 +851,6 @@ describe('ngtsc behavioral tests', () => {
         class FooCmp {}
     `);
     const errors = env.driveDiagnostics();
-    debugger;
     expect(trim(errors[0].messageText as string))
         .toContain('Cannot have a pipe in an action expression');
   });

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -97,7 +97,7 @@ export {compileInjector, compileNgModule, R3InjectorMetadata, R3NgModuleMetadata
 export {compilePipeFromMetadata, R3PipeMetadata} from './render3/r3_pipe_compiler';
 export {makeBindingParser, parseTemplate} from './render3/view/template';
 export {R3Reference} from './render3/util';
-export {compileBaseDefFromMetadata, R3BaseRefMetaData, compileComponentFromMetadata, compileDirectiveFromMetadata, parseHostBindings} from './render3/view/compiler';
+export {compileBaseDefFromMetadata, R3BaseRefMetaData, compileComponentFromMetadata, compileDirectiveFromMetadata, parseHostBindings, verifyHostBindings} from './render3/view/compiler';
 export {publishFacade} from './jit_compiler_facade';
 // This file only reexports content of the `src` folder. Keep it that way.
 

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -38,7 +38,7 @@ export interface CompilerFacade {
   compileComponent(
       angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3ComponentMetadataFacade): any;
 
-  createTypeSourceSpan(kind: string, typeName: string, sourceUrl: string): any;
+  createParseSourceSpan(kind: string, typeName: string, sourceUrl: string): ParseSourceSpan;
 
   R3ResolvedDependencyType: typeof R3ResolvedDependencyType;
 }

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -151,4 +151,8 @@ export interface R3QueryMetadataFacade {
   read: any|null;
 }
 
-export interface ParseSourceSpan { start: any, end: any, details: any }
+export interface ParseSourceSpan {
+  start: any;
+  end: any;
+  details: any;
+}

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -38,6 +38,8 @@ export interface CompilerFacade {
   compileComponent(
       angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3ComponentMetadataFacade): any;
 
+  createTypeSourceSpan(kind: string, typeName: string, sourceUrl: string): any;
+
   R3ResolvedDependencyType: typeof R3ResolvedDependencyType;
 }
 
@@ -109,7 +111,7 @@ export interface R3DirectiveMetadataFacade {
   name: string;
   type: any;
   typeArgumentCount: number;
-  typeSourceSpan: null;
+  typeSourceSpan: ParseSourceSpan;
   deps: R3DependencyMetadataFacade[]|null;
   selector: string|null;
   queries: R3QueryMetadataFacade[];
@@ -148,3 +150,5 @@ export interface R3QueryMetadataFacade {
   descendants: boolean;
   read: any|null;
 }
+
+export interface ParseSourceSpan { start: any, end: any, details: any }

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -13,13 +13,14 @@ import {HostBinding, HostListener, Input, Output, Type} from './core';
 import {compileInjectable} from './injectable_compiler_2';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from './ml_parser/interpolation_config';
 import {Expression, LiteralExpr, WrappedNodeExpr} from './output/output_ast';
+import {ParseError} from './parse_util';
 import {R3DependencyMetadata, R3ResolvedDependencyType} from './render3/r3_factory';
 import {jitExpression} from './render3/r3_jit';
 import {R3InjectorMetadata, R3NgModuleMetadata, compileInjector, compileNgModule} from './render3/r3_module_compiler';
 import {compilePipeFromMetadata} from './render3/r3_pipe_compiler';
 import {R3Reference} from './render3/util';
 import {R3DirectiveMetadata, R3QueryMetadata} from './render3/view/api';
-import {compileComponentFromMetadata, compileDirectiveFromMetadata, parseHostBindings} from './render3/view/compiler';
+import {compileComponentFromMetadata, compileDirectiveFromMetadata, parseHostBindings, verifyHostBindings} from './render3/view/compiler';
 import {makeBindingParser, parseTemplate} from './render3/view/template';
 import {DomElementSchemaRegistry} from './schema/dom_element_schema_registry';
 
@@ -250,22 +251,28 @@ function extractHostBindings(host: {[key: string]: string}, propMetadata: {[key:
   properties: StringMap,
 } {
   // First parse the declarations from the metadata.
-  const {attributes, listeners, properties} = parseHostBindings(host || {});
+  const bindings = parseHostBindings(host || {});
+
+  // After that check host bindings for errors
+  const errors = verifyHostBindings(bindings);
+  if (errors.length) {
+    throw new Error(errors.map((error: ParseError) => error.msg).join('\n'));
+  }
 
   // Next, loop over the properties of the object, looking for @HostBinding and @HostListener.
   for (const field in propMetadata) {
     if (propMetadata.hasOwnProperty(field)) {
       propMetadata[field].forEach(ann => {
         if (isHostBinding(ann)) {
-          properties[ann.hostPropertyName || field] = field;
+          bindings.properties[ann.hostPropertyName || field] = field;
         } else if (isHostListener(ann)) {
-          listeners[ann.eventName || field] = `${field}(${(ann.args || []).join(',')})`;
+          bindings.listeners[ann.eventName || field] = `${field}(${(ann.args || []).join(',')})`;
         }
       });
     }
   }
 
-  return {attributes, listeners, properties};
+  return bindings;
 }
 
 function isHostBinding(value: any): value is HostBinding {

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -144,7 +144,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
     return jitExpression(res.expression, angularCoreEnv, sourceMapUrl, preStatements);
   }
 
-  createTypeSourceSpan(kind: string, typeName: string, sourceUrl: string): any {
+  createParseSourceSpan(kind: string, typeName: string, sourceUrl: string): ParseSourceSpan {
     return r3JitTypeSourceSpan(kind, typeName, sourceUrl);
   }
 }

--- a/packages/compiler/src/parse_util.ts
+++ b/packages/compiler/src/parse_util.ts
@@ -139,3 +139,11 @@ export function typeSourceSpan(kind: string, type: CompileIdentifierMetadata): P
   return new ParseSourceSpan(
       new ParseLocation(sourceFile, -1, -1, -1), new ParseLocation(sourceFile, -1, -1, -1));
 }
+
+export function r3TypeSourceSpan(
+    kind: string, typeName: string, moduleUrl: string): ParseSourceSpan {
+  const sourceFileName = `in ${kind} ${typeName} in ${moduleUrl}`;
+  const sourceFile = new ParseSourceFile('', sourceFileName);
+  return new ParseSourceSpan(
+      new ParseLocation(sourceFile, -1, -1, -1), new ParseLocation(sourceFile, -1, -1, -1));
+}

--- a/packages/compiler/src/parse_util.ts
+++ b/packages/compiler/src/parse_util.ts
@@ -140,9 +140,17 @@ export function typeSourceSpan(kind: string, type: CompileIdentifierMetadata): P
       new ParseLocation(sourceFile, -1, -1, -1), new ParseLocation(sourceFile, -1, -1, -1));
 }
 
-export function r3TypeSourceSpan(
-    kind: string, typeName: string, moduleUrl: string): ParseSourceSpan {
-  const sourceFileName = `in ${kind} ${typeName} in ${moduleUrl}`;
+/**
+ * Generates Source Span object for a given R3 Type for JIT mode.
+ *
+ * @param kind Component or Directive.
+ * @param typeName name of the Component or Directive.
+ * @param sourceUrl reference to Component or Directive source.
+ * @returns instance of ParseSourceSpan that represent a given Component or Directive.
+ */
+export function r3JitTypeSourceSpan(
+    kind: string, typeName: string, sourceUrl: string): ParseSourceSpan {
+  const sourceFileName = `in ${kind} ${typeName} in ${sourceUrl}`;
   const sourceFile = new ParseSourceFile('', sourceFileName);
   return new ParseSourceSpan(
       new ParseLocation(sourceFile, -1, -1, -1), new ParseLocation(sourceFile, -1, -1, -1));

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -877,8 +877,9 @@ const enum HostBindingGroup {
 }
 
 interface ParsedHostBindings {
-  attributes: {[key: string]: string}, listeners: {[key: string]: string},
-      properties: {[key: string]: string},
+  attributes: {[key: string]: string};
+  listeners: {[key: string]: string};
+  properties: {[key: string]: string};
 }
 
 export function parseHostBindings(host: {[key: string]: string}): ParsedHostBindings {

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -877,7 +877,9 @@ const enum HostBindingGroup {
   Event = 2,
 }
 
-interface ParsedHostBindings {
+// Defines Host Bindings structure that contains attributes, listeners, and properties,
+// parsed from the `host` object defined for a Type.
+export interface ParsedHostBindings {
   attributes: {[key: string]: string};
   listeners: {[key: string]: string};
   properties: {[key: string]: string};
@@ -906,10 +908,18 @@ export function parseHostBindings(host: {[key: string]: string}): ParsedHostBind
   return {attributes, listeners, properties};
 }
 
+/**
+ * Verifies host bindings and returns the list of errors (if any). Empty array indicates that a
+ * given set of host bindings has no errors.
+ *
+ * @param bindings set of host bindings to verify.
+ * @param sourceSpan source span where host bindings were defined.
+ * @returns array of errors associated with a given set of host bindings.
+ */
 export function verifyHostBindings(
     bindings: ParsedHostBindings, sourceSpan: ParseSourceSpan): ParseError[] {
   const summary = metadataAsSummary({ host: bindings } as any);
-  // Abstract out host bindings verification logic and use it instead of
+  // TODO: abstract out host bindings verification logic and use it instead of
   // creating events and properties ASTs to detect errors (FW-996)
   const bindingParser = makeBindingParser();
   bindingParser.createDirectiveHostEventAsts(summary, sourceSpan);

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -38,7 +38,7 @@ export interface CompilerFacade {
   compileComponent(
       angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3ComponentMetadataFacade): any;
 
-  createTypeSourceSpan(kind: string, typeName: string, sourceUrl: string): any;
+  createParseSourceSpan(kind: string, typeName: string, sourceUrl: string): ParseSourceSpan;
 
   R3ResolvedDependencyType: typeof R3ResolvedDependencyType;
 }

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -151,4 +151,8 @@ export interface R3QueryMetadataFacade {
   read: any|null;
 }
 
-export interface ParseSourceSpan { start: any, end: any, details: any }
+export interface ParseSourceSpan {
+  start: any;
+  end: any;
+  details: any;
+}

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -38,6 +38,8 @@ export interface CompilerFacade {
   compileComponent(
       angularCoreEnv: CoreEnvironment, sourceMapUrl: string, meta: R3ComponentMetadataFacade): any;
 
+  createTypeSourceSpan(kind: string, typeName: string, sourceUrl: string): any;
+
   R3ResolvedDependencyType: typeof R3ResolvedDependencyType;
 }
 
@@ -109,7 +111,7 @@ export interface R3DirectiveMetadataFacade {
   name: string;
   type: any;
   typeArgumentCount: number;
-  typeSourceSpan: null;
+  typeSourceSpan: ParseSourceSpan;
   deps: R3DependencyMetadataFacade[]|null;
   selector: string|null;
   queries: R3QueryMetadataFacade[];
@@ -148,3 +150,5 @@ export interface R3QueryMetadataFacade {
   descendants: boolean;
   read: any|null;
 }
+
+export interface ParseSourceSpan { start: any, end: any, details: any }

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -54,8 +54,11 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
           throw new Error(error.join('\n'));
         }
 
+        const sourceMapUrl = `ng://${renderStringify(type)}/template.html`;
         const meta: R3ComponentMetadataFacade = {
           ...directiveMetadata(type, metadata),
+          typeSourceSpan:
+              compiler.createTypeSourceSpan('Component', renderStringify(type), sourceMapUrl),
           template: metadata.template || '',
           preserveWhitespaces: metadata.preserveWhitespaces || false,
           styles: metadata.styles || EMPTY_ARRAY,
@@ -68,8 +71,7 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
           interpolation: metadata.interpolation,
           viewProviders: metadata.viewProviders || null,
         };
-        ngComponentDef = compiler.compileComponent(
-            angularCoreEnv, `ng://${renderStringify(type)}/template.html`, meta);
+        ngComponentDef = compiler.compileComponent(angularCoreEnv, sourceMapUrl, meta);
 
         // When NgModule decorator executed, we enqueued the module definition such that
         // it would only dequeue and add itself as module scope to all of its declarations,
@@ -111,9 +113,13 @@ export function compileDirective(type: Type<any>, directive: Directive): void {
   Object.defineProperty(type, NG_DIRECTIVE_DEF, {
     get: () => {
       if (ngDirectiveDef === null) {
+        const name = type && type.name;
+        const sourceMapUrl = `ng://${name}/ngDirectiveDef.js`;
+        const compiler = getCompilerFacade();
         const facade = directiveMetadata(type as ComponentType<any>, directive);
-        ngDirectiveDef = getCompilerFacade().compileDirective(
-            angularCoreEnv, `ng://${type && type.name}/ngDirectiveDef.js`, facade);
+        facade.typeSourceSpan =
+            compiler.createTypeSourceSpan('Directive', renderStringify(type), sourceMapUrl);
+        ngDirectiveDef = compiler.compileDirective(angularCoreEnv, sourceMapUrl, facade);
       }
       return ngDirectiveDef;
     },

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -58,7 +58,7 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
         const meta: R3ComponentMetadataFacade = {
           ...directiveMetadata(type, metadata),
           typeSourceSpan:
-              compiler.createTypeSourceSpan('Component', renderStringify(type), sourceMapUrl),
+              compiler.createParseSourceSpan('Component', renderStringify(type), sourceMapUrl),
           template: metadata.template || '',
           preserveWhitespaces: metadata.preserveWhitespaces || false,
           styles: metadata.styles || EMPTY_ARRAY,
@@ -118,7 +118,7 @@ export function compileDirective(type: Type<any>, directive: Directive): void {
         const compiler = getCompilerFacade();
         const facade = directiveMetadata(type as ComponentType<any>, directive);
         facade.typeSourceSpan =
-            compiler.createTypeSourceSpan('Directive', renderStringify(type), sourceMapUrl);
+            compiler.createParseSourceSpan('Directive', renderStringify(type), sourceMapUrl);
         ngDirectiveDef = compiler.compileDirective(angularCoreEnv, sourceMapUrl, facade);
       }
       return ngDirectiveDef;

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -945,18 +945,24 @@ function declareTests(config?: {useJit: boolean}) {
             expect(tc.properties['title']).toBe(undefined);
           });
 
-      fixmeIvy('FW-725: Pipes in host bindings fail with a cryptic error')
-          .it('should not allow pipes in hostProperties', () => {
-            @Directive({selector: '[host-properties]', host: {'[id]': 'id | uppercase'}})
-            class DirectiveWithHostProps {
-            }
+      it('should not allow pipes in hostProperties', () => {
+        @Directive({selector: '[host-properties]', host: {'[id]': 'id | uppercase'}})
+        class DirectiveWithHostProps {
+        }
 
-            TestBed.configureTestingModule({declarations: [MyComp, DirectiveWithHostProps]});
-            const template = '<div host-properties></div>';
-            TestBed.overrideComponent(MyComp, {set: {template}});
-            expect(() => TestBed.createComponent(MyComp))
-                .toThrowError(/Host binding expression cannot contain pipes/);
-          });
+        TestBed.configureTestingModule({declarations: [MyComp, DirectiveWithHostProps]});
+        const template = '<div host-properties></div>';
+        TestBed.overrideComponent(MyComp, {set: {template}});
+
+        try {
+          TestBed.createComponent(MyComp);
+        } catch (e) {
+          debugger;
+        }
+
+        expect(() => TestBed.createComponent(MyComp))
+            .toThrowError(/Host binding expression cannot contain pipes/);
+      });
 
       it('should not use template variables for expressions in hostListeners', () => {
         @Directive({selector: '[host-listener]', host: {'(click)': 'doIt(id, unknownProp)'}})
@@ -981,18 +987,17 @@ function declareTests(config?: {useJit: boolean}) {
         expect(dir.receivedArgs).toEqual(['one', undefined]);
       });
 
-      fixmeIvy('FW-742: Pipes in host listeners should throw a descriptive error')
-          .it('should not allow pipes in hostListeners', () => {
-            @Directive({selector: '[host-listener]', host: {'(click)': 'doIt() | somePipe'}})
-            class DirectiveWithHostListener {
-            }
+      it('should not allow pipes in hostListeners', () => {
+        @Directive({selector: '[host-listener]', host: {'(click)': 'doIt() | somePipe'}})
+        class DirectiveWithHostListener {
+        }
 
-            TestBed.configureTestingModule({declarations: [MyComp, DirectiveWithHostListener]});
-            const template = '<div host-listener></div>';
-            TestBed.overrideComponent(MyComp, {set: {template}});
-            expect(() => TestBed.createComponent(MyComp))
-                .toThrowError(/Cannot have a pipe in an action expression/);
-          });
+        TestBed.configureTestingModule({declarations: [MyComp, DirectiveWithHostListener]});
+        const template = '<div host-listener></div>';
+        TestBed.overrideComponent(MyComp, {set: {template}});
+        expect(() => TestBed.createComponent(MyComp))
+            .toThrowError(/Cannot have a pipe in an action expression/);
+      });
 
 
 

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -953,13 +953,6 @@ function declareTests(config?: {useJit: boolean}) {
         TestBed.configureTestingModule({declarations: [MyComp, DirectiveWithHostProps]});
         const template = '<div host-properties></div>';
         TestBed.overrideComponent(MyComp, {set: {template}});
-
-        try {
-          TestBed.createComponent(MyComp);
-        } catch (e) {
-          debugger;
-        }
-
         expect(() => TestBed.createComponent(MyComp))
             .toThrowError(/Host binding expression cannot contain pipes/);
       });


### PR DESCRIPTION
Prior to this change we may encounter some errors (like pipes being used where they should not be used) while compiling Host Bindings and Listeners. With this update we move validation logic to the analyze phase and throw an error if something is wrong. This also aligns error messages between Ivy and VE.

This PR resolves FW-725 and FW-742.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No