### PR TITLE
ci: pin ChromeDriver to a version compatible with docker image's Chrome

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,9 +157,9 @@ jobs:
         # (Run before unit and e2e tests, which destroy the `dist/` directory.)
       - run: yarn --cwd aio payload-size
         # Run unit tests
-      - run: yarn --cwd aio test --watch=false
+      - run: yarn --cwd aio test --progress=false --watch=false
         # Run e2e tests
-      - run: yarn --cwd aio e2e
+      - run: yarn --cwd aio e2e --configuration=ci
         # Run unit tests for Firebase redirects
       - run: yarn --cwd aio redirects-test
 
@@ -197,9 +197,9 @@ jobs:
         # (Run before unit and e2e tests, which destroy the `dist/` directory.)
       - run: yarn --cwd aio test-pwa-score-localhost $CI_AIO_MIN_PWA_SCORE
         # Run unit tests
-      - run: yarn --cwd aio test --watch=false
+      - run: yarn --cwd aio test --progress=false --watch=false
         # Run e2e tests
-      - run: yarn --cwd aio e2e
+      - run: yarn --cwd aio e2e --configuration=ci
 
   test_aio_local_ivy:
     <<: *job_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,10 @@
 # needed for jobs that run tests without Bazel. Bazel runs tests with browsers that will be
 # fetched by the Webtesting rules. Therefore for jobs that run tests with Bazel, we don't need a
 # docker image with browsers pre-installed.
-# **NOTE**: If you change the version of the docker images, also change the `cache_key` suffix.
+# **NOTE 1**: If you change the version of the `*-browsers` docker image, make sure the
+#             `CI_CHROMEDRIVER_VERSION_ARG` env var (in `.circleci/env.sh`) points to a ChromeDriver
+#             version that is compatible with the Chrome version in the image.
+# **NOTE 2**: If you change the version of the docker images, also change the `cache_key` suffix.
 var_1: &default_docker_image circleci/node:10.12
 var_2: &browsers_docker_image circleci/node:10.12-browsers
 var_3: &cache_key v2-angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-node-10.12

--- a/.circleci/env-helpers.inc.sh
+++ b/.circleci/env-helpers.inc.sh
@@ -15,7 +15,7 @@
 #
 # Usage: `setPublicVar <name> <value>`
 function setPublicVar() {
-  setSecretVar $1 $2;
+  setSecretVar $1 "$2";
   echo "$1=$2";
 }
 

--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -18,6 +18,11 @@ setPublicVar PROJECT_ROOT "$(pwd)";
 setPublicVar CI_AIO_MIN_PWA_SCORE "95";
 # This is the branch being built; e.g. `pull/12345` for PR builds.
 setPublicVar CI_BRANCH "$CIRCLE_BRANCH";
+# ChromeDriver version compatible with the Chrome version included in the docker image used in
+# `.circleci/config.yml`. See http://chromedriver.chromium.org/downloads for a list of versions.
+# This variable is intended to be passed as an arg to the `webdriver-manager update` command (e.g.
+# `"postinstall": "webdriver-manager update $CI_CHROMEDRIVER_VERSION_ARG"`).
+setPublicVar CI_CHROMEDRIVER_VERSION_ARG "--versions.chrome 2.45";
 setPublicVar CI_COMMIT "$CIRCLE_SHA1";
 # `CI_COMMIT_RANGE` will only be available when `CIRCLE_COMPARE_URL` is also available (or can be
 # retrieved via `get-compare-url.js`), i.e. on push builds (a.k.a. non-PR, non-scheduled builds and

--- a/aio/angular.json
+++ b/aio/angular.json
@@ -104,6 +104,9 @@
             },
             "archive": {
               "browserTarget": "site:build:archive"
+            },
+            "ci": {
+              "progress": false
             }
           }
         },
