### PR TITLE
fix(ivy): do not inject attributes with namespace

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -279,7 +279,14 @@ export function injectAttributeImpl(tNode: TNode, attrNameToInject: string): str
       // If we hit a `Bindings` or `Template` marker then we are done.
       if (isNameOnlyAttributeMarker(value)) break;
 
-      if (typeof value === 'number') {
+      // Skip namespaced attributes
+      if (value === AttributeMarker.NamespaceURI) {
+        // we skip the next two values
+        // as namespaced attributes looks like
+        // [..., AttributeMarker.NamespaceURI, 'http://someuri.com/test', 'test:exist',
+        // 'existValue', ...]
+        i = i + 2;
+      } else if (typeof value === 'number') {
         // Skip to the first value of the marked attribute.
         i++;
         if (value === AttributeMarker.Classes && attrNameToInject === 'class') {
@@ -300,7 +307,6 @@ export function injectAttributeImpl(tNode: TNode, attrNameToInject: string): str
           }
         }
       } else if (value === attrNameToInject) {
-        // TODO(FW-1137): Skip namespaced attributes
         return attrs[i + 1] as string;
       } else {
         i = i + 2;

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -131,30 +131,62 @@ describe('di', () => {
     expect(fixture.componentInstance.myDir.localeId).toBe('en-GB');
   });
 
-  it('should be able to inject different kinds of attributes', () => {
-    @Directive({selector: '[dir]'})
-    class MyDir {
-      constructor(
-          @Attribute('class') public className: string,
-          @Attribute('style') public inlineStyles: string,
-          @Attribute('other-attr') public otherAttr: string) {}
-    }
-    @Component({
-      template:
-          '<div dir style="margin: 1px; color: red;" class="hello there" other-attr="value"></div>'
-    })
-    class MyComp {
-      @ViewChild(MyDir) directiveInstance !: MyDir;
-    }
+  describe('@Attribute', () => {
 
-    TestBed.configureTestingModule({declarations: [MyDir, MyComp, MyComp]});
-    const fixture = TestBed.createComponent(MyComp);
-    fixture.detectChanges();
+    it('should be able to inject different kinds of attributes', () => {
+      @Directive({selector: '[dir]'})
+      class MyDir {
+        constructor(
+            @Attribute('class') public className: string,
+            @Attribute('style') public inlineStyles: string,
+            @Attribute('other-attr') public otherAttr: string) {}
+      }
 
-    const directive = fixture.componentInstance.directiveInstance;
+      @Component({
+        template:
+            '<div dir style="margin: 1px; color: red;" class="hello there" other-attr="value"></div>'
+      })
+      class MyComp {
+        @ViewChild(MyDir) directiveInstance !: MyDir;
+      }
 
-    expect(directive.otherAttr).toBe('value');
-    expect(directive.className).toBe('hello there');
-    expect(directive.inlineStyles).toBe('margin: 1px; color: red;');
+      TestBed.configureTestingModule({declarations: [MyDir, MyComp]});
+      const fixture = TestBed.createComponent(MyComp);
+      fixture.detectChanges();
+
+      const directive = fixture.componentInstance.directiveInstance;
+
+      expect(directive.otherAttr).toBe('value');
+      expect(directive.className).toBe('hello there');
+      expect(directive.inlineStyles).toBe('margin: 1px; color: red;');
+
+    });
+
+    it('should not inject attributes with namespace', () => {
+      @Directive({selector: '[dir]'})
+      class MyDir {
+        constructor(
+            @Attribute('exist') public exist: string,
+            @Attribute('svg:exist') public namespacedExist: string,
+            @Attribute('other') public other: string) {}
+      }
+
+      @Component({
+        template: '<div dir exist="existValue" svg:exist="testExistValue" other="otherValue"></div>'
+      })
+      class MyComp {
+        @ViewChild(MyDir) directiveInstance !: MyDir;
+      }
+
+      TestBed.configureTestingModule({declarations: [MyDir, MyComp]});
+      const fixture = TestBed.createComponent(MyComp);
+      fixture.detectChanges();
+
+      const directive = fixture.componentInstance.directiveInstance;
+
+      expect(directive.exist).toBe('existValue');
+      expect(directive.namespacedExist).toBeNull();
+      expect(directive.other).toBe('otherValue');
+    });
   });
 });


### PR DESCRIPTION
When injecting with `@Attribute`, namespaced attributes should not match (in order to have feature parity with View Engine).

This PR resolves FW-1137

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: FW-1137


## What is the new behavior?

DI now skips namespaced attributes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No