### PR TITLE
refactor(ivy): remove unused notImplement function

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -196,11 +196,6 @@ function _queryNodeChildren(
     });
   }
 }
-
-function notImplemented(): Error {
-  throw new Error('Missing proper ivy implementation.');
-}
-
 class DebugNode__POST_R3__ implements DebugNode {
   readonly nativeNode: Node;
 


### PR DESCRIPTION
It has not been used since #27387 implemented the last missing methods in DebugNode

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

The `notImplemented`  function has not been used since #27387 implemented the last missing methods in `DebugNode`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No