### PR TITLE
fix(ivy): add any type to empty export

### DIFF
--- a/packages/compiler-cli/src/ngtsc/shims/src/summary_generator.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/summary_generator.ts
@@ -50,7 +50,7 @@ export class SummaryGenerator implements ShimGenerator {
     if (varLines.length === 0) {
       // In the event there are no other exports, add an empty export to ensure the generated
       // summary file is still an ES module.
-      varLines.push(`export const ɵempty = null;`);
+      varLines.push(`export const ɵempty: any = null;`);
     }
     const sourceText = varLines.join('\n');
     const genFile = ts.createSourceFile(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

When compiling with `ngtsc` and a tsconfig containing `allowEmptyCodegenFiles: true` and `noImplicitAny: true`, the following error is thrown:

```
Variable 'ɵempty' implicitly has an 'any' type.
```

## What is the new behavior?

This avoids the error by explicitely adding the `any` type.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

