### PR TITLE
ci: bazel saucelabs test job does not setup circleci bazelrc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,7 @@ jobs:
     steps:
       - *attach_workspace
       - *init_environment
+      - *setup_circleci_bazel_config
       - run:
           name: Preparing environment for running tests on Saucelabs.
           command: setSecretVar SAUCE_ACCESS_KEY $(echo $SAUCE_ACCESS_KEY | rev)


### PR DESCRIPTION
Currently the `test_saucelabs` job does not use our general
CircleCI bazel configuration. We should set this configuration
up, as it enables better logging, better use of the `xlarge`
resource class, and also sets up Bazel's integrated flakiness
retry functionality.