### PR TITLE
docs: add NG-DE 2019 to events page

### DIFF
--- a/aio/content/marketing/events.html
+++ b/aio/content/marketing/events.html
@@ -31,6 +31,12 @@
       <td>Copenhagen, Denmark</td>
       <td>May 26th Workshops, 27-28 conference, 2019</td>
     </tr>
+    <!-- NG-DE 2019-->
+    <tr>
+      <th><a href="https://ng-de.org/" title="NG-DE">NG-DE</a></th>
+      <td>Berlin, Germany</td>
+      <td>August 29th workshops, 30-31 conference, 2019</td>
+    </tr>
     </tbody>
   </table>
 


### PR DESCRIPTION
docs: add NG-DE 2019 to events page
I'm part of the Team and I want NG-DE to be listed there as well.