### PR TITLE
test(ivy): remove ngComponentOutlet example with a lazy-loaded NgModule

### DIFF
--- a/packages/common/src/directives/ng_component_outlet.ts
+++ b/packages/common/src/directives/ng_component_outlet.ts
@@ -60,10 +60,6 @@ import {ComponentFactoryResolver, ComponentRef, Directive, Injector, Input, NgMo
  * A more complete example with additional options:
  *
  * {@example common/ngComponentOutlet/ts/module.ts region='CompleteExample'}
-
- * A more complete example with ngModuleFactory:
- *
- * {@example common/ngComponentOutlet/ts/module.ts region='NgModuleFactoryExample'}
  *
  * @publicApi
  * @ngModule CommonModule

--- a/packages/examples/common/ngComponentOutlet/ts/e2e_test/ngComponentOutlet_spec.ts
+++ b/packages/examples/common/ngComponentOutlet/ts/e2e_test/ngComponentOutlet_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {fixmeIvy, modifiedInIvy} from '@angular/private/testing';
+import {modifiedInIvy} from '@angular/private/testing';
 import {$, ExpectedConditions, browser, by, element} from 'protractor';
 
 import {verifyNoBrowserErrors} from '../../../../test-utils';
@@ -17,33 +17,24 @@ function waitForElement(selector: string) {
   browser.wait(EC.presenceOf($(selector)), 20000);
 }
 
-fixmeIvy('FW-1022: JitCompilerFactory creates incorrect compiler instance')
-    .describe('ngComponentOutlet', () => {
-      const URL = '/ngComponentOutlet';
-      afterEach(verifyNoBrowserErrors);
+describe('ngComponentOutlet', () => {
+  const URL = '/ngComponentOutlet';
+  afterEach(verifyNoBrowserErrors);
 
-      describe('ng-component-outlet-example', () => {
-        it('should render simple', () => {
+  describe('ng-component-outlet-example', () => {
+    it('should render simple', () => {
+      browser.get(URL);
+      waitForElement('ng-component-outlet-simple-example');
+      expect(element.all(by.css('hello-world')).getText()).toEqual(['Hello World!']);
+    });
+
+    modifiedInIvy('Different behavior for projectableNodes in ViewContainerRef.createComponent')
+        .it('should render complete', () => {
           browser.get(URL);
-          waitForElement('ng-component-outlet-simple-example');
-          expect(element.all(by.css('hello-world')).getText()).toEqual(['Hello World!']);
-        });
-
-        modifiedInIvy('Different behavior for projectableNodes in ViewContainerRef.createComponent')
-            .it('should render complete', () => {
-              browser.get(URL);
-              waitForElement('ng-component-outlet-complete-example');
-              expect(element.all(by.css('complete-component')).getText()).toEqual([
-                'Complete: AhojSvet!'
-              ]);
-            });
-
-        it('should render other module', () => {
-          browser.get(URL);
-          waitForElement('ng-component-outlet-other-module-example');
-          expect(element.all(by.css('other-module-component')).getText()).toEqual([
-            'Other Module Component!'
+          waitForElement('ng-component-outlet-complete-example');
+          expect(element.all(by.css('complete-component')).getText()).toEqual([
+            'Complete: AhojSvet!'
           ]);
         });
-      });
-    });
+  });
+});

--- a/packages/examples/common/ngComponentOutlet/ts/module.ts
+++ b/packages/examples/common/ngComponentOutlet/ts/module.ts
@@ -6,11 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CommonModule} from '@angular/common';
-import {COMPILER_OPTIONS, Compiler, CompilerFactory, Component, Injectable, Injector, NgModule, NgModuleFactory} from '@angular/core';
+import {Component, Injectable, Injector, NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
-import {JitCompilerFactory} from '@angular/platform-browser-dynamic';
-
 
 
 // #docregion SimpleExample
@@ -63,65 +60,23 @@ export class NgTemplateOutletCompleteExample {
 }
 // #enddocregion
 
-// #docregion NgModuleFactoryExample
-@Component({selector: 'other-module-component', template: `Other Module Component!`})
-export class OtherModuleComponent {
-}
-
-@Component({
-  selector: 'ng-component-outlet-other-module-example',
-  template: `
-    <ng-container *ngComponentOutlet="OtherModuleComponent;
-                                      ngModuleFactory: myModule;"></ng-container>`
-})
-export class NgTemplateOutletOtherModuleExample {
-  // This field is necessary to expose OtherModuleComponent to the template.
-  OtherModuleComponent = OtherModuleComponent;
-  myModule: NgModuleFactory<any>;
-
-  constructor(compiler: Compiler) { this.myModule = compiler.compileModuleSync(OtherModule); }
-}
-// #enddocregion
-
 
 @Component({
   selector: 'example-app',
   template: `<ng-component-outlet-simple-example></ng-component-outlet-simple-example>
              <hr/>
-             <ng-component-outlet-complete-example></ng-component-outlet-complete-example>
-             <hr/>
-             <ng-component-outlet-other-module-example></ng-component-outlet-other-module-example>`
+             <ng-component-outlet-complete-example></ng-component-outlet-complete-example>`
 })
 export class AppComponent {
 }
 
 @NgModule({
-  imports: [CommonModule],
-  declarations: [OtherModuleComponent],
-  entryComponents: [OtherModuleComponent]
-})
-export class OtherModule {
-}
-
-export function createCompiler(compilerFactory: CompilerFactory) {
-  return compilerFactory.createCompiler();
-}
-
-@NgModule({
   imports: [BrowserModule],
   declarations: [
-    AppComponent, NgTemplateOutletSimpleExample, NgTemplateOutletCompleteExample,
-    NgTemplateOutletOtherModuleExample, HelloWorld, CompleteComponent
+    AppComponent, NgTemplateOutletSimpleExample, NgTemplateOutletCompleteExample, HelloWorld,
+    CompleteComponent
   ],
-  entryComponents: [HelloWorld, CompleteComponent],
-  providers: [
-    // Setup the JIT compiler that is not set up by default because the examples
-    // are bootstrapped using their NgModule factory. Since this example uses the
-    // JIT compiler, we manually set it up for this module.
-    {provide: COMPILER_OPTIONS, useValue: {}, multi: true},
-    {provide: CompilerFactory, useClass: JitCompilerFactory, deps: [COMPILER_OPTIONS]},
-    {provide: Compiler, useFactory: createCompiler, deps: [CompilerFactory]}
-  ]
+  entryComponents: [HelloWorld, CompleteComponent]
 })
 export class AppModule {
 }


### PR DESCRIPTION
This PR _removes_ one of the existing examples and the associated e2e test. This might sound like a terrible thing to do (why would one remove an example from documentation???) but I will argue that this example does more harm than good.

There are multiple levels of problems with the code being demonstrated and the test setup, let me explain it step by step:

- the primary problem is in the API of `ngComponentOutlet` - this directive takes component `Type` and `NgModuleFactory` as `@Input()`s. Normally the  `Type` should be enough but in view engine it is not enough for lazy loaded modules. So `NgModuleFactory` was introduced to support components from lazy-loaded modules but this is wrong API - `componentFactoryResolver` should have been used instead as it would cover both regular and lazy-loaded modules;
- `Type` was used instead of `componentFactoryResolver` since dealing with `componentFactoryResolver` is less ergonomic as compared to simply using `Type`. But this limitation will go away in ivy so introducing `componentFactoryResolver` into `ngComponentOutlet` at this point would just confuse everyone;
- so we are stuck with `NgModuleFactory` before ivy is default but getting an instance of  `NgModuleFactory` in practice is super-difficult for an end-user - one either need to lazy-load it _or_ use a `Compiler` (as in the example being deleted). I don't think that we want to teach people usage of `Compiler` for lazy loaded modules so this is why I'm claiming that the current example does more harm than good (teaches `Compiler` instead of lazy loading).

With ivy all those workflows (lazy loading, dynamic component instantiation) will get dramatically simpler so there is no great value in building examples on broken APIs and overly complex workflows.

As such I'm proposing the following:
* pre-ivy - re-move the confusing example (this is done in this PR);
* post-ivy: depreciate `ngComponentOutletNgModuleFactory !: NgModuleFactory<any>;` input 