### PR TITLE
Rename blacklist/whitelist to more accurate and appropriate names.

### DIFF
--- a/aio/aio-builds-setup/docs/image-config--environment-variables.md
+++ b/aio/aio-builds-setup/docs/image-config--environment-variables.md
@@ -22,7 +22,7 @@ you don't need to specify values for those.
   The domain name of the server.
 
 - `AIO_GITHUB_ORGANIZATION`:
-  The GitHub organization whose teams are whitelisted for accepting build artifacts.
+  The GitHub organization whose teams are allowed to accept build artifacts.
   See also `AIO_GITHUB_TEAM_SLUGS`.
 
 - `AIO_GITHUB_REPO`:

--- a/aio/aio-builds-setup/docs/overview--security-model.md
+++ b/aio/aio-builds-setup/docs/overview--security-model.md
@@ -98,7 +98,7 @@ This section describes how each of the aforementioned sub-tasks is accomplished:
       Such a label can only have been added by a maintainer (with the necessary rights) and
       designates that they have manually verified the PR contents.
    2. We can verify (again using the GitHub API) the author's membership in one of the
-      whitelisted/trusted GitHub teams. For this operation, we need a Personal Access Token with the
+      trusted GitHub teams. For this operation, we need a Personal Access Token with the
       `read:org` scope issued by a user that can "see" the specified GitHub organization.
       Here too, we use the token by @mary-poppins.
 

--- a/aio/content/guide/browser-support.md
+++ b/aio/content/guide/browser-support.md
@@ -48,7 +48,7 @@ Angular supports most recent browsers. This includes the following specific vers
       2 most recent major versions
     </td>
   </tr>
-  <tr> 
+  <tr>
     <td>
       IE
     </td>
@@ -57,7 +57,7 @@ Angular supports most recent browsers. This includes the following specific vers
     </td>
   </tr>
  <tr>
-   <tr> 
+   <tr>
     <td>
       IE Mobile
     </td>
@@ -82,7 +82,7 @@ Angular supports most recent browsers. This includes the following specific vers
     <td>
       2 most recent major versions
     </td>
-  </tr> 
+  </tr>
   <tr>
     <td>
       Android
@@ -91,7 +91,7 @@ Angular supports most recent browsers. This includes the following specific vers
     <td>
       Nougat (7.0)<br>Marshmallow (6.0)<br>Lollipop (5.0, 5.1)<br>KitKat (4.4)
     </td>
-  </tr> 
+  </tr>
 
 </table>
 
@@ -302,14 +302,14 @@ Here are the features which may require additional polyfills:
     <td>
 
     If you use the following deprecated i18n pipes:
-    
 
-     [date](api/common/DeprecatedDatePipe), 
-     
+
+     [date](api/common/DeprecatedDatePipe),
+
      [currency](api/common/DeprecatedCurrencyPipe),
-     
-     [decimal](api/common/DeprecatedDecimalPipe), 
-     
+
+     [decimal](api/common/DeprecatedDecimalPipe),
+
      [percent](api/common/DeprecatedPercentPipe)
 
     </td>
@@ -330,8 +330,8 @@ Here are the features which may require additional polyfills:
 
     <td>
 
-       [NgClass](api/common/NgClass) 
-       
+       [NgClass](api/common/NgClass)
+
        on SVG elements
     </td>
 
@@ -351,8 +351,8 @@ Here are the features which may require additional polyfills:
 
     <td>
 
-      [Http](guide/http) 
-      
+      [Http](guide/http)
+
       when sending and receiving binary data
     </td>
 
@@ -376,8 +376,8 @@ Here are the features which may require additional polyfills:
 
     <td>
 
