### PR TITLE
build: enable shard_count for some jasmine tests that have many specs

### DIFF
--- a/packages/compiler-cli/test/compliance/BUILD.bazel
+++ b/packages/compiler-cli/test/compliance/BUILD.bazel
@@ -21,6 +21,7 @@ jasmine_node_test(
     data = [
         "//packages/compiler-cli/test/ngtsc/fake_core:npm_package",
     ],
+    shard_count = 4,
     tags = [
         "ivy-only",
     ],

--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -23,6 +23,7 @@ jasmine_node_test(
     data = [
         "//packages/compiler-cli/test/ngtsc/fake_core:npm_package",
     ],
+    shard_count = 4,
     deps = [
         ":ngtsc_lib",
         "//tools/testing:node_no_angular",

--- a/packages/core/test/BUILD.bazel
+++ b/packages/core/test/BUILD.bazel
@@ -58,6 +58,7 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["angular/tools/testing/init_node_spec.js"],
+    shard_count = 4,
     deps = [
         ":test_lib",
         ":test_node_only_lib",


### PR DESCRIPTION
This partitions the specs across multiple processes so they run in parallel.
I chose the value 4 so that we don't spin up a lot of processes on a machine with few cores (doesn't everyone on angular team have at least 8 now?)

Marketing: https://twitter.com/Jakeherringbone/status/1104174841320501249

```
before //packages/compiler-cli/test/compliance:compliance                       PASSED in 37.0s
after //packages/compiler-cli/test/compliance:compliance                       PASSED in 14.3s
 Stats over 4 runs: max = 14.3s, min = 8.7s, avg = 10.4s, dev = 2.3s

//packages/compiler-cli/test/ngtsc:ngtsc                                 PASSED in 31.5s
->
//packages/compiler-cli/test/ngtsc:ngtsc                                 PASSED in 10.6s
 Stats over 4 runs: max = 10.6s, min = 9.2s, avg = 9.8s, dev = 0.5s
￼￼￼￼￼
just for fun, since my machine has 36 cores:
//packages/compiler-cli/test/ngtsc:ngtsc                                 PASSED in 6.2s
 Stats over 30 runs: max = 6.2s, min = 3.0s, avg = 4.1s, dev = 0.7s
```