### PR TITLE
fix(bazel): Add postinstall step to generate summaries

### DIFF
--- a/packages/bazel/src/schematics/bazel-workspace/files/angular-metadata.tsconfig.json.template
+++ b/packages/bazel/src/schematics/bazel-workspace/files/angular-metadata.tsconfig.json.template
@@ -1,0 +1,21 @@
+// Workaround for https://github.com/angular/angular/issues/18810
+// This file is required because when using the Angular NPM packages and building
+// with AOT compilation, NGC needs the "ngsummary.json" files.
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "es2015"
+    ],
+    "experimentalDecorators": true,
+    "types": []
+  },
+  "include": [
+    "node_modules/@angular/**/*"
+  ],
+  "exclude": [
+    "node_modules/@angular/bazel/**",
+    "node_modules/@angular/compiler-cli/**",
+    "node_modules/@angular/**/testing/**"
+  ]
+}

--- a/packages/bazel/src/schematics/ng-add/index_spec.ts
+++ b/packages/bazel/src/schematics/ng-add/index_spec.ts
@@ -17,45 +17,54 @@ describe('ng-add schematic', () => {
 
   beforeEach(() => {
     host = new UnitTestTree(new HostTree());
-    host.create('package.json', JSON.stringify({
-      name: 'demo',
-      dependencies: {
-        '@angular/core': '1.2.3',
-        'rxjs': '~6.3.3',
-      },
-      devDependencies: {
-        'typescript': '3.2.2',
-      },
-    }));
-    host.create('tsconfig.json', JSON.stringify({
-      compileOnSave: false,
-      compilerOptions: {
-        baseUrl: './',
-        outDir: './dist/out-tsc',
-      }
-    }));
-    host.create('angular.json', JSON.stringify({
-      projects: {
-        'demo': {
-          architect: {
-            build: {},
-            serve: {},
-            test: {},
-            'extract-i18n': {
-              builder: '@angular-devkit/build-angular:extract-i18n',
-            },
-          },
-        },
-        'demo-e2e': {
-          architect: {
-            e2e: {},
-            lint: {
-              builder: '@angular-devkit/build-angular:tslint',
-            },
-          },
-        },
-      },
-    }));
+    host.create(
+        'package.json', JSON.stringify(
+                            {
+                              name: 'demo',
+                              dependencies: {
+                                '@angular/core': '1.2.3',
+                                'rxjs': '~6.3.3',
+                              },
+                              devDependencies: {
+                                'typescript': '3.2.2',
+                              },
+                            },
+                            null, 2));
+    host.create(
+        'tsconfig.json', JSON.stringify(
+                             {
+                               compileOnSave: false,
+                               compilerOptions: {
+                                 baseUrl: './',
+                                 outDir: './dist/out-tsc',
+                               }
+                             },
+                             null, 2));
+    host.create(
+        'angular.json', JSON.stringify(
+                            {
+                              projects: {
+                                'demo': {
+                                  architect: {
+                                    build: {},
+                                    serve: {},
+                                    test: {},
+                                    'extract-i18n': {
+                                      builder: '@angular-devkit/build-angular:extract-i18n',
+                                    },
+                                  },
+                                },
+                                'demo-e2e': {
+                                  architect: {
+                                    e2e: {},
+                                    lint: {
+                                      builder: '@angular-devkit/build-angular:tslint',
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                            null, 2));
     schematicRunner =
         new SchematicTestRunner('@angular/bazel', require.resolve('../collection.json'));
   });
@@ -217,16 +226,19 @@ describe('ng-add schematic', () => {
     ];
     for (const [version, upgrade] of cases) {
       it(`should ${upgrade ? '' : 'not '}upgrade v${version}')`, () => {
-        host.overwrite('package.json', JSON.stringify({
-          name: 'demo',
-          dependencies: {
-            '@angular/core': '1.2.3',
-            'rxjs': version,
-          },
-          devDependencies: {
-            'typescript': '3.2.2',
-          },
-        }));
+        host.overwrite(
+            'package.json', JSON.stringify(
+                                {
+                                  name: 'demo',
+                                  dependencies: {
+                                    '@angular/core': '1.2.3',
+                                    'rxjs': version,
+                                  },
+                                  devDependencies: {
+                                    'typescript': '3.2.2',
+                                  },
+                                },
+                                null, 2));
         host = schematicRunner.runSchematic('ng-add', defaultOptions, host);
         expect(host.files).toContain('/package.json');
         const content = host.readContent('/package.json');
@@ -238,5 +250,13 @@ describe('ng-add schematic', () => {
         }
       });
     }
+  });
+
+  it('should add a postinstall step to package.json', () => {
+    host = schematicRunner.runSchematic('ng-add', defaultOptions, host);
+    expect(host.files).toContain('/package.json');
+    const content = host.readContent('/package.json');
+    const json = JSON.parse(content);
+    expect(json.scripts.postinstall).toBe('ngc -p ./angular-metadata.tsconfig.json');
   });
 });


### PR DESCRIPTION
This commit adds a postinstall step to the package.json generated by the
schematics to generate ng summary files needed for AOT. Summary files
are not published in npm packages.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
