### PR TITLE
fix(bazel): ng build should produce prod bundle

### DIFF
--- a/packages/bazel/src/schematics/ng-add/index.ts
+++ b/packages/bazel/src/schematics/ng-add/index.ts
@@ -127,14 +127,9 @@ function updateAngularJsonToUseBazelBuilder(options: Schema): Rule {
         recorder, architect, 'build', {
           builder: '@angular/bazel:build',
           options: {
-            targetLabel: '//src:bundle.js',
+            targetLabel: '//src:prodapp',
             bazelCommand: 'build',
-          },
-          configurations: {
-            production: {
-              targetLabel: '//src:bundle',
-            },
-          },
+          }
         },
         indent);
     replacePropertyInAstObject(


### PR DESCRIPTION
`ng build` should produce a bundle that could be readily deployed to
a web server, similar to the behavior of current `ng build` with
webpack.

Note that in Bazel, there is no `ng build` for dev bundles. Instead,
users are expected to run `ts_devserver`.

Closes https://github.com/angular/angular/issues/28877

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
