### PR TITLE
refactor(ivy): pass host into createLView explicitly

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -23,7 +23,7 @@ import {ComponentDef, ComponentType, RenderFlags} from './interfaces/definition'
 import {TElementNode, TNode, TNodeFlags, TNodeType} from './interfaces/node';
 import {PlayerHandler} from './interfaces/player';
 import {RElement, Renderer3, RendererFactory3, domRendererFactory3} from './interfaces/renderer';
-import {CONTEXT, FLAGS, HEADER_OFFSET, HOST, HOST_NODE, LView, LViewFlags, RootContext, RootContextFlags, TVIEW} from './interfaces/view';
+import {CONTEXT, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, RootContext, RootContextFlags, TVIEW, T_HOST} from './interfaces/view';
 import {enterView, getPreviousOrParentTNode, leaveView, resetComponentState, setCurrentDirectiveDef} from './state';
 import {defaultScheduler, getRootView, readPatchedLView, renderStringify} from './util';
 
@@ -122,8 +122,8 @@ export function renderComponent<T>(
 
   const renderer = rendererFactory.createRenderer(hostRNode, componentDef);
   const rootView: LView = createLView(
-      null, createTView(-1, null, 1, 0, null, null, null), rootContext, rootFlags, rendererFactory,
-      renderer, undefined, opts.injector || null);
+      null, createTView(-1, null, 1, 0, null, null, null), rootContext, rootFlags, null, null,
+      rendererFactory, renderer, undefined, opts.injector || null);
 
   const oldView = enterView(rootView, null);
   let component: T;
@@ -163,13 +163,13 @@ export function createRootComponentView(
     rendererFactory: RendererFactory3, renderer: Renderer3, sanitizer?: Sanitizer | null): LView {
   resetComponentState();
   const tView = rootView[TVIEW];
+  const tNode: TElementNode = createNodeAtIndex(0, TNodeType.Element, rNode, null, null);
   const componentView = createLView(
       rootView,
       getOrCreateTView(
           def.template, def.consts, def.vars, def.directiveDefs, def.pipeDefs, def.viewQuery),
-      null, def.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways, rendererFactory, renderer,
-      sanitizer);
-  const tNode = createNodeAtIndex(0, TNodeType.Element, rNode, null, null);
+      null, def.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways, rootView[HEADER_OFFSET], tNode,
+      rendererFactory, renderer, sanitizer);
 
   if (tView.firstTemplatePass) {
     diPublicInInjector(getOrCreateNodeInjectorForNode(tNode, rootView), rootView, def.type);
@@ -179,8 +179,6 @@ export function createRootComponentView(
   }
 
   // Store component view at node index, with node as the HOST
-  componentView[HOST] = rootView[HEADER_OFFSET];
-  componentView[HOST_NODE] = tNode as TElementNode;
   return rootView[HEADER_OFFSET] = componentView;
 }
 

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -161,7 +161,7 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
 
     // Create the root view. Uses empty TView and ContentTemplate.
     const rootLView = createLView(
-        null, createTView(-1, null, 1, 0, null, null, null), rootContext, rootFlags,
+        null, createTView(-1, null, 1, 0, null, null, null), rootContext, rootFlags, null, null,
         rendererFactory, renderer, sanitizer, rootViewInjector);
 
     // rootView is the parent when bootstrapping

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -18,7 +18,7 @@ import {NG_ELEMENT_ID} from './fields';
 import {DirectiveDef} from './interfaces/definition';
 import {NO_PARENT_INJECTOR, NodeInjectorFactory, PARENT_INJECTOR, RelativeInjectorLocation, RelativeInjectorLocationFlags, TNODE, isFactory} from './interfaces/injector';
 import {AttributeMarker, TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeFlags, TNodeProviderIndexes, TNodeType} from './interfaces/node';
-import {DECLARATION_VIEW, HOST_NODE, INJECTOR, LView, TData, TVIEW, TView} from './interfaces/view';
+import {DECLARATION_VIEW, INJECTOR, LView, TData, TVIEW, TView, T_HOST} from './interfaces/view';
 import {assertNodeOfPossibleTypes} from './node_assert';
 import {getLView, getPreviousOrParentTNode, setTNodeAndViewData} from './state';
 import {findComponentView, getParentInjectorIndex, getParentInjectorView, hasParentInjector, isComponent, isComponentDef, renderStringify} from './util';
