### PR TITLE
fix(bazel): Fix appending bazel-out to gitignore

### DIFF
--- a/packages/bazel/src/schematics/ng-new/index_spec.ts
+++ b/packages/bazel/src/schematics/ng-new/index_spec.ts
@@ -10,7 +10,7 @@ import {SchematicTestRunner} from '@angular-devkit/schematics/testing';
 
 describe('Ng-new Schematic', () => {
   const schematicRunner =
-      new SchematicTestRunner('@angular/bazel', require.resolve('../collection.json'), );
+      new SchematicTestRunner('@angular/bazel', require.resolve('../collection.json'));
   const defaultOptions = {
     name: 'demo',
     version: '7.0.0',
@@ -94,7 +94,7 @@ describe('Ng-new Schematic', () => {
     const {files} = host;
     expect(files).toContain('/demo/.gitignore');
     const content = host.readContent('/demo/.gitignore');
-    expect(content).toMatch('/bazel-out');
+    expect(content).toMatch('\n# compiled output\n/bazel-out\n');
   });
 
   it('should update angular.json to use Bazel builder', () => {


### PR DESCRIPTION
The current implementation appends '/bazel-out' to the wrong location
in the .gitignore file. This PR fixes that and adds a stricter test.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
