### PR TITLE
fix(ivy): query projected child elements by directive

### DIFF
--- a/packages/core/src/render3/context_discovery.ts
+++ b/packages/core/src/render3/context_discovery.ts
@@ -187,15 +187,11 @@ export function isDirectiveInstance(instance: any): boolean {
  * Locates the element within the given LView and returns the matching index
  */
 function findViaNativeElement(lView: LView, target: RElement): number {
-  let tNode = lView[TVIEW].firstChild;
-  while (tNode) {
-    const native = getNativeByTNode(tNode, lView) !;
-    if (native === target) {
-      return tNode.index;
+  for (let i = HEADER_OFFSET; i < lView[TVIEW].bindingStartIndex; i++) {
+    if (readElementValue(lView[i]) === target) {
+      return i;
     }
-    tNode = traverseNextElement(tNode);
   }
-
   return -1;
 }
 

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -325,6 +325,39 @@ class TestApp {
       expect(getDOM().hasClass(childTestEls[3].nativeElement, 'childnested')).toBe(true);
     });
 
+    it('should query projected child elements by directive', () => {
+      @Directive({selector: 'example-directive-a'})
+      class ExampleDirectiveA {
+      }
+
+      @Component({
+        selector: 'wrapper-component',
+        template: `
+          <ng-content select="example-directive-a"></ng-content>
+        `
+      })
+      class WrapperComponent {
+      }
+
+      TestBed.configureTestingModule({
+        declarations: [
+          WrapperComponent,
+          ExampleDirectiveA,
+        ]
+      });
+
+      TestBed.overrideTemplate(TestApp, `<wrapper-component>
+        <div></div>
+        <example-directive-a></example-directive-a>
+       </wrapper-component>`);
+
+      const fixture = TestBed.createComponent(TestApp);
+      fixture.detectChanges();
+
+      const debugElement = fixture.debugElement.query(By.directive(ExampleDirectiveA));
+      expect(debugElement).toBeTruthy();
+    });
+
     it('should list providerTokens', () => {
       fixture = TestBed.createComponent(ParentComp);
       fixture.detectChanges();


### PR DESCRIPTION
Context discvery needs to find a TNode based LView and a native element.
Before this change the algorithm was to traverse TNode tree following
child / next links between nodes. The problem with this approach is that
content projection can change TNodes relationship in a way that it is
impossible to reach all the nodes created in a given LView.

There are several ways we could go about fixing this problem. This WIP
PR takes the simplest possible approach and just iterates over all the
native nodes in a given view (we don't care about nodes relationship here
but simply looking up a node).

But the issue being fixed here also unearths an important problem -
content projection _is_ modifying TView structure (TNode relationship)
in a way that makes nodes traversal challenging. In other words each
node traversal algorithm will have to take content projection into account.
There are different things we could do to remedy this problem:

- change data structures so the projection doesn't modify original
  relationship between nodes;

- write a utility function / iterator that can traverse TView nodes
  taking projection into account;

- stick with the approach from this PR.

Opening a WIP PR so we can discuss.