### PR TITLE
build(docs-infra): use pinned dependencies as much as possible when using local Angular packages

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -105,6 +105,7 @@
     "@types/jasmine": "^2.5.52",
     "@types/jasminewd2": "^2.0.4",
     "@types/node": "~6.0.60",
+    "@yarnpkg/lockfile": "^1.1.0",
     "archiver": "^1.3.0",
     "canonical-path": "1.0.0",
     "chalk": "^2.1.0",

--- a/aio/tools/ng-packages-installer/index.js
+++ b/aio/tools/ng-packages-installer/index.js
@@ -166,11 +166,6 @@ class NgPackagesInstaller {
       }
     });
 
-    // FIXME: Temporarily use RxJS from root `node_modules/`.
-    if (peerDependencies.rxjs) {
-      peerDependencies.rxjs = `file:${ANGULAR_ROOT_DIR}/node_modules/rxjs`;
-    }
-
     return [mergedDependencies, peerDependencies];
   }
 

--- a/aio/tools/ng-packages-installer/index.js
+++ b/aio/tools/ng-packages-installer/index.js
@@ -88,10 +88,10 @@ class NgPackagesInstaller {
             });
           });
 
-          fs.writeFileSync(pkg.packageJsonPath, JSON.stringify(tmpConfig));
+          fs.writeFileSync(pkg.packageJsonPath, JSON.stringify(tmpConfig, null, 2));
         });
 
-        const packageConfigFile = fs.readFileSync(pathToPackageConfig);
+        const packageConfigFile = fs.readFileSync(pathToPackageConfig, 'utf8');
         const packageConfig = JSON.parse(packageConfigFile);
 
         const [dependencies, peers] = this._collectDependencies(packageConfig.dependencies || {}, packages);
@@ -118,7 +118,7 @@ class NgPackagesInstaller {
         this._log(`Restoring original ${PACKAGE_JSON} for local Angular packages.`);
         Object.keys(packages).forEach(key => {
           const pkg = packages[key];
-          fs.writeFileSync(pkg.packageJsonPath, JSON.stringify(pkg.config));
+          fs.writeFileSync(pkg.packageJsonPath, JSON.stringify(pkg.config, null, 2));
         });
       }
     }

