### PR TITLE
fix(ivy): unable to import shim factory files on case-insensitive platforms

### DIFF
--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -202,7 +202,7 @@ export class NgtscProgram implements api.Program {
       // Relative entry paths are disallowed.
       if (entryRoute.startsWith('.')) {
         throw new Error(
-            `Falied to list lazy routes: Resolution of relative paths (${entryRoute}) is not supported.`);
+            `Failed to list lazy routes: Resolution of relative paths (${entryRoute}) is not supported.`);
       }
 
       // Non-relative entry paths fall into one of the following categories:

--- a/packages/compiler-cli/src/ngtsc/shims/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/host.ts
@@ -95,11 +95,10 @@ export class GeneratedShimsHostWrapper implements ts.CompilerHost {
   getNewLine(): string { return this.delegate.getNewLine(); }
 
   fileExists(fileName: string): boolean {
-    const canonical = this.getCanonicalFileName(fileName);
     // Consider the file as existing whenever 1) it really does exist in the delegate host, or
     // 2) at least one of the shim generators recognizes it.
     return this.delegate.fileExists(fileName) ||
-        this.shimGenerators.some(gen => gen.recognize(canonical));
+        this.shimGenerators.some(gen => gen.recognize(fileName));
   }
 
   readFile(fileName: string): string|undefined { return this.delegate.readFile(fileName); }

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2520,9 +2520,9 @@ describe('ngtsc behavioral tests', () => {
           export class TestModule {}
         `);
 
-        const entryModule1 = path.join(env.basePath, 'test#TestModule');
-        const entryModule2 = path.join(env.basePath, 'not-test#TestModule');
-        const entryModule3 = path.join(env.basePath, 'test#NotTestModule');
+        const entryModule1 = path.posix.join(env.basePath, 'test#TestModule');
+        const entryModule2 = path.posix.join(env.basePath, 'not-test#TestModule');
+        const entryModule3 = path.posix.join(env.basePath, 'test#NotTestModule');
 
         expect(() => env.driveRoutes(entryModule1)).not.toThrow();
         expect(() => env.driveRoutes(entryModule2))

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1550,6 +1550,23 @@ describe('ngtsc behavioral tests', () => {
     expect(emptyFactory).toContain(`export var ɵNonEmptyModule = true;`);
   });
 
+  it('should be able to compile an app using the factory shim', () => {
+    env.tsconfig({'allowEmptyCodegenFiles': true});
+
+    env.write('test.ts', `        
+        export {MyModuleNgFactory} from './my-module.ngfactory';
+    `);
+
+    env.write('my-module.ts', `
+        import {NgModule} from '@angular/core';
+
+        @NgModule({})
+        export class MyModule {}
+    `);
+
+    env.driveMain();
+  });
+
   it('should generate correct imports in factory stubs when compiling @angular/core', () => {
     env.tsconfig({'allowEmptyCodegenFiles': true});
 


### PR DESCRIPTION
This change is kind of similar to #27466, but instead of ensuring that
these shims can be generated, we also need to make sure that developers
are able to also use the factory shims like with `ngc`.

This issue is now surfacing because we have various old examples which
are now also built with `ngtsc`  (due to the bazel migration). On case insensitive
platforms (e.g. windows) these examples cannot be built because ngtsc fails for
apps importing a generated shim file (such as the factory shim files).

This is because the `GeneratedShimsHostWrapper` TypeScript host uses
the `getCanonicalFileName` method in order to check whether a given
file/module exists in the generator file maps. e.g.

```ts
// Generator Map:
'C:/users/paul/_bazel_paul/lm3s4mgv/execroot/angular/packages/core/index.ngfactory.ts' =>
'C:/users/paul/_bazel_paul/lm3s4mgv/execroot/angular/packages/core/index.ts',

// Path passed into `fileExists`
C:/users/paul/_bazel_paul/lm3s4mgv/execroot/angular/packages/core/index.ngfactory.ts

// After getCanonicalFileName (notice the **lower-case drive name**)
c:/users/paul/_bazel_paul/lm3s4mgv/execroot/angular/packages/core/index.ngfactory.ts
```

As seen above, the generator map does not use the canonical file names, as well as
TypeScript internally does not pass around canonical file names. We can fix this by removing
the manual call to `getCanonicalFileName` and just following TypeScript internal-semantics.