### PR TITLE
fix(ivy): avoid innerHTML usage in exports test (to make it work in IE11)

### DIFF
--- a/packages/core/test/acceptance/exports_spec.ts
+++ b/packages/core/test/acceptance/exports_spec.ts
@@ -45,8 +45,8 @@ describe('exports', () => {
       const fixture = initWithTemplate(
           AppComp, '<div dir-on-change #myDir="dirOnChange" [in]="true"></div> {{ myDir.name }}');
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual('<div dir-on-change="" ng-reflect-in="true" title="Drew!?@"></div> Drew!?@');
+      expect(fixture.nativeElement.firstChild.title).toBe('Drew!?@');            // div element
+      expect(fixture.nativeElement.lastChild.textContent).toContain('Drew!?@');  // text node
     });
 
     modifiedInIvy('Supporting input changes in hooks is limited in Ivy')
@@ -55,8 +55,8 @@ describe('exports', () => {
               AppComp,
               '{{ myDir.name }} <div dir-on-change #myDir="dirOnChange" [in]="true"></div>');
           fixture.detectChanges();
-          expect(fixture.nativeElement.innerHTML)
-              .toEqual('Drew!?@ <div dir-on-change="" ng-reflect-in="true" title="Drew!?@"></div>');
+          expect(fixture.nativeElement.firstChild.textContent).toContain('Drew!?@');  // text node
+          expect(fixture.nativeElement.lastChild.title).toBe('Drew!?@');              // div element
         });
 
     onlyInIvy('Supporting input changes in hooks is limited in Ivy')
@@ -77,9 +77,8 @@ describe('exports', () => {
               AppComp,
               '<div dir-on-change #myDir="dirOnChange" [in]="true" [id]="myDir.name"></div>');
           fixture.detectChanges();
-          expect(fixture.nativeElement.innerHTML)
-              .toEqual(
-                  '<div dir-on-change="" ng-reflect-in="true" id="Drew!?@" title="Drew!?@"></div>');
+          expect(fixture.nativeElement.firstChild.id).toBe('Drew!?@');
+          expect(fixture.nativeElement.firstChild.title).toBe('Drew!?@');
         });
 
     onlyInIvy('Supporting input changes in hooks is limited in Ivy')
@@ -98,8 +97,7 @@ describe('exports', () => {
       const fixture =
           initWithTemplate(AppComp, '<div dir-on-change #myDir="dirOnChange" [in]="true"></div>');
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML)
-          .toEqual('<div dir-on-change="" ng-reflect-in="true" title="Drew!?@"></div>');
+      expect(fixture.nativeElement.firstChild.title).toBe('Drew!?@');
     });
   });
 


### PR DESCRIPTION
Some tests in exports spec rely on the exact output of innerHTML. In IE11 the order of attributes might change, thus causing tests to fail (in case an element contains more than one attribute). This commit avoids innerHTML usage and performs the necessary checks via element properties.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No