### PR TITLE
fix(docs-infra): upgrade codelyzer to 4.5.0

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -107,7 +107,7 @@
     "canonical-path": "1.0.0",
     "chalk": "^2.1.0",
     "cjson": "^0.5.0",
-    "codelyzer": "~4.2.1",
+    "codelyzer": "~4.5.0",
     "cross-spawn": "^5.1.0",
     "css-selector-parser": "^1.3.0",
     "dgeni": "^0.4.11",

--- a/aio/src/app/custom-elements/code/code-tabs.component.ts
+++ b/aio/src/app/custom-elements/code/code-tabs.component.ts
@@ -46,7 +46,7 @@ export interface TabInfo {
 export class CodeTabsComponent implements OnInit, AfterViewInit {
   tabs: TabInfo[];
 
-  @Input('linenums') linenums: string;
+  @Input() linenums: string;
 
   @ViewChild('content') content;
 

--- a/aio/src/app/layout/doc-viewer/dt.component.ts
+++ b/aio/src/app/layout/doc-viewer/dt.component.ts
@@ -15,7 +15,7 @@ import { DocumentContents } from 'app/documents/document.service';
 export class DtComponent {
 
   @Input() on = false;
-  @Input('doc') doc: DocumentContents;
+  @Input() doc: DocumentContents;
   @Output() docChange = new EventEmitter<DocumentContents>();
 
   @ViewChild('dt', { read: ElementRef })

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -798,9 +798,10 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-app-root-path@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
+app-root-path@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.1.0.tgz#98bf6599327ecea199309866e8140368fd2e646a"
+  integrity sha1-mL9lmTJ+zqGZMJhm6BQDaP0uZGo=
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -1976,16 +1977,17 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-codelyzer@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/codelyzer/-/codelyzer-4.2.1.tgz#d56eaacefca7e8138aac0a630e484bdb09988544"
+codelyzer@~4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/codelyzer/-/codelyzer-4.5.0.tgz#a65ddeeeca2894653253a89bfa229118ff9f59b1"
+  integrity sha512-oO6vCkjqsVrEsmh58oNlnJkRXuA30hF8cdNAQV9DytEalDwyOFRvHMnlKFzmOStNerOmPGZU9GAHnBo4tGvtiQ==
   dependencies:
-    app-root-path "^2.0.1"
+    app-root-path "^2.1.0"
     css-selector-tokenizer "^0.7.0"
     cssauron "^1.4.0"
     semver-dsl "^1.0.1"
-    source-map "^0.5.6"
-    sprintf-js "^1.0.3"
+    source-map "^0.5.7"
+    sprintf-js "^1.1.1"
 
 coffee-script@^1.12.5:
   version "1.12.7"
@@ -9291,9 +9293,10 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-sprintf-js@^1.0.3:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
+sprintf-js@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
+  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently, Codelyzer 4.2.1 has this peerDependencies:
```json
"peerDependencies": {
    "@angular/compiler": ">=2.3.1 <7.0.0 || >6.0.0-beta <7.0.0",
    "@angular/core": ">=2.3.1 <7.0.0 || >6.0.0-beta <7.0.0",
    "@angular/platform-browser-dynamic": ">=2.3.1 <7.0.0 || >6.0.0-beta <7.0.0",
    "@angular/platform-browser": ">=2.3.1 <7.0.0 || >6.0.0-beta <7.0.0",
    "@angular/common": ">=2.3.1 <7.0.0 || >6.0.0-beta <7.0.0",
    "tslint": "^5.0.0"
  }
```

Since Angular.io uses Angular ^7.0.0, we have to use Codelyzer 4.5.0 which has this peerDependencies:

```json
"peerDependencies": {
    "@angular/compiler": ">=2.3.1 <8.0.0 || >7.0.0-beta <8.0.0",
    "@angular/core": ">=2.3.1 <8.0.0 || >7.0.0-beta <8.0.0",
    "tslint": "^5.0.0"
  },
```

We can see that during the aio build:

```
[4/5] Linking dependencies...
warning "@angular-devkit/build-angular > @ngtools/webpack@7.0.1" has incorrect peer dependency "typescript@>=2.4.0 < 3.2".
warning " > @angular/compiler-cli@7.0.0" has incorrect peer dependency "typescript@>=3.1.1 <3.2".
warning " > codelyzer@4.2.1" has incorrect peer dependency "@angular/compiler@>=2.3.1 <7.0.0 || >6.0.0-beta <7.0.0".
warning " > codelyzer@4.2.1" has incorrect peer dependency "@angular/core@>=2.3.1 <7.0.0 || >6.0.0-beta <7.0.0".
warning " > codelyzer@4.2.1" has incorrect peer dependency "@angular/platform-browser-dynamic@>=2.3.1 <7.0.0 || >6.0.0-beta <7.0.0".
warning " > codelyzer@4.2.1" has incorrect peer dependency "@angular/platform-browser@>=2.3.1 <7.0.0 || >6.0.0-beta <7.0.0".
warning " > codelyzer@4.2.1" has incorrect peer dependency "@angular/common@>=2.3.1 <7.0.0 || >6.0.0-beta <7.0.0".
warning " > webpack-cli@3.1.2" has unmet peer dependency "webpack@^4.x.x".
[5/5] Building fresh packages...

```