### PR TITLE
docs(bazel): Use CLI 8 for Bazel schematics

### DIFF
--- a/packages/bazel/src/schematics/README.md
+++ b/packages/bazel/src/schematics/README.md
@@ -12,9 +12,9 @@ GitHub and ping [@mgechev](https://github.com/mgechev) or
 To create a new Angular project that builds with Bazel + CLI, the following
 packages have to be installed.
 
-Package | Minimum Version
---------|----------------
-@angular/cli | v7.3.x
+    Package    | Minimum Version
+---------------|----------------
+@angular/cli   | v8.0.x
 @angular/bazel | v8.0.x
 
 The `@angular/bazel` package contains schematics to generate necessary Bazel
@@ -24,7 +24,7 @@ If the packages are not on your system yet, install them with the following
 commands:
 
 ```
-yarn global add @angular/cli@latest @angular/bazel@next
+yarn global add @angular/cli@next @angular/bazel@next
 ```
 
 It is very *important* to meet the minimum version requirement of `@angular/cli`


### PR DESCRIPTION
CLI 8 (beta) is needed so that the projects pull in Angular version 8.
It will no longer build Angular from source.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
