### PR TITLE
build: enable bundle_dts for router package

### DIFF
--- a/packages/router/BUILD.bazel
+++ b/packages/router/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    bundle_dts = True,
     deps = [
         "//packages/common",
         "//packages/core",

--- a/packages/router/src/components/empty_outlet.ts
+++ b/packages/router/src/components/empty_outlet.ts
@@ -18,5 +18,7 @@ import {Component} from '@angular/core';
  * to this `EmptyOutletComponent`.
  */
 @Component({template: `<router-outlet></router-outlet>`})
-export class EmptyOutletComponent {
+export class ɵEmptyOutletComponent {
 }
+
+export {ɵEmptyOutletComponent as EmptyOutletComponent};

--- a/packages/router/src/private_export.ts
+++ b/packages/router/src/private_export.ts
@@ -7,6 +7,6 @@
  */
 
 
-export {EmptyOutletComponent as ɵEmptyOutletComponent} from './components/empty_outlet';
+export {ɵEmptyOutletComponent} from './components/empty_outlet';
 export {ROUTER_PROVIDERS as ɵROUTER_PROVIDERS} from './router_module';
 export {flatten as ɵflatten} from './utils/collection';

--- a/packages/router/testing/BUILD.bazel
+++ b/packages/router/testing/BUILD.bazel
@@ -7,6 +7,7 @@ load("//tools:defaults.bzl", "ng_module")
 ng_module(
     name = "testing",
     srcs = glob(["**/*.ts"]),
+    bundle_dts = True,
     deps = [
         "//packages/common",
         "//packages/common/testing",

--- a/packages/router/upgrade/BUILD.bazel
+++ b/packages/router/upgrade/BUILD.bazel
@@ -12,6 +12,7 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    bundle_dts = True,
     deps = [
         "//packages/common",
         "//packages/core",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
This PR also changes the name of `EmptyOutletComponent` to `ɵEmptyOutletComponent`. This is because `ngcc` requires the node to retain the original name while dts bundler will rename the node is it's only exported using the aliases.

Example typings files:
```ts
declare class EmptyOutletComponent {
}
export {EmptyOutletComponent as ɵEmptyOutletComponent}
```

will be emitted as 

```ts
export declare class ɵEmptyOutletComponent {
}
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
