### PR TITLE
fix(ivy): ngcc - handle prototype pseudo-member from typings file in ESM5 host

### DIFF
--- a/packages/compiler-cli/src/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/src/ngcc/src/host/esm2015_host.ts
@@ -775,6 +775,9 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
 
     const node = symbol.valueDeclaration || symbol.declarations && symbol.declarations[0];
     if (!node) {
+      // If the symbol has been imported from a TypeScript typings file then the compiler
+      // may pass the `prototype` symbol as an export of the class.
+      // But this has no declaration. In this case we just quietly ignore it.
       return null;
     }
 

--- a/packages/compiler-cli/src/ngcc/src/host/esm5_host.ts
+++ b/packages/compiler-cli/src/ngcc/src/host/esm5_host.ts
@@ -228,7 +228,7 @@ export class Esm5ReflectionHost extends Esm2015ReflectionHost {
   protected reflectMembers(symbol: ts.Symbol, decorators?: Decorator[], isStatic?: boolean):
       ClassMember[]|null {
     const node = symbol.valueDeclaration || symbol.declarations && symbol.declarations[0];
-    const propertyDefinition = getPropertyDefinition(node);
+    const propertyDefinition = node && getPropertyDefinition(node);
     if (propertyDefinition) {
       const members: ClassMember[] = [];
       if (propertyDefinition.setter) {

--- a/packages/compiler-cli/src/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/host/esm5_host_spec.ts
@@ -520,6 +520,15 @@ const DECORATED_FILES = [
   }
 ];
 
+const UNWANTED_PROTOTYPE_EXPORT_FILE = {
+  name: '/library.d.ts',
+  contents: `
+    export declare class SomeParam {
+      someInstanceMethod(): void;
+      static someStaticProp: any;
+    }`
+};
+
 describe('Esm5ReflectionHost', () => {
 
   describe('getDecoratorsOfDeclaration()', () => {
@@ -906,6 +915,16 @@ describe('Esm5ReflectionHost', () => {
         expect(decorators[0].args).toEqual([]);
       });
     });
+
+    it('should ignore the prototype pseudo-static property on class imported from typings files',
+       () => {
+         const program = makeTestProgram(UNWANTED_PROTOTYPE_EXPORT_FILE);
+         const host = new Esm5ReflectionHost(false, program.getTypeChecker());
+         const classNode = getDeclaration(
+             program, UNWANTED_PROTOTYPE_EXPORT_FILE.name, 'SomeParam', ts.isClassDeclaration);
+         const members = host.getMembersOfClass(classNode);
+         expect(members.find(m => m.name === 'prototype')).toBeUndefined();
+       });
   });
 
   describe('getConstructorParameters', () => {


### PR DESCRIPTION
When using the `Esm5ReflectionHost` to process a JavaScript program, it may
come across a symbol that has been imported from a TypeScript typings file.
In this case the compiler may pass the host the `prototype` symbol as an
export of the class.

But this pseudo-member symbol has no declarations, which caused the code
in `reflectMembers()` to crash. Now in this case we just quietly ignore
this symbol.

