### PR TITLE
fix(ivy): mark query as dirty upon view insertion

### DIFF
--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -191,19 +191,21 @@ function copyQueriesToView(query: LQuery<any>| null): LQuery<any>|null {
 
 function insertView(index: number, query: LQuery<any>| null) {
   while (query) {
-    ngDevMode &&
-        assertDefined(
-            query.containerValues, 'View queries need to have a pointer to container values.');
+    ngDevMode && assertViewQueryhasPointerToDeclarationContainer(query);
     query.containerValues !.splice(index, 0, query.values);
+
+    // mark a query as dirty only when inserted view had matching modes
+    if (query.values.length) {
+      query.list.setDirty();
+    }
+
     query = query.next;
   }
 }
 
 function removeView(query: LQuery<any>| null) {
   while (query) {
-    ngDevMode &&
-        assertDefined(
-            query.containerValues, 'View queries need to have a pointer to container values.');
+    ngDevMode && assertViewQueryhasPointerToDeclarationContainer(query);
 
     const containerValues = query.containerValues !;
     const viewValuesIdx = containerValues.indexOf(query.values);
@@ -219,6 +221,9 @@ function removeView(query: LQuery<any>| null) {
   }
 }
 
+function assertViewQueryhasPointerToDeclarationContainer(query: LQuery<any>) {
+  assertDefined(query.containerValues, 'View queries need to have a pointer to container values.');
+}
 
 /**
  * Iterates over local names for a given node and returns directive index


### PR DESCRIPTION
This PR updates tests to reflect change of the behaviour of ngIvy (as compared to the view engine) when it comes to query results from embedded views. 

### Scenario

Let's consider the following component:

```
@Component({
  selector: 'query-for-foo',
  template: `...`
})
class QueryForFoo {
  @ContentChildren('foo') foos: QueryList<ElementRef>;
}
```

and a template where it is used:

```
<query-for-foo>
    <div #foo></div>
    <ng-template playWithViewsDirective>
         <span #foo></span>
    </ng-template>  
</query-for-foo>
```

There are 2 elements that can match `@ContentChildren('foo')` query - one being a direct child and a second one being part of an embedded view. The `<div #foo></div>` will always match. The match from an embedded view depends on what happens with this view and there are 4 operations to consider here:
* view creation;
* view insertion (it is possible to create a view without attaching it to the views tree);
* view detaching (it is possible to detach a view without destroying it;
* view destruction.

Please note that there are logical pairs of equivalent operations here: create / destroy and insert / detach.

### View engine behaviour

In the view engine we need to _both_  create _and_ insert a view for the results from an embedded view to be reported to queries. The creation itself is not sufficient - we need to insert a view so its nodes are "visible" to queries. This seems like a logical and sensible behaviour.

Interestingly, detaching a view will _not_ make detached view results go away from queries - it is only when a view is destroyed that results are no longer reported. This seems counter intuitive and lacks symmetry when it comes to insert / detach  operations.

### ngIvy behaviour

ngIvy uses the  insert / detach  operations to add / remove query results from embedded view. It means that query results will be updated (removed) upon view detaching.


Additionally this PR fixes a bug in the ngIvy implementation where queries were not marked as dirty when a view was inserted.
