### PR TITLE
feat(ivy): implement listing lazy routes for specific entry point in `ngtsc`

### DIFF
--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -192,9 +192,7 @@ export class NgtscProgram implements api.Program {
 
   listLazyRoutes(entryRoute?: string|undefined): api.LazyRoute[] {
     this.ensureAnalyzed();
-    // Listing specific routes is unsupported for now, so we erroneously return
-    // all lazy routes instead (which should be okay for the CLI's usage).
-    return this.routeAnalyzer !.listLazyRoutes();
+    return this.routeAnalyzer !.listLazyRoutes(entryRoute);
   }
 
   getLibrarySummaries(): Map<string, api.LibrarySummary> {

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -199,11 +199,21 @@ export class NgtscProgram implements api.Program {
       // `@angular/cli` will always call this API with an absolute path, so the resolution step is
       // not necessary, but keeping it backwards compatible in case someone else is using the API.
 
+      // Relative entry paths are disallowed.
       if (entryRoute.startsWith('.')) {
-        throw new Error('Resolution of relative paths is not supported.');
+        throw new Error(
+            `Falied to list lazy routes: Resolution of relative paths (${entryRoute}) is not supported.`);
       }
 
-      // Any containing file gives the same result for absolute entry path.
+      // Non-relative entry paths fall into one of the following categories:
+      // - Absolute system paths (e.g. `/foo/bar/my-project/my-module`), which are unaffected by the
+      //   logic below.
+      // - Paths to enternal modules (e.g. `some-lib`).
+      // - Paths mapped to directories in `tsconfig.json` (e.g. `shared/my-module`).
+      //   (See https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping.)
+      //
+      // In all cases above, the `containingFile` argument is ignored, so we can just take the first
+      // of the root files.
       const containingFile = this.tsProgram.getRootFileNames()[0];
       const [entryPath, moduleName] = entryRoute.split('#');
       const resolved = ts.resolveModuleName(entryPath, containingFile, this.options, this.host);

--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -21,7 +21,7 @@ import {ImportRewriter, ModuleResolver, NoopImportRewriter, R3SymbolsImportRewri
 import {PartialEvaluator} from './partial_evaluator';
 import {TypeScriptReflectionHost} from './reflection';
 import {HostResourceLoader} from './resource_loader';
-import {NgModuleRouteAnalyzer} from './routing';
+import {NgModuleRouteAnalyzer, entryPointKeyFor} from './routing';
 import {FactoryGenerator, FactoryInfo, GeneratedShimsHostWrapper, ShimGenerator, SummaryGenerator, generatedFactoryTransform} from './shims';
 import {ivySwitchTransform} from './switch';
 import {IvyCompilation, declarationTransformFactory, ivyTransformFactory} from './transform';
@@ -191,6 +191,28 @@ export class NgtscProgram implements api.Program {
   }
 
   listLazyRoutes(entryRoute?: string|undefined): api.LazyRoute[] {
+    if (entryRoute) {
+      // Note:
+      // This resolution step is here to match the implementation of the old `AotCompilerHost` (see
+      // https://github.com/angular/angular/blob/50732e156/packages/compiler-cli/src/transformers/compiler_host.ts#L175-L188).
+      //
+      // `@angular/cli` will always call this API with an absolute path, so the resolution step is
+      // not necessary, but keeping it backwards compatible in case someone else is using the API.
+
+      if (entryRoute.startsWith('.')) {
+        throw new Error('Resolution of relative paths is not supported.');
+      }
+
+      // Any containing file gives the same result for absolute entry path.
+      const containingFile = this.tsProgram.getRootFileNames()[0];
+      const [entryPath, moduleName] = entryRoute.split('#');
+      const resolved = ts.resolveModuleName(entryPath, containingFile, this.options, this.host);
+
+      if (resolved.resolvedModule) {
+        entryRoute = entryPointKeyFor(resolved.resolvedModule.resolvedFileName, moduleName);
+      }
+    }
+
     this.ensureAnalyzed();
     return this.routeAnalyzer !.listLazyRoutes(entryRoute);
   }

--- a/packages/compiler-cli/src/ngtsc/routing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/routing/index.ts
@@ -9,3 +9,4 @@
 /// <reference types="node" />
 
 export {LazyRoute, NgModuleRouteAnalyzer} from './src/analyzer';
+export {entryPointKeyFor} from './src/route';

--- a/packages/compiler-cli/src/ngtsc/routing/src/analyzer.ts
+++ b/packages/compiler-cli/src/ngtsc/routing/src/analyzer.ts
@@ -12,7 +12,7 @@ import {ModuleResolver} from '../../imports';
 import {PartialEvaluator} from '../../partial_evaluator';
 
 import {scanForRouteEntryPoints} from './lazy';
-import {RouterEntryPointManager} from './route';
+import {RouterEntryPointManager, entryPointKeyFor} from './route';
 
 export interface NgModuleRawRouteData {
   sourceFile: ts.SourceFile;
@@ -38,9 +38,9 @@ export class NgModuleRouteAnalyzer {
 
   add(sourceFile: ts.SourceFile, moduleName: string, imports: ts.Expression|null,
       exports: ts.Expression|null, providers: ts.Expression|null): void {
-    const key = `${sourceFile.fileName}#${moduleName}`;
+    const key = entryPointKeyFor(sourceFile.fileName, moduleName);
     if (this.modules.has(key)) {
-      throw new Error(`Double route analyzing ${key}`);
+      throw new Error(`Double route analyzing for '${key}'.`);
     }
     this.modules.set(
         key, {

--- a/packages/compiler-cli/src/ngtsc/routing/src/route.ts
+++ b/packages/compiler-cli/src/ngtsc/routing/src/route.ts
@@ -23,6 +23,9 @@ class RouterEntryPointImpl implements RouterEntryPoint {
   constructor(readonly filePath: string, readonly moduleName: string) {}
 
   get name(): string { return this.moduleName; }
+
+  // For debugging purposes.
+  toString(): string { return `RouterEntryPoint(name: ${this.name}, filePath: ${this.filePath})`; }
 }
 
 export class RouterEntryPointManager {

--- a/packages/compiler-cli/src/ngtsc/routing/src/route.ts
+++ b/packages/compiler-cli/src/ngtsc/routing/src/route.ts
@@ -15,18 +15,14 @@ export abstract class RouterEntryPoint {
 
   abstract readonly moduleName: string;
 
-  // Alias of moduleName.
+  // Alias of moduleName for compatibility with what `ngtools_api` returned.
   abstract readonly name: string;
-
-  abstract toString(): string;
 }
 
 class RouterEntryPointImpl implements RouterEntryPoint {
   constructor(readonly filePath: string, readonly moduleName: string) {}
 
   get name(): string { return this.moduleName; }
-
-  toString(): string { return `${this.filePath}#${this.moduleName}`; }
 }
 
 export class RouterEntryPointManager {

--- a/packages/compiler-cli/src/ngtsc/routing/src/route.ts
+++ b/packages/compiler-cli/src/ngtsc/routing/src/route.ts
@@ -44,11 +44,15 @@ export class RouterEntryPointManager {
   }
 
   fromNgModule(sf: ts.SourceFile, moduleName: string): RouterEntryPoint {
-    const absoluteFile = sf.fileName;
-    const key = `${absoluteFile}#${moduleName}`;
+    const key = entryPointKeyFor(sf.fileName, moduleName);
     if (!this.map.has(key)) {
-      this.map.set(key, new RouterEntryPointImpl(absoluteFile, moduleName));
+      this.map.set(key, new RouterEntryPointImpl(sf.fileName, moduleName));
     }
     return this.map.get(key) !;
   }
+}
+
+export function entryPointKeyFor(filePath: string, moduleName: string): string {
+  // Drop the extension to be compatible with how cli calls `listLazyRoutes(entryRoute)`.
+  return `${filePath.replace(/\.tsx?$/i, '')}#${moduleName}`;
 }

--- a/packages/compiler-cli/test/ngtools_api_spec.ts
+++ b/packages/compiler-cli/test/ngtools_api_spec.ts
@@ -38,7 +38,7 @@ describe('ngtools_api (deprecated)', () => {
         export class ErrorComp2 {}
 
         @NgModule({
-          declarations: [ErrorComp2, NonExistentComp],
+          declarations: [ErrorComp2],
           imports: [RouterModule.forRoot([{loadChildren: './child#ChildModule'}])]
         })
         export class MainModule {}
@@ -61,7 +61,7 @@ describe('ngtools_api (deprecated)', () => {
     });
   }
 
-  fixmeIvy('FW-629: ngtsc lists lazy routes').it('should list lazy routes recursively', () => {
+  it('should list lazy routes recursively', () => {
     writeSomeRoutes();
     const {program, host, options} =
         createProgram(['src/main.ts', 'src/child.ts', 'src/child2.ts']);

--- a/packages/compiler-cli/test/ngtools_api_spec.ts
+++ b/packages/compiler-cli/test/ngtools_api_spec.ts
@@ -19,8 +19,7 @@ describe('ngtools_api (deprecated)', () => {
   beforeEach(() => { testSupport = setup(); });
 
   function createProgram(rootNames: string[]) {
-    const options =
-        testSupport.createCompilerOptions({enableIvy: ivyEnabled && 'ngtsc' as 'ngtsc'});
+    const options = testSupport.createCompilerOptions({enableIvy: ivyEnabled && 'ngtsc'});
     const host = ts.createCompilerHost(options, true);
     const program =
         ts.createProgram(rootNames.map(p => path.resolve(testSupport.basePath, p)), options, host);

--- a/packages/compiler-cli/test/ngtools_api_spec.ts
+++ b/packages/compiler-cli/test/ngtools_api_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {__NGTOOLS_PRIVATE_API_2 as NgTools_InternalApi_NG_2} from '@angular/compiler-cli';
-import {fixmeIvy} from '@angular/private/testing';
+import {fixmeIvy, ivyEnabled} from '@angular/private/testing';
 import * as path from 'path';
 import * as ts from 'typescript';
 
@@ -19,7 +19,8 @@ describe('ngtools_api (deprecated)', () => {
   beforeEach(() => { testSupport = setup(); });
 
   function createProgram(rootNames: string[]) {
-    const options = testSupport.createCompilerOptions();
+    const options =
+        testSupport.createCompilerOptions({enableIvy: ivyEnabled && 'ngtsc' as 'ngtsc'});
     const host = ts.createCompilerHost(options, true);
     const program =
         ts.createProgram(rootNames.map(p => path.resolve(testSupport.basePath, p)), options, host);
@@ -62,7 +63,8 @@ describe('ngtools_api (deprecated)', () => {
 
   fixmeIvy('FW-629: ngtsc lists lazy routes').it('should list lazy routes recursively', () => {
     writeSomeRoutes();
-    const {program, host, options} = createProgram(['src/main.ts']);
+    const {program, host, options} =
+        createProgram(['src/main.ts', 'src/child.ts', 'src/child2.ts']);
     const routes = NgTools_InternalApi_NG_2.listLazyRoutes({
       program,
       host,
@@ -77,7 +79,8 @@ describe('ngtools_api (deprecated)', () => {
 
   it('should allow to emit the program after analyzing routes', () => {
     writeSomeRoutes();
-    const {program, host, options} = createProgram(['src/main.ts']);
+    const {program, host, options} =
+        createProgram(['src/main.ts', 'src/child.ts', 'src/child2.ts']);
     NgTools_InternalApi_NG_2.listLazyRoutes({
       program,
       host,

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {LazyRoute} from '@angular/compiler-cli/src/ngtsc/routing';
+import * as path from 'path';
 import * as ts from 'typescript';
 
 import {NgtscTestEnvironment} from './env';
@@ -1439,13 +1441,13 @@ describe('ngtsc behavioral tests', () => {
       env.write('test.ts', `
         import {Component, NgModule} from '@angular/core';
         import {NormalComponent} from './cyclic';
-  
+
         @Component({
           selector: 'cyclic-component',
           template: 'Importing this causes a cycle',
         })
         export class CyclicComponent {}
-  
+
         @NgModule({
           declarations: [NormalComponent, CyclicComponent],
         })
@@ -1454,7 +1456,7 @@ describe('ngtsc behavioral tests', () => {
 
       env.write('cyclic.ts', `
         import {Component} from '@angular/core';
-  
+
         @Component({
           selector: 'normal-component',
           template: '<cyclic-component></cyclic-component>',
@@ -2022,91 +2024,410 @@ describe('ngtsc behavioral tests', () => {
     });
   });
 
-  it('should detect all lazy routes', () => {
-    env.tsconfig();
-    env.write('test.ts', `
-    import {NgModule} from '@angular/core';
-    import {RouterModule} from '@angular/router';
+  describe('listLazyRoutes()', () => {
+    const lazyRouteMatching =
+        (route: string, fromModulePath: RegExp, fromModuleName: string, toModulePath: RegExp,
+         toModuleName: string) => ({
+          route: route, module: jasmine.objectContaining({
+            name: fromModuleName,
+            filePath: jasmine.stringMatching(fromModulePath),
+          }),
+              referencedModule: jasmine.objectContaining({
+                name: toModuleName,
+                filePath: jasmine.stringMatching(toModulePath),
+              }),
+        } as unknown as LazyRoute);
 
-    @NgModule({
-      imports: [
-        RouterModule.forChild([
-          {path: '', loadChildren: './lazy#LazyModule'},
-        ]),
-      ],
-    })
-    export class TestModule {}
-    `);
-    env.write('lazy.ts', `
-    import {NgModule} from '@angular/core';
-    import {RouterModule} from '@angular/router';
+    beforeEach(() => {
+      env.tsconfig();
+      env.write('node_modules/@angular/router/index.d.ts', `
+        import {ModuleWithProviders} from '@angular/core';
 
-    @NgModule({})
-    export class LazyModule {}
-    `);
-    env.write('node_modules/@angular/router/index.d.ts', `
-    import {ModuleWithProviders} from '@angular/core';
+        export declare var ROUTES;
+        export declare class RouterModule {
+          static forRoot(arg1: any, arg2: any): ModuleWithProviders<RouterModule>;
+          static forChild(arg1: any): ModuleWithProviders<RouterModule>;
+        }
+      `);
+    });
 
-    export declare var ROUTES;
-    export declare class RouterModule {
-      static forRoot(arg1: any, arg2: any): ModuleWithProviders<RouterModule>;
-      static forChild(arg1: any): ModuleWithProviders<RouterModule>;
-    }
-    `);
+    describe('when called without arguments', () => {
+      it('should list all routes', () => {
+        env.write('test.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
 
-    const routes = env.driveRoutes();
-    expect(routes.length).toBe(1);
-    expect(routes[0].route).toEqual('./lazy#LazyModule');
-    expect(routes[0].module.filePath.endsWith('/test.ts')).toBe(true);
-    expect(routes[0].referencedModule.filePath.endsWith('/lazy.ts')).toBe(true);
-  });
+          @NgModule({
+            imports: [
+              RouterModule.forChild([
+                {path: '', loadChildren: './lazy#LazyModule'},
+              ]),
+            ],
+          })
+          export class TestModule {}
+        `);
+        env.write('lazy.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
 
-  it('should detect lazy routes in simple children routes', () => {
-    env.tsconfig();
-    env.write('test.ts', `
-    import {NgModule} from '@angular/core';
-    import {RouterModule} from '@angular/router';
-    
-    @Component({
-      selector: 'foo',
-      template: '<div>Foo</div>'
-    })
-    class FooCmp {}
+          @NgModule({})
+          export class LazyModule {}
+        `);
 
-    @NgModule({
-      imports: [
-        RouterModule.forRoot([
-          {path: '', children: [
-            {path: 'foo', component: FooCmp},
-            {path: 'lazy', loadChildren: './lazy#LazyModule'}
-          ]},
-        ]),
-      ],
-    })
-    export class TestModule {}
-    `);
-    env.write('lazy.ts', `
-    import {NgModule} from '@angular/core';
-    import {RouterModule} from '@angular/router';
+        const routes = env.driveRoutes();
+        expect(routes).toEqual([
+          lazyRouteMatching(
+              './lazy#LazyModule', /\/test\.ts$/, 'TestModule', /\/lazy\.ts$/, 'LazyModule'),
+        ]);
+      });
 
-    @NgModule({})
-    export class LazyModule {}
-    `);
-    env.write('node_modules/@angular/router/index.d.ts', `
-    import {ModuleWithProviders} from '@angular/core';
+      it('should detect lazy routes in simple children routes', () => {
+        env.write('test.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
 
-    export declare var ROUTES;
-    export declare class RouterModule {
-      static forRoot(arg1: any, arg2: any): ModuleWithProviders<RouterModule>;
-      static forChild(arg1: any): ModuleWithProviders<RouterModule>;
-    }
-    `);
+          @Component({
+            selector: 'foo',
+            template: '<div>Foo</div>'
+          })
+          class FooCmp {}
 
-    const routes = env.driveRoutes();
-    expect(routes.length).toBe(1);
-    expect(routes[0].route).toEqual('./lazy#LazyModule');
-    expect(routes[0].module.filePath.endsWith('/test.ts')).toBe(true);
-    expect(routes[0].referencedModule.filePath.endsWith('/lazy.ts')).toBe(true);
+          @NgModule({
+            imports: [
+              RouterModule.forRoot([
+                {path: '', children: [
+                  {path: 'foo', component: FooCmp},
+                  {path: 'lazy', loadChildren: './lazy#LazyModule'}
+                ]},
+              ]),
+            ],
+          })
+          export class TestModule {}
+        `);
+        env.write('lazy.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @NgModule({})
+          export class LazyModule {}
+        `);
+
+        const routes = env.driveRoutes();
+        expect(routes).toEqual([
+          lazyRouteMatching(
+              './lazy#LazyModule', /\/test\.ts$/, 'TestModule', /\/lazy\.ts$/, 'LazyModule'),
+        ]);
+      });
+    });
+
+    describe('when called with entry module', () => {
+      it('should throw if the entry module hasn\'t been analyzed', () => {
+        env.write('test.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @NgModule({
+            imports: [
+              RouterModule.forChild([
+                {path: '', loadChildren: './lazy#LazyModule'},
+              ]),
+            ],
+          })
+          export class TestModule {}
+        `);
+
+        const entryModule1 = path.join(env.basePath, 'test#TestModule');
+        const entryModule2 = path.join(env.basePath, 'not-test#TestModule');
+        const entryModule3 = path.join(env.basePath, 'test#NotTestModule');
+
+        expect(() => env.driveRoutes(entryModule1)).not.toThrow();
+        expect(() => env.driveRoutes(entryModule2))
+            .toThrowError(`Failed to list lazy routes: Unknown module '${entryModule2}'.`);
+        expect(() => env.driveRoutes(entryModule3))
+            .toThrowError(`Failed to list lazy routes: Unknown module '${entryModule3}'.`);
+      });
+
+      it('should list all transitive lazy routes', () => {
+        env.write('test.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+          import {Test1Module as Test1ModuleRenamed} from './test-1';
+          import {Test2Component, Test2Module} from './test-2';
+
+          @NgModule({
+            exports: [
+              Test1ModuleRenamed,
+              Test2Component,
+            ],
+            imports: [
+              Test2Module,
+              RouterModule.forRoot([
+                {path: '', loadChildren: './lazy/lazy#LazyModule'},
+              ]),
+            ],
+          })
+          export class TestModule {}
+        `);
+        env.write('test-1.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @NgModule({
+            imports: [
+              RouterModule.forChild([
+                {path: 'one', loadChildren: './lazy-1/lazy-1#Lazy1Module'},
+              ]),
+            ],
+          })
+          export class Test1Module {}
+        `);
+        env.write('test-2.ts', `
+          import {Component, NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @Component({
+            selector: 'test-2',
+            template: '',
+          })
+          export class Test2Component {}
+
+          @NgModule({
+            declarations: [
+              Test2Component,
+            ],
+            exports: [
+              Test2Component,
+              RouterModule.forChild([
+                {path: 'two', loadChildren: './lazy-2/lazy-2#Lazy2Module'},
+              ]),
+            ],
+          })
+          export class Test2Module {}
+        `);
+        env.write('lazy/lazy.ts', `
+          import {NgModule} from '@angular/core';
+
+          @NgModule({})
+          export class LazyModule {}
+        `);
+        env.write('lazy-1/lazy-1.ts', `
+          import {NgModule} from '@angular/core';
+
+          @NgModule({})
+          export class Lazy1Module {}
+        `);
+        env.write('lazy-2/lazy-2.ts', `
+          import {NgModule} from '@angular/core';
+
+          @NgModule({})
+          export class Lazy2Module {}
+        `);
+
+        const routes = env.driveRoutes(path.join(env.basePath, 'test#TestModule'));
+
+        expect(routes).toEqual([
+          lazyRouteMatching(
+              './lazy/lazy#LazyModule', /\/test\.ts$/, 'TestModule', /\/lazy\/lazy\.ts$/,
+              'LazyModule'),
+          lazyRouteMatching(
+              './lazy-1/lazy-1#Lazy1Module', /\/test-1\.ts$/, 'Test1Module',
+              /\/lazy-1\/lazy-1\.ts$/, 'Lazy1Module'),
+          lazyRouteMatching(
+              './lazy-2/lazy-2#Lazy2Module', /\/test-2\.ts$/, 'Test2Module',
+              /\/lazy-2\/lazy-2\.ts$/, 'Lazy2Module'),
+        ]);
+      });
+
+      it('should support `ModuleWithProviders`', () => {
+        env.write('test.ts', `
+          import {ModuleWithProviders, NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @NgModule({
+            imports: [
+              RouterModule.forChild([
+                {path: '', loadChildren: './lazy-2/lazy-2#Lazy2Module'},
+              ]),
+            ],
+          })
+          export class TestRoutingModule {
+            static forRoot(): ModuleWithProviders<TestRoutingModule> {
+              return {
+                ngModule: TestRoutingModule,
+                providers: [],
+              };
+            }
+          }
+
+          @NgModule({
+            imports: [
+              TestRoutingModule.forRoot(),
+              RouterModule.forRoot([
+                {path: '', loadChildren: './lazy-1/lazy-1#Lazy1Module'},
+              ]),
+            ],
+          })
+          export class TestModule {}
+        `);
+        env.write('lazy-1/lazy-1.ts', `
+          import {NgModule} from '@angular/core';
+
+          @NgModule({})
+          export class Lazy1Module {}
+        `);
+        env.write('lazy-2/lazy-2.ts', `
+          import {NgModule} from '@angular/core';
+
+          @NgModule({})
+          export class Lazy2Module {}
+        `);
+
+        const routes = env.driveRoutes(path.join(env.basePath, 'test#TestModule'));
+
+        expect(routes).toEqual([
+          lazyRouteMatching(
+              './lazy-1/lazy-1#Lazy1Module', /\/test\.ts$/, 'TestModule', /\/lazy-1\/lazy-1\.ts$/,
+              'Lazy1Module'),
+          lazyRouteMatching(
+              './lazy-2/lazy-2#Lazy2Module', /\/test\.ts$/, 'TestRoutingModule',
+              /\/lazy-2\/lazy-2\.ts$/, 'Lazy2Module'),
+        ]);
+      });
+
+      it('should only process each module once', () => {
+        env.write('test.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @NgModule({
+            imports: [
+              RouterModule.forChild([
+                {path: '', loadChildren: './lazy/lazy#LazyModule'},
+              ]),
+            ],
+          })
+          export class SharedModule {}
+
+          @NgModule({
+            imports: [
+              SharedModule,
+              RouterModule.forRoot([
+                {path: '', loadChildren: './lazy/lazy#LazyModule'},
+              ]),
+            ],
+          })
+          export class TestModule {}
+        `);
+        env.write('lazy/lazy.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @NgModule({
+            imports: [
+              RouterModule.forChild([
+                {path: '', loadChildren: '../lazier/lazier#LazierModule'},
+              ]),
+            ],
+          })
+          export class LazyModule {}
+        `);
+        env.write('lazier/lazier.ts', `
+          import {NgModule} from '@angular/core';
+
+          @NgModule({})
+          export class LazierModule {}
+        `);
+
+        const routes = env.driveRoutes(path.join(env.basePath, 'test#TestModule'));
+
+        // `LazyModule` is referenced in both `SharedModule` and `TestModule`,
+        // but it is only processed once (hence one `LazierModule` entry).
+        expect(routes).toEqual([
+          lazyRouteMatching(
+              './lazy/lazy#LazyModule', /\/test\.ts$/, 'TestModule', /\/lazy\/lazy\.ts$/,
+              'LazyModule'),
+          lazyRouteMatching(
+              './lazy/lazy#LazyModule', /\/test\.ts$/, 'SharedModule', /\/lazy\/lazy\.ts$/,
+              'LazyModule'),
+          lazyRouteMatching(
+              '../lazier/lazier#LazierModule', /\/lazy\/lazy\.ts$/, 'LazyModule',
+              /\/lazier\/lazier\.ts$/, 'LazierModule'),
+        ]);
+      });
+
+      it('should ignore modules not (transitively) referenced by the entry module', () => {
+        env.write('test.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @NgModule({
+            imports: [
+              RouterModule.forRoot([
+                {path: '', loadChildren: './lazy/lazy#Lazy1Module'},
+              ]),
+            ],
+          })
+          export class Test1Module {}
+
+          @NgModule({
+            imports: [
+              RouterModule.forRoot([
+                {path: '', loadChildren: './lazy/lazy#Lazy2Module'},
+              ]),
+            ],
+          })
+          export class Test2Module {}
+        `);
+        env.write('lazy/lazy.ts', `
+          import {NgModule} from '@angular/core';
+
+          @NgModule({})
+          export class Lazy1Module {}
+
+          @NgModule({})
+          export class Lazy2Module {}
+        `);
+
+        const routes = env.driveRoutes(path.join(env.basePath, 'test#Test1Module'));
+
+        expect(routes).toEqual([
+          lazyRouteMatching(
+              './lazy/lazy#Lazy1Module', /\/test\.ts$/, 'Test1Module', /\/lazy\/lazy\.ts$/,
+              'Lazy1Module'),
+        ]);
+      });
+
+      it('should ignore routes to unknown modules', () => {
+        env.write('test.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @NgModule({
+            imports: [
+              RouterModule.forRoot([
+                {path: '', loadChildren: './unknown/unknown#UnknownModule'},
+                {path: '', loadChildren: './lazy/lazy#LazyModule'},
+              ]),
+            ],
+          })
+          export class TestModule {}
+        `);
+        env.write('lazy/lazy.ts', `
+          import {NgModule} from '@angular/core';
+
+          @NgModule({})
+          export class LazyModule {}
+        `);
+
+        const routes = env.driveRoutes(path.join(env.basePath, 'test#TestModule'));
+
+        expect(routes).toEqual([
+          lazyRouteMatching(
+              './lazy/lazy#LazyModule', /\/test\.ts$/, 'TestModule', /\/lazy\/lazy\.ts$/,
+              'LazyModule'),
+        ]);
+      });
+    });
   });
 });
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2149,6 +2149,69 @@ describe('ngtsc behavioral tests', () => {
               './lazy#LazyModule', /\/test\.ts$/, 'TestModule', /\/lazy\.ts$/, 'LazyModule'),
         ]);
       });
+
+      it('should detect lazy routes in all root directories', () => {
+        env.tsconfig({}, ['./foo/other-root-dir', './bar/other-root-dir']);
+        env.write('src/test.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @NgModule({
+            imports: [
+              RouterModule.forRoot([
+                {path: '', loadChildren: './lazy-foo#LazyFooModule'},
+              ]),
+            ],
+          })
+          export class TestModule {}
+        `);
+        env.write('foo/other-root-dir/src/lazy-foo.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @NgModule({
+            imports: [
+              RouterModule.forChild([
+                {path: '', loadChildren: './lazy-bar#LazyBarModule'},
+              ]),
+            ],
+          })
+          export class LazyFooModule {}
+        `);
+        env.write('bar/other-root-dir/src/lazy-bar.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @NgModule({
+            imports: [
+              RouterModule.forChild([
+                {path: '', loadChildren: './lazier-bar#LazierBarModule'},
+              ]),
+            ],
+          })
+          export class LazyBarModule {}
+        `);
+        env.write('bar/other-root-dir/src/lazier-bar.ts', `
+          import {NgModule} from '@angular/core';
+
+          @NgModule({})
+          export class LazierBarModule {}
+        `);
+
+        const routes = env.driveRoutes();
+
+        expect(routes).toEqual([
+          lazyRouteMatching(
+              './lazy-foo#LazyFooModule', /\/test\.ts$/, 'TestModule',
+              /\/foo\/other-root-dir\/src\/lazy-foo\.ts$/, 'LazyFooModule'),
+          lazyRouteMatching(
+              './lazy-bar#LazyBarModule', /\/foo\/other-root-dir\/src\/lazy-foo\.ts$/,
+              'LazyFooModule', /\/bar\/other-root-dir\/src\/lazy-bar\.ts$/, 'LazyBarModule'),
+          lazyRouteMatching(
+              './lazier-bar#LazierBarModule', /\/bar\/other-root-dir\/src\/lazy-bar\.ts$/,
+              'LazyBarModule', /\/bar\/other-root-dir\/src\/lazier-bar\.ts$/, 'LazierBarModule'),
+        ]);
+      });
     });
 
     describe('when called with entry module', () => {
@@ -2439,6 +2502,69 @@ describe('ngtsc behavioral tests', () => {
           lazyRouteMatching(
               '../lazier/lazier#LazierModule', /\/lazy\/lazy\.ts$/, 'LazyModule',
               /\/lazier\/lazier\.ts$/, 'LazierModule'),
+        ]);
+      });
+
+      it('should detect lazy routes in all root directories', () => {
+        env.tsconfig({}, ['./foo/other-root-dir', './bar/other-root-dir']);
+        env.write('src/test.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @NgModule({
+            imports: [
+              RouterModule.forRoot([
+                {path: '', loadChildren: './lazy-foo#LazyFooModule'},
+              ]),
+            ],
+          })
+          export class TestModule {}
+        `);
+        env.write('foo/other-root-dir/src/lazy-foo.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @NgModule({
+            imports: [
+              RouterModule.forChild([
+                {path: '', loadChildren: './lazy-bar#LazyBarModule'},
+              ]),
+            ],
+          })
+          export class LazyFooModule {}
+        `);
+        env.write('bar/other-root-dir/src/lazy-bar.ts', `
+          import {NgModule} from '@angular/core';
+          import {RouterModule} from '@angular/router';
+
+          @NgModule({
+            imports: [
+              RouterModule.forChild([
+                {path: '', loadChildren: './lazier-bar#LazierBarModule'},
+              ]),
+            ],
+          })
+          export class LazyBarModule {}
+        `);
+        env.write('bar/other-root-dir/src/lazier-bar.ts', `
+          import {NgModule} from '@angular/core';
+
+          @NgModule({})
+          export class LazierBarModule {}
+        `);
+
+        const routes = env.driveRoutes(path.join(env.basePath, 'src/test#TestModule'));
+
+        expect(routes).toEqual([
+          lazyRouteMatching(
+              './lazy-foo#LazyFooModule', /\/test\.ts$/, 'TestModule',
+              /\/foo\/other-root-dir\/src\/lazy-foo\.ts$/, 'LazyFooModule'),
+          lazyRouteMatching(
+              './lazy-bar#LazyBarModule', /\/foo\/other-root-dir\/src\/lazy-foo\.ts$/,
+              'LazyFooModule', /\/bar\/other-root-dir\/src\/lazy-bar\.ts$/, 'LazyBarModule'),
+          lazyRouteMatching(
+              './lazier-bar#LazierBarModule', /\/bar\/other-root-dir\/src\/lazy-bar\.ts$/,
+              'LazyBarModule', /\/bar\/other-root-dir\/src\/lazier-bar\.ts$/, 'LazierBarModule'),
         ]);
       });
 

--- a/packages/compiler-cli/test/test_support.ts
+++ b/packages/compiler-cli/test/test_support.ts
@@ -75,13 +75,22 @@ function createTestSupportFor(basePath: string) {
     shouldNotExist
   };
 
-  function write(fileName: string, content: string) {
-    const dir = path.dirname(fileName);
-    if (dir != '.') {
-      const newDir = path.resolve(basePath, dir);
-      if (!fs.existsSync(newDir)) fs.mkdirSync(newDir);
+  function ensureDirExists(absolutePathToDir: string) {
+    if (fs.existsSync(absolutePathToDir)) {
+      if (!fs.statSync(absolutePathToDir).isDirectory()) {
+        throw new Error(`'${absolutePathToDir}' exists and is not a directory.`);
+      }
+    } else {
+      const parentDir = path.dirname(absolutePathToDir);
+      ensureDirExists(parentDir);
+      fs.mkdirSync(absolutePathToDir);
     }
-    fs.writeFileSync(path.resolve(basePath, fileName), content, {encoding: 'utf-8'});
+  }
+
+  function write(fileName: string, content: string) {
+    const absolutePathToFile = path.resolve(basePath, fileName);
+    ensureDirExists(path.dirname(absolutePathToFile));
+    fs.writeFileSync(absolutePathToFile, content);
   }
 
   function writeFiles(...mockDirs: {[fileName: string]: string}[]) {


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
- [x] Feature


## What is the current behavior?
`ngtsc`'s `listLazyRoutes()` does not support listing routes for a specific entry point. `@angular/cli` calls this API to get a list of lazy-loaded entry points (routes) so that the bundler can create separate bundles for each. Under certain circumstances (e.g. `jit` mode), the cli may need to list routes for a specific root entry point only.

Jira issue: [FW-860]


## What is the new behavior?
`ngtsc`'s `listLazyRoutes()` supports listing routes for a specific entry point.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
Related: angular/angular-cli#13532


[FW-860]: https://angular-team.atlassian.net/browse/FW-860