### PR TITLE
fix(core): call ngOnDestroy for tree-shakeable providers

### DIFF
--- a/packages/core/src/view/ng_module.ts
+++ b/packages/core/src/view/ng_module.ts
@@ -109,7 +109,7 @@ export function resolveNgModuleDep(
     } else if (
         (injectableDef = getInjectableDef(depDef.token)) && targetsModule(data, injectableDef)) {
       const index = data._providers.length;
-      data._def.providersByKey[depDef.tokenKey] = {
+      data._def.providers[index] = data._def.providersByKey[depDef.tokenKey] = {
         flags: NodeFlags.TypeFactoryProvider | NodeFlags.LazyProvider,
         value: injectableDef.factory,
         deps: [], index,

--- a/packages/core/test/di/r3_injector_spec.ts
+++ b/packages/core/test/di/r3_injector_spec.ts
@@ -200,11 +200,14 @@ describe('InjectorDef-based createInjector()', () => {
     });
   }
 
+  let scopedServiceDestroyed = false;
   class ScopedService {
     static ngInjectableDef = defineInjectable({
       providedIn: Module,
       factory: () => new ScopedService(),
     });
+
+    ngOnDestroy(): void { scopedServiceDestroyed = true; }
   }
 
   class WrongScopeService {
@@ -323,8 +326,16 @@ describe('InjectorDef-based createInjector()', () => {
 
   it('calls ngOnDestroy on services when destroyed', () => {
     injector.get(DeepService);
+    expect(deepServiceDestroyed).toBe(false, 'DeepService already destroyed');
     (injector as R3Injector).destroy();
     expect(deepServiceDestroyed).toBe(true, 'DeepService not destroyed');
+  });
+
+  it('calls ngOnDestroy on scoped providers', () => {
+    injector.get(ScopedService);
+    expect(scopedServiceDestroyed).toBe(false, 'ScopedService already destroyed');
+    (injector as R3Injector).destroy();
+    expect(scopedServiceDestroyed).toBe(true, 'ScopedService not destroyed');
   });
 
   it('does not allow injection after destroy', () => {

--- a/packages/core/test/view/ng_module_spec.ts
+++ b/packages/core/test/view/ng_module_spec.ts
@@ -200,6 +200,28 @@ describe('NgModuleRef_ injector', () => {
     expect(Service.destroyed).toBe(1);
   });
 
+  it('calls ngOnDestroy on scoped providers', () => {
+    class Module {}
+
+    class Service {
+      static destroyed = 0;
+
+      ngOnDestroy(): void { Service.destroyed++; }
+
+      static ngInjectableDef: InjectableDef<Service> = defineInjectable({
+        factory: () => new Service(),
+        providedIn: 'root',
+      });
+    }
+
+    const ref = createNgModuleRef(Module, Injector.NULL, [], makeFactoryProviders([], [Module]));
+
+    expect(ref.injector.get(Service)).toBeDefined();
+    expect(Service.destroyed).toBe(0);
+    ref.destroy();
+    expect(Service.destroyed).toBe(1);
+  });
+
   it('only calls ngOnDestroy once per instance', () => {
     class Module {}
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #28927

Prior to this change, any provider that was independently resolved using
its InjectableDef would not be considered when destroying the module it
was requested from.

## What is the new behavior?

This commit provides a fix for this issue by storing
the resolved provider in the module's list of provider definitions.

Additionally, a test for Ivy's module injector was added to prevent
regressing on this behavior going forward.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
