### PR TITLE
fix(bazel): ng-new should run yarn install

### DIFF
--- a/integration/bazel-schematics/test.sh
+++ b/integration/bazel-schematics/test.sh
@@ -10,7 +10,6 @@ function testBazel() {
   ng new demo --collection=@angular/bazel --defaults --skip-git
   node replace_angular_repo.js "./demo/WORKSPACE"
   cd demo
-  yarn install
   cp ../package.json.replace ./package.json
   ng build
   ng test

--- a/packages/bazel/src/schematics/ng-new/index.ts
+++ b/packages/bazel/src/schematics/ng-new/index.ts
@@ -201,10 +201,11 @@ export default function(options: Schema): Rule {
     validateProjectName(options.name);
 
     return chain([
-      externalSchematic('@schematics/angular', 'ng-new', {
-        ...options,
-        skipInstall: true,
-      }),
+      externalSchematic(
+          '@schematics/angular', 'ng-new',
+          {
+              ...options,
+          }),
       addDevDependenciesToPackageJson(options),
       addDevAndProdMainForAot(options),
       schematic('bazel-workspace', options),


### PR DESCRIPTION
`yarn install` was disabled in ng-new for Bazel schematics because
Bazel manages its own node_modules dependencies and therefore
there is no need to install dependencies twice.

However, the first yarn install is needed for `ng` commands to work,
most notably `ng build`.

This commit restores the original behavior.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
