### PR TITLE
fix(ivy): avoid missing imports for types that can be represented as values

### DIFF
--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -56,6 +56,7 @@ export class NgtscTestEnvironment {
 
     env.write('tsconfig-base.json', `{
       "compilerOptions": {
+        "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "skipLibCheck": true,
         "noImplicitAny": true,

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -26,6 +26,9 @@ const contentQueryRegExp = (predicate: string, descend: boolean, ref?: string): 
   return new RegExp(`i0\\.ɵcontentQuery\\(dirIndex, ${predicate}, ${descend}, ${maybeRef}\\)`);
 };
 
+const setClassMetadataRegExp = (expectedType: string): RegExp =>
+    new RegExp(`setClassMetadata(.*?${expectedType}.*?)`);
+
 describe('ngtsc behavioral tests', () => {
   let env !: NgtscTestEnvironment;
 
@@ -1869,8 +1872,6 @@ describe('ngtsc behavioral tests', () => {
     `);
 
     env.driveMain();
-    const setClassMetadataRegExp = (expectedType: string): RegExp =>
-        new RegExp(`setClassMetadata(.*?${expectedType}.*?)`);
     const jsContents = trim(env.getContents('test.js'));
     expect(jsContents).toContain(`import { MyTypeA, MyTypeB } from './types';`);
     expect(jsContents).toMatch(setClassMetadataRegExp('type: MyTypeA'));
@@ -1896,30 +1897,11 @@ describe('ngtsc behavioral tests', () => {
       }
     `);
 
-    const imports = `
-      import { MyType } from './types';
-    `;
-    // Note: `type: undefined` below, since MyType can't be represented as a value
-    const componentMeta = `
-      setClassMetadata(SomeComp, [{
-        type: Component,
-        args: [{
-            selector: 'some-comp',
-            template: '...',
-        }]
-      }], function () { return [{
-        type: undefined,
-        decorators: [{
-            type: Inject,
-            args: ['arg-token']
-        }]
-      }]; }, null);
-    `;
-
     env.driveMain();
     const jsContents = trim(env.getContents('test.js'));
-    expect(jsContents).not.toContain(trim(imports));
-    expect(jsContents).toContain(trim(componentMeta));
+    expect(jsContents).not.toContain(`import { MyType } from './types';`);
+    // Note: `type: undefined` below, since MyType can't be represented as a value
+    expect(jsContents).toMatch(setClassMetadataRegExp('type: undefined'));
   });
 
   it('should not throw in case whitespaces and HTML comments are present inside <ng-content>',

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1867,6 +1867,9 @@ describe('ngtsc behavioral tests', () => {
       }
     `);
 
+    const imports = `
+      import { MyType } from './types';
+    `;
     const injectableMeta = `
       setClassMetadata(SomeService, [{
         type: Injectable,
@@ -1892,9 +1895,10 @@ describe('ngtsc behavioral tests', () => {
     `;
 
     env.driveMain();
-    const jsContents = env.getContents('test.js');
-    expect(trim(jsContents)).toContain(trim(injectableMeta));
-    expect(trim(jsContents)).toContain(trim(componentMeta));
+    const jsContents = trim(env.getContents('test.js'));
+    expect(jsContents).toContain(trim(imports));
+    expect(jsContents).toContain(trim(injectableMeta));
+    expect(jsContents).toContain(trim(componentMeta));
   });
 
   it('should use `undefined` in setClassMetadata if types can\'t be represented as values', () => {
@@ -1918,6 +1922,9 @@ describe('ngtsc behavioral tests', () => {
       }
     `);
 
+    const imports = `
+      import { MyType } from './types';
+    `;
     // Note: `type: undefined` below, since MyType can't be represented as a value
     const componentMeta = `
       setClassMetadata(SomeComp, [{
@@ -1936,8 +1943,9 @@ describe('ngtsc behavioral tests', () => {
     `;
 
     env.driveMain();
-    const jsContents = env.getContents('test.js');
-    expect(trim(jsContents)).toContain(trim(componentMeta));
+    const jsContents = trim(env.getContents('test.js'));
+    expect(jsContents).not.toContain(trim(imports));
+    expect(jsContents).toContain(trim(componentMeta));
   });
 
   it('should not throw in case whitespaces and HTML comments are present inside <ng-content>',


### PR DESCRIPTION
Prior to this change, TypeScript stripped out some imports in case we reference a type that can be represented as a value (for ex. classes). This fix ensures that we use correct symbol identifier, which makes TypeScript retain the necessary import statements.

Thanks @alxhub for the help with investigation and fix.

This PR resolves FW-1099.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No