### PR TITLE
fix(ivy): proper component resolution in case of inheritance

### DIFF
--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -345,9 +345,12 @@ function setScopeOnDeclaredComponents(moduleType: Type<any>, ngModule: NgModule)
  */
 export function patchComponentDefWithScope<C>(
     componentDef: ComponentDef<C>, transitiveScopes: NgModuleTransitiveScopes) {
-  componentDef.directiveDefs = () => Array.from(transitiveScopes.compilation.directives)
-                                         .map(dir => getDirectiveDef(dir) || getComponentDef(dir) !)
-                                         .filter(def => !!def);
+  componentDef.directiveDefs = () =>
+      Array.from(transitiveScopes.compilation.directives)
+          .map(
+              dir => dir.hasOwnProperty(NG_COMPONENT_DEF) ? getComponentDef(dir) ! :
+                                                            getDirectiveDef(dir) !)
+          .filter(def => !!def);
   componentDef.pipeDefs = () =>
       Array.from(transitiveScopes.compilation.pipes).map(pipe => getPipeDef(pipe) !);
 }

--- a/packages/core/test/linker/inheritance_integration_spec.ts
+++ b/packages/core/test/linker/inheritance_integration_spec.ts
@@ -15,6 +15,12 @@ import {modifiedInIvy, onlyInIvy} from '@angular/private/testing';
 class DirectiveA {
 }
 
+@Directive({selector: '[directiveB]'})
+class DirectiveB {
+  @HostBinding('title')
+  title = 'DirectiveB Title';
+}
+
 @Component({selector: 'component-a', template: 'ComponentA Template'})
 class ComponentA {
 }
@@ -24,11 +30,15 @@ class ComponentA {
 class ComponentExtendsDirective extends DirectiveA {
 }
 
+class ComponentWithNoAnnotation extends ComponentA {}
+
 @Directive({selector: '[directiveExtendsComponent]'})
 class DirectiveExtendsComponent extends ComponentA {
   @HostBinding('title')
   title = 'DirectiveExtendsComponent Title';
 }
+
+class DirectiveWithNoAnnotation extends DirectiveB {}
 
 @Component({selector: 'my-app', template: '...'})
 class App {
@@ -42,6 +52,24 @@ describe('Inheritance logic', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     expect(fixture.nativeElement.firstChild.innerHTML).toBe('ComponentExtendsDirective Template');
+  });
+
+  it('should handle classes with no annotations that extend Components', () => {
+    TestBed.configureTestingModule({declarations: [ComponentWithNoAnnotation, App]});
+    const template = '<component-a></component-a>';
+    TestBed.overrideComponent(App, {set: {template}});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.firstChild.innerHTML).toBe('ComponentA Template');
+  });
+
+  it('should handle classes with no annotations that extend Directives', () => {
+    TestBed.configureTestingModule({declarations: [DirectiveWithNoAnnotation, App]});
+    const template = '<div directiveB></div>';
+    TestBed.overrideComponent(App, {set: {template}});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.firstChild.title).toBe('DirectiveB Title');
   });
 
   modifiedInIvy('View Engine allows Directives to extend Components')

