### PR TITLE
refactor(ivy): remove firstTemplatePass as global state

### DIFF
--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -24,7 +24,7 @@ import {unusedValueExportToPlacateAjd as unused2} from './interfaces/injector';
 import {TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeType, unusedValueExportToPlacateAjd as unused3} from './interfaces/node';
 import {LQueries, unusedValueExportToPlacateAjd as unused4} from './interfaces/query';
 import {CONTENT_QUERIES, HEADER_OFFSET, LView, TVIEW} from './interfaces/view';
-import {getCurrentQueryIndex, getFirstTemplatePass, getIsParent, getLView, getOrCreateCurrentQueries, setCurrentQueryIndex} from './state';
+import {getCurrentQueryIndex, getIsParent, getLView, getOrCreateCurrentQueries, setCurrentQueryIndex} from './state';
 import {isContentQueryHost} from './util';
 import {createElementRef, createTemplateRef} from './view_engine_compatibility';
 
@@ -444,7 +444,7 @@ export function contentQuery<T>(
   const tView = lView[TVIEW];
   const contentQuery: QueryList<T> = query<T>(predicate, descend, read);
   (lView[CONTENT_QUERIES] || (lView[CONTENT_QUERIES] = [])).push(contentQuery);
-  if (getFirstTemplatePass()) {
+  if (tView.firstTemplatePass) {
     const tViewContentQueries = tView.contentQueries || (tView.contentQueries = []);
     const lastSavedDirectiveIndex =
         tView.contentQueries.length ? tView.contentQueries[tView.contentQueries.length - 1] : -1;

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -229,17 +229,6 @@ export function setCheckNoChangesMode(mode: boolean): void {
   checkNoChangesMode = mode;
 }
 
-/** Whether or not this is the first time the current view has been processed. */
-let firstTemplatePass = true;
-
-export function getFirstTemplatePass(): boolean {
-  return firstTemplatePass;
-}
-
-export function setFirstTemplatePass(value: boolean): void {
-  firstTemplatePass = value;
-}
-
 /**
  * The root index from which pure function instructions should calculate their binding
  * indices. In component views, this is TView.bindingStartIndex. In a host binding
@@ -287,7 +276,6 @@ export function enterView(newView: LView, hostTNode: TElementNode | TViewNode | 
   const oldView = lView;
   if (newView) {
     const tView = newView[TVIEW];
-    firstTemplatePass = tView.firstTemplatePass;
     bindingRootIndex = tView.bindingStartIndex;
   }
 

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -288,9 +288,6 @@
     "name": "findDirectiveMatches"
   },
   {
-    "name": "firstTemplatePass"
-  },
-  {
     "name": "generateExpandoInstructionBlock"
   },
   {
@@ -325,9 +322,6 @@
   },
   {
     "name": "getElementDepthCount"
-  },
-  {
-    "name": "getFirstTemplatePass"
   },
   {
     "name": "getHighestElementOrICUContainer"
@@ -592,9 +586,6 @@
   },
   {
     "name": "setCurrentQueryIndex"
-  },
-  {
-    "name": "setFirstTemplatePass"
   },
   {
     "name": "setHostBindings"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -216,9 +216,6 @@
     "name": "extractPipeDef"
   },
   {
-    "name": "firstTemplatePass"
-  },
-  {
     "name": "generateExpandoInstructionBlock"
   },
   {
@@ -241,9 +238,6 @@
   },
   {
     "name": "getDirectiveDef"
-  },
-  {
-    "name": "getFirstTemplatePass"
   },
   {
     "name": "getHighestElementOrICUContainer"
@@ -421,9 +415,6 @@
   },
   {
     "name": "setCurrentQueryIndex"
-  },
-  {
-    "name": "setFirstTemplatePass"
   },
   {
     "name": "setHostBindings"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -594,9 +594,6 @@
     "name": "findViaComponent"
   },
   {
-    "name": "firstTemplatePass"
-  },
-  {
     "name": "forwardRef"
   },
   {
@@ -655,9 +652,6 @@
   },
   {
     "name": "getElementDepthCount"
-  },
-  {
-    "name": "getFirstTemplatePass"
   },
   {
     "name": "getHighestElementOrICUContainer"
@@ -1141,9 +1135,6 @@
   },
   {
     "name": "setDirty"
-  },
-  {
-    "name": "setFirstTemplatePass"
   },
   {
     "name": "setFlag"


### PR DESCRIPTION
Feels good to remove global state and few lines of code, isn't it?