### PR TITLE
fix(docs-infra): remove polyfill web-animations since we use Angular …

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -93,7 +93,6 @@
     "core-js": "^2.4.1",
     "rxjs": "^6.3.0",
     "tslib": "^1.9.0",
-    "web-animations-js": "^2.2.5",
     "zone.js": "^0.8.26"
   },
   "devDependencies": {

--- a/aio/src/ie-polyfills.js
+++ b/aio/src/ie-polyfills.js
@@ -16,6 +16,3 @@ import 'core-js/es6/set';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 import 'classlist.js';
-
-/** IE10 and IE11 requires the following to support `@angular/animation`. */
-import 'web-animations-js';

--- a/aio/src/ie-polyfills.js
+++ b/aio/src/ie-polyfills.js
@@ -16,3 +16,6 @@ import 'core-js/es6/set';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 import 'classlist.js';
+
+/** Only required if AnimationBuilder is used within the application and using IE/Edge or Safari. */
+// import 'web-animations-js';

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -10614,10 +10614,6 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-web-animations-js@^2.2.5:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/web-animations-js/-/web-animations-js-2.3.1.tgz#3a6d9bc15196377a90f8e2803fa5262165b04510"
-
 web-namespaces@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.2.tgz#c8dc267ab639505276bae19e129dbd6ae72b22b4"


### PR DESCRIPTION
…> 6 and we don't use `AnimationBuilder`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, we import the polyfill 'web-animation' for the older browsers (not es2015); Since Angular 6, this polyfill doesn't have to be imported.


## What is the new behavior?
The polyfill has been removed;

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
