### PR TITLE
test(ivy): update e2e tests to use Renderer2 instead of Renderer

### DIFF
--- a/modules/playground/e2e_test/hello_world/hello_world_spec.ts
+++ b/modules/playground/e2e_test/hello_world/hello_world_spec.ts
@@ -6,34 +6,32 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {fixmeIvy} from '@angular/private/testing';
 import {browser} from 'protractor';
 
 import {verifyNoBrowserErrors} from '../../../e2e_util/e2e_util';
 
-fixmeIvy('FW-1032: Ivy doesn\'t support injecting Renderer, the deprecated renderer V1')
-    .describe('hello world', function() {
+describe('hello world', function() {
 
-      afterEach(verifyNoBrowserErrors);
+  afterEach(verifyNoBrowserErrors);
 
-      describe('hello world app', function() {
-        const URL = '/';
+  describe('hello world app', function() {
+    const URL = '/';
 
-        it('should greet', function() {
-          browser.get(URL);
+    it('should greet', function() {
+      browser.get(URL);
 
-          expect(getComponentText('hello-app', '.greeting')).toEqual('hello world!');
-        });
-
-        it('should change greeting', function() {
-          browser.get(URL);
-
-          clickComponentButton('hello-app', '.changeButton');
-          expect(getComponentText('hello-app', '.greeting')).toEqual('howdy world!');
-        });
-      });
-
+      expect(getComponentText('hello-app', '.greeting')).toEqual('hello world!');
     });
+
+    it('should change greeting', function() {
+      browser.get(URL);
+
+      clickComponentButton('hello-app', '.changeButton');
+      expect(getComponentText('hello-app', '.greeting')).toEqual('howdy world!');
+    });
+  });
+
+});
 
 function getComponentText(selector: string, innerSelector: string) {
   return browser.executeScript(

--- a/modules/playground/e2e_test/web_workers/kitchen_sink/kitchen_sink_spec.ts
+++ b/modules/playground/e2e_test/web_workers/kitchen_sink/kitchen_sink_spec.ts
@@ -6,56 +6,54 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {fixmeIvy} from '@angular/private/testing';
 import {ExpectedConditions, browser, by, element, protractor} from 'protractor';
 
 import {verifyNoBrowserErrors} from '../../../../e2e_util/e2e_util';
 
-fixmeIvy('FW-1032: Ivy doesn\'t support injecting Renderer, the deprecated renderer V1')
-    .describe('WebWorkers Kitchen Sink', function() {
-      afterEach(() => {
-        verifyNoBrowserErrors();
-        browser.ignoreSynchronization = false;
-      });
-      const selector = 'hello-app .greeting';
-      const URL = '/';
+describe('WebWorkers Kitchen Sink', function() {
+  afterEach(() => {
+    verifyNoBrowserErrors();
+    browser.ignoreSynchronization = false;
+  });
+  const selector = 'hello-app .greeting';
+  const URL = '/';
 
-      it('should greet', () => {
-        // This test can't wait for Angular as Testability is not available when using WebWorker
-        browser.ignoreSynchronization = true;
-        browser.get(URL);
+  it('should greet', () => {
+    // This test can't wait for Angular as Testability is not available when using WebWorker
+    browser.ignoreSynchronization = true;
+    browser.get(URL);
 
-        browser.wait(protractor.until.elementLocated(by.css(selector)), 15000);
-        const elem = element(by.css(selector));
-        browser.wait(ExpectedConditions.textToBePresentInElement(elem, 'hello world!'), 5000);
-        expect(elem.getText()).toEqual('hello world!');
+    browser.wait(protractor.until.elementLocated(by.css(selector)), 15000);
+    const elem = element(by.css(selector));
+    browser.wait(ExpectedConditions.textToBePresentInElement(elem, 'hello world!'), 5000);
+    expect(elem.getText()).toEqual('hello world!');
 
-      });
+  });
 
-      it('should change greeting', () => {
-        // This test can't wait for Angular as Testability is not available when using WebWorker
-        browser.ignoreSynchronization = true;
-        browser.get(URL);
-        const changeButtonSelector = 'hello-app .changeButton';
+  it('should change greeting', () => {
+    // This test can't wait for Angular as Testability is not available when using WebWorker
+    browser.ignoreSynchronization = true;
+    browser.get(URL);
+    const changeButtonSelector = 'hello-app .changeButton';
 
-        browser.wait(protractor.until.elementLocated(by.css(changeButtonSelector)), 15000);
-        element(by.css(changeButtonSelector)).click();
-        const elem = element(by.css(selector));
-        browser.wait(ExpectedConditions.textToBePresentInElement(elem, 'howdy world!'), 5000);
-        expect(elem.getText()).toEqual('howdy world!');
-      });
+    browser.wait(protractor.until.elementLocated(by.css(changeButtonSelector)), 15000);
+    element(by.css(changeButtonSelector)).click();
+    const elem = element(by.css(selector));
+    browser.wait(ExpectedConditions.textToBePresentInElement(elem, 'howdy world!'), 5000);
+    expect(elem.getText()).toEqual('howdy world!');
+  });
 
-      it('should display correct key names', () => {
-        // This test can't wait for Angular as Testability is not available when using WebWorker
-        browser.ignoreSynchronization = true;
-        browser.get(URL);
-        browser.wait(protractor.until.elementLocated(by.css('.sample-area')), 15000);
+  it('should display correct key names', () => {
+    // This test can't wait for Angular as Testability is not available when using WebWorker
+    browser.ignoreSynchronization = true;
+    browser.get(URL);
+    browser.wait(protractor.until.elementLocated(by.css('.sample-area')), 15000);
 
-        const area = element.all(by.css('.sample-area')).first();
-        expect(area.getText()).toEqual('(none)');
+    const area = element.all(by.css('.sample-area')).first();
+    expect(area.getText()).toEqual('(none)');
 
-        area.sendKeys('u');
-        browser.wait(ExpectedConditions.textToBePresentInElement(area, 'U'), 5000);
-        expect(area.getText()).toEqual('U');
-      });
-    });
+    area.sendKeys('u');
+    browser.wait(ExpectedConditions.textToBePresentInElement(area, 'U'), 5000);
+    expect(area.getText()).toEqual('U');
+  });
+});

--- a/modules/playground/src/hello_world/index.ts
+++ b/modules/playground/src/hello_world/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, ElementRef, Injectable, NgModule, Renderer} from '@angular/core';
+import {Component, Directive, ElementRef, Injectable, NgModule, Renderer2} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
@@ -22,8 +22,8 @@ export class GreetingService {
 export class RedDec {
   // ElementRef is always injectable and it wraps the element on which the
   // directive was found by the compiler.
-  constructor(el: ElementRef, renderer: Renderer) {
-    renderer.setElementStyle(el.nativeElement, 'color', 'red');
+  constructor(el: ElementRef, renderer: Renderer2) {
+    renderer.setStyle(el.nativeElement, 'color', 'red');
   }
 }
 

--- a/modules/playground/src/web_workers/kitchen_sink/index_common.ts
+++ b/modules/playground/src/web_workers/kitchen_sink/index_common.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, ElementRef, Injectable, Renderer} from '@angular/core';
+import {Component, Directive, ElementRef, Injectable, Renderer2} from '@angular/core';
 
 // A service available to the Injector, used by the HelloCmp component.
 @Injectable()
@@ -20,8 +20,8 @@ export class GreetingService {
 export class RedDec {
   // ElementRef is always injectable and it wraps the element on which the
   // directive was found by the compiler.
-  constructor(el: ElementRef, renderer: Renderer) {
-    renderer.setElementStyle(el.nativeElement, 'color', 'red');
+  constructor(el: ElementRef, renderer: Renderer2) {
+    renderer.setStyle(el.nativeElement, 'color', 'red');
   }
 }
 


### PR DESCRIPTION
This is built on top of #28544, so only the last commit needs to be reviewed.

This PR fixes FW-1032. 
These two test suites are using the deprecated `Renderer`, which is not supported in Ivy. As discussed with @kara , they are updated to use `Renderer2` instead.