### PR TITLE
feat(docs-infra): add debouncing in storing scroll position

### DIFF
--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -169,13 +169,6 @@ describe('AppComponent', () => {
 
         expect(component.tocMaxHeight).toMatch(/^\d+\.\d{2}$/);
       });
-
-      it('should update `scrollService.updateScrollPositonInHistory()`', () => {
-        const scrollService = fixture.debugElement.injector.get<ScrollService>(ScrollService);
-        spyOn(scrollService, 'updateScrollPositionInHistory');
-        component.onScroll();
-        expect(scrollService.updateScrollPositionInHistory).toHaveBeenCalled();
-      });
     });
 
     describe('SideNav', () => {

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -339,9 +339,6 @@ export class AppComponent implements OnInit {
   // Dynamically change height of table of contents container
   @HostListener('window:scroll')
   onScroll() {
-
-    this.scrollService.updateScrollPositionInHistory();
-
     if (!this.tocMaxHeightOffset) {
       // Must wait until `mat-toolbar` is measurable.
       const el = this.hostElement.nativeElement as Element;

--- a/aio/src/app/shared/scroll.service.spec.ts
+++ b/aio/src/app/shared/scroll.service.spec.ts
@@ -55,11 +55,11 @@ describe('ScrollService', () => {
     const updateScrollPositionInHistorySpy = spyOn(scrollService, 'updateScrollPositionInHistory');
 
     window.dispatchEvent(new Event('scroll'));
-    tick(499);
+    tick(249);
     window.dispatchEvent(new Event('scroll'));
-    tick(499);
+    tick(249);
     window.dispatchEvent(new Event('scroll'));
-    tick(499);
+    tick(249);
     expect(updateScrollPositionInHistorySpy).not.toHaveBeenCalled();
     tick(1);
     expect(updateScrollPositionInHistorySpy).toHaveBeenCalledTimes(1);

--- a/aio/src/app/shared/scroll.service.spec.ts
+++ b/aio/src/app/shared/scroll.service.spec.ts
@@ -34,11 +34,6 @@ describe('ScrollService', () => {
     'viewportScroller',
     ['getScrollPosition', 'scrollToPosition']);
 
-
-  beforeEach(() => {
-    spyOn(window, 'scrollBy');
-  });
-
   beforeEach(() => {
     injector = ReflectiveInjector.resolveAndCreate([
         ScrollService,
@@ -52,7 +47,23 @@ describe('ScrollService', () => {
     document = injector.get(DOCUMENT);
     scrollService = injector.get(ScrollService);
     location = injector.get(Location);
+
+    spyOn(window, 'scrollBy');
   });
+
+  it('should debounce `updateScrollPositonInHistory()` after 500ms', fakeAsync(() => {
+    const updateScrollPositionInHistorySpy = spyOn(scrollService, 'updateScrollPositionInHistory');
+
+    window.dispatchEvent(new Event('scroll'));
+    tick(499);
+    window.dispatchEvent(new Event('scroll'));
+    tick(499);
+    window.dispatchEvent(new Event('scroll'));
+    tick(499);
+    expect(updateScrollPositionInHistorySpy).not.toHaveBeenCalled();
+    tick(1);
+    expect(updateScrollPositionInHistorySpy).toHaveBeenCalledTimes(1);
+  }));
 
   it('should set `scrollRestoration` to `manual` if supported', () => {
     if (scrollService.supportManualScrollRestoration) {

--- a/aio/src/app/shared/scroll.service.ts
+++ b/aio/src/app/shared/scroll.service.ts
@@ -62,6 +62,9 @@ export class ScrollService {
         if (event.type === 'hashchange') {
           this.scrollToPosition();
         } else {
+          // Navigating with forward/back, we have to remove the position from the session storage in order to avoid a
+          // race-condition
+          this.removeStoredScrollPosition();
           // The popstate event is always triggered by doing a browser action such as a click on the back or forward button.
           // It can be follow by a event of type `hashchange`.
           this.popStateFired = true;

--- a/aio/src/app/shared/scroll.service.ts
+++ b/aio/src/app/shared/scroll.service.ts
@@ -47,7 +47,7 @@ export class ScrollService {
     fromEvent(window, 'resize').subscribe(() => this._topOffset = null);
 
     fromEvent(window, 'scroll')
-      .pipe(debounceTime(500)).subscribe(() => this.updateScrollPositionInHistory());
+      .pipe(debounceTime(250)).subscribe(() => this.updateScrollPositionInHistory());
 
     this.supportManualScrollRestoration = !!window && 'scrollTo' in window && 'scrollX' in window
       && 'scrollY' in window && !!history && 'scrollRestoration' in history;

--- a/aio/src/app/shared/scroll.service.ts
+++ b/aio/src/app/shared/scroll.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Inject } from '@angular/core';
 import { Location, PlatformLocation, ViewportScroller } from '@angular/common';
 import { DOCUMENT } from '@angular/common';
 import { fromEvent } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
 
 export const topMargin = 16;
 /**
@@ -44,6 +45,9 @@ export class ScrollService {
       private location: Location) {
     // On resize, the toolbar might change height, so "invalidate" the top offset.
     fromEvent(window, 'resize').subscribe(() => this._topOffset = null);
+
+    fromEvent(window, 'scroll')
+      .pipe(debounceTime(500)).subscribe(() => this.updateScrollPositionInHistory());
 
     try {
       this.supportManualScrollRestoration = !!window && !!window.scrollTo && 'scrollX' in window

--- a/aio/src/app/shared/scroll.service.ts
+++ b/aio/src/app/shared/scroll.service.ts
@@ -49,12 +49,8 @@ export class ScrollService {
     fromEvent(window, 'scroll')
       .pipe(debounceTime(500)).subscribe(() => this.updateScrollPositionInHistory());
 
-    try {
-      this.supportManualScrollRestoration = !!window && !!window.scrollTo && 'scrollX' in window
-        && 'scrollY' in window && !!history && !!history.scrollRestoration;
-    } catch {
-      this.supportManualScrollRestoration = false;
-    }
+    this.supportManualScrollRestoration = !!window && 'scrollTo' in window && 'scrollX' in window
+      && 'scrollY' in window && !!history && 'scrollRestoration' in history;
 
     // Change scroll restoration strategy to `manual` if it's supported
     if (this.supportManualScrollRestoration) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #28332 

There is no debouncing when we store the scroll Position;
Chrome seems not happy with that:
We have a message in the console after a while:

> Throttling history state changes to prevent the browser from hanging.

FYI : https://bugs.chromium.org/p/chromium/issues/detail?id=786211
https://codereview.chromium.org/2972073002/#ps1

````
// TODO(crbug.com/394296): This is not the long-term fix to IPC flooding that we
// need. However, it does mitigate the immediate concern of \|pushState\| DoS
// (assuming the renderer has not been compromised).
bool History::IsHostFloodingPushState(const String& hostname) const {
const int kHostPushStateLimit = 50;
const HostLimit& current = host_limits.at(hostname);
 if (current.first > kHostPushStateLimit) {
    const double kHostPushStateLimitResetSeconds = 10.0;
    double now = MonotonicallyIncreasingTime();
    if (now - current.second > kHostPushStateLimitResetSeconds) {
      host_limits.Set(hostname, HostLimit{0, now});
    }
    return true;
  }

  host_limits.Set(hostname, HostLimit{current.first + 1, current.second});
  return false;
}
````
## What is the new behavior?
- There is now a debouncing before we store the scroll Position;
- Remove unnecessary(?) try/catch block
- Avoid a race-condition with navigating forward/back and immediately reloading

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
