### PR TITLE
test(ivy): diagnose root causes for MatInput

### DIFF
--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -239,7 +239,7 @@ window.testBlocklist = {
   },
   "MatInput without forms validates the type": {
     "error": "Error: Input type \"file\" isn't supported by matInput.",
-    "notes": "Unknown"
+    "notes": "Breaking change: Static directive inputs evaluated in creation mode - material test to be updated"
   },
   "MatInput with textarea autosize should work in a step": {
     "error": "TypeError: Cannot read property 'getBoundingClientRect' of null",


### PR DESCRIPTION
This PR diagnoses one of the root causes for MatInput (the other one is an issue in MatStepper). Additionally there is a failing TestBed case that exposes the problem without the Material dependency.
