### PR TITLE
refactor(ivy): remove superfluous isComponentDef function

### DIFF
--- a/packages/core/src/render3/features/inherit_definition_feature.ts
+++ b/packages/core/src/render3/features/inherit_definition_feature.ts
@@ -7,23 +7,12 @@
  */
 
 import {Type} from '../../interface/type';
-import {Component} from '../../metadata/directives';
 import {fillProperties} from '../../util/property';
 import {EMPTY_ARRAY, EMPTY_OBJ} from '../empty';
 import {ComponentDef, DirectiveDef, DirectiveDefFeature, RenderFlags} from '../interfaces/definition';
+import {isComponentDef} from '../util';
 
 import {NgOnChangesFeature} from './ng_onchanges_feature';
-
-
-/**
- * Determines if a definition is a {@link ComponentDef} or a {@link DirectiveDef}
- * @param definition The definition to examine
- */
-function isComponentDef<T>(definition: ComponentDef<T>| DirectiveDef<T>):
-    definition is ComponentDef<T> {
-  const def = definition as ComponentDef<T>;
-  return typeof def.template === 'function';
-}
 
 function getSuperType(type: Type<any>): Type<any>&
     {ngComponentDef?: ComponentDef<any>, ngDirectiveDef?: DirectiveDef<any>} {


### PR DESCRIPTION
Simply removes an unnecessary function declaration.