### PR TITLE
build: enable bundle_dts for a number of packages

### DIFF
--- a/packages/animations/BUILD.bazel
+++ b/packages/animations/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    bundle_dts = True,
     deps = [
         "//packages/core",
     ],

--- a/packages/animations/browser/BUILD.bazel
+++ b/packages/animations/browser/BUILD.bazel
@@ -12,6 +12,7 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    bundle_dts = True,
     deps = [
         "//packages/animations",
         "//packages/core",

--- a/packages/animations/browser/testing/BUILD.bazel
+++ b/packages/animations/browser/testing/BUILD.bazel
@@ -7,6 +7,7 @@ load("//tools:defaults.bzl", "ng_module")
 ng_module(
     name = "testing",
     srcs = glob(["**/*.ts"]),
+    bundle_dts = True,
     deps = [
         "//packages/animations",
         "//packages/animations/browser",

--- a/packages/elements/BUILD.bazel
+++ b/packages/elements/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    bundle_dts = True,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/packages/http/BUILD.bazel
+++ b/packages/http/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    bundle_dts = True,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/packages/http/testing/BUILD.bazel
+++ b/packages/http/testing/BUILD.bazel
@@ -7,6 +7,7 @@ load("//tools:defaults.bzl", "ng_module")
 ng_module(
     name = "testing",
     srcs = glob(["**/*.ts"]),
+    bundle_dts = True,
     deps = [
         "//packages/core",
         "//packages/http",

--- a/packages/platform-browser-dynamic/BUILD.bazel
+++ b/packages/platform-browser-dynamic/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    bundle_dts = True,
     deps = [
         "//packages:types",
         "//packages/common",

--- a/packages/platform-browser-dynamic/testing/BUILD.bazel
+++ b/packages/platform-browser-dynamic/testing/BUILD.bazel
@@ -7,6 +7,7 @@ load("//tools:defaults.bzl", "ng_module")
 ng_module(
     name = "testing",
     srcs = glob(["**/*.ts"]),
+    bundle_dts = True,
     deps = [
         "//packages/compiler",
         "//packages/compiler/testing",

--- a/packages/platform-browser/BUILD.bazel
+++ b/packages/platform-browser/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    bundle_dts = True,
     deps = [
         "//packages:types",
         "//packages/common",

--- a/packages/platform-browser/animations/BUILD.bazel
+++ b/packages/platform-browser/animations/BUILD.bazel
@@ -12,6 +12,7 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    bundle_dts = True,
     deps = [
         "//packages/animations",
         "//packages/animations/browser",

--- a/packages/platform-browser/testing/BUILD.bazel
+++ b/packages/platform-browser/testing/BUILD.bazel
@@ -7,6 +7,7 @@ load("//tools:defaults.bzl", "ng_module")
 ng_module(
     name = "testing",
     srcs = glob(["**/*.ts"]),
+    bundle_dts = True,
     deps = [
         "//packages/core",
         "//packages/core/testing",

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    bundle_dts = True,
     deps = [
         "//packages/animations/browser",
         "//packages/common",

--- a/packages/platform-server/testing/BUILD.bazel
+++ b/packages/platform-server/testing/BUILD.bazel
@@ -7,6 +7,7 @@ load("//tools:defaults.bzl", "ng_module")
 ng_module(
     name = "testing",
     srcs = glob(["**/*.ts"]),
+    bundle_dts = True,
     deps = [
         "//packages/core",
         "//packages/platform-browser-dynamic/testing",

--- a/packages/platform-webworker-dynamic/BUILD.bazel
+++ b/packages/platform-webworker-dynamic/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    bundle_dts = True,
     deps = [
         "//packages:types",
         "//packages/common",

--- a/packages/platform-webworker/BUILD.bazel
+++ b/packages/platform-webworker/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    bundle_dts = True,
     deps = [
         "//packages:types",
         "//packages/common",

--- a/packages/service-worker/BUILD.bazel
+++ b/packages/service-worker/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    bundle_dts = True,
     deps = [
         "//packages/common",
         "//packages/core",

--- a/packages/service-worker/config/BUILD.bazel
+++ b/packages/service-worker/config/BUILD.bazel
@@ -10,5 +10,6 @@ ng_module(
         "*.ts",
         "src/**/*.ts",
     ]),
+    bundle_dts = True,
     deps = ["//packages/core"],
 )


### PR DESCRIPTION
This change enables dts bundling for the following packages and their secondary entry points:

- @angular/animations
- @angular/elements
- @angular/http
- @angular/platform-browser
- @angular/platform-browser-dynamic
- @angular/platform-server
- @angular/platform-webworker
- @angular/platform-webworker-dynamic
- @angular/servce-worker

Dts bundling happens in `ng_module` bazel definition, hence packages such as `@angular/compiler`, `@angular/compiler-cli` and `@angular/langauge service` cannot be flattened as they use `ts_library`.

`@angular/core`, `@angular/common`, `@angular/upgrade` and `@angular/forms` will be done seperatly as it requires some changes either to their source or specs.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
