### PR TITLE
ci: add /packages/* to the @angular/fw-dev-infra CODEOWNERS group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -744,6 +744,7 @@ testing/**                                                      @angular/fw-test
 /.circleci/**                                                   @angular/fw-dev-infra
 /.github/**                                                     @angular/fw-dev-infra
 /docs/BAZEL.md                                                  @angular/fw-dev-infra
+/packages/*                                                     @angular/fw-dev-infra
 /scripts/**                                                     @angular/fw-dev-infra
 /third_party/**                                                 @angular/fw-dev-infra
 /tools/**                                                       @angular/fw-dev-infra


### PR DESCRIPTION
It was previously missing which is a bug.