### PR TITLE
build: fix bazel repositories not cached on circleci

### DIFF
--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -2,6 +2,10 @@
 # We do this by copying this file to /etc/bazel.bazelrc at the start of the build.
 # See documentation in /docs/BAZEL.md
 
+# Save downloaded repositories in a location that can be cached by CircleCI. This helps us
+# speeding up the analysis time significantly with Bazel managed node dependencies on the CI.
+build --repository_cache=/home/circleci/bazel_repository_cache
+
 # Don't be spammy in the logs
 # TODO(gmagolan): Hide progress again once build performance improves
 # Presently, CircleCI can timeout during bazel test ... with the following

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,10 @@ var_2: &browsers_docker_image circleci/node:10.12-browsers
 # We don't want to include the current branch name in the cache key because that would prevent
 # PRs from being able to restore the cache since the branch names are always different for PRs.
 # The cache key should only consist of dynamic values that change whenever something in the
-# cache changes. (e.g. Yarn lock file changes --> cached "node_modules" are different).
-var_3: &cache_key v2-angular-{{ checksum "yarn.lock" }}-node-10.12
+# cache changes. For example:
+# 1) yarn lock file changes --> cached "node_modules" are different.
+# 2) bazel repository definitions change --> cached bazel repositories are different.
+var_3: &cache_key v2-angular-{{ checksum "yarn.lock" }}-{{ checksum "WORKSPACE" }}-{{ checksum "packages/bazel/package.bzl" }}-node-10.12
 
 # Define common ENV vars
 var_4: &define_env_vars


### PR DESCRIPTION
Previously all Bazel repositories were cached on CircleCI because the
`experimental_repository_cache` flag has been specified and the given
repository cache directory has been included in the CircleCI cache storage.

The directory is currently still included in the CircleCI cache storage, but the
`--repository_cache` flag is no longer specified, and the cache directory is basically
empty all the time. The flag seems to have been removed accidentally within
SHA c8b70ae8e4a878c8855249df82bf3a46ce6ea0e5.

We should specifiy this flag on the CI again, so that Bazel doesn't need to install
the Bazel managed node modules all the time. This would slow down analysis phase
on CI, and also makes us dependent on the Yarn/NPM registry which often times
out if we fetch a lot of dependencies.