### PR TITLE
fix(core): allow Z variations of CSS transforms in sanitizer

### DIFF
--- a/packages/core/src/sanitization/style_sanitizer.ts
+++ b/packages/core/src/sanitization/style_sanitizer.ts
@@ -25,7 +25,7 @@ import {_sanitizeUrl} from './url_sanitizer';
  * transformation values.
  */
 const VALUES = '[-,."\'%_!# a-zA-Z0-9]+';
-const TRANSFORMATION_FNS = '(?:matrix|translate|scale|rotate|skew|perspective)(?:X|Y|3d)?';
+const TRANSFORMATION_FNS = '(?:matrix|translate|scale|rotate|skew|perspective)(?:X|Y|Z|3d)?';
 const COLOR_FNS = '(?:rgb|hsl)a?';
 const GRADIENTS = '(?:repeating-)?(?:linear|radial)-gradient';
 const CSS3_FNS = '(?:calc|attr)';


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

Sanitizer regex does not allow the Z variations of CSS transform values (translateZ, rotateZ, etc) which are supposed to be valid

Issue Number: N/A

## What is the new behavior?

Z variations of CSS transform values are allowed through the sanitizer, like the X and Y variations

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No