### PR TITLE
test(animations): fix unit-based delays within the animation DSL

### DIFF
--- a/packages/animations/browser/test/dsl/animation_spec.ts
+++ b/packages/animations/browser/test/dsl/animation_spec.ts
@@ -379,6 +379,40 @@ function createDiv() {
           ]);
           expect(finalPlayer.delay).toEqual(1500);
         });
+
+        it('should allow a float-based delay value to be used', () => {
+          let steps: any[] = [
+            animate('.75s 0.75s', style({width: '300px'})),
+          ];
+
+          let players = invokeAnimationSequence(rootElement, steps);
+          expect(players.length).toEqual(1);
+
+          let p1 = players.pop() !;
+          expect(p1.duration).toEqual(1500);
+          expect(p1.keyframes).toEqual([
+            {width: '*', offset: 0},
+            {width: '*', offset: 0.5},
+            {width: '300px', offset: 1},
+          ]);
+
+
+          steps = [
+            style({width: '100px'}),
+            animate('.5s .5s', style({width: '200px'})),
+          ];
+
+          players = invokeAnimationSequence(rootElement, steps);
+          expect(players.length).toEqual(1);
+
+          p1 = players.pop() !;
+          expect(p1.duration).toEqual(1000);
+          expect(p1.keyframes).toEqual([
+            {width: '100px', offset: 0},
+            {width: '100px', offset: 0.5},
+            {width: '200px', offset: 1},
+          ]);
+        });
       });
 
       describe('substitutions', () => {


### PR DESCRIPTION
Prior to this fix if a unit-based delay is provided (like `5s`)
then would not be treated accordingly. This fix ensures that the
unit is taken into consideration.

Closes #24291