### PR TITLE
fix(router): add warning for the relative route without the relativeT…

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1167,7 +1167,7 @@ export class Router {
    */
   navigate(commands: any[], extras: NavigationExtras = {skipLocationChange: false}):
       Promise<boolean> {
-    validateCommands(commands);
+    this.validateCommands(commands, extras);
     return this.navigateByUrl(this.createUrlTree(commands, extras), extras);
   }
 
@@ -1314,13 +1314,22 @@ export class Router {
     this.location.replaceState(
         this.urlSerializer.serialize(this.rawUrlTree), '', {navigationId: this.lastSuccessfulId});
   }
-}
 
-function validateCommands(commands: string[]): void {
-  for (let i = 0; i < commands.length; i++) {
-    const cmd = commands[i];
-    if (cmd == null) {
-      throw new Error(`The requested path contains ${cmd} segment at index ${i}`);
+  private validateCommands(commands: any[], extras: NavigationExtras): void {
+    for (let i = 0; i < commands.length; i++) {
+      const cmd = commands[i];
+      if (cmd == null) {
+        throw new Error(`The requested path contains ${cmd} segment at index ${i}`);
+      }
+
+      if (typeof cmd === 'string') {
+        const urlList = cmd.split('/');
+        const containRelativePath = urlList[0] === '.' || urlList.indexOf('..') !== -1;
+
+        if (containRelativePath && !extras.relativeTo) {
+          this.console.warn(`WARNING: using relative route without the 'relativeTo' property`);
+        }
+      }
     }
   }
 }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -302,6 +302,17 @@ describe('Integration', () => {
            expect(warnings.length).toBe(0);
          })));
     });
+
+    describe('with relative path', () => {
+      it('should warn when used without "relativeTo" property',
+         fakeAsync(inject([Router, NgZone], (router: Router, ngZone: NgZone) => {
+           ngZone.run(() => { router.navigate(['./simple']); });
+
+           expect(warnings.length).toBe(1);
+           expect(warnings[0])
+               .toBe(`WARNING: using relative route without the 'relativeTo' property`);
+         })));
+    });
   });
 
   describe('should execute navigations serially', () => {


### PR DESCRIPTION
…o property

Method 'validateCommands' moved to the class methods for use the context console for warnings.

Fixes #26027

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
When using `router.navigate(…)` with relative _url_ and without `relativeTo` property, angular does not show any warnings and behave in a confusing manner.

Issue Number: #26027


## What is the new behavior?
When You are using `router.navigate(…)` with relative _url_  and without setting `relativeTo` property, angular shows warning message in the console: `WARNING: using relative route without the 'relativeTo' property`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
I have chosen `validateCommands` for relative routing checks cuz of logical consistency.
Also, method `navigateByUrl` do not apply relative URLs so there no need to pass such checks there.