### PR TITLE
fix(ivy): support attribute selectors for content projection on inlin…

### DIFF
--- a/packages/compiler/src/core.ts
+++ b/packages/compiler/src/core.ts
@@ -436,4 +436,33 @@ export const enum AttributeMarker {
    * ['class', 'fade in', AttributeMarker.SelectOnly, 'foo', 'bar']
    */
   SelectOnly = 3,
+
+  /**
+   * This marker indicates that the following attributes were extracted onto an ng-template element
+   * that is synthesized from the contained element an inline template.
+   * This allows them to be used to match against content projection selectors.
+   *
+   * The AttributeMarker.Classes and AttributeMarker.Styles markers are still in effect.
+   * For example in `<div *ngIf="..." foo="bar" class="a b">` you would get the following:
+   *
+   * ```
+   * [
+   *   AttributeMarker.SelectOnly,
+   *   'ngIf',
+   *   AttributeMarker.ProjectionOnly,
+   *   'foo',
+   *   AttributeMarker.Classes,
+   *   'a',
+   *   'b'
+   * ]
+   * ```
+   *
+   * This allows the `foo` attribute and the `a` and `b` CSS classes to be used to match for
+   * content projection selection, e.g. `<ng-content select="div.b">` and
+   * `<ng-content select="[foo=bar]">` would match the example given above.
+   *
+   * Attributes that appear after the `AttributeMarker.ProjectionOnly` marker are not rendered
+   * and do not take part in directive matching.
+   */
+  ProjectionOnly = 4,
 }

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -74,10 +74,10 @@ export class Element implements Node {
 export class Template implements Node {
   constructor(
       public tagName: string, public attributes: TextAttribute[], public inputs: BoundAttribute[],
-      public outputs: BoundEvent[], public children: Node[], public references: Reference[],
-      public variables: Variable[], public sourceSpan: ParseSourceSpan,
-      public startSourceSpan: ParseSourceSpan|null, public endSourceSpan: ParseSourceSpan|null,
-      public i18n?: I18nAST) {}
+      public outputs: BoundEvent[], public projectionAttributes: TextAttribute[],
+      public children: Node[], public references: Reference[], public variables: Variable[],
+      public sourceSpan: ParseSourceSpan, public startSourceSpan: ParseSourceSpan|null,
+      public endSourceSpan: ParseSourceSpan|null, public i18n?: I18nAST) {}
   visit<Result>(visitor: Visitor<Result>): Result { return visitor.visitTemplate(this); }
 }
 
@@ -182,15 +182,19 @@ export class TransformVisitor implements Visitor<Node> {
     const newAttributes = transformAll(this, template.attributes);
     const newInputs = transformAll(this, template.inputs);
     const newOutputs = transformAll(this, template.outputs);
+    // const newProjectionAttributes = transformAll(this, template.projectionAttributes);
     const newChildren = transformAll(this, template.children);
     const newReferences = transformAll(this, template.references);
     const newVariables = transformAll(this, template.variables);
     if (newAttributes != template.attributes || newInputs != template.inputs ||
+        newOutputs != template.outputs ||
+        // newProjectionAttributes != template.projectionAttributes ||
         newChildren != template.children || newVariables != template.variables ||
         newReferences != template.references) {
       return new Template(
-          template.tagName, newAttributes, newInputs, newOutputs, newChildren, newReferences,
-          newVariables, template.sourceSpan, template.startSourceSpan, template.endSourceSpan);
+          template.tagName, newAttributes, newInputs, newOutputs, template.projectionAttributes,
+          newChildren, newReferences, newVariables, template.sourceSpan, template.startSourceSpan,
+          template.endSourceSpan);
     }
     return template;
   }

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -167,8 +167,9 @@ class HtmlAstToIvyAst implements html.Visitor {
       const attrs = this.extractAttributes(element.name, parsedProperties, i18nAttrsMeta);
 
       parsedElement = new t.Template(
-          element.name, attributes, attrs.bound, boundEvents, children, references, variables,
-          element.sourceSpan, element.startSourceSpan, element.endSourceSpan, element.i18n);
+          element.name, attributes, attrs.bound, boundEvents, [/* no projection attributes */],
+          children, references, variables, element.sourceSpan, element.startSourceSpan,
+          element.endSourceSpan, element.i18n);
     } else {
       const attrs = this.extractAttributes(element.name, parsedProperties, i18nAttrsMeta);
       parsedElement = new t.Element(
@@ -180,9 +181,9 @@ class HtmlAstToIvyAst implements html.Visitor {
       const attrs = this.extractAttributes('ng-template', templateParsedProperties, i18nAttrsMeta);
       // TODO(pk): test for this case
       parsedElement = new t.Template(
-          (parsedElement as t.Element).name, attrs.literal, attrs.bound, [], [parsedElement], [],
-          templateVariables, element.sourceSpan, element.startSourceSpan, element.endSourceSpan,
-          element.i18n);
+          (parsedElement as t.Element).name, attrs.literal, attrs.bound, [/* no outputs */],
+          attributes, [parsedElement], [/* no references */], templateVariables, element.sourceSpan,
+          element.startSourceSpan, element.endSourceSpan, element.i18n);
     }
     return parsedElement;
   }

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -792,6 +792,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     template.attributes.forEach(
         (a: t.TextAttribute) => { attrsExprs.push(asLiteral(a.name), asLiteral(a.value)); });
     attrsExprs.push(...this.prepareSelectOnlyAttrs(template.inputs, template.outputs));
