### PR TITLE
ci: run legacy saucelabs for every build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ jobs:
           path: dist/bin/packages/core/test/bundling/todo/bundle.min.js.br
           destination: core/todo/bundle.br
 
-  test_saucelabs:
+  test_saucelabs_bazel:
     <<: *job_defaults
     # In order to avoid the bottleneck of having a slow host machine, we acquire a better
     # container for this job. This is necessary because we launch a lot of browsers concurrently
@@ -592,6 +592,9 @@ workflows:
       - test_aio:
           requires:
           - setup
+      - legacy-unit-tests-saucelabs:
+          requires:
+          - setup
       - deploy_aio:
           requires:
             - test_aio
@@ -645,6 +648,7 @@ workflows:
             # since the publishing script expects the legacy outputs layout.
             - build-npm-packages
             - build-ivy-npm-packages
+            - legacy-unit-tests-saucelabs
             - legacy-misc-tests
       - material-unit-tests:
           requires:
@@ -653,14 +657,9 @@ workflows:
   saucelabs_tests:
     jobs:
       - setup
-      - test_saucelabs:
+      - test_saucelabs_bazel:
           requires:
             - setup
-      - legacy-unit-tests-saucelabs:
-          # Don't open up multiple saucelabs tunnels at the same
-          # time to minimize flakes
-          requires:
-            - test_saucelabs
     triggers:
       - schedule:
           # Runs the Saucelabs legacy tests every hour. We still want to run Saucelabs


### PR DESCRIPTION
Recently we moved the Saucelabs job into a cronjob in order to avoid
heavy flakiness that we experienced due to a Saucelabs connect bug
that has been supposedly fixed by the Saucelabs team (no new version
is released yet though).

Our initial assumption was that we very rarely hit specific browser failures
and can therefore move the Saucelabs tests into a cronjob, but after some
days of having the cronjob, we realized that we actually hit browser-specific
failures quite often and that we should run the tests for every PR (like before)

Additionally renames the `test_saucelabs` job to contain `bazel`, as this is still
an experiment and we haven't fully replaced the legacy tests with the Bazel
saucelabs tests. Meanwhile we keep the Bazel tests in the cronjob as these
are just a subset of the actual legacy tests.