### PR TITLE
fix(ivy): always convert `rootDirs` to `AbsoluteFsPath` in `getRootDirs`

### DIFF
--- a/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
@@ -78,6 +78,11 @@ export function getRootDirs(host: ts.CompilerHost, options: ts.CompilerOptions):
   } else {
     rootDirs.push(host.getCurrentDirectory());
   }
+
+  // In Windows the above might not always return posix separated paths
+  // See:
+  // https://github.com/Microsoft/TypeScript/blob/3f7357d37f66c842d70d835bc925ec2a873ecfec/src/compiler/sys.ts#L650
+  // Also compiler options might be set via an API which doesn't normalize paths
   return rootDirs.map(rootDir => AbsoluteFsPath.from(rootDir));
 }
 

--- a/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
@@ -78,7 +78,7 @@ export function getRootDirs(host: ts.CompilerHost, options: ts.CompilerOptions):
   } else {
     rootDirs.push(host.getCurrentDirectory());
   }
-  return rootDirs.map(rootDir => AbsoluteFsPath.fromUnchecked(rootDir));
+  return rootDirs.map(rootDir => AbsoluteFsPath.from(rootDir));
 }
 
 export function nodeDebugInfo(node: ts.Node): string {


### PR DESCRIPTION
tsc `getCurrentDirectory` directory doesn't return a posix separated normalized path. While `rootDir` and `rootDirs` should return posix separated paths, it's best to not assume as other paths within the compiler options can be returned not posix separated such as `basePath`

See: https://github.com/Microsoft/TypeScript/blob/master/src/compiler/sys.ts#L635

This partially fixes #29140, however there needs to be a change in the CLI as well to handle this, as at the moment we are leaking devkit paths which is not correct.

Fixes #29140
