### PR TITLE
fix(bazel): rxjs_umd_modules should always be present

### DIFF
--- a/packages/bazel/src/schematics/bazel-workspace/files/src/BUILD.bazel.template
+++ b/packages/bazel/src/schematics/bazel-workspace/files/src/BUILD.bazel.template
@@ -7,15 +7,6 @@ load("@build_bazel_rules_nodejs//internal/web_package:web_package.bzl", "web_pac
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_devserver", "ts_library")
 <% if (sass) { %>load("@io_bazel_rules_sass//:defs.bzl", "multi_sass_binary")
 
-filegroup(
-    name = "rxjs_umd_modules",
-    srcs = [
-        # do not sort
-        "@npm//node_modules/rxjs:bundles/rxjs.umd.js",
-        ":rxjs_shims.js",
-    ],
-)
-
 multi_sass_binary(
     name = "styles",
     srcs = glob(["**/*.scss"]),
@@ -71,6 +62,15 @@ history_server(
     name = "prodserver",
     data = [":prodapp"],
     templated_args = ["src/prodapp"],
+)
+
+filegroup(
+    name = "rxjs_umd_modules",
+    srcs = [
+        # do not sort
+        "@npm//node_modules/rxjs:bundles/rxjs.umd.js",
+        ":rxjs_shims.js",
+    ],
 )
 
 ts_devserver(


### PR DESCRIPTION
This commit fixes the bug whereby `rxjs_umd_modules` would only be generated
when Sass files are used.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
