### PR TITLE
docs(docs-infra): Move tutorial click handler from li to button

### DIFF
--- a/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.css
+++ b/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.css
@@ -5,28 +5,31 @@
   padding: 0;
   width: 15em;
 }
-.heroes li {
+.heroes li button {
   cursor: pointer;
-  position: relative;
-  left: 0;
   background-color: #EEE;
   margin: .5em;
-  padding: .3em 0;
+  padding: 0;
   height: 1.6em;
   border-radius: 4px;
+  height: 100%;
+  width: 100%;
+  text-align: left;
 }
-.heroes li:hover {
-  color: #607D8B;
+.heroes li button:hover,
+.heroes li button:focus {
+  color: black;
   background-color: #DDD;
   left: .1em;
 }
-.heroes li.selected {
+.heroes li.selected button {
   background-color: #CFD8DC;
-  color: white;
+  color: black;
 }
-.heroes li.selected:hover {
+.heroes li.selected button:hover,
+.heroes li.selected button:focus {
   background-color: #BBD8DC;
-  color: white;
+  color: black;
 }
 .heroes .badge {
   display: inline-block;
@@ -35,9 +38,6 @@
   padding: 0.8em 0.7em 0 0.7em;
   background-color:#405061;
   line-height: 1em;
-  position: relative;
-  left: -1px;
-  top: -4px;
   height: 1.8em;
   margin-right: .8em;
   border-radius: 4px 0 0 4px;

--- a/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.html
+++ b/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.html
@@ -3,9 +3,10 @@
 <ul class="heroes">
   <!-- #docregion li -->
   <li *ngFor="let hero of heroes"
-    [class.selected]="hero === selectedHero"
-    (click)="onSelect(hero)">
-    <span class="badge">{{hero.id}}</span> {{hero.name}}
+    [class.selected]="hero === selectedHero">
+    <button (click)="onSelect(hero)">
+      <span class="badge">{{hero.id}}</span> {{hero.name}}
+    </button>
   </li>
   <!-- #enddocregion li -->
 </ul>


### PR DESCRIPTION
I want to gauge interest in this change before fully implementing 
it, so that is why I have not checked the following boxes yet. I am
proposing this change for accessibility reasons.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The Tour of Heroes tutorial demonstrates click bindings by putting one
on an `li` element. This works but has some disadvantanges:

* `li` elements are not naturally in the tab order, so are
inaccessible to keyboard-only navigation
* click handlers on non-interactive elements is also problematic 
for screen readers

Issue Number: N/A


## What is the new behavior?

This commit places the contents of the `li` inside a button element in 
order to demonstrate accessible code to readers of the tutorial.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This commit is quick and dirty to illustrate what I want to change and
gauge interest from the angular team before continuing. A list of
further tasks is at the end of this commit message.

It makes sense that the Tour of Heroes tutorial is choosing to use
simple, short code to reduce the number of concepts that the reader needs
to be exposed to. However, click handlers on non-interactive elements is
a very common accessibility problem, so I think addressing it in a
popular tutorial could do some good.

If the direction of this PR is accepted, the following still need to be 
done:

[] update the css to style the button appropriately
[] update wording in the tutorial to reflect changes in code
[] change the code in all steps of the tutorial
[] learn how to build the documentation and make sure it looks right