### PR TITLE
fix(ivy): make ngtsc to recognize `{ngModule: T}` type

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/ng_module.ts
@@ -297,15 +297,16 @@ export class NgModuleDecoratorHandler implements DecoratorHandler<NgModuleAnalys
 
   /**
    * Retrieve an `NgModule` identifier (T) from the specified `type`, if it is of the form:
-   * `A|B|{ngModule: T}|C`.
+   * `A|B|{ngModule: T}|C` or `{ngModule: T}`.
    * @param type The type to reflect on.
    * @returns the identifier of the NgModule type if found, or null otherwise.
    */
   private _reflectModuleFromLiteralType(type: ts.TypeNode): ts.Expression|null {
-    if (!ts.isIntersectionTypeNode(type)) {
+    if (!ts.isIntersectionTypeNode(type) && !ts.isTypeLiteralNode(type)) {
       return null;
     }
-    for (const t of type.types) {
+    const types = ts.isTypeLiteralNode(type) ? [type] : type.types;
+    for (const t of types) {
       if (ts.isTypeLiteralNode(t)) {
         for (const m of t.members) {
           const ngModuleType = ts.isPropertySignature(m) && ts.isIdentifier(m.name) &&


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, `_reflectModuleFromLiteralType` can only detect `ngModule` from functions that have the return signature of intersect types. This cause compilation error for functions that return a literal object. For example, in `in-memory-web-api`:

https://github.com/angular/in-memory-web-api/blob/b71d39fd48cf189c831603e3ae8fd954216ce2ef/src/in-mem/http-client-in-memory-web-api.module.ts#L43-L52

Or in `@angular/fire`:

https://github.com/angular/angularfire2/blob/b91cd5a84c04628858e09ff19738e5797bd3f88c/src/core/firebase.app.module.ts#L62-L68

Issue Number: #28603


## What is the new behavior?
This PR enables `ngtsc` to recognize such functions.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
