### PR TITLE
fix(ivy): verify bootstrapped types are Components

### DIFF
--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -169,6 +169,7 @@ function verifySemanticsOfNgModuleDef(moduleType: NgModuleType): void {
     ngModule.imports &&
         flatten(ngModule.imports, unwrapModuleWithProvidersImports)
             .forEach(verifySemanticsOfNgModuleDef);
+    ngModule.bootstrap && ngModule.bootstrap.forEach(verifyCorrectBootstrapType);
     ngModule.bootstrap && ngModule.bootstrap.forEach(verifyComponentIsPartOfNgModule);
     ngModule.entryComponents && ngModule.entryComponents.forEach(verifyComponentIsPartOfNgModule);
   }
@@ -223,6 +224,13 @@ function verifySemanticsOfNgModuleDef(moduleType: NgModuleType): void {
     if (!existingModule) {
       errors.push(
           `Component ${renderStringify(type)} is not part of any NgModule or the module has not been imported into your module.`);
+    }
+  }
+
+  function verifyCorrectBootstrapType(type: Type<any>) {
+    type = resolveForwardRef(type);
+    if (!getComponentDef(type)) {
+      errors.push(`${renderStringify(type)} cannot be used as an entry component.`);
     }
   }
 

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -160,34 +160,34 @@ function bootstrap(
 
     afterEach(destroyPlatform);
 
-    // TODO(misko): can't use `fixmeIvy.it` because the `it` is somehow special here.
-    modifiedInIvy('bootstrapping non-Component throws in View Engine').isEnabled &&
-        it('should throw if bootstrapped Directive is not a Component',
-           inject([AsyncTestCompleter], (done: AsyncTestCompleter) => {
-             const logger = new MockConsole();
-             const errorHandler = new ErrorHandler();
-             (errorHandler as any)._console = logger as any;
-             expect(
-                 () => bootstrap(
-                     HelloRootDirectiveIsNotCmp, [{provide: ErrorHandler, useValue: errorHandler}]))
-                 .toThrowError(`HelloRootDirectiveIsNotCmp cannot be used as an entry component.`);
-             done.done();
-           }));
+    modifiedInIvy('bootstrapping non-Component throws in View Engine')
+        .it('should throw if bootstrapped Directive is not a Component',
+            inject([AsyncTestCompleter], (done: AsyncTestCompleter) => {
+              const logger = new MockConsole();
+              const errorHandler = new ErrorHandler();
+              (errorHandler as any)._console = logger as any;
+              expect(
+                  () => bootstrap(
+                      HelloRootDirectiveIsNotCmp,
+                      [{provide: ErrorHandler, useValue: errorHandler}]))
+                  .toThrowError(`HelloRootDirectiveIsNotCmp cannot be used as an entry component.`);
+              done.done();
+            }));
 
-    onlyInIvy('bootstrapping non-Component rejects Promise in Ivy').isEnabled &&
-        it('should throw if bootstrapped Directive is not a Component',
-           inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-             const logger = new MockConsole();
-             const errorHandler = new ErrorHandler();
-             (errorHandler as any)._console = logger as any;
-             bootstrap(HelloRootDirectiveIsNotCmp, [
-               {provide: ErrorHandler, useValue: errorHandler}
-             ]).catch((error: Error) => {
-               expect(error).toEqual(
-                   new Error(`HelloRootDirectiveIsNotCmp cannot be used as an entry component.`));
-               async.done();
-             });
-           }));
+    onlyInIvy('bootstrapping non-Component rejects Promise in Ivy')
+        .it('should throw if bootstrapped Directive is not a Component',
+            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+              const logger = new MockConsole();
+              const errorHandler = new ErrorHandler();
+              (errorHandler as any)._console = logger as any;
+              bootstrap(HelloRootDirectiveIsNotCmp, [
+                {provide: ErrorHandler, useValue: errorHandler}
+              ]).catch((error: Error) => {
+                expect(error).toEqual(
+                    new Error(`HelloRootDirectiveIsNotCmp cannot be used as an entry component.`));
+                async.done();
+              });
+            }));
 
     it('should throw if no element is found',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -160,34 +160,35 @@ function bootstrap(
 
     afterEach(destroyPlatform);
 
-    modifiedInIvy('bootstrapping non-Component throws in View Engine')
-        .it('should throw if bootstrapped Directive is not a Component',
-            inject([AsyncTestCompleter], (done: AsyncTestCompleter) => {
-              const logger = new MockConsole();
-              const errorHandler = new ErrorHandler();
-              (errorHandler as any)._console = logger as any;
-              expect(
-                  () => bootstrap(
-                      HelloRootDirectiveIsNotCmp,
-                      [{provide: ErrorHandler, useValue: errorHandler}]))
-                  .toThrowError(`HelloRootDirectiveIsNotCmp cannot be used as an entry component.`);
-              done.done();
-            }));
+    // TODO(misko): can't use `modifiedInIvy.it` because the `it` is somehow special here.
+    modifiedInIvy('bootstrapping non-Component throws in View Engine').isEnabled &&
+        it('should throw if bootstrapped Directive is not a Component',
+           inject([AsyncTestCompleter], (done: AsyncTestCompleter) => {
+             const logger = new MockConsole();
+             const errorHandler = new ErrorHandler();
+             (errorHandler as any)._console = logger as any;
+             expect(
+                 () => bootstrap(
+                     HelloRootDirectiveIsNotCmp, [{provide: ErrorHandler, useValue: errorHandler}]))
+                 .toThrowError(`HelloRootDirectiveIsNotCmp cannot be used as an entry component.`);
+             done.done();
+           }));
 
-    onlyInIvy('bootstrapping non-Component rejects Promise in Ivy')
-        .it('should throw if bootstrapped Directive is not a Component',
-            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-              const logger = new MockConsole();
-              const errorHandler = new ErrorHandler();
-              (errorHandler as any)._console = logger as any;
-              bootstrap(HelloRootDirectiveIsNotCmp, [
-                {provide: ErrorHandler, useValue: errorHandler}
-              ]).catch((error: Error) => {
-                expect(error).toEqual(
-                    new Error(`HelloRootDirectiveIsNotCmp cannot be used as an entry component.`));
-                async.done();
-              });
-            }));
+    // TODO(misko): can't use `onlyInIvy.it` because the `it` is somehow special here.
+    onlyInIvy('bootstrapping non-Component rejects Promise in Ivy').isEnabled &&
+        it('should throw if bootstrapped Directive is not a Component',
+           inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+             const logger = new MockConsole();
+             const errorHandler = new ErrorHandler();
+             (errorHandler as any)._console = logger as any;
+             bootstrap(HelloRootDirectiveIsNotCmp, [
+               {provide: ErrorHandler, useValue: errorHandler}
+             ]).catch((error: Error) => {
+               expect(error).toEqual(
+                   new Error(`HelloRootDirectiveIsNotCmp cannot be used as an entry component.`));
+               async.done();
+             });
+           }));
 
     it('should throw if no element is found',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -18,7 +18,7 @@ import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {DOCUMENT} from '@angular/platform-browser/src/dom/dom_tokens';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {fixmeIvy} from '@angular/private/testing';
+import {fixmeIvy, modifiedInIvy, onlyInIvy} from '@angular/private/testing';
 
 @Component({selector: 'non-existent', template: ''})
 class NonExistentComp {
@@ -161,9 +161,7 @@ function bootstrap(
     afterEach(destroyPlatform);
 
     // TODO(misko): can't use `fixmeIvy.it` because the `it` is somehow special here.
-    fixmeIvy(
-        'FW-876: Bootstrap factory method should throw if bootstrapped Directive is not a Component')
-            .isEnabled &&
+    modifiedInIvy('bootstrapping non-Component throws in View Engine').isEnabled &&
         it('should throw if bootstrapped Directive is not a Component',
            inject([AsyncTestCompleter], (done: AsyncTestCompleter) => {
              const logger = new MockConsole();
@@ -174,6 +172,21 @@ function bootstrap(
                      HelloRootDirectiveIsNotCmp, [{provide: ErrorHandler, useValue: errorHandler}]))
                  .toThrowError(`HelloRootDirectiveIsNotCmp cannot be used as an entry component.`);
              done.done();
+           }));
+
+    onlyInIvy('bootstrapping non-Component rejects Promise in Ivy').isEnabled &&
+        it('should throw if bootstrapped Directive is not a Component',
+           inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+             const logger = new MockConsole();
+             const errorHandler = new ErrorHandler();
+             (errorHandler as any)._console = logger as any;
+             bootstrap(HelloRootDirectiveIsNotCmp, [
+               {provide: ErrorHandler, useValue: errorHandler}
+             ]).catch((error: Error) => {
+               expect(error).toEqual(
+                   new Error(`HelloRootDirectiveIsNotCmp cannot be used as an entry component.`));
+               async.done();
+             });
            }));
 
     it('should throw if no element is found',


### PR DESCRIPTION
Prior to this change we didn't verify types passed to bootstrap as a part of NgModule semantics check. Now we verify whether all types passed to bootstrap are actually Components.

The way we handle this is a bit different with VE, when VE throws an error, in Ivy we reject the Promise returned by `bootstrapModule` function. This seems more consistent with the rest of the cases in `bootstrap_spec.ts` when we reject the promise instead of throwing an error.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No