### PR TITLE
fix(ivy): support web worker nodes in unknown property checks

### DIFF
--- a/modules/playground/e2e_test/web_workers/todo/BUILD.bazel
+++ b/modules/playground/e2e_test/web_workers/todo/BUILD.bazel
@@ -4,5 +4,4 @@ example_test(
     name = "todo",
     srcs = glob(["**/*.ts"]),
     server = "//modules/playground/src/web_workers/todo:devserver",
-    tags = ["fixme-ivy-aot"],
 )

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1217,6 +1217,8 @@ function validateAgainstUnknownProperties(
     element: RElement | RComment, propName: string, tNode: TNode) {
   // If prop is not a known property of the HTML element...
   if (!(propName in element) &&
+      // and we are in a browser context... (web worker nodes should be skipped)
+      typeof Node === 'function' && element instanceof Node &&
       // and isn't a synthetic animation property...
       propName[0] !== ANIMATION_PROP_PREFIX) {
     // ... it is probably a user error and we should throw.


### PR DESCRIPTION
We need to support rendering in contexts like web workers where
nodes are emulated and properties may not be set directly. This
commit gates property validation checks to environments that have
real Node objects.

FW-1043 #resolve