### PR TITLE
fix(ivy): extended lookup of the next pointer while traversing tNode tree

### DIFF
--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -150,7 +150,7 @@ function walkTNodeTree(
        */
       while (!nextTNode) {
         // If parent is null, we're crossing the view boundary, so we should get the host TNode.
-        tNode = tNode.parent || currentView[TVIEW].node;
+        tNode = tNode.parent || currentView[HOST_NODE];
 
         if (tNode === null || tNode === rootTNode) return null;
 
@@ -160,9 +160,26 @@ function walkTNodeTree(
           beforeNode = currentView[tNode.index][NATIVE];
         }
 
-        if (tNode.type === TNodeType.View && currentView[NEXT]) {
-          currentView = currentView[NEXT] as LView;
-          nextTNode = currentView[TVIEW].node;
+        if (tNode.type === TNodeType.View) {
+          /**
+           * If current lView doesn't have next pointer, we try to find it by going up parents
+           * chain until:
+           * - we find an lView with a next pointer
+           * - or find a tNode with a parent that has a next pointer
+           * - or reach root TNode (in which case we exit, since we traversed all nodes)
+           */
+          while (!currentView[NEXT] && currentView[PARENT] &&
+                 !(tNode.parent && tNode.parent.next)) {
+            if (tNode === rootTNode) return null;
+            currentView = currentView[PARENT] as LView;
+            tNode = currentView[HOST_NODE] !;
+          }
+          if (currentView[NEXT]) {
+            currentView = currentView[NEXT] as LView;
+            nextTNode = currentView[HOST_NODE];
+          } else {
+            nextTNode = tNode.next;
+          }
         } else {
           nextTNode = tNode.next;
         }

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -150,7 +150,7 @@ function walkTNodeTree(
        */
       while (!nextTNode) {
         // If parent is null, we're crossing the view boundary, so we should get the host TNode.
-        tNode = tNode.parent || currentView[HOST_NODE];
+        tNode = tNode.parent || currentView[T_HOST];
 
         if (tNode === null || tNode === rootTNode) return null;
 
@@ -172,11 +172,11 @@ function walkTNodeTree(
                  !(tNode.parent && tNode.parent.next)) {
             if (tNode === rootTNode) return null;
             currentView = currentView[PARENT] as LView;
-            tNode = currentView[HOST_NODE] !;
+            tNode = currentView[T_HOST] !;
           }
           if (currentView[NEXT]) {
             currentView = currentView[NEXT] as LView;
-            nextTNode = currentView[HOST_NODE];
+            nextTNode = currentView[T_HOST];
           } else {
             nextTNode = tNode.next;
           }

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {expect} from '@angular/platform-browser/testing/src/matchers';
+
+describe('projection', () => {
+  it('should handle projected containers inside other containers', () => {
+    @Component({
+      selector: 'child-comp',  //
+      template: '<ng-content></ng-content>'
+    })
+    class ChildComp {
+    }
+
+    @Component({
+      selector: 'root-comp',  //
+      template: '<ng-content></ng-content>'
+    })
+    class RootComp {
+    }
+
+    @Component({
+      selector: 'my-app',
+      template: `
+        <root-comp>
+          <ng-container *ngFor="let item of items; last as last">
+            <child-comp *ngIf="!last">{{ item }}|</child-comp>
+          </ng-container>
+        </root-comp>
+      `
+    })
+    class MyApp {
+      items: number[] = [1, 2, 3];
+    }
+
+    TestBed.configureTestingModule({declarations: [ChildComp, RootComp, MyApp]});
+    const fixture = TestBed.createComponent(MyApp);
+    fixture.detectChanges();
+
+    // expecting # of elements to be (items.length - 1), since last element is filtered out by
+    // *ngIf, this applies to all other assertions below
+    expect(fixture.nativeElement).toHaveText('1|2|');
+
+    fixture.componentInstance.items = [4, 5];
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveText('4|');
+
+    fixture.componentInstance.items = [6, 7, 8, 9];
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveText('6|7|8|');
+  });
+});


### PR DESCRIPTION
Prior to this change we only checked whether current lView has a next pointer while traversing tNode tree. However in some cases this pointer can be undefined and we need to look up parents chain to find suitable next pointer. This commit adds the logic of searching for the next pointer taking parents chain into account.

This PR resolves FW-911.

~~Note: changes to the `nativeRemoveChild` function will be reverted (and this PR rebased) once PR #28455 is in master.~~ PR is now (2/5/2019) rebased on top of the laster master and unrelated changes are now removed.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No