### PR TITLE
test(ivy): fix failing view ref test

### DIFF
--- a/packages/core/test/acceptance/view_ref_spec.ts
+++ b/packages/core/test/acceptance/view_ref_spec.ts
@@ -47,10 +47,10 @@ describe('ViewRef', () => {
     const appComponent = fixture.componentInstance;
     appComponent.create();
     fixture.detectChanges();
-    expect(document.body.querySelector('dynamic-cpt')).not.toBeUndefined();
+    expect(document.body.querySelector('dynamic-cpt')).not.toBeFalsy();
 
     appComponent.destroy();
     fixture.detectChanges();
-    expect(document.body.querySelector('dynamic-cpt')).toBeUndefined();
+    expect(document.body.querySelector('dynamic-cpt')).toBeFalsy();
   });
 });


### PR DESCRIPTION
ViewRef test was too prescriptive and failing on SauceLabs. Hopefully, this will fix it!