### PR TITLE
build(bazel): specify tsconfig-test dependency

### DIFF
--- a/packages/BUILD.bazel
+++ b/packages/BUILD.bazel
@@ -2,10 +2,10 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "tsconfig-build.json",
-    "tsconfig-test.json",
     "tsconfig.json",
 ])
 
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_config")
 load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
@@ -15,6 +15,12 @@ ts_library(
         "@ngdeps//@types/hammerjs",
         "@ngdeps//zone.js",
     ],
+)
+
+ts_config(
+    name = "tsconfig-test",
+    src = "tsconfig-test.json",
+    deps = [":tsconfig-build.json"],
 )
 
 exports_files([

--- a/packages/examples/testing/BUILD.bazel
+++ b/packages/examples/testing/BUILD.bazel
@@ -5,7 +5,7 @@ load("//tools:defaults.bzl", "ts_library")
 ts_library(
     name = "testing_examples",
     srcs = glob(["**/*.ts"]),
-    tsconfig = "//packages:tsconfig-test.json",
+    tsconfig = "//packages:tsconfig-test",
     deps = [
         "@ngdeps//@types/jasmine",
         "@ngdeps//@types/node",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -7,7 +7,7 @@ load("//packages/bazel:index.bzl", _ng_module = "ng_module", _ng_package = "ng_p
 load("//packages/bazel/src:ng_rollup_bundle.bzl", _ng_rollup_bundle = "ng_rollup_bundle")
 
 _DEFAULT_TSCONFIG_BUILD = "//packages:tsconfig-build.json"
-_DEFAULT_TSCONFIG_TEST = "//packages:tsconfig-test.json"
+_DEFAULT_TSCONFIG_TEST = "//packages:tsconfig-test"
 _DEFAULT_TS_TYPINGS = "@ngdeps//typescript:typescript__typings"
 _DEFAULT_KARMA_BIN = "@ngdeps//@bazel/karma/bin:karma"
 _INTERNAL_NG_MODULE_COMPILER = "//packages/bazel/src/ngc-wrapped"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Default test tsconfig only pointed at tsconfig-test.json.

Issue Number: N/A


## What is the new behavior?

Default test tsconfig points at tsconfig-test.json with proper dependencies.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This doesn't fix any known build issues, but it fixes Bazel build analysis tools that require explicit dependencies such as https://github.com/kythe/kythe/blob/1cd291dd874e50e4bb6fe80842f37b2eef118e50/kythe/extractors/BUILD#L100.