### PR TITLE
build: fix invalid bazel target referenced by benchmarks

### DIFF
--- a/bazel-out
+++ b/bazel-out
@@ -1,1 +1,0 @@
-/private/var/tmp/_bazel_misko/1126e726ab9a0d0ed3e2392a7bbe5a3c/execroot/angular/bazel-out

--- a/modules/benchmarks/src/largetable/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/BUILD.bazel
@@ -21,7 +21,7 @@ ts_library(
         "largetable_perf.spec.ts",
     ],
     deps = [
-        "//modules/e2e_util:lib",
+        "//modules/e2e_util",
         "//packages:types",
         "@ngdeps//protractor",
     ],

--- a/modules/e2e_util/BUILD.bazel
+++ b/modules/e2e_util/BUILD.bazel
@@ -3,7 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
-    name = "lib",
+    name = "e2e_util",
     testonly = 1,
     srcs = glob(["*.ts"]),
     deps = [


### PR DESCRIPTION
**[PATCH FIX]**

* Fixes that the recently migrated benchmark Bazel package references an invalid bazel target. This is because the patch branch is not completely in sync with `master`.
* Removes the `bazel-out` symlink that seems to have been introduced somewhere accidentally.