### PR TITLE
fix(ivy): update token used for fakeAsync test

### DIFF
--- a/packages/core/test/fake_async_spec.ts
+++ b/packages/core/test/fake_async_spec.ts
@@ -8,11 +8,8 @@
 
 import {discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, tick} from '@angular/core/testing';
 import {Log, beforeEach, describe, inject, it} from '@angular/core/testing/src/testing_internal';
+import {EventManager} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {fixmeIvy} from '@angular/private/testing';
-
-import {Parser} from '../../compiler/src/expression_parser/parser';
-
 
 const resolvedPromise = Promise.resolve(null);
 const ProxyZoneSpec: {assertPresent: () => void} = (Zone as any)['ProxyZoneSpec'];
@@ -33,11 +30,10 @@ const ProxyZoneSpec: {assertPresent: () => void} = (Zone as any)['ProxyZoneSpec'
       })('foo', 'bar');
     });
 
-    fixmeIvy('FW-806: Ivy\'s TestBed implementation doesn\'t inject compiler-related tokens')
-        .it('should work with inject()',
-            fakeAsync(inject([Parser], (parser: any /** TODO #9100 */) => {
-              expect(parser).toBeAnInstanceOf(Parser);
-            })));
+    it('should work with inject()',
+       fakeAsync(inject([EventManager], (eventManager: any /** TODO #9100 */) => {
+         expect(eventManager).toBeAnInstanceOf(EventManager);
+       })));
 
     it('should throw on nested calls', () => {
       expect(() => {

--- a/packages/core/test/fake_async_spec.ts
+++ b/packages/core/test/fake_async_spec.ts
@@ -31,7 +31,7 @@ const ProxyZoneSpec: {assertPresent: () => void} = (Zone as any)['ProxyZoneSpec'
     });
 
     it('should work with inject()',
-       fakeAsync(inject([EventManager], (eventManager: any /** TODO #9100 */) => {
+       fakeAsync(inject([EventManager], (eventManager: EventManager) => {
          expect(eventManager).toBeAnInstanceOf(EventManager);
        })));
 


### PR DESCRIPTION
This commit updates the token used in fakeAsync test to the one available in both VE and R3 TestBeds. The goal of the test is to verify that fakeAsync works with inject function, so the actual token that is used for a test is irrelevant in that case. The logic to retrieve tokens from compiler injector (that the comment in "fixmeIvy" refers to) was implemented in PR #28196.

This PR resolves FW-806.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No