### PR TITLE
docs: clarify process surrounding merge label

### DIFF
--- a/docs/TRIAGE_AND_LABELS.md
+++ b/docs/TRIAGE_AND_LABELS.md
@@ -126,7 +126,8 @@ Every triaged PR must have a `pr_action` label assigned to it:
 * `PR action: review` - work is complete and comment is needed from the reviewers.
 * `PR action: cleanup` - more work is needed from the author.
 * `PR action: discuss` - discussion is needed, to be led by the author.
-* `PR action: merge` - the PR author is ready for the changes to be merged by the caretaker.
+* `PR action: merge` - the PR author is ready for the changes to be merged by the caretaker as soon as the PR is green (or merge-assistance label is applied and caretaker has deemed it acceptable manually). In other words, this label indicates to "auto submit when ready". 
+
 
 In addition, PRs can have the following states:
 


### PR DESCRIPTION
In the TRIAGE_AND_LABELS doc, it was not clear that the merge label
may be applied by the author before the PR is green (as a sort of
auto-submit). After the label is applied, it is still up to the
caretaker to determine that the PR is acceptable before merging.
This commit adds that clarification.