### PR TITLE
feat(ivy): allow non-unique #localRefs to be defined in a template

### DIFF
--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1471,7 +1471,7 @@ describe('ngtsc behavioral tests', () => {
     });
   });
 
-  describe('duplicate local refs', () => {
+  describe('multiple local refs', () => {
     const getComponentScript = (template: string): string => `
       import {Component, Directive, NgModule} from '@angular/core';
 
@@ -1482,37 +1482,17 @@ describe('ngtsc behavioral tests', () => {
       class Module {}
     `;
 
-    // Components with templates listed below should
-    // throw the "ref is already defined" error
-    const invalidCases = [
+    const cases = [
       `
         <div #ref></div>
         <div #ref></div>
-      `,
-      `
-        <div #ref>
-          <div #ref></div>
-        </div>
-      `,
-      `
-        <div>
-          <div #ref></div>
-        </div>
-        <div>
-          <div #ref></div>
-        </div>
       `,
       `
         <ng-container>
           <div #ref></div>
         </ng-container>
         <div #ref></div>
-      `
-    ];
-
-    // Components with templates listed below should not throw
-    // the error, since refs are located in different scopes
-    const validCases = [
+      `,
       `
         <ng-template>
           <div #ref></div>
@@ -1529,18 +1509,8 @@ describe('ngtsc behavioral tests', () => {
       `
     ];
 
-    invalidCases.forEach(template => {
-      it('should throw in case of duplicate refs', () => {
-        env.tsconfig();
-        env.write('test.ts', getComponentScript(template));
-        const errors = env.driveDiagnostics();
-        expect(errors[0].messageText)
-            .toContain('Internal Error: The name ref is already defined in scope');
-      });
-    });
-
-    validCases.forEach(template => {
-      it('should not throw in case refs are in different scopes', () => {
+    cases.forEach(template => {
+      it('should not throw', () => {
         env.tsconfig();
         env.write('test.ts', getComponentScript(template));
         const errors = env.driveDiagnostics();

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1395,8 +1395,9 @@ export class BindingScope implements LocalResolver {
   set(retrievalLevel: number, name: string, lhs: o.ReadVarExpr,
       priority: number = DeclarationPriority.DEFAULT,
       declareLocalCallback?: DeclareLocalVarCallback, localRef?: true): BindingScope {
-    !this.map.has(name) ||
-        error(`The name ${name} is already defined in scope to be ${this.map.get(name)}`);
+    if (!localRef && this.map.has(name)) {
+      error(`The name ${name} is already defined in scope to be ${this.map.get(name)}`);
+    }
     this.map.set(name, {
       retrievalLevel: retrievalLevel,
       lhs: lhs,

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1395,7 +1395,12 @@ export class BindingScope implements LocalResolver {
   set(retrievalLevel: number, name: string, lhs: o.ReadVarExpr,
       priority: number = DeclarationPriority.DEFAULT,
       declareLocalCallback?: DeclareLocalVarCallback, localRef?: true): BindingScope {
-    if (!localRef && this.map.has(name)) {
+    if (this.map.has(name)) {
+      if (localRef) {
+        // Do not throw an error if it's a local ref and do not update existing value,
+        // so the first defined ref is always returned.
+        return this;
+      }
       error(`The name ${name} is already defined in scope to be ${this.map.get(name)}`);
     }
     this.map.set(name, {

--- a/packages/core/test/acceptance/exports_spec.ts
+++ b/packages/core/test/acceptance/exports_spec.ts
@@ -55,6 +55,19 @@ describe('exports', () => {
     expect(dirWithInput.comp).toEqual(myComp);
   });
 
+
+  it('should point to the first declared ref', () => {
+    const fixture = initWithTemplate(AppComp, `
+      <div>
+        <input value="First" #ref />
+        <input value="Second" #ref />
+        <input value="Third" #ref />
+        <span>{{ ref.value }}</span>
+      </div>
+    `);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('span').innerHTML).toBe('First');
+  });
 });
 
 function initWithTemplate(compType: Type<any>, template: string) {

--- a/packages/core/test/acceptance/exports_spec.ts
+++ b/packages/core/test/acceptance/exports_spec.ts
@@ -56,18 +56,20 @@ describe('exports', () => {
   });
 
 
-  it('should point to the first declared ref', () => {
-    const fixture = initWithTemplate(AppComp, `
-      <div>
-        <input value="First" #ref />
-        <input value="Second" #ref />
-        <input value="Third" #ref />
-        <span>{{ ref.value }}</span>
-      </div>
-    `);
-    fixture.detectChanges();
-    expect(fixture.nativeElement.querySelector('span').innerHTML).toBe('First');
-  });
+  onlyInIvy(
+      'in Ivy first declared ref is selected in case of multiple non-unique refs, when VE used the last one')
+      .it('should point to the first declared ref', () => {
+        const fixture = initWithTemplate(AppComp, `
+          <div>
+            <input value="First" #ref />
+            <input value="Second" #ref />
+            <input value="Third" #ref />
+            <span>{{ ref.value }}</span>
+          </div>
+        `);
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('span').innerHTML).toBe('First');
+      });
 });
 
 function initWithTemplate(compType: Type<any>, template: string) {

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -129,8 +129,7 @@ describe('query logic', () => {
      });
 
   onlyInIvy('multiple local refs are supported in Ivy')
-      .fit(
-          'should return ElementRefs when HTML elements are labelled and retrieved via Content query',
+      .it('should return ElementRefs when HTML elements are labelled and retrieved via Content query',
           () => {
             const template = `
               <local-ref-query-component #q>

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -1,0 +1,213 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, ContentChild, ContentChildren, ElementRef, QueryList, TemplateRef, Type, ViewChild, ViewChildren} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {onlyInIvy} from '@angular/private/testing';
+
+
+describe('query logic', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({declarations: [AppComp, QueryComp, SimpleCompA, SimpleCompB]});
+  });
+
+  it('should return Component instances when Components are labelled and retrieved via View query',
+     () => {
+       const template = `
+         <div><simple-comp-a #viewQuery></simple-comp-a></div>
+         <div><simple-comp-b #viewQuery></simple-comp-b></div>
+       `;
+       const fixture = initWithTemplate(QueryComp, template);
+       const comp = fixture.componentInstance;
+       expect(comp.viewChild).toBeAnInstanceOf(SimpleCompA);
+       expect(comp.viewChildren.first).toBeAnInstanceOf(SimpleCompA);
+       expect(comp.viewChildren.last).toBeAnInstanceOf(SimpleCompB);
+     });
+
+  it('should return Component instance when Component is labelled and retrieved via Content query',
+     () => {
+       const template = `
+         <local-ref-query-component #q>
+           <simple-comp-a #contentQuery></simple-comp-a>
+         </local-ref-query-component>
+       `;
+       const fixture = initWithTemplate(AppComp, template);
+       const comp = fixture.debugElement.children[0].references['q'];
+       expect(comp.contentChild).toBeAnInstanceOf(SimpleCompA);
+       expect(comp.contentChildren.first).toBeAnInstanceOf(SimpleCompA);
+     });
+
+  onlyInIvy('multiple local refs are supported in Ivy')
+      .it('should return Component instances when Components are labelled and retrieved via Content query',
+          () => {
+            const template = `
+              <local-ref-query-component #q>
+                <simple-comp-a #contentQuery></simple-comp-a>
+                <simple-comp-b #contentQuery></simple-comp-b>
+              </local-ref-query-component>
+            `;
+            const fixture = initWithTemplate(AppComp, template);
+            const comp = fixture.debugElement.children[0].references['q'];
+            expect(comp.contentChild).toBeAnInstanceOf(SimpleCompA);
+            expect(comp.contentChildren.first).toBeAnInstanceOf(SimpleCompA);
+            expect(comp.contentChildren.last).toBeAnInstanceOf(SimpleCompB);
+            expect(comp.contentChildren.length).toBe(2);
+          });
+
+  it('should return ElementRef when HTML element is labelled and retrieved via View query', () => {
+    const template = `
+      <div #viewQuery></div>
+    `;
+    const fixture = initWithTemplate(QueryComp, template);
+    const comp = fixture.componentInstance;
+    expect(comp.viewChild).toBeAnInstanceOf(ElementRef);
+    expect(comp.viewChildren.first).toBeAnInstanceOf(ElementRef);
+  });
+
+  onlyInIvy('multiple local refs are supported in Ivy')
+      .it('should return ElementRefs when HTML elements are labelled and retrieved via View query',
+          () => {
+            const template = `
+              <div #viewQuery #first>A</div>
+              <div #viewQuery #second>B</div>
+            `;
+            const fixture = initWithTemplate(QueryComp, template);
+            const comp = fixture.componentInstance;
+
+            expect(comp.viewChild).toBeAnInstanceOf(ElementRef);
+            expect(comp.viewChild.nativeElement)
+                .toBe(fixture.debugElement.children[0].nativeElement);
+
+            expect(comp.viewChildren.first).toBeAnInstanceOf(ElementRef);
+            expect(comp.viewChildren.last).toBeAnInstanceOf(ElementRef);
+            expect(comp.viewChildren.length).toBe(2);
+          });
+
+  it('should return TemplateRef when template is labelled and retrieved via View query', () => {
+    const template = `
+      <ng-template #viewQuery></ng-template>
+    `;
+    const fixture = initWithTemplate(QueryComp, template);
+    const comp = fixture.componentInstance;
+    expect(comp.viewChildren.first).toBeAnInstanceOf(TemplateRef);
+  });
+
+  onlyInIvy('multiple local refs are supported in Ivy')
+      .it('should return TemplateRefs when templates are labelled and retrieved via View query',
+          () => {
+            const template = `
+              <ng-template #viewQuery></ng-template>
+              <ng-template #viewQuery></ng-template>
+            `;
+            const fixture = initWithTemplate(QueryComp, template);
+            const comp = fixture.componentInstance;
+            expect(comp.viewChild).toBeAnInstanceOf(TemplateRef);
+            expect(comp.viewChild.elementRef.nativeElement)
+                .toBe(fixture.debugElement.childNodes[0].nativeNode);
+
+            expect(comp.viewChildren.first).toBeAnInstanceOf(TemplateRef);
+            expect(comp.viewChildren.last).toBeAnInstanceOf(TemplateRef);
+            expect(comp.viewChildren.length).toBe(2);
+          });
+
+  it('should return ElementRef when HTML element is labelled and retrieved via Content query',
+     () => {
+       const template = `
+         <local-ref-query-component #q>
+           <div #contentQuery></div>
+         </local-ref-query-component>
+       `;
+       const fixture = initWithTemplate(AppComp, template);
+       const comp = fixture.debugElement.children[0].references['q'];
+       expect(comp.contentChildren.first).toBeAnInstanceOf(ElementRef);
+     });
+
+  onlyInIvy('multiple local refs are supported in Ivy')
+      .fit(
+          'should return ElementRefs when HTML elements are labelled and retrieved via Content query',
+          () => {
+            const template = `
+              <local-ref-query-component #q>
+                <div #contentQuery></div>
+                <div #contentQuery></div>
+              </local-ref-query-component>
+            `;
+            const fixture = initWithTemplate(AppComp, template);
+            const firstChild = fixture.debugElement.children[0];
+            const comp = firstChild.references['q'];
+
+            expect(comp.contentChild).toBeAnInstanceOf(ElementRef);
+            expect(comp.contentChild.nativeElement).toBe(firstChild.children[0].nativeElement);
+
+            expect(comp.contentChildren.first).toBeAnInstanceOf(ElementRef);
+            expect(comp.contentChildren.last).toBeAnInstanceOf(ElementRef);
+            expect(comp.contentChildren.length).toBe(2);
+          });
+
+  it('should return TemplateRef when template is labelled and retrieved via Content query', () => {
+    const template = `
+       <local-ref-query-component #q>
+         <ng-template #contentQuery></ng-template>
+       </local-ref-query-component>
+     `;
+    const fixture = initWithTemplate(AppComp, template);
+    const comp = fixture.debugElement.children[0].references['q'];
+    expect(comp.contentChildren.first).toBeAnInstanceOf(TemplateRef);
+  });
+
+  onlyInIvy('multiple local refs are supported in Ivy')
+      .it('should return TemplateRefs when templates are labelled and retrieved via Content query',
+          () => {
+            const template = `
+              <local-ref-query-component #q>
+                <ng-template #contentQuery></ng-template>
+                <ng-template #contentQuery></ng-template>
+              </local-ref-query-component>
+            `;
+            const fixture = initWithTemplate(AppComp, template);
+            const firstChild = fixture.debugElement.children[0];
+            const comp = firstChild.references['q'];
+
+            expect(comp.contentChild).toBeAnInstanceOf(TemplateRef);
+            expect(comp.contentChild.elementRef.nativeElement)
+                .toBe(firstChild.childNodes[0].nativeNode);
+
+            expect(comp.contentChildren.first).toBeAnInstanceOf(TemplateRef);
+            expect(comp.contentChildren.last).toBeAnInstanceOf(TemplateRef);
+            expect(comp.contentChildren.length).toBe(2);
+          });
+});
+
+function initWithTemplate(compType: Type<any>, template: string) {
+  TestBed.overrideComponent(compType, {set: new Component({template})});
+  const fixture = TestBed.createComponent(compType);
+  fixture.detectChanges();
+  return fixture;
+}
+
+@Component({selector: 'local-ref-query-component', template: '<ng-content></ng-content>'})
+class QueryComp {
+  @ViewChild('viewQuery') viewChild !: any;
+  @ContentChild('contentQuery') contentChild !: any;
+
+  @ViewChildren('viewQuery') viewChildren !: QueryList<any>;
+  @ContentChildren('contentQuery') contentChildren !: QueryList<any>;
+}
+
+@Component({selector: 'app-comp', template: ``})
+class AppComp {
+}
+
+@Component({selector: 'simple-comp-a', template: ''})
+class SimpleCompA {
+}
+
+@Component({selector: 'simple-comp-b', template: ''})
+class SimpleCompB {
+}

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -559,6 +559,22 @@ function declareTests(config?: {useJit: boolean}) {
           expect(fixture.debugElement.children[0].children[0].references !['superAlice'])
               .toBeAnInstanceOf(ChildComp);
         });
+
+        it('should point to the last declared ref', () => {
+          TestBed.configureTestingModule({declarations: [MyComp, ChildComp]});
+          const template = `
+            <div>
+              <input value="First" #ref />
+              <input value="Second" #ref />
+              <input value="Third" #ref />
+              <span>{{ ref.value }}</span>
+            </div>
+          `;
+          TestBed.overrideComponent(MyComp, {set: {template}});
+          const fixture = TestBed.createComponent(MyComp);
+          fixture.detectChanges();
+          expect(fixture.nativeElement.querySelector('span')).toHaveText('Third');
+        });
       });
 
       describe('variables', () => {

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -559,22 +559,6 @@ function declareTests(config?: {useJit: boolean}) {
           expect(fixture.debugElement.children[0].children[0].references !['superAlice'])
               .toBeAnInstanceOf(ChildComp);
         });
-
-        it('should point to the last declared ref', () => {
-          TestBed.configureTestingModule({declarations: [MyComp, ChildComp]});
-          const template = `
-            <div>
-              <input value="First" #ref />
-              <input value="Second" #ref />
-              <input value="Third" #ref />
-              <span>{{ ref.value }}</span>
-            </div>
-          `;
-          TestBed.overrideComponent(MyComp, {set: {template}});
-          const fixture = TestBed.createComponent(MyComp);
-          fixture.detectChanges();
-          expect(fixture.nativeElement.querySelector('span')).toHaveText('Third');
-        });
       });
 
       describe('variables', () => {

--- a/packages/core/test/linker/query_integration_spec.ts
+++ b/packages/core/test/linker/query_integration_spec.ts
@@ -6,13 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, Component, ContentChild, ContentChildren, Directive, QueryList, TemplateRef, Type, ViewChild, ViewChildren, ViewContainerRef, asNativeElements} from '@angular/core';
+import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, Component, ContentChild, ContentChildren, Directive, ElementRef, QueryList, TemplateRef, Type, ViewChild, ViewChildren, ViewContainerRef, asNativeElements} from '@angular/core';
 import {ComponentFixture, TestBed, async} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {fixmeIvy, ivyEnabled, modifiedInIvy, onlyInIvy} from '@angular/private/testing';
 import {Subject} from 'rxjs';
 
