### PR TITLE
feat(forms): removeError and addError methods

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -672,6 +672,72 @@ export abstract class AbstractControl {
   }
 
   /**
+   * Adds an error on a form control when running validations manually,
+   * rather than automatically.
+   *
+   * Calling `addError` also updates the validity of the parent control.
+   *
+   * @usageNotes
+   * ### Manually add an error for a control
+   *
+   * ```
+   * const login = new FormControl('someLogin');
+   * login.addError('notUnique', true);
+   * login.addError('tooComplicated', 'errorValue');
+   *
+   * expect(login.valid).toEqual(false);
+   * expect(login.errors).toEqual({ notUnique: true, tooComplicated: 'errorValue' });
+   *
+   * login.setValue('someOtherLogin');
+   *
+   * expect(login.valid).toEqual(true);
+   * ```
+   */
+  addError(error: string, errorValue: any, opts: {emitEvent?: boolean} = {}): void {
+    const validationErrors = (this as{errors: ValidationErrors | null}).errors;
+    if (validationErrors) {
+      validationErrors[error] = errorValue;
+      this.setErrors(validationErrors, opts);
+    } else {
+      this.setErrors({[error]: errorValue}, opts);
+    }
+  }
+
+  /**
+   * Removes an error on a form control when running validations manually,
+   * rather than automatically.
+   *
+   * Calling `removeError` also updates the validity of the parent control.
+   *
+   * @usageNotes
+   * ### Manually remove an error for a control
+   *
+   * ```
+   * const login = new FormControl('someLogin');
+   * login.setErrors({
+   *   notUnique: true,
+   *   tooComplicated: 'errorValue'
+   * });
+   *
+   * expect(login.valid).toEqual(false);
+   * expect(login.errors).toEqual({ notUnique: true, tooComplicated: 'errorValue' });
+   *
+   * login.removeError('tooComplicated');
+   *
+   * expect(login.valid).toEqual(false);
+   * expect(login.errors).toEqual({ notUnique: true });
+   * ```
+   */
+  removeError(error: string, opts: {emitEvent?: boolean} = {}): void {
+    const validationErrors = (this as{errors: ValidationErrors | null}).errors;
+    if (validationErrors) {
+      delete validationErrors[error];
+      const noErrors = Object.keys(validationErrors).length === 0;
+      this.setErrors(noErrors ? null : validationErrors, opts);
+    }
+  }
+
+  /**
    * Retrieves a child control given the control's name or path.
    *
    * @param path A dot-delimited string or array of string/number values that define the path to the

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -886,6 +886,65 @@ import {FormArray} from '@angular/forms/src/model';
       });
     });
 
+    describe('addError', () => {
+      it('should add an error on a control', () => {
+        const c = new FormControl('someValue');
+
+        c.setErrors(null);
+        c.addError('someError', true);
+
+        expect(c.valid).toEqual(false);
+        expect(c.errors).toEqual({'someError': true});
+
+        c.addError('someOtherError', 'errorValue');
+
+        expect(c.valid).toEqual(false);
+        expect(c.errors).toEqual({'someError': true, 'someOtherError': 'errorValue'});
+      });
+
+      it('should update the value error if it is already present', () => {
+        const c = new FormControl('someValue');
+
+        c.setErrors({'someError': true});
+        c.addError('someError', 'otherValue');
+
+        expect(c.valid).toEqual(false);
+        expect(c.errors).toEqual({'someError': 'otherValue'});
+      });
+    });
+
+    describe('removeError', () => {
+      it('should remove an error on a control', () => {
+        const c = new FormControl('someValue');
+
+        c.setErrors({'someError': true, 'someOtherError': 'errorValue'});
+        c.removeError('someOtherError');
+
+        expect(c.valid).toEqual(false);
+        expect(c.errors).toEqual({'someError': true});
+      });
+
+      it('should remove the last error on a control and make it valid again', () => {
+        const c = new FormControl('someValue');
+
+        c.setErrors({'someError': true});
+        c.removeError('someError');
+
+        expect(c.valid).toEqual(true);
+        expect(c.errors).toEqual(null);
+      });
+
+      it('should do nothing if the error is not present', () => {
+        const c = new FormControl('someValue');
+
+        c.setErrors(null);
+        c.removeError('someOtherError');
+
+        expect(c.valid).toEqual(true);
+        expect(c.errors).toEqual(null);
+      });
+    });
+
     describe('disable() & enable()', () => {
 
       it('should mark the control as disabled', () => {

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -19,6 +19,9 @@ export declare abstract class AbstractControl {
     readonly value: any;
     readonly valueChanges: Observable<any>;
     constructor(validator: ValidatorFn | null, asyncValidator: AsyncValidatorFn | null);
+    addError(error: string, errorValue: any, opts?: {
+        emitEvent?: boolean;
+    }): void;
     clearAsyncValidators(): void;
     clearValidators(): void;
     disable(opts?: {
@@ -50,6 +53,9 @@ export declare abstract class AbstractControl {
         onlySelf?: boolean;
     }): void;
     abstract patchValue(value: any, options?: Object): void;
+    removeError(error: string, opts?: {
+        emitEvent?: boolean;
+    }): void;
     abstract reset(value?: any, options?: Object): void;
     setAsyncValidators(newValidator: AsyncValidatorFn | AsyncValidatorFn[] | null): void;
     setErrors(errors: ValidationErrors | null, opts?: {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently the only method to manually set errors is `setErrors`. Adding or removing a specific error could be simplified using the new methods introduced:

```typescript
const loginCtrl = new FormControl();
loginCtrl.setErrors({'notUnique': true});
loginCtrl.setErrors(null);
```

Issue Number: #17090

## What is the new behavior?

Adding or removing a specific error could be simplified using the new methods introduced:

```typescript
const loginCtrl = new FormControl();
loginCtrl.addError('notUnique', true);
loginCtrl.removeError('tooComplicated');
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
