### PR TITLE
fix(ivy): allow HTML comments to be present inside <ng-content>

### DIFF
--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1728,6 +1728,26 @@ describe('ngtsc behavioral tests', () => {
     expect(jsContents).toContain('ɵsetClassMetadata(TestPipe, ');
   });
 
+  it('should not throw in case whitespaces and HTML comments are present inside <ng-content>',
+     () => {
+       env.tsconfig();
+       env.write('test.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'cmp-a',
+            template: \`
+              <ng-content>
+                <!-- Some comments -->
+              </ng-content>
+            \`,
+          })
+          class CmpA {}
+       `);
+       const errors = env.driveDiagnostics();
+       expect(errors.length).toBe(0);
+     });
+
   it('should compile a template using multiple directives with the same selector', () => {
     env.tsconfig();
     env.write('test.ts', `

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -156,7 +156,9 @@ class HtmlAstToIvyAst implements html.Visitor {
     let parsedElement: t.Node|undefined;
     if (preparsedElement.type === PreparsedElementType.NG_CONTENT) {
       // `<ng-content>`
-      if (element.children && !element.children.every(isEmptyTextNode)) {
+      if (element.children &&
+          !element.children.every(
+              (node: html.Node) => isEmptyTextNode(node) || isCommentNode(node))) {
         this.reportError(`<ng-content> element cannot have content.`, element.sourceSpan);
       }
       const selector = preparsedElement.selectAttr;
@@ -412,4 +414,8 @@ function addEvents(events: ParsedEvent[], boundEvents: t.BoundEvent[]) {
 
 function isEmptyTextNode(node: html.Node): boolean {
   return node instanceof html.Text && node.value.trim().length == 0;
+}
+
+function isCommentNode(node: html.Node): boolean {
+  return node instanceof html.Comment;
 }


### PR DESCRIPTION
Prior to this change presence of HTML comments inside <ng-content> caused compiler to throw an error that <ng-content> is not empty. Now HTML comments are not considered as a meaningful content, thus no error is thrown. This behavior is now aligned in Ivy/VE.

This issue was causing some g3 targets build failures.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
