### PR TITLE
feat(ivy): add support for windows concrete types for paths

### DIFF
--- a/packages/compiler-cli/src/ngtsc/path/src/logical.ts
+++ b/packages/compiler-cli/src/ngtsc/path/src/logical.ts
@@ -17,6 +17,8 @@ import {stripExtension} from './util';
 /**
  * A path that's relative to the logical root of a TypeScript project (one of the project's
  * rootDirs).
+ *
+ * Paths in the type system use POSIX format.
  */
 export type LogicalProjectPath = BrandedPath<'LogicalProjectPath'>;
 

--- a/packages/compiler-cli/src/ngtsc/path/src/types.ts
+++ b/packages/compiler-cli/src/ngtsc/path/src/types.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {normalizeSeparators} from './util';
+import {isAbsolutePath, normalizeSeparators} from './util';
 
 /**
  * A `string` representing a specific type of path, with a particular brand `B`.
@@ -41,7 +41,7 @@ export const AbsoluteFsPath = {
    */
   from: function(str: string): AbsoluteFsPath {
     const normalized = normalizeSeparators(str);
-    if (!normalized.startsWith('/')) {
+    if (!isAbsolutePath(normalized)) {
       throw new Error(`Internal Error: AbsoluteFsPath.from(${str}): path is not absolute`);
     }
     return normalized as AbsoluteFsPath;
@@ -73,7 +73,7 @@ export const PathSegment = {
    */
   fromFsPath: function(str: string): PathSegment {
     const normalized = normalizeSeparators(str);
-    if (normalized.startsWith('/')) {
+    if (isAbsolutePath(normalized)) {
       throw new Error(`Internal Error: PathSegment.from(${str}): path is not relative`);
     }
     return normalized as PathSegment;

--- a/packages/compiler-cli/src/ngtsc/path/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/path/src/util.ts
@@ -30,5 +30,6 @@ export function stripExtension(path: string): string {
  * Returns true if the normalized path is an absolute path.
  */
 export function isAbsolutePath(path: string): boolean {
+  // TODO: use regExp based on OS in the future
   return ABSOLUTE_PATH.test(path);
 }

--- a/packages/compiler-cli/src/ngtsc/path/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/path/src/util.ts
@@ -9,9 +9,10 @@
 //  TODO(alxhub): Unify this file with `util/src/path`.
 
 const TS_DTS_JS_EXTENSION = /(?:\.d)?\.ts$|\.js$/;
+const ABSOLUTE_PATH = /^([a-zA-Z]\:\/|\/)/;
 
 /**
- * Convert Windows-style paths to POSIX paths.
+ * Convert Windows-style seperators to POSIX seperators.
  */
 export function normalizeSeparators(path: string): string {
   // TODO: normalize path only for OS that need it.
@@ -23,4 +24,11 @@ export function normalizeSeparators(path: string): string {
  */
 export function stripExtension(path: string): string {
   return path.replace(TS_DTS_JS_EXTENSION, '');
+}
+
+/**
+ * Returns true if the normalized path is an absolute path.
+ */
+export function isAbsolutePath(path: string): boolean {
+  return ABSOLUTE_PATH.test(path);
 }

--- a/packages/compiler-cli/src/ngtsc/path/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/path/src/util.ts
@@ -12,7 +12,7 @@ const TS_DTS_JS_EXTENSION = /(?:\.d)?\.ts$|\.js$/;
 const ABSOLUTE_PATH = /^([a-zA-Z]\:\/|\/)/;
 
 /**
- * Convert Windows-style seperators to POSIX seperators.
+ * Convert Windows-style separators to POSIX separators.
  */
 export function normalizeSeparators(path: string): string {
   // TODO: normalize path only for OS that need it.

--- a/packages/compiler-cli/src/ngtsc/path/test/types_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/path/test/types_spec.ts
@@ -10,10 +10,16 @@ import {AbsoluteFsPath} from '../src/types';
 
 describe('path types', () => {
   describe('AbsoluteFsPath', () => {
-    it('should not throw when creating one from a non-absolute path',
+    it('should not throw when creating one from an absolute path',
        () => { expect(AbsoluteFsPath.from('/test.txt')).toEqual('/test.txt'); });
+    it('should not throw when creating one from a windows absolute path',
+       () => { expect(AbsoluteFsPath.from('C:\\test.txt')).toEqual('C:/test.txt'); });
+    it('should not throw when creating one from a windows absolute path with POSIX separators',
+       () => { expect(AbsoluteFsPath.from('C:/test.txt')).toEqual('C:/test.txt'); });
     it('should throw when creating one from a non-absolute path',
        () => { expect(() => AbsoluteFsPath.from('test.txt')).toThrow(); });
+    it('should support windows drive letters',
+       () => { expect(AbsoluteFsPath.from('D:\\foo\\test.txt')).toEqual('D:/foo/test.txt'); });
     it('should convert Windows path separators to POSIX separators',
        () => { expect(AbsoluteFsPath.from('\\foo\\test.txt')).toEqual('/foo/test.txt'); });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Fixes https://github.com/angular/angular/issues/28754


## What is the new behavior?
This commit introduces support for the windows paths in the new concrete types mechanism that was introduced in this PR https://github.com/angular/angular/pull/28523

Normalized posix paths that start with either a `/` or `C:/` are considered to be an absolute path.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information