### PR TITLE
ci: add all required statuses to the requiredStatuses list for angular-robot

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -103,6 +103,11 @@ merge:
     requiredStatuses:
       - "ci/circleci: build"
       - "ci/circleci: lint"
+      - "ci/circleci: publish_snapshot"
+      - "ci/angular: size"
+      - "cla/google"
+      - "google3"
+
 
   # the comment that will be added when the merge label is added despite failing checks, leave empty or set to false to disable
   # {{MERGE_LABEL}} will be replaced by the value of the mergeLabel option


### PR DESCRIPTION
Somehow the current list ommits quite a few important targets. Especially the cla and google3.

This changes adds all the statuses that must always be present and green for this aggregate state expised as "ci/angular: merge status" to be green.

This is the problem that this PR is attempting to solve:
<img width="828" alt="screen shot 2019-02-07 at 10 00 33 pm" src="https://user-images.githubusercontent.com/216296/52461426-d346e800-2b23-11e9-891c-82bb02e38abb.png">

however after submitting this PR I realized that unless there is a google3 impacting change in the PR the bot doesn't push a commit status called "google3" so that status is currently only present for some changes.

BLOCKING NOTE: That means that this PR can't be merged as is, as is blocked on a fix in the bot that always pushes the g3 status to all PR. If a PR does not have g3 impact, it should be marked as green with a status note stating "No google3 impact" - See: https://github.com/angular/github-robot/issues/40