### PR TITLE
ci: print sauce-connect log output on timeout

### DIFF
--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -54,6 +54,7 @@ else
   setPublicVar SAUCE_USERNAME "angular-ci";
   setSecretVar SAUCE_ACCESS_KEY "9b988f434ff8-fbca-8aa4-4ae3-35442987";
 fi
+setPublicVar SAUCE_LOG_FILE /tmp/angular/sauce-connect.log
 setPublicVar SAUCE_READY_FILE /tmp/angular/sauce-connect-ready-file.lock
 setPublicVar SAUCE_PID_FILE /tmp/angular/sauce-connect-pid-file.lock
 setPublicVar SAUCE_TUNNEL_IDENTIFIER "angular-${CIRCLE_BUILD_NUM}-${CIRCLE_NODE_INDEX}"

--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -7,6 +7,11 @@ readonly currentDir=$(cd $(dirname $0); pwd)
 # Command arguments that will be passed to sauce-connect.
 sauceArgs=""
 
+if [[ ! -z "${SAUCE_LOG_FILE:-}" ]]; then
+  mkdir -p $(dirname ${SAUCE_LOG_FILE})
+  sauceArgs="${sauceArgs} --logfile ${SAUCE_LOG_FILE}"
+fi
+
 if [[ ! -z "${SAUCE_READY_FILE:-}" ]]; then
   mkdir -p $(dirname ${SAUCE_READY_FILE})
   sauceArgs="${sauceArgs} --readyfile ${SAUCE_READY_FILE}"

--- a/scripts/saucelabs/wait-for-tunnel.sh
+++ b/scripts/saucelabs/wait-for-tunnel.sh
@@ -13,8 +13,10 @@ while [[ ! -f ${SAUCE_READY_FILE} ]]; do
   # Counter needs to be multiplied by two because the while loop only sleeps a half second.
   # This has been made in favor of better progress logging (printing dots every half second)
   if [ $counter -gt $[${SAUCE_READY_FILE_TIMEOUT} * 2] ]; then
+    echo "Timed out after ${SAUCE_READY_FILE_TIMEOUT} seconds waiting for tunnel ready file."
+    echo "Printing logfile output:"
     echo ""
-    echo "Timed out after ${SAUCE_READY_FILE_TIMEOUT} seconds waiting for tunnel ready file"
+    cat ${SAUCE_LOG_FILE}
     exit 5
   fi
 


### PR DESCRIPTION
Currently when `sauce-connect` times out after 2min, we just
print a message saying that the SauceLabs tunnel didn't establish
within 2min. In order to make debugging easier, we now print the
full log file output on failure.