### PR TITLE
refactor(router): initalize browserUrlTree to empty tree

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -401,7 +401,7 @@ export class Router {
     this.resetConfig(config);
     this.currentUrlTree = createEmptyUrlTree();
     this.rawUrlTree = this.currentUrlTree;
-    this.browserUrlTree = this.parseUrl(this.location.path());
+    this.browserUrlTree = this.currentUrlTree;
 
     this.configLoader = new RouterConfigLoader(loader, compiler, onLoadStart, onLoadEnd);
     this.routerState = createEmptyState(this.currentUrlTree, this.rootComponentType);


### PR DESCRIPTION
The value here is unimportant on initialization since it's not looked at until the second navigation. However, sometimes in testing  the `Location` service is mocked out, or the Router constructor manually called. Assuming `Location` exists in the constructor leads to test failures in `google3` therefore we initialize to a value that will not cause errors.
