### PR TITLE
DebugNode.componentInstance

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -7,7 +7,7 @@
  */
 
 import {Injector} from '../di';
-import {getComponent, getContext, getInjectionTokens, getInjector, getListeners, getLocalRefs, isBrowserEvents, loadLContext, loadLContextFromNode} from '../render3/discovery_utils';
+import {getComponent, getContext, getInjectionTokens, getInjector, getListeners, getLocalRefs, getViewComponent, isBrowserEvents, loadLContext, loadLContextFromNode} from '../render3/discovery_utils';
 import {TNode} from '../render3/interfaces/node';
 import {StylingIndex} from '../render3/interfaces/styling';
 import {LView, TData, TVIEW} from '../render3/interfaces/view';
@@ -210,7 +210,8 @@ class DebugNode__POST_R3__ implements DebugNode {
 
   get componentInstance(): any {
     const nativeElement = this.nativeNode;
-    return nativeElement && getComponent(nativeElement as Element);
+    return nativeElement &&
+        (getComponent(nativeElement as Element) || getViewComponent(nativeElement));
   }
   get context(): any { return getContext(this.nativeNode as Element); }
 


### PR DESCRIPTION
This PR documents in test behaviour of both view engine and ivy when it comes to `DebugNode. componentInstance` logic. 

The ve semantics seems to be, for a given `DebugNode`:

* if a node is a host for a component, return this component instance
* if a node has no associated component move to a parent node and go back to the previous step;
* if there are no more parent nodes to check return a component that created a given `DebugNode`.


To be honest I find the view engine behaviour rather confusing and I've got no idea why we would go into the business of traversing up the nodes tree - after all we are asking for something associated with a given node and not some random node upwards.

For me the current ivy implementation makes much more sense (just return a component instance if a given node is a host node for a component). Given this I would vote to stick with the current ivy behaviour and mark this as a breaking change.


I'm splitting this PR into 2 parts (test documenting ve behaviour and second commit with adjustments for ivy) so we can easily go back-and-forth on ivy semantics.