### PR TITLE
build: improve VSCode settings for workspace

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+  // See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": [
+    "gkalpak.aio-docs-utils",
+    "ms-vscode.vscode-typescript-tslint-plugin",
+    "xaver.clang-format",
+  ],
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
-  "editor.formatOnSave": true,
+  "[javascript]": {
+    "editor.formatOnSave": true,
+  },
+  "[typescript]": {
+    "editor.formatOnSave": true,
+  },
   // Please install http://clang.llvm.org/docs/ClangFormat.html in VSCode to take advantage of clang-format
   "clang-format.executable": "${workspaceRoot}/node_modules/.bin/clang-format",
   "files.watcherExclude": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,8 @@
   "[typescript]": {
     "editor.formatOnSave": true,
   },
-  // Please install http://clang.llvm.org/docs/ClangFormat.html in VSCode to take advantage of clang-format
+  // Please install https://marketplace.visualstudio.com/items?itemName=xaver.clang-format to take advantage of `clang-format` in VSCode.
+  // (See https://clang.llvm.org/docs/ClangFormat.html for more info `clang-format`.)
   "clang-format.executable": "${workspaceRoot}/node_modules/.bin/clang-format",
   "files.watcherExclude": {
     "**/.git/objects/**": true,


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
- [x] Build related changes


## What is the current behavior and the new behavior?
This PR contains two changes:

- **build: update VSCode settings to limit auto-formatting on save to JS/TS files**

    Previously, auto-formatting on save was enabled for all file types, which meant also using default VSCode formatting settings for files where this was not desirable - for example HTML files (such as angular.io and docs examples templates) and JSON files (such as Firebase configurations).
    This was problematic for the following reasons:
    - Unlike with JS/TS files, the formatting of other file types is not checked/enforced on CI.
    - Formatting is subject to default VSCode settings and everyone's local VSCode settings overrides.
    - Especially for docs examples files, changing the layout might require updating the wording in corresponding guides (e.g. when referring to line-numbers).

    If we decide that we do want to lint those other file types as well (which sounds like a good idea), we should do it in a way that ensures consistent formatting and check the formatting on CI.

- **build: add VSCode extension recommendations**

    Previously, the VSCode settings for the workspace specified the `clang-format.executable` setting to configure auto-formatting to use `clang-format`. Yet, this setting has no effect without the extension that provides that configuration option namely [xaver.clang-format][1]).
    For people that didn't have the extension installed, VSCode would use the default formatters, resulting in vastly different file fomatting.

    This commit adds a set of [rcommended workspace extensions][2], to help people get the right extensions when checking out the repository.

    The recommended extensions are:
    - [gkalpak.aio-docs-utils][3]: Utilities to aid in authoring/viewing Angular documentation source code. Currently, mainly aid in working with
  `{@example}`/`<code-example>` tags.
    - [ms-vscode.vscode-typescript-tslint-plugin][4]: Add auto-linting for TS files using `tslint` while editing.
    - [xaver.clang-format][1]: Add auto-formatting for JS/TS files using `clang-format`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

[1]: https://marketplace.visualstudio.com/items?itemName=xaver.clang-format
[2]: http://go.microsoft.com/fwlink/?LinkId=827846
[3]: https://marketplace.visualstudio.com/items?itemName=gkalpak.aio-docs-utils
[4]: https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin
