### PR TITLE
ci: saucelabs-legacy job should not run schematic core tests

### DIFF
--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -32,6 +32,7 @@
     "bazel",
     "common/locales",
     "compiler-cli/integrationtest",
+    "core/schematics",
     "elements/schematics",
     // Do not build the example e2e spec files since those require custom typings and
     // aren't required to build all packages.


### PR DESCRIPTION
With 62157990554306fb76e1e254b31855f966ff65f2 we introduced schematics for `core`, but due to
the fact the Saucelabs legacy job does not run for PRs, we didn't realize
that the legacy Saucelabs job ends up running the schematic specs.

We don't want to run these schematic tests in the legacy-saucelabs job,
as these are node-only specs and the non-Bazel Karma setup is not set
up to provide the devkit schematic node modules.

We exclude the schematics folder in the `core` package in the
legacy-build tsconfig file (similar to how it is done for elements)