### PR TITLE
fix(ivy): support schemas at runtime

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -122,6 +122,8 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
       exports: exports.map(exp => this._toR3Reference(exp, valueContext, typeContext)),
       imports: imports.map(imp => this._toR3Reference(imp, valueContext, typeContext)),
       emitInline: false,
+      // TODO: to be implemented as a part of FW-1004.
+      schemas: [],
     };
 
     const providers: Expression = ngModule.has('providers') ?

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -97,6 +97,7 @@ export interface R3NgModuleMetadataFacade {
   imports: Function[];
   exports: Function[];
   emitInline: boolean;
+  schemas?: {name: string}[];
 }
 
 export interface R3InjectorMetadataFacade {

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -97,7 +97,7 @@ export interface R3NgModuleMetadataFacade {
   imports: Function[];
   exports: Function[];
   emitInline: boolean;
-  schemas?: {name: string}[];
+  schemas: {name: string}[]|null;
 }
 
 export interface R3InjectorMetadataFacade {

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -86,6 +86,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
       imports: facade.imports.map(wrapReference),
       exports: facade.exports.map(wrapReference),
       emitInline: true,
+      schemas: facade.schemas && facade.schemas.map(wrapReference),
     };
     const res = compileNgModule(meta);
     return this.jitExpression(res.expression, angularCoreEnv, sourceMapUrl, []);

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -86,7 +86,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
       imports: facade.imports.map(wrapReference),
       exports: facade.exports.map(wrapReference),
       emitInline: true,
-      schemas: facade.schemas && facade.schemas.map(wrapReference),
+      schemas: facade.schemas ? facade.schemas.map(wrapReference) : null,
     };
     const res = compileNgModule(meta);
     return this.jitExpression(res.expression, angularCoreEnv, sourceMapUrl, []);

--- a/packages/compiler/src/render3/r3_module_compiler.ts
+++ b/packages/compiler/src/render3/r3_module_compiler.ts
@@ -61,7 +61,7 @@ export interface R3NgModuleMetadata {
   /**
    * The set of schemas that declare elements to be allowed in the NgModule.
    */
-  schemas?: R3Reference[]|null;
+  schemas: R3Reference[]|null;
 }
 
 /**

--- a/packages/compiler/src/render3/r3_module_compiler.ts
+++ b/packages/compiler/src/render3/r3_module_compiler.ts
@@ -57,13 +57,18 @@ export interface R3NgModuleMetadata {
    * does not allow components to be tree-shaken, but is useful for JIT mode.
    */
   emitInline: boolean;
