### PR TITLE
fix(ivy): matches nodes in the logical tree in DebugNode.query

### DIFF
--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -7,7 +7,7 @@
  */
 
 
-import {Component, Directive, EventEmitter, Injectable, Input, NO_ERRORS_SCHEMA} from '@angular/core';
+import {Component, Directive, ElementRef, EventEmitter, Injectable, Input, NO_ERRORS_SCHEMA, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed, async} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
@@ -155,6 +155,15 @@ class BankAccount {
 }
 
 @Component({
+  template: `
+    <div class="content" #content>Some content</div>
+ `
+})
+class SimpleContentComp {
+  @ViewChild('content') content !: ElementRef;
+}
+
+@Component({
   selector: 'test-app',
   template: `
    <bank-account bank="RBC"
@@ -195,6 +204,7 @@ class TestCmpt {
           UsingFor,
           BankAccount,
           TestCmpt,
+          SimpleContentComp,
         ],
         providers: [Logger],
         schemas: [NO_ERRORS_SCHEMA],
@@ -463,5 +473,20 @@ class TestCmpt {
          });
     });
 
+    it('should be able to query for elements that are not in the same DOM tree anymore', () => {
+      fixture = TestBed.createComponent(SimpleContentComp);
+      fixture.detectChanges();
+
+      const parent = getDOM().parentElement(fixture.nativeElement) !;
+      const content = fixture.componentInstance.content.nativeElement;
+
+      // Move the content element outside the component
+      // so that it can't be reached via querySelector.
+      getDOM().appendChild(parent, content);
+
+      expect(fixture.debugElement.query(By.css('.content'))).toBeTruthy();
+
+      getDOM().remove(content);
+    });
   });
 }

--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -161,42 +161,6 @@ window.testBlocklist = {
     "error": "TypeError: Cannot read property 'getBoundingClientRect' of null",
     "notes": "Unknown"
   },
-  "Dialog should set the proper animation states": {
-    "error": "TypeError: Cannot read property 'componentInstance' of null",
-    "notes": "FW-1059: DebugNode.query should query nodes in the logical tree"
-  },
-  "MatAutocomplete aria should set role of autocomplete panel to listbox": {
-    "error": "TypeError: Cannot read property 'nativeElement' of null",
-    "notes": "FW-1059: DebugNode.query should query nodes in the logical tree"
-  },
-  "MatAutocomplete aria should set aria-owns based on the attached autocomplete": {
-    "error": "TypeError: Cannot read property 'nativeElement' of null",
-    "notes": "FW-1059: DebugNode.query should query nodes in the logical tree"
-  },
-  "MatDialog should set the proper animation states": {
-    "error": "TypeError: Cannot read property 'componentInstance' of null",
-    "notes": "FW-1059: DebugNode.query should query nodes in the logical tree"
-  },
-  "MatMenu animations should enable ripples on items by default": {
-    "error": "TypeError: Cannot read property 'query' of null",
-    "notes": "FW-1059: DebugNode.query should query nodes in the logical tree"
-  },
-  "MatMenu animations should disable ripples on disabled items": {
-    "error": "TypeError: Cannot read property 'query' of undefined",
-    "notes": "FW-1059: DebugNode.query should query nodes in the logical tree"
-  },
-  "MatMenu animations should disable ripples if disableRipple is set": {
-    "error": "TypeError: Cannot read property 'query' of undefined",
-    "notes": "FW-1059: DebugNode.query should query nodes in the logical tree"
-  },
-  "MatMenu nested menu should close submenu when hovering over disabled sibling item": {
-    "error": "TypeError: Cannot read property 'nativeElement' of undefined",
-    "notes": "FW-1059: DebugNode.query should query nodes in the logical tree"
-  },
-  "MatMenu nested menu should not open submenu when hovering over disabled trigger": {
-    "error": "TypeError: Cannot read property 'componentInstance' of null",
-    "notes": "FW-1059: DebugNode.query should query nodes in the logical tree"
-  },
   "MatSnackBar with TemplateRef should be able to open a snack bar using a TemplateRef": {
     "error": "Error: Expected ' Fries Pizza  ' to contain 'Pasta'.",
     "notes": "Breaking change: Change detection follows insertion tree only, not declaration tree (MatSnackBarContainer is OnPush)"


### PR DESCRIPTION
Fixes `DebugNode.query` not matching elements that have been moved to a different place in the DOM manually.

This PR resolves FW-1059.
