### PR TITLE
ci: share data between jobs using workspaces

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+aio/content
 aio/node_modules
 aio/tools/examples/shared/node_modules
 integration/bazel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ var_2: &browsers_docker_image circleci/node:10.12-browsers
 # **NOTE 1 **: If you change the cache key prefix, also sync the restore_cache fallback to match.
 # **NOTE 2 **: Keep the static part of the cache key as prefix to enable correct fallbacks.
 # See https://circleci.com/docs/2.0/caching/#restoring-cache for how prefixes work in CircleCI.
-var_3: &cache_key v2-angular-node-10.12-{{ checksum "yarn.lock" }}-{{ checksum "WORKSPACE" }}-{{ checksum "packages/bazel/package.bzl" }}
+var_3: &cache_key v3-angular-node-10.12-{{ checksum "yarn.lock" }}-{{ checksum "WORKSPACE" }}-{{ checksum "packages/bazel/package.bzl" }}-{{ checksum "aio/yarn.lock" }}
 
 # Initializes the CI environment by setting up common environment variables.
 var_4: &init_environment
@@ -39,6 +39,15 @@ var_4: &init_environment
       sudo chmod a+x $ourYarn
       sudo ln -fs $ourYarn /usr/local/bin/yarn
       echo "Yarn version: $(yarn --version)"
+
+      # Add GitHub to known hosts.
+      mkdir -p ~/.ssh
+      echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
+
+      # use git+ssh instead of https
+      git config --global url."ssh://git@github.com".insteadOf "https://github.com" || true
+      git config --global gc.auto 0 || true
+
 
 var_5: &setup_bazel_remote_execution
   run:
@@ -97,7 +106,7 @@ var_10: &restore_cache
     keys:
       - *cache_key
       # This fallback should be the cache_key without variables.
-      - v2-angular-node-10.12-
+      - v3-angular-node-10.12-
 
 # Branch filter that can be specified for jobs that should only run on publish branches
 # (e.g. master or the patch branch)
@@ -108,16 +117,36 @@ var_12: &publish_branches_filter
       # e.g. 7.0.x, 7.1.x, etc.
       - /\d+\.\d+\.x/
 
+# Workspace initially persisted by the `install` job, and then enhanced by test_aio and
+# build-npm-packages.
+# https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
+# https://circleci.com/blog/deep-diving-into-circleci-workspaces/
+var_13: &attach_options
+  at: .
+
 version: 2
 jobs:
-  lint:
+  install:
     <<: *job_defaults
     steps:
       - checkout
       - *post_checkout
+      # This cache is saved in the build-npm-packages so that Bazel cache is also included.
       - *restore_cache
       - *init_environment
       - *yarn_install
