### PR TITLE
fix(compiler-cli): resolve paths to absolute before injecting into ts…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/synthetic_files_compiler_host.ts
+++ b/packages/compiler-cli/src/ngtsc/synthetic_files_compiler_host.ts
@@ -30,7 +30,7 @@ export class SyntheticFilesCompilerHost implements PluginCompilerHost {
       private rootFiles: string[], private delegate: ts.CompilerHost,
       generatedFiles: (rootFiles: string[]) => {
         [fileName: string]: (host: ts.CompilerHost) => ts.SourceFile | undefined
-      }, ) {
+      }) {
     // Allow ngtsc to contribute in-memory synthetic files, which will be loaded
     // as if they existed on disk as action inputs.
     const angularGeneratedFiles = generatedFiles !(rootFiles);


### PR DESCRIPTION
….Program

This was caught when writing a ts_library integration test in google3 where tsickle requires all ts.SourceFiles in the program to have absolute paths