### PR TITLE
fix(bazel): api extractor don't generate tsdoc metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@bazel/jasmine": "0.26.0",
     "@bazel/karma": "0.26.0",
     "@bazel/typescript": "0.26.0",
-    "@microsoft/api-extractor": "^7.0.17",
+    "@microsoft/api-extractor": "^7.0.21",
     "@schematics/angular": "^7.3.2",
     "@types/angular": "^1.6.47",
     "@types/base64-js": "1.2.5",

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -22,7 +22,7 @@
     "@angular-devkit/core": "^7.0.4",
     "@angular-devkit/schematics": "^7.3.0-rc.0",
     "@bazel/typescript": "^0.26.0",
-    "@microsoft/api-extractor": "^7.0.17",
+    "@microsoft/api-extractor": "^7.0.21",
     "@schematics/angular": "^7.0.4",
     "@types/node": "6.0.84",
     "semver": "^5.6.0",

--- a/packages/bazel/src/api-extractor/index.ts
+++ b/packages/bazel/src/api-extractor/index.ts
@@ -89,6 +89,9 @@ export function runMain(
       enabled: !!dtsBundleOut,
       publishFolder: dtsBundleOut && path.resolve(path.dirname(dtsBundleOut)),
       mainDtsRollupPath: dtsBundleOut && path.basename(dtsBundleOut),
+    },
+    tsdocMetadata: {
+      enabled: false,
     }
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,12 +220,12 @@
     through2 "^2.0.0"
     xdg-basedir "^3.0.0"
 
-"@microsoft/api-extractor@^7.0.17":
-  version "7.0.17"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.0.17.tgz#fadb376908a57144ba4a8eb18787d6337bfe6b56"
-  integrity sha512-Mm+6x5/1HRAKno0vow4DyMKcVtB+b6wehMUx21huN+FSpfxID5kAEqKw9OR9XCp7YBXjiISqFBlY4dVYq/bdCw==
+"@microsoft/api-extractor@^7.0.21":
+  version "7.0.21"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.0.21.tgz#d5ff9bba4ff7283503aac83ad489b16cad293fc7"
+  integrity sha512-7lFcHNykVz0tvgOz9juXqP+a1j0EmnJ9J080CBE/171IxL4fBrpslPhqN86dNuavuPragRpBLc8Okv/bV7FJPQ==
   dependencies:
-    "@microsoft/node-core-library" "3.10.0"
+    "@microsoft/node-core-library" "3.12.0"
     "@microsoft/ts-command-line" "4.2.3"
     "@microsoft/tsdoc" "0.12.5"
     "@types/node" "8.5.8"
@@ -236,10 +236,10 @@
     typescript "~3.1.6"
     z-schema "~3.18.3"
 
-"@microsoft/node-core-library@3.10.0":
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/node-core-library/-/node-core-library-3.10.0.tgz#70e089534d8e20f6a0f9c7a4a12a6aeafd6a1ddb"
-  integrity sha512-1SbU+XNYAabhV9noGXHtsUVPc5ELV+oEuJQtZQoCncbOd6WAMeTgB1xFwh96hmdEXyKQyML/pnByiKocmh/nbQ==
+"@microsoft/node-core-library@3.12.0":
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/node-core-library/-/node-core-library-3.12.0.tgz#f9c27b8bb6b55d60b91d4e1962f42b03b9f8f47f"
+  integrity sha512-9T2dEXmmxZqnqcpHuIB8mTAOM/DNSi/QcAwKYDjvZvkd+PGT5lCUXjM9GL7SaR2NPa3UrWDGgFhNoqLqLfEPbw==
   dependencies:
     "@types/fs-extra" "5.0.4"
     "@types/jju" "~1.4.0"


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Tsdoc metadata is generated but not used.


## What is the new behaviour
tsdoc metadata is not needed for `ng_module` and with `@microsoft/api-extractor` version 7.0.21 there is a new flag to disable it's generation.

See: https://github.com/Microsoft/web-build-tools/issues/1051

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
