### PR TITLE
fix(ivy): inherited host listeners called twice

### DIFF
--- a/packages/core/src/reflection/reflection_capabilities.ts
+++ b/packages/core/src/reflection/reflection_capabilities.ts
@@ -214,7 +214,7 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
     if (!isType(typeOrFunc)) {
       return {};
     }
-    return this._ownPropMetadata(typeOrFunc, Object) || {};
+    return this._ownPropMetadata(typeOrFunc, getParentCtor(typeOrFunc)) || {};
   }
 
   hasLifecycleHook(type: any, lcProperty: string): boolean {

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -137,7 +137,7 @@ export function extendsDirectlyFromObject(type: Type<any>): boolean {
  * Extract the `R3DirectiveMetadata` for a particular directive (either a `Directive` or a
  * `Component`).
  */
-function directiveMetadata(type: Type<any>, metadata: Directive): R3DirectiveMetadataFacade {
+export function directiveMetadata(type: Type<any>, metadata: Directive): R3DirectiveMetadataFacade {
   // Reflect inputs and outputs.
   const propMetadata = getReflect().ownPropMetadata(type);
 

--- a/packages/core/test/render3/jit/directive_spec.ts
+++ b/packages/core/test/render3/jit/directive_spec.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {WrappedNodeExpr} from '@angular/compiler';
-import {convertToR3QueryMetadata, extendsDirectlyFromObject} from '../../../src/render3/jit/directive';
+import {Directive, HostListener} from '@angular/core';
+import {setClassMetadata} from '@angular/core/src/render3/metadata';
+
+import {convertToR3QueryMetadata, directiveMetadata, extendsDirectlyFromObject} from '../../../src/render3/jit/directive';
 
 describe('jit directive helper functions', () => {
 
@@ -95,5 +97,38 @@ describe('jit directive helper functions', () => {
       expect(converted.read).toEqual(Directive);
     });
 
+  });
+
+  describe('directiveMetadata', () => {
+    it('should not inherit propMetadata from super class', () => {
+      class SuperDirective {}
+      setClassMetadata(
+          SuperDirective, [{type: Directive, args: []}], null,
+          {handleClick: [{type: HostListener, args: ['click']}]});
+
+      class SubDirective extends SuperDirective {}
+      setClassMetadata(SubDirective, [{type: Directive, args: []}], null, null);
+
+      expect(directiveMetadata(SuperDirective, {}).propMetadata.handleClick).toBeTruthy();
+      expect(directiveMetadata(SubDirective, {}).propMetadata.handleClick).toBeFalsy();
+    });
+
+    it('should not inherit propMetadata from grand super class', () => {
+      class SuperSuperDirective {}
+      setClassMetadata(
+          SuperSuperDirective, [{type: Directive, args: []}], null,
+          {handleClick: [{type: HostListener, args: ['click']}]});
+
+      class SuperDirective {}
+      setClassMetadata(SuperDirective, [{type: Directive, args: []}], null, null);
+
+      class SubDirective extends SuperDirective {}
+
+      setClassMetadata(SubDirective, [{type: Directive, args: []}], null, null);
+
+      expect(directiveMetadata(SuperSuperDirective, {}).propMetadata.handleClick).toBeTruthy();
+      expect(directiveMetadata(SuperDirective, {}).propMetadata.handleClick).toBeFalsy();
+      expect(directiveMetadata(SubDirective, {}).propMetadata.handleClick).toBeFalsy();
+    });
   });
 });

--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -197,6 +197,26 @@ window.testBlocklist = {
     "error": "TypeError: Cannot read property 'nativeElement' of undefined",
     "notes": "Unknown"
   },
+  "MatStepper basic stepper should not do anything when pressing the ENTER key with a modifier": {
+    "error": "Expected 0 to be 1, 'Expected index of focused step to increase by 1 after pressing the next key.'",
+    "notes": "FW-1146: Components should be able to inherit view queries from directives"
+  },
+  "MatStepper basic stepper should not do anything when pressing the SPACE key with a modifier": {
+    "error": "Expected 0 to be 1, 'Expected index of focused step to increase by 1 after pressing the next key.'",
+    "notes": "FW-1146: Components should be able to inherit view queries from directives"
+  },
+  "MatStepper vertical stepper should support using the left/right arrows to move focus": {
+    "error": "Expected 0 to be 1, 'Expected index of focused step to increase by 1 after pressing the next key.'",
+    "notes": "FW-1146: Components should be able to inherit view queries from directives"
+  },
+  "MatStepper vertical stepper should support using the up/down arrows to move focus": {
+    "error": "Expected 0 to be 1, 'Expected index of focused step to increase by 1 after pressing the next key.'",
+    "notes": "FW-1146: Components should be able to inherit view queries from directives"
+  },
+  "MatStepper vertical stepper should reverse arrow key focus in RTL mode": {
+    "error": "Expected 0 to be 1",
+    "notes": "FW-1146: Components should be able to inherit view queries from directives"
+  },
   "MatSidenav should be fixed position when in fixed mode": {
     "error": "Error: Expected ng-tns-c24896-0 ng-trigger ng-trigger-transform mat-drawer mat-sidenav mat-drawer-over ng-star-inserted to contain 'mat-sidenav-fixed'.",
     "notes": "FW-1132: Host class bindings don't work if super class has host class bindings"


### PR DESCRIPTION
Fixes host listeners being inherited twice when going through `setClassMetadata`.

This PR resolves FW-1142.
