### PR TITLE
docs: fix minor typo

### DIFF
--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -428,7 +428,7 @@ to extract the setup variables that it needs.
 Many developers feel this approach is cleaner and more explicit than the
 traditional `beforeEach()` style.
 
-Although this testing guide follows the tradition style and
+Although this testing guide follows the traditional style and
 the default [CLI schematics](https://github.com/angular/angular-cli)
 generate test files with `beforeEach()` and `TestBed`,
 feel free to adopt _this alternative approach_ in your own projects.


### PR DESCRIPTION
There is a minor typo in the docs: tradition -> traditional

