### PR TITLE
fix(core): call ngOnDestroy on component level services that are provided using a factory function

### DIFF
--- a/goldens/public-api/forms/forms.d.ts
+++ b/goldens/public-api/forms/forms.d.ts
@@ -100,6 +100,8 @@ export declare class AbstractFormGroupDirective extends ControlContainer impleme
     get control(): FormGroup;
     get formDirective(): Form | null;
     get path(): string[];
+    get refCount(): number;
+    addRef(): void;
     ngOnDestroy(): void;
     ngOnInit(): void;
 }

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -542,7 +542,7 @@ function isExistingProvider(value: SingleProvider): value is ExistingProvider {
   return !!(value && (value as ExistingProvider).useExisting);
 }
 
-function isFactoryProvider(value: SingleProvider): value is FactoryProvider {
+export function isFactoryProvider(value: SingleProvider): value is FactoryProvider {
   return !!(value && (value as FactoryProvider).useFactory);
 }
 

--- a/packages/core/test/bundling/forms/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms/bundle.golden_symbols.json
@@ -1209,6 +1209,9 @@
     "name": "isEmptyInputValue"
   },
   {
+    "name": "isFactoryProvider"
+  },
+  {
     "name": "isForwardRef"
   },
   {
@@ -1387,6 +1390,9 @@
   },
   {
     "name": "ngOnChangesSetInput"
+  },
+  {
+    "name": "ngOnDestroyForFactoryProviders"
   },
   {
     "name": "noSideEffects"

--- a/packages/forms/src/directives/abstract_form_group_directive.ts
+++ b/packages/forms/src/directives/abstract_form_group_directive.ts
@@ -33,8 +33,19 @@ export class AbstractFormGroupDirective extends ControlContainer implements OnIn
   // TODO(issue/24571): remove '!'.
   _parent!: ControlContainer;
 
+  /**
+   * @description
+   * Counts the number of references it has.
+   * Used for correctly cleanup on ngOnDestroy when useFactory returns the same instance multiple
+   * times.
+   *
+   * @internal
+   */
+  private _refCount: number = 0;
+
   /** @nodoc */
   ngOnInit(): void {
+    this._refCount++;
     this._checkParentType();
     // Register the group with its parent group.
     this.formDirective!.addFormGroup(this);
@@ -42,7 +53,8 @@ export class AbstractFormGroupDirective extends ControlContainer implements OnIn
 
   /** @nodoc */
   ngOnDestroy(): void {
-    if (this.formDirective) {
+    this._refCount--;
+    if (this.formDirective && this._refCount === 0) {
       // Remove the group from its parent group.
       this.formDirective.removeFormGroup(this);
     }
@@ -70,6 +82,22 @@ export class AbstractFormGroupDirective extends ControlContainer implements OnIn
    */
   get formDirective(): Form|null {
     return this._parent ? this._parent.formDirective : null;
+  }
+
+  /**
+   * @description
+   * Returns the current number of references to this directive.
+   */
+  get refCount() {
+    return this._refCount;
+  }
+
+  /**
+   * @description
+   * Adds a reference into the total reference count.
+   */
+  addRef() {
+    this._refCount++;
   }
 
   /** @internal */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
ngOnDestroy is not called for Services provided via factory function into component level, 

Related Issues: **[28738](https://github.com/angular/angular/issues/28738)**; **[22466](https://github.com/angular/angular/issues/22466#issuecomment-463673658)** (this issue is closed, but it only does it for providers provided at module level, not at component level)

Fixes #28738

## What is the new behavior?
ngOnDestroy is called on services that are provided with a factory function at component level

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This solution is based on the ones that solved the same issue for the factory function services provided at Module level, see: https://github.com/angular/angular/commit/5581e97d2ac6b232cc7402370e681eb909bd63e7