### PR TITLE
test(ivy): re-enable ngIf protractor test

### DIFF
--- a/packages/examples/common/ngIf/ts/e2e_test/ngIf_spec.ts
+++ b/packages/examples/common/ngIf/ts/e2e_test/ngIf_spec.ts
@@ -46,20 +46,18 @@ describe('ngIf', () => {
   describe('ng-if-then-else', () => {
     let comp = 'ng-if-then-else';
 
-    modifiedInIvy('FW-1019: Design new API to replace static queries')
-        .it('should hide/show content', () => {
-          browser.get(URL);
-          waitForElement(comp);
-          expect(element.all(by.css(comp)).get(0).getText())
-              .toEqual('hideSwitch Primary show = true\nPrimary text to show');
-          element.all(by.css(comp + ' button')).get(1).click();
-          expect(element.all(by.css(comp)).get(0).getText())
-              .toEqual('hideSwitch Primary show = true\nSecondary text to show');
-          element.all(by.css(comp + ' button')).get(0).click();
-          expect(element.all(by.css(comp)).get(0).getText())
-              .toEqual(
-                  'showSwitch Primary show = false\nAlternate text while primary text is hidden');
-        });
+    it('should hide/show content', () => {
+      browser.get(URL);
+      waitForElement(comp);
+      expect(element.all(by.css(comp)).get(0).getText())
+          .toEqual('hideSwitch Primary show = true\nPrimary text to show');
+      element.all(by.css(comp + ' button')).get(1).click();
+      expect(element.all(by.css(comp)).get(0).getText())
+          .toEqual('hideSwitch Primary show = true\nSecondary text to show');
+      element.all(by.css(comp + ' button')).get(0).click();
+      expect(element.all(by.css(comp)).get(0).getText())
+          .toEqual('showSwitch Primary show = false\nAlternate text while primary text is hidden');
+    });
   });
 
   describe('ng-if-let', () => {

--- a/packages/examples/common/ngIf/ts/module.ts
+++ b/packages/examples/common/ngIf/ts/module.ts
@@ -60,7 +60,7 @@ export class NgIfThenElse implements OnInit {
   thenBlock: TemplateRef<any>|null = null;
   show: boolean = true;
 
-  @ViewChild('primaryBlock')
+  @ViewChild('primaryBlock', {static: true})
   primaryBlock: TemplateRef<any>|null = null;
   @ViewChild('secondaryBlock')
   secondaryBlock: TemplateRef<any>|null = null;


### PR DESCRIPTION
We previously disabled this test because we did not yet have
static query support in Ivy and the planned API would be
slightly different. Now that a static query flag is available
that works in both View Engine and Ivy, the test has been
updated to use that flag and has been turned on to run in CI.

Since the test was always unrelated to queries and was intended
to test *ngIf behavior, updating the test in this instance
seems reasonable.