### PR TITLE
fix(ivy): should mark OnPush ancestor of dynamically created views as…

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -30,7 +30,7 @@ import {AttributeMarker, InitialInputData, InitialInputs, LocalRefExtractor, Pro
 import {PlayerFactory} from './interfaces/player';
 import {CssSelectorList, NG_PROJECT_AS_ATTR_NAME} from './interfaces/projection';
 import {LQueries} from './interfaces/query';
-import {GlobalTargetResolver, ProceduralRenderer3, RComment, RElement, RNode, RText, Renderer3, RendererFactory3, isProceduralRenderer} from './interfaces/renderer';
+import {GlobalTargetResolver, ProceduralRenderer3, RComment, RElement, RText, Renderer3, RendererFactory3, isProceduralRenderer} from './interfaces/renderer';
 import {SanitizerFn} from './interfaces/sanitization';
 import {BINDING_INDEX, CLEANUP, CONTAINER_INDEX, CONTEXT, DECLARATION_VIEW, FLAGS, HEADER_OFFSET, HOST, INJECTOR, InitPhaseState, LView, LViewFlags, NEXT, OpaqueViewState, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, TAIL, TData, TVIEW, TView, T_HOST} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
@@ -41,7 +41,7 @@ import {getInitialClassNameValue, getInitialStyleStringValue, initializeStaticCo
 import {BoundPlayerFactory} from './styling/player_factory';
 import {ANIMATION_PROP_PREFIX, allocateDirectiveIntoContext, createEmptyStylingContext, forceClassesAsString, forceStylesAsString, getStylingContext, hasClassInput, hasStyleInput, hasStyling, isAnimationProp} from './styling/util';
 import {NO_CHANGE} from './tokens';
-import {INTERPOLATION_DELIMITER, findComponentView, getComponentViewByIndex, getNativeByIndex, getNativeByTNode, getRootContext, getRootView, getTNode, isComponent, isComponentDef, isContentQueryHost, loadInternal, readElementValue, readPatchedLView, renderStringify} from './util';
+import {INTERPOLATION_DELIMITER, findComponentView, getComponentViewByIndex, getNativeByIndex, getNativeByTNode, getRootContext, getRootView, getTNode, isComponent, isComponentDef, isContentQueryHost, isRootView, loadInternal, readElementValue, readPatchedLView, renderStringify} from './util';
 
 
 
@@ -2727,15 +2727,16 @@ function wrapListener(
  * @returns the root LView
  */
 export function markViewDirty(lView: LView): LView|null {
-  while (lView && !(lView[FLAGS] & LViewFlags.IsRoot)) {
+  while (lView) {
     lView[FLAGS] |= LViewFlags.Dirty;
+    // Stop traversing up as soon as you find a root view that wasn't attached to any container
+    if (isRootView(lView) && lView[CONTAINER_INDEX] === -1) {
+      return lView;
+    }
+    // continue otherwise
     lView = lView[PARENT] !;
   }
-  // Detached views do not have a PARENT and also aren't root views
-  if (lView) {
-    lView[FLAGS] |= LViewFlags.Dirty;
-  }
-  return lView;
+  return null;
 }
 
 /**

--- a/packages/core/src/render3/util.ts
+++ b/packages/core/src/render3/util.ts
@@ -16,7 +16,7 @@ import {NO_PARENT_INJECTOR, RelativeInjectorLocation, RelativeInjectorLocationFl
 import {TContainerNode, TElementNode, TNode, TNodeFlags, TNodeType} from './interfaces/node';
 import {RComment, RElement, RText} from './interfaces/renderer';
 import {StylingContext} from './interfaces/styling';
-import {CONTEXT, DECLARATION_VIEW, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, PARENT, RootContext, TData, TVIEW, TView, T_HOST} from './interfaces/view';
+import {CONTEXT, DECLARATION_VIEW, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, PARENT, RootContext, TData, TVIEW, T_HOST} from './interfaces/view';
 
 
 

--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -3008,39 +3008,11 @@ window.testBlocklist = {
   "MatTooltip special cases should clear the `-webkit-user-drag` on draggable elements": {
     "error": "Error: Expected 'none' to be falsy.",
     "notes": "Unknown"
-  },
-  "MatCalendarHeader standard calendar should go to previous and next year": {
-    "error": "Error: Expected 'multi-year' to be 'year'.",
-    "notes": "FW-1044: Events dispatched by dynamic components are not marking ancestor components dirty"
-  },
-  "MatCalendarHeader standard calendar should go back to month view after selecting year and month": {
-    "error": "Error: Expected 'multi-year' to be 'year'.",
-    "notes": "FW-1044: Events dispatched by dynamic components are not marking ancestor components dirty"
-  },
-  "MatCalendar standard calendar should emit the selected month on cell clicked in year view": {
-    "error": "Error: Expected 'multi-year' to be 'year'.",
-    "notes": "FW-1044: Events dispatched by dynamic components are not marking ancestor components dirty"
-  },
+  }, 
   "MatCalendar standard calendar should emit the selected year on cell clicked in multiyear view": {
     "error": "TypeError: Cannot read property 'getFullYear' of undefined",
     "notes": "Unknown"
-  },
-  "MatCalendar standard calendar a11y calendar body year view should return to month view on enter": {
-    "error": "Error: Expected 'multi-year' to be 'year'.",
-    "notes": "FW-1044: Events dispatched by dynamic components are not marking ancestor components dirty"
-  },
-  "MatCalendar standard calendar a11y calendar body year view should return to month view on space": {
-    "error": "Error: Expected 'multi-year' to be 'year'.",
-    "notes": "FW-1044: Events dispatched by dynamic components are not marking ancestor components dirty"
-  },
-  "MatCalendar standard calendar a11y calendar body multi-year view should go to year view on enter": {
-    "error": "Error: Expected 'multi-year' to be 'year'.",
-    "notes": "FW-1044: Events dispatched by dynamic components are not marking ancestor components dirty"
-  },
-  "MatCalendar standard calendar a11y calendar body multi-year view should go to year view on space": {
-    "error": "Error: Expected 'multi-year' to be 'year'.",
-    "notes": "FW-1044: Events dispatched by dynamic components are not marking ancestor components dirty"
-  },
+  },  
   "MatCalendar calendar with min and max date should not go back past min date": {
     "error": "Error: Expected false to be true, 'previous button should be disabled'.",
     "notes": "Unknown"
@@ -3068,10 +3040,6 @@ window.testBlocklist = {
   "MatCalendar calendar with min and max date should update the minDate in the child view if it changed after an interaction": {
     "error": "Error: This PortalOutlet has already been disposed",
     "notes": "Unknown"
-  },
-  "MatCalendar calendar with date filter a11y should allow entering month view at disabled month": {
-    "error": "Error: Expected 'multi-year' to be 'year'.",
-    "notes": "FW-1044: Events dispatched by dynamic components are not marking ancestor components dirty"
   },
   "MatPaginator when navigating with the next and previous buttons should be able to go to the next page": {
     "error": "TypeError: Cannot read property 'pageIndex' of undefined",


### PR DESCRIPTION
… dirty

While marking a given views tree as dirty we should go all the way to the
root of the views tree and cross boundaries of dynamically inserted views.
In other words the markForCheck functionality should consider parents of
dynamically inserted views.
