### PR TITLE
ci: fix the `aio_monitoring` job (and other minor improvements)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,12 +117,6 @@ jobs:
       - run: sudo cp .circleci/bazel.rc /etc/bazel.bazelrc
       - run: yarn bazel test //... --build_tag_filters=-ivy-only,local --test_tag_filters=-ivy-only,local
 
-      - save_cache:
-          key: *cache_key
-          paths:
-            - "node_modules"
-            - "~/bazel_repository_cache"
-
   # Temporary job to test what will happen when we flip the Ivy flag to true
   test_ivy_aot:
     <<: *job_defaults
@@ -354,6 +348,12 @@ jobs:
           root: dist
           paths:
             - packages-dist
+
+      - save_cache:
+          key: *cache_key
+          paths:
+            - "node_modules"
+            - "~/bazel_repository_cache"
 
 
   # Build the ivy npm packages.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,7 @@ var_9: &setup_circleci_bazel_config
 var_10: &download_yarn
   run:
     name: Downloading Yarn
-    command: |
-      echo "Attempting to install $CI_YARN_VERSION from https://yarnpkg.com" |
-      curl -o- -L https://yarnpkg.com/install.sh | PROFILE=$BASH_ENV bash -s -- --version "$CI_YARN_VERSION"
+    command: curl -o- -L https://yarnpkg.com/install.sh | PROFILE=$BASH_ENV bash -s -- --version "$CI_YARN_VERSION"
 
 version: 2
 jobs:
@@ -454,8 +452,8 @@ jobs:
           <<: *post_checkout
       - restore_cache:
           key: *cache_key
-      - *download_yarn
       - *define_env_vars
+      - *download_yarn
       - run:
           name: Run tests against the deployed apps
           command: ./aio/scripts/test-production.sh $CI_AIO_MIN_PWA_SCORE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,9 +106,9 @@ jobs:
       - restore_cache:
           key: *cache_key
       - *define_env_vars
-      - *setup_circleci_bazel_config
       - *download_yarn
       - *yarn_install
+      - *setup_circleci_bazel_config
 
       # Setup remote execution and run RBE-compatible tests.
       - *setup_bazel_remote_execution
@@ -133,9 +133,9 @@ jobs:
       - restore_cache:
           key: *cache_key
       - *define_env_vars
-      - *setup_circleci_bazel_config
       - *download_yarn
       - *yarn_install
+      - *setup_circleci_bazel_config
       - *setup_bazel_remote_execution
 
         # We need to explicitly specify the --symlink_prefix option because otherwise we would
@@ -321,7 +321,7 @@ jobs:
           key: *cache_key
       - *define_env_vars
       - *download_yarn
-      - run: yarn install --cwd aio --frozen-lockfile --non-interactive
+      - run: yarn --cwd aio install --frozen-lockfile --non-interactive
       - run:
           name: Wait for preview and run tests
           command: node aio/scripts/test-preview.js $CI_PULL_REQUEST $CI_COMMIT $CI_AIO_MIN_PWA_SCORE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,8 +278,6 @@ jobs:
           at: dist
       - *define_env_vars
       - *download_yarn
-        # Install root
-      - *yarn_install
         # Install aio
       - run: yarn --cwd aio install --frozen-lockfile --non-interactive
         # Run examples tests. The "CIRCLE_NODE_INDEX" will be set if "parallelism" is enabled.
@@ -299,7 +297,6 @@ jobs:
           key: *cache_key
       - *define_env_vars
       - *download_yarn
-      - *yarn_install
       - run: ./aio/scripts/build-artifacts.sh $AIO_SNAPSHOT_ARTIFACT_PATH $CI_PULL_REQUEST $CI_COMMIT
       - store_artifacts:
           path: *aio_preview_artifact_path
@@ -408,6 +405,8 @@ jobs:
           at: dist
       - *define_env_vars
       - *download_yarn
