### PR TITLE
build: use correct path to tslint rules

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,6 @@
 {
   "rulesDirectory": [
-    "dist/tools/tslint",
+    "tools/tslint",
     "node_modules/vrsource-tslint-rules/rules",
     "node_modules/tslint-eslint-rules/dist/rules"
   ],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The current rules point to the `dist/tools/tslint` directory which does not exist, even after running the build.

Issue Number: N/A


## What is the new behavior?
The rules point to `tools/tslint` directory which exists.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I ran into this while doing the Bazel training. Webstorm highlights the line with the path that cannot be resolved.