+    attrsExprs.push(...this.prepareProjectionOnlyAttrs(template.projectionAttributes));
     parameters.push(this.toAttrsParam(attrsExprs));
 
     // local refs (ex.: <ng-template #foo>)
@@ -1089,6 +1090,14 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     }
 
     return attrExprs;
+  }
+
+  private prepareProjectionOnlyAttrs(attrsExprs: t.TextAttribute[]): o.Expression[] {
+    const preparedAttrs: o.Expression[] =
+        attrsExprs.length ? [o.literal(core.AttributeMarker.ProjectionOnly)] : [];
+    attrsExprs.forEach(
+        (a: t.TextAttribute) => { preparedAttrs.push(asLiteral(a.name), asLiteral(a.value)); });
+    return preparedAttrs;
   }
 
   private toAttrsParam(attrsExprs: o.Expression[]): o.Expression {

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -35,7 +35,7 @@ import {SanitizerFn} from './interfaces/sanitization';
 import {BINDING_INDEX, CLEANUP, CONTAINER_INDEX, CONTEXT, DECLARATION_VIEW, FLAGS, HEADER_OFFSET, HOST, INJECTOR, InitPhaseState, LView, LViewFlags, NEXT, OpaqueViewState, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, TAIL, TData, TVIEW, TView, T_HOST} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
 import {appendChild, appendProjectedNode, createTextNode, getLViewChild, insertView, removeView} from './node_manipulation';
-import {isNodeMatchingSelectorList, matchingSelectorIndex} from './node_selector_matcher';
+import {isNodeMatchingSelectorList, matchingProjectionSelectorIndex} from './node_selector_matcher';
 import {decreaseElementDepthCount, enterView, getBindingsEnabled, getCheckNoChangesMode, getContextLView, getCurrentDirectiveDef, getElementDepthCount, getIsParent, getLView, getPreviousOrParentTNode, increaseElementDepthCount, isCreationMode, leaveView, nextContextImpl, resetComponentState, setBindingRoot, setCheckNoChangesMode, setCurrentDirectiveDef, setCurrentQueryIndex, setIsParent, setPreviousOrParentTNode} from './state';
 import {getInitialClassNameValue, initializeStaticContext as initializeStaticStylingContext, patchContextWithStaticAttrs, renderInitialStylesAndClasses, renderStyling, updateClassProp as updateElementClassProp, updateContextWithBindings, updateStyleProp as updateElementStyleProp, updateStylingMap} from './styling/class_and_style_bindings';
 import {BoundPlayerFactory} from './styling/player_factory';
@@ -2055,14 +2055,14 @@ function generateInitialInputs(
   let i = 0;
   while (i < attrs.length) {
     const attrName = attrs[i];
-    // If we hit Select-Only, Classes or Styles, we're done anyway. None of those are valid inputs.
-    if (attrName === AttributeMarker.SelectOnly || attrName === AttributeMarker.Classes ||
-        attrName === AttributeMarker.Styles)
-      break;
     if (attrName === AttributeMarker.NamespaceURI) {
       // We do not allow inputs on namespaced attributes.
       i += 4;
       continue;
+    }
+    // If we hit any other attribute markers, we're done anyway. None of those are valid inputs.
+    if (typeof attrName === 'number') {
+      break;
     }
     const minifiedInputName = inputs[attrName];
     const attrValue = attrs[i + 1];
@@ -2483,8 +2483,9 @@ export function projectionDef(selectors?: CssSelectorList[], textSelectors?: str
     let componentChild: TNode|null = componentNode.child;
 
     while (componentChild !== null) {
-      const bucketIndex =
-          selectors ? matchingSelectorIndex(componentChild, selectors, textSelectors !) : 0;
+      const bucketIndex = selectors ?
+          matchingProjectionSelectorIndex(componentChild, selectors, textSelectors !) :
+          0;
       const nextNode = componentChild.next;
 
       if (tails[bucketIndex]) {

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -110,6 +110,35 @@ export const enum AttributeMarker {
    * ['class', 'fade in', AttributeMarker.SelectOnly, 'foo', 'bar']
    */
   SelectOnly = 3,
+
+  /**
+   * This marker indicates that the following attributes were extracted onto an ng-template element
+   * that is synthesized from the contained element an inline template.
+   * This allows them to be used to match against content projection selectors.
+   *
+   * The AttributeMarker.Classes and AttributeMarker.Styles markers are still in effect.
+   * For example in `<div *ngIf="..." foo="bar" class="a b">` you would get the following:
+   *
+   * ```
+   * [
+   *   AttributeMarker.SelectOnly,
+   *   'ngIf',
+   *   AttributeMarker.ProjectionOnly,
+   *   'foo',
+   *   AttributeMarker.Classes,
+   *   'a',
+   *   'b'
+   * ]
+   * ```
+   *
+   * This allows the `foo` attribute and the `a` and `b` CSS classes to be used to match for
+   * content projection selection, e.g. `<ng-content select="div.b">` and
+   * `<ng-content select="[foo=bar]">` would match the example given above.
+   *
+   * Attributes that appear after the `AttributeMarker.ProjectionOnly` marker are not rendered
+   * and do not take part in directive matching.
+   */
+  ProjectionOnly = 4,
 }
 
 /**

--- a/packages/core/src/render3/styling/class_and_style_bindings.ts
+++ b/packages/core/src/render3/styling/class_and_style_bindings.ts
@@ -57,7 +57,7 @@ export function initializeStaticContext(attrs: TAttributes) {
       initialStyles.push(attr as string, attrs[++i] as string);
     } else if (mode === AttributeMarker.Classes) {
       initialClasses.push(attr as string, true);
-    } else if (mode === AttributeMarker.SelectOnly) {
+    } else if (mode === AttributeMarker.SelectOnly || mode === AttributeMarker.ProjectionOnly) {
       break;
     }
   }
@@ -99,6 +99,8 @@ export function patchContextWithStaticAttrs(
       } else if (mode == AttributeMarker.Styles) {
         initialStyles = initialStyles || context[StylingIndex.InitialStyleValuesPosition];
         patchInitialStylingValue(initialStyles, attr, attrs[++i]);
+      } else if (mode === AttributeMarker.SelectOnly || mode === AttributeMarker.ProjectionOnly) {
+        break;
       }
     }
   }

--- a/packages/core/src/render3/styling/util.ts
+++ b/packages/core/src/render3/styling/util.ts
@@ -193,6 +193,8 @@ export function hasStyling(attrs: TAttributes): boolean {
   for (let i = 0; i < attrs.length; i++) {
     const attr = attrs[i];
     if (attr == AttributeMarker.Classes || attr == AttributeMarker.Styles) return true;
+    if (attr === AttributeMarker.SelectOnly || attr === AttributeMarker.ProjectionOnly)
+      return false;
   }
   return false;
 }

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
+import {Component, Directive} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
@@ -55,5 +55,86 @@ describe('projection', () => {
     fixture.componentInstance.items = [6, 7, 8, 9];
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('6|7|8|');
+  });
+
+  it('should project selected inline templates matching element name', () => {
+    let divDirectives = 0;
+    @Component({selector: 'selector-proj', template: '<ng-content select="div"></ng-content>'})
+    class SelectedNgContentComp {
+    }
+
+    @Directive({selector: 'div'})
+    class DivDirective {
+      constructor() { divDirectives++; }
+    }
+
+    @Component({
+      selector: 'main-selector',
+      template: '<selector-proj><div x="true" *ngIf="true">Hello world!</div></selector-proj>'
+    })
+    class SelectorMainComp {
+    }
+
+    TestBed.configureTestingModule(
+        {declarations: [DivDirective, SelectedNgContentComp, SelectorMainComp]});
+    const fixture = TestBed.createComponent<SelectorMainComp>(SelectorMainComp);
+
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveText('Hello world!');
+    expect(divDirectives).toEqual(1);
+  });
+
+  it('should select selected inline templates matching attributes', () => {
+    let xDirectives = 0;
+    @Component({selector: 'selector-proj', template: '<ng-content select="[x]"></ng-content>'})
+    class SelectedNgContentComp {
+    }
+
+    @Directive({selector: '[x]'})
+    class XDirective {
+      constructor() { xDirectives++; }
+    }
+
+    @Component({
+      selector: 'main-selector',
+      template: '<selector-proj><div x="true" *ngIf="true">Hello world!</div></selector-proj>'
+    })
+    class SelectorMainComp {
+    }
+
+    TestBed.configureTestingModule(
+        {declarations: [XDirective, SelectedNgContentComp, SelectorMainComp]});
+    const fixture = TestBed.createComponent<SelectorMainComp>(SelectorMainComp);
+
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveText('Hello world!');
+    expect(xDirectives).toEqual(1);
+  });
+
+  it('should select selected inline templates matching classes', () => {
+    let xDirectives = 0;
+    @Component({selector: 'selector-proj', template: '<ng-content select=".x"></ng-content>'})
+    class SelectedNgContentComp {
+    }
+
+    @Directive({selector: '.x'})
+    class XDirective {
+      constructor() { xDirectives++; }
+    }
+
+    @Component({
+      selector: 'main-selector',
+      template: '<selector-proj><div class="x" *ngIf="true">Hello world!</div></selector-proj>'
+    })
+    class SelectorMainComp {
+    }
+
+    TestBed.configureTestingModule(
+        {declarations: [XDirective, SelectedNgContentComp, SelectorMainComp]});
+    const fixture = TestBed.createComponent<SelectorMainComp>(SelectorMainComp);
+
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveText('Hello world!');
+    expect(xDirectives).toEqual(1);
   });
 });


### PR DESCRIPTION
…e templates

The content projection mechanism is static, in that it only looks at the static
template nodes before directives are matched and change detection is run.
When you have a selector-based content projection the selection is based
on nodes that are available in the template.

For example:

```
<ng-content selector="[some-attr]"></ng-content>
```

would match

```
<div some-attr="..."></div>
```

If you have an inline template in your projected nodes. For example:

```
<div *ngIf="..." some-attr="..."></div>
```

This gets pre-parsed and converted to a canonical form.

For example:

```
<ng-template [ngIf]="...">
  <div some-attr=".."></div>
</ng-template>
```

Note that non-`*` attributes stay with the content nodes
rather than the `<ng-template>` node.

When this happens in ivy, the ng-template content is removed
from the component template function and is compiled into its own
template function. But this means that the information about the
attributes that were on the content are lost and the projection
selection mechanism is unable to match the original
`<div *ngIf="..." some-attr>`.

This commit adds support for this in ivy by passing these "projection-only"
attributes to the `template()` instruction, so that it can be matched against
selectors that matched the origjnal inline template element attributes.

This is achieved by adding a new `AttributeMarker.ProjectionOnly` marker,
which must appear after the `AttributeMarker.SelectOnly` marked attribute
names. Attributes after this new marker are not rendered, nor are they considered
for matching directives. They are only used when matching content projection
selectors.


Fixes FW-1002