### PR TITLE
fix(ivy): mark view as dirty in listener

### DIFF
--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -637,44 +637,43 @@ function declareTests(config?: {useJit: boolean}) {
              }));
         }
 
-        fixmeIvy('FW-758: OnPush events not marking view dirty when using renderer2')
-            .it('should be checked when an event is fired', () => {
-              TestBed.configureTestingModule(
-                  {declarations: [MyComp, PushCmp, EventCmp], imports: [CommonModule]});
-              const template = '<push-cmp [prop]="ctxProp" #cmp></push-cmp>';
-              TestBed.overrideComponent(MyComp, {set: {template}});
-              const fixture = TestBed.createComponent(MyComp);
+        it('should be checked when an event is fired', () => {
+          TestBed.configureTestingModule(
+              {declarations: [MyComp, PushCmp, EventCmp], imports: [CommonModule]});
+          const template = '<push-cmp [prop]="ctxProp" #cmp></push-cmp>';
+          TestBed.overrideComponent(MyComp, {set: {template}});
+          const fixture = TestBed.createComponent(MyComp);
 
-              const cmpEl = fixture.debugElement.children[0];
-              const cmp = cmpEl.componentInstance;
-              fixture.detectChanges();
-              fixture.detectChanges();
-              expect(cmp.numberOfChecks).toEqual(1);
+          const cmpEl = fixture.debugElement.children[0];
+          const cmp = cmpEl.componentInstance;
+          fixture.detectChanges();
+          fixture.detectChanges();
+          expect(cmp.numberOfChecks).toEqual(1);
 
-              // regular element
-              cmpEl.children[0].triggerEventHandler('click', <Event>{});
-              fixture.detectChanges();
-              fixture.detectChanges();
-              expect(cmp.numberOfChecks).toEqual(2);
+          // regular element
+          cmpEl.children[0].triggerEventHandler('click', <Event>{});
+          fixture.detectChanges();
+          fixture.detectChanges();
+          expect(cmp.numberOfChecks).toEqual(2);
 
-              // element inside of an *ngIf
-              cmpEl.children[1].triggerEventHandler('click', <Event>{});
-              fixture.detectChanges();
-              fixture.detectChanges();
-              expect(cmp.numberOfChecks).toEqual(3);
+          // element inside of an *ngIf
+          cmpEl.children[1].triggerEventHandler('click', <Event>{});
+          fixture.detectChanges();
+          fixture.detectChanges();
+          expect(cmp.numberOfChecks).toEqual(3);
 
-              // element inside a nested component
-              cmpEl.children[2].children[0].triggerEventHandler('click', <Event>{});
-              fixture.detectChanges();
-              fixture.detectChanges();
-              expect(cmp.numberOfChecks).toEqual(4);
+          // element inside a nested component
+          cmpEl.children[2].children[0].triggerEventHandler('click', <Event>{});
+          fixture.detectChanges();
+          fixture.detectChanges();
+          expect(cmp.numberOfChecks).toEqual(4);
 
-              // host element
-              cmpEl.triggerEventHandler('click', <Event>{});
-              fixture.detectChanges();
-              fixture.detectChanges();
-              expect(cmp.numberOfChecks).toEqual(5);
-            });
+          // host element
+          cmpEl.triggerEventHandler('click', <Event>{});
+          fixture.detectChanges();
+          fixture.detectChanges();
+          expect(cmp.numberOfChecks).toEqual(5);
+        });
 
         it('should not affect updating properties on the component', () => {
           TestBed.configureTestingModule({declarations: [MyComp, [[PushCmpWithRef]]]});


### PR DESCRIPTION
Fixes Ivy not marking the view as dirty with OnPush and Renderer2, in order to [match the ViewEngine behavior](https://github.com/angular/angular/blob/master/packages/core/src/view/util.ts#L127).

This PR resolves the fixme associated with FW-758.