### PR TITLE
ci: move material-ci blocklist into core approval group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -749,6 +749,11 @@ testing/**                                                      @angular/fw-test
 /tools/**                                                       @angular/fw-dev-infra
 *.bzl                                                           @angular/fw-dev-infra
 
+# ================================================
+#  Material CI
+# ================================================
+
+/tools/material-ci/**                                           @angular/fw-core @angular/fw-dev-infra
 
 
 # ================================================


### PR DESCRIPTION
The only items in the `tools/material-ci` folder are the test blocklist and the instructions, neither of which are owned by dev-infra. This commit moves code ownership to core.