### PR TITLE
fix(bazel): add @npm//tslib dep to e2e ts_library target in bazel-workspace schematic

### DIFF
--- a/packages/bazel/src/schematics/bazel-workspace/files/e2e/BUILD.bazel.template
+++ b/packages/bazel/src/schematics/bazel-workspace/files/e2e/BUILD.bazel.template
@@ -12,6 +12,7 @@ ts_library(
       "@npm//@types/node",
       "@npm//jasmine",
       "@npm//protractor",
+      "@npm//tslib",
     ],
     data = [
       "//:tsconfig.json",


### PR DESCRIPTION
`@npm//tslib` needs to be a dep in all ts_library rules if `importHelpers` is set to true. It doesn’t need to be in the application ts_library targets since `@npm//tslib` will be a transitive dep of the angular packages and we don’t do strict type checking for npm deps.

Technically, typescript does not actually need tslib available at that point since the tslib import is not typechecked and only added at the emit step but it looks like typescript is checking that the library is there since `importHelpers` is on.