@@ -166,6 +169,11 @@
           "options": {
             "protractorConfig": "tests/e2e/protractor.conf.js",
             "devServerTarget": "site:serve"
+          },
+          "configurations": {
+            "ci": {
+              "devServerTarget": "site:serve:ci"
+            }
           }
         },
         "lint": {

--- a/aio/package.json
+++ b/aio/package.json
@@ -62,7 +62,7 @@
     "generate-stackblitz": "node ./tools/stackblitz-builder/generateStackblitz",
     "generate-zips": "node ./tools/example-zipper/generateZips",
     "build-404-page": "node scripts/build-404-page",
-    "update-webdriver": "webdriver-manager update --standalone false --gecko false $CHROMEDRIVER_VERSION_ARG",
+    "update-webdriver": "webdriver-manager update --standalone false --gecko false $CI_CHROMEDRIVER_VERSION_ARG",
     "~~check-env": "node scripts/check-environment",
     "~~clean-generated": "node --eval \"require('shelljs').rm('-rf', 'src/generated')\"",
     "~~build": "ng build --configuration=stable",

--- a/aio/tools/examples/shared/package.json
+++ b/aio/tools/examples/shared/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "http-server": "http-server",
     "protractor": "protractor",
-    "webdriver:update": "webdriver-manager update --standalone false --gecko false $CHROMEDRIVER_VERSION_ARG",
+    "webdriver:update": "webdriver-manager update --standalone false --gecko false $CI_CHROMEDRIVER_VERSION_ARG",
     "preinstall": "node ../../../../tools/yarn/check-yarn.js",
     "postinstall": "yarn webdriver:update"
   },

