### PR TITLE
fix(locales): allow coma as decimal separator in French

### DIFF
--- a/packages/common/locales/closure-locale.ts
+++ b/packages/common/locales/closure-locale.ts
@@ -1821,7 +1821,7 @@ export const locale_fi = [
 ];
 
 function plural_fr(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }
@@ -1899,7 +1899,7 @@ export const locale_fr = [
 ];
 
 function plural_fr_CA(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-BE.ts
+++ b/packages/common/locales/fr-BE.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-BF.ts
+++ b/packages/common/locales/fr-BF.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-BI.ts
+++ b/packages/common/locales/fr-BI.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-BJ.ts
+++ b/packages/common/locales/fr-BJ.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-BL.ts
+++ b/packages/common/locales/fr-BL.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-CA.ts
+++ b/packages/common/locales/fr-CA.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-CD.ts
+++ b/packages/common/locales/fr-CD.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-CF.ts
+++ b/packages/common/locales/fr-CF.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-CG.ts
+++ b/packages/common/locales/fr-CG.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-CH.ts
+++ b/packages/common/locales/fr-CH.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-CI.ts
+++ b/packages/common/locales/fr-CI.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-CM.ts
+++ b/packages/common/locales/fr-CM.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-DJ.ts
+++ b/packages/common/locales/fr-DJ.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-DZ.ts
+++ b/packages/common/locales/fr-DZ.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-GA.ts
+++ b/packages/common/locales/fr-GA.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-GF.ts
+++ b/packages/common/locales/fr-GF.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-GN.ts
+++ b/packages/common/locales/fr-GN.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-GP.ts
+++ b/packages/common/locales/fr-GP.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-GQ.ts
+++ b/packages/common/locales/fr-GQ.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-HT.ts
+++ b/packages/common/locales/fr-HT.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-KM.ts
+++ b/packages/common/locales/fr-KM.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-LU.ts
+++ b/packages/common/locales/fr-LU.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-MA.ts
+++ b/packages/common/locales/fr-MA.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-MC.ts
+++ b/packages/common/locales/fr-MC.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-MF.ts
+++ b/packages/common/locales/fr-MF.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-MG.ts
+++ b/packages/common/locales/fr-MG.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-ML.ts
+++ b/packages/common/locales/fr-ML.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-MQ.ts
+++ b/packages/common/locales/fr-MQ.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-MR.ts
+++ b/packages/common/locales/fr-MR.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-MU.ts
+++ b/packages/common/locales/fr-MU.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-NC.ts
+++ b/packages/common/locales/fr-NC.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-NE.ts
+++ b/packages/common/locales/fr-NE.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-PF.ts
+++ b/packages/common/locales/fr-PF.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-PM.ts
+++ b/packages/common/locales/fr-PM.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-RE.ts
+++ b/packages/common/locales/fr-RE.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-RW.ts
+++ b/packages/common/locales/fr-RW.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-SC.ts
+++ b/packages/common/locales/fr-SC.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-SN.ts
+++ b/packages/common/locales/fr-SN.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-SY.ts
+++ b/packages/common/locales/fr-SY.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-TD.ts
+++ b/packages/common/locales/fr-TD.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-TG.ts
+++ b/packages/common/locales/fr-TG.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-TN.ts
+++ b/packages/common/locales/fr-TN.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-VU.ts
+++ b/packages/common/locales/fr-VU.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-WF.ts
+++ b/packages/common/locales/fr-WF.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr-YT.ts
+++ b/packages/common/locales/fr-YT.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }

--- a/packages/common/locales/fr.ts
+++ b/packages/common/locales/fr.ts
@@ -12,7 +12,7 @@
 const u = undefined;
 
 function plural(n: number): number {
-  let i = Math.floor(Math.abs(n));
+  let i = Math.floor(Math.abs(parseFloat(n.toString().replace(',', '.'))));
   if (i === 0 || i === 1) return 1;
   return 5;
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
"1,5 litres" with an s is wrong in French, everything > -2 and < 2 is singular in French, and comma is the correct decimal separator in French


## What is the new behavior?
"1,5 litre" correct singular even using coma.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No