### PR TITLE
fix(core): improve TestBed.configureTestingModule type safety

### DIFF
--- a/goldens/public-api/core/testing/testing.d.ts
+++ b/goldens/public-api/core/testing/testing.d.ts
@@ -131,9 +131,9 @@ export declare class TestComponentRenderer {
 }
 
 export declare type TestModuleMetadata = {
-    providers?: any[];
-    declarations?: any[];
-    imports?: any[];
+    providers?: Provider[];
+    declarations?: Array<Type<any> | any[] | any>;
+    imports?: Array<Type<any> | any[] | any>;
     schemas?: Array<SchemaMetadata | any[]>;
     aotSummaries?: () => any[];
 };

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -6,11 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AbstractType, Component, Directive, InjectFlags, InjectionToken, NgModule, Pipe, PlatformRef, SchemaMetadata, Type} from '@angular/core';
-
-import {ComponentFixture} from './component_fixture';
-import {MetadataOverride} from './metadata_override';
-import {TestBed} from './test_bed';
+import { AbstractType, Component, Directive, InjectFlags, InjectionToken, NgModule, Pipe, PlatformRef, Provider, SchemaMetadata, Type } from '@angular/core';
+import { ComponentFixture } from './component_fixture';
+import { MetadataOverride } from './metadata_override';
+import { TestBed } from './test_bed';
 
 /**
  * An abstract class for inserting the root test component element in a platform independent way.
@@ -36,9 +35,9 @@ export const ComponentFixtureNoNgZone = new InjectionToken<boolean[]>('Component
  * @publicApi
  */
 export type TestModuleMetadata = {
-  providers?: any[],
-  declarations?: any[],
-  imports?: any[],
+  providers?: Provider[],
+  declarations?: Array<Type<any>|any[]|any>,
+  imports?: Array<Type<any>|any[]|any>,
   schemas?: Array<SchemaMetadata|any[]>,
   aotSummaries?: () => any[],
 };


### PR DESCRIPTION
Added the same typings used in https://github.com/angular/angular/blob/master/packages/core/testing/src/test_bed.ts#L263-L267

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ x ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

It is currently possible to pass anything in the `configureTestingModule` function.


## What is the new behavior?

Typescript will now throw errors when providing garbage.

## Does this PR introduce a breaking change?

- [x ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Typescript builds are going to start failing if an error is present in user code.

## Other information
