### PR TITLE
fix(ivy): update test after Content Queries inheritance fix

### DIFF
--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -591,7 +591,7 @@
     "name": "setCurrentDirectiveDef"
   },
   {
-    "name": "setCurrentViewQueryIndex"
+    "name": "setCurrentQueryIndex"
   },
   {
     "name": "setFirstTemplatePass"

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -2791,13 +2791,11 @@ describe('query', () => {
           type: ContentQueryDirective,
           selectors: [['', 'content-query', '']],
           factory: () => contentQueryDirective = new ContentQueryDirective(),
-          contentQueries:
-              (dirIndex) => { registerContentQuery(query(TextDirective, true), dirIndex); },
-          contentQueriesRefresh: (dirIndex: number, queryStartIdx: number) => {
+          contentQueries: (dirIndex: number) => { contentQuery(dirIndex, TextDirective, true); },
+          contentQueriesRefresh: (dirIndex: number) => {
             let tmp: any;
             const instance = load<ContentQueryDirective>(dirIndex);
-            queryRefresh(tmp = loadQueryList<TextDirective>(queryStartIdx)) &&
-                (instance.texts = tmp);
+            queryRefresh(tmp = loadContentQuery<TextDirective>()) && (instance.texts = tmp);
           }
         });
       }


### PR DESCRIPTION
This commit updates test that was added after Content Queries inheritance fix (that renames some instructions) was merged into master. The test used previous version of instructions, thus causing failures after merging Content Queries inheritance fix.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No