### PR TITLE
docs(router): align examples in interfaces docs

### DIFF
--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -47,7 +47,7 @@ import {UrlSegment, UrlTree} from './url_tree';
  *     RouterModule.forRoot([
  *       {
  *         path: 'team/:id',
- *         component: TeamCmp,
+ *         component: TeamComponent,
  *         canActivate: [CanActivateTeam]
  *       }
  *     ])
@@ -65,7 +65,7 @@ import {UrlSegment, UrlTree} from './url_tree';
  *     RouterModule.forRoot([
  *       {
  *         path: 'team/:id',
- *         component: TeamCmp,
+ *         component: TeamComponent,
  *         canActivate: ['canActivateTeam']
  *       }
  *     ])
@@ -128,7 +128,7 @@ export type CanActivateFn = (route: ActivatedRouteSnapshot, state: RouterStateSn
  *         children: [
  *           {
  *              path: 'team/:id',
- *              component: Team
+ *              component: TeamComponent
  *           }
  *         ]
  *       }
@@ -151,7 +151,7 @@ export type CanActivateFn = (route: ActivatedRouteSnapshot, state: RouterStateSn
  *         children: [
  *           {
  *             path: 'team/:id',
- *             component: Team
+ *             component: TeamComponent
  *           }
  *         ]
  *       }
@@ -213,7 +213,7 @@ export type CanActivateChildFn = (childRoute: ActivatedRouteSnapshot, state: Rou
  *     RouterModule.forRoot([
  *       {
  *         path: 'team/:id',
- *         component: TeamCmp,
+ *         component: TeamComponent,
  *         canDeactivate: [CanDeactivateTeam]
  *       }
  *     ])
@@ -231,7 +231,7 @@ export type CanActivateChildFn = (childRoute: ActivatedRouteSnapshot, state: Rou
  *     RouterModule.forRoot([
  *       {
  *         path: 'team/:id',
- *         component: TeamCmp,
+ *         component: TeamComponent,
  *         canDeactivate: ['canDeactivateTeam']
  *       }
  *     ])
@@ -290,7 +290,7 @@ export type CanDeactivateFn<T> =
  *     RouterModule.forRoot([
  *       {
  *         path: 'team/:id',
- *         component: TeamCmp,
+ *         component: TeamComponent,
  *         resolve: {
  *           team: TeamResolver
  *         }
@@ -310,7 +310,7 @@ export type CanDeactivateFn<T> =
  *     RouterModule.forRoot([
  *       {
  *         path: 'team/:id',
- *         component: TeamCmp,
+ *         component: TeamComponent,
  *         resolve: {
  *           team: 'teamResolver'
  *         }
@@ -361,7 +361,7 @@ export interface Resolve<T> {
  *     RouterModule.forRoot([
  *       {
  *         path: 'team/:id',
- *         component: TeamCmp,
+ *         component: TeamComponent,
  *         loadChildren: 'team.js',
  *         canLoad: [CanLoadTeamSection]
  *       }
@@ -380,7 +380,7 @@ export interface Resolve<T> {
  *     RouterModule.forRoot([
  *       {
  *         path: 'team/:id',
- *         component: TeamCmp,
+ *         component: TeamComponent,
  *         loadChildren: 'team.js',
  *         canLoad: ['canLoadTeamSection']
  *       }


### PR DESCRIPTION
* Use exclusively `TeamComponent` class for examples, as currently there are at least 3 different component classes being used, one of which is a type argument for a `Resolve<T>` implementation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Inconsistent component class for examples

## What is the new behavior?

Examples are aligned by using the same component class

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
