### PR TITLE
build: disable tsc_wrapped workers

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,8 +10,10 @@ build:angular-team --remote_http_cache=https://storage.googleapis.com/angular-te
 
 # Make compilation fast, by keeping a few copies of the compilers
 # running as daemons, and cache SourceFile AST's to reduce parse time.
-build --strategy=TypeScriptCompile=worker
 build --strategy=AngularTemplateCompile=worker
+# TODO(alexeagle): re-enable after fixing worker instability with rxjs typings
+# build --strategy=TypeScriptCompile=worker
+build --strategy=TypeScriptCompile=standalone
 
 # Enable debugging tests with --config=debug
 test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results

--- a/packages/bazel/src/schematics/ng-add/index.ts
+++ b/packages/bazel/src/schematics/ng-add/index.ts
@@ -227,7 +227,7 @@ function updateTsconfigJson(): Rule {
     if (!host.exists(tsconfigPath)) {
       return host;
     }
-    const contentRaw = host.read(tsconfigPath).toString();
+    const contentRaw = host.read(tsconfigPath) !.toString();
     if (!contentRaw) {
       return host;
     }


### PR DESCRIPTION
Angular devs are hitting a bug with typings forcing them to run "bazel shutdown"
