### PR TITLE
fix(ivy): attached flag not being reset when view is destroyed

### DIFF
--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -425,6 +425,10 @@ function cleanUpView(viewOrContainer: LView | LContainer): void {
   if ((viewOrContainer as LView).length >= HEADER_OFFSET) {
     const view = viewOrContainer as LView;
 
+    // Usually the Attached flag is removed when the view is detached from its parent, however
+    // if it's a root view, the flag won't be unset hence why we're also removing on destroy.
+    view[FLAGS] &= ~LViewFlags.Attached;
+
     // Mark the LView as destroyed *before* executing the onDestroy hooks. An onDestroy hook
     // runs arbitrary user code, which could include its own `viewRef.destroy()` (or similar). If
     // We don't flag the view as destroyed before the hooks, this could lead to an infinite loop.

--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -653,10 +653,6 @@ window.testBlocklist = {
     "error": "Error: Expected 'none' to be falsy.",
     "notes": "Unknown"
   },
-  "MatCalendar calendar with min and max date should update the minDate in the child view if it changed after an interaction": {
-    "error": "Error: This PortalOutlet has already been disposed",
-    "notes": "Unknown"
-  },
   "MatTable with basic data source should be able to create a table with the right content and without when row": {
     "error": "TypeError: Cannot read property 'querySelectorAll' of null",
     "notes": "Unknown"


### PR DESCRIPTION
Currently we only reset the `Attached` flag of a view if it is detached through its parent, however this means that if a root view is destroyed, its flag will never be reset. This manifested itself in one of the Material tests where we were destroying the root view.

This PR resolves FW-1130.