### PR TITLE
build(docs-infra): upgrade cli command docs sources to b5e796a03

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -19,7 +19,7 @@
     "build-local": "yarn ~~build",
     "prebuild-with-ivy": "yarn setup-local && yarn ivy-ngcc",
     "build-with-ivy": "node scripts/build-with-ivy",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 699743282",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js b5e796a03",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#7.2.x](https://github.com/angular/angular/tree/7.2.x) from [cli-builds#7.3.x](https://github.com/angular/cli-builds/tree/7.3.x).
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/699743282...b5e796a03):

**Modified**
- help/add.json
- help/build.json
- help/generate.json
- help/new.json