### PR TITLE
ci: update docker image to circleci/node:10.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@
 # fetched by the Webtesting rules. Therefore for jobs that run tests with Bazel, we don't need a
 # docker image with browsers pre-installed.
 # **NOTE**: If you change the version of the docker images, also change the `cache_key` suffix.
-var_1: &default_docker_image circleci/node:10.12
-var_2: &browsers_docker_image circleci/node:10.12-browsers
-var_3: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-node-10.12
+var_1: &default_docker_image circleci/node:10.15
+var_2: &browsers_docker_image circleci/node:10.15-browsers
+var_3: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-node-10.15
 
 # Define common ENV vars
 var_4: &define_env_vars


### PR DESCRIPTION
This is primarily to update the yarn version because we are using v1.10.1.
This PR updates yarn to v1.12.3.
The latest yarn version is v.1.13.0, but that version is not in a circleci/node version yet.