### PR TITLE
FW-1064 don't modify TNode next pointer when projecting nodes 

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -1308,6 +1308,7 @@ export function createTNode(
     outputs: undefined,
     tViews: null,
     next: null,
+    projectionNext: null,
     child: null,
     parent: tParent,
     stylingTemplate: null,
@@ -2550,26 +2551,24 @@ export function projectionDef(selectors?: CssSelectorList[], textSelectors?: str
 
   if (!componentNode.projection) {
     const noOfNodeBuckets = selectors ? selectors.length + 1 : 1;
-    const pData: (TNode | null)[] = componentNode.projection =
+    const projectionHeads: (TNode | null)[] = componentNode.projection =
         new Array(noOfNodeBuckets).fill(null);
-    const tails: (TNode | null)[] = pData.slice();
+    const tails: (TNode | null)[] = projectionHeads.slice();
 
     let componentChild: TNode|null = componentNode.child;
 
     while (componentChild !== null) {
       const bucketIndex =
           selectors ? matchingSelectorIndex(componentChild, selectors, textSelectors !) : 0;
-      const nextNode = componentChild.next;
 
       if (tails[bucketIndex]) {
-        tails[bucketIndex] !.next = componentChild;
+        tails[bucketIndex] !.projectionNext = componentChild;
       } else {
-        pData[bucketIndex] = componentChild;
+        projectionHeads[bucketIndex] = componentChild;
       }
-      componentChild.next = null;
       tails[bucketIndex] = componentChild;
 
-      componentChild = nextNode;
+      componentChild = componentChild.next;
     }
   }
 }

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -284,6 +284,14 @@ export interface TNode {
   next: TNode|null;
 
   /**
+   * The next projected sibling. Since in Angular content projection works on the node-by-node basis
+   * the act of projecting nodes might change nodes relationship at the insertion point (target
+   * view). At the same time we need to keep initial relationship between nodes as expressed in
+   * content view.
+   */
+  projectionNext: TNode|null;
+
+  /**
    * First child of the current node.
    *
    * For component nodes, the child will always be a ContentChild (in same view).

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -329,6 +329,39 @@ class TestCmpt {
       expect(getDOM().hasClass(childTestEls[3].nativeElement, 'childnested')).toBe(true);
     });
 
+    it('should query projected child elements by directive', () => {
+      @Directive({selector: 'example-directive-a'})
+      class ExampleDirectiveA {
+      }
+
+      @Component({
+        selector: 'wrapper-component',
+        template: `
+          <ng-content select="example-directive-a"></ng-content>
+        `
+      })
+      class WrapperComponent {
+      }
+
+      TestBed.configureTestingModule({
+        declarations: [
+          WrapperComponent,
+          ExampleDirectiveA,
+        ]
+      });
+
+      TestBed.overrideTemplate(TestApp, `<wrapper-component>
+        <div></div>
+        <example-directive-a></example-directive-a>
+       </wrapper-component>`);
+
+      const fixture = TestBed.createComponent(TestApp);
+      fixture.detectChanges();
+
+      const debugElement = fixture.debugElement.query(By.directive(ExampleDirectiveA));
+      expect(debugElement).toBeTruthy();
+    });
+
     it('should list providerTokens', () => {
       fixture = TestBed.createComponent(ParentComp);
       fixture.detectChanges();

--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -173,26 +173,6 @@ window.testBlocklist = {
     "error": "TypeError: Cannot read property 'focus' of undefined",
     "notes": "MatChipList does not find MatChip content children because descendants is not true anymore. TODO: Fix spec so that it does not have the wrapping div"
   },
-  "MatChipList FormFieldChipList keyboard behavior should maintain focus if the active chip is deleted": {
-    "error": "TypeError: Cannot read property 'nativeElement' of null",
-    "notes": "FW-1064: debugElement.query does not find directive when that directive precedes another"
-  },
-  "MatChipList FormFieldChipList keyboard behavior when the input has focus should not focus the last chip when press DELETE": {
-    "error": "TypeError: Cannot read property 'nativeElement' of null",
-    "notes": "FW-1064: debugElement.query does not find directive when that directive precedes another"
-  },
-  "MatChipList FormFieldChipList keyboard behavior when the input has focus should focus the last chip when press BACKSPACE": {
-    "error": "TypeError: Cannot read property 'nativeElement' of null",
-    "notes": "FW-1064: debugElement.query does not find directive when that directive precedes another"
-  },
-  "MatChipList FormFieldChipList should complete the stateChanges stream on destroy": {
-    "error": "TypeError: Cannot read property 'nativeElement' of null",
-    "notes": "FW-1064: debugElement.query does not find directive when that directive precedes another"
-  },
-  "MatChipList FormFieldChipList should point the label id to the chip input": {
-    "error": "TypeError: Cannot read property 'nativeElement' of null",
-    "notes": "FW-1064: debugElement.query does not find directive when that directive precedes another"
-  },
   "MatChipList with chip remove should properly focus next item if chip is removed through click": {
     "error": "TypeError: Cannot read property 'focus' of undefined",
     "notes": "MatChipList does not find MatChip content children because descendants is not true anymore. TODO: Fix spec so that it does not have the wrapping div"


### PR DESCRIPTION
Previously the act of projecting nodes could change connection between `TNodes` (`next` was assigned to point to a next _projected_ node) thus destroying relationship between nodes _before_ content projection. Due to this we were not traverse nodes as they appear in the original template (content nodes before projection). 

This PR introduces the `nextProjected` pointer so we can can track relationship between nodes both _before_ and _after_ projection.  