### PR TITLE
fix(bazel): Schematics should upgrade rxjs to 6.4.0

### DIFF
--- a/packages/bazel/src/schematics/ng-add/index_spec.ts
+++ b/packages/bazel/src/schematics/ng-add/index_spec.ts
@@ -21,6 +21,7 @@ describe('ng-add schematic', () => {
       name: 'demo',
       dependencies: {
         '@angular/core': '1.2.3',
+        'rxjs': '~6.3.3',
       },
       devDependencies: {
         'typescript': '3.2.2',
@@ -197,5 +198,45 @@ describe('ng-add schematic', () => {
         outDir: './dist/out-tsc',
       }
     });
+  });
+
+  describe('rxjs', () => {
+    const cases = [
+      // version|upgrade
+      ['6.3.3', true],
+      ['~6.3.3', true],
+      ['^6.3.3', true],
+      ['~6.3.11', true],
+      ['6.4.0', false],
+      ['~6.4.0', false],
+      ['~6.4.1', false],
+      ['6.5.0', false],
+      ['~6.5.0', false],
+      ['^6.5.0', false],
+      ['~7.0.1', false],
+    ];
+    for (const [version, upgrade] of cases) {
+      it(`should ${upgrade ? '' : 'not '}upgrade v${version}')`, () => {
+        host.overwrite('package.json', JSON.stringify({
+          name: 'demo',
+          dependencies: {
+            '@angular/core': '1.2.3',
+            'rxjs': version,
+          },
+          devDependencies: {
+            'typescript': '3.2.2',
+          },
+        }));
+        host = schematicRunner.runSchematic('ng-add', defaultOptions, host);
+        expect(host.files).toContain('/package.json');
+        const content = host.readContent('/package.json');
+        const json = JSON.parse(content);
+        if (upgrade) {
+          expect(json.dependencies.rxjs).toBe('~6.4.0');
+        } else {
+          expect(json.dependencies.rxjs).toBe(version);
+        }
+      });
+    }
   });
 });


### PR DESCRIPTION
Since rxjs is no longer built from source in Bazel schematics, the
minimum version ought to be at least 6.4.0.

This commit adds function to bump the version in package.json.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