+      - run: yarn --cwd aio install --frozen-lockfile --non-interactive
+      # Persist any changes at this point to be reused by further jobs.
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./*
+
+  lint:
+    <<: *job_defaults
+    steps:
+      - attach_workspace: *attach_options
+      - *init_environment
 
       - run: 'yarn bazel:format -mode=check ||
               (echo "BUILD files not formatted. Please run ''yarn bazel:format''" ; exit 1)'
@@ -131,11 +160,8 @@ jobs:
     <<: *job_defaults
     resource_class: xlarge
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
+      - attach_workspace: *attach_options
       - *init_environment
-      - *yarn_install
       - *setup_circleci_bazel_config
 
       # Setup remote execution and run RBE-compatible tests.
@@ -150,11 +176,8 @@ jobs:
     <<: *job_defaults
     resource_class: xlarge
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
+      - attach_workspace: *attach_options
       - *init_environment
-      - *yarn_install
       - *setup_circleci_bazel_config
       - *setup_bazel_remote_execution
 
@@ -188,9 +211,7 @@ jobs:
       # Needed because the AIO tests and the PWA score test depend on Chrome being available.
       - image: *browsers_docker_image
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
+      - attach_workspace: *attach_options
       - *init_environment
         # Build aio
       - run: yarn --cwd aio build --progress=false
@@ -215,9 +236,7 @@ jobs:
     # Needed because before deploying the deploy-production script runs the PWA score tests.
     - image: *browsers_docker_image
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
+      - attach_workspace: *attach_options
       - *init_environment
         # Deploy angular.io to production (if necessary)
       - run: setPublicVar CI_STABLE_BRANCH "$(npm info @angular/core dist-tags.latest | sed -r 's/^\s*([0-9]+\.[0-9]+)\.[0-9]+.*$/\1.x/')"
@@ -229,11 +248,7 @@ jobs:
       # Needed because the AIO tests and the PWA score test depend on Chrome being available.
       - image: *browsers_docker_image
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
-      - attach_workspace:
-          at: dist
+      - attach_workspace: *attach_options
       - *init_environment
         # Build aio (with local Angular packages)
       - run: yarn --cwd aio build-local --progress=false
@@ -248,11 +263,7 @@ jobs:
   test_aio_local_ivy:
     <<: *job_defaults
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
-      - attach_workspace:
-          at: dist
+      - attach_workspace: *attach_options
       - *init_environment
         # Build aio with Ivy (using local Angular packages)
       - run: yarn --cwd aio build-with-ivy --progress=false
@@ -260,11 +271,7 @@ jobs:
   test_aio_tools:
     <<: *job_defaults
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
-      - attach_workspace:
-          at: dist
+      - attach_workspace: *attach_options
       - *init_environment
         # Install
       - run: yarn --cwd aio install --frozen-lockfile --non-interactive
@@ -280,11 +287,7 @@ jobs:
       - image: *browsers_docker_image
     parallelism: 3
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
-      - attach_workspace:
-          at: dist
+      - attach_workspace: *attach_options
       - *init_environment
         # Install aio
       - run: yarn --cwd aio install --frozen-lockfile --non-interactive
@@ -300,11 +303,7 @@ jobs:
       - image: *browsers_docker_image
     parallelism: 3
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
-      - attach_workspace:
-          at: dist
+      - attach_workspace: *attach_options
       - *init_environment
         # Install aio
       - run: yarn --cwd aio install --frozen-lockfile --non-interactive
@@ -319,9 +318,7 @@ jobs:
     environment:
        AIO_SNAPSHOT_ARTIFACT_PATH: &aio_preview_artifact_path 'aio/tmp/snapshot.tgz'
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
+      - attach_workspace: *attach_options
       - *init_environment
       - run: ./aio/scripts/build-artifacts.sh $AIO_SNAPSHOT_ARTIFACT_PATH $CI_PULL_REQUEST $CI_COMMIT
       - store_artifacts:
@@ -338,9 +335,7 @@ jobs:
       # Needed because the test-preview script runs e2e tests and the PWA score test with Chrome.
       - image: *browsers_docker_image
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
+      - attach_workspace: *attach_options
       - *init_environment
       - run: yarn --cwd aio install --frozen-lockfile --non-interactive
       - run:
@@ -360,27 +355,24 @@ jobs:
     <<: *job_defaults
     resource_class: xlarge
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
+      - attach_workspace: *attach_options
       - *init_environment
-      - *yarn_install
       - *setup_circleci_bazel_config
       - *setup_bazel_remote_execution
 
       - run: scripts/build-packages-dist.sh
 
       # Save the npm packages from //packages/... for other workflow jobs to read
-      # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
       - persist_to_workspace:
-          root: dist
+          root: .
           paths:
-            - packages-dist
+            - dist/packages-dist
 
       - save_cache:
           key: *cache_key
           paths:
             - "node_modules"
+            - "aio/node_modules"
             - "~/bazel_repository_cache"
 
 
@@ -389,22 +381,18 @@ jobs:
     <<: *job_defaults
     resource_class: xlarge
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
+      - attach_workspace: *attach_options
       - *init_environment
-      - *yarn_install
       - *setup_circleci_bazel_config
       - *setup_bazel_remote_execution
 
       - run: scripts/build-ivy-npm-packages.sh
 
       # Save the npm packages from //packages/... for other workflow jobs to read
-      # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
       - persist_to_workspace:
-          root: dist
+          root: .
           paths:
-            - packages-dist-ivy-aot
+            - dist/packages-dist-ivy-aot
 
   # We run the integration tests outside of Bazel for now.
   # They are a separate workflow job so that they can be easily re-run.
@@ -423,14 +411,8 @@ jobs:
     # on a 4G worker so we use a larger machine here too.
     resource_class: xlarge
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
-      - attach_workspace:
-          at: dist
+      - attach_workspace: *attach_options
       - *init_environment
-      # Some integration tests get their dependencies from the root `node_modules/`.
-      - *yarn_install
       # Runs the integration tests in parallel across multiple CircleCI container instances. The
       # amount of container nodes for this job is controlled by the "parallelism" option.
       - run: ./integration/run_tests.sh ${CIRCLE_NODE_INDEX} ${CIRCLE_NODE_TOTAL}
@@ -440,8 +422,7 @@ jobs:
   publish_snapshot:
     <<: *job_defaults
     steps:
-      - checkout
-      - *post_checkout
+      - attach_workspace: *attach_options
       - *init_environment
       # See below - ideally this job should not trigger for non-upstream builds.
       # But since it does, we have to check this condition.
@@ -453,8 +434,6 @@ jobs:
               || "$CI_REPO_OWNER" != "angular"
               || "$CI_REPO_NAME" != "angular"
           ]] && circleci step halt || true'
-      - attach_workspace:
-          at: dist
       # CircleCI has a config setting to force SSH for all github connections
       # This is not compatible with our mechanism of using a Personal Access Token
       # Clear the global setting
@@ -492,11 +471,8 @@ jobs:
     # and therefore the tunnel and Karma need to process a lot of file requests and tests.
     resource_class: xlarge
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
+      - attach_workspace: *attach_options
       - *init_environment
-      - *yarn_install
       - run:
           name: Preparing environment for running tests on Saucelabs.
           command: |
@@ -517,13 +493,8 @@ jobs:
   legacy-misc-tests:
     <<: *job_defaults
     steps:
-      - checkout
-      - *post_checkout
-      - *restore_cache
+      - attach_workspace: *attach_options
       - *init_environment
-      - *yarn_install
-      - attach_workspace:
-          at: dist
       - run: yarn gulp check-cycle
       # TODO: disabled because the Bazel packages-dist does not seem to have map files for
       # the ESM5/ES2015 output. See: https://github.com/angular/angular/issues/27966
@@ -537,23 +508,33 @@ jobs:
     docker:
       - image: *browsers_docker_image
     steps:
-      - checkout
-      - *post_checkout
+      - attach_workspace: *attach_options
       - *init_environment
-      - attach_workspace:
-          at: dist
       - run: ./scripts/ci/run_angular_material_unit_tests.sh
 
 workflows:
   version: 2
   default_workflow:
     jobs:
-      - lint
-      - test
-      - test_ivy_aot
-      - build-npm-packages
-      - build-ivy-npm-packages
-      - test_aio
+      - install
+      - lint:
+          requires:
+          - install
+      - test:
+          requires:
+          - install
+      - test_ivy_aot:
+          requires:
+          - install
+      - build-npm-packages:
+          requires:
+          - install
+      - build-ivy-npm-packages:
+          requires:
+          - install
+      - test_aio:
+          requires:
+          - install
       - deploy_aio:
           requires:
             - test_aio
@@ -576,6 +557,8 @@ workflows:
           requires:
             - build-npm-packages
       - aio_preview:
+          requires:
+            - install
           # Only run on PR builds. (There can be no previews for non-PR builds.)
           filters:
             branches:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the new behavior?

This PR expands usage of the [CircleCI workspaces feature](https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs) to share artifacts between jobs of the same workflow.

The current mindset WRT to artifacts is that we cache some artifacts at the end of the `build-npm-packages` job, which is then restored on each job. This works well even for jobs prior to that specific cache because of partial cache hits.

With workspaces the mindset is slightly different. There is an initial job that creates a workspace from the cache, which other jobs use and might enhance. 

The key difference is that subsequent jobs do not repeat setup, which can yield different results since part of setup is merging a PR with latest master. Another desirable characteristic of this setup is that it enables easier sharing of artifacts between jobs, and lessens repetition in the circleci configuration.

Here is a sample of comparison of workflows taken roughly at the same time. It's important to capture this comparison at similar times because CircleCI workload varies during the day:

Before: https://circleci.com/workflow-run/155fc8ea-2ea5-45ec-8f75-05f3297f4052
After: https://circleci.com/workflow-run/97e4f222-75f3-426c-bcdf-a583f1524045

Of these we can compare specific jobs:
- lint
  - before https://circleci.com/gh/angular/angular/218672
  - after https://circleci.com/gh/angular/angular/218906
  - the checkout/post checkout/restoring cache/yarn install steps (total 51s) are replaced by the single attaching workspace step that takes 15s
- build-ivy-npm-packages 
  - before https://circleci.com/gh/angular/angular/218673
  - after https://circleci.com/gh/angular/angular/218901
  - the checkout/post checkout/restoring cache/yarn install steps (total 27s) are replaced by the single attaching workspace step that takes 12s

The gains in individual job setup are lessened by the new common `install` step though. In https://circleci.com/gh/angular/angular/218899 we can see it took 1m58s. 

Of these, 27s seem to be due to yarn behaviour where `--frozen-lockfile` with a cached directory can still fetch dependencies in some cases (https://github.com/yarnpkg/yarn/issues/5840#issuecomment-415209523). Updating the AIO lockfile should reduce it to ~2s.

The gain on correctness cannot be compared. Under the previous setup it was possible for individual jobs to run over different code.

Further additions to persisted workspace files can also improve performance of subsequent runs.

It's also important to note that this PR also adds caching of AIO node_modules, which wasn't done before.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
