### PR TITLE
fix(ivy): incorrectly remapping certain properties that refer to inputs

### DIFF
--- a/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
+++ b/packages/compiler-cli/test/compliance/r3_view_compiler_binding_spec.ts
@@ -137,6 +137,48 @@ describe('compiler compliance: bindings', () => {
       const result = compile(files, angularFiles);
       expect(result.source).not.toContain('i0.ɵelementProperty');
     });
+
+    it('should not remap property names whose names do not correspond to their attribute names',
+       () => {
+         const files = {
+           app: {
+             'spec.ts': `
+              import {Component, NgModule} from '@angular/core';
+
+              @Component({
+                selector: 'my-component',
+                template: \`
+                  <label [for]="forValue"></label>\`
+              })
+              export class MyComponent {
+                forValue = 'some-input';
+              }
+
+              @NgModule({declarations: [MyComponent]})
+              export class MyModule {}
+          `
+           }
+         };
+
+         const template = `
+      const $c0$ = [${AttributeMarker.SelectOnly}, "for"];
+
+      // ...
+
+      function MyComponent_Template(rf, ctx) {
+        if (rf & 1) {
+            $i0$.ɵelement(0, "label", _c0);
+        }
+        if (rf & 2) {
+            $i0$.ɵelementProperty(0, "for", $i0$.ɵbind(ctx.forValue));
+        }
+      }`;
+
+         const result = compile(files, angularFiles);
+
+         expectEmit(result.source, template, 'Incorrect template');
+       });
+
   });
 
   describe('host bindings', () => {

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -242,11 +242,11 @@ class HtmlAstToIvyAst implements html.Visitor {
         literal.push(new t.TextAttribute(
             prop.name, prop.expression.source || '', prop.sourceSpan, undefined, i18n));
       } else {
-        // we skip validation here, since we do this check at runtime due to the fact that we need
-        // to make sure a given prop is not an input of some Directive (thus should not be a subject
-        // of this check) and Directive matching happens at runtime
+        // Note that validation is skipped and property mapping is disabled
+        // due to the fact that we need to make sure a given prop is not an
+        // input of a directive and directive matching happens at runtime.
         const bep = this.bindingParser.createBoundElementProperty(
-            elementName, prop, /* skipValidation */ true);
+            elementName, prop, /* skipValidation */ true, /* mapPropertyName */ false);
         bound.push(t.BoundAttribute.fromBoundElementProperty(bep, i18n));
       }
     });

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -240,8 +240,8 @@ export class BindingParser {
   }
 
   createBoundElementProperty(
-      elementSelector: string, boundProp: ParsedProperty,
-      skipValidation: boolean = false): BoundElementProperty {
+      elementSelector: string, boundProp: ParsedProperty, skipValidation: boolean = false,
+      mapPropertyName: boolean = true): BoundElementProperty {
     if (boundProp.isAnimation) {
       return new BoundElementProperty(
           boundProp.name, BindingType.Animation, SecurityContext.NONE, boundProp.expression, null,
@@ -286,12 +286,13 @@ export class BindingParser {
 
     // If not a special case, use the full property name
     if (boundPropertyName === null) {
-      boundPropertyName = this._schemaRegistry.getMappedPropName(boundProp.name);
+      const mappedPropName = this._schemaRegistry.getMappedPropName(boundProp.name);
+      boundPropertyName = mapPropertyName ? mappedPropName : boundProp.name;
       securityContexts = calcPossibleSecurityContexts(
-          this._schemaRegistry, elementSelector, boundPropertyName, false);
+          this._schemaRegistry, elementSelector, mappedPropName, false);
       bindingType = BindingType.Property;
       if (!skipValidation) {
-        this._validatePropertyOrAttributeName(boundPropertyName, boundProp.sourceSpan, false);
+        this._validatePropertyOrAttributeName(mappedPropName, boundProp.sourceSpan, false);
       }
     }
 

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -176,10 +176,10 @@ describe('R3 template transform', () => {
       ]);
     });
 
-    it('should normalize property names via the element schema', () => {
+    it('should not normalize property names via the element schema', () => {
       expectFromHtml('<div [mappedAttr]="v"></div>').toEqual([
         ['Element', 'div'],
-        ['BoundAttribute', BindingType.Property, 'mappedProp', 'v'],
+        ['BoundAttribute', BindingType.Property, 'mappedAttr', 'v'],
       ]);
     });
 

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1213,6 +1213,18 @@ export function componentHostSyntheticProperty<T>(
   elementPropertyInternal(index, propName, value, sanitizer, nativeOnly, loadComponentRenderer);
 }
 
+/**
+ * Mapping between attributes names that don't correspond to their element property names.
+ */
+const ATTR_TO_PROP: {[name: string]: string} = {
+  'class': 'className',
+  'for': 'htmlFor',
+  'formaction': 'formAction',
+  'innerHtml': 'innerHTML',
+  'readonly': 'readOnly',
+  'tabindex': 'tabIndex',
+};
+
 function elementPropertyInternal<T>(
     index: number, propName: string, value: T | NO_CHANGE, sanitizer?: SanitizerFn | null,
     nativeOnly?: boolean,
@@ -1233,6 +1245,8 @@ function elementPropertyInternal<T>(
       }
     }
   } else if (tNode.type === TNodeType.Element) {
+    propName = ATTR_TO_PROP[propName] || propName;
+
     if (ngDevMode) {
       validateAgainstEventProperties(propName);
       validateAgainstUnknownProperties(lView, element, propName, tNode);

--- a/packages/core/test/acceptance/properties_spec.ts
+++ b/packages/core/test/acceptance/properties_spec.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, Input} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {expect} from '@angular/platform-browser/testing/src/matchers';
+
+describe('elementProperty', () => {
+  it('should bind to properties whose names do not correspond to their attribute names', () => {
+    @Component({template: '<label [for]="forValue"></label>'})
+    class MyComp {
+      forValue?: string;
+    }
+
+    TestBed.configureTestingModule({declarations: [MyComp]});
+    const fixture = TestBed.createComponent(MyComp);
+    const labelNode = fixture.debugElement.query(By.css('label'));
+
+    fixture.componentInstance.forValue = 'some-input';
+    fixture.detectChanges();
+
+    expect(labelNode.nativeElement.getAttribute('for')).toBe('some-input');
+
+    fixture.componentInstance.forValue = 'some-textarea';
+    fixture.detectChanges();
+
+    expect(labelNode.nativeElement.getAttribute('for')).toBe('some-textarea');
+  });
+
+  it('should not map properties whose names do not correspond to their attribute names, ' +
+         'if they correspond to inputs',
+     () => {
+
+       @Component({template: '', selector: 'my-comp'})
+       class MyComp {
+        @Input() for !:string;
+       }
+
+       @Component({template: '<my-comp [for]="forValue"></my-comp>'})
+       class App {
+         forValue?: string;
+       }
+
+       TestBed.configureTestingModule({declarations: [App, MyComp]});
+       const fixture = TestBed.createComponent(App);
+       const myCompNode = fixture.debugElement.query(By.directive(MyComp));
+       fixture.componentInstance.forValue = 'hello';
+       fixture.detectChanges();
+       expect(myCompNode.nativeElement.getAttribute('for')).toBeFalsy();
+       expect(myCompNode.componentInstance.for).toBe('hello');
+
+       fixture.componentInstance.forValue = 'hej';
+       fixture.detectChanges();
+       expect(myCompNode.nativeElement.getAttribute('for')).toBeFalsy();
+       expect(myCompNode.componentInstance.for).toBe('hej');
+     });
+});

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -6,6 +6,9 @@
     "name": "ANIMATION_PROP_PREFIX"
   },
   {
+    "name": "ATTR_TO_PROP"
+  },
+  {
     "name": "BINDING_INDEX"
   },
   {

--- a/packages/core/test/render3/properties_spec.ts
+++ b/packages/core/test/render3/properties_spec.ts
@@ -76,26 +76,6 @@ describe('elementProperty', () => {
     expect(fixture.html).toEqual('<span id="_otherId_"></span>');
   });
 
-  it('should map properties whose names do not correspond to their attribute names', () => {
-    const App = createComponent('app', function(rf: RenderFlags, ctx: any) {
-      if (rf & RenderFlags.Create) {
-        element(0, 'label');
-      }
-      if (rf & RenderFlags.Update) {
-        elementProperty(0, 'for', bind(ctx.forValue));
-      }
-    }, 1, 1);
-
-    const fixture = new ComponentFixture(App);
-    fixture.component.forValue = 'some-input';
-    fixture.update();
-    expect(fixture.html).toEqual('<label for="some-input"></label>');
-
-    fixture.component.forValue = 'some-textarea';
-    fixture.update();
-    expect(fixture.html).toEqual('<label for="some-textarea"></label>');
-  });
-
   describe('input properties', () => {
     let button: MyButton;
     let otherDir: OtherDir;
@@ -383,50 +363,6 @@ describe('elementProperty', () => {
       expect(idDir !.idNumber).toEqual('four');
       expect(otherDir !.id).toEqual(3);
     });
-
-    it('should not map properties whose names do not correspond to their attribute names, ' +
-           'if they correspond to inputs',
-       () => {
-         let comp: Comp;
-
-         class Comp {
-           // TODO(issue/24571): remove '!'.
-           // clang-format off
-           for !: string;
-           // clang-format on
-
-            static ngComponentDef = defineComponent({
-              type: Comp,
-              selectors: [['comp']],
-              consts: 0,
-              vars: 0,
-              template: function(rf: RenderFlags, ctx: any) {},
-              factory: () => comp = new Comp(),
-              inputs: {for: 'for'}
-            });
-         }
-
-         /** <comp [for]="forValue"></comp> */
-         const App = createComponent('app', function(rf: RenderFlags, ctx: any) {
-           if (rf & RenderFlags.Create) {
-             element(0, 'comp');
-           }
-           if (rf & RenderFlags.Update) {
-             elementProperty(0, 'for', bind(ctx.forValue));
-           }
-         }, 1, 1, [Comp]);
-
-         const fixture = new ComponentFixture(App);
-         fixture.component.forValue = 'hello';
-         fixture.update();
-         expect(fixture.html).toEqual(`<comp></comp>`);
-         expect(comp !.for).toEqual('hello');
-
-         fixture.component.forValue = 'hej';
-         fixture.update();
-         expect(fixture.html).toEqual(`<comp></comp>`);
-         expect(comp !.for).toEqual('hej');
-       });
 
   });
 

--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -961,73 +961,9 @@ window.testBlocklist = {
     "error": "Error: Expected null not to be null.",
     "notes": "Unknown"
   },
-  "MatDatepicker with MatNativeDateModule datepicker with formControl should update datepicker when formControl changes": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with formControl should update formControl when date is selected": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with formControl should disable input when form control disabled": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with formControl should disable toggle when form control disabled": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with mat-datepicker-toggle should set `aria-haspopup` on the toggle button": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with mat-datepicker-toggle should open calendar when toggle clicked": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with mat-datepicker-toggle should not open calendar when toggle clicked if datepicker is disabled": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with mat-datepicker-toggle should not open calendar when toggle clicked if input is disabled": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with mat-datepicker-toggle should set the `button` type on the trigger to prevent form submissions": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with mat-datepicker-toggle should remove the underlying SVG icon from the tab order": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with mat-datepicker-toggle should restore focus to the toggle after the calendar is closed": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with mat-datepicker-toggle should re-render when the i18n labels change": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
   "MatDatepicker with MatNativeDateModule datepicker with mat-datepicker-toggle should toggle the active state of the datepicker toggle": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with custom mat-datepicker-toggle icon should be able to override the mat-datepicker-toggle icon": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with tabindex on mat-datepicker-toggle should forward the tabindex to the underlying button": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with tabindex on mat-datepicker-toggle should clear the tabindex from the mat-datepicker-toggle host": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with tabindex on mat-datepicker-toggle should forward focus to the underlying button when the host is focused": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
+    "error": "Error: this._portalOutlet is undefined.",
+    "notes": "FW-1019: Design new API to replace static queries"
   },
   "MatDatepicker with MatNativeDateModule datepicker inside mat-form-field should pass the form field theme color to the overlay": {
     "error": "TypeError: Cannot read property 'classList' of null",
@@ -1037,37 +973,9 @@ window.testBlocklist = {
     "error": "TypeError: Cannot read property 'classList' of null",
     "notes": "Unknown"
   },
-  "MatDatepicker with MatNativeDateModule datepicker with min and max dates and validation should use min and max dates specified by the input": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with min and max dates and validation should mark invalid when value is before min": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with min and max dates and validation should mark invalid when value is after max": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with min and max dates and validation should not mark invalid when value equals min": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with min and max dates and validation should not mark invalid when value equals max": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with min and max dates and validation should not mark invalid when value is between min and max": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
-  "MatDatepicker with MatNativeDateModule datepicker with filter and validation should mark input invalid": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
-  },
   "MatDatepicker with MatNativeDateModule datepicker with filter and validation should disable filtered calendar cells": {
-    "error": "Error: Template error: Can't bind to 'htmlFor' since it isn't a known property of 'mat-datepicker-toggle'.",
-    "notes": "Unknown"
+    "error": "Error: this._portalOutlet is undefined.",
+    "notes": "FW-1019: Design new API to replace static queries"
   },
   "MatDialog should set the proper animation states": {
     "error": "TypeError: Cannot read property 'componentInstance' of null",


### PR DESCRIPTION
During build time we remap particular property bindings, because their names don't match their attribute equivalents (e.g. the property for the `for` attribute is called `htmlFor`). This breaks down if the particular element has an input that has the same name, because the property gets mapped to something invalid.

The following changes address the issue by mapping the name during runtime, because that's when directives are resolved and we know all of the inputs that are associated with a particular element.
