### PR TITLE
fix(ivy): run annotations handlers' `resolve()` in `ngcc`

### DIFF
--- a/packages/compiler-cli/src/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/src/ngcc/src/analysis/decoration_analyzer.ts
@@ -116,8 +116,10 @@ export class DecorationAnalyzer {
                               .map(sourceFile => this.analyzeFile(sourceFile))
                               .filter(isDefined);
     const compiledFiles = analysedFiles.map(analysedFile => this.compileFile(analysedFile));
-    compiledFiles.forEach(
-        compiledFile => decorationAnalyses.set(compiledFile.sourceFile, compiledFile));
+    compiledFiles.forEach(compiledFile => {
+      this.resolveFile(compiledFile);
+      decorationAnalyses.set(compiledFile.sourceFile, compiledFile);
+    });
     return decorationAnalyses;
   }
 
@@ -201,6 +203,16 @@ export class DecorationAnalyzer {
       }
     }
     return compilations;
+  }
+
+  protected resolveFile(compiledFile: CompiledFile): void {
+    compiledFile.compiledClasses.forEach(({declaration, matches}) => {
+      matches.forEach(({handler, analysis}) => {
+        if ((handler.resolve !== undefined) && analysis) {
+          handler.resolve(declaration, analysis);
+        }
+      });
+    });
   }
 }
 

--- a/packages/compiler-cli/src/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/src/ngcc/src/analysis/decoration_analyzer.ts
@@ -115,11 +115,10 @@ export class DecorationAnalyzer {
     const analysedFiles = this.program.getSourceFiles()
                               .map(sourceFile => this.analyzeFile(sourceFile))
                               .filter(isDefined);
+    analysedFiles.forEach(analysedFile => this.resolveFile(analysedFile));
     const compiledFiles = analysedFiles.map(analysedFile => this.compileFile(analysedFile));
-    compiledFiles.forEach(compiledFile => {
-      this.resolveFile(compiledFile);
-      decorationAnalyses.set(compiledFile.sourceFile, compiledFile);
-    });
+    compiledFiles.forEach(
+        compiledFile => decorationAnalyses.set(compiledFile.sourceFile, compiledFile));
     return decorationAnalyses;
   }
 
@@ -205,8 +204,8 @@ export class DecorationAnalyzer {
     return compilations;
   }
 
-  protected resolveFile(compiledFile: CompiledFile): void {
-    compiledFile.compiledClasses.forEach(({declaration, matches}) => {
+  protected resolveFile(analyzedFile: AnalyzedFile): void {
+    analyzedFile.analyzedClasses.forEach(({declaration, matches}) => {
       matches.forEach(({handler, analysis}) => {
         if ((handler.resolve !== undefined) && analysis) {
           handler.resolve(declaration, analysis);

--- a/packages/compiler-cli/src/ngtsc/imports/src/emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/emitter.ts
@@ -54,8 +54,8 @@ export interface ReferenceEmitStrategy {
 /**
  * Generates `Expression`s which refer to `Reference`s in a given context.
  *
- * A `ReferenceEmitter` uses one or more `ReferenceEmitStrategy` implementations to produce a
- * an `Expression` which refers to a `Reference` in the context of a particular file.
+ * A `ReferenceEmitter` uses one or more `ReferenceEmitStrategy` implementations to produce an
+ * `Expression` which refers to a `Reference` in the context of a particular file.
  */
 export class ReferenceEmitter {
   constructor(private strategies: ReferenceEmitStrategy[]) {}

--- a/packages/compiler-cli/src/ngtsc/imports/src/find_export.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/find_export.ts
@@ -23,9 +23,10 @@ export function findExportedNameOfNode(
   // Look for the export which declares the node.
   const found = exports.find(sym => symbolDeclaresNode(sym, target, checker));
   if (found === undefined) {
-    throw new Error(`failed to find target in ${file.fileName}`);
+    throw new Error(
+        `Failed to find exported name of node (${target.getText()}) in '${file.fileName}'.`);
   }
-  return found !== undefined ? found.name : null;
+  return found.name;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/path/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/path/src/util.ts
@@ -9,7 +9,7 @@
 //  TODO(alxhub): Unify this file with `util/src/path`.
 
 const TS_DTS_JS_EXTENSION = /(?:\.d)?\.ts$|\.js$/;
-const ABSOLUTE_PATH = /^([a-zA-Z]\:\/|\/)/;
+const ABSOLUTE_PATH = /^([a-zA-Z]:\/|\/)/;
 
 /**
  * Convert Windows-style separators to POSIX separators.


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
- [x] Bugfix


## What is the current behavior?
The `resolve` phase (run after all handlers have compiled) was introduced in 7d954df, but `ngcc` was not updated to run the handlers' `resolve()` methods. As a result, certain operations (such as listing directives used in component templates) would not be performed by `ngcc`.


## What is the new behavior?
This PR fixes it by running the `resolve()` methods once compilation has been completed.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
Jirs issue: [FW-1149][1]

[1]: https://angular-team.atlassian.net/browse/FW-1149
