### PR TITLE
fix(ivy): properly detect "inputs" and "outputs" field names that should be wrapped in quotes

### DIFF
--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2167,21 +2167,34 @@ describe('ngtsc behavioral tests', () => {
   it('should wrap "inputs" and "outputs" keys if they contain unsafe characters', () => {
     env.tsconfig({});
     env.write(`test.ts`, `
-      import {Directive} from '@angular/core';
+      import {Directive, Input} from '@angular/core';
 
       @Directive({
         selector: '[somedir]',
-        inputs: ['input-track-type', 'inputTrackName'],
-        outputs: ['output-track-type', 'outputTrackName']
+        inputs: ['track-type', 'track-name', 'inputTrackName'],
+        outputs: ['output-track-type', 'output-track-name', 'outputTrackName']
       })
-      export class SomeDir {}
+      export class SomeDir {
+        @Input('track-type') trackType: string;
+        @Input('track-name') trackName: string;
+      }
     `);
 
     env.driveMain();
     const jsContents = env.getContents('test.js');
     const inputsAndOutputs = `
-      inputs: { "input-track-type": "input-track-type", inputTrackName: "inputTrackName" },
-      outputs: { "output-track-type": "output-track-type", outputTrackName: "outputTrackName" }
+      inputs: {
+        "track-type": "track-type",
+        "track-name": "track-name",
+        inputTrackName: "inputTrackName",
+        trackType: ["track-type", "trackType"],
+        trackName: ["track-name", "trackName"]
+      },
+      outputs: {
+        "output-track-type": "output-track-type",
+        "output-track-name": "output-track-name",
+        outputTrackName: "outputTrackName"
+      }
     `;
     expect(trim(jsContents)).toContain(trim(inputsAndOutputs));
   });

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -21,7 +21,7 @@ import {isI18nAttribute} from './i18n/util';
  * TODO(FW-1136): this is a temporary solution, we need to come up with a better way of working with
  * inputs that contain potentially unsafe chars.
  */
-const UNSAFE_OBJECT_KEY_NAME_REGEXP = /-/g;
+const UNSAFE_OBJECT_KEY_NAME_REGEXP = /-/;
 
 /** Name of the temporary to use during data binding */
 export const TEMPORARY_NAME = '_t';


### PR DESCRIPTION
Prior to this change, the RegExp that was used to check for dashes in field names used "g" (global) flag that retains lastIndex, which might result in skipping some fields that should be wrapped in quotes (since lastIndex advanced beyond the next "-" location). This commit removes this flag and updates the test to make sure there are no regressions.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No