--- a/aio/tools/ng-packages-installer/index.js
+++ b/aio/tools/ng-packages-installer/index.js
@@ -107,7 +107,7 @@ class NgPackagesInstaller {
         try {
           this._log(`Writing temporary local ${PACKAGE_JSON} to ${pathToPackageConfig}`);
           fs.writeFileSync(pathToPackageConfig, localPackageConfigJson);
-          this._installDeps('--no-lockfile', '--check-files');
+          this._installDeps('--pure-lockfile', '--check-files');
           this._setLocalMarker(localPackageConfigJson);
         } finally {
           this._log(`Restoring original ${PACKAGE_JSON} to ${pathToPackageConfig}`);

--- a/aio/tools/ng-packages-installer/index.js
+++ b/aio/tools/ng-packages-installer/index.js
@@ -62,7 +62,7 @@ class NgPackagesInstaller {
    * contents and acts as an indicator that dependencies have been overridden.
    */
   installLocalDependencies() {
-    if (this._checkLocalMarker() !== true || this.force) {
+    if (this.force || !this._checkLocalMarker()) {
       const pathToPackageConfig = path.resolve(this.projectDir, PACKAGE_JSON);
       const packages = this._getDistPackages();
 

--- a/aio/tools/ng-packages-installer/index.spec.js
+++ b/aio/tools/ng-packages-installer/index.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs-extra');
+const lockfile = require('@yarnpkg/lockfile');
 const path = require('canonical-path');
 const shelljs = require('shelljs');
 
@@ -11,6 +12,7 @@ describe('NgPackagesInstaller', () => {
   const absoluteRootDir = path.resolve(rootDir);
   const nodeModulesDir = path.resolve(absoluteRootDir, 'node_modules');
   const packageJsonPath = path.resolve(absoluteRootDir, 'package.json');
+  const yarnLockPath = path.resolve(absoluteRootDir, 'yarn.lock');
   const packagesDir = path.resolve(path.resolve(__dirname, '../../../dist/packages-dist'));
   const toolsDir = path.resolve(path.resolve(__dirname, '../../../dist/tools/@angular'));
   let installer;
@@ -55,12 +57,23 @@ describe('NgPackagesInstaller', () => {
       spyOn(installer, '_installDeps');
       spyOn(installer, '_setLocalMarker');
 
+      spyOn(installer, '_parseLockfile').and.returnValue({
+        'rxjs@^6.3.0': {version: '6.3.3'},
+        'zone.js@^0.8.26': {version: '0.8.27'}
+      });
+
       // These are the packages that are "found" in the dist directory
       dummyNgPackages = {
         '@angular/core': {
           parentDir: packagesDir,
           packageJsonPath: `${packagesDir}/core/package.json`,
-          config: { peerDependencies: { 'some-package': '5.0.1' } }
+          config: {
+            peerDependencies: {
+              'rxjs': '^6.4.0',
+              'some-package': '5.0.1',
+              'zone.js': '~0.8.26'
+            }
+          }
         },
         '@angular/common': {
           parentDir: packagesDir,
@@ -95,10 +108,12 @@ describe('NgPackagesInstaller', () => {
       dummyPackage = {
         dependencies: {
           '@angular/core': '4.4.1',
-          '@angular/common': '4.4.1'
+          '@angular/common': '4.4.1',
+          rxjs: '^6.3.0'
         },
         devDependencies: {
-          '@angular/compiler-cli': '4.4.1'
+          '@angular/compiler-cli': '4.4.1',
+          'zone.js': '^0.8.26'
         }
       };
       dummyPackageJson = JSON.stringify(dummyPackage);
@@ -106,14 +121,23 @@ describe('NgPackagesInstaller', () => {
 
       // This is the package.json that is temporarily written to the "test" folder
       // Note that the Angular (dev)dependencies have been modified to use a "file:" path
-      // And that the peerDependencies from `dummyNgPackages` have been added as (dev)dependencies.
+      // And that the peerDependencies from `dummyNgPackages` have been updated or added as
+      // (dev)dependencies (unless the current version in lockfile satisfies semver).
+      //
+      // For example, `zone.js@0.8.27` (from lockfile) satisfies `zone.js@~0.8.26` (from
+      // `@angular/core`), thus `zone.js: ^0.8.26` (from original `package.json`) is retained.
+      // In contrast, `rxjs@6.3.3` (from lockfile) does not satisfy `rxjs@^6.4.0 (from
+      // `@angular/core`), thus `rxjs: ^6.3.0` (from original `package.json`) is replaced with
+      // `rxjs: ^6.4.0` (from `@angular/core`).
       expectedModifiedPackage = {
         dependencies: {
           '@angular/core': `file:${packagesDir}/core`,
-          '@angular/common': `file:${packagesDir}/common`
+          '@angular/common': `file:${packagesDir}/common`,
+          'rxjs': '^6.4.0'
         },
         devDependencies: {
           '@angular/compiler-cli': `file:${toolsDir}/compiler-cli`,
+          'zone.js': '^0.8.26',
           'some-package': '5.0.1',
           typescript: '^2.4.2'
         },
@@ -150,8 +174,9 @@ describe('NgPackagesInstaller', () => {
         installer.installLocalDependencies();
       });
 
-      it('should get the dist packages', () => {
+      it('should parse the lockfile and get the dist packages', () => {
         expect(installer._checkLocalMarker).toHaveBeenCalled();
+        expect(installer._parseLockfile).toHaveBeenCalledWith(yarnLockPath);
         expect(installer._getDistPackages).toHaveBeenCalled();
       });
 
@@ -271,6 +296,42 @@ describe('NgPackagesInstaller', () => {
       installer.debug = true;
       installer._log('bar');
       expect(console.info).toHaveBeenCalledWith('  [NgPackagesInstaller]: bar');
+    });
+  });
+
+  describe('_parseLockfile()', () => {
+    let originalLockfileParseDescriptor;
+
+    beforeEach(() => {
+      // Workaround for `lockfile.parse()` being non-writable.
+      let parse = lockfile.parse;
+      originalLockfileParseDescriptor = Object.getOwnPropertyDescriptor(lockfile, 'parse');
+      Object.defineProperty(lockfile, 'parse', {
+        get() { return parse; },
+        set(newParse) { parse = newParse; },
+      });
+
+      fs.readFileSync.and.returnValue('mock content');
+      spyOn(lockfile, 'parse').and.returnValue({type: 'success', object: {foo: {version: 'bar'}}});
+    });
+
+    afterEach(() => Object.defineProperty(lockfile, 'parse', originalLockfileParseDescriptor));
+
+    it('should parse the specified lockfile', () => {
+      installer._parseLockfile('/foo/bar/yarn.lock');
+      expect(fs.readFileSync).toHaveBeenCalledWith('/foo/bar/yarn.lock', 'utf8');
+      expect(lockfile.parse).toHaveBeenCalledWith('mock content');
+    });
+
+    it('should throw if parsing the lockfile fails', () => {
+      lockfile.parse.and.returnValue({type: 'not success'});
+      expect(() => installer._parseLockfile('/foo/bar/yarn.lock')).toThrowError(
+          '[NgPackagesInstaller]: Error parsing lockfile \'/foo/bar/yarn.lock\' (result type: not success).');
+    });
+
+    it('should return the parsed lockfile content as an object', () => {
+      const parsed = installer._parseLockfile('/foo/bar/yarn.lock');
+      expect(parsed).toEqual({foo: {version: 'bar'}});
     });
   });
 

--- a/aio/tools/ng-packages-installer/index.spec.js
+++ b/aio/tools/ng-packages-installer/index.spec.js
@@ -52,6 +52,8 @@ describe('NgPackagesInstaller', () => {
 
     beforeEach(() => {
       spyOn(installer, '_checkLocalMarker');
+      spyOn(installer, '_installDeps');
+      spyOn(installer, '_setLocalMarker');
 
       // These are the packages that are "found" in the dist directory
       dummyNgPackages = {
@@ -121,11 +123,19 @@ describe('NgPackagesInstaller', () => {
     });
 
     describe('when there is a local package marker', () => {
+      beforeEach(() => installer._checkLocalMarker.and.returnValue(true));
+
       it('should not continue processing', () => {
-        installer._checkLocalMarker.and.returnValue(true);
         installer.installLocalDependencies();
         expect(installer._checkLocalMarker).toHaveBeenCalled();
         expect(installer._getDistPackages).not.toHaveBeenCalled();
+      });
+
+      it('should continue processing (without checking for local marker) if `force` is true', () => {
+        installer.force = true;
+        installer.installLocalDependencies();
+        expect(installer._checkLocalMarker).not.toHaveBeenCalled();
+        expect(installer._getDistPackages).toHaveBeenCalled();
       });
     });
 
@@ -135,8 +145,7 @@ describe('NgPackagesInstaller', () => {
       beforeEach(() => {
         log = [];
         fs.writeFileSync.and.callFake((filePath, contents) => filePath === packageJsonPath && log.push(`writeFile: ${contents}`));
-        spyOn(installer, '_installDeps').and.callFake(() => log.push('installDeps:'));
-        spyOn(installer, '_setLocalMarker');
+        installer._installDeps.and.callFake(() => log.push('installDeps:'));
         installer._checkLocalMarker.and.returnValue(false);
         installer.installLocalDependencies();
       });

--- a/aio/tools/ng-packages-installer/index.spec.js
+++ b/aio/tools/ng-packages-installer/index.spec.js
@@ -145,7 +145,7 @@ describe('NgPackagesInstaller', () => {
       beforeEach(() => {
         log = [];
         fs.writeFileSync.and.callFake((filePath, contents) => filePath === packageJsonPath && log.push(`writeFile: ${contents}`));
-        installer._installDeps.and.callFake(() => log.push('installDeps:'));
+        installer._installDeps.and.callFake((...args) => log.push(`installDeps: ${args.join(' ')}`));
         installer._checkLocalMarker.and.returnValue(false);
         installer.installLocalDependencies();
       });
@@ -198,7 +198,7 @@ describe('NgPackagesInstaller', () => {
       it('should overwrite package.json, then install deps, then restore original package.json', () => {
         expect(log).toEqual([
           `writeFile: ${expectedModifiedPackageJson}`,
-          `installDeps:`,
+          `installDeps: --pure-lockfile --check-files`,
           `writeFile: ${dummyPackageJson}`
         ]);
       });

--- a/aio/tools/ng-packages-installer/index.spec.js
+++ b/aio/tools/ng-packages-installer/index.spec.js
@@ -150,31 +150,32 @@ describe('NgPackagesInstaller', () => {
         const pkgJsonFor = pkgName => dummyNgPackages[`@angular/${pkgName}`].packageJsonPath;
         const pkgConfigFor = pkgName => copyJsonObj(dummyNgPackages[`@angular/${pkgName}`].config);
         const overwriteConfigFor = (pkgName, newProps) => Object.assign(pkgConfigFor(pkgName), newProps);
+        const stringifyConfig = config => JSON.stringify(config, null, 2);
 
         const allArgs = fs.writeFileSync.calls.allArgs();
         const firstFiveArgs = allArgs.slice(0, 5);
         const lastFiveArgs = allArgs.slice(-5);
 
         expect(firstFiveArgs).toEqual([
-          [pkgJsonFor('core'), JSON.stringify(overwriteConfigFor('core', {private: true}))],
-          [pkgJsonFor('common'), JSON.stringify(overwriteConfigFor('common', {private: true}))],
-          [pkgJsonFor('compiler'), JSON.stringify(overwriteConfigFor('compiler', {private: true}))],
-          [pkgJsonFor('compiler-cli'), JSON.stringify(overwriteConfigFor('compiler-cli', {
+          [pkgJsonFor('core'), stringifyConfig(overwriteConfigFor('core', {private: true}))],
+          [pkgJsonFor('common'), stringifyConfig(overwriteConfigFor('common', {private: true}))],
+          [pkgJsonFor('compiler'), stringifyConfig(overwriteConfigFor('compiler', {private: true}))],
+          [pkgJsonFor('compiler-cli'), stringifyConfig(overwriteConfigFor('compiler-cli', {
             private: true,
             dependencies: { '@angular/tsc-wrapped': `file:${toolsDir}/tsc-wrapped` }
           }))],
-          [pkgJsonFor('tsc-wrapped'), JSON.stringify(overwriteConfigFor('tsc-wrapped', {
+          [pkgJsonFor('tsc-wrapped'), stringifyConfig(overwriteConfigFor('tsc-wrapped', {
             private: true,
             devDependencies: { '@angular/common': `file:${packagesDir}/common` }
           }))],
         ]);
 
         expect(lastFiveArgs).toEqual(['core', 'common', 'compiler', 'compiler-cli', 'tsc-wrapped']
-            .map(pkgName => [pkgJsonFor(pkgName), JSON.stringify(pkgConfigFor(pkgName))]));
+            .map(pkgName => [pkgJsonFor(pkgName), stringifyConfig(pkgConfigFor(pkgName))]));
       });
 
       it('should load the package.json', () => {
-        expect(fs.readFileSync).toHaveBeenCalledWith(packageJsonPath);
+        expect(fs.readFileSync).toHaveBeenCalledWith(packageJsonPath, 'utf8');
       });
 
       it('should overwrite package.json with modified config', () => {

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -537,7 +537,7 @@
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
 
-"@yarnpkg/lockfile@1.1.0":
+"@yarnpkg/lockfile@1.1.0", "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
- [x] Build related changes
- [x] angular.io application / infrastructure changes


## What is the current behavior and the new behavior?
The main commits are:

**build(docs-infra): keep other dependencies pinned when installing local Angular packages**

`ng-packages-installer` can be used to replace Angular packages with locally built ones (from `dist/packages-dist/`) along with their peer dependencies.

Previously, in order to achieve this, `yarn install` was called with the `--no-lockfile` option, which resulted in installing the latest versions of all dependencies (including transitive ones) permitted by the corresponding version ranges in `package.json` files. As a result, newly released versions would be picked, resulting in unexpected, non-deterministic breakages in CI.

This commit calls `yarn install` with the `--pure-lockfile` option instead. As a result, only the Angular packages (for which the locally built ones are used) and their peer dependencies are unpinned; the pinned versions from `yarn.lock` are used for all other (direct and transitive) dependencies.

While this does not eliminate non-determinism across builds, it significantly reduces it.

**build(docs-infra): use pinned dependencies when possible in `ng-packages-installer`**

Previously, `ng-packages-installer` would replace the version ranges for all dependencies that were peer dependencies of an Angular package with the version range used in the Angular package. This effectively meant that the pinned version (from `yarn.lock`) for that dependency was ignored (even if the pinned version satisfied the new version range).

This commit reduces non-determinism in CI jobs using the locally built Angular packages by always using pinned versions of dependencies for Angular package peer dependencies if possible.

For example, assuming the following versions for the RxJS dependency:

- **aio/package.json**: `rxjs: ^6.3.0`
- **aio/yarn.lock**: `rxjs@^6.3.0: 6.3.3`
- **@angular/core#peerDependencies**: `rxjs: ^6.0.0`

...the following versions would be used with `ng-packages-installer`:

- Before this commit:
  - **aio/package.json**: `rxjs: ^6.0.0`
  - **node_modules/rxjs/**: `6.4.0` (latest version satisfying `^6.0.0`)
- After this commit:
  - **aio/package.json**: `rxjs: ^6.3.0`
  - **node_modules/rxjs/**: `6.3.3` (because it satisfies `^6.0.0`)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
