### PR TITLE
fix(bazel): add missing binary path for api-extractor

### DIFF
--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -5,6 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "bin": {
+    "api-extractor": "./src/api-extractor/index.js",
     "ngc-wrapped": "./src/ngc-wrapped/index.js",
     "packager": "./src/ng_package/packager.js",
     "xi18n": "./src/ngc-wrapped/extract_i18n.js",

--- a/packages/bazel/src/external.bzl
+++ b/packages/bazel/src/external.bzl
@@ -33,6 +33,7 @@ compile_ts = _compile_ts
 DEPS_ASPECTS = _DEPS_ASPECTS
 ts_providers_dict_to_struct = _ts_providers_dict_to_struct
 
+DEFAULT_API_EXTRACTOR = "@npm//@angular/bazel/bin:api-extractor"
 DEFAULT_NG_COMPILER = "@npm//@angular/bazel/bin:ngc-wrapped"
 DEFAULT_NG_XI18N = "@npm//@angular/bazel/bin:xi18n"
 FLAT_DTS_FILE_SUFFIX = ".bundle.d.ts"

--- a/packages/bazel/src/ng_module.bzl
+++ b/packages/bazel/src/ng_module.bzl
@@ -9,6 +9,7 @@ load(
     ":external.bzl",
     "COMMON_ATTRIBUTES",
     "COMMON_OUTPUTS",
+    "DEFAULT_API_EXTRACTOR",
     "DEFAULT_NG_COMPILER",
     "DEFAULT_NG_XI18N",
     "DEPS_ASPECTS",
@@ -450,7 +451,7 @@ def ngc_compile_action(
         ctx.actions.run(
             progress_message = "Bundling DTS %s" % str(ctx.label),
             mnemonic = "APIExtractor",
-            executable = ctx.executable._api_extractor,
+            executable = ctx.executable.api_extractor,
             inputs = filter_inputs,
             outputs = dts_bundles_out,
             arguments = [
@@ -716,8 +717,8 @@ NG_MODULE_RULE_ATTRS = dict(dict(COMMON_ATTRIBUTES, **NG_MODULE_ATTRIBUTES), **{
     # https://github.com/angular/angular/blob/master/packages/compiler-cli/src/transformers/api.ts
     "flat_module_out_file": attr.string(),
     "bundle_dts": attr.bool(default = False),
-    "_api_extractor": attr.label(
-        default = Label("//packages/bazel/src/api-extractor:api_extractor"),
+    "api_extractor": attr.label(
+        default = Label(DEFAULT_API_EXTRACTOR),
         executable = True,
         cfg = "host",
     ),

--- a/packages/compiler-cli/integrationtest/bazel/ng_module/BUILD.bazel
+++ b/packages/compiler-cli/integrationtest/bazel/ng_module/BUILD.bazel
@@ -6,6 +6,7 @@ ng_module(
     name = "test_module",
     testonly = True,
     srcs = glob(["*.ts"]),
+    api_extractor = "//packages/bazel/src/api-extractor:api_extractor",
     compiler = "//packages/bazel/src/ngc-wrapped",
     entry_point = "index.ts",
     flat_module_out_file = "flat_module_filename",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -9,6 +9,7 @@ load("//packages/bazel/src:ng_rollup_bundle.bzl", _ng_rollup_bundle = "ng_rollup
 
 _DEFAULT_TSCONFIG_BUILD = "//packages:tsconfig-build.json"
 _DEFAULT_TSCONFIG_TEST = "//packages:tsconfig-test"
+_INTERNAL_NG_MODULE_API_EXTRACTOR = "//packages/bazel/src/api-extractor:api_extractor"
 _INTERNAL_NG_MODULE_COMPILER = "//packages/bazel/src/ngc-wrapped"
 _INTERNAL_NG_MODULE_XI18N = "//packages/bazel/src/ngc-wrapped:xi18n"
 _INTERNAL_NG_PACKAGER_PACKAGER = "//packages/bazel/src/ng_package:packager"
@@ -124,6 +125,7 @@ def ng_module(name, tsconfig = None, entry_point = None, testonly = False, deps 
         bundle_dts = bundle_dts,
         deps = deps,
         compiler = _INTERNAL_NG_MODULE_COMPILER,
+        api_extractor = _INTERNAL_NG_MODULE_API_EXTRACTOR,
         ng_xi18n = _INTERNAL_NG_MODULE_XI18N,
         module_name = module_name,
         **kwargs


### PR DESCRIPTION
`api-extractor` binary is required for external consumers of `ng_module` that want to use the `bundle_dts` flag.

This also sets a different api-exttractor binary to use for ng_module, based if it's internal or external.

