### PR TITLE
build(bazel): cleanup the jasmine bootstrap code

### DIFF
--- a/tools/testing/init_node_no_angular_spec.ts
+++ b/tools/testing/init_node_no_angular_spec.ts
@@ -6,21 +6,5 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// This hack is needed to get jasmine, node and zone working inside bazel.
-// 1) we load `jasmine-core` which contains the ENV: it, describe etc...
-const jasmineCore: any = require('jasmine-core');
-// 2) We create an instance of `jasmine` ENV.
-const patchedJasmine = jasmineCore.boot(jasmineCore);
-// 3) Save the `jasmine` into global so that `zone.js/dist/jasmine-patch.js` can get a hold of it to
-// patch it.
-(global as any)['jasmine'] = patchedJasmine;
-// 4) Change the `jasmine-core` to make sure that all subsequent jasmine's have the same ENV,
-// otherwise the patch will not work.
-//    This is needed since Bazel creates a new instance of jasmine and it's ENV and we want to make
-//    sure it gets the same one.
-jasmineCore.boot = function() {
-  return patchedJasmine;
-};
-
 (global as any).isNode = true;
 (global as any).isBrowser = false;


### PR DESCRIPTION
Now that https://github.com/bazelbuild/rules_nodejs/pull/539 has landed, the jasmine bootstrap code can be cleaned up. Also, this removes the old bootstrap code from `tools/testing/init_node_no_angular_spec.ts` as its not needed there at all.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
