### PR TITLE
feat(common): expose the new `BrowserXhr` class in the public API

### DIFF
--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -15,5 +15,5 @@ export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule, HttpInter
 export {HttpParameterCodec, HttpParams, HttpUrlEncodingCodec} from './src/params';
 export {HttpRequest} from './src/request';
 export {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpProgressEvent, HttpResponse, HttpResponseBase, HttpSentEvent, HttpUserEvent} from './src/response';
-export {HttpXhrBackend, XhrFactory} from './src/xhr';
+export {BrowserXhr, HttpXhrBackend, XhrFactory} from './src/xhr';
 export {HttpXsrfTokenExtractor} from './src/xsrf';

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -40,7 +40,7 @@ export abstract class XhrFactory { abstract build(): XMLHttpRequest; }
 /**
  * A factory for @{link HttpXhrBackend} that uses the `XMLHttpRequest` browser API.
  *
- *
+ * @publicApi
  */
 @Injectable()
 export class BrowserXhr implements XhrFactory {

--- a/tools/public_api_guard/common/http.d.ts
+++ b/tools/public_api_guard/common/http.d.ts
@@ -1,3 +1,8 @@
+export declare class BrowserXhr implements XhrFactory {
+    constructor();
+    build(): any;
+}
+
 export declare const HTTP_INTERCEPTORS: InjectionToken<HttpInterceptor[]>;
 
 export declare abstract class HttpBackend implements HttpHandler {


### PR DESCRIPTION
The old `@angular/http` had a `BrowserXhr` implementation, which
was deprecated along with the rest of the package in v5. This
commit adds the new implementation to the publicApi to make the
migration easier for those using the old implementation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
