### PR TITLE
fix(service-worker): can't cache resource with space in url

### DIFF
--- a/packages/service-worker/config/src/generator.ts
+++ b/packages/service-worker/config/src/generator.ts
@@ -124,9 +124,9 @@ function globListToMatcher(globs: string[]): (file: string) => boolean {
 function matches(file: string, patterns: {positive: boolean, regex: RegExp}[]): boolean {
   const res = patterns.reduce((isMatch, pattern) => {
     if (pattern.positive) {
-      return isMatch || pattern.regex.test(file);
+      return isMatch || pattern.regex.test(file.replace('%20', ' '));
     } else {
-      return isMatch && !pattern.regex.test(file);
+      return isMatch && !pattern.regex.test(file.replace('%20', ' '));
     }
   }, false);
   return res;


### PR DESCRIPTION
Replaced '%20' string with space char

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #25443


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