-import {ElementRef} from '../../src/core';
 import {stringify} from '../../src/util/stringify';
 
 describe('Query API', () => {

--- a/packages/core/test/linker/query_integration_spec.ts
+++ b/packages/core/test/linker/query_integration_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, Component, ContentChild, ContentChildren, Directive, ElementRef, QueryList, TemplateRef, Type, ViewChild, ViewChildren, ViewContainerRef, asNativeElements} from '@angular/core';
+import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, Component, ContentChild, ContentChildren, Directive, QueryList, TemplateRef, Type, ViewChild, ViewChildren, ViewContainerRef, asNativeElements} from '@angular/core';
 import {ComponentFixture, TestBed, async} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {fixmeIvy, ivyEnabled, modifiedInIvy, onlyInIvy} from '@angular/private/testing';

--- a/packages/core/test/linker/query_integration_spec.ts
+++ b/packages/core/test/linker/query_integration_spec.ts
@@ -12,6 +12,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {fixmeIvy, ivyEnabled, modifiedInIvy, onlyInIvy} from '@angular/private/testing';
 import {Subject} from 'rxjs';
 
+import {ElementRef} from '../../src/core';
 import {stringify} from '../../src/util/stringify';
 
 describe('Query API', () => {
@@ -19,6 +20,9 @@ describe('Query API', () => {
   beforeEach(() => TestBed.configureTestingModule({
     declarations: [
       MyComp0,
+      SimpleCompA,
+      SimpleCompB,
+      LocalRefQueryComp,
       NeedsQuery,
       NeedsQueryDesc,
       NeedsQueryByLabel,
@@ -251,19 +255,15 @@ describe('Query API', () => {
   });
 
   describe('read a different token', () => {
-    modifiedInIvy(
-        'Breaking change in Ivy: no longer allow multiple local refs with the same name, all local refs are now unique')
-        .it('should contain all content children', () => {
-          const template =
-              '<needs-content-children-read #q text="ca"><div #q text="cb"></div></needs-content-children-read>';
-          const view = createTestCmpAndDetectChanges(MyComp0, template);
+    it('should contain all content children', () => {
+      const template =
+          '<needs-content-children-read #q text="ca"><div #q text="cb"></div></needs-content-children-read>';
+      const view = createTestCmpAndDetectChanges(MyComp0, template);
 
-          const comp: NeedsContentChildrenWithRead =
-              view.debugElement.children[0].injector.get(NeedsContentChildrenWithRead);
-          expect(comp.textDirChildren.map(textDirective => textDirective.text)).toEqual([
-            'ca', 'cb'
-          ]);
-        });
+      const comp: NeedsContentChildrenWithRead =
+          view.debugElement.children[0].injector.get(NeedsContentChildrenWithRead);
+      expect(comp.textDirChildren.map(textDirective => textDirective.text)).toEqual(['ca', 'cb']);
+    });
 
     it('should contain the first content child', () => {
       const template =
@@ -457,6 +457,150 @@ describe('Query API', () => {
       expect(q.textDirChildren.length).toEqual(1);
       expect(q.numberOfChildrenAfterViewInit).toEqual(1);
     });
+
+    it('should return Component instances when Components are labelled and retrieved via View query',
+       () => {
+         const template = `
+           <div><simple-comp-a #viewQuery></simple-comp-a></div>
+           <div><simple-comp-b #viewQuery></simple-comp-b></div>
+         `;
+         const view = createTestCmpAndDetectChanges(LocalRefQueryComp, template);
+         const queryList = view.componentInstance.viewQueryResults;
+         expect(queryList.first).toBeAnInstanceOf(SimpleCompA);
+         expect(queryList.last).toBeAnInstanceOf(SimpleCompB);
+       });
+
+    it('should return Component instance when Component is labelled and retrieved via Content query',
+       () => {
+         const template = `
+           <local-ref-query-component #q>
+             <simple-comp-a #contentQuery></simple-comp-a>
+           </local-ref-query-component>
+         `;
+         const view = createTestCmpAndDetectChanges(MyComp0, template);
+         const queryList = view.debugElement.children[0].references['q'].contentQueryResults;
+         expect(queryList.first).toBeAnInstanceOf(SimpleCompA);
+       });
+
+    onlyInIvy('multiple local refs are supported in Ivy')
+        .it('should return Component instances when Components are labelled and retrieved via Content query',
+            () => {
+              const template = `
+               <local-ref-query-component #q>
+                 <simple-comp-a #contentQuery></simple-comp-a>
+                 <simple-comp-b #contentQuery></simple-comp-b>
+               </local-ref-query-component>
+             `;
+              const view = createTestCmpAndDetectChanges(MyComp0, template);
+              const queryList = view.debugElement.children[0].references['q'].contentQueryResults;
+              expect(queryList.first).toBeAnInstanceOf(SimpleCompA);
+              expect(queryList.last).toBeAnInstanceOf(SimpleCompB);
+              expect(queryList.length).toBe(2);
+            });
+
+    it('should return ElementRef when HTML element is labelled and retrieved via View query',
+       () => {
+         const template = `
+            <div #viewQuery></div>
+        `;
+         const view = createTestCmpAndDetectChanges(LocalRefQueryComp, template);
+         const queryList = view.componentInstance.viewQueryResults;
+         expect(queryList.first).toBeAnInstanceOf(ElementRef);
+       });
+
+    onlyInIvy('multiple local refs are supported in Ivy')
+        .it('should return ElementRefs when HTML elements are labelled and retrieved via View query',
+            () => {
+              const template = `
+                <div #viewQuery></div>
+                <div #viewQuery></div>
+              `;
+              const view = createTestCmpAndDetectChanges(LocalRefQueryComp, template);
+              const queryList = view.componentInstance.viewQueryResults;
+              expect(queryList.first).toBeAnInstanceOf(ElementRef);
+              expect(queryList.last).toBeAnInstanceOf(ElementRef);
+              expect(queryList.length).toBe(2);
+            });
+
+    it('should return TemplateRef when template is labelled and retrieved via View query', () => {
+      const template = `
+        <ng-template #viewQuery></ng-template>
+      `;
+      const view = createTestCmpAndDetectChanges(LocalRefQueryComp, template);
+      const queryList = view.componentInstance.viewQueryResults;
+      expect(queryList.first).toBeAnInstanceOf(TemplateRef);
+    });
+
+    onlyInIvy('multiple local refs are supported in Ivy')
+        .it('should return TemplateRefs when templates are labelled and retrieved via View query',
+            () => {
+              const template = `
+                <ng-template #viewQuery></ng-template>
+                <ng-template #viewQuery></ng-template>
+              `;
+              const view = createTestCmpAndDetectChanges(LocalRefQueryComp, template);
+              const queryList = view.componentInstance.viewQueryResults;
+              expect(queryList.first).toBeAnInstanceOf(TemplateRef);
+              expect(queryList.last).toBeAnInstanceOf(TemplateRef);
+              expect(queryList.length).toBe(2);
+            });
+
+    it('should return ElementRef when HTML element is labelled and retrieved via Content query',
+       () => {
+         const template = `
+           <local-ref-query-component #q>
+             <div #contentQuery></div>
+           </local-ref-query-component>
+         `;
+         const view = createTestCmpAndDetectChanges(MyComp0, template);
+         const queryList = view.debugElement.children[0].references['q'].contentQueryResults;
+         expect(queryList.first).toBeAnInstanceOf(ElementRef);
+       });
+
+    onlyInIvy('multiple local refs are supported in Ivy')
+        .it('should return ElementRefs when HTML elements are labelled and retrieved via Content query',
+            () => {
+              const template = `
+                <local-ref-query-component #q>
+                  <div #contentQuery></div>
+                  <div #contentQuery></div>
+                </local-ref-query-component>
+              `;
+              const view = createTestCmpAndDetectChanges(MyComp0, template);
+              const queryList = view.debugElement.children[0].references['q'].contentQueryResults;
+              expect(queryList.first).toBeAnInstanceOf(ElementRef);
+              expect(queryList.last).toBeAnInstanceOf(ElementRef);
+              expect(queryList.length).toBe(2);
+            });
+
+    it('should return TemplateRef when template is labelled and retrieved via Content query',
+       () => {
+         const template = `
+            <local-ref-query-component #q>
+              <ng-template #contentQuery></ng-template>
+            </local-ref-query-component>
+          `;
+         const view = createTestCmpAndDetectChanges(MyComp0, template);
+         const queryList = view.debugElement.children[0].references['q'].contentQueryResults;
+         debugger;
+         expect(queryList.first).toBeAnInstanceOf(TemplateRef);
+       });
+
+    onlyInIvy('multiple local refs are supported in Ivy')
+        .it('should return TemplateRefs when templates are labelled and retrieved via Content query',
+            () => {
+              const template = `
+                <local-ref-query-component #q>
+                  <ng-template #contentQuery></ng-template>
+                  <ng-template #contentQuery></ng-template>
+                </local-ref-query-component>
+              `;
+              const view = createTestCmpAndDetectChanges(MyComp0, template);
+              const queryList = view.debugElement.children[0].references['q'].contentQueryResults;
+              expect(queryList.first).toBeAnInstanceOf(TemplateRef);
+              expect(queryList.last).toBeAnInstanceOf(TemplateRef);
+              expect(queryList.length).toBe(2);
+            });
   });
 
   describe('querying in the view', () => {
@@ -1008,6 +1152,20 @@ class NeedsViewContainerWithRead {
   @ContentChild(TemplateRef) template !: TemplateRef<Object>;
 
   createView() { this.vc.createEmbeddedView(this.template); }
+}
+
+@Component({selector: 'local-ref-query-component', template: '<ng-content></ng-content>'})
+class LocalRefQueryComp {
+  @ViewChildren('viewQuery') viewQueryResults !: QueryList<any>;
+  @ContentChildren('contentQuery') contentQueryResults !: QueryList<any>;
+}
+
+@Component({selector: 'simple-comp-a', template: ''})
+class SimpleCompA {
+}
+
+@Component({selector: 'simple-comp-b', template: ''})
+class SimpleCompB {
 }
 
 @Component({selector: 'has-null-query-condition', template: '<div></div>'})

--- a/packages/core/test/linker/query_integration_spec.ts
+++ b/packages/core/test/linker/query_integration_spec.ts
@@ -581,7 +581,6 @@ describe('Query API', () => {
           `;
          const view = createTestCmpAndDetectChanges(MyComp0, template);
          const queryList = view.debugElement.children[0].references['q'].contentQueryResults;
-         debugger;
          expect(queryList.first).toBeAnInstanceOf(TemplateRef);
        });
 

--- a/packages/core/test/linker/query_integration_spec.ts
+++ b/packages/core/test/linker/query_integration_spec.ts
@@ -19,9 +19,6 @@ describe('Query API', () => {
   beforeEach(() => TestBed.configureTestingModule({
     declarations: [
       MyComp0,
-      SimpleCompA,
-      SimpleCompB,
-      LocalRefQueryComp,
       NeedsQuery,
       NeedsQueryDesc,
       NeedsQueryByLabel,
@@ -456,149 +453,6 @@ describe('Query API', () => {
       expect(q.textDirChildren.length).toEqual(1);
       expect(q.numberOfChildrenAfterViewInit).toEqual(1);
     });
-
-    it('should return Component instances when Components are labelled and retrieved via View query',
-       () => {
-         const template = `
-           <div><simple-comp-a #viewQuery></simple-comp-a></div>
-           <div><simple-comp-b #viewQuery></simple-comp-b></div>
-         `;
-         const view = createTestCmpAndDetectChanges(LocalRefQueryComp, template);
-         const queryList = view.componentInstance.viewQueryResults;
-         expect(queryList.first).toBeAnInstanceOf(SimpleCompA);
-         expect(queryList.last).toBeAnInstanceOf(SimpleCompB);
-       });
-
-    it('should return Component instance when Component is labelled and retrieved via Content query',
-       () => {
-         const template = `
-           <local-ref-query-component #q>
-             <simple-comp-a #contentQuery></simple-comp-a>
-           </local-ref-query-component>
-         `;
-         const view = createTestCmpAndDetectChanges(MyComp0, template);
-         const queryList = view.debugElement.children[0].references['q'].contentQueryResults;
-         expect(queryList.first).toBeAnInstanceOf(SimpleCompA);
-       });
-
-    onlyInIvy('multiple local refs are supported in Ivy')
-        .it('should return Component instances when Components are labelled and retrieved via Content query',
-            () => {
-              const template = `
-               <local-ref-query-component #q>
-                 <simple-comp-a #contentQuery></simple-comp-a>
-                 <simple-comp-b #contentQuery></simple-comp-b>
-               </local-ref-query-component>
-             `;
-              const view = createTestCmpAndDetectChanges(MyComp0, template);
-              const queryList = view.debugElement.children[0].references['q'].contentQueryResults;
-              expect(queryList.first).toBeAnInstanceOf(SimpleCompA);
-              expect(queryList.last).toBeAnInstanceOf(SimpleCompB);
-              expect(queryList.length).toBe(2);
-            });
-
-    it('should return ElementRef when HTML element is labelled and retrieved via View query',
-       () => {
-         const template = `
-            <div #viewQuery></div>
-        `;
-         const view = createTestCmpAndDetectChanges(LocalRefQueryComp, template);
-         const queryList = view.componentInstance.viewQueryResults;
-         expect(queryList.first).toBeAnInstanceOf(ElementRef);
-       });
-
-    onlyInIvy('multiple local refs are supported in Ivy')
-        .it('should return ElementRefs when HTML elements are labelled and retrieved via View query',
-            () => {
-              const template = `
-                <div #viewQuery></div>
-                <div #viewQuery></div>
-              `;
-              const view = createTestCmpAndDetectChanges(LocalRefQueryComp, template);
-              const queryList = view.componentInstance.viewQueryResults;
-              expect(queryList.first).toBeAnInstanceOf(ElementRef);
-              expect(queryList.last).toBeAnInstanceOf(ElementRef);
-              expect(queryList.length).toBe(2);
-            });
-
-    it('should return TemplateRef when template is labelled and retrieved via View query', () => {
-      const template = `
-        <ng-template #viewQuery></ng-template>
-      `;
-      const view = createTestCmpAndDetectChanges(LocalRefQueryComp, template);
-      const queryList = view.componentInstance.viewQueryResults;
-      expect(queryList.first).toBeAnInstanceOf(TemplateRef);
-    });
-
-    onlyInIvy('multiple local refs are supported in Ivy')
-        .it('should return TemplateRefs when templates are labelled and retrieved via View query',
-            () => {
-              const template = `
-                <ng-template #viewQuery></ng-template>
-                <ng-template #viewQuery></ng-template>
-              `;
-              const view = createTestCmpAndDetectChanges(LocalRefQueryComp, template);
-              const queryList = view.componentInstance.viewQueryResults;
-              expect(queryList.first).toBeAnInstanceOf(TemplateRef);
-              expect(queryList.last).toBeAnInstanceOf(TemplateRef);
-              expect(queryList.length).toBe(2);
-            });
-
-    it('should return ElementRef when HTML element is labelled and retrieved via Content query',
-       () => {
-         const template = `
-           <local-ref-query-component #q>
-             <div #contentQuery></div>
-           </local-ref-query-component>
-         `;
-         const view = createTestCmpAndDetectChanges(MyComp0, template);
-         const queryList = view.debugElement.children[0].references['q'].contentQueryResults;
-         expect(queryList.first).toBeAnInstanceOf(ElementRef);
-       });
-
-    onlyInIvy('multiple local refs are supported in Ivy')
-        .it('should return ElementRefs when HTML elements are labelled and retrieved via Content query',
-            () => {
-              const template = `
-                <local-ref-query-component #q>
-                  <div #contentQuery></div>
-                  <div #contentQuery></div>
-                </local-ref-query-component>
-              `;
-              const view = createTestCmpAndDetectChanges(MyComp0, template);
-              const queryList = view.debugElement.children[0].references['q'].contentQueryResults;
-              expect(queryList.first).toBeAnInstanceOf(ElementRef);
-              expect(queryList.last).toBeAnInstanceOf(ElementRef);
-              expect(queryList.length).toBe(2);
-            });
-
-    it('should return TemplateRef when template is labelled and retrieved via Content query',
-       () => {
-         const template = `
-            <local-ref-query-component #q>
-              <ng-template #contentQuery></ng-template>
-            </local-ref-query-component>
-          `;
-         const view = createTestCmpAndDetectChanges(MyComp0, template);
-         const queryList = view.debugElement.children[0].references['q'].contentQueryResults;
-         expect(queryList.first).toBeAnInstanceOf(TemplateRef);
-       });
-
-    onlyInIvy('multiple local refs are supported in Ivy')
-        .it('should return TemplateRefs when templates are labelled and retrieved via Content query',
-            () => {
-              const template = `
-                <local-ref-query-component #q>
-                  <ng-template #contentQuery></ng-template>
-                  <ng-template #contentQuery></ng-template>
-                </local-ref-query-component>
-              `;
-              const view = createTestCmpAndDetectChanges(MyComp0, template);
-              const queryList = view.debugElement.children[0].references['q'].contentQueryResults;
-              expect(queryList.first).toBeAnInstanceOf(TemplateRef);
-              expect(queryList.last).toBeAnInstanceOf(TemplateRef);
-              expect(queryList.length).toBe(2);
-            });
   });
 
   describe('querying in the view', () => {
@@ -1150,20 +1004,6 @@ class NeedsViewContainerWithRead {
   @ContentChild(TemplateRef) template !: TemplateRef<Object>;
 
   createView() { this.vc.createEmbeddedView(this.template); }
-}
-
-@Component({selector: 'local-ref-query-component', template: '<ng-content></ng-content>'})
-class LocalRefQueryComp {
-  @ViewChildren('viewQuery') viewQueryResults !: QueryList<any>;
-  @ContentChildren('contentQuery') contentQueryResults !: QueryList<any>;
-}
-
-@Component({selector: 'simple-comp-a', template: ''})
-class SimpleCompA {
-}
-
-@Component({selector: 'simple-comp-b', template: ''})
-class SimpleCompB {
 }
 
 @Component({selector: 'has-null-query-condition', template: '<div></div>'})


### PR DESCRIPTION
Prior to this change in Ivy we had strict check that disabled non-unique #localRefs usage within a given template. While this limitation was technically present in View Engine, in many cases View Engine neglected this restriction and as a result, some apps relied on a fact that multiple non-unique #localRefs can be defined and utilized to query elements via `@ViewChild(ren)` and `@ContentChild(ren)`. In order to provide better compatibility with View Engine, this commit removes existing restriction.

As a part of this commit, are few tests were added to verify VE and Ivy compatibility in most common use-cases where multiple non-unique #localRefs were used.


## PR Type
What kind of change does this PR introduce?

- [x] Feature


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No