### PR TITLE
remove default setting: pinch and rotate event as enabled on hammerjs

### DIFF
--- a/packages/platform-browser/src/dom/events/hammer_gestures.ts
+++ b/packages/platform-browser/src/dom/events/hammer_gestures.ts
@@ -139,9 +139,6 @@ export class HammerGestureConfig {
   buildHammer(element: HTMLElement): HammerInstance {
     const mc = new Hammer !(element, this.options);
 
-    mc.get('pinch').set({enable: true});
-    mc.get('rotate').set({enable: true});
-
     for (const eventName in this.overrides) {
       mc.get(eventName).set(this.overrides[eventName]);
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ x ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://stackoverflow.com/questions/41017202/vertical-scroll-is-not-working-with-hammerjs-and-angular2
https://github.com/hammerjs/hammer.js/issues/1014#issuecomment-372513548
Issue Number: N/A
Hammerjs event got blocked because `pinch` and `rotate` events are enabled. 
From http://hammerjs.github.io/getting-started/ website:

![screenshot from 2019-02-28 22-57-29](https://user-images.githubusercontent.com/14946674/53604831-e7778580-3bb5-11e9-9d6f-4515c11335f5.png)

## What is the new behavior?
HammerJS events no longer got blocked.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
