### PR TITLE
ci: keep job alive when yarn request takes more than 10 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,13 @@ var_7: &post_checkout
 var_8: &yarn_install
   run:
     name: Running Yarn install
-    command: yarn install --frozen-lockfile --non-interactive
+    command: |
+      # Yarn's requests sometimes take more than 10mins to complete.
+      # Print something to stdout, to prevent CircleCI from failing due to not output.
+      while true; do sleep 60; echo "[`date`] Keeping alive..."; done &
+      KEEP_ALIVE_PID=$!
+      yarn install --frozen-lockfile --non-interactive
+      kill $KEEP_ALIVE_PID
 
 var_9: &setup_circleci_bazel_config
   run:


### PR DESCRIPTION
Occasionally, yarn's requests take more than 10 minutes to complete/fail, by which time CircleCI jobs due to no output.
This PR works around the issue by periodically printing something to stdout.

This avoids flakes, but builds can take up much more time (e.g. 30mins), which is slower than waiting for the build to fail and restart (10mins + 10mins) 🤷‍♂️ 