### PR TITLE
feat(common): add 'elseContext' to 'ngIf' directive

### DIFF
--- a/goldens/public-api/common/common.d.ts
+++ b/goldens/public-api/common/common.d.ts
@@ -239,6 +239,7 @@ export declare class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> 
 export declare class NgIf<T = unknown> {
     set ngIf(condition: T);
     set ngIfElse(templateRef: TemplateRef<NgIfContext<T>> | null);
+    set ngIfElseContext(context: Object);
     set ngIfThen(templateRef: TemplateRef<NgIfContext<T>> | null);
     constructor(_viewContainer: ViewContainerRef, templateRef: TemplateRef<NgIfContext<T>>);
     static ngTemplateGuard_ngIf: 'binding';

--- a/packages/common/src/directives/ng_if.ts
+++ b/packages/common/src/directives/ng_if.ts
@@ -76,6 +76,11 @@ import {Directive, EmbeddedViewRef, Input, TemplateRef, ViewContainerRef, ɵstri
  *
  * {@example common/ngIf/ts/module.ts region='NgIfElse'}
  *
+ * ### Attaching a custom context to the `else` template
+ *
+ * When using an external `else` template, you can attach a custom context to the provided
+ * `<ng-template>` using `elseContext`
+ *
  * ### Using an external `then` template
  *
  * In the previous example, the then-clause template is specified inline, as the content of the
@@ -154,7 +159,9 @@ export class NgIf<T = unknown> {
   private _thenTemplateRef: TemplateRef<NgIfContext<T>>|null = null;
   private _elseTemplateRef: TemplateRef<NgIfContext<T>>|null = null;
   private _thenViewRef: EmbeddedViewRef<NgIfContext<T>>|null = null;
-  private _elseViewRef: EmbeddedViewRef<NgIfContext<T>>|null = null;
+  private _elseViewRef: EmbeddedViewRef<NgIfContext<T>|Object>|null = null;
+  private _condition: T|null = null;
+  private _elseTemplateContext: Object|NgIfContext|undefined;
 
   constructor(private _viewContainer: ViewContainerRef, templateRef: TemplateRef<NgIfContext<T>>) {
     this._thenTemplateRef = templateRef;
@@ -165,6 +172,7 @@ export class NgIf<T = unknown> {
    */
   @Input()
   set ngIf(condition: T) {
+    this._condition = condition;
     this._context.$implicit = this._context.ngIf = condition;
     this._updateView();
   }
@@ -191,8 +199,17 @@ export class NgIf<T = unknown> {
     this._updateView();
   }
 
+  /**
+   * A context to assign to else template
+   */
+  @Input()
+  set ngIfElseContext(context: Object) {
+    this._elseTemplateContext = context;
+  }
+
+
   private _updateView() {
-    if (this._context.$implicit) {
+    if (this._condition) {
       if (!this._thenViewRef) {
         this._viewContainer.clear();
         this._elseViewRef = null;
@@ -206,8 +223,8 @@ export class NgIf<T = unknown> {
         this._viewContainer.clear();
         this._thenViewRef = null;
         if (this._elseTemplateRef) {
-          this._elseViewRef =
-              this._viewContainer.createEmbeddedView(this._elseTemplateRef, this._context);
+          this._elseViewRef = this._viewContainer.createEmbeddedView(
+              this._elseTemplateRef, this._elseTemplateContext || this._context);
         }
       }
     }

--- a/packages/common/test/directives/ng_if_spec.ts
+++ b/packages/common/test/directives/ng_if_spec.ts
@@ -250,6 +250,37 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
            fixture.detectChanges();
            expect(fixture.nativeElement).toHaveText('false');
          }));
+
+      it('should support elseContext', waitForAsync(() => {
+           const template =
+               '<span *ngIf="booleanCondition; else elseBlock; elseContext {$implicit: \'TEST\'}">TRUE</span>' +
+               '<ng-template #elseBlock let-test>{{test}}</ng-template>';
+
+           fixture = createTestComponent(template);
+
+           fixture.detectChanges();
+           expect(fixture.nativeElement).toHaveText('TRUE');
+
+           getComponent().booleanCondition = false;
+           fixture.detectChanges();
+           expect(fixture.nativeElement).toHaveText('TEST');
+         }));
+
+      it('should support elseContext and then', waitForAsync(() => {
+           const template =
+               '<span *ngIf="booleanCondition; then thenBlock; else elseBlock; elseContext {$implicit: \'TEST\'}">IGNORE</span>' +
+               '<ng-template #thenBlock>THEN</ng-template>' +
+               '<ng-template #elseBlock let-test>{{test}}</ng-template>';
+
+           fixture = createTestComponent(template);
+
+           fixture.detectChanges();
+           expect(fixture.nativeElement).toHaveText('THEN');
+
+           getComponent().booleanCondition = false;
+           fixture.detectChanges();
+           expect(fixture.nativeElement).toHaveText('TEST');
+         }));
     });
 
     describe('Type guarding', () => {


### PR DESCRIPTION
Prior to this commit it wasn't possible to assign a custom context to the `else` template reference.

Fixes #28336

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
It's not possible to attach a custom context to the templateRef used in else block

Issue Number: #28336


## What is the new behavior?
It's now possible to pass a context to the else block template reference

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