+      # Some integration tests get their dependencies from the root `node_modules/`.
+      - *yarn_install
       # Runs the integration tests in parallel across multiple CircleCI container instances. The
       # amount of container nodes for this job is controlled by the "parallelism" option.
       - run: ./integration/run_tests.sh ${CIRCLE_NODE_INDEX} ${CIRCLE_NODE_TOTAL}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,7 +458,9 @@ jobs:
           command: ./aio/scripts/test-production.sh $CI_AIO_MIN_PWA_SCORE
       - run:
           name: Notify caretaker about failure
-          command: 'curl --request POST --header "Content-Type: application/json" --data "{\"text\":\":x: \`$CIRCLE_JOB\` job failed on build $CIRCLE_BUILD_NUM: $CIRCLE_BUILD_URL :scream:\"}" $CI_SECRET_SLACK_CARETAKER_WEBHOOK_URL'
+          # `$SLACK_CARETAKER_WEBHOOK_URL` is a secret env var defined in CircleCI project settings.
+          # The URL comes from https://angular-team.slack.com/apps/A0F7VRE7N-circleci.
+          command: 'curl --request POST --header "Content-Type: application/json" --data "{\"text\":\":x: \`$CIRCLE_JOB\` job failed on build $CIRCLE_BUILD_NUM: $CIRCLE_BUILD_URL :scream:\"}" $SLACK_CARETAKER_WEBHOOK_URL'
           when: on_fail
 
   legacy-unit-tests-local:

--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -39,8 +39,6 @@ setPublicVar CI_YARN_VERSION "1.13.0";
 ####################################################################################################
 setSecretVar CI_SECRET_AIO_DEPLOY_FIREBASE_TOKEN "$AIO_DEPLOY_TOKEN";
 setSecretVar CI_SECRET_PAYLOAD_FIREBASE_TOKEN "$ANGULAR_PAYLOAD_TOKEN";
-# Defined in https://angular-team.slack.com/apps/A0F7VRE7N-circleci.
-setSecretVar CI_SECRET_SLACK_CARETAKER_WEBHOOK_URL "$SLACK_CARETAKER_WEBHOOK_URL";
 
 
 ####################################################################################################

--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -18,7 +18,6 @@ setPublicVar PROJECT_ROOT "$(pwd)";
 setPublicVar CI_AIO_MIN_PWA_SCORE "95";
 # This is the branch being built; e.g. `pull/12345` for PR builds.
 setPublicVar CI_BRANCH "$CIRCLE_BRANCH";
-setPublicVar CI_YARN_VERSION "1.13.0"
 # ChromeDriver version compatible with the Chrome version included in the docker image used in
 # `.circleci/config.yml`. See http://chromedriver.chromium.org/downloads for a list of versions.
 # This variable is intended to be passed as an arg to the `webdriver-manager update` command (e.g.
@@ -32,6 +31,7 @@ setPublicVar CI_COMMIT_RANGE "`[[ ${CIRCLE_PR_NUMBER:-false} != false ]] && echo
 setPublicVar CI_PULL_REQUEST "${CIRCLE_PR_NUMBER:-false}";
 setPublicVar CI_REPO_NAME "$CIRCLE_PROJECT_REPONAME";
 setPublicVar CI_REPO_OWNER "$CIRCLE_PROJECT_USERNAME";
+setPublicVar CI_YARN_VERSION "1.13.0";
 
 
 ####################################################################################################


### PR DESCRIPTION
The main changes are:

- **ci(docs-infra): fix `download_yarn` in `aio_monitoring`**
  The `download_yarn` step depends on the `CI_YARN_VERSION` environment variable and thus has to be run after the `define_env_vars` step.
  Accidentally broken in [#28546][1].

- **ci: save the cache in `build-npm-packages` job instead of `test`**
  In most cases, it doesn't make a difference, because the cache does already exist and is not saved. In the few cases where the dependencies change (and the cache needs to be updated), it makes more sense to save the cache in the `build-npm-packages` job, because most jobs depend on it and thus will be able to take advantage of the updated cache right away.
  This seems to be an oversight in b26ac1c.