### PR TITLE
build: enable dts bundling by default for public api

### DIFF
--- a/packages/animations/BUILD.bazel
+++ b/packages/animations/BUILD.bazel
@@ -10,7 +10,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages/core",
     ],

--- a/packages/animations/browser/BUILD.bazel
+++ b/packages/animations/browser/BUILD.bazel
@@ -12,7 +12,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages/animations",
         "//packages/core",

--- a/packages/animations/browser/testing/BUILD.bazel
+++ b/packages/animations/browser/testing/BUILD.bazel
@@ -7,7 +7,6 @@ exports_files(["package.json"])
 ng_module(
     name = "testing",
     srcs = glob(["**/*.ts"]),
-    bundle_dts = True,
     deps = [
         "//packages/animations",
         "//packages/animations/browser",

--- a/packages/bazel/test/ng_package/example/BUILD.bazel
+++ b/packages/bazel/test/ng_package/example/BUILD.bazel
@@ -5,7 +5,6 @@ package(default_visibility = ["//packages/bazel/test:__subpackages__"])
 ng_module(
     name = "example",
     srcs = glob(["*.ts"]),
-    bundle_dts = True,
     module_name = "example",
     deps = [
         "//packages/bazel/test/ng_package/example/secondary",

--- a/packages/common/BUILD.bazel
+++ b/packages/common/BUILD.bazel
@@ -10,7 +10,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages/core",
         "@npm//rxjs",

--- a/packages/common/http/BUILD.bazel
+++ b/packages/common/http/BUILD.bazel
@@ -12,7 +12,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages/common",
         "//packages/core",

--- a/packages/common/http/testing/BUILD.bazel
+++ b/packages/common/http/testing/BUILD.bazel
@@ -12,7 +12,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages/common/http",
         "//packages/core",

--- a/packages/common/testing/BUILD.bazel
+++ b/packages/common/testing/BUILD.bazel
@@ -7,7 +7,6 @@ exports_files(["package.json"])
 ng_module(
     name = "testing",
     srcs = glob(["**/*.ts"]),
-    bundle_dts = True,
     deps = [
         "//packages/common",
         "//packages/core",

--- a/packages/compiler/testing/BUILD.bazel
+++ b/packages/compiler/testing/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
         ["**/*.ts"],
         exclude = ["testing.ts"],
     ),
+    bundle_dts = False,
     deps = [
         "//packages:types",
         "//packages/compiler",

--- a/packages/compiler/testing/BUILD.bazel
+++ b/packages/compiler/testing/BUILD.bazel
@@ -10,6 +10,7 @@ ng_module(
         ["**/*.ts"],
         exclude = ["testing.ts"],
     ),
+    # compiler package is built using ts_library which doesn't support bundling yet.
     bundle_dts = False,
     deps = [
         "//packages:types",

--- a/packages/core/BUILD.bazel
+++ b/packages/core/BUILD.bazel
@@ -10,6 +10,8 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
+    # PR to support this https://github.com/angular/angular/pull/28884
+    bundle_dts = False,
     deps = [
         "//packages:types",
         "//packages/core/src/compiler",

--- a/packages/core/testing/BUILD.bazel
+++ b/packages/core/testing/BUILD.bazel
@@ -9,6 +9,8 @@ ng_module(
     srcs = glob(
         ["**/*.ts"],
     ),
+    # PR to support this https://github.com/angular/angular/pull/28884
+    bundle_dts = False,
     deps = [
         "//packages:types",
         "//packages/compiler",

--- a/packages/elements/BUILD.bazel
+++ b/packages/elements/BUILD.bazel
@@ -10,7 +10,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/packages/http/BUILD.bazel
+++ b/packages/http/BUILD.bazel
@@ -10,7 +10,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/packages/http/testing/BUILD.bazel
+++ b/packages/http/testing/BUILD.bazel
@@ -7,7 +7,6 @@ exports_files(["package.json"])
 ng_module(
     name = "testing",
     srcs = glob(["**/*.ts"]),
-    bundle_dts = True,
     deps = [
         "//packages/core",
         "//packages/http",

--- a/packages/platform-browser-dynamic/BUILD.bazel
+++ b/packages/platform-browser-dynamic/BUILD.bazel
@@ -10,7 +10,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages:types",
         "//packages/common",

--- a/packages/platform-browser-dynamic/testing/BUILD.bazel
+++ b/packages/platform-browser-dynamic/testing/BUILD.bazel
@@ -7,7 +7,6 @@ exports_files(["package.json"])
 ng_module(
     name = "testing",
     srcs = glob(["**/*.ts"]),
-    bundle_dts = True,
     deps = [
         "//packages/compiler",
         "//packages/compiler/testing",

--- a/packages/platform-browser/BUILD.bazel
+++ b/packages/platform-browser/BUILD.bazel
@@ -10,7 +10,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages:types",
         "//packages/common",

--- a/packages/platform-browser/animations/BUILD.bazel
+++ b/packages/platform-browser/animations/BUILD.bazel
@@ -12,7 +12,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages/animations",
         "//packages/animations/browser",

--- a/packages/platform-browser/testing/BUILD.bazel
+++ b/packages/platform-browser/testing/BUILD.bazel
@@ -7,7 +7,6 @@ exports_files(["package.json"])
 ng_module(
     name = "testing",
     srcs = glob(["**/*.ts"]),
-    bundle_dts = True,
     deps = [
         "//packages/core",
         "//packages/core/testing",

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -10,7 +10,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages/animations/browser",
         "//packages/common",

--- a/packages/platform-server/testing/BUILD.bazel
+++ b/packages/platform-server/testing/BUILD.bazel
@@ -7,7 +7,6 @@ exports_files(["package.json"])
 ng_module(
     name = "testing",
     srcs = glob(["**/*.ts"]),
-    bundle_dts = True,
     deps = [
         "//packages/core",
         "//packages/platform-browser-dynamic/testing",

--- a/packages/platform-webworker-dynamic/BUILD.bazel
+++ b/packages/platform-webworker-dynamic/BUILD.bazel
@@ -10,7 +10,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages:types",
         "//packages/common",

--- a/packages/platform-webworker/BUILD.bazel
+++ b/packages/platform-webworker/BUILD.bazel
@@ -10,7 +10,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages:types",
         "//packages/common",

--- a/packages/router/BUILD.bazel
+++ b/packages/router/BUILD.bazel
@@ -10,7 +10,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages/common",
         "//packages/core",

--- a/packages/router/testing/BUILD.bazel
+++ b/packages/router/testing/BUILD.bazel
@@ -7,7 +7,6 @@ exports_files(["package.json"])
 ng_module(
     name = "testing",
     srcs = glob(["**/*.ts"]),
-    bundle_dts = True,
     deps = [
         "//packages/common",
         "//packages/common/testing",

--- a/packages/router/upgrade/BUILD.bazel
+++ b/packages/router/upgrade/BUILD.bazel
@@ -12,7 +12,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages/common",
         "//packages/core",

--- a/packages/service-worker/BUILD.bazel
+++ b/packages/service-worker/BUILD.bazel
@@ -10,7 +10,6 @@ ng_module(
             "src/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages/common",
         "//packages/core",

--- a/packages/service-worker/config/BUILD.bazel
+++ b/packages/service-worker/config/BUILD.bazel
@@ -13,6 +13,5 @@ ng_module(
         "*.ts",
         "src/**/*.ts",
     ]),
-    bundle_dts = True,
     deps = ["//packages/core"],
 )

--- a/packages/upgrade/BUILD.bazel
+++ b/packages/upgrade/BUILD.bazel
@@ -11,7 +11,6 @@ ng_module(
             "src/dynamic/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/packages/upgrade/static/BUILD.bazel
+++ b/packages/upgrade/static/BUILD.bazel
@@ -15,7 +15,6 @@ ng_module(
             "src/static/**/*.ts",
         ],
     ),
-    bundle_dts = True,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -99,7 +99,7 @@ def ts_library(tsconfig = None, testonly = False, deps = [], module_name = None,
         **kwargs
     )
 
-def ng_module(name, tsconfig = None, entry_point = None, testonly = False, deps = [], module_name = None, **kwargs):
+def ng_module(name, tsconfig = None, entry_point = None, testonly = False, deps = [], module_name = None, bundle_dts = True, **kwargs):
     """Default values for ng_module"""
     deps = deps + ["@npm//tslib"]
     if testonly:
@@ -121,6 +121,7 @@ def ng_module(name, tsconfig = None, entry_point = None, testonly = False, deps 
         tsconfig = tsconfig,
         entry_point = entry_point,
         testonly = testonly,
+        bundle_dts = bundle_dts,
         deps = deps,
         compiler = _INTERNAL_NG_MODULE_COMPILER,
         ng_xi18n = _INTERNAL_NG_MODULE_XI18N,


### PR DESCRIPTION
- build: turn off dts bundling for packages that still are not supported

- build: enable dts bundling by default for public facing packages
With this change dts bundling is turned on by default for public facing packages
 
- build: remove now redundant `bundle_dts = True` attribute
This is now turned on by default in the ng_module macro