### PR TITLE
build(bazel): revert back to non-vendored yarn in node_repositories()

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,7 +51,7 @@ node_repositories(
     node_version = "10.9.0",
     package_json = ["//:package.json"],
     preserve_symlinks = True,
-    vendored_yarn = "@angular//third_party/github.com/yarnpkg/yarn/releases/download:v1.13.0",
+    yarn_version = "1.12.1",
 )
 
 # Setup the angular toolchain which installs npm dependencies into @ngdeps


### PR DESCRIPTION
Resolves Windows issue https://github.com/bazelbuild/rules_nodejs/issues/588
