### PR TITLE
fix(bazel): Add SHA256 for rules_sass

### DIFF
--- a/packages/bazel/src/schematics/bazel-workspace/files/WORKSPACE.template
+++ b/packages/bazel/src/schematics/bazel-workspace/files/WORKSPACE.template
@@ -13,10 +13,9 @@ workspace(name = "<%= utils.underscore(name) %>")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 RULES_NODEJS_VERSION = "<%= RULES_NODEJS_VERSION %>"
-RULES_NODEJS_SHA256 = "<%= RULES_NODEJS_SHA256 %>"
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "%s" % RULES_NODEJS_SHA256,
+    sha256 = "<%= RULES_NODEJS_SHA256 %>",
     url = "https://github.com/bazelbuild/rules_nodejs/releases/download/%s/rules_nodejs-%s.tar.gz" % (RULES_NODEJS_VERSION, RULES_NODEJS_VERSION),
 )
 
@@ -25,6 +24,7 @@ http_archive(
 RULES_SASS_VERSION = "<%= RULES_SASS_VERSION %>"
 http_archive(
     name = "io_bazel_rules_sass",
+    sha256 = "<%= RULES_SASS_SHA256 %>",
     url = "https://github.com/bazelbuild/rules_sass/archive/%s.zip" % RULES_SASS_VERSION,
     strip_prefix = "rules_sass-%s" % RULES_SASS_VERSION,
 )

--- a/packages/bazel/src/schematics/bazel-workspace/index.ts
+++ b/packages/bazel/src/schematics/bazel-workspace/index.ts
@@ -59,7 +59,8 @@ export default function(options: BazelWorkspaceOptions): Rule {
     const workspaceVersions = {
       'RULES_NODEJS_VERSION': '0.18.6',
       'RULES_NODEJS_SHA256': '1416d03823fed624b49a0abbd9979f7c63bbedfd37890ddecedd2fe25cccebc6',
-      'RULES_SASS_VERSION': '1.17.0',
+      'RULES_SASS_VERSION': '1.17.2',
+      'RULES_SASS_SHA256': 'e5316ee8a09d1cbb732d3938b400836bf94dba91a27476e9e27706c4c0edae1f',
     };
 
     return mergeWith(apply(url('./files'), [


### PR DESCRIPTION
This will make the debugging output go away
DEBUG: Rule 'io_bazel_rules_sass' modified arguments {"sha256": "6caffb8277b3033d6b5117b77437faaa6cd3c6679d6d6c81284511225aa54711"}

Also bump rules_sass from 1.17.0 to 1.17.2

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
