### PR TITLE
fix(bazel): fix integration test for bazel-schematics

### DIFF
--- a/integration/bazel-schematics/test.sh
+++ b/integration/bazel-schematics/test.sh
@@ -10,6 +10,8 @@ function testBazel() {
   ng new demo --collection=@angular/bazel --defaults --skip-git --style=scss
   node replace_angular_repo.js "./demo/WORKSPACE"
   cd demo
+  # TODO(kyliau) pin @angular/bazel version to 7.2.2 due to builder bug in 7.2.3
+  yarn add @angular/bazel@7.2.2
   cp ../package.json.replace ./package.json
   ng generate component widget --style=css
   ng build


### PR DESCRIPTION
With the release of @angular/bazel v7.2.3, the npm install step right
after `ng new` installs this version. However there is a bug in the
builder which results in bazel executable not found.

This bug was not discovered before because the dependencies of the
project created by `ng new` are not pinned.

The fix is to pin the version of @angular/bazel to 7.2.2 which relies on
global installation of bazel. This serves to unblock the broken CI. A proper
fix will be submitted in a follow-up PR.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
