### PR TITLE
fix(ivy): resolve forwardRef when analyzing NgModule

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/util.ts
@@ -11,6 +11,7 @@ import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
 import {ImportMode, Reference, ReferenceEmitter} from '../../imports';
+import {ForeignFunctionResolver} from '../../partial_evaluator';
 import {ClassMemberKind, CtorParameter, Decorator, ReflectionHost} from '../../reflection';
 
 export enum ConstructorDepErrorKind {
@@ -212,4 +213,22 @@ export function forwardRefResolver(
     return null;
   }
   return expandForwardRef(args[0]);
+}
+
+/**
+ * Combines an array of resolver functions into a one.
+ * @param resolvers Resolvers to be combined.
+ */
+export function combineResolvers(resolvers: ForeignFunctionResolver[]): ForeignFunctionResolver {
+  return (ref: Reference<ts.FunctionDeclaration|ts.MethodDeclaration>,
+          args: ts.Expression[]): ts.Expression |
+      null => {
+    for (const resolver of resolvers) {
+      const resolved = resolver(ref, args);
+      if (resolved !== null) {
+        return resolved;
+      }
+    }
+    return null;
+  };
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {WrappedNodeExpr} from '@angular/compiler';
+import {R3Reference} from '@angular/compiler/src/compiler';
+import * as ts from 'typescript';
+
+import {LocalIdentifierStrategy, ReferenceEmitter} from '../../imports';
+import {PartialEvaluator} from '../../partial_evaluator';
+import {TypeScriptReflectionHost} from '../../reflection';
+import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../scope';
+import {getDeclaration, makeProgram} from '../../testing/in_memory_typescript';
+import {NgModuleDecoratorHandler} from '../src/ng_module';
+import {NoopReferencesRegistry} from '../src/references_registry';
+
+describe('NgModuleDecoratorHandler', () => {
+  it('should resolve forwardRef', () => {
+    const {program} = makeProgram([
+      {
+        name: 'node_modules/@angular/core/index.d.ts',
+        contents: `
+          export const Component: any;
+          export const NgModule: any;
+          export declare function forwardRef(fn: () => any): any;
+        `,
+      },
+      {
+        name: 'entry.ts',
+        contents: `
+          import {Component, forwardRef, NgModule} from '@angular/core';
+
+          @Component({
+            template: '',
+          })
+          export class TestComp {}
+
+          @NgModule()
+          export class TestModuleDependency {}
+
+          @NgModule({
+            declarations: [forwardRef(() => TestComp)],
+            exports: [forwardRef(() => TestComp)],
+            imports: [forwardRef(() => TestModuleDependency)]
+          })
+          export class TestModule {}
+        `
+      },
+    ]);
+    const checker = program.getTypeChecker();
+    const reflectionHost = new TypeScriptReflectionHost(checker);
+    const evaluator = new PartialEvaluator(reflectionHost, checker);
+    const referencesRegistry = new NoopReferencesRegistry();
+    const scopeRegistry = new LocalModuleScopeRegistry(
+        new MetadataDtsModuleScopeResolver(checker, reflectionHost, null), new ReferenceEmitter([]),
+        null);
+    const refEmitter = new ReferenceEmitter([new LocalIdentifierStrategy()]);
+
+    const handler = new NgModuleDecoratorHandler(
+        reflectionHost, evaluator, scopeRegistry, referencesRegistry, false, null, refEmitter);
+    const TestModule = getDeclaration(program, 'entry.ts', 'TestModule', ts.isClassDeclaration);
+    const detected =
+        handler.detect(TestModule, reflectionHost.getDecoratorsOfDeclaration(TestModule));
+    if (detected === undefined) {
+      return fail('Failed to recognize @NgModule');
+    }
+    const moduleDef = handler.analyze(TestModule, detected.metadata).analysis !.ngModuleDef;
+
+    expect(getReferenceIdentifierTexts(moduleDef.declarations)).toEqual(['TestComp']);
+    expect(getReferenceIdentifierTexts(moduleDef.exports)).toEqual(['TestComp']);
+    expect(getReferenceIdentifierTexts(moduleDef.imports)).toEqual(['TestModuleDependency']);
+
+    function getReferenceIdentifierTexts(references: R3Reference[]) {
+      return references.map(ref => (ref.value as WrappedNodeExpr<ts.Identifier>).node.text);
+    }
+  });
+
+});


### PR DESCRIPTION
Fixes forward refs not being resolved when an NgModule is being analyzed by ngtsc.

This PR resolves FW-1094.