+
+  /**
+   * The set of schemas that declare elements to be allowed in the NgModule.
+   */
+  schemas?: R3Reference[]|null;
 }
 
 /**
  * Construct an `R3NgModuleDef` for the given `R3NgModuleMetadata`.
  */
 export function compileNgModule(meta: R3NgModuleMetadata): R3NgModuleDef {
-  const {type: moduleType, bootstrap, declarations, imports, exports} = meta;
+  const {type: moduleType, bootstrap, declarations, imports, exports, schemas} = meta;
   const definitionMap = {
     type: moduleType
   } as{
@@ -71,7 +76,8 @@ export function compileNgModule(meta: R3NgModuleMetadata): R3NgModuleDef {
     bootstrap: o.LiteralArrayExpr,
     declarations: o.LiteralArrayExpr,
     imports: o.LiteralArrayExpr,
-    exports: o.LiteralArrayExpr
+    exports: o.LiteralArrayExpr,
+    schemas: o.LiteralArrayExpr
   };
 
   // Only generate the keys in the metadata if the arrays have values.
@@ -89,6 +95,10 @@ export function compileNgModule(meta: R3NgModuleMetadata): R3NgModuleDef {
 
   if (exports.length) {
     definitionMap.exports = o.literalArr(exports.map(ref => ref.value));
+  }
+
+  if (schemas && schemas.length) {
+    definitionMap.schemas = o.literalArr(schemas.map(ref => ref.value));
   }
 
   const expression = o.importExpr(R3.defineNgModule).callFn([mapToMapExpression(definitionMap)]);

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -97,6 +97,7 @@ export interface R3NgModuleMetadataFacade {
   imports: Function[];
   exports: Function[];
   emitInline: boolean;
+  schemas?: {name: string}[];
 }
 
 export interface R3InjectorMetadataFacade {

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -97,7 +97,7 @@ export interface R3NgModuleMetadataFacade {
   imports: Function[];
   exports: Function[];
   emitInline: boolean;
-  schemas?: {name: string}[];
+  schemas: {name: string}[]|null;
 }
 
 export interface R3InjectorMetadataFacade {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -14,12 +14,14 @@
 import {Attribute} from './di';
 import {ContentChild, ContentChildren, Query, ViewChild, ViewChildren} from './metadata/di';
 import {Component, Directive, HostBinding, HostListener, Input, Output, Pipe} from './metadata/directives';
-import {DoBootstrap, ModuleWithProviders, NgModule, SchemaMetadata} from './metadata/ng_module';
+import {DoBootstrap, ModuleWithProviders, NgModule} from './metadata/ng_module';
+import {SchemaMetadata} from './metadata/schema';
 import {ViewEncapsulation} from './metadata/view';
 
 export {Attribute} from './di';
 export {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, DoCheck, OnChanges, OnDestroy, OnInit} from './interface/lifecycle_hooks';
 export {ANALYZE_FOR_ENTRY_COMPONENTS, ContentChild, ContentChildDecorator, ContentChildren, ContentChildrenDecorator, Query, ViewChild, ViewChildDecorator, ViewChildren, ViewChildrenDecorator} from './metadata/di';
 export {Component, ComponentDecorator, Directive, DirectiveDecorator, HostBinding, HostListener, Input, Output, Pipe} from './metadata/directives';
-export {CUSTOM_ELEMENTS_SCHEMA, DoBootstrap, ModuleWithProviders, NO_ERRORS_SCHEMA, NgModule, SchemaMetadata} from './metadata/ng_module';
+export {DoBootstrap, ModuleWithProviders, NgModule} from './metadata/ng_module';
+export {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA, SchemaMetadata} from './metadata/schema';
 export {ViewEncapsulation} from './metadata/view';

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -11,6 +11,7 @@ import {InjectorType, defineInjector} from '../di/interface/defs';
 import {Provider} from '../di/interface/provider';
 import {convertInjectableProviderToFactory} from '../di/util';
 import {Type} from '../interface/type';
+import {SchemaMetadata} from '../metadata/schema';
 import {NgModuleType} from '../render3';
 import {compileNgModule as render3CompileNgModule} from '../render3/jit/module';
 import {TypeDecorator, makeDecorator} from '../util/decorators';
@@ -28,7 +29,7 @@ import {TypeDecorator, makeDecorator} from '../util/decorators';
 export interface NgModuleTransitiveScopes {
   compilation: {directives: Set<any>; pipes: Set<any>;};
   exported: {directives: Set<any>; pipes: Set<any>;};
-  schemas?: SchemaMetadata[]|null;
+  schemas: SchemaMetadata[]|null;
 }
 
 export type NgModuleDefWithMeta<T, Declarations, Imports, Exports> = NgModuleDef<T>;
@@ -70,7 +71,7 @@ export interface NgModuleDef<T> {
   transitiveCompileScopes: NgModuleTransitiveScopes|null;
 
   /** The set of schemas that declare elements to be allowed in the NgModule. */
-  schemas?: SchemaMetadata[]|null;
+  schemas: SchemaMetadata[]|null;
 }
 
 /**
@@ -86,38 +87,6 @@ export interface ModuleWithProviders<
   ngModule: Type<T>;
   providers?: Provider[];
 }
-
-/**
- * A schema definition associated with an NgModule.
- *
- * @see `@NgModule`, `CUSTOM_ELEMENTS_SCHEMA`, `NO_ERRORS_SCHEMA`
- *
- * @param name The name of a defined schema.
- *
- * @publicApi
- */
-export interface SchemaMetadata { name: string; }
-
-/**
- * Defines a schema that allows an NgModule to contain the following:
- * - Non-Angular elements named with dash case (`-`).
- * - Element properties named with dash case (`-`).
- * Dash case is the naming convention for custom elements.
- *
- * @publicApi
- */
-export const CUSTOM_ELEMENTS_SCHEMA: SchemaMetadata = {
-  name: 'custom-elements'
-};
-
-/**
- * Defines a schema that allows any property on any element.
- *
- * @publicApi
- */
-export const NO_ERRORS_SCHEMA: SchemaMetadata = {
-  name: 'no-errors-schema'
-};
 
 
 /**

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -28,6 +28,7 @@ import {TypeDecorator, makeDecorator} from '../util/decorators';
 export interface NgModuleTransitiveScopes {
   compilation: {directives: Set<any>; pipes: Set<any>;};
   exported: {directives: Set<any>; pipes: Set<any>;};
+  schemas?: SchemaMetadata[]|null;
 }
 
 export type NgModuleDefWithMeta<T, Declarations, Imports, Exports> = NgModuleDef<T>;
@@ -67,6 +68,9 @@ export interface NgModuleDef<T> {
    * This should never be read directly, but accessed via `transitiveScopesFor`.
    */
   transitiveCompileScopes: NgModuleTransitiveScopes|null;
+
+  /** The set of schemas that declare elements to be allowed in the NgModule. */
+  schemas?: SchemaMetadata[]|null;
 }
 
 /**

--- a/packages/core/src/metadata/schema.ts
+++ b/packages/core/src/metadata/schema.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+
+/**
+ * A schema definition associated with an NgModule.
+ *
+ * @see `@NgModule`, `CUSTOM_ELEMENTS_SCHEMA`, `NO_ERRORS_SCHEMA`
+ *
+ * @param name The name of a defined schema.
+ *
+ * @publicApi
+ */
+export interface SchemaMetadata { name: string; }
+
+/**
+ * Defines a schema that allows an NgModule to contain the following:
+ * - Non-Angular elements named with dash case (`-`).
+ * - Element properties named with dash case (`-`).
+ * Dash case is the naming convention for custom elements.
+ *
+ * @publicApi
+ */
+export const CUSTOM_ELEMENTS_SCHEMA: SchemaMetadata = {
+  name: 'custom-elements'
+};
+
+/**
+ * Defines a schema that allows any property on any element.
+ *
+ * @publicApi
+ */
+export const NO_ERRORS_SCHEMA: SchemaMetadata = {
+  name: 'no-errors-schema'
+};

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -122,7 +122,7 @@ export function renderComponent<T>(
 
   const renderer = rendererFactory.createRenderer(hostRNode, componentDef);
   const rootView: LView = createLView(
-      null, createTView(-1, null, 1, 0, null, null, null), rootContext, rootFlags, null, null,
+      null, createTView(-1, null, 1, 0, null, null, null, null), rootContext, rootFlags, null, null,
       rendererFactory, renderer, undefined, opts.injector || null);
 
   const oldView = enterView(rootView, null);

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -165,9 +165,9 @@ export function createRootComponentView(
   const tView = rootView[TVIEW];
   const tNode: TElementNode = createNodeAtIndex(0, TNodeType.Element, rNode, null, null);
   const componentView = createLView(
-      rootView,
-      getOrCreateTView(
-          def.template, def.consts, def.vars, def.directiveDefs, def.pipeDefs, def.viewQuery),
+      rootView, getOrCreateTView(
+                    def.template, def.consts, def.vars, def.directiveDefs, def.pipeDefs,
+                    def.viewQuery, def.schemas),
       null, def.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways, rootView[HEADER_OFFSET], tNode,
       rendererFactory, renderer, sanitizer);
 

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -161,8 +161,8 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
 
     // Create the root view. Uses empty TView and ContentTemplate.
     const rootLView = createLView(
-        null, createTView(-1, null, 1, 0, null, null, null), rootContext, rootFlags, null, null,
-        rendererFactory, renderer, sanitizer, rootViewInjector);
+        null, createTView(-1, null, 1, 0, null, null, null, null), rootContext, rootFlags, null,
+        null, rendererFactory, renderer, sanitizer, rootViewInjector);
 
     // rootView is the parent when bootstrapping
     const oldLView = enterView(rootLView, null);

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -10,7 +10,8 @@ import '../util/ng_dev_mode';
 
 import {ChangeDetectionStrategy} from '../change_detection/constants';
 import {Mutable, Type} from '../interface/type';
-import {NgModuleDef, SchemaMetadata} from '../metadata/ng_module';
+import {NgModuleDef} from '../metadata/ng_module';
+import {SchemaMetadata} from '../metadata/schema';
 import {ViewEncapsulation} from '../metadata/view';
 import {noSideEffects} from '../util/closure';
 import {stringify} from '../util/stringify';
@@ -279,7 +280,7 @@ export function defineComponent<T>(componentDefinition: {
     styles: componentDefinition.styles || EMPTY_ARRAY,
     _: null as never,
     setInput: null,
-    schemas: componentDefinition.schemas,
+    schemas: componentDefinition.schemas || null,
   };
   def._ = noSideEffects(() => {
     const directiveTypes = componentDefinition.directives !;
@@ -332,7 +333,7 @@ export function defineNgModule<T>(def: {type: T} & Partial<NgModuleDef<T>>): nev
     imports: def.imports || EMPTY_ARRAY,
     exports: def.exports || EMPTY_ARRAY,
     transitiveCompileScopes: null,
-    schemas: def.schemas,
+    schemas: def.schemas || null,
   };
   return res as never;
 }

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -10,7 +10,7 @@ import '../util/ng_dev_mode';
 
 import {ChangeDetectionStrategy} from '../change_detection/constants';
 import {Mutable, Type} from '../interface/type';
-import {NgModuleDef} from '../metadata/ng_module';
+import {NgModuleDef, SchemaMetadata} from '../metadata/ng_module';
 import {ViewEncapsulation} from '../metadata/view';
 import {noSideEffects} from '../util/closure';
 import {stringify} from '../util/stringify';
@@ -234,6 +234,11 @@ export function defineComponent<T>(componentDefinition: {
    * `PipeDefs`s. The function is necessary to be able to support forward declarations.
    */
   pipes?: PipeTypesOrFactory | null;
+
+  /**
+   * The set of schemas that declare elements to be allowed in the component's template.
+   */
+  schemas?: SchemaMetadata[] | null;
 }): never {
   const type = componentDefinition.type;
   const typePrototype = type.prototype;
@@ -274,6 +279,7 @@ export function defineComponent<T>(componentDefinition: {
     styles: componentDefinition.styles || EMPTY_ARRAY,
     _: null as never,
     setInput: null,
+    schemas: componentDefinition.schemas,
   };
   def._ = noSideEffects(() => {
     const directiveTypes = componentDefinition.directives !;
@@ -326,6 +332,7 @@ export function defineNgModule<T>(def: {type: T} & Partial<NgModuleDef<T>>): nev
     imports: def.imports || EMPTY_ARRAY,
     exports: def.exports || EMPTY_ARRAY,
     transitiveCompileScopes: null,
+    schemas: def.schemas,
   };
   return res as never;
 }

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -282,7 +282,7 @@ export interface ComponentDef<T> extends DirectiveDef<T> {
   /**
    * The set of schemas that declare elements to be allowed in the component's template.
    */
-  schemas?: SchemaMetadata[]|null;
+  schemas: SchemaMetadata[]|null;
 
   /**
    * Used to store the result of `noSideEffects` function so that it is not removed by closure

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ViewEncapsulation} from '../../core';
+import {SchemaMetadata, ViewEncapsulation} from '../../core';
 import {Type} from '../../interface/type';
 import {CssSelectorList} from './projection';
 
@@ -264,7 +264,6 @@ export interface ComponentDef<T> extends DirectiveDef<T> {
   readonly onPush: boolean;
 
   /**
-
    * Registry of directives and components that may be found in this view.
    *
    * The property is either an array of `DirectiveDef`s or a function which returns the array of
@@ -279,6 +278,11 @@ export interface ComponentDef<T> extends DirectiveDef<T> {
    * `PipeDefs`s. The function is necessary to be able to support forward declarations.
    */
   pipeDefs: PipeDefListOrFactory|null;
+
+  /**
+   * The set of schemas that declare elements to be allowed in the component's template.
+   */
+  schemas?: SchemaMetadata[]|null;
 
   /**
    * Used to store the result of `noSideEffects` function so that it is not removed by closure

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -10,6 +10,7 @@ import {InjectionToken} from '../../di/injection_token';
 import {Injector} from '../../di/injector';
 import {Type} from '../../interface/type';
 import {QueryList} from '../../linker';
+import {SchemaMetadata} from '../../metadata';
 import {Sanitizer} from '../../sanitization/security';
 
 import {LContainer} from './container';
@@ -528,6 +529,11 @@ export interface TView {
    * A list of indices for child directives that have content queries.
    */
   contentQueries: number[]|null;
+
+  /**
+   * Set of schemas that declare elements to be allowed inside the view.
+   */
+  schemas?: SchemaMetadata[]|null;
 }
 
 export const enum RootContextFlags {Empty = 0b00, DetectChanges = 0b01, FlushPlayers = 0b10}

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -533,7 +533,7 @@ export interface TView {
   /**
    * Set of schemas that declare elements to be allowed inside the view.
    */
-  schemas?: SchemaMetadata[]|null;
+  schemas: SchemaMetadata[]|null;
 }
 
 export const enum RootContextFlags {Empty = 0b00, DetectChanges = 0b01, FlushPlayers = 0b10}

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -13,7 +13,7 @@ import {reflectDependencies} from '../../di/jit/util';
 import {Type} from '../../interface/type';
 import {registerNgModuleType} from '../../linker/ng_module_factory_loader';
 import {Component} from '../../metadata';
-import {ModuleWithProviders, NgModule, NgModuleDef, NgModuleTransitiveScopes, SchemaMetadata} from '../../metadata/ng_module';
+import {ModuleWithProviders, NgModule, NgModuleDef, NgModuleTransitiveScopes} from '../../metadata/ng_module';
 import {assertDefined} from '../../util/assert';
 import {getComponentDef, getDirectiveDef, getNgModuleDef, getPipeDef} from '../definition';
 import {NG_COMPONENT_DEF, NG_DIRECTIVE_DEF, NG_MODULE_DEF, NG_PIPE_DEF} from '../fields';
@@ -115,7 +115,7 @@ export function compileNgModuleDefs(moduleType: NgModuleType, ngModule: NgModule
               exports: flatten(ngModule.exports || EMPTY_ARRAY, resolveForwardRef)
                            .map(expandModuleWithProviders),
               emitInline: true,
-              schemas: ngModule.schemas && flatten(ngModule.schemas),
+              schemas: ngModule.schemas ? flatten(ngModule.schemas) : null,
             });
       }
       return ngModuleDef;
@@ -377,7 +377,7 @@ export function transitiveScopesFor<T>(
   }
 
   const scopes: NgModuleTransitiveScopes = {
-    schemas: def.schemas,
+    schemas: def.schemas || null,
     compilation: {
       directives: new Set<any>(),
       pipes: new Set<any>(),

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -13,7 +13,7 @@ import {reflectDependencies} from '../../di/jit/util';
 import {Type} from '../../interface/type';
 import {registerNgModuleType} from '../../linker/ng_module_factory_loader';
 import {Component} from '../../metadata';
-import {ModuleWithProviders, NgModule, NgModuleDef, NgModuleTransitiveScopes} from '../../metadata/ng_module';
+import {ModuleWithProviders, NgModule, NgModuleDef, NgModuleTransitiveScopes, SchemaMetadata} from '../../metadata/ng_module';
 import {assertDefined} from '../../util/assert';
 import {getComponentDef, getDirectiveDef, getNgModuleDef, getPipeDef} from '../definition';
 import {NG_COMPONENT_DEF, NG_DIRECTIVE_DEF, NG_MODULE_DEF, NG_PIPE_DEF} from '../fields';
@@ -115,6 +115,7 @@ export function compileNgModuleDefs(moduleType: NgModuleType, ngModule: NgModule
               exports: flatten(ngModule.exports || EMPTY_ARRAY, resolveForwardRef)
                            .map(expandModuleWithProviders),
               emitInline: true,
+              schemas: ngModule.schemas && flatten(ngModule.schemas),
             });
       }
       return ngModuleDef;
@@ -353,6 +354,7 @@ export function patchComponentDefWithScope<C>(
           .filter(def => !!def);
   componentDef.pipeDefs = () =>
       Array.from(transitiveScopes.compilation.pipes).map(pipe => getPipeDef(pipe) !);
+  componentDef.schemas = transitiveScopes.schemas;
 }
 
 /**
@@ -375,6 +377,7 @@ export function transitiveScopesFor<T>(
   }
 
   const scopes: NgModuleTransitiveScopes = {
+    schemas: def.schemas,
     compilation: {
       directives: new Set<any>(),
       pipes: new Set<any>(),

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ANALYZE_FOR_ENTRY_COMPONENTS, CUSTOM_ELEMENTS_SCHEMA, Compiler, Component, ComponentFactoryResolver, Directive, HostBinding, Inject, Injectable, InjectionToken, Injector, Input, NgModule, NgModuleRef, Optional, Pipe, Provider, Self, Type, forwardRef, getModuleFactory, ɵivyEnabled as ivyEnabled} from '@angular/core';
+import {ANALYZE_FOR_ENTRY_COMPONENTS, CUSTOM_ELEMENTS_SCHEMA, ChangeDetectorRef, Compiler, Component, ComponentFactoryResolver, Directive, HostBinding, Inject, Injectable, InjectionToken, Injector, Input, NgModule, NgModuleRef, Optional, Pipe, Provider, Self, Type, forwardRef, getModuleFactory, ɵivyEnabled as ivyEnabled} from '@angular/core';
 import {Console} from '@angular/core/src/console';
 import {InjectableDef, defineInjectable} from '@angular/core/src/di/interface/defs';
 import {getNgModuleDef} from '@angular/core/src/render3/definition';
@@ -266,22 +266,25 @@ function declareTests(config?: {useJit: boolean}) {
             expect(() => fixture.detectChanges()).toThrowError(/Can't bind to 'someUnknownProp'/);
           });
 
-      fixmeIvy('FW-819: ngtsc compiler should support schemas')
-          .it('should not error on unknown bound properties on custom elements when using the CUSTOM_ELEMENTS_SCHEMA',
-              () => {
-                @Component({template: '<some-element [someUnknownProp]="true"></some-element>'})
-                class ComponentUsingInvalidProperty {
-                }
+      it('should not error on unknown bound properties on custom elements when using the CUSTOM_ELEMENTS_SCHEMA',
+         () => {
+           @Component({template: '<some-element [someUnknownProp]="true"></some-element>'})
+           class ComponentUsingInvalidProperty {
+           }
 
-                @NgModule({
-                  schemas: [CUSTOM_ELEMENTS_SCHEMA],
-                  declarations: [ComponentUsingInvalidProperty]
-                })
-                class SomeModule {
-                }
+           @NgModule({
+             schemas: [CUSTOM_ELEMENTS_SCHEMA],
+             declarations: [ComponentUsingInvalidProperty],
+             entryComponents: [ComponentUsingInvalidProperty]
+           })
+           class SomeModule {
+           }
 
-                expect(() => createModule(SomeModule)).not.toThrow();
-              });
+           expect(() => {
+             const fixture = createComp(ComponentUsingInvalidProperty, SomeModule);
+             fixture.detectChanges();
+           }).not.toThrow();
+         });
     });
 
     describe('id', () => {

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -275,6 +275,10 @@ function declareTests(config?: {useJit: boolean}) {
            @NgModule({
              schemas: [CUSTOM_ELEMENTS_SCHEMA],
              declarations: [ComponentUsingInvalidProperty],
+
+             // Note that we need to add the component to `entryComponents`, because of the
+             // `createComp` call below. In Ivy the property validation happens during the
+             //  update phase so we need to create the component, in order for it to run.
              entryComponents: [ComponentUsingInvalidProperty]
            })
            class SomeModule {

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -2320,8 +2320,8 @@ describe('di', () => {
   describe('getOrCreateNodeInjector', () => {
     it('should handle initial undefined state', () => {
       const contentView = createLView(
-          null, createTView(-1, null, 1, 0, null, null, null), null, LViewFlags.CheckAlways, null,
-          null, {} as any, {} as any);
+          null, createTView(-1, null, 1, 0, null, null, null, null), null, LViewFlags.CheckAlways,
+          null, null, {} as any, {} as any);
       const oldView = enterView(contentView, null);
       try {
         const parentTNode = createNodeAtIndex(0, TNodeType.Element, null, null, null);

--- a/packages/core/test/render3/styling/class_and_style_bindings_spec.ts
+++ b/packages/core/test/render3/styling/class_and_style_bindings_spec.ts
@@ -34,8 +34,8 @@ describe('style and class based bindings', () => {
     const rootContext =
         createRootContext(requestAnimationFrame.bind(window), playerHandler || null);
     const lView = createLView(
-        null, createTView(-1, null, 1, 0, null, null, null), rootContext, LViewFlags.IsRoot, null,
-        null, domRendererFactory3, domRendererFactory3.createRenderer(element, null));
+        null, createTView(-1, null, 1, 0, null, null, null, null), rootContext, LViewFlags.IsRoot,
+        null, null, domRendererFactory3, domRendererFactory3.createRenderer(element, null));
     return lView;
   }
 


### PR DESCRIPTION
Accounts for schemas in when validating properties in Ivy.

This PR resolves FW-819.

A couple of notes:
* I had to rework the test slightly, in order to have it fail when we expect it to. The one in master is passing since Ivy's validation runs during the update phase, rather than creation.
* I had to deviate from the design in FW-819 and not add an `enableSchema` instruction, because the schema is part of the `NgModule` scope, however the scope is only assigned to a component once all of the module's declarations have been resolved and some of them can be async. Instead, I opted to have the `schemas` on the component definition.