### PR TITLE
fix(ivy): getSourceFile() of transformed nodes returns undefined

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -167,7 +167,10 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
     if (analysis.metadataStmt !== null) {
       ngModuleStatements.push(analysis.metadataStmt);
     }
-    const context = node.getSourceFile();
+    let context = node.getSourceFile();
+    if (context === undefined) {
+      context = ts.getOriginalNode(node).getSourceFile();
+    }
     for (const decl of analysis.declarations) {
       if (this.scopeRegistry.requiresRemoteScope(decl.node)) {
         const scope = this.scopeRegistry.lookupCompilationScopeAsRefs(decl.node);


### PR DESCRIPTION
In some cases, calling getSourceFile() on a node from within a TS
transform can return undefined (against the signature of the method).
In these cases, getting the original node first will work.

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
