### PR TITLE
fix(bazel): Pin browsers for schematics

### DIFF
--- a/packages/bazel/src/schematics/bazel-workspace/files/WORKSPACE.template
+++ b/packages/bazel/src/schematics/bazel-workspace/files/WORKSPACE.template
@@ -49,12 +49,11 @@ install_bazel_dependencies()
 load("@npm_bazel_karma//:package.bzl", "rules_karma_dependencies")
 rules_karma_dependencies()
 
-load("@io_bazel_rules_webtesting//web:repositories.bzl", "browser_repositories", "web_test_repositories")
+load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories")
 web_test_repositories()
-browser_repositories(
-    chromium = True,
-    firefox = True,
-)
+
+load("@npm_bazel_karma//:browser_repositories.bzl", "browser_repositories")
+browser_repositories()
 
 load("@npm_bazel_typescript//:defs.bzl", "ts_setup_workspace")
 ts_setup_workspace()


### PR DESCRIPTION
Pin versions for Chrome, ChromeDriver, Firefox, and GeckoDriver.

https://github.com/bazelbuild/rules_typescript/blob/c09bc740230ce0fbf3ca92b6c8755da577ef1de2/internal/karma/browser_repositories.bzl

This is a temporary workaround until fix lands in web_testing.

***This change requires Angular 8.0.0-beta.6 and above***

PR closes https://github.com/angular/angular/issues/28724

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