--- a/integration/bazel-schematics/test.sh
+++ b/integration/bazel-schematics/test.sh
@@ -11,6 +11,7 @@ function testBazel() {
   node replace_angular_repo.js "./demo/WORKSPACE"
   cd demo
   yarn add @angular/bazel@file:../../../dist/packages-dist/bazel
+  yarn webdriver-manager update --gecko=false --standalone=false $CI_CHROMEDRIVER_VERSION_ARG
   cp ../package.json.replace ./package.json
   ng generate component widget --style=css
   ng build
@@ -24,7 +25,7 @@ function testNonBazel() {
   rm -rf dist src/main.dev.ts src/main.prod.ts
   ng build --progress=false
   ng test --progress=false --watch=false
-  ng e2e --configuration=ci
+  ng e2e --configuration=ci --webdriver-update=false
 }
 
 testBazel

--- a/integration/cli-hello-world-ivy/package.json
+++ b/integration/cli-hello-world-ivy/package.json
@@ -7,7 +7,7 @@
     "e2e": "ng e2e --webdriver-update=false",
     "lint": "ng lint",
     "ng": "ng",
-    "postinstall": "webdriver-manager update --gecko=false --standalone=false $CHROMEDRIVER_VERSION_ARG && yarn ivy-ngcc",
+    "postinstall": "webdriver-manager update --gecko=false --standalone=false $CI_CHROMEDRIVER_VERSION_ARG && yarn ivy-ngcc",
     "start": "ng serve",
     "pretest": "ng version",
     "//test1": "TODO FW-813: Re-enable `ci-production`. Currently, it fails after a timeout as Protractor reports Angular cannot be found on the page",

--- a/integration/cli-hello-world/package.json
+++ b/integration/cli-hello-world/package.json
@@ -7,7 +7,7 @@
     "e2e": "ng e2e --webdriver-update=false",
     "lint": "ng lint",
     "ng": "ng",
-    "postinstall": "webdriver-manager update --gecko=false --standalone=false $CHROMEDRIVER_VERSION_ARG",
+    "postinstall": "webdriver-manager update --gecko=false --standalone=false $CI_CHROMEDRIVER_VERSION_ARG",
     "start": "ng serve",
     "pretest": "ng version",
     "test": "ng test --progress=false --watch=false && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production"

--- a/integration/dynamic-compiler/package.json
+++ b/integration/dynamic-compiler/package.json
@@ -10,7 +10,7 @@
     "ngc": "ngc -p tsconfig.json",
     "rollup": "rollup -f iife -c rollup.config.js -o dist/bundle.es2015.js",
     "rollup:lazy": "rollup -f cjs -c rollup.lazy.config.js -o dist/lazy.bundle.es2015.js",
-    "postinstall": "webdriver-manager update --gecko false --standalone false $CHROMEDRIVER_VERSION_ARG",
+    "postinstall": "webdriver-manager update --gecko false --standalone false $CI_CHROMEDRIVER_VERSION_ARG",
     "preprotractor": "tsc -p e2e",
     "protractor": "protractor e2e/protractor.config.js",
     "serve": "lite-server -c e2e/browser.config.json",

--- a/integration/hello_world__closure/package.json
+++ b/integration/hello_world__closure/package.json
@@ -22,7 +22,7 @@
     "protractor": "file:../../node_modules/protractor"
   },
   "scripts": {
-    "postinstall": "webdriver-manager update --gecko false --standalone false $CHROMEDRIVER_VERSION_ARG",
+    "postinstall": "webdriver-manager update --gecko false --standalone false $CI_CHROMEDRIVER_VERSION_ARG",
     "closure": "java -jar node_modules/google-closure-compiler/compiler.jar --flagfile closure.conf",
     "test": "ngc && yarn run closure && concurrently \"yarn run serve\" \"yarn run protractor\" --kill-others --success first",
     "serve": "lite-server -c e2e/browser.config.json",

--- a/integration/hello_world__systemjs_umd/package.json
+++ b/integration/hello_world__systemjs_umd/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "postinstall": "webdriver-manager update --gecko false --standalone false $CHROMEDRIVER_VERSION_ARG",
+    "postinstall": "webdriver-manager update --gecko false --standalone false $CI_CHROMEDRIVER_VERSION_ARG",
     "test": "concurrently \"yarn serve\" \"yarn protractor\" --kill-others --success first",
     "serve": "lite-server -c bs-config.e2e.json",
     "preprotractor": "tsc -p e2e",

--- a/integration/i18n/package.json
+++ b/integration/i18n/package.json
@@ -23,7 +23,7 @@
     "protractor": "file:../../node_modules/protractor"
   },
   "scripts": {
-    "postinstall": "webdriver-manager update --gecko false --standalone false $CHROMEDRIVER_VERSION_ARG",
+    "postinstall": "webdriver-manager update --gecko false --standalone false $CI_CHROMEDRIVER_VERSION_ARG",
     "closure": "java -jar node_modules/google-closure-compiler/compiler.jar --flagfile closure.conf",
     "test": "ngc && yarn run closure && concurrently \"yarn run serve\" \"yarn run protractor\" --kill-others --success first && npm run test-locale-folder",
     "test-locale-folder": "node test-locale-folder.js",

--- a/integration/ng_elements/package.json
+++ b/integration/ng_elements/package.json
@@ -23,7 +23,7 @@
     "protractor": "file:../../node_modules/protractor"
   },
   "scripts": {
-    "postinstall": "webdriver-manager update --gecko false --standalone false $CHROMEDRIVER_VERSION_ARG",
+    "postinstall": "webdriver-manager update --gecko false --standalone false $CI_CHROMEDRIVER_VERSION_ARG",
     "closure": "java -jar node_modules/google-closure-compiler/compiler.jar --flagfile closure.conf",
     "test": "ngc && yarn run closure && concurrently \"yarn run serve\" \"yarn run protractor\" --kill-others --success first",
     "serve": "lite-server -c e2e/browser.config.json",

--- a/integration/platform-server/package.json
+++ b/integration/platform-server/package.json
@@ -34,7 +34,7 @@
     "webpack": "^2.2.1"
   },
   "scripts": {
-    "postinstall": "webdriver-manager update --gecko false --standalone false $CHROMEDRIVER_VERSION_ARG",
+    "postinstall": "webdriver-manager update --gecko false --standalone false $CI_CHROMEDRIVER_VERSION_ARG",
     "build": "./build.sh",
     "test": "npm run build && concurrently \"npm run serve\" \"npm run protractor\" --kill-others --success first",
     "serve": "node built/server-bundle.js",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bazel:lint-fix": "yarn bazel:format --lint=fix",
     "preinstall": "node tools/yarn/check-yarn.js",
     "postinstall": "yarn update-webdriver && node --preserve-symlinks --preserve-symlinks-main ./tools/postinstall-patches.js",
-    "update-webdriver": "webdriver-manager update --gecko false $CHROMEDRIVER_VERSION_ARG",
+    "update-webdriver": "webdriver-manager update --gecko false $CI_CHROMEDRIVER_VERSION_ARG",
     "check-env": "gulp check-env",
     "commitmsg": "node ./scripts/git/commit-msg.js",
     "test-ivy-aot": "bazel test --define=compile=aot --build_tag_filters=-no-ivy-aot,-fixme-ivy-aot --test_tag_filters=-no-ivy-aot,-fixme-ivy-aot",


### PR DESCRIPTION
## PR Type
- [x] CI related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## What is the current/new behavior?
By default, `webdriver-manager update` will download the latest ChromeDriver version, which might not be compatible with the Chrome version included in the [docker image used on CI], causing CI failures.
Previously, we used to pin the ChromeDriver version on CI in [ngcontainer's Dockerfile][2]. This was accidentally broken in #26691, while moving from ngcontainer to default CircleCI docker images.

This commit fixes the issue by pinning ChromeDriver to a known compatible version.

[1]: https://github.com/angular/angular/blob/bfd48d156d5663cc49d1ec40c2d73ff76a2fe62f/.circleci/config.yml#L16
[2]: https://github.com/angular/angular/blob/bfd48d156d5663cc49d1ec40c2d73ff76a2fe62f/tools/ngcontainer/Dockerfile#L63
