### PR TITLE
test(ivy): fix export tests to work in IE

### DIFF
--- a/packages/core/test/acceptance/exports_spec.ts
+++ b/packages/core/test/acceptance/exports_spec.ts
@@ -43,19 +43,20 @@ describe('exports', () => {
   describe('input changes in hooks', () => {
     it('should support forward reference', () => {
       const fixture = initWithTemplate(
-          AppComp, '<div dirOnChange #myDir="dirOnChange" [in]="true"></div> {{ myDir.name }}');
+          AppComp, '<div dir-on-change #myDir="dirOnChange" [in]="true"></div> {{ myDir.name }}');
       fixture.detectChanges();
       expect(fixture.nativeElement.innerHTML)
-          .toEqual('<div dironchange="" ng-reflect-in="true" title="Drew!?@"></div> Drew!?@');
+          .toEqual('<div dir-on-change="" ng-reflect-in="true" title="Drew!?@"></div> Drew!?@');
     });
 
     modifiedInIvy('Supporting input changes in hooks is limited in Ivy')
         .it('should support backward reference', () => {
           const fixture = initWithTemplate(
-              AppComp, '{{ myDir.name }} <div dirOnChange #myDir="dirOnChange" [in]="true"></div>');
+              AppComp,
+              '{{ myDir.name }} <div dir-on-change #myDir="dirOnChange" [in]="true"></div>');
           fixture.detectChanges();
           expect(fixture.nativeElement.innerHTML)
-              .toEqual('Drew!?@ <div dironchange="" ng-reflect-in="true" title="Drew!?@"></div>');
+              .toEqual('Drew!?@ <div dir-on-change="" ng-reflect-in="true" title="Drew!?@"></div>');
         });
 
     onlyInIvy('Supporting input changes in hooks is limited in Ivy')
@@ -63,7 +64,7 @@ describe('exports', () => {
           expect(() => {
             const fixture = initWithTemplate(
                 AppComp,
-                '{{ myDir.name }} <div dirOnChange #myDir="dirOnChange" [in]="true"></div>');
+                '{{ myDir.name }} <div dir-on-change #myDir="dirOnChange" [in]="true"></div>');
             fixture.detectChanges();
           })
               .toThrowError(
@@ -74,11 +75,11 @@ describe('exports', () => {
         .it('should support reference on the same node', () => {
           const fixture = initWithTemplate(
               AppComp,
-              '<div dirOnChange #myDir="dirOnChange" [in]="true" [id]="myDir.name"></div>');
+              '<div dir-on-change #myDir="dirOnChange" [in]="true" [id]="myDir.name"></div>');
           fixture.detectChanges();
           expect(fixture.nativeElement.innerHTML)
               .toEqual(
-                  '<div dironchange="" ng-reflect-in="true" id="Drew!?@" title="Drew!?@"></div>');
+                  '<div dir-on-change="" ng-reflect-in="true" id="Drew!?@" title="Drew!?@"></div>');
         });
 
     onlyInIvy('Supporting input changes in hooks is limited in Ivy')
@@ -86,7 +87,7 @@ describe('exports', () => {
           expect(() => {
             const fixture = initWithTemplate(
                 AppComp,
-                '<div dirOnChange #myDir="dirOnChange" [in]="true" [id]="myDir.name"></div>');
+                '<div dir-on-change #myDir="dirOnChange" [in]="true" [id]="myDir.name"></div>');
             fixture.detectChanges();
           })
               .toThrowError(
@@ -95,10 +96,10 @@ describe('exports', () => {
 
     it('should support input referenced by host binding on that directive', () => {
       const fixture =
-          initWithTemplate(AppComp, '<div dirOnChange #myDir="dirOnChange" [in]="true"></div>');
+          initWithTemplate(AppComp, '<div dir-on-change #myDir="dirOnChange" [in]="true"></div>');
       fixture.detectChanges();
       expect(fixture.nativeElement.innerHTML)
-          .toEqual('<div dironchange="" ng-reflect-in="true" title="Drew!?@"></div>');
+          .toEqual('<div dir-on-change="" ng-reflect-in="true" title="Drew!?@"></div>');
     });
   });
 
@@ -162,7 +163,7 @@ class DirWithCompInput {
   @Input('dirWithInput') comp: ComponentToReference|null = null;
 }
 
-@Directive({selector: '[dirOnChange]', exportAs: 'dirOnChange', host: {'[title]': 'name'}})
+@Directive({selector: '[dir-on-change]', exportAs: 'dirOnChange', host: {'[title]': 'name'}})
 class DirToReferenceWithPreOrderHooks implements OnInit, OnChanges, DoCheck {
   @Input() in : any = null;
   name = 'Drew';


### PR DESCRIPTION
Some of the export tests had assertions that relied on capitalization
of attributes in the DOM. IE treats capitalization somewhat differently,
so our SauceLabs tests were failing.

This commit tweaks the tests so that the assertions do not rely on
attributes to be capitalized or not.
