### PR TITLE
FW-869: Refactor view container and view manipulations for embedded views and projections

### DIFF
--- a/integration/_payload-limits.json
+++ b/integration/_payload-limits.json
@@ -12,7 +12,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1440,
-        "main": 13921,
+        "main": 13620,
         "polyfills": 38390
       }
     }

--- a/packages/animations/browser/src/render/animation_engine_next.ts
+++ b/packages/animations/browser/src/render/animation_engine_next.ts
@@ -62,8 +62,9 @@ export class AnimationEngine {
     this._transitionEngine.destroy(namespaceId, context);
   }
 
-  onInsert(namespaceId: string, element: any, parent: any, insertBefore: boolean): void {
-    this._transitionEngine.insertNode(namespaceId, element, parent, insertBefore);
+  onInsert(namespaceId: string, element: any, parent: any, shouldCollectEnterElement: boolean):
+      void {
+    this._transitionEngine.insertNode(namespaceId, element, parent, shouldCollectEnterElement);
   }
 
   onRemove(namespaceId: string, element: any, context: any, isHostElement?: boolean): void {

--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -657,7 +657,8 @@ export class TransitionAnimationEngine {
     return false;
   }
 
-  insertNode(namespaceId: string, element: any, parent: any, insertBefore: boolean): void {
+  insertNode(namespaceId: string, element: any, parent: any, shouldCollectEnterElement: boolean):
+      void {
     if (!isElementNode(element)) return;
 
     // special case for when an element is removed and reinserted (move operation)
@@ -688,8 +689,8 @@ export class TransitionAnimationEngine {
       }
     }
 
-    // only *directives and host elements are inserted before
-    if (insertBefore) {
+    // For embedded views (*directives)
+    if (shouldCollectEnterElement) {
       this.collectEnterElement(element);
     }
   }

--- a/packages/core/src/linker/query_list.ts
+++ b/packages/core/src/linker/query_list.ts
@@ -93,20 +93,33 @@ export class QueryList<T>/* implements Iterable<T> */ {
     return this._results.some(fn);
   }
 
+  /**
+   * Returns a copy of the internal results list as an Array.
+   */
   toArray(): T[] { return this._results.slice(); }
 
   [getSymbolIterator()](): Iterator<T> { return (this._results as any)[getSymbolIterator()](); }
 
   toString(): string { return this._results.toString(); }
 
-  reset(res: Array<T|any[]>): void {
-    this._results = flatten(res);
+  /**
+   * Updates the stored data of the query list, and resets the `dirty` flag to `false`, so that
+   * on change detection, it will not notify of changes to the queries, unless a new change
+   * occurs.
+   *
+   * @param resultsTree The results tree to store
+   */
+  reset(resultsTree: Array<T|any[]>): void {
+    this._results = depthFirstFlatten(resultsTree);
     (this as{dirty: boolean}).dirty = false;
     (this as{length: number}).length = this._results.length;
     (this as{last: T}).last = this._results[this.length - 1];
     (this as{first: T}).first = this._results[0];
   }
 
+  /**
+   * Triggers a change event by emitting on the `changes` {@link EventEmitter}.
+   */
   notifyOnChanges(): void { (this.changes as EventEmitter<any>).emit(this); }
 
   /** internal */
@@ -119,9 +132,9 @@ export class QueryList<T>/* implements Iterable<T> */ {
   }
 }
 
-function flatten<T>(list: Array<T|T[]>): T[] {
+function depthFirstFlatten<T>(list: Array<T|T[]>): T[] {
   return list.reduce((flat: any[], item: T | T[]): T[] => {
-    const flatItem = Array.isArray(item) ? flatten(item) : item;
+    const flatItem = Array.isArray(item) ? depthFirstFlatten(item) : item;
     return (<T[]>flat).concat(flatItem);
   }, []);
 }

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -32,15 +32,15 @@ import {AttributeMarker, InitialInputData, InitialInputs, LocalRefExtractor, Pro
 import {PlayerFactory} from './interfaces/player';
 import {CssSelectorList} from './interfaces/projection';
 import {LQueries} from './interfaces/query';
-import {GlobalTargetResolver, RComment, RElement, RText, Renderer3, RendererFactory3, isProceduralRenderer} from './interfaces/renderer';
+import {GlobalTargetResolver, RComment, RElement, RNode, RText, Renderer3, RendererFactory3, isProceduralRenderer} from './interfaces/renderer';
 import {SanitizerFn} from './interfaces/sanitization';
 import {StylingContext} from './interfaces/styling';
-import {BINDING_INDEX, CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_VIEW, ExpandoInstructions, FLAGS, HEADER_OFFSET, HOST, INJECTOR, InitPhaseState, LView, LViewFlags, NEXT, OpaqueViewState, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, TData, TVIEW, TView, T_HOST} from './interfaces/view';
+import {BINDING_INDEX, CHILD_HEAD, CLEANUP, CONTEXT, DECLARATION_VIEW, ExpandoInstructions, FLAGS, HEADER_OFFSET, HOST, INJECTOR, InitPhaseState, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, TData, TVIEW, TView, T_HOST, View} from './interfaces/view';
 import {assertNodeOfPossibleTypes, assertNodeType} from './node_assert';
-import {appendChild, appendProjectedNodes, createTextNode, insertView, removeView} from './node_manipulation';
+import {appendChild, appendChildView, appendProjectedNodes, createTextNode, getBeforeNodeForContainedView, getRenderParent, insertView, removeView} from './node_manipulation';
 import {isNodeMatchingSelectorList, matchingProjectionSelectorIndex} from './node_selector_matcher';
 import {applyOnCreateInstructions} from './node_util';
-import {decreaseElementDepthCount, enterView, getBindingsEnabled, getCheckNoChangesMode, getContextLView, getCurrentDirectiveDef, getElementDepthCount, getIsParent, getLView, getPreviousOrParentTNode, increaseElementDepthCount, isCreationMode, leaveView, nextContextImpl, resetComponentState, setBindingRoot, setCheckNoChangesMode, setCurrentDirectiveDef, setCurrentQueryIndex, setIsParent, setPreviousOrParentTNode} from './state';
+import {decreaseElementDepthCount, enterView, getBindingsEnabled, getCheckNoChangesMode, getContextLView, getCurrentDirectiveDef, getElementDepthCount, getIsParent, getLView, getPreviousOrParentTNode, increaseElementDepthCount, isCreationMode, leaveView, nextContextImpl, resetComponentState, setAddingEmbeddedRootChild, setBindingRoot, setCheckNoChangesMode, setCurrentDirectiveDef, setCurrentQueryIndex, setIsParent, setPreviousOrParentTNode} from './state';
 import {getInitialClassNameValue, getInitialStyleStringValue, initializeStaticContext as initializeStaticStylingContext, patchContextWithStaticAttrs, renderInitialClasses, renderInitialStyles, renderStyling, updateClassProp as updateElementClassProp, updateContextWithBindings, updateStyleProp as updateElementStyleProp, updateStylingMap} from './styling/class_and_style_bindings';
 import {BoundPlayerFactory} from './styling/player_factory';
 import {ANIMATION_PROP_PREFIX, allocateDirectiveIntoContext, createEmptyStylingContext, forceClassesAsString, forceStylesAsString, getStylingContext, hasClassInput, hasStyleInput, isAnimationProp} from './styling/util';
@@ -48,7 +48,7 @@ import {NO_CHANGE} from './tokens';
 import {attrsStylingIndexOf, setUpAttributes} from './util/attrs_utils';
 import {INTERPOLATION_DELIMITER, renderStringify} from './util/misc_utils';
 import {findComponentView, getLViewParent, getRootContext, getRootView} from './util/view_traversal_utils';
-import {getComponentViewByIndex, getNativeByIndex, getNativeByTNode, getTNode, isComponent, isComponentDef, isContentQueryHost, isRootView, loadInternal, readPatchedLView, resetPreOrderHookFlags, unwrapRNode, viewAttachedToChangeDetector} from './util/view_utils';
+import {getComponentViewByIndex, getNativeByIndex, getNativeByTNode, getTNode, isComponent, isComponentDef, isContentQueryHost, isLContainer, isRootView, lViewToView, loadInternal, readPatchedLView, resetPreOrderHookFlags, unwrapRNode, viewAttachedToChangeDetector} from './util/view_utils';
 
 
 
@@ -274,7 +274,7 @@ export function assignTViewNodeToLView(
   // View nodes are not stored in data because they can be added / removed at runtime (which
   // would cause indices to change). Their TNodes are instead stored in tView.node.
   let tNode = tView.node;
-  if (tNode == null) {
+  if (tNode === null) {
     ngDevMode && tParentNode &&
         assertNodeOfPossibleTypes(tParentNode, TNodeType.Element, TNodeType.Container);
     tView.node = tNode = createTNode(
@@ -394,29 +394,29 @@ export function createEmbeddedViewAndNode<T>(
  * can't store TViews in the template function itself (as we do for comps). Instead, we store the
  * TView for dynamically created views on their host TNode, which only has one instance.
  */
-export function renderEmbeddedTemplate<T>(viewToRender: LView, tView: TView, context: T) {
+export function renderEmbeddedTemplate<T>(lViewToRender: LView, tView: TView, context: T) {
   const _isParent = getIsParent();
   const _previousOrParentTNode = getPreviousOrParentTNode();
   let oldView: LView;
-  if (viewToRender[FLAGS] & LViewFlags.IsRoot) {
+  if (lViewToRender[FLAGS] & LViewFlags.IsRoot) {
     // This is a root view inside the view tree
-    tickRootContext(getRootContext(viewToRender));
+    tickRootContext(getRootContext(lViewToRender));
   } else {
     try {
       setIsParent(true);
       setPreviousOrParentTNode(null !);
 
-      oldView = enterView(viewToRender, viewToRender[T_HOST]);
-      resetPreOrderHookFlags(viewToRender);
+      oldView = enterView(lViewToRender, lViewToRender[T_HOST]);
+      resetPreOrderHookFlags(lViewToRender);
       namespaceHTML();
-      tView.template !(getRenderFlags(viewToRender), context);
+      tView.template !(getRenderFlags(lViewToRender), context);
       // This must be set to false immediately after the first creation run because in an
       // ngFor loop, all the views will be created together before update mode runs and turns
       // off firstTemplatePass. If we don't set it here, instances will perform directive
       // matching, etc again and again.
-      viewToRender[TVIEW].firstTemplatePass = false;
+      lViewToRender[TVIEW].firstTemplatePass = false;
 
-      refreshDescendantViews(viewToRender);
+      refreshDescendantViews(lViewToRender);
     } finally {
       leaveView(oldView !);
       setIsParent(_isParent);
@@ -430,7 +430,7 @@ export function renderEmbeddedTemplate<T>(viewToRender: LView, tView: TView, con
  * Will get the next level up if level is not specified.
  *
  * This is used to save contexts of parent views so they can be bound in embedded views, or
- * in conjunction with reference() to bind a ref from a parent view.
+ * in conjunction with {@link reference} to bind a ref from a parent view.
  *
  * @param level The relative level of the view from which to grab context compared to contextVewData
  * @returns context
@@ -691,6 +691,7 @@ export function elementStart(
     lView[QUERIES] = currentQueries.clone();
   }
   executeContentQueries(tView, tNode, lView);
+  setAddingEmbeddedRootChild(false);
 }
 
 /**
@@ -912,7 +913,7 @@ export function listener(
  * @param eventTargetResolver Function that returns global target information in case this listener
  * should be attached to a global object like window, document or body
  */
-export function componentHostSyntheticListener<T>(
+export function componentHostSyntheticListener(
     eventName: string, listenerFn: (e?: any) => any, useCapture = false,
     eventTargetResolver?: GlobalTargetResolver): void {
   listenerInternal(eventName, listenerFn, useCapture, eventTargetResolver, loadComponentRenderer);
@@ -1294,7 +1295,6 @@ function savePropertyDebugData(
  * @param adjustedIndex The index of the TNode in TView.data, adjusted for HEADER_OFFSET
  * @param tagName The tag name of the node
  * @param attrs The attributes defined on this node
- * @param tViews Any TViews attached to this node
  * @returns the TNode object
  */
 export function createTNode(
@@ -1657,7 +1657,7 @@ function booleanOrNull(value: any): boolean|null {
  *
  * @publicApi
  */
-export function elementStylingMap<T>(
+export function elementStylingMap(
     index: number, classes: {[key: string]: any} | string | NO_CHANGE | null,
     styles?: {[styleName: string]: any} | NO_CHANGE | null, directive?: {}): void {
   const lView = getLView();
@@ -2065,7 +2065,7 @@ function addComponentLogic<T>(
   // Only component views should be added to the view tree directly. Embedded views are
   // accessed through their containers because they may be removed / re-added later.
   const rendererFactory = lView[RENDERER_FACTORY];
-  const componentView = addToViewTree(
+  const componentView = appendChildView(
       lView, createLView(
                  lView, tView, null, def.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways,
                  lView[previousOrParentTNode.index], previousOrParentTNode as TElementNode,
@@ -2194,11 +2194,37 @@ export function createLContainer(
 }
 
 /**
- * Creates an LContainer for an ng-template (dynamically-inserted view), e.g.
+ * Creates an LContainer for an ng-template (dynamically-inserted view).
  *
+ * For example:
+ *
+ * ```html
  * <ng-template #foo>
  *    <div></div>
  * </ng-template>
+ * ```
+ *
+ * Note that when used in conjunction with the {@link reference} instruction, you must allocate one
+ * index for the template, and one index for each item in `localRefs` (Any template retrieved
+ * via `reference`). For example `template(1, ....)` might be retrieved via `reference(2)` and
+ * `reference(3)`. In that case, an element that follows that template must have an index of `4`.
+ *
+ * ```ts
+ * function (rf: RenderFlags) {
+ *   if (rf & RenderFlags.Create) {
+ *     elementStart(1, 'div');
+ *     template(1, someTemplate, 0, 0);
+ *     element(5, button);
+ *     elementEnd();
+ *   }
+ *   if (rf & RenderFlags.Update) {
+ *     someRef = reference(2);
+ *     someOtherRef = reference(3);
+ *     someMoreRef = reference(4);
+ *   }
+ * }
+ * ```
+ *
  *
  * @param index The index of the container in the data array
  * @param templateFn Inline template
@@ -2223,6 +2249,17 @@ export function template(
     tContainerNode.tViews = createTView(
         -1, templateFn, consts, vars, tView.directiveRegistry, tView.pipeRegistry, null, null);
   }
+  // TODO(misko): we should capture the current LQueries here so that we can refer to them when we
+  // instantiate the template. Using the Container as a storage mechanism for queries is wrong.
+  // Container should not know about queries, since it is always the declaration query which matter
+  // not the insertion.
+
+  // TODO(pk): agreed! What would be even better if template instruction would be creating a new
+  // type of node (TTemplateNode?) as what we are doing here is marking a _declaration_ point, not
+  // the insertion point. The insertion point _might_ (or might no) be created on the same node
+  // (if there is a directive asking for a ViewContainerRef) but creation of TContainerNode /
+  // LContainer should not be systematic (we might <ng-template> without any directive asking for
+  // VCRef on it).
 
   createDirectivesAndLocals(tView, lView, localRefs, localRefExtractor);
   addTContainerToQueries(lView, tContainerNode);
@@ -2261,13 +2298,14 @@ function containerInternal(
   const comment = lView[RENDERER].createComment(ngDevMode ? 'container' : '');
   ngDevMode && ngDevMode.rendererCreateComment++;
   const tNode = createNodeAtIndex(index, TNodeType.Container, comment, tagName, attrs);
-  const lContainer = lView[adjustedIndex] = createLContainer(lView[adjustedIndex], lView, comment);
+  const lContainer = lView[adjustedIndex] =
+      createLContainer(lView[adjustedIndex], lView, comment, false);
 
   appendChild(comment, tNode, lView);
 
   // Containers are added to the current view tree instead of their embedded views
   // because views can be removed and re-inserted.
-  addToViewTree(lView, lContainer);
+  appendChildView(lView, lContainer);
 
   ngDevMode && assertNodeType(getPreviousOrParentTNode(), TNodeType.Container);
   return tNode;
@@ -2344,19 +2382,21 @@ export function containerRefreshEnd(): void {
  * by executing an associated template function.
  */
 function refreshDynamicEmbeddedViews(lView: LView) {
-  for (let current = lView[CHILD_HEAD]; current !== null; current = current[NEXT]) {
-    // Note: current can be an LView or an LContainer instance, but here we are only interested
-    // in LContainer. We can tell it's an LContainer because its length is less than the LView
-    // header.
-    if (current.length < HEADER_OFFSET && current[ACTIVE_INDEX] === -1) {
-      const container = current as LContainer;
-      for (let i = 0; i < container[VIEWS].length; i++) {
-        const dynamicViewData = container[VIEWS][i];
+  let current = lView[CHILD_HEAD];
+  while (current) {
+    // We are only interested in LContainer here, because embedded views are always in a container.
+    if (isLContainer(current) && current[ACTIVE_INDEX] === -1) {
+      const views = current[VIEWS];
+      for (let i = 0; i < views.length; i++) {
+        const dynamicViewData = views[i];
         // The directives and pipes are not needed here as an existing view is only being refreshed.
         ngDevMode && assertDefined(dynamicViewData[TVIEW], 'TView must be allocated');
-        renderEmbeddedTemplate(dynamicViewData, dynamicViewData[TVIEW], dynamicViewData[CONTEXT] !);
+        // Legacy behavior expects some context.
+        const context = dynamicViewData[CONTEXT] || {};
+        renderEmbeddedTemplate(dynamicViewData, dynamicViewData[TVIEW], context);
       }
     }
+    current = current[NEXT];
   }
 }
 
@@ -2489,7 +2529,7 @@ export function embeddedViewEnd(): void {
  *
  * @param adjustedElementIndex  Element index in LView[] (adjusted for HEADER_OFFSET)
  */
-export function componentRefresh<T>(adjustedElementIndex: number): void {
+export function componentRefresh(adjustedElementIndex: number): void {
   const lView = getLView();
   ngDevMode && assertDataInRange(lView, adjustedElementIndex);
   const hostView = getComponentViewByIndex(adjustedElementIndex, lView);
@@ -2510,7 +2550,7 @@ export function componentRefresh<T>(adjustedElementIndex: number): void {
  * will be skipped. However, consider this case of two components side-by-side:
  *
  * App template:
- * ```
+ * ```html
  * <comp></comp>
  * <comp></comp>
  * ```
@@ -2537,7 +2577,7 @@ function syncViewWithBlueprint(componentView: LView) {
 }
 
 /**
- * Instruction to distribute projectable nodes among <ng-content> occurrences in a given template.
+ * Instruction to distribute project-able nodes among <ng-content> occurrences in a given template.
  * It takes all the selectors from the entire component's template and decides where
  * each projected node belongs (it re-distributes nodes among "buckets" where each "bucket" is
  * backed by a selector).
@@ -2555,7 +2595,7 @@ function syncViewWithBlueprint(componentView: LView) {
  * template author).
  *
  * @param selectors A collection of parsed CSS selectors
- * @param rawSelectors A collection of CSS selectors in the raw, un-parsed form
+ * @param textSelectors A collection of CSS selectors in the raw, un-parsed form
  */
 export function projectionDef(selectors?: CssSelectorList[], textSelectors?: string[]): void {
   const componentNode = findComponentView(getLView())[T_HOST] as TElementNode;
@@ -2602,37 +2642,23 @@ export function projection(nodeIndex: number, selectorIndex: number = 0, attrs?:
 
   // We can't use viewData[HOST_NODE] because projection nodes can be nested in embedded views.
   if (tProjectionNode.projection === null) tProjectionNode.projection = selectorIndex;
+  ngDevMode &&
+      assertEqual(selectorIndex, tProjectionNode.projection, 'selectorIndex must match projection');
 
   // `<ng-content>` has no content
   setIsParent(false);
 
   // re-distribution of projectable nodes is stored on a component's view level
-  appendProjectedNodes(lView, tProjectionNode, selectorIndex, findComponentView(lView));
-}
-
-/**
- * Adds LView or LContainer to the end of the current view tree.
- *
- * This structure will be used to traverse through nested views to remove listeners
- * and call onDestroy callbacks.
- *
- * @param lView The view where LView or LContainer should be added
- * @param adjustedHostIndex Index of the view's host node in LView[], adjusted for header
- * @param lViewOrLContainer The LView or LContainer to add to the view tree
- * @returns The state passed in
- */
-export function addToViewTree<T extends LView|LContainer>(lView: LView, lViewOrLContainer: T): T {
-  // TODO(benlesh/misko): This implementation is incorrect, because it always adds the LContainer to
-  // the end of the queue, which means if the developer retrieves the LContainers from RNodes out of
-  // order, the change detection will run out of order, as the act of retrieving the the LContainer
-  // from the RNode is what adds it to the queue.
-  if (lView[CHILD_HEAD]) {
-    lView[CHILD_TAIL] ![NEXT] = lViewOrLContainer;
-  } else {
-    lView[CHILD_HEAD] = lViewOrLContainer;
+  const renderParent = getRenderParent(tProjectionNode, lView) !;
+  let insertBeforeNode: RNode|null = null;
+  const lContainer = lView[PARENT] !;
+  if (tProjectionNode.parent === null && isLContainer(lContainer)) {
+    insertBeforeNode = getBeforeNodeForContainedView(lContainer, lView);
   }
-  lView[CHILD_TAIL] = lViewOrLContainer;
-  return lViewOrLContainer;
+
+  appendProjectedNodes(
+      lView, tProjectionNode, selectorIndex, findComponentView(lView), renderParent,
+      insertBeforeNode);
 }
 
 ///////////////////////////////
@@ -2649,8 +2675,8 @@ function markDirtyIfOnPush(lView: LView, viewIndex: number): void {
 }
 
 /**
- * Wraps an event listener with a function that marks ancestors dirty and prevents default behavior,
- * if applicable.
+ * Wraps an event listener with a function that marks ancestors dirty and prevents default
+ * behavior, if applicable.
  *
  * @param tNode The TNode associated with this listener
  * @param lView The LView that contains this listener
@@ -2723,7 +2749,7 @@ export function markViewDirty(lView: LView): LView|null {
  * `scheduleTick` requests. The scheduling function can be overridden in
  * `renderComponent`'s `scheduler` option.
  */
-export function scheduleTick<T>(rootContext: RootContext, flags: RootContextFlags) {
+export function scheduleTick(rootContext: RootContext, flags: RootContextFlags) {
   const nothingScheduled = rootContext.flags === RootContextFlags.Empty;
   rootContext.flags |= flags;
 
@@ -2859,7 +2885,9 @@ export function checkNoChangesInRootView(lView: LView): void {
   }
 }
 
-/** Checks the view of the component provided. Does not gate on dirty checks or execute doCheck. */
+/**
+ * Checks the view of the component provided. Does not gate on dirty checks or execute doCheck.
+ */
 export function checkView<T>(hostView: LView, component: T) {
   const hostTView = hostView[TVIEW];
   const oldView = enterView(hostView, hostView[T_HOST]);
@@ -3221,12 +3249,21 @@ export function store<T>(index: number, value: T): void {
 }
 
 /**
- * Retrieves a local reference from the current contextViewData.
+ * Retrieves a local reference from the current context {@link LView}'s data.
  *
  * If the reference to retrieve is in a parent view, this instruction is used in conjunction
- * with a nextContext() call, which walks up the tree and updates the contextViewData instance.
+ * with a call to {@link nextContext}, which walks up the tree and updates the contextViewData
+ * instance.
  *
- * @param index The index of the local ref in contextViewData.
+ * Whenever there is a local ref defined on a node, you must allocate an extra slot for each ref
+ * for that template, for example, you might pass 3 to the {@link template}, `template(3, ...)`, then
+ * you'd
+ * use `reference(4)` to get a reference to the template
+ *
+ * @see template
+ *
+ * @param index The index of the local ref to retrieve, it should be `templateIndex + 1` for any
+ * `template(templateIndex, ...)`.
  */
 export function reference<T>(index: number) {
   const contextLView = getContextLView();
@@ -3305,8 +3342,8 @@ function initializeTNodeInputs(tNode: TNode | null): PropertyAliases|null {
  * of the current view and restore it when listeners are invoked. This allows
  * walking the declaration view tree in listeners to get vars from parent views.
  */
-export function getCurrentView(): OpaqueViewState {
-  return getLView() as any as OpaqueViewState;
+export function getCurrentView(): View {
+  return lViewToView(getLView());
 }
 
 function getCleanup(view: LView): any[] {

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -57,9 +57,9 @@ export interface LContainer extends Array<any> {
   /**
    * The next active index in the views array to read or write to. This helps us
    * keep track of where we are in the views array.
-   * In the case the LContainer is created for a ViewContainerRef,
-   * it is set to null to identify this scenario, as indices are "absolute" in that case,
-   * i.e. provided directly by the user of the ViewContainerRef API.
+   *
+   * This is only used for JavaScript inline templates, in the case of dynamically
+   * created views (ViewContainerRef), this should be set to -1.
    */
   [ACTIVE_INDEX]: number;
 

--- a/packages/core/src/render3/interfaces/i18n.ts
+++ b/packages/core/src/render3/interfaces/i18n.ts
@@ -19,28 +19,50 @@
 import {SanitizerFn} from './sanitization';
 
 export const enum I18nMutateOpCode {
-  /// Stores shift amount for bits 17-3 that contain reference index.
+  /**
+   * Stores shift amount for bits 17-3 that contain reference index.
+   */
   SHIFT_REF = 3,
-  /// Stores shift amount for bits 31-17 that contain parent index.
+  /**
+   * Stores shift amount for bits 31-17 that contain parent index.
+   */
   SHIFT_PARENT = 17,
-  /// Mask for OpCode
+  /**
+   * Mask for OpCode
+   */
   MASK_OPCODE = 0b111,
-  /// Mask for reference index.
+  /**
+   * Mask for reference index
+   */
   MASK_REF = ((2 ^ 16) - 1) << SHIFT_REF,
 
-  /// OpCode to select a node. (next OpCode will contain the operation.)
+  /**
+   * OpCode to select a node. (next OpCode will contain the operation.)
+   */
   Select = 0b000,
-  /// OpCode to append the current node to `PARENT`.
+  /**
+   * OpCode to append the current node to `PARENT`.
+   */
   AppendChild = 0b001,
-  /// OpCode to insert the current node to `PARENT` before `REF`.
+  /**
+   * OpCode to insert the current node to `PARENT` before `REF`.
+   */
   InsertBefore = 0b010,
-  /// OpCode to remove the `REF` node from `PARENT`.
+  /**
+   * OpCode to remove the `REF` node from `PARENT`.
+   */
   Remove = 0b011,
-  /// OpCode to set the attribute of a node.
+  /**
+   * OpCode to set the attribute of a node.
+   */
   Attr = 0b100,
-  /// OpCode to simulate elementEnd()
+  /**
+   * OpCode to simulate elementEnd()
+   */
   ElementEnd = 0b101,
-  /// OpCode to read the remove OpCodes for the nested ICU
+  /**
+   * OpCode to read the remove OpCodes for the nested ICU
+   */
   RemoveNestedIcu = 0b110,
 }
 
@@ -69,7 +91,7 @@ export interface COMMENT_MARKER { marker: 'comment'; }
  * Array storing OpCode for dynamically creating `i18n` blocks.
  *
  * Example:
- * ```
+ * ```ts
  * <I18nCreateOpCode>[
  *   // For adding text nodes
  *   // ---------------------
@@ -143,22 +165,38 @@ export interface I18nMutateOpCodes extends Array<number|string|ELEMENT_MARKER|CO
 }
 
 export const enum I18nUpdateOpCode {
-  /// Stores shift amount for bits 17-2 that contain reference index.
+  /**
+   * Stores shift amount for bits 17-2 that contain reference index.
+   */
   SHIFT_REF = 2,
-  /// Stores shift amount for bits 31-17 that contain which ICU in i18n block are we referring to.
+  /**
+   * Stores shift amount for bits 31-17 that contain which ICU in i18n block are we referring to.
+   */
   SHIFT_ICU = 17,
-  /// Mask for OpCode
+  /**
+   * Mask for OpCode
+   */
   MASK_OPCODE = 0b11,
-  /// Mask for reference index.
+  /**
+   * Mask for reference index.
+   */
   MASK_REF = ((2 ^ 16) - 1) << SHIFT_REF,
 
-  /// OpCode to update a text node.
+  /**
+   * OpCode to update a text node.
+   */
   Text = 0b00,
-  /// OpCode to update a attribute of a node.
+  /**
+   * OpCode to update a attribute of a node.
+   */
   Attr = 0b01,
-  /// OpCode to switch the current ICU case.
+  /**
+   * OpCode to switch the current ICU case.
+   */
   IcuSwitch = 0b10,
-  /// OpCode to update the current ICU case.
+  /**
+   * OpCode to update the current ICU case.
+   */
   IcuUpdate = 0b11,
 }
 
@@ -176,7 +214,7 @@ export const enum I18nUpdateOpCode {
  * ## Example
  *
  * Assume
- * ```
+ * ```ts
  *   if (rf & RenderFlags.Update) {
  *    i18nExp(bind(ctx.exp1)); // If changed set mask bit 1
  *    i18nExp(bind(ctx.exp2)); // If changed set mask bit 2
@@ -188,8 +226,8 @@ export const enum I18nUpdateOpCode {
  * We can assume that each call to `i18nExp` sets an internal `changeMask` bit depending on the
  * index of `i18nExp`.
  *
- * OpCodes
- * ```
+ * ### OpCodes
+ * ```ts
  * <I18nUpdateOpCodes>[
  *   // The following OpCodes represent: `<div i18n-title="pre{{exp1}}in{{exp2}}post">`
  *   // If `changeMask & 0b11`
@@ -312,7 +350,7 @@ export interface TIcu {
    * to know which child ICUs to run clean up for as well.
    *
    * In the above example this would be:
-   * ```
+   * ```ts
    * [
    *   [],   // `=0` has no sub ICUs
    *   [1],  // `other` has one subICU at `1`st index.

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -20,7 +20,6 @@ export const enum TNodeType {
   Projection = 0b001,
   View = 0b010,
   Element = 0b011,
-  ViewOrElement = 0b010,
   ElementContainer = 0b100,
   IcuContainer = 0b101,
 }

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -49,14 +49,42 @@ export const PREORDER_HOOK_FLAGS = 18;
 /** Size of LView's header. Necessary to adjust for it when setting slots.  */
 export const HEADER_OFFSET = 20;
 
-
-// This interface replaces the real LView interface if it is an arg or a
-// return value of a public instruction. This ensures we don't need to expose
-// the actual interface, which should be kept private.
-export interface OpaqueViewState {
-  '__brand__': 'Brand for OpaqueViewState that nothing will match';
+/**
+ * This interface replaces the real {@link LView} interface if it is an argument or the return value
+ * of a public API. This ensures we don't expose implementation details.
+ */
+export interface View<T extends{} = {}> {
+  __ng_brand__: 'Angular opaque reference representing a View. DO NOT READ/MANIPULATE!';
 }
 
+/**
+ * This interface replaces the real {@link LContainer} interface if it is an argument or the return
+ * value of a public API. This ensures we don't expose implementation details.
+ */
+export interface ViewContainer {
+  __ng_brand__: 'Angular opaque reference representing a ViewContainer. DO NOT READ/MANIPULATE!';
+}
+
+/**
+ * The public API for creating an embedded view.
+ *
+ * @see getEmbeddedViewFactory
+ */
+export interface EmbeddedViewFactory<T extends{}> {
+  /**
+   * Creates an embedded view.
+   * @param context The context to give to the embedded view
+   */
+  (context: T): View<T>;
+}
+
+export interface EmbeddedViewFactoryInternal<T extends{}> {
+  /**
+   * The internal method for creating an {@link LView} for an embedded view.
+   * @param context
+   */
+  (context: T): LView;
+}
 
 /**
  * `LView` stores all of the information needed to process the instructions as
@@ -366,7 +394,7 @@ export interface TView {
    * If this is a `TElementNode`, this is the view of a root component. It has exactly one
    * root TNode.
    *
-   * If this is null, this is the view of a component that is not at root. We do not store
+   * If this is `null`, this is the view of a component that is not at root. We do not store
    * the host TNodes for child component views because they can potentially have several
    * different host TNodes, depending on where the component is being used. These host
    * TNodes cannot be shared (due to different indices, etc).

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -365,7 +365,8 @@ export function query<T>(
 /**
  * Refreshes a query by combining matches from all active views and removing matches from deleted
  * views.
- * Returns true if a query got dirty during change detection, false otherwise.
+ *
+ * @returns `true` if a query got dirty during change detection, `false` otherwise.
  */
 export function queryRefresh(queryList: QueryList<any>): boolean {
   const queryListImpl = (queryList as any as QueryList_<any>);

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -6,16 +6,47 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {assertDefined} from '../util/assert';
+import {assertDefined, assertEqual} from '../util/assert';
 
 import {assertLViewOrUndefined} from './assert';
 import {executeHooks} from './hooks';
 import {ComponentDef, DirectiveDef} from './interfaces/definition';
 import {TElementNode, TNode, TViewNode} from './interfaces/node';
-import {BINDING_INDEX, CONTEXT, DECLARATION_VIEW, FLAGS, InitPhaseState, LView, LViewFlags, OpaqueViewState, TVIEW} from './interfaces/view';
+import {BINDING_INDEX, CONTEXT, DECLARATION_VIEW, FLAGS, InitPhaseState, LView, LViewFlags, TVIEW, View} from './interfaces/view';
 import {resetPreOrderHookFlags} from './util/view_utils';
 
 
+let _addingEmbeddedRootChild = false;
+let _useIvyAnimationCheck = false;
+
+/**
+ * Returns whether or not we're adding children at the root of an embedded view.
+ *
+ * This is used primarily to tell {@link AnimationRenderer} how to handle insertions appropriately.
+ */
+export function getAddingEmbeddedRootChild() {
+  ngDevMode && assertEqual(_useIvyAnimationCheck, true, 'Call setAddingEmbeddedRootChild first');
+  return _addingEmbeddedRootChild;
+}
+
+/**
+ * Sets whether or not the node being added is a root child of an embedded view.
+ * When we start adding nodes as direct children to embedded views, this flag should be flipped on.
+ *
+ * This is used to tell {@link AnimationRenderer} how to handle insertions appropriately.
+ */
+export function setAddingEmbeddedRootChild(value: boolean) {
+  _useIvyAnimationCheck = true;
+  _addingEmbeddedRootChild = value;
+}
+
+/**
+ * Returns true if Ivy path has been touched and {@link AnimationRenderer} needs to take the
+ * appropriate path on `appendChild` or `insertBefore`.
+ */
+export function shouldUseIvyAnimationCheck() {
+  return _useIvyAnimationCheck;
+}
 
 /**
  * Store the element depth count. This is used to identify the root elements of the template
@@ -128,7 +159,7 @@ export function getLView(): LView {
  *
  * @param viewToRestore The OpaqueViewState instance to restore.
  */
-export function restoreView(viewToRestore: OpaqueViewState) {
+export function restoreView(viewToRestore: View) {
   contextLView = viewToRestore as any as LView;
 }
 

--- a/packages/core/src/render3/view.ts
+++ b/packages/core/src/render3/view.ts
@@ -1,0 +1,344 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {assertDomNode, assertEqual} from '../util/assert';
+
+import {assertLContainer, assertLView, assertLViewOrUndefined} from './assert';
+import {getLContext} from './context_discovery';
+import {assignTViewNodeToLView, createLContainer, createLView, renderEmbeddedTemplate} from './instructions';
+import {ACTIVE_INDEX, LContainer, NATIVE, VIEWS} from './interfaces/container';
+import {TNode, TNodeType} from './interfaces/node';
+import {RComment, RElement, RNode} from './interfaces/renderer';
+import {DECLARATION_VIEW, EmbeddedViewFactory, EmbeddedViewFactoryInternal, HOST, LView, LViewFlags, QUERIES, RENDERER, TVIEW, View, ViewContainer} from './interfaces/view';
+import {addRemoveViewFromContainer, destroyLView, detachView, insertLContainerIntoParentLView, insertView, nativeNextSibling} from './node_manipulation';
+import {getAddingEmbeddedRootChild, getIsParent, getPreviousOrParentTNode, setAddingEmbeddedRootChild, setIsParent, setPreviousOrParentTNode, shouldUseIvyAnimationCheck} from './state';
+import {getLastRootElementFromView, lContainerToViewContainer, unwrapLContainer, unwrapRNode, viewContainerToLContainer, viewToLView} from './util/view_utils';
+
+
+
+// TODO: The example below needs to be put in a proper `{@example}`.
+
+/**
+ * Gets an {@link EmbeddedViewFactory} that will produce an embedded view.
+ * The DOM node that is provided should be a comment looking like `<!-- container -->`.
+ * This is rendered to the DOM for an instruction such as `<ng-template>`.
+ *
+ * For example, given the following template:
+ *
+ * ```html
+ * <div id="foo">
+ *   <ng-template>I am from a template</ng-template>
+ *   <span>{{someText}}</span>
+ * </div>
+ * ```
+ *
+ * ... you might have the following rendered DOM (represented here in HTML):
+ *
+ * ```html
+ * <div id="foo">
+ *  <!-- container -->
+ *  <span>some text</span>
+ * </div>
+ * ```
+ *
+ * You can select the container's anchor node, and retrieve an embedded view factory like so:
+ *
+ * ```ts
+ * const foo = document.querySelector('#foo');
+ * const containerComment = foo.firstChild;
+ * const embeddedViewFactory = getEmbeddedViewFactory(containerComment);
+ * ```
+ *
+ * From there you can get an embedded {@link View} by calling the factory with any valid context for that view.
+ *
+ * ```ts
+ * const embeddedView: View = embeddedViewFactory({ foo: 'bar' });
+ * ```
+ *
+ * To insert or review this embedded view, you would use {@link getViewContainer} to get a {@link ViewContainer}.
+ * Then use {@link viewContainerInsertAfter} to insert the `embeddedView` into the `ViewContainer` instance.
+ *
+ * You retrieve a `ViewContainer` similarly from a `<!-- container -->` comment node.
+ * In this example we can just reuse the one comment node we already have:
+ *
+ * ```ts
+ * const viewContainer = getViewContainer(containerComment);
+ * ```
+ *
+ * ...now we can insert the embedded view's DOM like so:
+ *
+ * ```ts
+ * // Append the view to the container.
+ * viewContainerInsertAfter(viewContainer, embeddedView, null);
+ * ```
+ *
+ * The resulting rendered DOM will look as follows (shown in HTML):
+ *
+ * ```html
+ * <div id="foo">
+ *   I am from a template.
+ *   <span>some text</span>
+ * </div>
+ * ```
+ *
+ * @see viewContainerInsertAfter
+ * @see getViewContainer
+ * @see viewContainerRemove
+ *
+ * @param containerComment The DOM node to get the embedded view factory for.
+ * @returns A function that will produce an embedded view.
+ */
+export function getEmbeddedViewFactory<T extends{}>(containerComment: RComment):
+    EmbeddedViewFactory<T>|null {
+  ngDevMode && assertDomNode(containerComment);
+  const lContext = getLContext(containerComment);
+  if (lContext) {
+    const declarationLView = lContext.lView;
+    const declarationTView = declarationLView[TVIEW];
+    const declarationTNode = declarationTView.data[lContext.nodeIndex] as TNode;
+    return getEmbeddedViewFactoryInternal<T>(declarationTNode, declarationLView) as any;
+  }
+  return null;
+}
+
+/**
+ * The internal implementation for {@link getEmbeddedViewFactory}.
+ *
+ * @param declarationTNode The template node where the embedded template was declared
+ * @param declarationLView The local view where the embedded template was declared
+ */
+export function getEmbeddedViewFactoryInternal<T extends{}>(
+    declarationTNode: TNode, declarationLView: LView): EmbeddedViewFactoryInternal<T>|null {
+  const templateTView = declarationTNode.tViews;
+  if (templateTView) {
+    if (Array.isArray(templateTView)) {
+      throw new Error('Array of TViews not supported');
+    }
+
+    return function embeddedViewFactory(context: T) {
+      const _isParent = getIsParent();
+      const _previousOrParentTNode = getPreviousOrParentTNode();
+      const _useIvyAnimationCheck = shouldUseIvyAnimationCheck();
+      const _addingEmbeddedRootChild = _useIvyAnimationCheck && getAddingEmbeddedRootChild();
+      try {
+        setIsParent(true);
+        setPreviousOrParentTNode(null !);
+        setAddingEmbeddedRootChild(true);
+        const lView = createLView(
+            declarationLView, templateTView, context, LViewFlags.CheckAlways, null, null);
+        lView[DECLARATION_VIEW] = declarationLView;
+
+        // TODO: Because the embedded view is always embedded into a container, this should be
+        // always true. Perhaps the declarationTNode type should be adjusted to be TContainerNode
+        if (declarationTNode.type === TNodeType.Container) {
+          const declarationContainer = unwrapLContainer(declarationLView[declarationTNode.index]) !;
+          ngDevMode && assertLContainer(declarationContainer);
+          const declarationQueries = declarationContainer[QUERIES];
+          if (declarationQueries) {
+            lView[QUERIES] = declarationQueries.createView();
+          }
+        }
+
+        assignTViewNodeToLView(templateTView, null, -1, lView);
+
+        if (templateTView.firstTemplatePass) {
+          templateTView.node !.injectorIndex = declarationTNode.injectorIndex;
+        }
+
+        renderEmbeddedTemplate(lView, templateTView, context);
+
+        return lView;
+      } finally {
+        _useIvyAnimationCheck && setAddingEmbeddedRootChild(_addingEmbeddedRootChild);
+        setIsParent(_isParent);
+        setPreviousOrParentTNode(_previousOrParentTNode);
+      }
+    };
+  }
+  return null;
+}
+
+/**
+ * Gets a {@link ViewContainer} instance from a container comment DOM node (`<!-- container -->`),
+ * this is something generally added to the DOM by template instructions and other mechanisms that
+ * use embedded views such as {@link ngIf} or {@link ngForOf}.
+ * @param containerComment The DOM node to use to find the view container instance.
+ */
+export function getViewContainer(containerComment: RComment): ViewContainer|null {
+  ngDevMode && assertDomNode(containerComment);
+  const lContext = getLContext(containerComment);
+  let viewContainer: ViewContainer|null = null;
+  if (lContext) {
+    const lView = lContext.lView;
+    const nodeIndex = lContext.nodeIndex;
+    const lViewContainerOrElement: LContainer|RNode = lView[nodeIndex];
+    let lContainer = unwrapLContainer(lViewContainerOrElement);
+    if (!lContainer) {
+      lContainer = lView[nodeIndex] = createLContainer(
+          lViewContainerOrElement as RElement | RComment, lView,
+          lViewContainerOrElement as RComment, true);
+      insertLContainerIntoParentLView(lView, lContainer);
+      const queries = lView[QUERIES];
+      if (queries) {
+        lContainer[QUERIES] = queries.container();
+      }
+    }
+    viewContainer = lContainerToViewContainer(lContainer);
+  }
+  return viewContainer;
+}
+
+
+/**
+ * Inserts or appends a {@link View} into a {@link ViewContainer}.
+ *
+ * @param viewContainer The container to insert the view into.
+ * @param view The view to insert into the container.
+ * @param insertAfterView The view in the container the inserted view should be inserted after. If
+ * `null`, this will just append the `view` as the last view in the `viewContainer`.
+ */
+export function viewContainerInsertAfter(
+    viewContainer: ViewContainer, view: View, insertAfterView: View | null): void {
+  ngDevMode && assertLContainer(viewContainer);
+  ngDevMode && assertLView(view);
+  ngDevMode && assertLViewOrUndefined(insertAfterView);
+
+  return viewContainerInsertAfterInternal(
+      viewContainerToLContainer(viewContainer), viewToLView(view),
+      insertAfterView as any as LView | null);
+}
+
+/**
+ * The internal implementation of {@link viewContainerInsertAfter}.
+ *
+ * @param lContainer The container to insert the view into
+ * @param lView The view to insert into the container
+ * @param insertAfterLView The optional view in the container that the inserted view should be
+ * inserted behind. If `null`, we will insert the view at the end of the container.
+ */
+function viewContainerInsertAfterInternal(
+    lContainer: LContainer, lView: LView, insertAfterLView: LView | null) {
+  const _inContainer = getAddingEmbeddedRootChild();
+  try {
+    setAddingEmbeddedRootChild(true);
+    const commentNode = lContainer[NATIVE];
+
+    // Because we're dynamically adding a view to the container, we reset the ACTIVE_INDEX to ensure
+    // the container is updated.
+    lContainer[ACTIVE_INDEX] = -1;
+
+    const insertAfterNode =
+        insertAfterLView ? getLastRootElementFromView(insertAfterLView) : commentNode;
+    ngDevMode && assertDomNode(insertAfterNode);
+    const tView = lView[TVIEW];
+    let tNode = tView.firstChild;
+
+    const index =
+        insertAfterLView ? viewContainerIndexOfInternal(lContainer, insertAfterLView) + 1 : 0;
+    insertView(lView, lContainer, index);
+
+    const renderer = lView[RENDERER];
+    const beforeNode = nativeNextSibling(renderer, insertAfterNode);
+    ngDevMode && assertEqual(tNode && tNode.parent, null, 'tNode parent should be null');
+
+    addRemoveViewFromContainer(lView, true, beforeNode);
+  } finally {
+    setAddingEmbeddedRootChild(_inContainer);
+  }
+}
+
+/**
+ * Searches the `viewContainer` for a the first instance of a given `view` and returns its index
+ * within the container, if the `view` is not found, it returns `-1`.
+ * @param viewContainer The container to search
+ * @param view The view to search for
+ */
+export function viewContainerIndexOf(viewContainer: ViewContainer, view: View): number {
+  ngDevMode && assertLContainer(viewContainer);
+  ngDevMode && assertLView(view);
+
+  return viewContainerIndexOfInternal(viewContainer as any, view as any);
+}
+
+function viewContainerIndexOfInternal(lContainer: LContainer, lView: LView) {
+  const views = lContainer[VIEWS] as LView[];
+  if (views) {
+    for (let i = 0; i < views.length; i++) {
+      if (lView === views[i]) return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Used to remove (embedded) views from a container. Will detach the view and destroy it, and will
+ * also remove all DOM nodes associated with the view.
+ *
+ * @param viewContainer The container to remove the view from
+ * @param view The view to remove from the container
+ * @param shouldDestroy Whether or not the view should be destroyed in the process.
+ */
+export function viewContainerRemove(
+    viewContainer: ViewContainer, view: View, shouldDestroy: boolean = true): void {
+  viewContainerRemoveInternal(
+      viewContainerToLContainer(viewContainer), viewToLView(view), shouldDestroy);
+}
+
+/**
+ * The internal implementation of {@link viewContainerRemove}
+ * @param lContainer The container to remove the view from
+ * @param lView The view to remove
+ * @param shouldDestroy Whether or not the view should be destroyed in the process.
+ */
+export function viewContainerRemoveInternal(
+    lContainer: LContainer, lView: LView, shouldDestroy: boolean): void {
+  const index = viewContainerIndexOfInternal(lContainer, lView);
+  if (index >= 0) {
+    detachView(lContainer, index);
+    shouldDestroy && destroyLView(lView);
+  }
+}
+
+/**
+ * Gets the number of views in the container.
+ * @param viewContainer The view container examine for length.
+ */
+export function viewContainerLength(viewContainer: ViewContainer): number {
+  ngDevMode && assertLContainer(viewContainer);
+  return viewContainerLengthInternal(viewContainer as any);
+}
+
+function viewContainerLengthInternal(lContainer: LContainer): number {
+  const views = lContainer[VIEWS];
+  return Array.isArray(views) ? views.length : 0;
+}
+
+/**
+ * Retrieves a view from a container by index.
+ * @param viewContainer The container to get the view from
+ * @param index The index of the view to retrieve within the container.
+ */
+export function viewContainerGet(viewContainer: ViewContainer, index: number): View|null {
+  ngDevMode && assertLContainer(viewContainer);
+  const lView = viewContainerGetInternal(viewContainer as any, index);
+  return lView as any;
+}
+
+function viewContainerGetInternal(lContainer: LContainer, index: number): LView|null {
+  return lContainer[VIEWS][index] || null;
+}
+
+/**
+ * Destroys the view and cleans up accompanying data structures Ivy uses to optimize
+ * performance.
+ *
+ * @param view The view to destroy.
+ */
+export function viewDestroy(view: View): void {
+  destroyLView(viewToLView(view));
+}

--- a/packages/core/src/util/assert.ts
+++ b/packages/core/src/util/assert.ts
@@ -34,6 +34,12 @@ export function assertSame<T>(actual: T, expected: T, msg: string) {
   }
 }
 
+export function assertNotSame<T>(actual: T, expected: T, msg: string) {
+  if (actual === expected) {
+    throwError(msg);
+  }
+}
+
 export function assertLessThan<T>(actual: T, expected: T, msg: string) {
   if (actual >= expected) {
     throwError(msg);
@@ -45,6 +51,13 @@ export function assertGreaterThan<T>(actual: T, expected: T, msg: string) {
     throwError(msg);
   }
 }
+
+export function assertGreaterOrEqual<T>(actual: T, expected: T, msg: string) {
+  if (actual < expected) {
+    throwError(msg);
+  }
+}
+
 
 export function assertNotDefined<T>(actual: T, msg: string) {
   if (actual != null) {
@@ -64,12 +77,14 @@ export function throwError(msg: string): never {
   throw new Error(`ASSERTION ERROR: ${msg}`);
 }
 
+export function isDomNode(node: any): boolean {
+  return (typeof Node !== 'undefined' && node instanceof Node) ||
+      (node != null && typeof node === 'object' && node.constructor.name === 'WebWorkerRenderNode');
+}
+
 export function assertDomNode(node: any) {
   // If we're in a worker, `Node` will not be defined.
-  assertEqual(
-      (typeof Node !== 'undefined' && node instanceof Node) ||
-          (typeof node === 'object' && node.constructor.name === 'WebWorkerRenderNode'),
-      true, 'The provided value must be an instance of a DOM Node');
+  assertEqual(isDomNode(node), true, 'The provided value must be an instance of a DOM Node');
 }
 
 

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -147,9 +147,6 @@
     "name": "ViewEncapsulation"
   },
   {
-    "name": "__values"
-  },
-  {
     "name": "_currentNamespace"
   },
   {
@@ -165,9 +162,6 @@
     "name": "addOrUpdateStaticStyle"
   },
   {
-    "name": "addToViewTree"
-  },
-  {
     "name": "allocStylingContext"
   },
   {
@@ -178,6 +172,9 @@
   },
   {
     "name": "appendChild"
+  },
+  {
+    "name": "appendChildView"
   },
   {
     "name": "applyOnCreateInstructions"
@@ -315,7 +312,7 @@
     "name": "generatePropertyAliases"
   },
   {
-    "name": "getBeforeNodeForView"
+    "name": "getBeforeNodeForContainedView"
   },
   {
     "name": "getBindingsEnabled"
@@ -376,9 +373,6 @@
   },
   {
     "name": "getNameOnlyMarkerIndex"
-  },
-  {
-    "name": "getNativeAnchorNode"
   },
   {
     "name": "getNativeByTNode"
@@ -459,6 +453,12 @@
     "name": "insertBloom"
   },
   {
+    "name": "insertChildBefore"
+  },
+  {
+    "name": "insertNodeOrNodesBefore"
+  },
+  {
     "name": "instantiateAllDirectives"
   },
   {
@@ -531,12 +531,6 @@
     "name": "namespaceHTML"
   },
   {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
-  },
-  {
     "name": "nativeInsertBefore"
   },
   {
@@ -591,6 +585,9 @@
     "name": "registerPreOrderHooks"
   },
   {
+    "name": "renderChild"
+  },
+  {
     "name": "renderComponent"
   },
   {
@@ -622,6 +619,9 @@
   },
   {
     "name": "saveResolvedLocalsInData"
+  },
+  {
+    "name": "setAddingEmbeddedRootChild"
   },
   {
     "name": "setBindingRoot"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -126,19 +126,16 @@
     "name": "ViewEncapsulation"
   },
   {
-    "name": "__values"
-  },
-  {
     "name": "_global"
   },
   {
     "name": "_renderCompCount"
   },
   {
-    "name": "addToViewTree"
+    "name": "appendChild"
   },
   {
-    "name": "appendChild"
+    "name": "appendChildView"
   },
   {
     "name": "applyOnCreateInstructions"
@@ -228,7 +225,7 @@
     "name": "generateExpandoInstructionBlock"
   },
   {
-    "name": "getBeforeNodeForView"
+    "name": "getBeforeNodeForContainedView"
   },
   {
     "name": "getCheckNoChangesMode"
@@ -271,9 +268,6 @@
   },
   {
     "name": "getLViewParent"
-  },
-  {
-    "name": "getNativeAnchorNode"
   },
   {
     "name": "getNativeByTNode"
@@ -330,6 +324,12 @@
     "name": "insertBloom"
   },
   {
+    "name": "insertChildBefore"
+  },
+  {
+    "name": "insertNodeOrNodesBefore"
+  },
+  {
     "name": "instantiateRootComponent"
   },
   {
@@ -369,12 +369,6 @@
     "name": "namespaceHTML"
   },
   {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
-  },
-  {
     "name": "nativeInsertBefore"
   },
   {
@@ -409,6 +403,9 @@
   },
   {
     "name": "refreshDynamicEmbeddedViews"
+  },
+  {
+    "name": "renderChild"
   },
   {
     "name": "renderComponent"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -291,6 +291,9 @@
     "name": "__values"
   },
   {
+    "name": "_addingEmbeddedRootChild"
+  },
+  {
     "name": "_c0"
   },
   {
@@ -375,6 +378,9 @@
     "name": "_symbolIterator"
   },
   {
+    "name": "_useIvyAnimationCheck"
+  },
+  {
     "name": "addComponentLogic"
   },
   {
@@ -390,9 +396,6 @@
     "name": "addTContainerToQueries"
   },
   {
-    "name": "addToViewTree"
-  },
-  {
     "name": "allocPlayerContext"
   },
   {
@@ -406,6 +409,9 @@
   },
   {
     "name": "appendChild"
+  },
+  {
+    "name": "appendChildView"
   },
   {
     "name": "applyOnCreateInstructions"
@@ -484,9 +490,6 @@
   },
   {
     "name": "createElementRef"
-  },
-  {
-    "name": "createEmbeddedViewAndNode"
   },
   {
     "name": "createEmptyStylingContext"
@@ -654,7 +657,10 @@
     "name": "generatePropertyAliases"
   },
   {
-    "name": "getBeforeNodeForView"
+    "name": "getAddingEmbeddedRootChild"
+  },
+  {
+    "name": "getBeforeNodeForContainedView"
   },
   {
     "name": "getBindingsEnabled"
@@ -705,6 +711,9 @@
     "name": "getElementDepthCount"
   },
   {
+    "name": "getEmbeddedViewFactoryInternal"
+  },
+  {
     "name": "getErrorLogger"
   },
   {
@@ -750,6 +759,9 @@
     "name": "getLViewParent"
   },
   {
+    "name": "getLastRootElementFromView"
+  },
+  {
     "name": "getMatchingBindingIndex"
   },
   {
@@ -763,9 +775,6 @@
   },
   {
     "name": "getNameOnlyMarkerIndex"
-  },
-  {
-    "name": "getNativeAnchorNode"
   },
   {
     "name": "getNativeByIndex"
@@ -930,6 +939,12 @@
     "name": "insertBloom"
   },
   {
+    "name": "insertChildBefore"
+  },
+  {
+    "name": "insertNodeOrNodesBefore"
+  },
+  {
     "name": "insertView"
   },
   {
@@ -1023,6 +1038,12 @@
     "name": "iterateListLike"
   },
   {
+    "name": "lContainerToViewContainer"
+  },
+  {
+    "name": "lViewToView"
+  },
+  {
     "name": "leaveView"
   },
   {
@@ -1063,12 +1084,6 @@
   },
   {
     "name": "namespaceHTML"
-  },
-  {
-    "name": "nativeAppendChild"
-  },
-  {
-    "name": "nativeAppendOrInsertBefore"
   },
   {
     "name": "nativeInsertBefore"
@@ -1158,7 +1173,7 @@
     "name": "removeListeners"
   },
   {
-    "name": "removeView"
+    "name": "renderChild"
   },
   {
     "name": "renderComponent"
@@ -1213,6 +1228,9 @@
   },
   {
     "name": "searchTokensOnInjector"
+  },
+  {
+    "name": "setAddingEmbeddedRootChild"
   },
   {
     "name": "setBindingRoot"
@@ -1293,6 +1311,9 @@
     "name": "shouldSearchParent"
   },
   {
+    "name": "shouldUseIvyAnimationCheck"
+  },
+  {
     "name": "storeBindingMetadata"
   },
   {
@@ -1323,6 +1344,9 @@
     "name": "trackByIdentity"
   },
   {
+    "name": "unwrapLContainer"
+  },
+  {
     "name": "unwrapRNode"
   },
   {
@@ -1342,6 +1366,33 @@
   },
   {
     "name": "viewAttachedToContainer"
+  },
+  {
+    "name": "viewContainerGet"
+  },
+  {
+    "name": "viewContainerGetInternal"
+  },
+  {
+    "name": "viewContainerIndexOfInternal"
+  },
+  {
+    "name": "viewContainerInsertAfter"
+  },
+  {
+    "name": "viewContainerInsertAfterInternal"
+  },
+  {
+    "name": "viewContainerRemove"
+  },
+  {
+    "name": "viewContainerRemoveInternal"
+  },
+  {
+    "name": "viewContainerToLContainer"
+  },
+  {
+    "name": "viewToLView"
   },
   {
     "name": "walkTNodeTree"

--- a/packages/core/test/i18n_integration_spec.ts
+++ b/packages/core/test/i18n_integration_spec.ts
@@ -9,7 +9,7 @@
 import {Component, ContentChild, ContentChildren, Directive, QueryList, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {onlyInIvy, polyfillGoogGetMsg} from '@angular/private/testing';
+import {fixmeIvy, onlyInIvy, polyfillGoogGetMsg} from '@angular/private/testing';
 
 @Directive({
   selector: '[tplRef]',
@@ -230,13 +230,14 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       const content = 'Hello {{ name }}';
       const template = `
         <div *ngIf="visible">
-          <div i18n>${content}</div>
+          <div class="test" i18n>${content}</div>
         </div>
       `;
       const fixture = getFixtureWithOverrides({template});
 
-      const element = fixture.nativeElement.firstChild;
-      expect(element.children[0]).toHaveText('Bonjour John');
+      const element = fixture.nativeElement.querySelector('.test');
+
+      expect(element).toHaveText('Bonjour John');
     });
 
     it('should ignore i18n attributes on self-closing tags', () => {
@@ -250,11 +251,11 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
     it('should handle i18n attribute with directives', () => {
       const content = 'Hello {{ name }}';
       const template = `
-        <div *ngIf="visible" i18n>${content}</div>
+        <div class="test" *ngIf="visible" i18n>${content}</div>
       `;
       const fixture = getFixtureWithOverrides({template});
 
-      const element = fixture.nativeElement.firstChild;
+      const element = fixture.nativeElement.querySelector('.test');
       expect(element).toHaveText('Bonjour John');
     });
 
@@ -284,8 +285,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
       `;
       const fixture = getFixtureWithOverrides({template});
 
-      const element = fixture.nativeElement.firstChild;
-      expect(element).toHaveText('Bonjour John');
+      expect(fixture.nativeElement.innerHTML).toBe('<!--ng-container-->Bonjour John');
     });
 
     it('should handle single translation message within ng-template', () => {
@@ -460,7 +460,7 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
     it('should handle multiple ICUs in one block', () => {
       const template = `
             <div i18n>
-              {age, select, 10 {ten} 20 {twenty} other {other}} - 
+              {age, select, 10 {ten} 20 {twenty} other {other}} -
               {count, select, 1 {one} 2 {two} other {more than two}}
             </div>
           `;
@@ -552,8 +552,9 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
           .replace(/<!--bindings=\{(\W.*\W\s*)?\}-->/g, '');
     }
 
-    it('detached nodes should still be part of query', () => {
-      const template = `
+    fixmeIvy('FW-1166: i18n not removing TNodes properly')
+        .it('detached nodes should still be part of query', () => {
+          const template = `
           <div-query #q i18n>
             <ng-template>
               <div>
@@ -565,50 +566,50 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
           </div-query>
         `;
 
-      @Directive({selector: '[text]', inputs: ['text'], exportAs: 'textDir'})
-      class TextDirective {
-        // TODO(issue/24571): remove '!'.
-        text !: string;
-        constructor() {}
-      }
+          @Directive({selector: '[text]', inputs: ['text'], exportAs: 'textDir'})
+          class TextDirective {
+            // TODO(issue/24571): remove '!'.
+            text !: string;
+            constructor() {}
+          }
 
-      @Component({selector: 'div-query', template: '<ng-container #vc></ng-container>'})
-      class DivQuery {
-        // TODO(issue/24571): remove '!'.
-        @ContentChild(TemplateRef) template !: TemplateRef<any>;
+          @Component({selector: 'div-query', template: '<ng-container #vc></ng-container>'})
+          class DivQuery {
+            // TODO(issue/24571): remove '!'.
+            @ContentChild(TemplateRef) template !: TemplateRef<any>;
 
-        // TODO(issue/24571): remove '!'.
-        @ViewChild('vc', {read: ViewContainerRef})
-        vc !: ViewContainerRef;
+            // TODO(issue/24571): remove '!'.
+            @ViewChild('vc', {read: ViewContainerRef})
+            vc !: ViewContainerRef;
 
-        // TODO(issue/24571): remove '!'.
-        @ContentChildren(TextDirective, {descendants: true})
-        query !: QueryList<TextDirective>;
+            // TODO(issue/24571): remove '!'.
+            @ContentChildren(TextDirective, {descendants: true})
+            query !: QueryList<TextDirective>;
 
-        create() { this.vc.createEmbeddedView(this.template); }
+            create() { this.vc.createEmbeddedView(this.template); }
 
-        destroy() { this.vc.clear(); }
-      }
+            destroy() { this.vc.clear(); }
+          }
 
-      TestBed.configureTestingModule({declarations: [TextDirective, DivQuery]});
-      const fixture = getFixtureWithOverrides({template});
-      const q = fixture.debugElement.children[0].references.q;
-      expect(q.query.length).toEqual(0);
+          TestBed.configureTestingModule({declarations: [TextDirective, DivQuery]});
+          const fixture = getFixtureWithOverrides({template});
+          const q = fixture.debugElement.children[0].references.q;
+          expect(q.query.length).toEqual(0);
 
-      // Create embedded view
-      q.create();
-      fixture.detectChanges();
-      expect(q.query.length).toEqual(1);
-      expect(toHtml(fixture.nativeElement))
-          .toEqual(`<div-query><!--ng-container-->Contenu<!--container--></div-query>`);
+          // Create embedded view
+          q.create();
+          fixture.detectChanges();
+          expect(q.query.length).toEqual(1);
+          expect(toHtml(fixture.nativeElement))
+              .toEqual(`<div-query><!--ng-container-->Contenu<!--container--></div-query>`);
 
-      // Disable ng-if
-      fixture.componentInstance.visible = false;
-      fixture.detectChanges();
-      expect(q.query.length).toEqual(0);
-      expect(toHtml(fixture.nativeElement))
-          .toEqual(`<div-query><!--ng-container-->Contenu<!--container--></div-query>`);
-    });
+          // Disable ng-if
+          fixture.componentInstance.visible = false;
+          fixture.detectChanges();
+          expect(q.query.length).toEqual(0);
+          expect(toHtml(fixture.nativeElement))
+              .toEqual(`<div-query><!--ng-container-->Contenu<!--container--></div-query>`);
+        });
   });
 
   it('should handle multiple i18n sections', () => {

--- a/packages/core/test/linker/projection_integration_spec.ts
+++ b/packages/core/test/linker/projection_integration_spec.ts
@@ -477,25 +477,23 @@ describe('projection', () => {
     });
   }
 
-  fixmeIvy('FW-869: debugElement.queryAllNodes returns nodes in the wrong order')
-      .it('should support nested conditionals that contain ng-contents', () => {
-        TestBed.configureTestingModule(
-            {declarations: [ConditionalTextComponent, ManualViewportDirective]});
-        TestBed.overrideComponent(
-            MainComp, {set: {template: `<conditional-text>a</conditional-text>`}});
-        const main = TestBed.createComponent(MainComp);
+  it('should support nested conditionals that contain ng-contents', () => {
+    TestBed.configureTestingModule(
+        {declarations: [ConditionalTextComponent, ManualViewportDirective]});
+    TestBed.overrideComponent(
+        MainComp, {set: {template: `<conditional-text>a</conditional-text>`}});
+    const main = TestBed.createComponent(MainComp);
 
-        expect(main.nativeElement).toHaveText('MAIN()');
+    expect(main.nativeElement).toHaveText('MAIN()');
 
-        let viewportElement =
-            main.debugElement.queryAllNodes(By.directive(ManualViewportDirective))[0];
-        viewportElement.injector.get(ManualViewportDirective).show();
-        expect(main.nativeElement).toHaveText('MAIN(FIRST())');
+    let viewportElement = main.debugElement.queryAllNodes(By.directive(ManualViewportDirective))[0];
+    viewportElement.injector.get(ManualViewportDirective).show();
+    expect(main.nativeElement).toHaveText('MAIN(FIRST())');
 
-        viewportElement = main.debugElement.queryAllNodes(By.directive(ManualViewportDirective))[1];
-        viewportElement.injector.get(ManualViewportDirective).show();
-        expect(main.nativeElement).toHaveText('MAIN(FIRST(SECOND(a)))');
-      });
+    viewportElement = main.debugElement.queryAllNodes(By.directive(ManualViewportDirective))[1];
+    viewportElement.injector.get(ManualViewportDirective).show();
+    expect(main.nativeElement).toHaveText('MAIN(FIRST(SECOND(a)))');
+  });
 
   it('should allow to switch the order of nested components via ng-content', () => {
     TestBed.configureTestingModule({declarations: [CmpA, CmpB, CmpD, CmpC]});
@@ -605,49 +603,48 @@ describe('projection', () => {
     expect(main.nativeElement).toHaveText('ABC');
   });
 
-  fixmeIvy('FW-869: debugElement.queryAllNodes returns nodes in the wrong order')
-      .it('should project filled view containers into a view container', () => {
-        TestBed.configureTestingModule(
-            {declarations: [ConditionalContentComponent, ManualViewportDirective]});
-        TestBed.overrideComponent(MainComp, {
-          set: {
-            template: '<conditional-content>' +
-                '<div class="left">A</div>' +
-                '<ng-template manual class="left">B</ng-template>' +
-                '<div class="left">C</div>' +
-                '<div>D</div>' +
-                '</conditional-content>'
-          }
-        });
-        const main = TestBed.createComponent(MainComp);
+  it('should project filled view containers into a view container', () => {
+    TestBed.configureTestingModule(
+        {declarations: [ConditionalContentComponent, ManualViewportDirective]});
+    TestBed.overrideComponent(MainComp, {
+      set: {
+        template: '<conditional-content>' +
+            '<div class="left">A</div>' +
+            '<ng-template manual class="left">B</ng-template>' +
+            '<div class="left">C</div>' +
+            '<div>D</div>' +
+            '</conditional-content>'
+      }
+    });
+    const main = TestBed.createComponent(MainComp);
 
-        const conditionalComp = main.debugElement.query(By.directive(ConditionalContentComponent));
+    const conditionalComp = main.debugElement.query(By.directive(ConditionalContentComponent));
 
-        const viewViewportDir =
-            conditionalComp.queryAllNodes(By.directive(ManualViewportDirective))[0].injector.get(
-                ManualViewportDirective);
+    const viewViewportDir =
+        conditionalComp.queryAllNodes(By.directive(ManualViewportDirective))[0].injector.get(
+            ManualViewportDirective);
 
-        expect(main.nativeElement).toHaveText('(, D)');
-        expect(main.nativeElement).toHaveText('(, D)');
+    expect(main.nativeElement).toHaveText('(, D)');
+    expect(main.nativeElement).toHaveText('(, D)');
 
-        viewViewportDir.show();
-        main.detectChanges();
-        expect(main.nativeElement).toHaveText('(AC, D)');
+    viewViewportDir.show();
+    main.detectChanges();
+    expect(main.nativeElement).toHaveText('(AC, D)');
 
-        const contentViewportDir =
-            conditionalComp.queryAllNodes(By.directive(ManualViewportDirective))[1].injector.get(
-                ManualViewportDirective);
+    const contentViewportDir =
+        conditionalComp.queryAllNodes(By.directive(ManualViewportDirective))[1].injector.get(
+            ManualViewportDirective);
 
-        contentViewportDir.show();
-        main.detectChanges();
-        expect(main.nativeElement).toHaveText('(ABC, D)');
+    contentViewportDir.show();
+    main.detectChanges();
+    expect(main.nativeElement).toHaveText('(ABC, D)');
 
-        // hide view viewport, and test that it also hides
-        // the content viewport's views
-        viewViewportDir.hide();
-        main.detectChanges();
-        expect(main.nativeElement).toHaveText('(, D)');
-      });
+    // hide view viewport, and test that it also hides
+    // the content viewport's views
+    viewViewportDir.hide();
+    main.detectChanges();
+    expect(main.nativeElement).toHaveText('(, D)');
+  });
 
   describe('projectable nodes', () => {
 

--- a/packages/core/test/render3/content_spec.ts
+++ b/packages/core/test/render3/content_spec.ts
@@ -16,6 +16,7 @@ import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {TemplateRef, ViewContainerRef, QueryList} from '@angular/core';
 import {NgIf, NgForOf} from './common_with_def';
 import {ComponentFixture, createComponent, getDirectiveOnNode, renderComponent, toHtml} from './render_util';
+import {fixmeIvy} from '@angular/private/testing';
 
 describe('content projection', () => {
   it('should project content', () => {
@@ -573,6 +574,7 @@ describe('content projection', () => {
        expect(toHtml(parent)).toEqual('<child><div></div></child>');
      });
 
+
   it('should project containers into containers', () => {
     /**
      * <div>
@@ -745,6 +747,7 @@ describe('content projection', () => {
     expect(fixture.html)
         .toEqual('<parent><child><div>Before text-After text</div></child></parent>');
   });
+
 
   it('should support projection into embedded views when ng-content is a root node of an embedded view, with other nodes after',
      () => {

--- a/packages/core/test/render3/i18n_spec.ts
+++ b/packages/core/test/render3/i18n_spec.ts
@@ -19,6 +19,7 @@ import {allocHostVars, element, elementEnd, elementStart, template, text, nextCo
 import {COMMENT_MARKER, ELEMENT_MARKER, I18nMutateOpCode, I18nUpdateOpCode, I18nUpdateOpCodes, TI18n} from '../../src/render3/interfaces/i18n';
 import {HEADER_OFFSET, LView, TVIEW} from '../../src/render3/interfaces/view';
 import {ComponentFixture, TemplateFixture} from './render_util';
+import {fixmeIvy} from '@angular/private/testing';
 
 const Component: typeof _Component = function(...args: any[]): any {
   // In test we use @Component for documentation only so it's safe to mock out the implementation.

--- a/packages/core/test/render3/query_spec.ts
+++ b/packages/core/test/render3/query_spec.ts
@@ -1603,6 +1603,7 @@ describe('query', () => {
          });
 
       // https://stackblitz.com/edit/angular-7vvo9j?file=src%2Fapp%2Fapp.component.ts
+      // https://stackblitz.com/edit/angular-xzwp6n
       it('should report results when the same TemplateRef is inserted into different ViewContainerRefs',
          () => {
            let tpl: TemplateRef<{}>;

--- a/packages/core/test/render3/view_container_ref_spec.ts
+++ b/packages/core/test/render3/view_container_ref_spec.ts
@@ -23,6 +23,7 @@ import {NgForOf} from '../../test/render3/common_with_def';
 
 import {getRendererFactory2} from './imported_renderer2';
 import {ComponentFixture, createComponent, getDirectiveOnNode, TemplateFixture,} from './render_util';
+import {fixmeIvy} from '@angular/private/testing';
 
 const Component: typeof _Component = function(...args: any[]): any {
   // In test we use @Component for documentation only so it's safe to mock out the implementation.
@@ -911,8 +912,21 @@ describe('ViewContainerRef', () => {
         fixture.update();
         expect(fixture.html).toEqual('<p vcref=""></p>ABC');
 
+        /**
+         * Current state of the DOM should be:
+         *
+         * <div>
+         *   <!-- container -->
+         *   <p vcref=""></p>
+         *   <!-- container -->
+         *   A  <-- text node
+         *   B  <-- text node
+         *   C  <-- text node
+         * </div>
+         */
+
         // The DOM is manually modified here to ensure that the text node is actually moved
-        fixture.hostElement.childNodes[2].nodeValue = '**A**';
+        fixture.hostElement.childNodes[3].nodeValue = '**A**';
         expect(fixture.html).toEqual('<p vcref=""></p>**A**BC');
 
         let viewRef = directiveInstance !.vcref.get(0);

--- a/packages/core/test/render3/view_spec.ts
+++ b/packages/core/test/render3/view_spec.ts
@@ -1,0 +1,428 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {TemplateFixture} from './render_util';
+import {template, element, RenderFlags, elementEnd, elementStart, text, textBinding, bind} from '@angular/core/src/render3';
+import {getEmbeddedViewFactory, viewContainerInsertAfter, getViewContainer, viewContainerRemove, viewContainerGet, viewContainerIndexOf, viewContainerLength} from '@angular/core/src/render3/view';
+import {CHILD_HEAD, NEXT, CHILD_TAIL} from '@angular/core/src/render3/interfaces/view';
+
+describe('ViewContainer manipulation commands', () => {
+  it('should get the embedded view from a comment added by ng-template and be able to insert it', () => {
+    /*
+    <div></div>
+    <ng-template>
+      <b>Hello </b>
+      <i>{{name}}</i>
+    </ng-template>
+    */
+    const fixture = new TemplateFixture(
+        () => {
+          element(0, 'div');
+          template(1, (rf: RenderFlags, ctx: any) => {
+            if (rf & RenderFlags.Create) {
+              elementStart(0, 'b');
+              text(1, 'Hello ');
+              elementEnd();
+              elementStart(2, 'i');
+              text(3);
+              elementEnd();
+            }
+            if (rf & RenderFlags.Update) {
+              textBinding(3, bind(ctx.name));
+            }
+          }, 4, 1);
+        },
+        () => {
+
+        },
+        2, 0);
+
+    /*
+    <div></div>
+    <!-- container -->
+    */
+    const comment = fixture.hostElement.lastChild !;
+    expect(comment.nodeType).toBe(Node.COMMENT_NODE);
+    const embeddedViewFactory = getEmbeddedViewFactory(comment) !;
+    expect(typeof embeddedViewFactory).toEqual('function');
+
+    const commentViewContainer = getViewContainer(comment) !;
+
+    const bView = embeddedViewFactory({name: 'B'});
+    // Putting this in the very front.
+    viewContainerInsertAfter(commentViewContainer, bView, null);
+
+    // Now putting this in front of B (because it's in the very front).
+    viewContainerInsertAfter(commentViewContainer, embeddedViewFactory({name: 'A'}), null);
+
+    // Putting this one after B
+    viewContainerInsertAfter(commentViewContainer, embeddedViewFactory({name: 'C'}), bView);
+
+    // Putting this one right after that initial <div></div>
+    const divViewContainer = getViewContainer(fixture.hostElement.firstChild !) !;
+    viewContainerInsertAfter(divViewContainer, embeddedViewFactory({name: 'X'}), null);
+
+    fixture.update();
+    expect(fixture.htmlWithContainerComments)
+        .toEqual(
+            '<div></div><b>Hello </b><i>X</i><!--container--><b>Hello </b><i>A</i><b>Hello </b><i>B</i><b>Hello </b><i>C</i>');
+  });
+
+  describe('getViewContainer', () => {
+    it('should lazily create LContainers and add them to the internal linked list in the order of DOM',
+       () => {
+         /*
+          <one/>
+          <two/>
+          <three/>
+          <four/>
+         */
+         const fixture = new TemplateFixture(
+             () => {
+               element(0, 'one');
+               element(1, 'two');
+               element(2, 'three');
+               element(3, 'four');
+             },
+             () => {
+
+             },
+             4, 0);
+
+         const one = fixture.hostElement.querySelector('one') !;
+         const two = fixture.hostElement.querySelector('two') !;
+         const three = fixture.hostElement.querySelector('three') !;
+         const four = fixture.hostElement.querySelector('four') !;
+
+         // This is adding to the CHILD_HEAD and CHILD_TAIL
+         const threeContainer = getViewContainer(three);
+         // This is inserting to CHILD_HEAD infront of existing CHILD_HEAD
+         const oneContainer = getViewContainer(one);
+         // This is inserting at CHILD_TAIL, after existing CHILD_TAIL
+         const fourContainer = getViewContainer(four);
+         // This is inserting in the middle of the list
+         const twoContainer = getViewContainer(two);
+
+         let cursor = fixture.hostView[CHILD_HEAD];
+
+         expect(cursor).toBe(oneContainer as any);
+
+         cursor = cursor ![NEXT];
+         expect(cursor).toBe(twoContainer as any);
+
+         cursor = cursor ![NEXT];
+         expect(cursor).toBe(threeContainer as any);
+
+         cursor = cursor ![NEXT];
+         expect(cursor).toBe(fourContainer as any);
+
+         expect(fixture.hostView[CHILD_TAIL]).toBe(cursor);
+         expect(cursor ![NEXT]).toEqual(null);
+       });
+
+    it('should lazily create LContainers and add them to the internal linked list in order of DOM, depth first',
+       () => {
+         /*
+           <one>
+             <two>
+               <three>
+                 <four/>
+               </three>
+             </two>
+           </one>
+         */
+         const fixture = new TemplateFixture(
+             () => {
+               elementStart(0, 'one');
+               {
+                 elementStart(1, 'two');
+
+                 {
+                   elementStart(2, 'three');
+                   {
+                     element(3, 'four');  //
+                   }
+                   elementEnd();
+                 }
+                 elementEnd();
+               }
+               elementEnd();
+             },
+             () => {
+
+             },
+             4, 0);
+
+         const one = fixture.hostElement.querySelector('one') !;
+         const two = fixture.hostElement.querySelector('two') !;
+         const three = fixture.hostElement.querySelector('three') !;
+         const four = fixture.hostElement.querySelector('four') !;
+
+         // This is adding to the CHILD_HEAD and CHILD_TAIL
+         const threeContainer = getViewContainer(three);
+         // This is inserting to CHILD_HEAD infront of existing CHILD_HEAD
+         const oneContainer = getViewContainer(one);
+         // This is inserting at CHILD_TAIL, after existing CHILD_TAIL
+         const fourContainer = getViewContainer(four);
+         // This is inserting in the middle of the list
+         const twoContainer = getViewContainer(two);
+
+         let cursor = fixture.hostView[CHILD_HEAD];
+
+         expect(cursor).toBe(oneContainer as any);
+
+         cursor = cursor ![NEXT];
+         expect(cursor).toBe(twoContainer as any);
+
+         cursor = cursor ![NEXT];
+         expect(cursor).toBe(threeContainer as any);
+
+         cursor = cursor ![NEXT];
+         expect(cursor).toBe(fourContainer as any);
+
+         expect(fixture.hostView[CHILD_TAIL]).toBe(cursor);
+         expect(cursor ![NEXT]).toEqual(null);
+       });
+  });
+
+  describe('viewContainerRemove', () => {
+    it('should remove views from a container', () => {
+      /*
+       <div></div><ng-template><span></span></ng-template>
+      */
+      const fixture = new TemplateFixture(
+          () => {
+            element(0, 'div');
+            template(1, (rf: RenderFlags, ctx: any) => {
+              if (rf & RenderFlags.Create) {
+                element(0, 'span');
+              }
+            }, 1, 0);
+          },
+          () => {
+
+          },
+          2, 0);
+
+      expect(fixture.htmlWithContainerComments).toEqual('<div></div><!--container-->');
+      const containerComment = fixture.hostElement.lastChild !;
+      const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+      const view = embeddedViewFactory({});
+      const container = getViewContainer(containerComment) !;
+      viewContainerInsertAfter(container, view, null);
+      expect(fixture.htmlWithContainerComments).toEqual('<div></div><!--container--><span></span>');
+      viewContainerRemove(container, view);
+      expect(fixture.htmlWithContainerComments).toEqual('<div></div><!--container-->');
+    });
+
+    it('should remove all dom elements for a view, as there could be more than one', () => {
+      /*
+      <ul>
+        <ng-template>
+          <li>one</li>
+          <li>two</li>
+          <li>three</li>
+        </ng-template>
+      </ul>
+      */
+      const fixture = new TemplateFixture(
+          () => {
+            elementStart(0, 'ul');
+            template(1, (rf: RenderFlags, ctx: any) => {
+              if (rf & RenderFlags.Create) {
+                elementStart(0, 'li');
+                text(1, 'one');
+                elementEnd();
+                elementStart(2, 'li');
+                text(3, 'two');
+                elementEnd();
+                elementStart(4, 'li');
+                text(5, 'three');
+                elementEnd();
+              }
+            }, 6, 0);
+            elementEnd();
+          },
+          () => {
+
+          },
+          2, 0);
+
+      expect(fixture.htmlWithContainerComments).toEqual('<ul><!--container--></ul>');
+      const containerComment = fixture.hostElement.firstChild !.firstChild !;
+      const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+      const container = getViewContainer(containerComment) !;
+      const view = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view, null);
+      expect(fixture.htmlWithContainerComments)
+          .toEqual('<ul><!--container--><li>one</li><li>two</li><li>three</li></ul>');
+      viewContainerRemove(container, view);
+      expect(fixture.htmlWithContainerComments).toEqual('<ul><!--container--></ul>');
+    });
+  });
+
+  describe('viewContainerInsertAfter', () => {
+    it('should insert views in the container', () => {
+      /*
+        <div></div><ng-template><span></span></ng-template>
+      */
+      const fixture = new TemplateFixture(
+          () => {
+            element(0, 'div');
+            template(1, (rf: RenderFlags, ctx: any) => {
+              if (rf & RenderFlags.Create) {
+                element(0, 'span');
+              }
+            }, 1, 0);
+          },
+          () => {
+
+          },
+          2, 0);
+
+      const containerComment = fixture.hostElement.lastChild !;
+      const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+      const container = getViewContainer(containerComment) !;
+
+      expect(viewContainerLength(container)).toBe(0);
+
+      const view1 = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view1, null);
+      expect(viewContainerLength(container)).toBe(1);
+      expect(viewContainerGet(container, 0)).toBe(view1);
+
+      const view2 = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view2, view1);
+      expect(viewContainerLength(container)).toBe(2);
+      expect(viewContainerGet(container, 1)).toBe(view2);
+
+      const view3 = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view3, view2);
+      expect(viewContainerLength(container)).toBe(3);
+      expect(viewContainerGet(container, 2)).toBe(view3);
+
+      // assure that passing null will prepend even if other views are in there.
+      const viewA = embeddedViewFactory({});
+
+      viewContainerInsertAfter(container, viewA, null);
+      expect(viewContainerLength(container)).toBe(4);
+      expect(viewContainerGet(container, 0)).toBe(viewA);
+      expect(viewContainerGet(container, 1)).toBe(view1);
+      expect(viewContainerGet(container, 2)).toBe(view2);
+      expect(viewContainerGet(container, 3)).toBe(view3);
+    });
+  });
+
+  describe('viewContainerIndexOf', () => {
+    it('should find the first index of a container within a view, and return -1 if it cannot find it',
+       () => {
+         /*
+          <div></div><ng-template><span></span></ng-template>
+         */
+         const fixture = new TemplateFixture(
+             () => {
+               element(0, 'div');
+               template(1, (rf: RenderFlags, ctx: any) => {
+                 if (rf & RenderFlags.Create) {
+                   element(0, 'span');
+                 }
+               }, 1, 0);
+             },
+             () => {
+
+             },
+             2, 0);
+
+         const containerComment = fixture.hostElement.lastChild !;
+         const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+         const view = embeddedViewFactory({});
+         const container = getViewContainer(containerComment) !;
+
+         expect(viewContainerIndexOf(container, view))
+             .toBe(-1);  // not found because it's not inserted yet.
+
+         // insert one view and see if an index is returned.
+         viewContainerInsertAfter(container, view, null);
+         expect(viewContainerIndexOf(container, view)).toBe(0);
+
+         // insert the view twice, just to make sure the first index is returned.
+         viewContainerInsertAfter(container, view, null);
+         expect(viewContainerIndexOf(container, view)).toBe(0);
+       });
+  });
+
+  describe('viewContainerGet', () => {
+    it('should get a view by index from the container', () => {
+      /*
+        <div></div><ng-template><span></span></ng-template>
+      */
+      const fixture = new TemplateFixture(
+          () => {
+            element(0, 'div');
+            template(1, (rf: RenderFlags, ctx: any) => {
+              if (rf & RenderFlags.Create) {
+                element(0, 'span');
+              }
+            }, 1, 0);
+          },
+          () => {
+
+          },
+          2, 0);
+
+      const containerComment = fixture.hostElement.lastChild !;
+      const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+      const container = getViewContainer(containerComment) !;
+
+      const view1 = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view1, null);
+
+
+      const view2 = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view2, view1);
+
+      expect(viewContainerGet(container, 0)).toBe(view1);
+      expect(viewContainerGet(container, 1)).toBe(view2);
+    });
+  });
+
+  describe('viewContainerLength', () => {
+    it('should get the current length of the container, by contained view count', () => {
+      /*
+        <div></div><ng-template><span></span></ng-template>
+      */
+      const fixture = new TemplateFixture(
+          () => {
+            element(0, 'div');
+            template(1, (rf: RenderFlags, ctx: any) => {
+              if (rf & RenderFlags.Create) {
+                element(0, 'span');
+              }
+            }, 1, 0);
+          },
+          () => {
+
+          },
+          2, 0);
+
+      const containerComment = fixture.hostElement.lastChild !;
+      const embeddedViewFactory = getEmbeddedViewFactory(containerComment) !;
+      const container = getViewContainer(containerComment) !;
+      expect(viewContainerLength(container)).toBe(0);
+
+      const view1 = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view1, null);
+      expect(viewContainerLength(container)).toBe(1);
+
+
+      const view2 = embeddedViewFactory({});
+      viewContainerInsertAfter(container, view2, view1);
+      expect(viewContainerLength(container)).toBe(2);
+    });
+  });
+});

--- a/packages/platform-browser/animations/src/animation_renderer.ts
+++ b/packages/platform-browser/animations/src/animation_renderer.ts
@@ -8,6 +8,7 @@
 import {AnimationTriggerMetadata} from '@angular/animations';
 import {ɵAnimationEngine as AnimationEngine} from '@angular/animations/browser';
 import {Injectable, NgZone, Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2} from '@angular/core';
+import {getAddingEmbeddedRootChild, shouldUseIvyAnimationCheck} from '@angular/core/src/render3/state';
 
 const ANIMATION_PREFIX = '@';
 const DISABLE_ANIMATIONS_FLAG = '@.disabled';
@@ -140,12 +141,16 @@ export class BaseAnimationRenderer implements Renderer2 {
 
   appendChild(parent: any, newChild: any): void {
     this.delegate.appendChild(parent, newChild);
-    this.engine.onInsert(this.namespaceId, newChild, parent, false);
+    const shouldCollectEnterElement =
+        shouldUseIvyAnimationCheck() ? getAddingEmbeddedRootChild() : false;
+    this.engine.onInsert(this.namespaceId, newChild, parent, shouldCollectEnterElement);
   }
 
   insertBefore(parent: any, newChild: any, refChild: any): void {
     this.delegate.insertBefore(parent, newChild, refChild);
-    this.engine.onInsert(this.namespaceId, newChild, parent, true);
+    const shouldCollectEnterElement =
+        shouldUseIvyAnimationCheck() ? getAddingEmbeddedRootChild() : true;
+    this.engine.onInsert(this.namespaceId, newChild, parent, shouldCollectEnterElement);
   }
 
   removeChild(parent: any, oldChild: any, isHostElement: boolean): void {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -1630,7 +1630,7 @@ describe('Integration', () => {
          expect(location.path()).toEqual('/team/22');
          expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
-         const teamCmp = fixture.debugElement.childNodes[1].componentInstance;
+         const teamCmp = fixture.debugElement.childNodes[2].componentInstance;
 
          teamCmp.routerLink = ['/team/0'];
          advance(fixture);


### PR DESCRIPTION
Views were being added to containers in such a way that they were out of sync with the order their corresponding elements existed in the DOM (and in the templates). This caused issues with how query results would come back, specifically that they would be in seemingly arbitrary order based off of the order in which they were retrieved (and therefor set up). Another side effect of this is that change detection was processed in the aforementioned order.

The fix was to refactor the view container and view interaction APIs, and rework the logic where views were being added to the container and linked to one another.

This also switches from an "insert before" strategy to an "insert after" strategy for adding DOM nodes.

**Before**:

```html
<span>inserted 1</span><span>inserted 2</span><!-- container -->
```

**After**:

```html
<!-- container --><span>inserted 1</span><span>inserted 2</span>
```

This also uncovered an issue related to i18n that has been marked with `fixmeIvy('FW-1112: ...') ` in this PR. (attn @ocombe)

Thanks to @pkozlowski-opensource for the rapid assist with the query-related issue, @mhevery's guidance/ideas and @combe for helping track down what was going on with the i18n test marked for fixing.

### Update (2019-03-07) --------------

Everything was rebased as of last night at 8pm PST.

Two remaining known issue:

- There are a few tests marked `fixmeIvy('FW-????: ....')`, I plan on replacing that `????` with an actual Jira number when this PR is closer to landing.
- I have asked @ocombe to look into the remaining failing tests for i18n.

Because this is a large refactor, it's going to take a while to review and refine, so I'd like to get started with reviews prior to the above remaining issues being resolved.
