### PR TITLE
fix(ivy): unable to inject class and style attributes

### DIFF
--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {ChangeDetectorRef, Component, Directive, Inject, LOCALE_ID, Optional, Pipe, PipeTransform, SkipSelf, ViewChild} from '@angular/core';
+import {Attribute, ChangeDetectorRef, Component, Directive, Inject, LOCALE_ID, Optional, Pipe, PipeTransform, SkipSelf, ViewChild} from '@angular/core';
 import {ViewRef} from '@angular/core/src/render3/view_ref';
 import {TestBed} from '@angular/core/testing';
 
@@ -129,5 +129,32 @@ describe('di', () => {
     const fixture = TestBed.createComponent(MyComp);
     fixture.detectChanges();
     expect(fixture.componentInstance.myDir.localeId).toBe('en-GB');
+  });
+
+  it('should be able to inject different kinds of attributes', () => {
+    @Directive({selector: '[dir]'})
+    class MyDir {
+      constructor(
+          @Attribute('class') public className: string,
+          @Attribute('style') public inlineStyles: string,
+          @Attribute('other-attr') public otherAttr: string) {}
+    }
+    @Component({
+      template:
+          '<div dir style="margin: 1px; color: red;" class="hello there" other-attr="value"></div>'
+    })
+    class MyComp {
+      @ViewChild(MyDir) directiveInstance !: MyDir;
+    }
+
+    TestBed.configureTestingModule({declarations: [MyDir, MyComp, MyComp]});
+    const fixture = TestBed.createComponent(MyComp);
+    fixture.detectChanges();
+
+    const directive = fixture.componentInstance.directiveInstance;
+
+    expect(directive.otherAttr).toBe('value');
+    expect(directive.className).toBe('hello there');
+    expect(directive.inlineStyles).toBe('margin: 1px; color: red;');
   });
 });


### PR DESCRIPTION
Fixes not being able to inject the `class` and `style` attributes via the `Attribute` decorator.

This PR resolves FW-1139.
