### PR TITLE
refactor(ivy): remove unused parameter in postProcessBaseDirective

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1678,7 +1678,7 @@ export function instantiateRootComponent<T>(
   }
   const directive =
       getNodeInjectable(tView.data, viewData, viewData.length - 1, rootTNode as TElementNode);
-  postProcessBaseDirective(viewData, rootTNode, directive, def as DirectiveDef<T>);
+  postProcessBaseDirective(viewData, rootTNode, directive);
   return directive;
 }
 
@@ -1806,7 +1806,7 @@ function prefillHostVars(tView: TView, lView: LView, totalHostVars: number): voi
 function postProcessDirective<T>(
     viewData: LView, directive: T, def: DirectiveDef<T>, directiveDefIdx: number): void {
   const previousOrParentTNode = getPreviousOrParentTNode();
-  postProcessBaseDirective(viewData, previousOrParentTNode, directive, def);
+  postProcessBaseDirective(viewData, previousOrParentTNode, directive);
   ngDevMode && assertDefined(previousOrParentTNode, 'previousOrParentTNode');
   if (previousOrParentTNode && previousOrParentTNode.attrs) {
     setInputsFromAttrs(directiveDefIdx, directive, def, previousOrParentTNode);
@@ -1826,7 +1826,7 @@ function postProcessDirective<T>(
  * A lighter version of postProcessDirective() that is used for the root component.
  */
 function postProcessBaseDirective<T>(
-    lView: LView, previousOrParentTNode: TNode, directive: T, def: DirectiveDef<T>): void {
+    lView: LView, previousOrParentTNode: TNode, directive: T): void {
   const native = getNativeByTNode(previousOrParentTNode, lView);
 
   ngDevMode && assertEqual(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?
https://github.com/angular/angular/pull/28089/files#diff-ce885db4223480bd4f7b78bd22b6f058L1650 removed the use of `def` in `postProcessBaseDirective`, making the parameter now useless.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
