### PR TITLE
fix(ivy): properly query root nodes of embedded views(shallow queries)

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -532,6 +532,21 @@ export function elementContainerStart(
   const currentQueries = lView[QUERIES];
   if (currentQueries) {
     currentQueries.addNode(tNode);
+    lView[QUERIES] = currentQueries.clone();
+  }
+  executeContentQueries(tView, tNode);
+}
+
+function executeContentQueries(tView: TView, tNode: TNode) {
+  if (isContentQueryHost(tNode)) {
+    const start = tNode.directiveStart;
+    const end = tNode.directiveEnd;
+    for (let i = start; i < end; i++) {
+      const def = tView.data[i] as DirectiveDef<any>;
+      if (def.contentQueries) {
+        def.contentQueries(i);
+      }
+    }
   }
 }
 
@@ -543,7 +558,7 @@ export function elementContainerEnd(): void {
   if (getIsParent()) {
     setIsParent(false);
   } else {
-    ngDevMode && assertHasParent(getPreviousOrParentTNode());
+    ngDevMode && assertHasParent(previousOrParentTNode);
     previousOrParentTNode = previousOrParentTNode.parent !;
     setPreviousOrParentTNode(previousOrParentTNode);
   }
@@ -551,8 +566,7 @@ export function elementContainerEnd(): void {
   ngDevMode && assertNodeType(previousOrParentTNode, TNodeType.ElementContainer);
   const currentQueries = lView[QUERIES];
   if (currentQueries) {
-    lView[QUERIES] =
-        isContentQueryHost(previousOrParentTNode) ? currentQueries.parent : currentQueries;
+    lView[QUERIES] = currentQueries.parent;
   }
 
   registerPostOrderHooks(tView, previousOrParentTNode);
@@ -630,7 +644,9 @@ export function elementStart(
   const currentQueries = lView[QUERIES];
   if (currentQueries) {
     currentQueries.addNode(tNode);
+    lView[QUERIES] = currentQueries.clone();
   }
+  executeContentQueries(tView, tNode);
 }
 
 /**
@@ -668,17 +684,9 @@ function createDirectivesAndLocals(
   const previousOrParentTNode = getPreviousOrParentTNode();
   if (tView.firstTemplatePass) {
     ngDevMode && ngDevMode.firstTemplatePass++;
-
     resolveDirectives(
         tView, lView, findDirectiveMatches(tView, lView, previousOrParentTNode),
         previousOrParentTNode, localRefs || null);
-  } else {
-    // During first template pass, queries are created or cloned when first requested
-    // using `getOrCreateCurrentQueries`. For subsequent template passes, we clone
-    // any current LQueries here up-front if the current node hosts a content query.
-    if (isContentQueryHost(getPreviousOrParentTNode()) && lView[QUERIES]) {
-      lView[QUERIES] = lView[QUERIES] !.clone();
-    }
   }
   instantiateAllDirectives(tView, lView, previousOrParentTNode);
   invokeDirectivesHostBindings(tView, lView, previousOrParentTNode);
@@ -1068,8 +1076,7 @@ export function elementEnd(): void {
   const lView = getLView();
   const currentQueries = lView[QUERIES];
   if (currentQueries) {
-    lView[QUERIES] =
-        isContentQueryHost(previousOrParentTNode) ? currentQueries.parent : currentQueries;
+    lView[QUERIES] = currentQueries.parent;
   }
 
   registerPostOrderHooks(getLView()[TVIEW], previousOrParentTNode);
@@ -1803,8 +1810,8 @@ function postProcessDirective<T>(
     setInputsFromAttrs(directiveDefIdx, directive, def, previousOrParentTNode);
   }
 
-  if (def.contentQueries) {
-    def.contentQueries(directiveDefIdx);
+  if (viewData[TVIEW].firstTemplatePass && def.contentQueries) {
+    previousOrParentTNode.flags |= TNodeFlags.hasContentQuery;
   }
 
   if (isComponentDef(def)) {
@@ -2189,7 +2196,7 @@ function containerInternal(
 function addTContainerToQueries(lView: LView, tContainerNode: TContainerNode): void {
   const queries = lView[QUERIES];
   if (queries) {
-    lView[QUERIES] = queries.addNode(tContainerNode);
+    queries.addNode(tContainerNode);
     const lContainer = lView[tContainerNode.index];
     lContainer[QUERIES] = queries.container();
   }

--- a/packages/core/src/render3/interfaces/query.ts
+++ b/packages/core/src/render3/interfaces/query.ts
@@ -35,7 +35,7 @@ export interface LQueries {
    * Notify `LQueries` that a new `TNode` has been created and needs to be added to query results
    * if matching query predicate.
    */
-  addNode(tNode: TElementNode|TContainerNode|TElementContainerNode): LQueries|null;
+  addNode(tNode: TElementNode|TContainerNode|TElementContainerNode): void;
 
   /**
    * Notify `LQueries` that a new LContainer was added to ivy data structures. As a result we need

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -10,11 +10,8 @@ import {assertDefined} from '../util/assert';
 
 import {executeHooks} from './hooks';
 import {ComponentDef, DirectiveDef} from './interfaces/definition';
-import {TElementNode, TNode, TNodeFlags, TViewNode} from './interfaces/node';
-import {LQueries} from './interfaces/query';
-import {BINDING_INDEX, CONTEXT, DECLARATION_VIEW, FLAGS, InitPhaseState, LView, LViewFlags, OpaqueViewState, QUERIES, TVIEW, T_HOST} from './interfaces/view';
-import {isContentQueryHost} from './util';
-
+import {TElementNode, TNode, TViewNode} from './interfaces/node';
+import {BINDING_INDEX, CONTEXT, DECLARATION_VIEW, FLAGS, InitPhaseState, LView, LViewFlags, OpaqueViewState, TVIEW} from './interfaces/view';
 
 
 /**
@@ -165,28 +162,6 @@ export function setIsParent(value: boolean): void {
   isParent = value;
 }
 
-/**
- * Query instructions can ask for "current queries" in 2 different cases:
- * - when creating view queries (at the root of a component view, before any node is created - in
- * this case currentQueries points to view queries)
- * - when creating content queries (i.e. this previousOrParentTNode points to a node on which we
- * create content queries).
- */
-export function getOrCreateCurrentQueries(
-    QueryType: {new (parent: null, shallow: null, deep: null): LQueries}): LQueries {
-  const lView = getLView();
-  let currentQueries = lView[QUERIES];
-  // If this is the first content query on a node, any existing LQueries needs to be cloned.
-  // In subsequent template passes, the cloning occurs before directive instantiation
-  // in `createDirectivesAndLocals`.
-  if (previousOrParentTNode && previousOrParentTNode !== lView[T_HOST] &&
-      !isContentQueryHost(previousOrParentTNode)) {
-    currentQueries && (currentQueries = lView[QUERIES] = currentQueries.clone());
-    previousOrParentTNode.flags |= TNodeFlags.hasContentQuery;
-  }
-
-  return currentQueries || (lView[QUERIES] = new QueryType(null, null, null));
-}
 
 /** Checks whether a given view is in creation mode */
 export function isCreationMode(view: LView = lView): boolean {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -51,9 +51,6 @@
     "name": "HOST"
   },
   {
-    "name": "T_HOST"
-  },
-  {
     "name": "INJECTOR"
   },
   {
@@ -130,6 +127,9 @@
   },
   {
     "name": "TVIEW"
+  },
+  {
+    "name": "T_HOST"
   },
   {
     "name": "TriggerComponent"
@@ -265,6 +265,9 @@
   },
   {
     "name": "enterView"
+  },
+  {
+    "name": "executeContentQueries"
   },
   {
     "name": "executeHooks"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -81,9 +81,6 @@
     "name": "HOST"
   },
   {
-    "name": "T_HOST"
-  },
-  {
     "name": "INJECTOR"
   },
   {
@@ -217,6 +214,9 @@
   },
   {
     "name": "TVIEW"
+  },
+  {
+    "name": "T_HOST"
   },
   {
     "name": "TemplateRef"
@@ -571,6 +571,9 @@
   },
   {
     "name": "enterView"
+  },
+  {
+    "name": "executeContentQueries"
   },
   {
     "name": "executeHooks"

--- a/packages/core/test/forward_ref_integration_spec.ts
+++ b/packages/core/test/forward_ref_integration_spec.ts
@@ -40,8 +40,8 @@ class App {
 }
 
 @Component({
-  selector: 'lock',
-  template: `{{frame.name}}(<span *ngFor="let  lock of locks">{{lock.name}}</span>)`,
+  selector: 'door',
+  template: `{{frame.name}}(<span *ngFor="let lock of locks">{{lock.name}}</span>)`,
 })
 class Door {
   // TODO(issue/24571): remove '!'.

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -2385,7 +2385,7 @@ describe('query', () => {
               `Expected content query results to be available when ngAfterContentChecked was called.`);
     });
 
-    it('should support content query matches on directive hosts', () => {
+    it('should not match directive host with content queries', () => {
       /**
        * <div with-content #foo>
        * </div>
@@ -2398,7 +2398,7 @@ describe('query', () => {
 
       const fixture = new ComponentFixture(AppComponent);
       expect(withContentInstance !.foos.length)
-          .toBe(1, `Expected content query to match <div with-content #foo>.`);
+          .toBe(0, `Expected content query not to match <div with-content #foo>.`);
     });
 
     it('should match shallow content queries in views inserted / removed by ngIf', () => {
@@ -2629,7 +2629,7 @@ describe('query', () => {
 
       const fixture = new ComponentFixture(AppComponent);
       expect(outInstance !.fooBars.length).toBe(1);
-      expect(inInstance !.fooBars.length).toBe(2);
+      expect(inInstance !.fooBars.length).toBe(1);
     });
 
     it('should support nested shallow content queries across multiple component instances', () => {
@@ -2668,7 +2668,11 @@ describe('query', () => {
           function(rf: RenderFlags, ctx: any) {
             if (rf & RenderFlags.Create) {
               elementStart(0, 'div', ['query', ''], ['out', 'query']);
-              { element(2, 'div', ['query', ''], ['in', 'query', 'foo', '']); }
+              {
+                elementStart(2, 'div', ['query', ''], ['in', 'query', 'foo', '']);
+                { element(5, 'span', ['id', 'bar'], ['foo', '']); }
+                elementEnd();
+              }
               elementEnd();
             }
             if (rf & RenderFlags.Update) {
@@ -2676,7 +2680,7 @@ describe('query', () => {
               inInstance = load<QueryDirective>(3);
             }
           },
-          5, 0, [QueryDirective]);
+          7, 0, [QueryDirective]);
 
       const fixture1 = new ComponentFixture(AppComponent);
       expect(outInstance !.fooBars.length).toBe(1);

--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AfterContentInit, ChangeDetectorRef, ContentChildren, Directive, ElementRef, Input, OnChanges, OnDestroy, QueryList, Renderer2, SimpleChanges} from '@angular/core';
+import {AfterContentInit, ContentChildren, Directive, ElementRef, Input, OnChanges, OnDestroy, Optional, QueryList, Renderer2, SimpleChanges} from '@angular/core';
 import {Subscription} from 'rxjs';
 
 import {NavigationEnd, RouterEvent} from '../events';
@@ -93,7 +93,8 @@ export class RouterLinkActive implements OnChanges,
 
   constructor(
       private router: Router, private element: ElementRef, private renderer: Renderer2,
-      private cdr: ChangeDetectorRef) {
+      @Optional() private link?: RouterLink,
+      @Optional() private linkWithHref?: RouterLinkWithHref) {
     this.subscription = router.events.subscribe((s: RouterEvent) => {
       if (s instanceof NavigationEnd) {
         this.update();
@@ -140,7 +141,9 @@ export class RouterLinkActive implements OnChanges,
   }
 
   private hasActiveLinks(): boolean {
-    return this.links.some(this.isLinkActive(this.router)) ||
-        this.linksWithHrefs.some(this.isLinkActive(this.router));
+    const isActiveCheckFn = this.isLinkActive(this.router);
+    return this.link && isActiveCheckFn(this.link) ||
+        this.linkWithHref && isActiveCheckFn(this.linkWithHref) ||
+        this.links.some(isActiveCheckFn) || this.linksWithHrefs.some(isActiveCheckFn);
   }
 }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -3578,7 +3578,6 @@ describe('Integration', () => {
 
          TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
          const router: Router = TestBed.get(Router);
-         const loc: any = TestBed.get(Location);
 
          const f = TestBed.createComponent(RootCmpWithLink);
          advance(f);

--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -389,14 +389,6 @@ window.testBlocklist = {
     "error": "TypeError: Cannot read property 'removeEventListener' of null",
     "notes": "FW-1010: onDestroy hook is called twice for directives that are also used in a provider"
   },
-  "CdkDrag in a drop container should dispatch the `dropped` event when an item has been dropped": {
-    "error": "TypeError: Cannot read property 'clientRect' of undefined",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "CdkDrag in a drop container should expose whether an item was dropped over a container": {
-    "error": "TypeError: Cannot read property 'clientRect' of undefined",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
   "CdkDrag in a drop container should dispatch the `sorted` event as an item is being sorted": {
     "error": "TypeError: Cannot read property 'args' of undefined",
     "notes": "Unknown"
@@ -405,41 +397,9 @@ window.testBlocklist = {
     "error": "Error: Expected $.previousIndex = -1 to equal 0.",
     "notes": "Unknown"
   },
-  "CdkDrag in a drop container should not move the original element from its initial DOM position": {
-    "error": "TypeError: Cannot read property 'clientRect' of undefined",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "CdkDrag in a drop container should dispatch the `dropped` event in a horizontal drop zone": {
-    "error": "TypeError: Cannot read property 'clientRect' of undefined",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "CdkDrag in a drop container should dispatch the correct `dropped` event in RTL horizontal drop zone": {
-    "error": "TypeError: Cannot read property 'clientRect' of undefined",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
   "CdkDrag in a drop container should not move items in a horizontal list if pointer is too far away": {
     "error": "Error: Expected $.previousIndex = -1 to equal 0.",
     "notes": "Unknown"
-  },
-  "CdkDrag in a drop container should remove the preview if its `transitionend` event timed out": {
-    "error": "TypeError: Cannot read property 'clientRect' of undefined",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "CdkDrag in a drop container should emit the released event as soon as the item is released": {
-    "error": "TypeError: Cannot read property 'clientRect' of undefined",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "CdkDrag in a drop container should reset immediately when failed drag happens after a successful one": {
-    "error": "TypeError: Cannot read property 'clientRect' of undefined",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "CdkDrag in a drop container should not wait for transition that are not on the `transform` property": {
-    "error": "TypeError: Cannot read property 'clientRect' of undefined",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "CdkDrag in a drop container should pick out the `transform` duration if multiple properties are being transitioned": {
-    "error": "TypeError: Cannot read property 'clientRect' of undefined",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
   },
   "CdkDrag in a drop container should move the placeholder as an item is being sorted down": {
     "error": "Error: Expected 0 to be 1.",
@@ -3248,66 +3208,6 @@ window.testBlocklist = {
   "MatGridList should throw error if rowHeight ratio is invalid": {
     "error": "Error: mat-grid-list: invalid ratio given for row-height: \"4:3:2\"",
     "notes": "Unknown"
-  },
-  "MatSelectionList without forms with list option should restore focus if active option is destroyed": {
-    "error": "Error: Expected -1 to be 3.",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "MatSelectionList without forms with list option should not attempt to focus the next option when the destroyed option was not focused": {
-    "error": "Error: Expected -1 to be 3.",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "MatSelectionList without forms with list option should focus and toggle the next item when pressing SHIFT + UP_ARROW": {
-    "error": "Error: Expected -1 to be 3.",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "MatSelectionList without forms with list option should focus next item when press DOWN ARROW": {
-    "error": "Error: Expected 0 to equal 3.",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "MatSelectionList without forms with list option should focus the last item when pressing END": {
-    "error": "Error: Expected 2 to be 3.",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "MatSelectionList without forms with list option should select all items using ctrl + a": {
-    "error": "Error: Expected false to be true.",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "MatSelectionList without forms with list option should select all items using ctrl + a if some items are selected": {
-    "error": "Error: Expected false to be true.",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "MatSelectionList without forms with list option should be able to jump focus down to an item by typing": {
-    "error": "Error: Expected 1 to be 3.",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "MatSelectionList with forms and ngModel should update the model if an option got selected programmatically": {
-    "error": "Error: Expected 0 to be 1, 'Expected first list option to be selected'.",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "MatSelectionList with forms and ngModel should update the model if an option got clicked": {
-    "error": "Error: Expected 0 to be 1, 'Expected first list option to be selected'.",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "MatSelectionList with forms and ngModel should remove a selected option from the value on destroy": {
-    "error": "Error: Expected $.length = 0 to equal 2.",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "MatSelectionList with forms and ngModel should update the model if an option got selected via the model": {
-    "error": "Error: Expected $.length = 0 to equal 1.",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "MatSelectionList with forms and ngModel should be able to programmatically set an array with duplicate values": {
-    "error": "Error: Expected $[0] = false to equal true.",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "MatSelectionList with forms preselected values should show the item as selected when preselected inside OnPush parent": {
-    "error": "Error: Expected false to be true.",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
-  },
-  "MatSelectionList with forms with custom compare function should use a custom comparator to determine which options are selected": {
-    "error": "Error: Expected spy comparator to have been called.",
-    "notes": "FW-803: Queries for root nodes of embedded views aren't working properly"
   }
 };
 // clang-format on

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -390,7 +390,7 @@ export declare class RouterLinkActive implements OnChanges, OnDestroy, AfterCont
     routerLinkActiveOptions: {
         exact: boolean;
     };
-    constructor(router: Router, element: ElementRef, renderer: Renderer2, cdr: ChangeDetectorRef);
+    constructor(router: Router, element: ElementRef, renderer: Renderer2, link?: RouterLink | undefined, linkWithHref?: RouterLinkWithHref | undefined);
     ngAfterContentInit(): void;
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;


### PR DESCRIPTION
This PR fixes FW-803 (Queries for root nodes of embedded views aren't working properly).

While fixing this bug and going through the existing query logic I've realised that:
* with the current implementation a content child / children query can select a host node on which it is defined - while this is the behaviour of the view engine, it is also very counter-intuitive and was reported as a bug (#10098) breaking several real-life use cases;
* the fact that a query can match its host significantly contributes to the queries code complexity so actually fixing makes the query code smaller and easier to follow.

Given the above this PR can be seen as:
* a fix for FW-803;
* a fix for #10098
* a refactoring that significantly simplifies existing queries code (several methods with non-trivial branching logic are simplified - `getOrCreateCurrentQueries ` goes away and `addNode` becomes trivial).

**Note**:  a fix for #10098 could be seen as a breaking change, as proven by the needed fix to the `routerLinkActive` directive. It is definitively a change in behaviour but I would argue that this is a fix / improvement as previously people had trouble properly write tree-like directives. Not to mention that  `ContentChild` \ `ContentChildren` name indicates that a query should look for its children (and not try to match itself).

**Note**:  @IgorMinar `public_api_guard/router/router.d.ts` file changed while it _is_ a breaking change, technically speaking, its impact on the real-life code should be minimal. Nothing changes in the template usage and the only impact could happen in the following cases:
* instantiating a directive directly (ex. in tests) - I don't believe that anyone is doing this as this directive can't function without providing child elements and you can't do this when testing a class directly;
* extending a directive - it might happen that people extend the `RouterLinkActive` directive and in this case they would be impacted. At the same time I'm not sure if we officially support this usage.
