### PR TITLE
ci: downgrade to sauce-connect v4.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "rewire": "2.5.2",
     "rollup-plugin-commonjs": "8.1.0",
     "rxjs": "^6.3.0",
-    "sauce-connect": "https://saucelabs.com/downloads/sc-4.5.3-linux.tar.gz",
+    "sauce-connect": "https://saucelabs.com/downloads/sc-4.5.1-linux.tar.gz",
     "semver": "5.4.1",
     "tslint": "5.7.0",
     "tslint-eslint-rules": "4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8905,9 +8905,9 @@ sauce-connect-launcher@^1.2.4:
     lodash "^4.16.6"
     rimraf "^2.5.4"
 
-"sauce-connect@https://saucelabs.com/downloads/sc-4.5.3-linux.tar.gz":
+"sauce-connect@https://saucelabs.com/downloads/sc-4.5.1-linux.tar.gz":
   version "0.0.0"
-  resolved "https://saucelabs.com/downloads/sc-4.5.3-linux.tar.gz#c7ad595a2a42f837fab91de3c3f51b49f2af6b36"
+  resolved "https://saucelabs.com/downloads/sc-4.5.1-linux.tar.gz#5ca9328724c5ff16b12ea49e7a748d44f7305be5"
 
 saucelabs@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
We currently face a lot of flakiness with our Saucelabs CI jobs. 
These randomly exceed the 10min CircleCI no-output limit because
something throws off `sauce-connect` in a long-lasting loop where
it tries to connect to some of their Saucelabs servers. The initial
assumption from the Saucelabs team was that we might have some
invalid firewall rules, but this does not answer why this happens
_randomly_, so the latest update from the support is that there have
been some changes in the latest version of `sauce-connect` version that
**could** cause this flakiness.

I've manually did multiple test runs and was only able to reproduce the issues
with v4.5.3 (latest version), so it might be worth downgrading to v4.5.1. This is
also what the Saucelabs support proposed us to do (though it's not guaranteed
that v4.5.1 is unaffected by the same issue)