### PR TITLE
feat(ivy): open up ivy_switch_mode to non-core packages

### DIFF
--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -280,9 +280,7 @@ export class NgtscProgram implements api.Program {
       beforeTransforms.push(
           generatedFactoryTransform(this.factoryToSourceInfo, this.importRewriter));
     }
-    if (this.isCore) {
-      beforeTransforms.push(ivySwitchTransform);
-    }
+    beforeTransforms.push(ivySwitchTransform);
     if (customTransforms && customTransforms.beforeTs) {
       beforeTransforms.push(...customTransforms.beforeTs);
     }

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2932,6 +2932,37 @@ describe('ngtsc behavioral tests', () => {
       });
     });
   });
+
+  describe('ivy switch mode', () => {
+    it('should allow for symbols to be renamed when they use a SWITCH_IVY naming mechanism', () => {
+      env.tsconfig();
+      env.write('test.ts', `
+export const FooCmp__POST_R3__ = 1;
+export const FooCmp__PRE_R3__ = 2;
+export const FooCmp = FooCmp__PRE_R3__;`);
+      env.driveMain();
+
+      const source = env.getContents('test.js');
+      expect(source).toContain(`export var FooCmp = FooCmp__POST_R3__`);
+      expect(source).not.toContain(`export var FooCmp = FooCmp__PRE_R3__`);
+    });
+
+    it('should allow for SWITCH_IVY naming even even if it occurs outside of core', () => {
+      const content = `
+export const Foo__POST_R3__ = 1;
+export const Foo__PRE_R3__ = 2;
+export const Foo = Foo__PRE_R3__;
+`;
+      env.tsconfig();
+      env.write('test_outside_angular_core.ts', content);
+      env.write('test_inside_angular_core.ts', content + '\nexport const ITS_JUST_ANGULAR = true;');
+      env.driveMain();
+
+      const sourceTestOutsideAngularCore = env.getContents('test_outside_angular_core.js');
+      const sourceTestInsideAngularCore = env.getContents('test_inside_angular_core.js');
+      expect(sourceTestInsideAngularCore).toContain(sourceTestOutsideAngularCore);
+    });
+  });
 });
 
 function expectTokenAtPosition<T extends ts.Node>(


### PR DESCRIPTION
Prior to this fix, using the compiler's ivy_switch mechanism was
only available to core packages. This patch allows for this variable
switching mechanism to work across all other angular packages.