### PR TITLE
ci/angular bot exclude third party

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -57,6 +57,7 @@ merge:
       - "**/.gitkeep"
       - "**/yarn.lock"
       - "**/package.json"
+      - "**/third_party/**"
       - "**/tsconfig-build.json"
       - "**/tsconfig.json"
       - "**/BUILD.bazel"


### PR DESCRIPTION
this pattern is being excluded in copybara. see cl/234807990.
