### PR TITLE
build: fix `validate-commit-message`

### DIFF
--- a/tools/gulp-tasks/validate-commit-message.js
+++ b/tools/gulp-tasks/validate-commit-message.js
@@ -9,45 +9,51 @@
 
 // tslint:disable:no-console
 module.exports = (gulp) => () => {
-  const validateCommitMessage = require('../validate-commit-message');
-  const shelljs = require('shelljs');
+  try {
+    const validateCommitMessage = require('../validate-commit-message');
+    const shelljs = require('shelljs');
 
-  let baseBranch = 'master';
-  const currentVersion = require('semver').parse(require('../../package.json').version);
-  const baseHead =
-      shelljs.exec(`git ls-remote --heads origin ${currentVersion.major}.${currentVersion.minor}.*`)
-          .trim()
-          .split('\n')
-          .pop();
-  if (baseHead) {
-    const match = /refs\/heads\/(.+)/.exec(baseHead);
-    baseBranch = match && match[1] || baseBranch;
-  }
+    shelljs.set('-e');  // Break on error.
 
-  // We need to fetch origin explicitly because it might be stale.
-  // I couldn't find a reliable way to do this without fetch.
-  result = shelljs.exec(
-      `git fetch origin ${baseBranch} && git log --reverse --format=%s HEAD ^origin/${baseBranch}`);
+    let baseBranch = 'master';
+    const currentVersion = require('semver').parse(require('../../package.json').version);
+    const baseHead =
+        shelljs
+            .exec(`git ls-remote --heads origin ${currentVersion.major}.${currentVersion.minor}.*`)
+            .trim()
+            .split('\n')
+            .pop();
+    if (baseHead) {
+      const match = /refs\/heads\/(.+)/.exec(baseHead);
+      baseBranch = match && match[1] || baseBranch;
+    }
 
-  if (result.code) {
-    console.log(result.stderr);
-    process.exit(1);
-  }
+    // We need to fetch origin explicitly because it might be stale.
+    // I couldn't find a reliable way to do this without fetch.
+    const result = shelljs.exec(
+        `git fetch origin ${baseBranch} && git log --reverse --format=%s HEAD ^origin/${baseBranch}`);
 
-  const commitsByLine = result.trim().split(/\n/).filter(line => line != '');
+    if (result.code) {
+      throw new Error(`Failed to fetch commits: ${result.stderr}`);
+    }
 
-  console.log(`Examining ${commitsByLine.length} commits between HEAD and ${baseBranch}`);
+    const commitsByLine = result.trim().split(/\n/).filter(line => line != '');
 
-  if (commitsByLine.length == 0) {
-    console.log(`There are zero new commits between this HEAD and ${baseBranch}`);
-  }
+    console.log(`Examining ${commitsByLine.length} commits between HEAD and ${baseBranch}`);
 
-  const someCommitsInvalid = !commitsByLine.every(validateCommitMessage);
+    if (commitsByLine.length == 0) {
+      console.log(`There are zero new commits between this HEAD and ${baseBranch}`);
+    }
 
-  if (someCommitsInvalid) {
-    console.log('Please fix the failing commit messages before continuing...');
-    console.log(
-        'Commit message guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines');
+    const someCommitsInvalid = !commitsByLine.every(validateCommitMessage);
+
+    if (someCommitsInvalid) {
+      throw new Error(
+          'Please fix the failing commit messages before continuing...\n' +
+          'Commit message guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines');
+    }
+  } catch (err) {
+    console.error(err);
     process.exit(1);
   }
 };

--- a/tools/gulp-tasks/validate-commit-message.js
+++ b/tools/gulp-tasks/validate-commit-message.js
@@ -31,7 +31,7 @@ module.exports = (gulp) => () => {
     // We need to fetch origin explicitly because it might be stale.
     // I couldn't find a reliable way to do this without fetch.
     const result = shelljs.exec(
-        `git fetch origin ${baseBranch} && git log --reverse --format=%s HEAD ^origin/${baseBranch}`);
+        `git fetch origin ${baseBranch} && git log --reverse --format=%s origin/${baseBranch}..HEAD`);
 
     if (result.code) {
       throw new Error(`Failed to fetch commits: ${result.stderr}`);
@@ -39,10 +39,10 @@ module.exports = (gulp) => () => {
 
     const commitsByLine = result.trim().split(/\n/).filter(line => line != '');
 
-    console.log(`Examining ${commitsByLine.length} commits between HEAD and ${baseBranch}`);
+    console.log(`Examining ${commitsByLine.length} commit(s) between ${baseBranch} and HEAD`);
 
     if (commitsByLine.length == 0) {
-      console.log(`There are zero new commits between this HEAD and ${baseBranch}`);
+      console.log(`There are zero new commits between ${baseBranch} and HEAD`);
     }
 
     const someCommitsInvalid = !commitsByLine.every(validateCommitMessage);


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
- [x] Bugfix
- [x] Build related changes


## What is the current behavior?
The `validate-commit-message` gulp task
- does not always stop execution, when an error occurs
- does not work correctly on Windows

Issue Numbers: #16829, #16830


## What is the new behavior?
- Execution stops, when an error occurs.
- It works correctly on Windows.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
