### PR TITLE
fix(ivy): replace templateUrl and styleUrls with resolved values in class metadata

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -283,6 +283,41 @@ export class ComponentDecoratorHandler implements
       animations = new WrappedNodeExpr(component.get('animations') !);
     }
 
+    // Replace `templateUrl` and `styleUrls` with resolved content in class metadata.
+    // This is needed to let AOT-compiled components be recompiled in JIT mode when some metadata
+    // changes as a result of overrides application.
+    // TODO(FW-1104): method is not efficient and we should revist that: TestBed overrides should
+    // not require full Component recompilation.
+    const decoratorArgsOverrideFn = (args: ts.NodeArray<ts.ObjectLiteralElementLike>):
+                                        ts.NodeArray<ts.ObjectLiteralElementLike> => {
+      const hasTemplateUrl = component.has('templateUrl');
+      const hasStyleUrls = styleUrls && styleUrls.length > 0;
+
+      // Filter out fields related to external resources
+      const overriddenArgs = args.filter((arg) => {
+        if (ts.isPropertyAssignment(arg) && ts.isIdentifier(arg.name)) {
+          const field = arg.name.text;
+          return field !== 'styleUrls' && field !== 'templateUrl' &&  //
+              !(field === 'styles' && hasStyleUrls) &&                //
+              !(field === 'template' && hasTemplateUrl);
+        }
+        return true;
+      });
+
+      // Append template content in case `templateUrl` field is present
+      if (hasTemplateUrl) {
+        const templateLiteral = ts.createLiteral(template.templateStr);
+        overriddenArgs.push(ts.createPropertyAssignment('template', templateLiteral));
+      }
+
+      // Append styles in case `styleUrls` field is present
+      if (hasStyleUrls) {
+        const stylesLiteral = ts.createArrayLiteral(styles !.map(style => ts.createLiteral(style)));
+        overriddenArgs.push(ts.createPropertyAssignment('styles', stylesLiteral));
+      }
+      return ts.createNodeArray(overriddenArgs);
+    };
+
     const output = {
       analysis: {
         meta: {
@@ -302,7 +337,8 @@ export class ComponentDecoratorHandler implements
           viewProviders,
           i18nUseExternalIds: this.i18nUseExternalIds, relativeContextFilePath
         },
-        metadataStmt: generateSetClassMetadataCall(node, this.reflector, this.isCore),
+        metadataStmt: generateSetClassMetadataCall(
+            node, this.reflector, this.isCore, decoratorArgsOverrideFn),
         parsedTemplate: template.nodes,
       },
       typeCheck: true,
@@ -541,7 +577,7 @@ export class ComponentDecoratorHandler implements
     }
 
     return {
-        interpolation, ...parseTemplate(templateStr, templateUrl, {
+        templateStr, interpolation, ...parseTemplate(templateStr, templateUrl, {
           preserveWhitespaces,
           interpolationConfig: interpolation,
           range: templateRange, escapedString
@@ -608,4 +644,5 @@ interface ParsedTemplate {
   nodes: TmplAstNode[];
   styleUrls: string[];
   styles: string[];
+  templateStr: string;
 }


### PR DESCRIPTION
AOT-compiled components preserve templateUrl and styleUrls values defined in @Component decorator's argument. That is causing problems in TestBed, since we need to have a way of recompiling components in case metadata is changed (as a part of applying overrides in tests). As a result, while recompiling components using JIT compiler, we try to fetch resources again, which is causing errors.

Current solution replaces templateUrl and styleUrls with corresponding resolved values to let JIT recompile components. Moving forward we should replace this with more granular recompilation/updates of component metadata.

This PR resolves FW-1103.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No