### PR TITLE
build: `gulp format` only changed lines by default (Proposal)

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -105,8 +105,8 @@ Angular uses [clang-format](http://clang.llvm.org/docs/ClangFormat.html) to form
 If the source code is not properly formatted, the CI will fail and the PR can not be merged.
 
 You can automatically format your code by running:
-- `gulp format`: format all source code
-- `gulp format:changed`: re-format only edited source code.
+- `gulp format`: re-format only edited source code.
+- `gulp format:all`: format _all_ source code
 
 A better way is to set up your IDE to format the changed file on each file save.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,11 +27,25 @@ function loadTask(fileName, taskName) {
   return task(gulp);
 }
 
+// Check source code for formatting errors in all source files.
 gulp.task('format:enforce', loadTask('format', 'enforce'));
-gulp.task('format', loadTask('format', 'format'));
+
+// Format all source files.
+gulp.task('format:all', loadTask('format', 'format'));
+
+// Format only untracked source code files.
 gulp.task('format:untracked', loadTask('format', 'format-untracked'));
+
+// Format only the changed, tracked source code files.
 gulp.task('format:diff', loadTask('format', 'format-diff'));
+
+// Format only changed lines based on the diff from the provided --branch
+// argument (or `master` by default).
 gulp.task('format:changed', ['format:untracked', 'format:diff']);
+
+// Alias for `format:changed` that formerly formatted all files.
+gulp.task('format', ['format:changed']);
+
 gulp.task('lint', ['format:enforce', 'validate-commit-messages', 'tslint']);
 gulp.task('tslint', ['tools:build'], loadTask('lint'));
 gulp.task('validate-commit-messages', loadTask('validate-commit-message'));


### PR DESCRIPTION
Changes `gulp format` to format only changed lines by default
(`gulp format:changed`) and introduces a new task, `gulp format:all` to
format all source files. Since formatting only changed lines should be
the more common action, it makes more sense as the shorter default.