### PR TITLE
docs(docs-infra): updates to doc codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -275,6 +275,7 @@
 #  @angular/fw-docs-intro
 # ===========================================================
 #
+#   - jenniferfell
 #   - brandonroberts
 #   - IgorMinar
 #   - stephenfluin
@@ -305,6 +306,18 @@
 #   - hansl
 #   - IgorMinar
 #   - mgechev
+
+
+# ===========================================================
+#  @angular/tools-docs-schematics
+# ===========================================================
+#
+#   - alan-agius4
+#   - alexeagle
+#   - hansl
+#   - IgorMinar
+#   - mgechev
+
 
 
 # ===========================================================
@@ -763,7 +776,6 @@ testing/**                                                      @angular/fw-test
 /aio/content/images/guide/getting-started/**                    @angular/fw-docs-intro @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 
 
-
 # ================================================
 #  Docs: observables
 # ================================================
@@ -806,6 +818,17 @@ testing/**                                                      @angular/fw-test
 /aio/content/guide/creating-libraries.md                        @angular/tools-docs-libraries @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /aio/content/guide/libraries.md                                 @angular/tools-docs-libraries @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 /aio/content/guide/using-libraries.md                           @angular/tools-docs-libraries @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
+
+
+# ================================================
+#  Docs: schematics
+# ================================================
+
+/aio/content/guide/schematics.md                               @angular/tools-docs-schematics @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
+/aio/content/guide/schematics-authoring.md                     @angular/tools-docs-schematics @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
+/aio/content/guide/schematics-for-libraries.md                 @angular/tools-docs-schematics @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
+/aio/content/images/guide/schematics/**                        @angular/tools-docs-schematics @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
+/aio/content/examples/schematics-for-libraries/**              @angular/tools-docs-schematics @angular/framework-global-approvers @angular/framework-global-approvers-for-docs-only-changes
 
 
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Change to codeowners for docs

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [X] Other... Please describe: codeowners


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Docs lead cannot approve changes to docs intro materials, such as TOH, setup, and getting started.

No doc codeowners for schematics docs. 

Issue Number: N/A


## What is the new behavior?
Docs lead can approve changes to docs intro materials. 

Tooling team can approve changes to schematics docs. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
