### PR TITLE
fix(ivy): track cyclic imports that are added

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {R3TargetBinder, SelectorMatcher, TmplAstNode} from '@angular/compiler';
+import {BoundTarget} from '@angular/compiler';
 import * as ts from 'typescript';
 
 import {NoopImportRewriter, ReferenceEmitter} from '../../imports';
@@ -47,21 +47,12 @@ export class TypeCheckContext {
    * @param template AST nodes of the template being recorded.
    * @param matcher `SelectorMatcher` which tracks directives that are in scope for this template.
    */
-  addTemplate(
-      node: ts.ClassDeclaration, template: TmplAstNode[],
-      matcher: SelectorMatcher<TypeCheckableDirectiveMeta>): void {
+  addTemplate(node: ts.ClassDeclaration, boundTarget: BoundTarget<TypeCheckableDirectiveMeta>):
+      void {
     // Only write TCBs for named classes.
     if (node.name === undefined) {
       throw new Error(`Assertion: class must be named`);
     }
-
-    // Bind the template, which will:
-    //   - Extract the metadata needed to generate type check blocks.
-    //   - Perform directive matching, which informs the context which directives are used in the
-    //     template. This allows generation of type constructors for only those directives which
-    //     are actually used by the templates.
-    const binder = new R3TargetBinder(matcher);
-    const boundTarget = binder.bind({template});
 
     // Get all of the directives used in the template and record type constructors for all of them.
     boundTarget.getUsedDirectives().forEach(dir => {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2020,6 +2020,41 @@ describe('ngtsc behavioral tests', () => {
               /i\d\.ɵsetComponentScope\(NormalComponent,\s+\[NormalComponent,\s+CyclicComponent\],\s+\[\]\)/);
       expect(jsContents).not.toContain('/*__PURE__*/ i0.ɵsetComponentScope');
     });
+
+    it('should detect a cycle added entirely during compilation', () => {
+      env.tsconfig();
+      env.write('test.ts', `
+        import {NgModule} from '@angular/core';
+        import {ACmp} from './a';
+        import {BCmp} from './b';
+
+        @NgModule({declarations: [ACmp, BCmp]})
+        export class Module {}
+      `);
+      env.write('a.ts', `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'a-cmp',
+          template: '<b-cmp></b-cmp>',
+        })
+        export class ACmp {}
+      `);
+      env.write('b.ts', `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'b-cmp',
+          template: '<a-cmp></a-cmp>',
+        })
+        export class BCmp {}
+      `);
+      env.driveMain();
+      const aJsContents = env.getContents('a.js');
+      const bJsContents = env.getContents('b.js');
+      expect(aJsContents).toMatch(/import \* as i\d? from ".\/b"/);
+      expect(bJsContents).not.toMatch(/import \* as i\d? from ".\/a"/);
+    });
   });
 
   describe('multiple local refs', () => {

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -136,4 +136,9 @@ export interface BoundTarget<DirectiveT extends DirectiveMeta> {
    * Get a list of all the directives used by the target.
    */
   getUsedDirectives(): DirectiveT[];
+
+  /**
+   * Get a list of all the pipes used by the target.
+   */
+  getUsedPipes(): string[];
 }


### PR DESCRIPTION
ngtsc has cyclic import detection, to determine when adding an import to a
directive or pipe would create a cycle. However, this detection must also
account for already inserted imports, as it's possible for both directions
of a circular import to be inserted by Ivy (as opposed to at least one of
those edges existing in the user's program).

This commit fixes the circular import detection for components to take into
consideration already added edges.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
