### PR TITLE
docs: fix wrong filename ngsw-config.json in service worker fail-safe

### DIFF
--- a/aio/content/guide/service-worker-devops.md
+++ b/aio/content/guide/service-worker-devops.md
@@ -301,7 +301,7 @@ an administrator ever needs to deactivate the service worker quickly.
 ### Fail-safe
 
 To deactivate the service worker, remove or rename the
-`ngsw-config.json` file. When the service worker's request
+`ngsw.json` file. When the service worker's request
 for `ngsw.json` returns a `404`, then the service worker
 removes all of its caches and de-registers itself,
 essentially self-destructing.


### PR DESCRIPTION
This should be `ngsw.json` not `ngsw-config.json` as the latter is only the src file that gets then compiled into the `ngsw.json` and placed into the `dist` folder

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The filename in the paragraph about service worker "fail-safe" is wrong. it should be `ngsw.json` rather than `ngsw-config.json`.

Issue Number: N/A


## What is the new behavior?

Fixes that typo.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
