### PR TITLE
test(ivy): diagnose root causes of failures in MatSnackBar

### DIFF
--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -311,7 +311,7 @@ window.testBlocklist = {
   },
   "MatSnackBar with TemplateRef should be able to open a snack bar using a TemplateRef": {
     "error": "Error: Expected ' Fries Pizza  ' to contain 'Pasta'.",
-    "notes": "Unknown"
+    "notes": "FW-842: View engine dirty-checks projected views when the declaration place is checked"
   },
   "MatTooltip special cases should clear the `user-select` when a tooltip is set on a text field": {
     "error": "Error: Expected 'none' to be falsy.",


### PR DESCRIPTION
This fixes FW-1128