### PR TITLE
docs(core): added description to HostBinding

### DIFF
--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -787,7 +787,17 @@ export const Output: OutputDecorator = makePropDecorator(
  * @publicApi
  */
 export interface HostBindingDecorator {
-  /**
+  (hostPropertyName?: string): any;
+  new (hostPropertyName?: string): any;
+}
+
+/**
+ * Type of the HostBinding metadata.
+ *
+ * @publicApi
+ */
+export interface HostBinding { hostPropertyName?: string; }
+/**
    * Decorator that marks a DOM property as a host-binding property and supplies configuration
    * metadata.
    * Angular automatically checks host property bindings during change detection, and
@@ -816,17 +826,6 @@ export interface HostBindingDecorator {
    * ```
    *
    */
-  (hostPropertyName?: string): any;
-  new (hostPropertyName?: string): any;
-}
-
-/**
- * Type of the HostBinding metadata.
- *
- * @publicApi
- */
-export interface HostBinding { hostPropertyName?: string; }
-
 /**
  * @Annotation
  * @publicApi


### PR DESCRIPTION
i think the description for HostBinding was misplaced and because of which no description is shown for HostBinding
you can check 
https://angular.io/api/core/HostBinding#hostbinding

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

added description to HostBinding in docs
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
