### PR TITLE
fix(ivy): don't increment `expandoStartIndex` after directives are matched

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -266,17 +266,24 @@ export function assignTViewNodeToLView(
  * i18nApply() or ComponentFactory.create), we need to adjust the blueprint for future
  * template passes.
  */
-export function allocExpando(view: LView) {
+export function allocExpando(view: LView, totalHostVars: number) {
   const tView = view[TVIEW];
   if (tView.firstTemplatePass) {
+    for (let i = 0; i < totalHostVars; i++) {
+      tView.blueprint.push(null);
+      tView.data.push(null);
+      view.push(null);
+    }
+
     // We should only increment the expando start index if there aren't already directives
     // and injectors saved in the "expando" section
-    if (tView.blueprint.length === tView.expandoStartIndex) {
-      tView.expandoStartIndex++;
+    if (!tView.expandoInstructions) {
+      tView.expandoStartIndex += totalHostVars;
+    } else {
+      // Since we're adding the dynamic nodes into the expando section, we need to let the host
+      // bindings know that they should skip x slots
+      tView.expandoInstructions.push(totalHostVars);
     }
-    tView.blueprint.push(null);
-    tView.data.push(null);
-    view.push(null);
   }
 }
 

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -269,7 +269,11 @@ export function assignTViewNodeToLView(
 export function allocExpando(view: LView) {
   const tView = view[TVIEW];
   if (tView.firstTemplatePass) {
-    tView.expandoStartIndex++;
+    // We should only increment the expando start index if there aren't already directives
+    // and injectors saved in the "expando" section
+    if (tView.blueprint.length === tView.expandoStartIndex) {
+      tView.expandoStartIndex++;
+    }
     tView.blueprint.push(null);
     tView.data.push(null);
     view.push(null);

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -266,10 +266,10 @@ export function assignTViewNodeToLView(
  * i18nApply() or ComponentFactory.create), we need to adjust the blueprint for future
  * template passes.
  */
-export function allocExpando(view: LView, totalHostVars: number) {
+export function allocExpando(view: LView, numSlotsToAlloc: number) {
   const tView = view[TVIEW];
   if (tView.firstTemplatePass) {
-    for (let i = 0; i < totalHostVars; i++) {
+    for (let i = 0; i < numSlotsToAlloc; i++) {
       tView.blueprint.push(null);
       tView.data.push(null);
       view.push(null);
@@ -278,11 +278,11 @@ export function allocExpando(view: LView, totalHostVars: number) {
     // We should only increment the expando start index if there aren't already directives
     // and injectors saved in the "expando" section
     if (!tView.expandoInstructions) {
-      tView.expandoStartIndex += totalHostVars;
+      tView.expandoStartIndex += numSlotsToAlloc;
     } else {
       // Since we're adding the dynamic nodes into the expando section, we need to let the host
       // bindings know that they should skip x slots
-      tView.expandoInstructions.push(totalHostVars);
+      tView.expandoInstructions.push(numSlotsToAlloc);
     }
   }
 }

--- a/packages/core/src/render3/interfaces/i18n.ts
+++ b/packages/core/src/render3/interfaces/i18n.ts
@@ -246,14 +246,6 @@ export interface TI18n {
   vars: number;
 
   /**
-   * Index in EXPANDO where the i18n stores its DOM nodes.
-   *
-   * When the bindings are processed by the `i18nEnd` instruction it is necessary to know where the
-   * newly created DOM nodes will be inserted.
-   */
-  expandoStartIndex: number;
-
-  /**
    * A set of OpCodes which will create the Text Nodes and ICU anchors for the translation blocks.
    *
    * NOTE: The ICU anchors are filled in with ICU Update OpCode.
@@ -331,14 +323,6 @@ export interface TIcu {
    * represents the child ICUs to clean up. There may be more than one child ICUs per case.
    */
   childIcus: number[][];
-
-  /**
-   * Index in EXPANDO where the i18n stores its DOM nodes.
-   *
-   * When the bindings are processed by the `i18nEnd` instruction it is necessary to know where the
-   * newly created DOM nodes will be inserted.
-   */
-  expandoStartIndex: number;
 
   /**
    * A list of case values which the current ICU will try to match.

--- a/packages/core/test/render3/i18n_spec.ts
+++ b/packages/core/test/render3/i18n_spec.ts
@@ -8,14 +8,13 @@
 
 import {noop} from '../../../compiler/src/render3/view/util';
 import {Component as _Component} from '../../src/core';
-import {defineComponent} from '../../src/render3/definition';
+import {defineComponent, defineDirective} from '../../src/render3/definition';
 import {getTranslationForTemplate, i18n, i18nApply, i18nAttributes, i18nEnd, i18nExp, i18nPostprocess, i18nStart} from '../../src/render3/i18n';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
+import {AttributeMarker} from '../../src/render3/interfaces/node';
 import {getNativeByIndex} from '../../src/render3/util';
-
 import {NgIf} from './common_with_def';
-
-import {element, elementEnd, elementStart, template, text, nextContext, bind, elementProperty, projectionDef, projection, elementContainerStart, elementContainerEnd} from '../../src/render3/instructions';
+import {allocHostVars, element, elementEnd, elementStart, template, text, nextContext, bind, elementProperty, projectionDef, projection, elementContainerStart, elementContainerEnd} from '../../src/render3/instructions';
 import {COMMENT_MARKER, ELEMENT_MARKER, I18nMutateOpCode, I18nUpdateOpCode, I18nUpdateOpCodes, TI18n} from '../../src/render3/interfaces/i18n';
 import {HEADER_OFFSET, LView, TVIEW} from '../../src/render3/interfaces/view';
 import {ComponentFixture, TemplateFixture} from './render_util';
@@ -1348,6 +1347,105 @@ describe('Runtime i18n', () => {
 
       const fixture = new ComponentFixture(MyApp);
       expect(fixture.html).toEqual(`<div title="start 2 middle 1 end">trad 1</div>`);
+    });
+
+    it('should work with directives and host bindings', () => {
+      let directiveInstance: Directive;
+      const elementIndices: number[] = [];
+
+      class Directive {
+        // @HostBinding('className')
+        klass = 'foo';
+
+        static ngDirectiveDef = defineDirective({
+          type: Directive,
+          selectors: [['', 'dir', '']],
+          factory: () => directiveInstance = new Directive,
+          hostBindings: (rf: RenderFlags, ctx: any, elementIndex: number) => {
+            elementIndices.push(elementIndex);
+            if (rf & RenderFlags.Create) {
+              allocHostVars(1);
+            }
+            if (rf & RenderFlags.Update) {
+              elementProperty(elementIndex, 'className', bind(ctx.klass), null, true);
+            }
+          }
+        });
+      }
+
+      // Translated template:
+      // <div i18n [test]="false" i18n-title title="start {{exp2}} middle {{exp1}} end">
+      //    trad {�0�, plural,
+      //         =0 {no <b title="none">emails</b>!}
+      //         =1 {one <i>email</i>}
+      //         other {�0� emails}
+      //       }
+      // </div>
+
+      const MSG_DIV_1 = `trad {�0�, plural, 
+        =0 {no <b title="none">emails</b>!} 
+        =1 {one <i>email</i>} 
+        other {�0� emails}
+      }`;
+      const MSG_DIV_1_ATTR_1 = ['title', `start �1� middle �0� end`];
+
+      class MyApp {
+        exp1 = 1;
+        exp2 = 2;
+
+        static ngComponentDef = defineComponent({
+          type: MyApp,
+          selectors: [['my-app']],
+          factory: () => new MyApp(),
+          consts: 5,
+          vars: 5,
+          directives: [Directive],
+          template: (rf: RenderFlags, ctx: MyApp) => {
+            if (rf & RenderFlags.Create) {
+              elementStart(0, 'div', [AttributeMarker.SelectOnly, 'dir']);
+              {
+                i18nAttributes(1, MSG_DIV_1_ATTR_1);
+                i18nStart(2, MSG_DIV_1);
+                {
+                  elementStart(3, 'b');  // Will be removed
+                  { i18nAttributes(4, MSG_DIV_1_ATTR_1); }
+                  elementEnd();
+                }
+                i18nEnd();
+              }
+              elementEnd();
+            }
+            if (rf & RenderFlags.Update) {
+              i18nExp(bind(ctx.exp1));
+              i18nExp(bind(ctx.exp2));
+              i18nApply(1);
+              i18nExp(bind(ctx.exp1));
+              i18nApply(2);
+              i18nExp(bind(ctx.exp1));
+              i18nExp(bind(ctx.exp2));
+              i18nApply(4);
+            }
+          }
+        });
+      }
+
+      const fixture = new ComponentFixture(MyApp);
+      // the "test" attribute should not be reflected in the DOM as it is here only for directive
+      // matching purposes
+      expect(fixture.html)
+          .toEqual(
+              `<div class="foo" title="start 2 middle 1 end">trad one <i>email</i><!--ICU 22--></div>`);
+
+      directiveInstance !.klass = 'bar';
+      fixture.component.exp1 = 2;
+      fixture.component.exp2 = 3;
+      fixture.update();
+      expect(fixture.html)
+          .toEqual(
+              `<div class="bar" title="start 3 middle 2 end">trad 2 emails<!--ICU 22--></div>`);
+
+      // verify that we always call `hostBindings` function with the same element index
+      expect(elementIndices.every(id => id === elementIndices[0])).toBeTruthy();
     });
 
     describe('projection', () => {


### PR DESCRIPTION
i18n instructions create text nodes dynamically and save them between bindings and the expando block in `LView`. e.g., they try to create the following order in `LView`.

```
| -- elements -- | -- bindings -- | -- dynamic i18n text -- | -- expando (dirs, injectors) -- |
```

Each time a new text node is created, it is pushed to the end of the array and the `expandoStartIndex` marker is incremented, so the section begins slightly later. This happens in `allocExpando`.

This is fine if no directives have been created yet. The end of the array will be in the "dynamic text node" section.

| -- elements -- | -- bindings -- | -- dynamic i18n text -- |

However, this approach doesn't work if dynamic text nodes are created after directives are matched (for example when the directive uses host bindings). In that case, there are already directives and injectors saved in the "expando" section. So pushing to the end of `LView` actually pushes after the expando section. What we get is this:

```
| -- elements -- | -- bindings -- | -- dynamic i18n text -- | -- expando -- | -- dynamic i18n text-- |
```

In this case, the `expandoStartIndex` shouldn't be incremented because we are not inserting anything before the expando section (it's now after the expando section). But because it is incremented in the code right now, it's now pointing to an index in the middle of the expando section.

This PR fixes that so that we only increment the `expandoStartIndex` if nothing was pushed into the expando section.

FW-978 #resolve