### PR TITLE
fix(ivy): ensure static styling is properly inherited into child components

### DIFF
--- a/packages/core/src/render3/interfaces/styling.ts
+++ b/packages/core/src/render3/interfaces/styling.ts
@@ -323,9 +323,9 @@ export interface StylingContext extends
  *
  * See [InitialStylingValuesIndex] for a breakdown of how all this works.
  */
-export interface InitialStylingValues extends Array<string|boolean|null> {
+export interface InitialStylingValues extends Array<string|boolean|number|null> {
   [InitialStylingValuesIndex.DefaultNullValuePosition]: null;
-  [InitialStylingValuesIndex.InitialClassesStringPosition]: string|null;
+  [InitialStylingValuesIndex.CachedStringValuePosition]: string|null;
 }
 
 /**
@@ -432,12 +432,48 @@ export interface InitialStylingValues extends Array<string|boolean|null> {
  * ```
  */
 export const enum InitialStylingValuesIndex {
+  /**
+   * The first value is always `null` so that `styles[0] == null` for unassigned values
+   */
   DefaultNullValuePosition = 0,
-  InitialClassesStringPosition = 1,
+
+  /**
+   * Used for non-styling code to examine what the style or className string is:
+   * styles: ['width', '100px', 0, 'opacity', null, 0, 'height', '200px', 0]
+   *    => initialStyles[CachedStringValuePosition] = 'width:100px;height:200px';
+   * classes: ['foo', true, 0, 'bar', false, 0, 'baz', true, 0]
+   *    => initialClasses[CachedStringValuePosition] = 'foo bar';
+   *
+   * Note that this value is `null` by default and it will only be populated
+   * once `getInitialStyleStringValue` or `getInitialClassNameValue` is executed.
+   */
+  CachedStringValuePosition = 1,
+
+  /**
+   * Where the style or class values start in the tuple
+   */
   KeyValueStartPosition = 2,
+
+  /**
+   * The offset value (index + offset) for the property value for each style/class entry
+   */
   PropOffset = 0,
+
+  /**
+   * The offset value (index + offset) for the style/class value for each style/class entry
+   */
   ValueOffset = 1,
-  Size = 2
+
+  /**
+   * The offset value (index + offset) for the style/class directive owner for each style/class
+     entry
+   */
+  DirectiveOwnerOffset = 2,
+
+  /**
+   * The total size for each style/class entry (prop + value + directiveOwner)
+   */
+  Size = 3
 }
 
 /**

--- a/packages/core/src/render3/util/attrs_utils.ts
+++ b/packages/core/src/render3/util/attrs_utils.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {AttributeMarker, TAttributes} from '../interfaces/node';
+import {NG_PROJECT_AS_ATTR_NAME} from '../interfaces/projection';
+import {ProceduralRenderer3, RElement, isProceduralRenderer} from '../interfaces/renderer';
+import {RENDERER} from '../interfaces/view';
+import {getLView} from '../state';
+import {isAnimationProp} from '../styling/util';
+
+
+
+/**
+ * Assigns all attribute values to the provided element via the inferred renderer.
+ *
+ * This function accepts two forms of attribute entries:
+ *
+ * default: (key, value):
+ *  attrs = [key1, value1, key2, value2]
+ *
+ * namespaced: (NAMESPACE_MARKER, uri, name, value)
+ *  attrs = [NAMESPACE_MARKER, uri, name, value, NAMESPACE_MARKER, uri, name, value]
+ *
+ * The `attrs` array can contain a mix of both the default and namespaced entries.
+ * The "default" values are set without a marker, but if the function comes across
+ * a marker value then it will attempt to set a namespaced value. If the marker is
+ * not of a namespaced value then the function will quit and return the index value
+ * where it stopped during the iteration of the attrs array.
+ *
+ * See [AttributeMarker] to understand what the namespace marker value is.
+ *
+ * Note that this instruction does not support assigning style and class values to
+ * an element. See `elementStart` and `elementHostAttrs` to learn how styling values
+ * are applied to an element.
+ *
+ * @param native The element that the attributes will be assigned to
+ * @param attrs The attribute array of values that will be assigned to the element
+ * @returns the index value that was last accessed in the attributes array
+ */
+export function setUpAttributes(native: RElement, attrs: TAttributes): number {
+  const renderer = getLView()[RENDERER];
+  const isProc = isProceduralRenderer(renderer);
+
+  let i = 0;
+  while (i < attrs.length) {
+    const value = attrs[i];
+    if (typeof value === 'number') {
+      // only namespaces are supported. Other value types (such as style/class
+      // entries) are not supported in this function.
+      if (value !== AttributeMarker.NamespaceURI) {
+        break;
+      }
+
+      // we just landed on the marker value ... therefore
+      // we should skip to the next entry
+      i++;
+
+      const namespaceURI = attrs[i++] as string;
+      const attrName = attrs[i++] as string;
+      const attrVal = attrs[i++] as string;
+      ngDevMode && ngDevMode.rendererSetAttribute++;
+      isProc ?
+          (renderer as ProceduralRenderer3).setAttribute(native, attrName, attrVal, namespaceURI) :
+          native.setAttributeNS(namespaceURI, attrName, attrVal);
+    } else {
+      /// attrName is string;
+      const attrName = value as string;
+      const attrVal = attrs[++i];
+      if (attrName !== NG_PROJECT_AS_ATTR_NAME) {
+        // Standard attributes
+        ngDevMode && ngDevMode.rendererSetAttribute++;
+        if (isAnimationProp(attrName)) {
+          if (isProc) {
+            (renderer as ProceduralRenderer3).setProperty(native, attrName, attrVal);
+          }
+        } else {
+          isProc ?
+              (renderer as ProceduralRenderer3)
+                  .setAttribute(native, attrName as string, attrVal as string) :
+              native.setAttribute(attrName as string, attrVal as string);
+        }
+      }
+      i++;
+    }
+  }
+
+  // another piece of code may iterate over the same attributes array. Therefore
+  // it may be helpful to return the exact spot where the attributes array exited
+  // whether by running into an unsupported marker or if all the static values were
+  // iterated over.
+  return i;
+}
+
+
+export function attrsStylingIndexOf(attrs: TAttributes, startIndex: number): number {
+  for (let i = startIndex; i < attrs.length; i++) {
+    const val = attrs[i];
+    if (val === AttributeMarker.Classes || val === AttributeMarker.Styles) {
+      return i;
+    }
+  }
+  return -1;
+}

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -9,39 +9,9 @@ import {Component, Directive, HostBinding, HostListener, Input, QueryList, ViewC
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {onlyInIvy} from '@angular/private/testing';
+import {ivyEnabled, onlyInIvy} from '@angular/private/testing';
 
 describe('acceptance integration tests', () => {
-  onlyInIvy('[style] and [class] bindings are a new feature')
-      .it('should render host bindings on the root component', () => {
-        @Component({template: '...'})
-        class MyApp {
-          @HostBinding('style') public myStylesExp = {};
-          @HostBinding('class') public myClassesExp = {};
-        }
-
-        TestBed.configureTestingModule({declarations: [MyApp]});
-        const fixture = TestBed.createComponent(MyApp);
-        const element = fixture.nativeElement;
-        fixture.detectChanges();
-
-        const component = fixture.componentInstance;
-        component.myStylesExp = {width: '100px'};
-        component.myClassesExp = 'foo';
-        fixture.detectChanges();
-
-        expect(element.style['width']).toEqual('100px');
-        expect(element.classList.contains('foo')).toBeTruthy();
-
-        component.myStylesExp = {width: '200px'};
-        component.myClassesExp = 'bar';
-        fixture.detectChanges();
-
-        expect(element.style['width']).toEqual('200px');
-        expect(element.classList.contains('foo')).toBeFalsy();
-        expect(element.classList.contains('bar')).toBeTruthy();
-      });
-
   it('should only call inherited host listeners once', () => {
     let clicks = 0;
 
@@ -97,20 +67,6 @@ describe('acceptance integration tests', () => {
     expect(subInstance.dirs.first).toBeAnInstanceOf(SomeDir);
   });
 
-  it('should render host class and style on the root component', () => {
-    @Component({template: '...', host: {class: 'foo', style: 'color: red'}})
-    class MyApp {
-    }
-
-    TestBed.configureTestingModule({declarations: [MyApp]});
-    const fixture = TestBed.createComponent(MyApp);
-    const element = fixture.nativeElement;
-    fixture.detectChanges();
-
-    expect(element.style['color']).toEqual('red');
-    expect(element.classList.contains('foo')).toBeTruthy();
-  });
-
   it('should not set inputs after destroy', () => {
     @Directive({
       selector: '[no-assign-after-destroy]',
@@ -146,5 +102,4 @@ describe('acceptance integration tests', () => {
       fixture.detectChanges();
     }).not.toThrow();
   });
-
 });

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Component, HostBinding} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {ivyEnabled, onlyInIvy} from '@angular/private/testing';
+
+describe('acceptance integration tests', () => {
+  onlyInIvy('[style] and [class] bindings are a new feature')
+      .it('should render host bindings on the root component', () => {
+        @Component({template: '...'})
+        class MyApp {
+          @HostBinding('style') public myStylesExp = {};
+          @HostBinding('class') public myClassesExp = {};
+        }
+
+        TestBed.configureTestingModule({declarations: [MyApp]});
+        const fixture = TestBed.createComponent(MyApp);
+        const element = fixture.nativeElement;
+        fixture.detectChanges();
+
+        const component = fixture.componentInstance;
+        component.myStylesExp = {width: '100px'};
+        component.myClassesExp = 'foo';
+        fixture.detectChanges();
+
+        expect(element.style['width']).toEqual('100px');
+        expect(element.classList.contains('foo')).toBeTruthy();
+
+        component.myStylesExp = {width: '200px'};
+        component.myClassesExp = 'bar';
+        fixture.detectChanges();
+
+        expect(element.style['width']).toEqual('200px');
+        expect(element.classList.contains('foo')).toBeFalsy();
+        expect(element.classList.contains('bar')).toBeTruthy();
+      });
+
+  it('should render host class and style on the root component', () => {
+    @Component({template: '...', host: {class: 'foo', style: 'color: red'}})
+    class MyApp {
+    }
+
+    TestBed.configureTestingModule({declarations: [MyApp]});
+    const fixture = TestBed.createComponent(MyApp);
+    const element = fixture.nativeElement;
+    fixture.detectChanges();
+
+    expect(element.style['color']).toEqual('red');
+    expect(element.classList.contains('foo')).toBeTruthy();
+  });
+
+  it('should combine the inherited static styles of a parent and child component', () => {
+    @Component({template: '...', host: {'style': 'width:100px; height:100px;'}})
+    class ParentCmp {
+    }
+
+    @Component({template: '...', host: {'style': 'width:200px; color:red'}})
+    class ChildCmp extends ParentCmp {
+    }
+
+    TestBed.configureTestingModule({declarations: [ChildCmp]});
+    const fixture = TestBed.createComponent(ChildCmp);
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement;
+    if (ivyEnabled) {
+      expect(element.style['height']).toEqual('100px');
+    }
+    expect(element.style['width']).toEqual('200px');
+    expect(element.style['color']).toEqual('red');
+  });
+
+  it('should combine the inherited static classes of a parent and child component', () => {
+    @Component({template: '...', host: {'class': 'foo bar'}})
+    class ParentCmp {
+    }
+
+    @Component({template: '...', host: {'class': 'foo baz'}})
+    class ChildCmp extends ParentCmp {
+    }
+
+    TestBed.configureTestingModule({declarations: [ChildCmp]});
+    const fixture = TestBed.createComponent(ChildCmp);
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement;
+    if (ivyEnabled) {
+      expect(element.classList.contains('bar')).toBeTruthy();
+    }
+    expect(element.classList.contains('foo')).toBeTruthy();
+    expect(element.classList.contains('baz')).toBeTruthy();
+  });
+});

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -159,6 +159,9 @@
     "name": "addComponentLogic"
   },
   {
+    "name": "addOrUpdateStaticStyle"
+  },
+  {
     "name": "addToViewTree"
   },
   {
@@ -168,6 +171,9 @@
     "name": "allocateDirectiveIntoContext"
   },
   {
+    "name": "allowValueChange"
+  },
+  {
     "name": "appendChild"
   },
   {
@@ -175,6 +181,9 @@
   },
   {
     "name": "attachPatchData"
+  },
+  {
+    "name": "attrsStylingIndexOf"
   },
   {
     "name": "baseResolveDirective"
@@ -324,6 +333,9 @@
     "name": "getDirectiveDef"
   },
   {
+    "name": "getDirectiveRegistryValuesIndexOf"
+  },
+  {
     "name": "getElementDepthCount"
   },
   {
@@ -415,9 +427,6 @@
   },
   {
     "name": "hasStyleInput"
-  },
-  {
-    "name": "hasStyling"
   },
   {
     "name": "hasTagAndTypeMatch"
@@ -523,6 +532,12 @@
   },
   {
     "name": "noSideEffects"
+  },
+  {
+    "name": "patchContextWithStaticAttrs"
+  },
+  {
+    "name": "patchInitialStylingValue"
   },
   {
     "name": "postProcessBaseDirective"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -363,6 +363,9 @@
     "name": "addComponentLogic"
   },
   {
+    "name": "addOrUpdateStaticStyle"
+  },
+  {
     "name": "addPlayerInternal"
   },
   {
@@ -400,6 +403,9 @@
   },
   {
     "name": "attachPatchData"
+  },
+  {
+    "name": "attrsStylingIndexOf"
   },
   {
     "name": "baseResolveDirective"
@@ -855,9 +861,6 @@
     "name": "hasStyleInput"
   },
   {
-    "name": "hasStyling"
-  },
-  {
     "name": "hasTagAndTypeMatch"
   },
   {
@@ -1063,6 +1066,12 @@
   },
   {
     "name": "noSideEffects"
+  },
+  {
+    "name": "patchContextWithStaticAttrs"
+  },
+  {
+    "name": "patchInitialStylingValue"
   },
   {
     "name": "pointers"

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -1678,7 +1678,7 @@ describe('render3 integration test', () => {
              if (rf & RenderFlags.Create) {
                elementStart(
                    0, 'div',
-                   ['DirWithClass', AttributeMarker.Classes, 'apple', 'orange', 'banana']);
+                   ['DirWithClass', '', AttributeMarker.Classes, 'apple', 'orange', 'banana']);
                elementStyling();
                elementEnd();
              }
@@ -1698,9 +1698,9 @@ describe('render3 integration test', () => {
             */
            const App = createComponent('app', function(rf: RenderFlags, ctx: any) {
              if (rf & RenderFlags.Create) {
-               elementStart(
-                   0, 'div',
-                   ['DirWithStyle', AttributeMarker.Styles, 'width', '100px', 'height', '200px']);
+               elementStart(0, 'div', [
+                 'DirWithStyle', '', AttributeMarker.Styles, 'width', '100px', 'height', '200px'
+               ]);
                elementStyling();
                elementEnd();
              }

--- a/packages/core/test/render3/node_selector_matcher_spec.ts
+++ b/packages/core/test/render3/node_selector_matcher_spec.ts
@@ -317,7 +317,7 @@ describe('css selector matching', () => {
            expect(isMatching('div', tNode, selector)).toBeTruthy();
 
            // <div class="abc"> (with styling context but without attrs)
-           tNode.stylingTemplate = initializeStaticContext([AttributeMarker.Classes, 'abc']);
+           tNode.stylingTemplate = initializeStaticContext([AttributeMarker.Classes, 'abc'], 0);
            tNode.attrs = null;
            expect(isMatching('div', tNode, selector)).toBeTruthy();
          });

--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -17,37 +17,33 @@
 // tslint:disable
 
 window.testBlocklist = {
-  "Portals CdkPortalOutlet should not clear programmatically-attached portals on init": {
-    "error": "ObjectUnsubscribedError: object unsubscribed",
-    "notes": "Unknown"
-  },
   "Portals DomPortalOutlet should attach and detach a component portal without a ViewContainerRef": {
     "error": "Error: Expected '<pizza-msg><p>Pizza</p><p>Chocolate</p></pizza-msg>' to be '', 'Expected the DomPortalOutlet to be empty after detach'.",
     "notes": "Unknown"
   },
   "CdkDrag in a drop container should be able to customize the preview element": {
     "error": "Error: Expected cdk-drag cdk-drag-preview to contain 'custom-preview'.",
-    "notes": "FW-1134: Queries don't match structural directives with ng-template in selector"
+    "notes": "Unknown"
   },
   "CdkDrag in a drop container should position custom previews next to the pointer": {
     "error": "Error: Expected 'translate3d(8px, 33px, 0px)' to be 'translate3d(50px, 50px, 0px)'.",
-    "notes": "FW-1134: Queries don't match structural directives with ng-template in selector"
+    "notes": "Unknown"
   },
   "CdkDrag in a drop container should lock position inside a drop container along the x axis": {
     "error": "Error: Expected 'translate3d(58px, 33px, 0px)' to be 'translate3d(100px, 50px, 0px)'.",
-    "notes": "FW-1134: Queries don't match structural directives with ng-template in selector"
+    "notes": "Unknown"
   },
   "CdkDrag in a drop container should lock position inside a drop container along the y axis": {
     "error": "Error: Expected 'translate3d(8px, 83px, 0px)' to be 'translate3d(50px, 100px, 0px)'.",
-    "notes": "FW-1134: Queries don't match structural directives with ng-template in selector"
+    "notes": "Unknown"
   },
   "CdkDrag in a drop container should inherit the position locking from the drop container": {
     "error": "Error: Expected 'translate3d(58px, 33px, 0px)' to be 'translate3d(100px, 50px, 0px)'.",
-    "notes": "FW-1134: Queries don't match structural directives with ng-template in selector"
+    "notes": "Unknown"
   },
   "CdkDrag in a drop container should be able to customize the placeholder": {
     "error": "Error: Expected cdk-drag cdk-drag-placeholder to contain 'custom-placeholder'.",
-    "notes": "FW-1134: Queries don't match structural directives with ng-template in selector"
+    "notes": "Unknown"
   },
   "CdkTable should be able to render multiple header and footer rows": {
     "error": "Error: Missing definitions for header, footer, and row; cannot determine which columns should be rendered.",
@@ -129,21 +125,13 @@ window.testBlocklist = {
     "error": "Error: Failed: Expected node descendant num to be 2 but was 0",
     "notes": "Unknown"
   },
-  "MatInput without forms validates the type": {
-    "error": "Error: Input type \"file\" isn't supported by matInput.",
-    "notes": "Unknown"
-  },
-  "MatInput with textarea autosize should work in a step": {
-    "error": "TypeError: Cannot read property 'getBoundingClientRect' of null",
-    "notes": "Unknown"
-  },
   "MatChipList StandardChipList basic behaviors should toggle the chips disabled state based on whether it is disabled": {
     "error": "Error: Expected true to be false.",
-    "notes": "MatChipList does not find MatChip content children because descendants is not true anymore. TODO: Fix spec so that it does not have the wrapping div"
+    "notes": "Unknown"
   },
   "MatChipList StandardChipList focus behaviors should focus the first chip on focus": {
     "error": "Error: Expected -1 to be 0.",
-    "notes": "MatChipList does not find MatChip content children because descendants is not true anymore. TODO: Fix spec so that it does not have the wrapping div"
+    "notes": "Unknown"
   },
   "MatChipList StandardChipList focus behaviors should watch for chip focus": {
     "error": "TypeError: Cannot read property 'focus' of undefined",
@@ -187,23 +175,23 @@ window.testBlocklist = {
   },
   "MatChipList FormFieldChipList keyboard behavior should maintain focus if the active chip is deleted": {
     "error": "TypeError: Cannot read property 'nativeElement' of null",
-    "notes": "FW-1064: debugElement.query does not find directive when that directive precedes another"
+    "notes": "Unknown"
   },
   "MatChipList FormFieldChipList keyboard behavior when the input has focus should not focus the last chip when press DELETE": {
     "error": "TypeError: Cannot read property 'nativeElement' of null",
-    "notes": "FW-1064: debugElement.query does not find directive when that directive precedes another"
+    "notes": "Unknown"
   },
   "MatChipList FormFieldChipList keyboard behavior when the input has focus should focus the last chip when press BACKSPACE": {
     "error": "TypeError: Cannot read property 'nativeElement' of null",
-    "notes": "FW-1064: debugElement.query does not find directive when that directive precedes another"
+    "notes": "Unknown"
   },
   "MatChipList FormFieldChipList should complete the stateChanges stream on destroy": {
     "error": "TypeError: Cannot read property 'nativeElement' of null",
-    "notes": "FW-1064: debugElement.query does not find directive when that directive precedes another"
+    "notes": "Unknown"
   },
   "MatChipList FormFieldChipList should point the label id to the chip input": {
     "error": "TypeError: Cannot read property 'nativeElement' of null",
-    "notes": "FW-1064: debugElement.query does not find directive when that directive precedes another"
+    "notes": "Unknown"
   },
   "MatChipList with chip remove should properly focus next item if chip is removed through click": {
     "error": "TypeError: Cannot read property 'focus' of undefined",
@@ -229,28 +217,8 @@ window.testBlocklist = {
     "error": "TypeError: Cannot read property 'nativeElement' of undefined",
     "notes": "Unknown"
   },
-  "MatStepper basic stepper should set the correct aria-posinset and aria-setsize": {
-    "error": "Error: Expected $.length = 0 to equal 3.",
-    "notes": "Unknown"
-  },
   "MatStepper linear stepper should not move to next step if current step is pending": {
     "error": "TypeError: Cannot read property 'nativeElement' of undefined",
-    "notes": "Unknown"
-  },
-  "MatStepper aria labelling should not set aria-label or aria-labelledby attributes if they are not passed in": {
-    "error": "TypeError: Cannot read property 'hasAttribute' of null",
-    "notes": "Unknown"
-  },
-  "MatStepper aria labelling should set the aria-label attribute": {
-    "error": "TypeError: Cannot read property 'getAttribute' of null",
-    "notes": "Unknown"
-  },
-  "MatStepper aria labelling should set the aria-labelledby attribute": {
-    "error": "TypeError: Cannot read property 'getAttribute' of null",
-    "notes": "Unknown"
-  },
-  "MatStepper aria labelling should not be able to set both an aria-label and aria-labelledby": {
-    "error": "TypeError: Cannot read property 'getAttribute' of null",
     "notes": "Unknown"
   },
   "MatStepper stepper with error state should show error state": {
@@ -266,44 +234,36 @@ window.testBlocklist = {
     "notes": "Unknown"
   },
   "MatSidenav should be fixed position when in fixed mode": {
-    "error": "Error: Expected ng-tns-c28435-0 ng-trigger ng-trigger-transform mat-drawer mat-drawer-over ng-star-inserted to contain 'mat-sidenav-fixed'.",
-    "notes": "FW-1132: Host class bindings don't work if super class has host class bindings"
+    "error": "Error: Expected ng-tns-c21962-0 ng-trigger ng-trigger-transform mat-drawer mat-sidenav mat-drawer-over ng-star-inserted to contain 'mat-sidenav-fixed'.",
+    "notes": "Unknown"
   },
   "MatSidenav should set fixed bottom and top when in fixed mode": {
     "error": "Error: Expected '' to be '20px'.",
-    "notes": "FW-1132: Host class bindings don't work if super class has host class bindings"
-  },
-  "MatTree flat tree should initialize with rendered dataNodes": {
-    "error": "TypeError: Cannot read property 'classList' of undefined",
     "notes": "FW-1081: Static host classes don't work if component has superclass with host classes"
   },
   "MatTree flat tree with toggle should expand/collapse the node": {
-    "error": "TypeError: Cannot read property 'click' of undefined",
-    "notes": "FW-1081: Static host classes don't work if component has superclass with host classes"
+    "error": "Error: Expected 0 to be 1, 'Expect node expanded one level'.",
+    "notes": "Unknown"
   },
   "MatTree flat tree with toggle should expand/collapse the node recursively": {
-    "error": "TypeError: Cannot read property 'click' of undefined",
-    "notes": "FW-1081: Static host classes don't work if component has superclass with host classes"
-  },
-  "MatTree flat tree with undefined or null children should initialize with rendered dataNodes": {
-    "error": "TypeError: Cannot read property 'classList' of undefined",
-    "notes": "FW-1081: Static host classes don't work if component has superclass with host classes"
-  },
-  "MatTree nested tree with undefined or null children should initialize with rendered dataNodes": {
-    "error": "TypeError: Cannot read property 'classList' of undefined",
-    "notes": "FW-1081: Static host classes don't work if component has superclass with host classes"
-  },
-  "MatTree nested tree should initialize with rendered dataNodes": {
-    "error": "TypeError: Cannot read property 'classList' of undefined",
-    "notes": "FW-1081: Static host classes don't work if component has superclass with host classes"
+    "error": "Error: Expected 0 to be 3, 'Expect nodes expanded'.",
+    "notes": "Unknown"
   },
   "MatTree nested tree with toggle should expand/collapse the node": {
-    "error": "TypeError: Cannot read property 'click' of undefined",
-    "notes": "FW-1081: Static host classes don't work if component has superclass with host classes"
+    "error": "Error: Expected 0 to be 1, 'Expect node expanded'.",
+    "notes": "Unknown"
   },
   "MatTree nested tree with toggle should expand/collapse the node recursively": {
-    "error": "TypeError: Cannot read property 'click' of undefined",
-    "notes": "FW-1081: Static host classes don't work if component has superclass with host classes"
+    "error": "Error: Expected 0 to be 3, 'Expect node expanded'.",
+    "notes": "Unknown"
+  },
+  "MatInput without forms validates the type": {
+    "error": "Error: Input type \"file\" isn't supported by matInput.",
+    "notes": "Unknown"
+  },
+  "MatInput with textarea autosize should work in a step": {
+    "error": "TypeError: Cannot read property 'getBoundingClientRect' of null",
+    "notes": "Unknown"
   },
   "Dialog should set the proper animation states": {
     "error": "TypeError: Cannot read property 'componentInstance' of null",
@@ -355,78 +315,46 @@ window.testBlocklist = {
   },
   "MatTooltip special cases should clear the `user-select` when a tooltip is set on a text field": {
     "error": "Error: Expected 'none' to be falsy.",
-    "notes": "FW-1133: Inline styles are not applied before constructor is run"
+    "notes": "Unknown"
   },
   "MatTooltip special cases should clear the `-webkit-user-drag` on draggable elements": {
     "error": "Error: Expected 'none' to be falsy.",
-    "notes": "FW-1133: Inline styles are not applied before constructor is run"
-  },
-  "MatTable with basic data source should be able to create a table with the right content and without when row": {
-    "error": "TypeError: Cannot read property 'querySelectorAll' of null",
-    "notes": "Unknown"
-  },
-  "MatTable with basic data source should create a table with special when row": {
-    "error": "TypeError: Cannot read property 'querySelectorAll' of null",
-    "notes": "Unknown"
-  },
-  "MatTable with basic data source should create a table with multiTemplateDataRows true": {
-    "error": "TypeError: Cannot read property 'querySelectorAll' of null",
     "notes": "Unknown"
   },
   "MatTable should be able to render a table correctly with native elements": {
     "error": "Error: Missing definitions for header, footer, and row; cannot determine which columns should be rendered.",
     "notes": "Unknown"
   },
-  "MatTable should render with MatTableDataSource and sort": {
-    "error": "TypeError: Cannot read property 'querySelectorAll' of null",
-    "notes": "Unknown"
-  },
-  "MatTable should render with MatTableDataSource and pagination": {
-    "error": "TypeError: Cannot read property 'querySelectorAll' of null",
-    "notes": "Unknown"
-  },
   "MatTable should apply custom sticky CSS class to sticky cells": {
     "error": "Error: Missing definitions for header, footer, and row; cannot determine which columns should be rendered.",
     "notes": "Unknown"
   },
-  "MatTable with MatTableDataSource and sort/pagination/filter should create table and display data source contents": {
-    "error": "TypeError: Cannot read property 'querySelectorAll' of null",
-    "notes": "Unknown"
-  },
-  "MatTable with MatTableDataSource and sort/pagination/filter changing data should update the table contents": {
-    "error": "TypeError: Cannot read property 'querySelectorAll' of null",
-    "notes": "Unknown"
-  },
   "MatTable with MatTableDataSource and sort/pagination/filter should be able to filter the table contents": {
-    "error": "TypeError: Cannot read property 'querySelectorAll' of null",
-    "notes": "Unknown"
-  },
-  "MatTable with MatTableDataSource and sort/pagination/filter should not match concatenated words": {
-    "error": "TypeError: Cannot read property 'querySelectorAll' of null",
+    "error": "TypeError: Cannot read property 'length' of undefined",
     "notes": "Unknown"
   },
   "MatTable with MatTableDataSource and sort/pagination/filter should be able to sort the table contents": {
-    "error": "TypeError: Cannot read property 'querySelectorAll' of null",
+    "error": "Error: Failed: Expected cell contents to be a_3 but was a_1",
     "notes": "Unknown"
   },
   "MatTable with MatTableDataSource and sort/pagination/filter should by default correctly sort an empty string": {
-    "error": "TypeError: Cannot read property 'querySelectorAll' of null",
+    "error": "Error: Failed: Expected cell contents to be  but was a_1",
     "notes": "Unknown"
   },
   "MatTable with MatTableDataSource and sort/pagination/filter should by default correctly sort undefined values": {
-    "error": "TypeError: Cannot read property 'querySelectorAll' of null",
+    "error": "Error: Failed: Expected cell contents to be  but was a_1",
     "notes": "Unknown"
   },
   "MatTable with MatTableDataSource and sort/pagination/filter should sort zero correctly": {
-    "error": "TypeError: Cannot read property 'querySelectorAll' of null",
+    "error": "Error: Failed: Expected cell contents to be -1 but was a_1",
     "notes": "Unknown"
   },
   "MatTable with MatTableDataSource and sort/pagination/filter should be able to page the table contents": {
-    "error": "TypeError: Cannot read property 'querySelectorAll' of null",
+    "error": "Error: Failed: Expected 7 total rows but got 105",
     "notes": "Unknown"
   },
   "MatTable with MatTableDataSource and sort/pagination/filter should sort strings with numbers larger than MAX_SAFE_INTEGER correctly": {
-    "error": "TypeError: Cannot read property 'querySelectorAll' of null",
+    "error": "Error: Failed: Expected cell contents to be 9563256840123535 but was a_1",
     "notes": "Unknown"
   }
 };


### PR DESCRIPTION
Angular supports having a component extend off of a parent component.
When this happens, all annotation-level data is inherited including styles
and classes. Up until now, Ivy only paid attention to static styling
values on the parent component and not the child component. This patch
ensures that both the parent's component and child component's styling
data is merged and rendered accordingly.

Jira Issue: FW-1081