### PR TITLE
build(bazel): update to rules_nodejs 0.18.6

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,8 +15,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch rules_nodejs so we can install our npm dependencies
 http_archive(
     name = "build_bazel_rules_nodejs",
-    strip_prefix = "rules_nodejs-0.16.8",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/archive/0.16.8.zip"],
+    sha256 = "1416d03823fed624b49a0abbd9979f7c63bbedfd37890ddecedd2fe25cccebc6",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.18.6/rules_nodejs-0.18.6.tar.gz"],
 )
 
 # Fetch the rxjs repository since we build rxjs from source

--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -5,8 +5,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch rules_nodejs so we can install our npm dependencies
 http_archive(
     name = "build_bazel_rules_nodejs",
-    strip_prefix = "rules_nodejs-0.16.8",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/archive/0.16.8.zip"],
+    sha256 = "1416d03823fed624b49a0abbd9979f7c63bbedfd37890ddecedd2fe25cccebc6",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.18.6/rules_nodejs-0.18.6.tar.gz"],
 )
 
 # Fetch sass rules for compiling sass files

--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -13,7 +13,9 @@ It packages your library following the Angular Package Format, see the
 specification of this format at https://goo.gl/jB3GVv
 """
 
-load("@build_bazel_rules_nodejs//:internal/collect_es6_sources.bzl", "collect_es6_sources")
+load("@build_bazel_rules_nodejs//internal/common:collect_es6_sources.bzl", "collect_es6_sources")
+load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleInfo")
+load("@build_bazel_rules_nodejs//internal/common:sources_aspect.bzl", "sources_aspect")
 load(
     "@build_bazel_rules_nodejs//:internal/rollup/rollup_bundle.bzl",
     "ROLLUP_ATTRS",
@@ -27,8 +29,6 @@ load(
     "NPM_PACKAGE_OUTPUTS",
     "create_package",
 )
-load("@build_bazel_rules_nodejs//:internal/node.bzl", "sources_aspect")
-load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleInfo")
 load("//packages/bazel/src:esm5.bzl", "esm5_outputs_aspect", "esm5_root_dir", "flatten_esm5")
 load("//packages/bazel/src/ng_package:collect-type-definitions.bzl", "collect_type_definitions")
 

--- a/packages/bazel/src/ng_rollup_bundle.bzl
+++ b/packages/bazel/src/ng_rollup_bundle.bzl
@@ -24,7 +24,7 @@ load(
     "run_uglify",
     "write_rollup_config",
 )
-load("@build_bazel_rules_nodejs//internal:collect_es6_sources.bzl", collect_es2015_sources = "collect_es6_sources")
+load("@build_bazel_rules_nodejs//internal/common:collect_es6_sources.bzl", collect_es2015_sources = "collect_es6_sources")
 load(":esm5.bzl", "esm5_outputs_aspect", "esm5_root_dir", "flatten_esm5")
 
 PACKAGES = [

--- a/packages/bazel/src/protractor/protractor_web_test.bzl
+++ b/packages/bazel/src/protractor/protractor_web_test.bzl
@@ -4,14 +4,11 @@
 # found in the LICENSE file at https://angular.io/license
 "Run end-to-end tests with Protractor"
 
-load(
-    "@build_bazel_rules_nodejs//internal:node.bzl",
-    "expand_path_into_runfiles",
-    "sources_aspect",
-)
 load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_suite")
 load("@io_bazel_rules_webtesting//web/internal:constants.bzl", "DEFAULT_WRAPPED_TEST_TAGS")
 load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
+load("@build_bazel_rules_nodejs//internal/common:expand_into_runfiles.bzl", "expand_path_into_runfiles")
+load("@build_bazel_rules_nodejs//internal/common:sources_aspect.bzl", "sources_aspect")
 
 _CONF_TMPL = "//packages/bazel/src/protractor:protractor.conf.js"
 

--- a/packages/bazel/src/schematics/bazel-workspace/files/WORKSPACE.template
+++ b/packages/bazel/src/schematics/bazel-workspace/files/WORKSPACE.template
@@ -13,10 +13,11 @@ workspace(name = "<%= utils.underscore(name) %>")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 RULES_NODEJS_VERSION = "<%= RULES_NODEJS_VERSION %>"
+RULES_NODEJS_SHA256 = "<%= RULES_NODEJS_SHA256 %>"
 http_archive(
     name = "build_bazel_rules_nodejs",
-    url = "https://github.com/bazelbuild/rules_nodejs/archive/%s.zip" % RULES_NODEJS_VERSION,
-    strip_prefix = "rules_nodejs-%s" % RULES_NODEJS_VERSION,
+    sha256 = "%s" % RULES_NODEJS_SHA256,
+    url = "https://github.com/bazelbuild/rules_nodejs/releases/download/%s/rules_nodejs-%s.tar.gz" % (RULES_NODEJS_VERSION, RULES_NODEJS_VERSION),
 )
 
 # The @angular repo contains rule for building Angular applications

--- a/packages/bazel/src/schematics/bazel-workspace/index.ts
+++ b/packages/bazel/src/schematics/bazel-workspace/index.ts
@@ -91,7 +91,8 @@ export default function(options: BazelWorkspaceOptions): Rule {
     }
 
     const workspaceVersions = {
-      'RULES_NODEJS_VERSION': '0.16.8',
+      'RULES_NODEJS_VERSION': '0.18.6',
+      'RULES_NODEJS_SHA256': '1416d03823fed624b49a0abbd9979f7c63bbedfd37890ddecedd2fe25cccebc6',
       'ANGULAR_VERSION': existingVersions.Angular || clean(latestVersions.Angular),
       'RXJS_VERSION': existingVersions.RxJs || clean(latestVersions.RxJs),
       // TODO(kyliau): Consider moving this to latest-versions.ts


### PR DESCRIPTION
* Fixes jasmine_node_test node patch issue. Node patch which was applied in bootstrap of jasmine_node_test was being discarded for tests since a new jasmine instance was created. This was fixed in 0.18.5.

* 0.18.6 adds es2015 package.json support to rollup_bundle so after we can stop building rxjs from source under Bazel