@@ -205,11 +205,11 @@ export function getParentInjectorLocation(tNode: TNode, view: LView): RelativeIn
   // For most cases, the parent injector index can be found on the host node (e.g. for component
   // or container), so this loop will be skipped, but we must keep the loop here to support
   // the rarer case of deeply nested <ng-template> tags or inline views.
-  let hostTNode = view[HOST_NODE];
+  let hostTNode = view[T_HOST];
   let viewOffset = 1;
   while (hostTNode && hostTNode.injectorIndex === -1) {
     view = view[DECLARATION_VIEW] !;
-    hostTNode = view ? view[HOST_NODE] : null;
+    hostTNode = view ? view[T_HOST] : null;
     viewOffset++;
   }
 
@@ -332,7 +332,7 @@ export function getOrCreateInjectable<T>(
       let injectorIndex = getInjectorIndex(tNode, lView);
       let parentLocation: RelativeInjectorLocation = NO_PARENT_INJECTOR;
       let hostTElementNode: TNode|null =
-          flags & InjectFlags.Host ? findComponentView(lView)[HOST_NODE] : null;
+          flags & InjectFlags.Host ? findComponentView(lView)[T_HOST] : null;
 
       // If we should skip this injector, or if there is no injector on this node, start by
       // searching

--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -19,7 +19,7 @@ import {TElementNode, TIcuContainerNode, TNode, TNodeType} from './interfaces/no
 import {RComment, RElement} from './interfaces/renderer';
 import {SanitizerFn} from './interfaces/sanitization';
 import {StylingContext} from './interfaces/styling';
-import {BINDING_INDEX, HEADER_OFFSET, HOST_NODE, LView, RENDERER, TVIEW, TView} from './interfaces/view';
+import {BINDING_INDEX, HEADER_OFFSET, LView, RENDERER, TVIEW, TView, T_HOST} from './interfaces/view';
 import {appendChild, createTextNode, nativeRemoveNode} from './node_manipulation';
 import {getIsParent, getLView, getPreviousOrParentTNode, setIsParent, setPreviousOrParentTNode} from './state';
 import {NO_CHANGE} from './tokens';
@@ -368,9 +368,8 @@ function i18nStartFirstPass(
   const previousOrParentTNode = getPreviousOrParentTNode();
   const parentTNode = getIsParent() ? getPreviousOrParentTNode() :
                                       previousOrParentTNode && previousOrParentTNode.parent;
-  let parentIndex = parentTNode && parentTNode !== viewData[HOST_NODE] ?
-      parentTNode.index - HEADER_OFFSET :
-      index;
+  let parentIndex =
+      parentTNode && parentTNode !== viewData[T_HOST] ? parentTNode.index - HEADER_OFFSET : index;
   let parentIndexPointer = 0;
   parentIndexStack[parentIndexPointer] = parentIndex;
   const createOpCodes: I18nMutateOpCodes = [];
@@ -482,7 +481,7 @@ function appendI18nNode(tNode: TNode, parentTNode: TNode, previousTNode: TNode |
     tNode.next = null;
   }
 
-  if (parentTNode !== viewData[HOST_NODE]) {
+  if (parentTNode !== viewData[T_HOST]) {
     tNode.parent = parentTNode as TElementNode;
   }
 
@@ -665,7 +664,7 @@ function readCreateOpCodes(
           if (destinationNodeIndex === index) {
             // If the destination node is `i18nStart`, we don't have a
             // top-level node and we should use the host node instead
-            destinationTNode = viewData[HOST_NODE] !;
+            destinationTNode = viewData[T_HOST] !;
           } else {
             destinationTNode = getTNode(destinationNodeIndex, viewData);
           }

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -32,7 +32,7 @@ export const PARENT = 2;
 export const NEXT = 3;
 export const QUERIES = 4;
 export const HOST = 5;
-export const HOST_NODE = 6;  // Rename to `T_HOST`?
+export const T_HOST = 6;
 export const BINDING_INDEX = 7;
 export const CLEANUP = 8;
 export const CONTEXT = 9;
@@ -118,7 +118,7 @@ export interface LView extends Array<any> {
    *
    * If null, this is the root view of an application (root component is in this view).
    */
-  [HOST_NODE]: TViewNode|TElementNode|null;
+  [T_HOST]: TViewNode|TElementNode|null;
 
   /**
    * The binding index we should access next.

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -7,6 +7,7 @@
  */
 
 import {ViewEncapsulation} from '../metadata/view';
+
 import {attachPatchData} from './context_discovery';
 import {callHooks} from './hooks';
 import {LContainer, NATIVE, VIEWS, unusedValueExportToPlacateAjd as unused1} from './interfaces/container';
@@ -14,7 +15,7 @@ import {ComponentDef} from './interfaces/definition';
 import {TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeFlags, TNodeType, TViewNode, unusedValueExportToPlacateAjd as unused2} from './interfaces/node';
 import {unusedValueExportToPlacateAjd as unused3} from './interfaces/projection';
 import {ProceduralRenderer3, RComment, RElement, RNode, RText, Renderer3, isProceduralRenderer, unusedValueExportToPlacateAjd as unused4} from './interfaces/renderer';
-import {CLEANUP, CONTAINER_INDEX, FLAGS, HEADER_OFFSET, HOST_NODE, HookData, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, TVIEW, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
+import {CLEANUP, CONTAINER_INDEX, FLAGS, HEADER_OFFSET, HookData, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, TVIEW, T_HOST, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
 import {assertNodeType} from './node_assert';
 import {findComponentView, getNativeByTNode, isComponent, isLContainer, isRootView, readElementValue, renderStringify} from './util';
 
@@ -107,7 +108,7 @@ function walkTNodeTree(
       }
     } else if (tNode.type === TNodeType.Projection) {
       const componentView = findComponentView(currentView !);
-      const componentHost = componentView[HOST_NODE] as TElementNode;
+      const componentHost = componentView[T_HOST] as TElementNode;
       const head: TNode|null =
           (componentHost.projection as(TNode | null)[])[tNode.projection as number];
 
@@ -398,7 +399,7 @@ export function destroyLView(view: LView) {
  */
 export function getParentState(state: LView | LContainer, rootView: LView): LView|LContainer|null {
   let tNode;
-  if (state.length >= HEADER_OFFSET && (tNode = (state as LView) ![HOST_NODE]) &&
+  if (state.length >= HEADER_OFFSET && (tNode = (state as LView) ![T_HOST]) &&
       tNode.type === TNodeType.View) {
     // if it's an embedded view, the state needs to go up to the container, in case the
     // container has a next
@@ -429,7 +430,7 @@ function cleanUpView(viewOrContainer: LView | LContainer): void {
 
     executeOnDestroys(view);
     removeListeners(view);
-    const hostTNode = view[HOST_NODE];
+    const hostTNode = view[T_HOST];
     // For component views only, the local renderer is destroyed as clean up time.
     if (hostTNode && hostTNode.type === TNodeType.Element && isProceduralRenderer(view[RENDERER])) {
       ngDevMode && ngDevMode.rendererDestroy++;
@@ -513,7 +514,7 @@ function getRenderParent(tNode: TNode, currentView: LView): RElement|null {
   // If the parent is null, then we are inserting across views: either into an embedded view or a
   // component view.
   if (parent == null) {
-    const hostTNode = currentView[HOST_NODE] !;
+    const hostTNode = currentView[T_HOST] !;
     if (hostTNode.type === TNodeType.View) {
       // We are inserting a root element of an embedded view We might delay insertion of children
       // for a given view if it is disconnected. This might happen for 2 main reasons:
@@ -556,7 +557,7 @@ function getRenderParent(tNode: TNode, currentView: LView): RElement|null {
  * a host element.
  */
 function getHostNative(currentView: LView): RElement|null {
-  const hostTNode = currentView[HOST_NODE];
+  const hostTNode = currentView[T_HOST];
   return hostTNode && hostTNode.type === TNodeType.Element ?
       (getNativeByTNode(hostTNode, currentView[PARENT] !) as RElement) :
       null;
@@ -651,7 +652,7 @@ export function appendChild(childEl: RNode | RNode[], childTNode: TNode, current
   const renderParent = getRenderParent(childTNode, currentView);
   if (renderParent != null) {
     const renderer = currentView[RENDERER];
-    const parentTNode: TNode = childTNode.parent || currentView[HOST_NODE] !;
+    const parentTNode: TNode = childTNode.parent || currentView[T_HOST] !;
     const anchorNode = getNativeAnchorNode(parentTNode, currentView);
     if (Array.isArray(childEl)) {
       for (let nativeNode of childEl) {
@@ -680,7 +681,7 @@ function getHighestElementOrICUContainer(tNode: TNode): TNode {
 export function getBeforeNodeForView(index: number, views: LView[], containerNative: RComment) {
   if (index + 1 < views.length) {
     const view = views[index + 1] as LView;
-    const viewTNode = view[HOST_NODE] as TViewNode;
+    const viewTNode = view[T_HOST] as TViewNode;
     return viewTNode.child ? getNativeByTNode(viewTNode.child, view) : containerNative;
   } else {
     return containerNative;

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -7,11 +7,12 @@
  */
 
 import {assertDefined} from '../util/assert';
+
 import {executeHooks} from './hooks';
 import {ComponentDef, DirectiveDef} from './interfaces/definition';
 import {TElementNode, TNode, TNodeFlags, TViewNode} from './interfaces/node';
 import {LQueries} from './interfaces/query';
-import {BINDING_INDEX, CONTEXT, DECLARATION_VIEW, FLAGS, HOST_NODE, InitPhaseState, LView, LViewFlags, OpaqueViewState, QUERIES, TVIEW} from './interfaces/view';
+import {BINDING_INDEX, CONTEXT, DECLARATION_VIEW, FLAGS, InitPhaseState, LView, LViewFlags, OpaqueViewState, QUERIES, TVIEW, T_HOST} from './interfaces/view';
 import {isContentQueryHost} from './util';
 
 
@@ -178,7 +179,7 @@ export function getOrCreateCurrentQueries(
   // If this is the first content query on a node, any existing LQueries needs to be cloned.
   // In subsequent template passes, the cloning occurs before directive instantiation
   // in `createDirectivesAndLocals`.
-  if (previousOrParentTNode && previousOrParentTNode !== lView[HOST_NODE] &&
+  if (previousOrParentTNode && previousOrParentTNode !== lView[T_HOST] &&
       !isContentQueryHost(previousOrParentTNode)) {
     currentQueries && (currentQueries = lView[QUERIES] = currentQueries.clone());
     previousOrParentTNode.flags |= TNodeFlags.hasContentQuery;

--- a/packages/core/src/render3/util.ts
+++ b/packages/core/src/render3/util.ts
@@ -16,7 +16,8 @@ import {NO_PARENT_INJECTOR, RelativeInjectorLocation, RelativeInjectorLocationFl
 import {TContainerNode, TElementNode, TNode, TNodeFlags, TNodeType} from './interfaces/node';
 import {RComment, RElement, RText} from './interfaces/renderer';
 import {StylingContext} from './interfaces/styling';
-import {CONTEXT, DECLARATION_VIEW, FLAGS, HEADER_OFFSET, HOST, HOST_NODE, LView, LViewFlags, PARENT, RootContext, TData, TVIEW, TView} from './interfaces/view';
+import {CONTEXT, DECLARATION_VIEW, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, PARENT, RootContext, TData, TVIEW, TView, T_HOST} from './interfaces/view';
+
 
 
 /**
@@ -235,12 +236,12 @@ export function getParentInjectorTNode(
   let viewOffset = getParentInjectorViewOffset(location);
   // view offset is 1
   let parentView = startView;
-  let parentTNode = startView[HOST_NODE] as TElementNode;
+  let parentTNode = startView[T_HOST] as TElementNode;
 
   // view offset is superior to 1
   while (viewOffset > 1) {
     parentView = parentView[DECLARATION_VIEW] !;
-    parentTNode = parentView[HOST_NODE] as TElementNode;
+    parentTNode = parentView[T_HOST] as TElementNode;
     viewOffset--;
   }
   return parentTNode;
@@ -270,12 +271,12 @@ export function addAllToArray(items: any[], arr: any[]) {
  * @returns The host node
  */
 export function findComponentView(lView: LView): LView {
-  let rootTNode = lView[HOST_NODE];
+  let rootTNode = lView[T_HOST];
 
   while (rootTNode && rootTNode.type === TNodeType.View) {
     ngDevMode && assertDefined(lView[DECLARATION_VIEW], 'lView[DECLARATION_VIEW]');
     lView = lView[DECLARATION_VIEW] !;
-    rootTNode = lView[HOST_NODE];
+    rootTNode = lView[T_HOST];
   }
 
   return lView;

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -16,17 +16,19 @@ import {ViewContainerRef as ViewEngine_ViewContainerRef} from '../linker/view_co
 import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, ViewRef as viewEngine_ViewRef} from '../linker/view_ref';
 import {Renderer2} from '../render/api';
 import {assertDefined, assertGreaterThan, assertLessThan} from '../util/assert';
+
 import {NodeInjector, getParentInjectorLocation} from './di';
 import {addToViewTree, createEmbeddedViewAndNode, createLContainer, renderEmbeddedTemplate} from './instructions';
 import {ACTIVE_INDEX, LContainer, NATIVE, VIEWS} from './interfaces/container';
 import {TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeType, TViewNode} from './interfaces/node';
 import {RComment, RElement, Renderer3, isProceduralRenderer} from './interfaces/renderer';
-import {CONTAINER_INDEX, CONTEXT, HOST_NODE, LView, QUERIES, RENDERER, TView} from './interfaces/view';
+import {CONTAINER_INDEX, CONTEXT, LView, QUERIES, RENDERER, TView, T_HOST} from './interfaces/view';
 import {assertNodeOfPossibleTypes} from './node_assert';
 import {addRemoveViewFromContainer, appendChild, detachView, getBeforeNodeForView, insertView, nativeInsertBefore, nativeNextSibling, nativeParentNode, removeView} from './node_manipulation';
 import {getLView, getPreviousOrParentTNode} from './state';
 import {findComponentView, getComponentViewByIndex, getNativeByTNode, getParentInjectorTNode, getParentInjectorView, hasParentInjector, isComponent, isLContainer, isRootView} from './util';
 import {ViewRef} from './view_ref';
+
 
 
 /**
@@ -112,7 +114,7 @@ export function createTemplateRef<T>(
         }
         renderEmbeddedTemplate(lView, this._tView, context);
         const viewRef = new ViewRef(lView, context, -1);
-        viewRef._tViewNode = lView[HOST_NODE] as TViewNode;
+        viewRef._tViewNode = lView[T_HOST] as TViewNode;
         return viewRef;
       }
     };

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -13,7 +13,7 @@ import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, InternalViewRef as viewEn
 
 import {checkNoChanges, checkNoChangesInRootView, checkView, detectChangesInRootView, detectChangesInternal, markViewDirty, storeCleanupFn, viewAttached} from './instructions';
 import {TNode, TNodeType, TViewNode} from './interfaces/node';
-import {FLAGS, HOST, HOST_NODE, LView, LViewFlags, PARENT, RENDERER_FACTORY} from './interfaces/view';
+import {FLAGS, HOST, LView, LViewFlags, PARENT, RENDERER_FACTORY, T_HOST} from './interfaces/view';
 import {destroyLView} from './node_manipulation';
 import {getNativeByTNode} from './util';
 
@@ -41,7 +41,7 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
 
   get rootNodes(): any[] {
     if (this._lView[HOST] == null) {
-      const tView = this._lView[HOST_NODE] as TViewNode;
+      const tView = this._lView[T_HOST] as TViewNode;
       return collectNativeNodes(this._lView, tView, []);
     }
     return [];

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -51,7 +51,7 @@
     "name": "HOST"
   },
   {
-    "name": "HOST_NODE"
+    "name": "T_HOST"
   },
   {
     "name": "INJECTOR"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -45,7 +45,7 @@
     "name": "HOST"
   },
   {
-    "name": "HOST_NODE"
+    "name": "T_HOST"
   },
   {
     "name": "INJECTOR"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -81,7 +81,7 @@
     "name": "HOST"
   },
   {
-    "name": "HOST_NODE"
+    "name": "T_HOST"
   },
   {
     "name": "INJECTOR"

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -2320,8 +2320,8 @@ describe('di', () => {
   describe('getOrCreateNodeInjector', () => {
     it('should handle initial undefined state', () => {
       const contentView = createLView(
-          null, createTView(-1, null, 1, 0, null, null, null), null, LViewFlags.CheckAlways,
-          {} as any, {} as any);
+          null, createTView(-1, null, 1, 0, null, null, null), null, LViewFlags.CheckAlways, null,
+          null, {} as any, {} as any);
       const oldView = enterView(contentView, null);
       try {
         const parentTNode = createNodeAtIndex(0, TNodeType.Element, null, null, null);

--- a/packages/core/test/render3/styling/class_and_style_bindings_spec.ts
+++ b/packages/core/test/render3/styling/class_and_style_bindings_spec.ts
@@ -34,8 +34,8 @@ describe('style and class based bindings', () => {
     const rootContext =
         createRootContext(requestAnimationFrame.bind(window), playerHandler || null);
     const lView = createLView(
-        null, createTView(-1, null, 1, 0, null, null, null), rootContext, LViewFlags.IsRoot,
-        domRendererFactory3, domRendererFactory3.createRenderer(element, null));
+        null, createTView(-1, null, 1, 0, null, null, null), rootContext, LViewFlags.IsRoot, null,
+        null, domRendererFactory3, domRendererFactory3.createRenderer(element, null));
     return lView;
   }
 


### PR DESCRIPTION
`LView` `HOST` was set in most cases right after creating `LView`.
This makes the API cleaner by explicitly passing it ont `createLView`.
