### PR TITLE
fix(ivy): scan simple children routes with no infinite recursion

### DIFF
--- a/packages/compiler-cli/src/ngtsc/routing/src/lazy.ts
+++ b/packages/compiler-cli/src/ngtsc/routing/src/lazy.ts
@@ -111,7 +111,7 @@ function scanForLazyRoutes(routes: ResolvedValue[]): string[] {
       } else if (route.has('children')) {
         const children = route.get('children');
         if (Array.isArray(children)) {
-          recursivelyScanRoutes(routes);
+          recursivelyScanRoutes(children);
         }
       }
     }

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1999,7 +1999,7 @@ describe('ngtsc behavioral tests', () => {
     expect(routes[0].referencedModule.filePath.endsWith('/lazy.ts')).toBe(true);
   });
 
-  it('should detect no lazy routes for simple children routes', () => {
+  it('should detect lazy routes in simple children routes', () => {
     env.tsconfig();
     env.write('test.ts', `
     import {NgModule} from '@angular/core';
@@ -2015,12 +2015,20 @@ describe('ngtsc behavioral tests', () => {
       imports: [
         RouterModule.forRoot([
           {path: '', children: [
-            {path: 'foo', component: FooCmp}
+            {path: 'foo', component: FooCmp},
+            {path: 'lazy', loadChildren: './lazy#LazyModule'}
           ]},
         ]),
       ],
     })
     export class TestModule {}
+    `);
+    env.write('lazy.ts', `
+    import {NgModule} from '@angular/core';
+    import {RouterModule} from '@angular/router';
+
+    @NgModule({})
+    export class LazyModule {}
     `);
     env.write('node_modules/@angular/router/index.d.ts', `
     import {ModuleWithProviders} from '@angular/core';
@@ -2033,7 +2041,10 @@ describe('ngtsc behavioral tests', () => {
     `);
 
     const routes = env.driveRoutes();
-    expect(routes.length).toBe(0);
+    expect(routes.length).toBe(1);
+    expect(routes[0].route).toEqual('./lazy#LazyModule');
+    expect(routes[0].module.filePath.endsWith('/test.ts')).toBe(true);
+    expect(routes[0].referencedModule.filePath.endsWith('/lazy.ts')).toBe(true);
   });
 });
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1998,6 +1998,43 @@ describe('ngtsc behavioral tests', () => {
     expect(routes[0].module.filePath.endsWith('/test.ts')).toBe(true);
     expect(routes[0].referencedModule.filePath.endsWith('/lazy.ts')).toBe(true);
   });
+
+  it('should detect no lazy routes for simple children routes', () => {
+    env.tsconfig();
+    env.write('test.ts', `
+    import {NgModule} from '@angular/core';
+    import {RouterModule} from '@angular/router';
+    
+    @Component({
+      selector: 'foo',
+      template: '<div>Foo</div>'
+    })
+    class FooCmp {}
+
+    @NgModule({
+      imports: [
+        RouterModule.forRoot([
+          {path: '', children: [
+            {path: 'foo', component: FooCmp}
+          ]},
+        ]),
+      ],
+    })
+    export class TestModule {}
+    `);
+    env.write('node_modules/@angular/router/index.d.ts', `
+    import {ModuleWithProviders} from '@angular/core';
+
+    export declare var ROUTES;
+    export declare class RouterModule {
+      static forRoot(arg1: any, arg2: any): ModuleWithProviders<RouterModule>;
+      static forChild(arg1: any): ModuleWithProviders<RouterModule>;
+    }
+    `);
+
+    const routes = env.driveRoutes();
+    expect(routes.length).toBe(0);
+  });
 });
 
 function expectTokenAtPosition<T extends ts.Node>(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Now that PR #27697 landed for lazy route analysis in ngtsc, a simple route config with:

```typescript
{ path: '', children: [
  { path: 'foo', component: FooComp }
] }
```

results in a `ERROR in Maximum call stack size exceeded` when running `ngtsc`.


## What is the new behavior?

This PR fixes the infinite recursion introduced and adds a simple test that demonstrates it
(without the fix, the test itself triggers an infinite loop).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
