### PR TITLE
fix(http): add default parameter for HttpErrorResponse

### DIFF
--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -312,7 +312,7 @@ export class HttpErrorResponse extends HttpResponseBase implements Error {
 
   constructor(init: {
     error?: any; headers?: HttpHeaders; status?: number; statusText?: string; url?: string;
-  }) {
+  } = {}) {
     // Initialize with a default status of 0 / Unknown Error.
     super(init, 0, 'Unknown Error');
 

--- a/tools/public_api_guard/common/http.d.ts
+++ b/tools/public_api_guard/common/http.d.ts
@@ -1499,7 +1499,7 @@ export declare class HttpErrorResponse extends HttpResponseBase implements Error
     readonly message: string;
     readonly name = "HttpErrorResponse";
     readonly ok = false;
-    constructor(init: {
+    constructor(init?: {
         error?: any;
         headers?: HttpHeaders;
         status?: number;


### PR DESCRIPTION
All fields on the Init Object parameter on the HttpErrorResponse
are optional, which makes the whole Object optional.
For that reason a default empty Object was added.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The default constructor has to be given an empty Object.

## What is the new behavior?
The default constructor doesn't require an Init Object.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications  -->