### PR TITLE
fix(ivy): rethrow event handler errors in tests

### DIFF
--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -15,6 +15,7 @@ import {
   Compiler,
   Component,
   Directive,
+  ErrorHandler,
   Injector,
   ModuleWithComponentFactories,
   NgModule,
@@ -600,6 +601,7 @@ export class TestBedRender3 implements Injector, TestBed {
     const providers = [
       {provide: NgZone, useValue: ngZone},
       {provide: Compiler, useFactory: () => new R3TestCompiler(this)},
+      {provide: ErrorHandler, useClass: R3TestErrorHandler},
       ...this._providers,
       ...this._providerOverrides,
     ];
@@ -812,4 +814,9 @@ class R3TestCompiler implements Compiler {
     const meta = this.testBed._getModuleResolver().resolve(moduleType);
     return meta && meta.id || undefined;
   }
+}
+
+/** Error handler used for tests. Rethrows errors rather than logging them out. */
+class R3TestErrorHandler extends ErrorHandler {
+  handleError(error: any) { throw error; }
 }

--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -1273,6 +1273,10 @@ window.testBlocklist = {
     "error": "Error: Expected mat-slide-toggle-thumb-container to contain 'mat-dragging'.",
     "notes": "Unknown"
   },
+  "MatSlideToggle without forms custom action configuration should not change value on click when click action is noop": {
+    "error": "TypeError: this._inputElement is undefined",
+    "notes": "Unknown"
+  },
   "MatDrawer methods should be able to open": {
     "error": "Error: Expected 0 to be 1.",
     "notes": "Unknown"


### PR DESCRIPTION
Currently errors thrown inside event handlers in Ivy are caught and forwarded to the `ErrorHandler`, however this means that if they happen during a unit test, the test won't fail. These changes add a test-specific `ErrorHandler` that throws the error rather than logging it out.