-      [Router](guide/router) 
-      
+      [Router](guide/router)
+
       when using [hash-based routing](guide/router#appendix-locationstrategy-and-browser-url-styles)
     </td>
 
@@ -604,7 +604,7 @@ If you are not using the CLI, you should add your polyfill scripts directly to t
      */
     // __Zone_disable_requestAnimationFrame = true; // disable patch requestAnimationFrame
     // __Zone_disable_on_property = true; // disable patch onProperty such as onclick
-    // __zone_symbol__BLACK_LISTED_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames
+    // __zone_symbol_DISABLE_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames
 
     /*
      * in IE/Edge developer tools, the addEventListener will also be wrapped by zone.js

--- a/aio/tools/examples/shared/boilerplate/cli/src/polyfills.ts
+++ b/aio/tools/examples/shared/boilerplate/cli/src/polyfills.ts
@@ -60,26 +60,38 @@ import 'core-js/es7/reflect';
  * Standard animation support in Angular DOES NOT require any polyfills (as of Angular 6.0).
  **/
 // import 'web-animations-js';  // Run `npm install --save web-animations-js`.
-
 /**
  * By default, zone.js will patch all possible macroTask and DomEvents
  * user can disable parts of macroTask/DomEvents patch by setting following flags
- */
-
- // (window as any).__Zone_disable_requestAnimationFrame = true; // disable patch requestAnimationFrame
- // (window as any).__Zone_disable_on_property = true; // disable patch onProperty such as onclick
- // (window as any).__zone_symbol__BLACK_LISTED_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames
-
- /*
- * in IE/Edge developer tools, the addEventListener will also be wrapped by zone.js
+ * because those flags need to be set before `zone.js` being loaded, and webpack
+ * will put import in the top of bundle, so user need to create a separate file
+ * in this directory (for example: zone-flags.ts), and put the following flags
+ * into that file, and then add the following code before importing zone.js.
+ * import './zone-flags.ts';
+ *
+ * The flags allowed in zone-flags.ts are listed here.
+ *
+ * The following flags will work for all browsers.
+ *
+ * ```js
+ * (window as any).__Zone_disable_requestAnimationFrame = true; // disable patch
+ * requestAnimationFrame
+ * (window as any).__Zone_disable_on_property = true; // disable patch onProperty such as onclick
+ * (window as any).__zone_symbol__DISABLE_EVENTS = ['scroll', 'mousemove']; // disable patch
+ * specified eventNames
+ * ```
+ *
+ * In IE/Edge developer tools, the addEventListener will also be wrapped by zone.js
  * with the following flag, it will bypass `zone.js` patch for IE/Edge
+ *
+ * ```js
+ * (window as any).__Zone_enable_cross_context_check = true;
+ * ```
  */
-// (window as any).__Zone_enable_cross_context_check = true;
-
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js/dist/zone'; // Included with Angular CLI.
 
 
 

--- a/aio/tools/transforms/angular-base-package/processors/createSitemap.js
+++ b/aio/tools/transforms/angular-base-package/processors/createSitemap.js
@@ -1,15 +1,11 @@
 module.exports = function createSitemap() {
   return {
-    blacklistedDocTypes: [
+    ignoredDocTypes: [
       'navigation-json',
       'contributors-json',
       'resources-json',
     ],
-    blacklistedPaths: [
-      'test',
-      'file-not-found',
-      'overview-dump'
-    ],
+    ignoredPaths: ['test', 'file-not-found', 'overview-dump'],
     $runAfter: ['paths-computed'],
     $runBefore: ['rendering-docs'],
     $process(docs) {
@@ -19,15 +15,15 @@ module.exports = function createSitemap() {
         outputPath: '../sitemap.xml',
         template: 'sitemap.template.xml',
         urls: docs
-          // Filter out docs that are not outputted
-          .filter(doc => doc.outputPath)
-          // Filter out unwanted docs
-          .filter(doc => this.blacklistedDocTypes.indexOf(doc.docType) === -1)
-          .filter(doc => this.blacklistedPaths.indexOf(doc.path) === -1)
-          // Capture the path of each doc
-          .map(doc => doc.path)
-          // Convert the homepage: `index` to `/`
-          .map(path => path === 'index' ? '' : path)
+                  // Filter out docs that are not outputted
+                  .filter(doc => doc.outputPath)
+                  // Filter out unwanted docs
+                  .filter(doc => this.ignoredDocTypes.indexOf(doc.docType) === -1)
+                  .filter(doc => this.ignoredPaths.indexOf(doc.path) === -1)
+                  // Capture the path of each doc
+                  .map(doc => doc.path)
+                  // Convert the homepage: `index` to `/`
+                  .map(path => path === 'index' ? '' : path)
       });
     }
   };

--- a/aio/tools/transforms/angular-base-package/processors/createSitemap.spec.js
+++ b/aio/tools/transforms/angular-base-package/processors/createSitemap.spec.js
@@ -11,17 +11,13 @@ describe('createSitemap processor', () => {
     processor = injector.get('createSitemap');
   });
 
-  it('should be available from the injector', () => {
-    expect(processor).toBeDefined();
-  });
+  it('should be available from the injector', () => { expect(processor).toBeDefined(); });
 
-  it('should run after "paths-computed"', () => {
-    expect(processor.$runAfter).toEqual(['paths-computed']);
-  });
+  it('should run after "paths-computed"',
+     () => { expect(processor.$runAfter).toEqual(['paths-computed']); });
 
-  it('should run before "rendering-docs"', () => {
-    expect(processor.$runBefore).toEqual(['rendering-docs']);
-  });
+  it('should run before "rendering-docs"',
+     () => { expect(processor.$runBefore).toEqual(['rendering-docs']); });
 
   describe('$process', () => {
     describe('should add a sitemap doc', () => {
@@ -39,41 +35,41 @@ describe('createSitemap processor', () => {
 
       it('with an array of urls for each doc that has an outputPath', () => {
         const docs = [
-          { path: 'abc', outputPath: 'abc' },
-          { path: 'cde' },
-          { path: 'fgh', outputPath: 'fgh' },
+          {path: 'abc', outputPath: 'abc'},
+          {path: 'cde'},
+          {path: 'fgh', outputPath: 'fgh'},
         ];
         processor.$process(docs);
         expect(docs.pop().urls).toEqual(['abc', 'fgh']);
       });
 
-      it('ignoring blacklisted doc types', () => {
+      it('ignoring blocked doc types', () => {
         const docs = [
-          { path: 'abc', outputPath: 'abc', docType: 'good' },
-          { path: 'cde', outputPath: 'cde', docType: 'bad' },
-          { path: 'fgh', outputPath: 'fgh', docType: 'good' },
+          {path: 'abc', outputPath: 'abc', docType: 'good'},
+          {path: 'cde', outputPath: 'cde', docType: 'bad'},
+          {path: 'fgh', outputPath: 'fgh', docType: 'good'},
         ];
-        processor.blacklistedDocTypes = ['bad'];
+        processor.ignoredDocTypes = ['bad'];
         processor.$process(docs);
         expect(docs.pop().urls).toEqual(['abc', 'fgh']);
       });
 
-      it('ignoring blacklisted paths', () => {
+      it('ignoring blocked paths', () => {
         const docs = [
-          { path: 'abc', outputPath: 'abc' },
-          { path: 'cde', outputPath: 'cde' },
-          { path: 'fgh', outputPath: 'fgh' },
+          {path: 'abc', outputPath: 'abc'},
+          {path: 'cde', outputPath: 'cde'},
+          {path: 'fgh', outputPath: 'fgh'},
         ];
-        processor.blacklistedPaths = ['cde'];
+        processor.ignoredPaths = ['cde'];
         processor.$process(docs);
         expect(docs.pop().urls).toEqual(['abc', 'fgh']);
       });
 
       it('mapping the home page\'s path to `/`', () => {
         const docs = [
-          { path: 'abc', outputPath: 'abc' },
-          { path: 'index', outputPath: 'index.json' },
-          { path: 'fgh', outputPath: 'fgh' },
+          {path: 'abc', outputPath: 'abc'},
+          {path: 'index', outputPath: 'index.json'},
+          {path: 'fgh', outputPath: 'fgh'},
         ];
         processor.$process(docs);
         expect(docs.pop().urls).toEqual(['abc', '', 'fgh']);

--- a/integration/cli-hello-world-ivy-compat/src/polyfills.ts
+++ b/integration/cli-hello-world-ivy-compat/src/polyfills.ts
@@ -63,21 +63,26 @@
  *
  * The following flags will work for all browsers.
  *
- * (window as any).__Zone_disable_requestAnimationFrame = true; // disable patch requestAnimationFrame
+ * ```js
+ * (window as any).__Zone_disable_requestAnimationFrame = true; // disable patch
+ * requestAnimationFrame
  * (window as any).__Zone_disable_on_property = true; // disable patch onProperty such as onclick
- * (window as any).__zone_symbol__BLACK_LISTED_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames
+ * (window as any).__zone_symbol__DISABLE_EVENTS = ['scroll', 'mousemove']; // disable patch
+ * specified eventNames
+ * ```
  *
- *  in IE/Edge developer tools, the addEventListener will also be wrapped by zone.js
- *  with the following flag, it will bypass `zone.js` patch for IE/Edge
+ * In IE/Edge developer tools, the addEventListener will also be wrapped by zone.js
+ * with the following flag, it will bypass `zone.js` patch for IE/Edge
  *
- *  (window as any).__Zone_enable_cross_context_check = true;
- *
+ * ```js
+ * (window as any).__Zone_enable_cross_context_check = true;
+ * ```
  */
 
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js/dist/zone'; // Included with Angular CLI.
 
 
 /***************************************************************************************************

--- a/integration/cli-hello-world/src/polyfills.ts
+++ b/integration/cli-hello-world/src/polyfills.ts
@@ -63,21 +63,26 @@
  *
  * The following flags will work for all browsers.
  *
- * (window as any).__Zone_disable_requestAnimationFrame = true; // disable patch requestAnimationFrame
+ * ```js
+ * (window as any).__Zone_disable_requestAnimationFrame = true; // disable patch
+ * requestAnimationFrame
  * (window as any).__Zone_disable_on_property = true; // disable patch onProperty such as onclick
- * (window as any).__zone_symbol__BLACK_LISTED_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames
+ * (window as any).__zone_symbol__DISABLE_EVENTS = ['scroll', 'mousemove']; // disable patch
+ * specified eventNames
+ * ```
  *
- *  in IE/Edge developer tools, the addEventListener will also be wrapped by zone.js
- *  with the following flag, it will bypass `zone.js` patch for IE/Edge
+ * In IE/Edge developer tools, the addEventListener will also be wrapped by zone.js
+ * with the following flag, it will bypass `zone.js` patch for IE/Edge
  *
+ * ```js
  *  (window as any).__Zone_enable_cross_context_check = true;
- *
+ * ```
  */
 
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js/dist/zone'; // Included with Angular CLI.
 
 
 /***************************************************************************************************

--- a/packages/compiler/src/assertions.ts
+++ b/packages/compiler/src/assertions.ts
@@ -20,7 +20,7 @@ export function assertArrayOfStrings(identifier: string, value: any) {
   }
 }
 
-const INTERPOLATION_BLACKLIST_REGEXPS = [
+const FORBIDDEN_INTERPOLATION_REGEXPS = [
   /^\s*$/,        // empty
   /[<>]/,         // html tag
   /^[{}]$/,       // i18n expansion
@@ -34,8 +34,8 @@ export function assertInterpolationSymbols(identifier: string, value: any): void
   } else if (value != null) {
     const start = value[0] as string;
     const end = value[1] as string;
-    // black list checking
-    INTERPOLATION_BLACKLIST_REGEXPS.forEach(regexp => {
+    // check to see if the interpolation is forbidden
+    FORBIDDEN_INTERPOLATION_REGEXPS.forEach(regexp => {
       if (regexp.test(start) || regexp.test(end)) {
         throw new Error(`['${start}', '${end}'] contains unusable interpolation symbol.`);
       }

--- a/packages/compiler/src/schema/dom_element_schema_registry.ts
+++ b/packages/compiler/src/schema/dom_element_schema_registry.ts
@@ -328,9 +328,9 @@ export class DomElementSchemaRegistry extends ElementSchemaRegistry {
    * Tag and property name are statically known and cannot change at runtime, i.e. it is not
    * possible to bind a value into a changing attribute or tag name.
    *
-   * The filtering is white list based. All attributes in the schema above are assumed to have the
-   * 'NONE' security context, i.e. that they are safe inert string values. Only specific well known
-   * attack vectors are assigned their appropriate context.
+   * The filtering is based on known values. All attributes in the schema above are assumed to have
+   * the 'NONE' security context, i.e. that they are safe inert string values. Only specific well
+   * known attack vectors are assigned their appropriate context.
    */
   securityContext(tagName: string, propName: string, isAttribute: boolean): SecurityContext {
     if (isAttribute) {

--- a/packages/core/src/sanitization/url_sanitizer.ts
+++ b/packages/core/src/sanitization/url_sanitizer.ts
@@ -15,7 +15,7 @@ import {isDevMode} from '../util/is_dev_mode';
  * execution if used in URL context within a HTML document. Specifically, this
  * regular expression matches if (comment from here on and regex copied from
  * Soy's EscapingConventions):
- * (1) Either a protocol in a whitelist (http, https, mailto or ftp).
+ * (1) Either an allowed protocol (http, https, mailto or ftp).
  * (2) or no protocol.  A protocol must be followed by a colon. The below
  *     allows that by allowing colons only after one of the characters [/?#].
  *     A colon after a hash (#) must be in the fragment.
@@ -35,9 +35,6 @@ import {isDevMode} from '../util/is_dev_mode';
  * This regular expression was taken from the Closure sanitization library.
  */
 const SAFE_URL_PATTERN = /^(?:(?:https?|mailto|ftp|tel|file):|[^&:/?#]*(?:[/?#]|$))/gi;
-
-/* A pattern that matches safe srcset values */
-const SAFE_SRCSET_PATTERN = /^(?:(?:https?|file):|[^&:/?#]*(?:[/?#]|$))/gi;
 
 /** A pattern that matches safe data URLs. Only matches image, video and audio types. */
 const DATA_URL_PATTERN =

--- a/packages/platform-browser/test/dom/events/event_manager_spec.ts
+++ b/packages/platform-browser/test/dom/events/event_manager_spec.ts
@@ -296,7 +296,7 @@ import {el} from '../../../testing/src/browser_util';
       expect(receivedEvents).toEqual([]);
     });
 
-    it('should run blockListedEvents handler outside of ngZone', () => {
+    it('should run disallowedEvents handler outside of ngZone', () => {
       const Zone = (window as any)['Zone'];
       const element = el('<div><div></div></div>');
       getDOM().appendChild(doc.body, element);

--- a/packages/platform-browser/testing/src/browser_util.ts
+++ b/packages/platform-browser/testing/src/browser_util.ts
@@ -107,7 +107,7 @@ export function normalizeCSS(css: string): string {
       .replace(/\[(.+)=([^"\]]+)\]/g, (...match: string[]) => `[${match[1]}="${match[2]}"]`);
 }
 
-const _singleTagWhitelist = ['br', 'hr', 'input'];
+const _safeTags = ['br', 'hr', 'input'];
 export function stringifyElement(el: any /** TODO #9100 */): string {
   let result = '';
   if (getDOM().isElementNode(el)) {
@@ -144,7 +144,7 @@ export function stringifyElement(el: any /** TODO #9100 */): string {
     }
 
     // Closing tag
-    if (_singleTagWhitelist.indexOf(tagName) == -1) {
+    if (_safeTags.indexOf(tagName) == -1) {
       result += `</${tagName}>`;
     }
   } else if (getDOM().isCommentNode(el)) {

--- a/test-events.js
+++ b/test-events.js
@@ -6,4 +6,4 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-Zone[Zone.__symbol__('BLACK_LISTED_EVENTS')] = ['scroll'];
+Zone[Zone.__symbol__('DISABLE_EVENTS')] = ['scroll'];

--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -16,7 +16,7 @@
 // clang-format off
 // tslint:disable
 
-window.testBlocklist = {
+window.testBlockList = {
   "Portals CdkPortalOutlet should load a template into the portal": {
     "error": "TypeError: Cannot read property 'createEmbeddedView' of undefined",
     "notes": "Unknown"

--- a/tools/ts-api-guardian/lib/cli.ts
+++ b/tools/ts-api-guardian/lib/cli.ts
@@ -173,10 +173,10 @@ Options:
 
         --rootDir <dir>                 Specify the root directory of input files
 
-        --useAngularTagRules <boolean>  Whether the Angular specific tag rules should be used.                                        
+        --useAngularTagRules <boolean>  Whether the Angular specific tag rules should be used.
         --stripExportPattern <regexp>   Do not output exports matching the pattern
         --allowModuleIdentifiers <identifier>
-                                        Whitelist identifier for "* as foo" imports`);
+                                        Allow an identifier for "* as foo" imports`);
   process.exit(error ? 1 : 0);
 }
 

--- a/tools/ts-api-guardian/lib/serializer.ts
+++ b/tools/ts-api-guardian/lib/serializer.ts
@@ -38,14 +38,14 @@ export interface SerializationOptions {
    */
   stripExportPattern?: RegExp|RegExp[];
   /**
-   * Whitelists these identifiers as modules in the output. For example,
-   * ```
+   * Allow these identifiers as modules in the output. For example,
+   * ```ts
    * import * as angular from './angularjs';
    *
    * export class Foo extends angular.Bar {}
    * ```
    * will produce `export class Foo extends angular.Bar {}` and requires
-   * whitelisting angular.
+   * allowing angular.
    */
   allowModuleIdentifiers?: string[];
 
@@ -242,7 +242,7 @@ class ResolvedDeclarationEmitter {
           message: createErrorMessage(
               firstQualifier,
               `Module identifier "${firstQualifier.text}" is not allowed. Remove it ` +
-                  `from source or whitelist it via --allowModuleIdentifiers.`)
+                  `from source or allow it via --allowModuleIdentifiers.`)
         });
       }
     }

--- a/tools/ts-api-guardian/test/unit_test.ts
+++ b/tools/ts-api-guardian/test/unit_test.ts
@@ -357,7 +357,7 @@ describe('unit test', () => {
     check({'file.d.ts': input}, expected, {stripExportPattern: /^__.*/});
   });
 
-  it('should throw on using non-whitelisted module imports in expression position', () => {
+  it('should throw on using disallowed module imports in expression position', () => {
     const input = `
       import * as foo from './foo';
       export declare class A extends foo.A {
@@ -365,20 +365,22 @@ describe('unit test', () => {
     `;
     checkThrows(
         {'file.d.ts': input}, 'file.d.ts(2,32): error: Module identifier "foo" is not allowed. ' +
-            'Remove it from source or whitelist it via --allowModuleIdentifiers.');
+            'Remove it from source or allow it via --allowModuleIdentifiers.');
   });
 
-  it('should throw on using non-whitelisted module imports in type position', () => {
-    const input = `
+  it('should throw on using an import from something not in allowed module imports in type position',
+     () => {
+       const input = `
       import * as foo from './foo';
       export type A = foo.A;
     `;
-    checkThrows(
-        {'file.d.ts': input}, 'file.d.ts(2,17): error: Module identifier "foo" is not allowed. ' +
-            'Remove it from source or whitelist it via --allowModuleIdentifiers.');
-  });
+       checkThrows(
+           {'file.d.ts': input},
+           'file.d.ts(2,17): error: Module identifier "foo" is not allowed. ' +
+               'Remove it from source or allow it via --allowModuleIdentifiers.');
+     });
 
-  it('should not throw on using whitelisted module imports', () => {
+  it('should not throw on using allowed module imports', () => {
     const input = `
       import * as foo from './foo';
       export declare class A extends foo.A {
@@ -391,7 +393,7 @@ describe('unit test', () => {
     check({'file.d.ts': input}, expected, {allowModuleIdentifiers: ['foo']});
   });
 
-  it('should not throw if non-whitelisted module imports are not written', () => {
+  it('should not throw if allowed module imports are not written', () => {
     const input = `
       import * as foo from './foo';
       export declare class A {


### PR DESCRIPTION
This PR renames all uses of "blacklist" and "whitelist" to more accurate and appropriate names.

The Angular team is committed to making sure this is an inclusive environment for all. This PR is not about the origins of the phrases, rather it's about making everyone feel welcome and comfortable while reading our code base. 
