### PR TITLE
fix(ivy): remove nested placeholders with i18n

### DIFF
--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -854,9 +854,6 @@ function removeNode(index: number, viewData: LView) {
     nativeRemoveNode(viewData[RENDERER], removedPhRNode);
   }
 
-  removedPhTNode.detached = true;
-  ngDevMode && ngDevMode.rendererRemoveNode++;
-
   const slotValue = load(index) as RElement | RComment | LContainer | StylingContext;
   if (isLContainer(slotValue)) {
     const lContainer = slotValue as LContainer;
@@ -864,6 +861,8 @@ function removeNode(index: number, viewData: LView) {
       nativeRemoveNode(viewData[RENDERER], lContainer[NATIVE]);
     }
   }
+
+  ngDevMode && ngDevMode.rendererRemoveNode++;
 }
 
 /**

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1274,7 +1274,6 @@ export function createTNode(
     next: null,
     child: null,
     parent: tParent,
-    detached: null,
     stylingTemplate: null,
     projection: null
   };
@@ -2227,7 +2226,7 @@ export function containerRefreshEnd(): void {
 
   // remove extra views at the end of the container
   while (nextIndex < lContainer[VIEWS].length) {
-    removeView(lContainer, previousOrParentTNode as TContainerNode, nextIndex);
+    removeView(lContainer, nextIndex);
   }
 }
 
@@ -2258,14 +2257,11 @@ function refreshDynamicEmbeddedViews(lView: LView) {
  * Removes views that need to be deleted in the process.
  *
  * @param lContainer to search for views
- * @param tContainerNode to search for views
  * @param startIdx starting index in the views array to search from
  * @param viewBlockId exact view block id to look for
  * @returns index of a found view or -1 if not found
  */
-function scanForView(
-    lContainer: LContainer, tContainerNode: TContainerNode, startIdx: number,
-    viewBlockId: number): LView|null {
+function scanForView(lContainer: LContainer, startIdx: number, viewBlockId: number): LView|null {
   const views = lContainer[VIEWS];
   for (let i = startIdx; i < views.length; i++) {
     const viewAtPositionId = views[i][TVIEW].id;
@@ -2273,7 +2269,7 @@ function scanForView(
       return views[i];
     } else if (viewAtPositionId < viewBlockId) {
       // found a view that should not be at this position - remove
-      removeView(lContainer, tContainerNode, i);
+      removeView(lContainer, i);
     } else {
       // found a view with id greater than the one we are searching for
       // which means that required view doesn't exist and can't be found at
@@ -2300,8 +2296,7 @@ export function embeddedViewStart(viewBlockId: number, consts: number, vars: num
   const lContainer = lView[containerTNode.index] as LContainer;
 
   ngDevMode && assertNodeType(containerTNode, TNodeType.Container);
-  let viewToRender = scanForView(
-      lContainer, containerTNode as TContainerNode, lContainer[ACTIVE_INDEX] !, viewBlockId);
+  let viewToRender = scanForView(lContainer, lContainer[ACTIVE_INDEX] !, viewBlockId);
 
   if (viewToRender) {
     setIsParent(true);

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -304,12 +304,6 @@ export interface TNode {
    */
   parent: TElementNode|TContainerNode|null;
 
-  /**
-   * If this node is part of an i18n block, it indicates whether this node is part of the DOM.
-   * If this node is not part of an i18n block, this field is null.
-   */
-  detached: boolean|null;
-
   stylingTemplate: StylingContext|null;
   /**
    * List of projected TNodes for a given component host element OR index into the said nodes.

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -323,19 +323,16 @@ export function insertView(
  *
  * @param lContainer The container from which to detach a view
  * @param removeIndex The index of the view to detach
- * @param detached Whether or not this view is already detached.
  * @returns Detached LView instance.
  */
-export function detachView(lContainer: LContainer, removeIndex: number, detached: boolean): LView {
+export function detachView(lContainer: LContainer, removeIndex: number): LView {
   const views = lContainer[VIEWS];
   const viewToDetach = views[removeIndex];
   if (removeIndex > 0) {
     views[removeIndex - 1][NEXT] = viewToDetach[NEXT] as LView;
   }
   views.splice(removeIndex, 1);
-  if (!detached) {
-    addRemoveViewFromContainer(viewToDetach, false);
-  }
+  addRemoveViewFromContainer(viewToDetach, false);
 
   if (viewToDetach[QUERIES]) {
     viewToDetach[QUERIES] !.removeView();
@@ -351,14 +348,11 @@ export function detachView(lContainer: LContainer, removeIndex: number, detached
  * Removes a view from a container, i.e. detaches it and then destroys the underlying LView.
  *
  * @param lContainer The container from which to remove a view
- * @param tContainer The TContainer node associated with the LContainer
  * @param removeIndex The index of the view to remove
  */
-export function removeView(
-    lContainer: LContainer, containerHost: TElementNode | TContainerNode | TElementContainerNode,
-    removeIndex: number) {
+export function removeView(lContainer: LContainer, removeIndex: number) {
   const view = lContainer[VIEWS][removeIndex];
-  detachView(lContainer, removeIndex, !!containerHost.detached);
+  detachView(lContainer, removeIndex);
   destroyLView(view);
 }
 

--- a/packages/core/src/render3/view_engine_compatibility.ts
+++ b/packages/core/src/render3/view_engine_compatibility.ts
@@ -264,13 +264,13 @@ export function createContainerRef(
 
       remove(index?: number): void {
         const adjustedIdx = this._adjustIndex(index, -1);
-        removeView(this._lContainer, this._hostTNode, adjustedIdx);
+        removeView(this._lContainer, adjustedIdx);
         this._viewRefs.splice(adjustedIdx, 1);
       }
 
       detach(index?: number): viewEngine_ViewRef|null {
         const adjustedIdx = this._adjustIndex(index, -1);
-        const view = detachView(this._lContainer, adjustedIdx, !!this._hostTNode.detached);
+        const view = detachView(this._lContainer, adjustedIdx);
         const wasDetached = this._viewRefs.splice(adjustedIdx, 1)[0] != null;
         return wasDetached ? new ViewRef(view, view[CONTEXT], view[CONTAINER_INDEX]) : null;
       }

--- a/packages/core/test/render3/i18n_spec.ts
+++ b/packages/core/test/render3/i18n_spec.ts
@@ -1771,7 +1771,7 @@ describe('Runtime i18n', () => {
             selectors: [['parent']],
             directives: [Child],
             factory: () => new Parent(),
-            consts: 2,
+            consts: 3,
             vars: 0,
             template: (rf: RenderFlags, cmp: Parent) => {
               if (rf & RenderFlags.Create) {


### PR DESCRIPTION
While testing that queries where unaffected by i18n translation that removed placeholders, I noticed that we actually forgot to remove nested placeholders because the logic to check for removed placeholders was wrong. We were using `previousOrParentTNode` to get the last created node, but it turns out that when you call `elementEnd`, `previousOrParentTNode` becomes the parent of the current node, and we would stop our check at the wrong index (index of the parent instead of the index of the last node).