### PR TITLE
ci: run saucelabs legacy tests every hour

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -599,8 +599,12 @@ workflows:
       - legacy-unit-tests-saucelabs
     triggers:
       - schedule:
-          # Runs the Saucelabs legacy tests every four hours.
-          cron: "0 0,4,8,12,16,20 * * *"
+          # Runs the Saucelabs legacy tests every hour. We still want to run Saucelabs
+          # frequently as the caretaker needs up-to-date results when merging PRs or creating
+          # a new release. Also we primarily moved the Saucelabs job into a cronjob that doesn't
+          # run for PRs, in order to ensure that PRs are not affected by Saucelabs flakiness or
+          # incidents. This is still guaranteed (even if we run the job every hour).
+          cron: "0 * * * *"
           filters: *publish_branches_filter
 
   aio_monitoring:


### PR DESCRIPTION
Initially when we introduced the cronjob for Saucelabs, we specified that
the tests should run every 4h. Since the caretaker needs more recent results
when merging PRs or before creating a release, we should run the saucelabs
tests every hour. 

This still ensures that PRs are not affected by Saucelabs flakiness or incidents, and
the caretaker can also react better to real browser failures (not blocked on a 4h time frame)