### PR TITLE
docs: update developer guide for testing and IntelliJ

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -85,12 +85,15 @@ To build Angular run:
 
 Bazel is used as the primary tool for building and testing Angular. Building and testing is
 incremental with Bazel, and it's possible to only run tests for an individual package instead
-of for all packages.
+of for all packages. Read more about this in the [BAZEL.md](./BAZEL.md) document. 
 
-Read more about this in the [BAZEL.md](./BAZEL.md) document. You should execute all test suites
-before submitting a PR to Github.
+You should execute all test suites before submitting a PR to GitHub:
+- `yarn bazel test packages/...`
 
-All the tests are executed on our Continuous Integration infrastructure and a PR could only be
+**Note**: The first test run will be much slower than future runs. This is because future runs will
+benefit from Bazel's capability to do incremental builds. 
+
+All the tests are executed on our Continuous Integration infrastructure. PRs can only be
 merged if the code is formatted properly and all tests are passing.
 
 ## <a name="clang-format"></a> Formatting your source code
@@ -108,6 +111,13 @@ A better way is to set up your IDE to format the changed file on each file save.
 1. Install [Clang-Format](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format) extension for VS Code.
 
 It will automatically pick up the settings from Angular's [settings.json](../.vscode/settings.json).
+
+### WebStorm / IntelliJ
+1. Install the [ClangFormatIJ](https://plugins.jetbrains.com/plugin/8396-clangformatij) plugin
+1. Open `Preferences->Tools->clang-format`
+1. Find the field named "PATH"
+1. Add `<PATH_TO_YOUR_WORKSPACE>/angular/node_modules/clang-format/bin/<OS>/`
+  where the OS options are: `darwin_x64`, `linux_x64`, and `win32`.
 
 ## Linting/verifying your source code
 
@@ -128,17 +138,17 @@ You may find that your un-merged change needs some validation from external part
 Rather than requiring them to pull your Pull Request and build Angular locally, you can
 publish the `*-builds` snapshots just like our CircleCI build does.
 
-First time, you need to create the github repositories:
+First time, you need to create the GitHub repositories:
 
 ``` shell
 $ export TOKEN=[get one from https://github.com/settings/tokens]
-$ CREATE_REPOS=1 ./scripts/ci/publish-build-artifacts.sh [github username]
+$ CREATE_REPOS=1 ./scripts/ci/publish-build-artifacts.sh [GitHub username]
 ```
 
 For subsequent snapshots, just run
 
 ``` shell
-$ ./scripts/ci/publish-build-artifacts.sh [github username]
+$ ./scripts/ci/publish-build-artifacts.sh [GitHub username]
 ```
 
 The script will publish the build snapshot to a branch with the same name as your current branch,
@@ -148,3 +158,9 @@ and create it if it doesn't exist.
 ### VS Code
 
 1. Install [Bazel](https://marketplace.visualstudio.com/items?itemName=DevonDCarew.bazel-code) extension for VS Code.
+
+### WebStorm / IntelliJ
+1. Install the [Bazel](https://plugins.jetbrains.com/plugin/8609-bazel) plugin
+1. You can find the settings under `Preferences->Other Settings->Bazel Settings`
+
+It will automatically recognize `*.bazel` and `*.bzl` files.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
New contributors are told to run all test suites before submitting a PR, but then they have to go read a whole Bazel doc just to find that command.
There are plugin details about VS Code, but nothing for WebStorm and IntelliJ IDEs.

Issue Number: N/A


## What is the new behavior?

- provide the command for running all test suites
  - don't make new contributors read the whole Bazel doc
- add info about ClangFormatIJ plugin for IntelliJ
- add info about Bazel plugin for IntelliJ
- fix inconsistent casing of GitHub

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I am working on some blog posts for contributing to Angular and these issues stood out as some minor pain points.