### PR TITLE
docs: add note about ngModel usage in structural directives guide

### DIFF
--- a/aio/content/guide/structural-directives.md
+++ b/aio/content/guide/structural-directives.md
@@ -590,7 +590,11 @@ The drop down works properly.
   <img src='generated/images/guide/structural-directives/select-ngcontainer-anim.gif' alt="ngcontainer options work properly">
 </figure>
 
-<i>Note: You need to import the FormsModule package from @angular/forms in your Angular app.module.ts file to try the above example. ngModel is under FormsModule.</i>
+<div class="alert is-important">
+
+**Note:** You need to add the `FormsModule` to your `NgModule` imports array to use ngModel in the example above.
+
+</div>
 
 The `<ng-container>` is a syntax element recognized by the Angular parser.
 It's not a directive, component, class, or interface.

--- a/aio/content/guide/structural-directives.md
+++ b/aio/content/guide/structural-directives.md
@@ -590,7 +590,7 @@ The drop down works properly.
   <img src='generated/images/guide/structural-directives/select-ngcontainer-anim.gif' alt="ngcontainer options work properly">
 </figure>
 
-
+<i>Note: You need to import the FormsModule package from @angular/forms in your Angular app.module.ts file to try the above example. ngModel is under FormsModule.</i>
 
 The `<ng-container>` is a syntax element recognized by the Angular parser.
 It's not a directive, component, class, or interface.


### PR DESCRIPTION
When I tried one of the examples provided in the documention, encountered the " Can't bind to 'ngModel' since it isn't a known property of 'select' ” error. So to resolve it I imported the FormsModule in ngModule. If it is mentioned in the documentation, it would be handy for the beginners to try and learn. Thanks for considering.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