--- a/packages/core/test/linker/inheritance_integration_spec.ts
+++ b/packages/core/test/linker/inheritance_integration_spec.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, Directive, HostBinding} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {describe, expect, it} from '@angular/core/testing/src/testing_internal';
+import {modifiedInIvy, onlyInIvy} from '@angular/private/testing';
+
+@Directive({selector: '[directiveA]'})
+class DirectiveA {
+}
+
+@Component({selector: 'component-a', template: 'ComponentA Template'})
+class ComponentA {
+}
+
+@Component(
+    {selector: 'component-extends-directive', template: 'ComponentExtendsDirective Template'})
+class ComponentExtendsDirective extends DirectiveA {
+}
+
+@Directive({selector: '[directiveExtendsComponent]'})
+class DirectiveExtendsComponent extends ComponentA {
+  @HostBinding('title')
+  title = 'DirectiveExtendsComponent Title';
+}
+
+@Component({selector: 'my-app', template: '...'})
+class App {
+}
+
+describe('Inheritance logic', () => {
+  it('should handle Components that extend Directives', () => {
+    TestBed.configureTestingModule({declarations: [ComponentExtendsDirective, App]});
+    const template = '<component-extends-directive></component-extends-directive>';
+    TestBed.overrideComponent(App, {set: {template}});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.firstChild.innerHTML).toBe('ComponentExtendsDirective Template');
+  });
+
+  modifiedInIvy('View Engine allows Directives to extend Components')
+      .it('should handle Directives that extend Components', () => {
+        TestBed.configureTestingModule({declarations: [DirectiveExtendsComponent, App]});
+        const template = '<div directiveExtendsComponent>Some content</div>';
+        TestBed.overrideComponent(App, {set: {template}});
+        const fixture = TestBed.createComponent(App);
+        fixture.detectChanges();
+        expect(fixture.nativeElement.firstChild.title).toBe('DirectiveExtendsComponent Title');
+      });
+
+  onlyInIvy('Ivy does not allow Directives to extend Components')
+      .it('should throw in case a Directive tries to extend a Component', () => {
+        TestBed.configureTestingModule({declarations: [DirectiveExtendsComponent, App]});
+        const template = '<div directiveExtendsComponent>Some content</div>';
+        TestBed.overrideComponent(App, {set: {template}});
+        expect(() => TestBed.createComponent(App))
+            .toThrowError('Directives cannot inherit Components');
+      });
+});

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -338,6 +338,12 @@ export class TestBedRender3 implements Injector, TestBed {
     this._initiaNgDefs.forEach((value: [string, PropertyDescriptor], type: Type<any>) => {
       const [prop, descriptor] = value;
       if (!descriptor) {
+        // Delete operations are generally undesirable since they have performance implications on
+        // objects they were applied to. In this particular case, situations where this code is
+        // invoked should be quite rare to cause any noticable impact, since it's applied only to
+        // some test cases (for example when class with no annotations extends some @Component) when
+        // we need to clear 'ngComponentDef' field on a given class to restore its original state
+        // (before applying overrides and running tests).
         delete (type as any)[prop];
       } else {
         Object.defineProperty(type, prop, descriptor);

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -336,7 +336,12 @@ export class TestBedRender3 implements Injector, TestBed {
 
     // restore initial component/directive/pipe defs
     this._initiaNgDefs.forEach((value: [string, PropertyDescriptor], type: Type<any>) => {
-      Object.defineProperty(type, value[0], value[1]);
+      const [prop, descriptor] = value;
+      if (!descriptor) {
+        delete (type as any)[prop];
+      } else {
+        Object.defineProperty(type, prop, descriptor);
+      }
     });
     this._initiaNgDefs.clear();
     clearResolutionOfComponentResourcesQueue();

--- a/packages/core/testing/src/resolvers.ts
+++ b/packages/core/testing/src/resolvers.ts
@@ -13,8 +13,6 @@ import {MetadataOverrider} from './metadata_overrider';
 
 const reflection = new ReflectionCapabilities();
 
-const knownTypes: Type<any>[] = [Directive, Component, Pipe, NgModule];
-
 /**
  * Base interface to resolve `@Component`, `@Directive`, `@Pipe` and `@NgModule`.
  */
@@ -46,9 +44,11 @@ abstract class OverrideResolver<T> implements Resolver<T> {
     // both Directive and Component annotations would be present), so we always check if the known
     // annotation has the right type.
     for (let i = annotations.length - 1; i >= 0; i--) {
-      const isKnownType = knownTypes.some((type: Type<any>) => annotations[i] instanceof type);
+      const annotation = annotations[i];
+      const isKnownType = annotation instanceof Directive || annotation instanceof Component ||
+          annotation instanceof Pipe || annotation instanceof NgModule;
       if (isKnownType) {
-        return annotations[i] instanceof this.type ? annotations[i] : null;
+        return annotation instanceof this.type ? annotation : null;
       }
     }
     return null;


### PR DESCRIPTION
Ivy allows Components to extend Directives (but not the other way around) and as a result we may have Component and Directive annotations present at the same time. The logic that resolves annotations to pick the necessary one didn't take this into account and as a result Components were recognized as Directives (and vice versa) in case of inheritance. This change updates the resolution logic by picking known annotation that is the nearest one (in inheritance tree) and compares it with expected type. That should help avoid mis-classification of Components/Directives during resolution.

This PR resolves FW-966 and unblocks a portion of Material tests (related to Stepper component) to run under Ivy.

**UPDATE (1/31)**: I've also added a couple tests to verify that classes with no annotations that extend Components/Directives are also supported. This triggered an issue in R3TestBed where we tried to restore ng def when it was not defined. So there are some additional changes (to the code and tests) related to R3testBed fix.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No