### PR TITLE
fix(router): routerLink remove tabindex attribute

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -7,7 +7,7 @@
  */
 
 import {LocationStrategy} from '@angular/common';
-import {Attribute, Directive, ElementRef, HostBinding, HostListener, Input, OnChanges, OnDestroy, Renderer2, isDevMode} from '@angular/core';
+import {Directive, HostBinding, HostListener, Input, OnChanges, OnDestroy, isDevMode} from '@angular/core';
 import {Subscription} from 'rxjs';
 
 import {QueryParamsHandling} from '../config';
@@ -130,13 +130,7 @@ export class RouterLink {
   // TODO(issue/24571): remove '!'.
   private preserve !: boolean;
 
-  constructor(
-      private router: Router, private route: ActivatedRoute,
-      @Attribute('tabindex') tabIndex: string, renderer: Renderer2, el: ElementRef) {
-    if (tabIndex == null) {
-      renderer.setAttribute(el.nativeElement, 'tabindex', '0');
-    }
-  }
+  constructor(private router: Router, private route: ActivatedRoute) {}
 
   @Input()
   set routerLink(commands: any[]|string) {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1806,7 +1806,7 @@ describe('Integration', () => {
          expect(fixture.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
          const button = fixture.nativeElement.querySelector('button');
-         expect(button.getAttribute('tabindex')).toEqual('0');
+         expect(button.getAttribute('tabindex')).toEqual(null);
          button.click();
          advance(fixture);
 

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -378,7 +378,7 @@ export declare class RouterLink {
         [k: string]: any;
     };
     readonly urlTree: UrlTree;
-    constructor(router: Router, route: ActivatedRoute, tabIndex: string, renderer: Renderer2, el: ElementRef);
+    constructor(router: Router, route: ActivatedRoute);
     onClick(): boolean;
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, `routerLink` directive adds `tabindex` attribute if not set.
That behavior blocks users from creating their own widgets with custom
focus managing via ARIA attributes, because there is no way to unset
that attribute. It has also been stated that it's not `routerLink`
resposibility to make app more accesible and it also caused some problems
because it wasn't obvious to everyone why elements are focusable (#10895).

Issue Number: #28345

## What is the new behavior?

With an approach proposed by this PR `tabindex` can (and in many cases should) be still set manually.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

BREAKING CHANGE: Previously `tabindex` has been set for any element
that had `routerLink` directive applied. Change in this PR can introduce
situation when previously reachable elements with a keyboard won't be
focusable anymore unless explicitly set with `tabindex="0"`.

## Other information

PR Close #28345