### PR TITLE
docs: add angular.de to the workshops page

### DIFF
--- a/aio/content/marketing/resources.json
+++ b/aio/content/marketing/resources.json
@@ -856,6 +856,13 @@
             "rev": true,
             "title": "StrongBrew",
             "url": "https://strongbrew.io/"
+          },
+          "angular.de": {
+            "desc": "Onsite Angular Training delivered by the greatest community in the german speaking area in Germany, Austria and Switzerland. We also regularly post articles and tutorials on our blog.",
+            "logo": "https://angular.de/assets/img/angular-de-logo.svg",
+            "rev": true,
+            "title": "Angular.de (German)",
+            "url": "https://angular.de/"
           }
         }
       }


### PR DESCRIPTION
I added our community (angular.de) to the workshops page (https://angular.io/resources)
We offer public and inhouse Workshops onsite since 2013