### PR TITLE
build: remove legacy-unit-tests-local job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -460,20 +460,6 @@ jobs:
           command: 'curl --request POST --header "Content-Type: application/json" --data "{\"text\":\":x: \`$CIRCLE_JOB\` job failed on build $CIRCLE_BUILD_NUM: $CIRCLE_BUILD_URL :scream:\"}" $SLACK_CARETAKER_WEBHOOK_URL'
           when: on_fail
 
-  legacy-unit-tests-local:
-    <<: *job_defaults
-    docker:
-      - image: *browsers_docker_image
-    steps:
-      - checkout:
-          <<: *post_checkout
-      - *restore_cache
-      - *init_environment
-      - *yarn_install
-      - run: yarn tsc -p packages
-      - run: yarn tsc -p modules
-      - run: yarn karma start ./karma-js.conf.js --single-run --browsers=ChromeNoSandbox
-
   legacy-unit-tests-saucelabs:
     <<: *job_defaults
     # In order to avoid the bottleneck of having a slow host machine, we acquire a better
@@ -543,7 +529,6 @@ workflows:
       - build-npm-packages
       - build-ivy-npm-packages
       - test_aio
-      - legacy-unit-tests-local
       - legacy-unit-tests-saucelabs
       - deploy_aio:
           requires:
@@ -597,7 +582,6 @@ workflows:
             - build-npm-packages
             - build-ivy-npm-packages
             - legacy-misc-tests
-            - legacy-unit-tests-local
             - legacy-unit-tests-saucelabs
       - material-unit-tests:
           requires:

--- a/packages/examples/core/BUILD.bazel
+++ b/packages/examples/core/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//packages/bazel:index.bzl", "protractor_web_test_suite")
-load("//tools:defaults.bzl", "ng_module", "ts_library")
+load("//tools:defaults.bzl", "jasmine_node_test", "ng_module", "ts_library")
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_devserver")
 
 ng_module(
@@ -23,6 +23,19 @@ ng_module(
         "//packages/platform-browser/animations",
         "//packages/router",
         "@ngdeps//rxjs",
+    ],
+)
+
+ts_library(
+    name = "core_tests_lib",
+    testonly = True,
+    srcs = glob(
+        ["**/*_spec.ts"],
+        exclude = ["**/e2e_test/*"],
+    ),
+    deps = [
+        "//packages/core",
+        "//packages/core/testing",
     ],
 )
 
@@ -63,5 +76,14 @@ protractor_web_test_suite(
         ":core_e2e_tests_lib",
         "@ngdeps//protractor",
         "@ngdeps//selenium-webdriver",
+    ],
+)
+
+jasmine_node_test(
+    name = "test",
+    bootstrap = ["angular/tools/testing/init_node_spec.js"],
+    deps = [
+        ":core_tests_lib",
+        "//tools/testing:node",
     ],
 )


### PR DESCRIPTION
See individual commits.

---

I've also made some coverage comparisons for Bazel tests vs legacy unit tests and everything looks if we remove the legacy unit tests job. All spec files being run in the legacy job are also running with Bazel.

https://docs.google.com/document/d/1SD2qEGm22yehmJLmeYodgP2eRyCXNuZtYTZj3WuAldg/edit?usp=sharing