### PR TITLE
fix(ivy): correctly evaluate enum references in template expressions

### DIFF
--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -193,7 +193,10 @@ export class StaticInterpreter {
     const pieces: string[] = [node.head.text];
     for (let i = 0; i < node.templateSpans.length; i++) {
       const span = node.templateSpans[i];
-      const value = this.visit(span.expression, context);
+      let value = this.visit(span.expression, context);
+      if (value instanceof EnumValue) {
+        value = value.resolved;
+      }
       if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' ||
           value == null) {
         pieces.push(`${value}`);

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
@@ -307,6 +307,12 @@ describe('ngtsc metadata', () => {
     const prop = expr.properties[0] as ts.PropertyAssignment;
     expect(value.node).toBe(prop.initializer);
   });
+
+  it('should resolve enums in template expressions', () => {
+    const value =
+        evaluate(`enum Test { VALUE = 'test', } const value = \`a.\${Test.VALUE}.b\`;`, 'value');
+    expect(value).toBe('a.test.b');
+  });
 });
 
 function owningModuleOf(ref: Reference): string|null {


### PR DESCRIPTION
The ngtsc partial evaluator previously would not handle an enum reference
inside a template string expression correctly. Enums are resolved to an
`EnumValue` type, which has a `resolved` property with the actual value.

When effectively toString-ing a `ResolvedValue` as part of visiting a
template expression, the partial evaluator needs to translate `EnumValue`s
to their fully resolved value, which this commit does.