### PR TITLE
build(bazel): update to bazel 0.22.0 and turn on --incompatible_strict_action_env flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -42,6 +42,16 @@ build --watchfs
 run --nolegacy_external_runfiles
 test --nolegacy_external_runfiles
 
+# Turn on --incompatible_strict_action_env which was on by default
+# in Bazel 0.21.0 but turned off again in 0.22.0. Follow
+# https://github.com/bazelbuild/bazel/issues/7026 for more details.
+# This flag is needed to so that the bazel cache is not invalidated
+# when running bazel via `yarn bazel`.
+# See https://github.com/angular/angular/issues/27514.
+build --incompatible_strict_action_env
+run --incompatible_strict_action_env
+test --incompatible_strict_action_env
+
 ###############################
 # Release support             #
 # Turn on these settings with #

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,8 +62,8 @@ local_repository(
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version", "node_repositories", "yarn_install")
 
 # Bazel version must be at least v0.21.0 because:
-#   - 0.21.0 --experimental_strict_action_env flag turned on by default which fixes cache when
-#            running `yarn bazel` (see https://github.com/angular/angular/issues/27514#issuecomment-451438271)
+#   - 0.21.0 Using --incompatible_strict_action_env flag fixes cache when running `yarn bazel`
+#            (see https://github.com/angular/angular/issues/27514#issuecomment-451438271)
 check_bazel_version("0.21.0", """
 You no longer need to install Bazel on your machine.
 Angular has a dependency on the @bazel/bazel package which supplies it.

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   "// 3": "when updating @bazel/bazel version you also need to update the RBE settings in .bazelrc (see https://github.com/angular/angular/pull/27935)",
   "devDependencies": {
     "@angular/cli": "^7.3.0-rc.0",
-    "@bazel/bazel": "~0.21.0",
+    "@bazel/bazel": "~0.22.0",
     "@bazel/buildifier": "^0.19.2",
     "@bazel/ibazel": "~0.9.0",
     "@types/angular": "^1.6.47",

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,29 +96,29 @@
     semver "5.6.0"
     symbol-observable "1.2.0"
 
-"@bazel/bazel-darwin_x64@0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@bazel/bazel-darwin_x64/-/bazel-darwin_x64-0.21.0.tgz#db033b6880294ed274489d3bce4a36c77dbf5a7a"
-  integrity sha512-9lI9SFHUm50ufJHD/5gOdJeuaI/hdGji5d0ezYWJdJK55tj4VhcatkJumjYD6yp1nPNnU038AZ7JvkPcTgt7OA==
+"@bazel/bazel-darwin_x64@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@bazel/bazel-darwin_x64/-/bazel-darwin_x64-0.22.0.tgz#a2bea5922dba9a32554a218ba4849a200115b248"
+  integrity sha512-LFxkyQgPATeB64z/1IvOWZhK+lc3JVHejbmdo96qB4lsoD8zselvOlgHvVXxlAjRxVZ9mlmXDvDRDyaXyyRdwA==
 
-"@bazel/bazel-linux_x64@0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@bazel/bazel-linux_x64/-/bazel-linux_x64-0.21.0.tgz#d9ba05ff405c52d09878ecfb89872bda2fda418e"
-  integrity sha512-CyOblC7pMIMaXwkQazo/jz2ipmIkxngmVCTzjNKGO9GiZK71L4X/B8Simy3tFhDHZFxso2HkvJTiY1UJozFyZw==
+"@bazel/bazel-linux_x64@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@bazel/bazel-linux_x64/-/bazel-linux_x64-0.22.0.tgz#12e5884f2a7b7f3b62afbef9f8da4de0976f3bc8"
+  integrity sha512-xDs8cb2bbGZ9uvzYZOzCVrMBywzRhLj0J/t+py+FYZj+VO5B3wVg9eUf6nWWR0oJ2mzvToI9h31t2tNdqwy2kQ==
 
-"@bazel/bazel-win32_x64@0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@bazel/bazel-win32_x64/-/bazel-win32_x64-0.21.0.tgz#f2f40f40b862f368d8596b4f69152640bd15e2ed"
-  integrity sha512-ELNF4ddUCnd1Qx9359tJ5DenlVK0e5Yoe7PVv+qWNQKSCjguh8jtRy9IlzGZHjn8tFMSnTQjYYY0DgW1W1sbSA==
+"@bazel/bazel-win32_x64@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@bazel/bazel-win32_x64/-/bazel-win32_x64-0.22.0.tgz#a8a65986639583a8cc7b018e001aedfdafe41b50"
+  integrity sha512-FbJaXVDoCLnpIFLnPHFkQdfriYPXfnfQNuf9EXMliERdRuoeBVbwEZfwcuArxZWNFus7bD8QiTj0XzKVWO+Wbw==
 
-"@bazel/bazel@~0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@bazel/bazel/-/bazel-0.21.0.tgz#8582f225a70d8edff26bd89efad5550c4fc17140"
-  integrity sha512-XeT0omRhtUMSzX0Gjme2ECnWtHRPD2Gak7/ewfpGs0pw1IaCvVy/ilaqr6u5g0Kr8SI8KevP7ezKrejXXpJwbQ==
+"@bazel/bazel@~0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@bazel/bazel/-/bazel-0.22.0.tgz#feb0f2d82f9d169cb47951d95d55e512eda72bc9"
+  integrity sha512-uaXZsfCXOASBXzmge56akRIhJnKYdShn1X3AdEBzq2NNCf2llkc1H25gKGm4BfuWDBXRbXDMmcXup+fw39h+WQ==
   optionalDependencies:
-    "@bazel/bazel-darwin_x64" "0.21.0"
-    "@bazel/bazel-linux_x64" "0.21.0"
-    "@bazel/bazel-win32_x64" "0.21.0"
+    "@bazel/bazel-darwin_x64" "0.22.0"
+    "@bazel/bazel-linux_x64" "0.22.0"
+    "@bazel/bazel-win32_x64" "0.22.0"
 
 "@bazel/buildifier-darwin_x64@0.19.2":
   version "0.19.2"


### PR DESCRIPTION
`--incompatible_strict_action_env` needs to be turned on because it got flipped back to default false in Bazel 0.22.0 (it was default true in Bazel 0.21.0). Follow https://github.com/bazelbuild/bazel/issues/7026 for more details.

No update to .bazelrc RBE section for this release as there is no `bazel-0.22.0.bazelrc` file released: https://github.com/bazelbuild/bazel-toolchains/tree/master/bazelrc. Will still reference the 0.21.0.bazelrc file in `/.bazelrc`:

```
# Load default settings for Remote Build Execution
# When updating, the URLs of bazel_toolchains in packages/bazel/package.bzl
# may also need to be updated (see https://github.com/angular/angular/pull/27935)
import %workspace%/third_party/github.com/bazelbuild/bazel-toolchains/bazelrc/bazel-0.21.0.bazelrc
```

Also no new release of bazel_toolchains to update to in `packages/bazel/package.bzl` for bazel 0.22.0: https://github.com/bazelbuild/bazel-toolchains/releases.

This PR only updates the build. `packages/bazel/src/schematics/ng-new/index.ts` remaining at 0.21.0 for angular bazel ng-new.

For reference, here is the 0.21.0 update: https://github.com/angular/angular/pull/27935.