### PR TITLE
fix(ivy): restore @fileoverview annotations location for Closure

### DIFF
--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -272,8 +272,9 @@ export class NgtscProgram implements api.Program {
         };
 
     const customTransforms = opts && opts.customTransformers;
-    const beforeTransforms =
-        [ivyTransformFactory(compilation, this.reflector, this.importRewriter, this.isCore)];
+    const beforeTransforms = [ivyTransformFactory(
+        compilation, this.reflector, this.importRewriter, this.isCore,
+        this.closureCompilerEnabled)];
     const afterDeclarationsTransforms = [declarationTransformFactory(compilation)];
 
     if (this.factoryToSourceInfo !== null) {

--- a/packages/compiler-cli/src/ngtsc/transform/src/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/utils.ts
@@ -31,8 +31,12 @@ export function addImports(
   const body = sf.statements.filter(stmt => !isImportStatement(stmt));
   // Prepend imports if needed.
   if (addedImports.length > 0) {
-    sf.statements =
-        ts.createNodeArray([...existingImports, ...addedImports, ...extraStatements, ...body]);
+    // If we prepend imports, we also prepend NotEmittedStatement to use it as an anchor
+    // for @fileoverview Closure annotation. If there is no @fileoverview annotations, this
+    // statement would be a noop.
+    const fileoverviewAnchorStmt = ts.createNotEmittedStatement(sf);
+    sf.statements = ts.createNodeArray(
+        [fileoverviewAnchorStmt, ...existingImports, ...addedImports, ...extraStatements, ...body]);
   }
 
   return sf;

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2162,6 +2162,81 @@ describe('ngtsc behavioral tests', () => {
     expect(afterCount).toBe(1);
   });
 
+  describe('@fileoverview Closure annotations', () => {
+    it('should be produced if not present in source file', () => {
+      env.tsconfig({
+        'annotateForClosureCompiler': true,
+      });
+      env.write(`test.ts`, `
+        import {Component} from '@angular/core';
+
+        @Component({
+          template: '<div class="test"></div>',
+        })
+        export class SomeComp {}
+      `);
+
+      env.driveMain();
+      const jsContents = env.getContents('test.js');
+      const fileoverview = `
+        /**
+         * @fileoverview added by tsickle
+         * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+         */
+      `;
+      expect(trim(jsContents).startsWith(trim(fileoverview))).toBeTruthy();
+    });
+
+    it('should be produced for empty source files', () => {
+      env.tsconfig({
+        'annotateForClosureCompiler': true,
+      });
+      env.write(`test.ts`, ``);
+
+      env.driveMain();
+      const jsContents = env.getContents('test.js');
+      const fileoverview = `
+        /**
+         * @fileoverview added by tsickle
+         * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+         */
+      `;
+      expect(trim(jsContents).startsWith(trim(fileoverview))).toBeTruthy();
+    });
+
+    it('should always be at the very beginning of a script', () => {
+      env.tsconfig({
+        'annotateForClosureCompiler': true,
+      });
+      env.write(`test.ts`, `
+        /**
+         * @fileoverview Some Comp overview
+         * @modName {some_comp}
+         */
+
+        import {Component} from '@angular/core';
+
+        @Component({
+          template: '<div class="test"></div>',
+        })
+        export class SomeComp {}
+      `);
+
+      env.driveMain();
+      const jsContents = env.getContents('test.js');
+      const fileoverview = `
+        /**
+         *
+         * @fileoverview Some Comp overview
+         * @modName {some_comp}
+         *
+         * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+         */
+      `;
+      expect(trim(jsContents).startsWith(trim(fileoverview))).toBeTruthy();
+    });
+  });
+
   describe('sanitization', () => {
     it('should generate sanitizers for unsafe attributes in hostBindings fn in Directives', () => {
       env.tsconfig();

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2204,7 +2204,7 @@ describe('ngtsc behavioral tests', () => {
       expect(trim(jsContents).startsWith(trim(fileoverview))).toBeTruthy();
     });
 
-    it('should always be at the very beginning of a script', () => {
+    it('should always be at the very beginning of a script (if placed above imports)', () => {
       env.tsconfig({
         'annotateForClosureCompiler': true,
       });
@@ -2220,6 +2220,34 @@ describe('ngtsc behavioral tests', () => {
           template: '<div class="test"></div>',
         })
         export class SomeComp {}
+      `);
+
+      env.driveMain();
+      const jsContents = env.getContents('test.js');
+      const fileoverview = `
+        /**
+         *
+         * @fileoverview Some Comp overview
+         * @modName {some_comp}
+         *
+         * @suppress {checkTypes,extraRequire,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+         */
+      `;
+      expect(trim(jsContents).startsWith(trim(fileoverview))).toBeTruthy();
+    });
+
+    it('should always be at the very beginning of a script (if placed above non-imports)', () => {
+      env.tsconfig({
+        'annotateForClosureCompiler': true,
+      });
+      env.write(`test.ts`, `
+        /**
+         * @fileoverview Some Comp overview
+         * @modName {some_comp}
+         */
+
+        const testConst = 'testConstValue';
+        const testFn = function() { return true; }
       `);
 
       env.driveMain();


### PR DESCRIPTION
Prior to this change, the @fileoverview annotations added by users in source files or by tsickle during compilation might have change a location due to the fact that Ngtsc may prepend extra imports or constants. As a result, the output file is considered invalid by Closure (misplaced @fileoverview annotation). In order to resolve the problem we relocate @fileoverview annotation if we detect that its host node shifted.

This PR resolves FW-1006.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No