### PR TITLE
docs: display the beginning label in interpolation guide example

### DIFF
--- a/aio/content/examples/interpolation/src/app/app.component.html
+++ b/aio/content/examples/interpolation/src/app/app.component.html
@@ -50,9 +50,10 @@
 
 <div (keyup)="0">
   <h4>Template context: template reference variables (#customerInput):</h4>
-  <label>Type something:
   <!-- #docregion template-reference-variable -->
-  <input #customerInput>{{customerInput.value}}</label>
+  <label>Type something:
+    <input #customerInput>{{customerInput.value}}
+  </label>
   <!-- #enddocregion template-reference-variable -->
 </div>
 


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The docs looked strange with a hanging </label> tag. I included the full context. 
Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
