### PR TITLE
refactor(bazel): use multi_sass_binary rule

### DIFF
--- a/packages/bazel/src/schematics/bazel-workspace/files/src/BUILD.bazel.template
+++ b/packages/bazel/src/schematics/bazel-workspace/files/src/BUILD.bazel.template
@@ -5,16 +5,12 @@ load("@build_bazel_rules_karma//:defs.bzl", "ts_web_test_suite")
 load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle", "history_server")
 load("@build_bazel_rules_nodejs//internal/web_package:web_package.bzl", "web_package")
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_devserver", "ts_library")
-<% if (sass) { %>load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")
+<% if (sass) { %>load("@io_bazel_rules_sass//:defs.bzl", "multi_sass_binary")
 
-[
-sass_binary(
-    name = "style_" + x,
-    src = x,
-    deps = [],
+multi_sass_binary(
+    name = "styles",
+    srcs = glob(["**/*.scss"]),
 )
-for x in glob(["**/*.scss"])
-]
 <% } %>
 ng_module(
     name = "src",
@@ -30,7 +26,7 @@ ng_module(
     assets = glob([
       "**/*.css",
       "**/*.html",
-    ])<% if (sass) { %> + [":style_" + x for x in glob(["**/*.scss"])]<% } %>,
+    ])<% if (sass) { %> + [":styles"]<% } %>,
     deps = [
         "@angular//packages/core",
         "@angular//packages/platform-browser",<% if (routing) { %>

--- a/packages/bazel/src/schematics/bazel-workspace/index.ts
+++ b/packages/bazel/src/schematics/bazel-workspace/index.ts
@@ -95,7 +95,7 @@ export default function(options: BazelWorkspaceOptions): Rule {
       'ANGULAR_VERSION': existingVersions.Angular || clean(latestVersions.Angular),
       'RXJS_VERSION': existingVersions.RxJs || clean(latestVersions.RxJs),
       // TODO(kyliau): Consider moving this to latest-versions.ts
-      'RULES_SASS_VERSION': '1.15.1',
+      'RULES_SASS_VERSION': '1.17.0',
     };
 
     return mergeWith(apply(url('./files'), [

--- a/packages/bazel/src/schematics/bazel-workspace/index_spec.ts
+++ b/packages/bazel/src/schematics/bazel-workspace/index_spec.ts
@@ -100,9 +100,9 @@ describe('Bazel-workspace Schematic', () => {
           'load("@io_bazel_rules_sass//sass:sass_repositories.bzl", "sass_repositories")');
     });
 
-    it('should add sass_binary rules in src/BUILD', () => {
+    it('should add multi_sass_binary rule in src/BUILD', () => {
       const content = host.readContent('/src/BUILD.bazel');
-      expect(content).toContain('load("@io_bazel_rules_sass//:defs.bzl", "sass_binary")');
+      expect(content).toContain('load("@io_bazel_rules_sass//:defs.bzl", "multi_sass_binary")');
       expect(content).toContain('glob(["**/*.scss"])');
     });
   });


### PR DESCRIPTION
`multi_sass_binary` rules is reinstated in rules_sass v1.17.0
and it is a better solution than list comprehension currently used
because it handles imports correctly.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
