### PR TITLE
fix(ivy): change for-of to forEach for pipes represented with Map

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -371,9 +371,7 @@ export class ComponentDecoratorHandler implements
         for (const dir of directives) {
           this._recordSyntheticImport(dir.expression, context);
         }
-        for (const [name, pipe] of pipes) {
-          this._recordSyntheticImport(pipe, context);
-        }
+        pipes.forEach((pipe: Expression) => this._recordSyntheticImport(pipe, context));
 
         const binder = new R3TargetBinder(matcher);
         const bound = binder.bind({template: metadata.template.nodes});


### PR DESCRIPTION
This commit fixes the problem with using for-of for pipes represented with Map (by replacing it with forEach operation).

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No