### PR TITLE
fix(ivy): escape all required characters in reexport aliases

### DIFF
--- a/packages/compiler-cli/src/ngtsc/imports/src/alias.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/alias.ts
@@ -12,8 +12,8 @@ import * as ts from 'typescript';
 import {FileToModuleHost, ReferenceEmitStrategy} from './emitter';
 import {ImportMode, Reference} from './references';
 
-// Escape anything that isn't alphanumeric, '/', '_', '.', or '$'.
-const CHARS_TO_ESCAPE = /[^a-zA-Z0-9/_\.$]/g;
+// Escape anything that isn't alphanumeric, '/' or '_'.
+const CHARS_TO_ESCAPE = /[^a-zA-Z0-9/_]/g;
 
 export class AliasGenerator {
   constructor(private fileToModuleHost: FileToModuleHost) {}

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -3537,6 +3537,36 @@ export const Foo = Foo__PRE_R3__;
       const jsContents = env.getContents('index.js');
       expect(jsContents).toContain('export { FooDir as ɵng$root$foo$$FooDir } from "root/foo";');
     });
+
+    it('should escape unusual characters in aliased filenames', () => {
+      env.tsconfig({'_useHostForImportGeneration': true});
+      env.write('other._$test.ts', `
+        import {Directive, NgModule} from '@angular/core';
+
+        @Directive({selector: 'test'})
+        export class TestDir {}
+
+        @NgModule({
+          declarations: [TestDir],
+          exports: [TestDir],
+        })
+        export class OtherModule {}
+      `);
+      env.write('index.ts', `
+        import {NgModule} from '@angular/core';
+        import {OtherModule} from './other._$test';
+
+        @NgModule({
+          exports: [OtherModule],
+        })
+        export class IndexModule {}
+      `);
+      env.driveMain();
+      const jsContents = env.getContents('index.js');
+      expect(jsContents)
+          .toContain(
+              'export { TestDir as ɵng$root$other___test$$TestDir } from "root/other._$test";');
+    });
   });
 
   describe('inline resources', () => {


### PR DESCRIPTION
Previously, the compiler did not escape . or $, and this was causing issues
in google3. Now these characters are escaped.
