### PR TITLE
fix(ivy): reuse default exports in type-to-value references

### DIFF
--- a/packages/compiler-cli/src/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/src/ngcc/src/analysis/decoration_analyzer.ts
@@ -12,7 +12,7 @@ import * as ts from 'typescript';
 
 import {BaseDefDecoratorHandler, ComponentDecoratorHandler, DirectiveDecoratorHandler, InjectableDecoratorHandler, NgModuleDecoratorHandler, PipeDecoratorHandler, ReferencesRegistry, ResourceLoader} from '../../../ngtsc/annotations';
 import {CycleAnalyzer, ImportGraph} from '../../../ngtsc/cycles';
-import {AbsoluteModuleStrategy, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, ReferenceEmitter} from '../../../ngtsc/imports';
+import {AbsoluteModuleStrategy, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, NOOP_DEFAULT_IMPORT_RECORDER, ReferenceEmitter} from '../../../ngtsc/imports';
 import {PartialEvaluator} from '../../../ngtsc/partial_evaluator';
 import {AbsoluteFsPath, LogicalFileSystem} from '../../../ngtsc/path';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../../ngtsc/scope';
@@ -85,14 +85,18 @@ export class DecorationAnalyzer {
     new ComponentDecoratorHandler(
         this.reflectionHost, this.evaluator, this.scopeRegistry, this.isCore, this.resourceManager,
         this.rootDirs, /* defaultPreserveWhitespaces */ false, /* i18nUseExternalIds */ true,
-        this.moduleResolver, this.cycleAnalyzer, this.refEmitter),
+        this.moduleResolver, this.cycleAnalyzer, this.refEmitter, NOOP_DEFAULT_IMPORT_RECORDER),
     new DirectiveDecoratorHandler(
-        this.reflectionHost, this.evaluator, this.scopeRegistry, this.isCore),
-    new InjectableDecoratorHandler(this.reflectionHost, this.isCore, /* strictCtorDeps */ false),
+        this.reflectionHost, this.evaluator, this.scopeRegistry, NOOP_DEFAULT_IMPORT_RECORDER,
+        this.isCore),
+    new InjectableDecoratorHandler(
+        this.reflectionHost, NOOP_DEFAULT_IMPORT_RECORDER, this.isCore, /* strictCtorDeps */ false),
     new NgModuleDecoratorHandler(
         this.reflectionHost, this.evaluator, this.scopeRegistry, this.referencesRegistry,
-        this.isCore, /* routeAnalyzer */ null, this.refEmitter),
-    new PipeDecoratorHandler(this.reflectionHost, this.evaluator, this.scopeRegistry, this.isCore),
+        this.isCore, /* routeAnalyzer */ null, this.refEmitter, NOOP_DEFAULT_IMPORT_RECORDER),
+    new PipeDecoratorHandler(
+        this.reflectionHost, this.evaluator, this.scopeRegistry, NOOP_DEFAULT_IMPORT_RECORDER,
+        this.isCore),
   ];
 
   constructor(

--- a/packages/compiler-cli/src/ngcc/src/host/esm2015_host.ts
+++ b/packages/compiler-cli/src/ngcc/src/host/esm2015_host.ts
@@ -901,8 +901,9 @@ export class Esm2015ReflectionHost extends TypeScriptReflectionHost implements N
       return {
         name: getNameText(nameNode),
         nameNode,
-        typeValueReference:
-            typeExpression !== null ? {local: true as true, expression: typeExpression} : null,
+        typeValueReference: typeExpression !== null ?
+            {local: true as true, expression: typeExpression, defaultImportStatement: null} :
+            null,
         typeNode: null, decorators
       };
     });

--- a/packages/compiler-cli/src/ngcc/src/rendering/esm_renderer.ts
+++ b/packages/compiler-cli/src/ngcc/src/rendering/esm_renderer.ts
@@ -25,17 +25,10 @@ export class EsmRenderer extends Renderer {
   /**
    *  Add the imports at the top of the file
    */
-  addImports(output: MagicString, imports: {
-    specifier: string; qualifier: string; isDefault: boolean
-  }[]): void {
+  addImports(output: MagicString, imports: {specifier: string; qualifier: string;}[]): void {
     // The imports get inserted at the very top of the file.
-    imports.forEach(i => {
-      if (!i.isDefault) {
-        output.appendLeft(0, `import * as ${i.qualifier} from '${i.specifier}';\n`);
-      } else {
-        output.appendLeft(0, `import ${i.qualifier} from '${i.specifier}';\n`);
-      }
-    });
+    imports.forEach(
+        i => { output.appendLeft(0, `import * as ${i.qualifier} from '${i.specifier}';\n`); });
   }
 
   addExports(output: MagicString, entryPointBasePath: string, exports: ExportInfo[]): void {

--- a/packages/compiler-cli/src/ngcc/test/host/esm2015_host_import_helper_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/host/esm2015_host_import_helper_spec.ts
@@ -302,7 +302,8 @@ describe('Fesm2015ReflectionHost [import helper style]', () => {
           const ctrDecorators = host.getConstructorParameters(classNode) !;
           const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference !as{
                                                  local: true,
-                                                 expression: ts.Identifier
+                                                 expression: ts.Identifier,
+                                                 defaultImportStatement: null,
                                                }).expression;
 
           const expectedDeclarationNode = getDeclaration(

--- a/packages/compiler-cli/src/ngcc/test/host/esm2015_host_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/host/esm2015_host_spec.ts
@@ -1295,7 +1295,8 @@ describe('Fesm2015ReflectionHost', () => {
       const ctrDecorators = host.getConstructorParameters(classNode) !;
       const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference !as{
                                              local: true,
-                                             expression: ts.Identifier
+                                             expression: ts.Identifier,
+                                             defaultImportStatement: null,
                                            }).expression;
 
       const expectedDeclarationNode = getDeclaration(

--- a/packages/compiler-cli/src/ngcc/test/host/esm5_host_import_helper_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/host/esm5_host_import_helper_spec.ts
@@ -338,7 +338,8 @@ describe('Esm5ReflectionHost [import helper style]', () => {
           const ctrDecorators = host.getConstructorParameters(classNode) !;
           const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference !as{
                                                  local: true,
-                                                 expression: ts.Identifier
+                                                 expression: ts.Identifier,
+                                                 defaultImportStatement: null,
                                                }).expression;
 
           const expectedDeclarationNode = getDeclaration(

--- a/packages/compiler-cli/src/ngcc/test/host/esm5_host_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/host/esm5_host_spec.ts
@@ -1276,7 +1276,8 @@ describe('Esm5ReflectionHost', () => {
       const ctrDecorators = host.getConstructorParameters(classNode) !;
       const identifierOfViewContainerRef = (ctrDecorators[0].typeValueReference !as{
                                              local: true,
-                                             expression: ts.Identifier
+                                             expression: ts.Identifier,
+                                             defaultImportStatement: null,
                                            }).expression;
 
       const expectedDeclarationNode = getDeclaration(

--- a/packages/compiler-cli/src/ngcc/test/rendering/esm2015_renderer_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/rendering/esm2015_renderer_spec.ts
@@ -116,22 +116,13 @@ describe('Esm2015Renderer', () => {
       const {renderer} = setup(PROGRAM);
       const output = new MagicString(PROGRAM.contents);
       renderer.addImports(output, [
-        {specifier: '@angular/core', qualifier: 'i0', isDefault: false},
-        {specifier: '@angular/common', qualifier: 'i1', isDefault: false}
+        {specifier: '@angular/core', qualifier: 'i0'},
+        {specifier: '@angular/common', qualifier: 'i1'}
       ]);
       expect(output.toString()).toContain(`import * as i0 from '@angular/core';
 import * as i1 from '@angular/common';
 
 /* A copyright notice */`);
-    });
-
-    it('should insert a default import at the start of the source file', () => {
-      const {renderer} = setup(PROGRAM);
-      const output = new MagicString(PROGRAM.contents);
-      renderer.addImports(output, [
-        {specifier: 'test', qualifier: 'i0', isDefault: true},
-      ]);
-      expect(output.toString()).toContain(`import i0 from 'test';`);
     });
   });
 

--- a/packages/compiler-cli/src/ngcc/test/rendering/esm5_renderer_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/rendering/esm5_renderer_spec.ts
@@ -153,22 +153,13 @@ describe('Esm5Renderer', () => {
       const {renderer} = setup(PROGRAM);
       const output = new MagicString(PROGRAM.contents);
       renderer.addImports(output, [
-        {specifier: '@angular/core', qualifier: 'i0', isDefault: false},
-        {specifier: '@angular/common', qualifier: 'i1', isDefault: false}
+        {specifier: '@angular/core', qualifier: 'i0'},
+        {specifier: '@angular/common', qualifier: 'i1'}
       ]);
       expect(output.toString()).toContain(`import * as i0 from '@angular/core';
 import * as i1 from '@angular/common';
 
 /* A copyright notice */`);
-    });
-
-    it('should insert a default import at the start of the source file', () => {
-      const {renderer} = setup(PROGRAM);
-      const output = new MagicString(PROGRAM.contents);
-      renderer.addImports(output, [
-        {specifier: 'test', qualifier: 'i0', isDefault: true},
-      ]);
-      expect(output.toString()).toContain(`import i0 from 'test';`);
     });
   });
 

--- a/packages/compiler-cli/src/ngcc/test/rendering/renderer_spec.ts
+++ b/packages/compiler-cli/src/ngcc/test/rendering/renderer_spec.ts
@@ -23,8 +23,7 @@ class TestRenderer extends Renderer {
   constructor(host: Esm2015ReflectionHost, isCore: boolean, bundle: EntryPointBundle) {
     super(host, isCore, bundle, '/src', '/dist');
   }
-  addImports(
-      output: MagicString, imports: {specifier: string, qualifier: string, isDefault: boolean}[]) {
+  addImports(output: MagicString, imports: {specifier: string, qualifier: string}[]) {
     output.prepend('\n// ADD IMPORTS\n');
   }
   addExports(output: MagicString, baseEntryPointPath: string, exports: {
@@ -172,7 +171,7 @@ A.ngComponentDef = ɵngcc0.ɵdefineComponent({ type: A, selectors: [["a"]], fact
            const addImportsSpy = renderer.addImports as jasmine.Spy;
            expect(addImportsSpy.calls.first().args[0].toString()).toEqual(RENDERED_CONTENTS);
            expect(addImportsSpy.calls.first().args[1]).toEqual([
-             {specifier: '@angular/core', qualifier: 'ɵngcc0', isDefault: false}
+             {specifier: '@angular/core', qualifier: 'ɵngcc0'}
            ]);
          });
 
@@ -289,7 +288,7 @@ A.ngDirectiveDef = ɵngcc0.ɵdefineDirective({ type: A, selectors: [["", "a", ""
             .toContain(`/*@__PURE__*/ ɵngcc0.setClassMetadata(`);
         const addImportsSpy = renderer.addImports as jasmine.Spy;
         expect(addImportsSpy.calls.first().args[1]).toEqual([
-          {specifier: './r3_symbols', qualifier: 'ɵngcc0', isDefault: false}
+          {specifier: './r3_symbols', qualifier: 'ɵngcc0'}
         ]);
       });
 
@@ -505,9 +504,9 @@ A.ngDirectiveDef = ɵngcc0.ɵdefineDirective({ type: A, selectors: [["", "a", ""
             export declare function withProviders8(): (MyModuleWithProviders)&{ngModule:SomeModule};`);
 
         expect(renderer.addImports).toHaveBeenCalledWith(jasmine.any(MagicString), [
-          {specifier: './module', qualifier: 'ɵngcc0', isDefault: false},
-          {specifier: '@angular/core', qualifier: 'ɵngcc1', isDefault: false},
-          {specifier: 'some-library', qualifier: 'ɵngcc2', isDefault: false},
+          {specifier: './module', qualifier: 'ɵngcc0'},
+          {specifier: '@angular/core', qualifier: 'ɵngcc1'},
+          {specifier: 'some-library', qualifier: 'ɵngcc2'},
         ]);
 
 

--- a/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/component.ts
@@ -12,7 +12,7 @@ import * as ts from 'typescript';
 
 import {CycleAnalyzer} from '../../cycles';
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
-import {ModuleResolver, Reference, ReferenceEmitter} from '../../imports';
+import {DefaultImportRecorder, ModuleResolver, Reference, ReferenceEmitter} from '../../imports';
 import {EnumValue, PartialEvaluator} from '../../partial_evaluator';
 import {Decorator, ReflectionHost, filterToMembersWithDecorator, reflectObjectLiteral} from '../../reflection';
 import {LocalModuleScopeRegistry, ScopeDirective, extractDirectiveGuards} from '../../scope';
@@ -45,7 +45,7 @@ export class ComponentDecoratorHandler implements
       private resourceLoader: ResourceLoader, private rootDirs: string[],
       private defaultPreserveWhitespaces: boolean, private i18nUseExternalIds: boolean,
       private moduleResolver: ModuleResolver, private cycleAnalyzer: CycleAnalyzer,
-      private refEmitter: ReferenceEmitter) {}
+      private refEmitter: ReferenceEmitter, private defaultImportRecorder: DefaultImportRecorder) {}
 
   private literalCache = new Map<Decorator, ts.ObjectLiteralExpression>();
   private boundTemplateCache = new Map<ts.Declaration, BoundTarget<ScopeDirective>>();
@@ -135,7 +135,7 @@ export class ComponentDecoratorHandler implements
     // @Component inherits @Directive, so begin by extracting the @Directive metadata and building
     // on it.
     const directiveResult = extractDirectiveMetadata(
-        node, decorator, this.reflector, this.evaluator, this.isCore,
+        node, decorator, this.reflector, this.evaluator, this.defaultImportRecorder, this.isCore,
         this.elementSchemaRegistry.getDefaultComponentElementName());
     if (directiveResult === undefined) {
       // `extractDirectiveMetadata` returns undefined when the @Directive has `jit: true`. In this
@@ -302,7 +302,8 @@ export class ComponentDecoratorHandler implements
           viewProviders,
           i18nUseExternalIds: this.i18nUseExternalIds, relativeContextFilePath
         },
-        metadataStmt: generateSetClassMetadataCall(node, this.reflector, this.isCore),
+        metadataStmt: generateSetClassMetadataCall(
+            node, this.reflector, this.defaultImportRecorder, this.isCore),
         parsedTemplate: template.nodes,
       },
       typeCheck: true,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -10,7 +10,7 @@ import {LiteralExpr, R3PipeMetadata, Statement, WrappedNodeExpr, compilePipeFrom
 import * as ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
-import {Reference} from '../../imports';
+import {DefaultImportRecorder, Reference} from '../../imports';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {Decorator, ReflectionHost, reflectObjectLiteral} from '../../reflection';
 import {LocalModuleScopeRegistry} from '../../scope/src/local';
@@ -27,7 +27,8 @@ export interface PipeHandlerData {
 export class PipeDecoratorHandler implements DecoratorHandler<PipeHandlerData, Decorator> {
   constructor(
       private reflector: ReflectionHost, private evaluator: PartialEvaluator,
-      private scopeRegistry: LocalModuleScopeRegistry, private isCore: boolean) {}
+      private scopeRegistry: LocalModuleScopeRegistry,
+      private defaultImportRecorder: DefaultImportRecorder, private isCore: boolean) {}
 
   readonly precedence = HandlerPrecedence.PRIMARY;
 
@@ -98,9 +99,12 @@ export class PipeDecoratorHandler implements DecoratorHandler<PipeHandlerData, D
           name,
           type,
           pipeName,
-          deps: getValidConstructorDependencies(clazz, this.reflector, this.isCore), pure,
+          deps: getValidConstructorDependencies(
+              clazz, this.reflector, this.defaultImportRecorder, this.isCore),
+          pure,
         },
-        metadataStmt: generateSetClassMetadataCall(clazz, this.reflector, this.isCore),
+        metadataStmt: generateSetClassMetadataCall(
+            clazz, this.reflector, this.defaultImportRecorder, this.isCore),
       },
     };
   }

--- a/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/component_spec.ts
@@ -10,7 +10,7 @@ import * as ts from 'typescript';
 
 import {CycleAnalyzer, ImportGraph} from '../../cycles';
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
-import {ModuleResolver, ReferenceEmitter} from '../../imports';
+import {ModuleResolver, NOOP_DEFAULT_IMPORT_RECORDER, ReferenceEmitter} from '../../imports';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {TypeScriptReflectionHost} from '../../reflection';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../scope';
@@ -55,7 +55,7 @@ describe('ComponentDecoratorHandler', () => {
 
     const handler = new ComponentDecoratorHandler(
         reflectionHost, evaluator, scopeRegistry, false, new NoopResourceLoader(), [''], false,
-        true, moduleResolver, cycleAnalyzer, refEmitter);
+        true, moduleResolver, cycleAnalyzer, refEmitter, NOOP_DEFAULT_IMPORT_RECORDER);
     const TestCmp = getDeclaration(program, 'entry.ts', 'TestCmp', ts.isClassDeclaration);
     const detected = handler.detect(TestCmp, reflectionHost.getDecoratorsOfDeclaration(TestCmp));
     if (detected === undefined) {

--- a/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/directive_spec.ts
@@ -8,7 +8,7 @@
 
 import * as ts from 'typescript';
 
-import {ReferenceEmitter} from '../../imports';
+import {NOOP_DEFAULT_IMPORT_RECORDER, ReferenceEmitter} from '../../imports';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {TypeScriptReflectionHost} from '../../reflection';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../scope';
@@ -43,7 +43,8 @@ describe('DirectiveDecoratorHandler', () => {
     const scopeRegistry = new LocalModuleScopeRegistry(
         new MetadataDtsModuleScopeResolver(checker, reflectionHost, null), new ReferenceEmitter([]),
         null);
-    const handler = new DirectiveDecoratorHandler(reflectionHost, evaluator, scopeRegistry, false);
+    const handler = new DirectiveDecoratorHandler(
+        reflectionHost, evaluator, scopeRegistry, NOOP_DEFAULT_IMPORT_RECORDER, false);
 
     const analyzeDirective = (dirName: string) => {
       const DirNode = getDeclaration(program, 'entry.ts', dirName, ts.isClassDeclaration);

--- a/packages/compiler-cli/src/ngtsc/annotations/test/metadata_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/metadata_spec.ts
@@ -8,11 +8,10 @@
 
 import * as ts from 'typescript';
 
-import {NoopImportRewriter} from '../../imports';
+import {NOOP_DEFAULT_IMPORT_RECORDER, NoopImportRewriter} from '../../imports';
 import {TypeScriptReflectionHost} from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing/in_memory_typescript';
 import {ImportManager, translateStatement} from '../../translator';
-
 import {generateSetClassMetadataCall} from '../src/metadata';
 
 const CORE = {
@@ -83,13 +82,13 @@ function compileAndPrint(contents: string): string {
   ]);
   const host = new TypeScriptReflectionHost(program.getTypeChecker());
   const target = getDeclaration(program, 'index.ts', 'Target', ts.isClassDeclaration);
-  const call = generateSetClassMetadataCall(target, host, false);
+  const call = generateSetClassMetadataCall(target, host, NOOP_DEFAULT_IMPORT_RECORDER, false);
   if (call === null) {
     return '';
   }
   const sf = program.getSourceFile('index.ts') !;
   const im = new ImportManager(new NoopImportRewriter(), 'i');
-  const tsStatement = translateStatement(call, im);
+  const tsStatement = translateStatement(call, im, NOOP_DEFAULT_IMPORT_RECORDER);
   const res = ts.createPrinter().printNode(ts.EmitHint.Unspecified, tsStatement, sf);
   return res.replace(/\s+/g, ' ');
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/test/ng_module_spec.ts
@@ -10,7 +10,7 @@ import {WrappedNodeExpr} from '@angular/compiler';
 import {R3Reference} from '@angular/compiler/src/compiler';
 import * as ts from 'typescript';
 
-import {LocalIdentifierStrategy, ReferenceEmitter} from '../../imports';
+import {LocalIdentifierStrategy, NOOP_DEFAULT_IMPORT_RECORDER, ReferenceEmitter} from '../../imports';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {TypeScriptReflectionHost} from '../../reflection';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../scope';
@@ -61,7 +61,8 @@ describe('NgModuleDecoratorHandler', () => {
     const refEmitter = new ReferenceEmitter([new LocalIdentifierStrategy()]);
 
     const handler = new NgModuleDecoratorHandler(
-        reflectionHost, evaluator, scopeRegistry, referencesRegistry, false, null, refEmitter);
+        reflectionHost, evaluator, scopeRegistry, referencesRegistry, false, null, refEmitter,
+        NOOP_DEFAULT_IMPORT_RECORDER);
     const TestModule = getDeclaration(program, 'entry.ts', 'TestModule', ts.isClassDeclaration);
     const detected =
         handler.detect(TestModule, reflectionHost.getDecoratorsOfDeclaration(TestModule));

--- a/packages/compiler-cli/src/ngtsc/imports/index.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/index.ts
@@ -8,6 +8,7 @@
 
 export {AliasGenerator, AliasStrategy} from './src/alias';
 export {ImportRewriter, NoopImportRewriter, R3SymbolsImportRewriter, validateAndRewriteCoreSymbol} from './src/core';
+export {DefaultImportRecorder, DefaultImportTracker, NOOP_DEFAULT_IMPORT_RECORDER} from './src/default';
 export {AbsoluteModuleStrategy, FileToModuleHost, FileToModuleStrategy, LocalIdentifierStrategy, LogicalProjectStrategy, ReferenceEmitStrategy, ReferenceEmitter} from './src/emitter';
 export {Reexport} from './src/reexport';
 export {ImportMode, OwningModule, Reference} from './src/references';

--- a/packages/compiler-cli/src/ngtsc/imports/src/default.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/default.ts
@@ -1,0 +1,188 @@
+/**
+* @license
+* Copyright Google Inc. All Rights Reserved.
+*
+* Use of this source code is governed by an MIT-style license that can be
+* found in the LICENSE file at https://angular.io/license
+*/
+
+import * as ts from 'typescript';
+
+import {getSourceFile} from '../../util/src/typescript';
+
+/**
+ * Registers and records usages of `ts.Identifer`s that came from default import statements.
+ *
+ * See `DefaultImportTracker` for details.
+ */
+export interface DefaultImportRecorder {
+  /**
+   * Record an association between a `ts.Identifier` which might be emitted and the
+   * `ts.ImportDeclaration` from which it came.
+   *
+   * Alone, this method has no effect as the `ts.Identifier` might not be used in the output.
+   * The identifier must later be marked as used with `recordUsedIdentifier` in order for its
+   * import to be preserved.
+   */
+  recordImportedIdentifier(id: ts.Identifier, decl: ts.ImportDeclaration): void;
+
+  /**
+   * Record the fact that the given `ts.Identifer` will be emitted, and thus its
+   * `ts.ImportDeclaration`, if it was a previously registered default import, must be preserved.
+   *
+   * This method can be called safely for any `ts.Identifer`, regardless of its origin. It will only
+   * have an effect if the identifier came from a `ts.ImportDeclaration` default import which was
+   * previously registered with `recordImportedIdentifier`.
+   */
+  recordUsedIdentifier(id: ts.Identifier): void;
+}
+
+/**
+ * An implementation of `DefaultImportRecorder` which does nothing.
+ *
+ * This is useful when default import tracking isn't required, such as when emitting .d.ts code
+ * or for ngcc.
+ */
+export const NOOP_DEFAULT_IMPORT_RECORDER: DefaultImportRecorder = {
+  recordImportedIdentifier: (id: ts.Identifier) => void{},
+  recordUsedIdentifier: (id: ts.Identifier) => void{},
+};
+
+/**
+ * TypeScript has trouble with generating default imports inside of transformers for some module
+ * formats. The issue is that for the statement:
+ *
+ * import X from 'some/module';
+ * console.log(X);
+ *
+ * TypeScript will not use the "X" name in generated code. For normal user code, this is fine
+ * because references to X will also be renamed. However, if both the import and any references are
+ * added in a transformer, TypeScript does not associate the two, and will leave the "X" references
+ * dangling while renaming the import variable. The generated code looks something like:
+ *
+ * const module_1 = require('some/module');
+ * console.log(X); // now X is a dangling reference.
+ *
+ * Therefore, we cannot synthetically add default imports, and must reuse the imports that users
+ * include. Doing this poses a challenge for imports that are only consumed in the type position in
+ * the user's code. If Angular reuses the imported symbol in a value position (for example, we
+ * see a constructor parameter of type Foo and try to write "inject(Foo)") we will also end up with
+ * a dangling reference, as TS will elide the import because it was only used in the type position
+ * originally.
+ *
+ * To avoid this, the compiler must "touch" the imports with `ts.updateImportClause`, and should
+ * only do this for imports which are actually consumed. The `DefaultImportTracker` keeps track of
+ * these imports as they're encountered and emitted, and implements a transform which can correctly
+ * flag the imports as required.
+ *
+ * This problem does not exist for non-default imports as the compiler can easily insert
+ * "import * as X" style imports for those, and the "X" identifier survives transformation.
+ */
+export class DefaultImportTracker implements DefaultImportRecorder {
+  /**
+   * A `Map` which tracks the `Map` of default import `ts.Identifier`s to their
+   * `ts.ImportDeclaration`s. These declarations are not guaranteed to be used.
+   */
+  private sourceFileToImportMap =
+      new Map<ts.SourceFile, Map<ts.Identifier, ts.ImportDeclaration>>();
+
+  /**
+   * A `Map` which tracks the `Set` of `ts.ImportDeclaration`s for default imports that were used in
+   * a given `ts.SourceFile` and need to be preserved.
+   */
+  private sourceFileToUsedImports = new Map<ts.SourceFile, Set<ts.ImportDeclaration>>();
+  recordImportedIdentifier(id: ts.Identifier, decl: ts.ImportDeclaration): void {
+    const sf = getSourceFile(id);
+    if (!this.sourceFileToImportMap.has(sf)) {
+      this.sourceFileToImportMap.set(sf, new Map<ts.Identifier, ts.ImportDeclaration>());
+    }
+    this.sourceFileToImportMap.get(sf) !.set(id, decl);
+  }
+
+  recordUsedIdentifier(id: ts.Identifier): void {
+    const sf = getSourceFile(id);
+    if (!this.sourceFileToImportMap.has(sf)) {
+      // The identifier's source file has no registered default imports at all.
+      return;
+    }
+    const identiferToDeclaration = this.sourceFileToImportMap.get(sf) !;
+    if (!identiferToDeclaration.has(id)) {
+      // The identifier isn't from a registered default import.
+      return;
+    }
+    const decl = identiferToDeclaration.get(id) !;
+
+    // Add the default import declaration to the set of used import declarations for the file.
+    if (!this.sourceFileToUsedImports.has(sf)) {
+      this.sourceFileToUsedImports.set(sf, new Set<ts.ImportDeclaration>());
+    }
+    this.sourceFileToUsedImports.get(sf) !.add(decl);
+  }
+
+  /**
+   * Get a `ts.TransformerFactory` which will preserve default imports that were previously marked
+   * as used.
+   *
+   * This transformer must run after any other transformers which call `recordUsedIdentifier`.
+   */
+  importPreservingTransformer(): ts.TransformerFactory<ts.SourceFile> {
+    return (context: ts.TransformationContext) => {
+      return (sf: ts.SourceFile) => { return this.transformSourceFile(sf); };
+    };
+  }
+
+  /**
+   * Process a `ts.SourceFile` and replace any `ts.ImportDeclaration`s.
+   */
+  private transformSourceFile(sf: ts.SourceFile): ts.SourceFile {
+    const originalSf = ts.getOriginalNode(sf) as ts.SourceFile;
+    // Take a fast path if no import declarations need to be preserved in the file.
+    if (!this.sourceFileToUsedImports.has(originalSf)) {
+      return sf;
+    }
+
+    // There are declarations that need to be preserved.
+    const importsToPreserve = this.sourceFileToUsedImports.get(originalSf) !;
+
+    // Generate a new statement list which preserves any imports present in `importsToPreserve`.
+    const statements = sf.statements.map(stmt => {
+      if (ts.isImportDeclaration(stmt) && importsToPreserve.has(stmt)) {
+        // Preserving an import that's marked as unreferenced (type-only) is tricky in TypeScript.
+        //
+        // Various approaches have been tried, with mixed success:
+        //
+        // 1. Using `ts.updateImportDeclaration` does not cause the import to be retained.
+        //
+        // 2. Using `ts.createImportDeclaration` with the same `ts.ImportClause` causes the import
+        //    to correctly be retained, but when emitting CommonJS module format code, references
+        //    to the imported value will not match the import variable.
+        //
+        // 3. Emitting "import * as" imports instead generates the correct import variable, but
+        //    references are missing the ".default" access. This happens to work for tsickle code
+        //    with goog.module transformations as tsickle strips the ".default" anyway.
+        //
+        // 4. It's possible to trick TypeScript by setting `ts.NodeFlag.Synthesized` on the import
+        //    declaration. This causes the import to be correctly retained and generated, but can
+        //    violate invariants elsewhere in the compiler and cause crashes.
+        //
+        // 5. Using `ts.getMutableClone` seems to correctly preserve the import and correctly
+        //    generate references to the import variable across all module types.
+        //
+        // Therefore, option 5 is the one used here. It seems to be implemented as the correct way
+        // to perform option 4, which preserves all the compiler's invariants.
+        //
+        // TODO(alxhub): discuss with the TypeScript team and determine if there's a better way to
+        // deal with this issue.
+        stmt = ts.getMutableClone(stmt);
+      }
+      return stmt;
+    });
+
+    // Save memory - there's no need to keep these around once the transform has run for the given
+    // file.
+    this.sourceFileToImportMap.delete(originalSf);
+    this.sourceFileToUsedImports.delete(originalSf);
+
+    return ts.updateSourceFileNode(sf, statements);
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/imports/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/imports/test/BUILD.bazel
@@ -1,0 +1,26 @@
+load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob([
+        "**/*.ts",
+    ]),
+    deps = [
+        "//packages:types",
+        "//packages/compiler-cli/src/ngtsc/imports",
+        "//packages/compiler-cli/src/ngtsc/testing",
+        "@npm//typescript",
+    ],
+)
+
+jasmine_node_test(
+    name = "test",
+    bootstrap = ["angular/tools/testing/init_node_no_angular_spec.js"],
+    deps = [
+        ":test_lib",
+        "//tools/testing:node_no_angular",
+    ],
+)

--- a/packages/compiler-cli/src/ngtsc/imports/test/default_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/test/default_spec.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {getDeclaration, makeProgram} from '../../testing/in_memory_typescript';
+import {DefaultImportTracker} from '../src/default';
+
+describe('DefaultImportTracker', () => {
+  it('should prevent a default import from being elided if used', () => {
+    const {program, host} = makeProgram(
+        [
+          {name: 'dep.ts', contents: `export default class Foo {}`},
+          {name: 'test.ts', contents: `import Foo from './dep'; export function test(f: Foo) {}`},
+
+          // This control file is identical to the test file, but will not have its import marked
+          // for preservation. It exists to verify that it is in fact the action of
+          // DefaultImportTracker and not some other artifact of the test setup which causes the
+          // import to be preserved. It will also verify that DefaultImportTracker does not preserve
+          // imports which are not marked for preservation.
+          {name: 'ctrl.ts', contents: `import Foo from './dep'; export function test(f: Foo) {}`},
+        ],
+        {
+          module: ts.ModuleKind.ES2015,
+        });
+    const fooClause = getDeclaration(program, 'test.ts', 'Foo', ts.isImportClause);
+    const fooId = fooClause.name !;
+    const fooDecl = fooClause.parent;
+
+    const tracker = new DefaultImportTracker();
+    tracker.recordImportedIdentifier(fooId, fooDecl);
+    tracker.recordUsedIdentifier(fooId);
+    program.emit(undefined, undefined, undefined, undefined, {
+      before: [tracker.importPreservingTransformer()],
+    });
+    const testContents = host.readFile('/test.js') !;
+    expect(testContents).toContain(`import Foo from './dep';`);
+
+    // The control should have the import elided.
+    const ctrlContents = host.readFile('/ctrl.js');
+    expect(ctrlContents).not.toContain(`import Foo from './dep';`);
+  });
+
+  it('should transpile imports correctly into commonjs', () => {
+    const {program, host} = makeProgram(
+        [
+          {name: 'dep.ts', contents: `export default class Foo {}`},
+          {name: 'test.ts', contents: `import Foo from './dep'; export function test(f: Foo) {}`},
+        ],
+        {
+          module: ts.ModuleKind.CommonJS,
+        });
+    const fooClause = getDeclaration(program, 'test.ts', 'Foo', ts.isImportClause);
+    const fooId = ts.updateIdentifier(fooClause.name !);
+    const fooDecl = fooClause.parent;
+
+    const tracker = new DefaultImportTracker();
+    tracker.recordImportedIdentifier(fooId, fooDecl);
+    tracker.recordUsedIdentifier(fooId);
+    program.emit(undefined, undefined, undefined, undefined, {
+      before: [
+        addReferenceTransformer(fooId),
+        tracker.importPreservingTransformer(),
+      ],
+    });
+    const testContents = host.readFile('/test.js') !;
+    expect(testContents).toContain(`var dep_1 = require("./dep");`);
+    expect(testContents).toContain(`var ref = dep_1["default"];`);
+  });
+});
+
+function addReferenceTransformer(id: ts.Identifier): ts.TransformerFactory<ts.SourceFile> {
+  return (context: ts.TransformationContext) => {
+    return (sf: ts.SourceFile) => {
+      if (id.getSourceFile().fileName === sf.fileName) {
+        return ts.updateSourceFileNode(sf, [
+          ...sf.statements, ts.createVariableStatement(undefined, ts.createVariableDeclarationList([
+            ts.createVariableDeclaration('ref', undefined, id),
+          ]))
+        ]);
+      }
+      return sf;
+    };
+  };
+}

--- a/packages/compiler-cli/src/ngtsc/reflection/index.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/index.ts
@@ -7,5 +7,5 @@
  */
 
 export * from './src/host';
-export {DEFAULT_EXPORT_NAME, typeNodeToValueExpr} from './src/type_to_value';
+export {typeNodeToValueExpr} from './src/type_to_value';
 export {TypeScriptReflectionHost, filterToMembersWithDecorator, reflectIdentifierOfDeclaration, reflectNameOfDeclaration, reflectObjectLiteral, reflectTypeEntityToDeclaration} from './src/typescript';

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -167,7 +167,7 @@ export interface ClassMember {
  * valid within the local file where the type was referenced.
  */
 export type TypeValueReference = {
-  local: true; expression: ts.Expression;
+  local: true; expression: ts.Expression; defaultImportStatement: ts.ImportDeclaration | null;
 } |
 {
   local: false;

--- a/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
@@ -171,7 +171,12 @@ describe('reflector', () => {
       const host = new TypeScriptReflectionHost(checker);
       const args = host.getConstructorParameters(clazz) !;
       expect(args.length).toBe(1);
-      expectParameter(args[0], 'bar', {moduleName: './bar', name: '*'});
+      const param = args[0].typeValueReference;
+      if (param === null || !param.local) {
+        return fail('Expected local parameter');
+      }
+      expect(param).not.toBeNull();
+      expect(param.defaultImportStatement).not.toBeNull();
     });
 
     it('should reflect a nullable argument', () => {

--- a/packages/compiler-cli/src/ngtsc/testing/in_memory_typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/in_memory_typescript.ts
@@ -133,6 +133,10 @@ export function getDeclaration<T extends ts.Declaration>(
       if (stmt.name !== undefined && stmt.name.text === name) {
         chosenDecl = stmt;
       }
+    } else if (
+        ts.isImportDeclaration(stmt) && stmt.importClause !== undefined &&
+        stmt.importClause.name !== undefined && stmt.importClause.name.text === name) {
+      chosenDecl = stmt.importClause;
     }
   });
 

--- a/packages/compiler-cli/src/ngtsc/transform/src/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/utils.ts
@@ -20,16 +20,9 @@ export function addImports(
   // Generate the import statements to prepend.
   const addedImports = importManager.getAllImports(sf.fileName).map(i => {
     const qualifier = ts.createIdentifier(i.qualifier);
-    let importClause: ts.ImportClause;
-    if (!i.isDefault) {
-      importClause = ts.createImportClause(
-          /* name */ undefined,
-          /* namedBindings */ ts.createNamespaceImport(qualifier));
-    } else {
-      importClause = ts.createImportClause(
-          /* name */ qualifier,
-          /* namedBindings */ undefined);
-    }
+    const importClause = ts.createImportClause(
+        /* name */ undefined,
+        /* namedBindings */ ts.createNamespaceImport(qualifier));
     return ts.createImportDeclaration(
         /* decorators */ undefined,
         /* modifiers */ undefined,

--- a/packages/compiler-cli/src/ngtsc/translator/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/translator/BUILD.bazel
@@ -9,7 +9,6 @@ ts_library(
         "//packages:types",
         "//packages/compiler",
         "//packages/compiler-cli/src/ngtsc/imports",
-        "//packages/compiler-cli/src/ngtsc/reflection",
         "//packages/compiler-cli/src/ngtsc/util",
         "@npm//typescript",
     ],

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -135,13 +135,7 @@ export class TypeCheckContext {
 
     // Write out the imports that need to be added to the beginning of the file.
     let imports = importManager.getAllImports(sf.fileName)
-                      .map(i => {
-                        if (!i.isDefault) {
-                          return `import * as ${i.qualifier} from '${i.specifier}';`;
-                        } else {
-                          return `import ${i.qualifier} from '${i.specifier}';`;
-                        }
-                      })
+                      .map(i => `import * as ${i.qualifier} from '${i.specifier}';`)
                       .join('\n');
     code = imports + '\n' + code;
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -9,7 +9,7 @@
 import {AST, BindingType, BoundTarget, ImplicitReceiver, PropertyRead, TmplAstBoundAttribute, TmplAstBoundText, TmplAstElement, TmplAstNode, TmplAstTemplate, TmplAstTextAttribute, TmplAstVariable} from '@angular/compiler';
 import * as ts from 'typescript';
 
-import {Reference, ReferenceEmitter} from '../../imports';
+import {NOOP_DEFAULT_IMPORT_RECORDER, Reference, ReferenceEmitter} from '../../imports';
 import {ImportManager, translateExpression} from '../../translator';
 
 import {TypeCheckBlockMetadata, TypeCheckableDirectiveMeta} from './api';
@@ -83,7 +83,7 @@ class Context {
     }
 
     // Use `translateExpression` to convert the `Expression` into a `ts.Expression`.
-    return translateExpression(ngExpr, this.importManager);
+    return translateExpression(ngExpr, this.importManager, NOOP_DEFAULT_IMPORT_RECORDER);
   }
 }
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2121,9 +2121,9 @@ describe('ngtsc behavioral tests', () => {
 
        env.driveMain();
        const jsContents = trim(env.getContents('test.js'));
-       expect(jsContents).toContain(`import * as types from './types';`);
-       expect(jsContents).toMatch(setClassMetadataRegExp('type: i\\d\\.MyTypeA'));
-       expect(jsContents).toMatch(setClassMetadataRegExp('type: i\\d\\.MyTypeB'));
+       expect(jsContents).toContain(`import * as i1 from "./types";`);
+       expect(jsContents).toMatch(setClassMetadataRegExp('type: i1.MyTypeA'));
+       expect(jsContents).toMatch(setClassMetadataRegExp('type: i1.MyTypeB'));
      });
 
   it('should use default-imported types if they can be represented as values', () => {
@@ -2146,12 +2146,12 @@ describe('ngtsc behavioral tests', () => {
 
     env.driveMain();
     const jsContents = trim(env.getContents('test.js'));
-    expect(jsContents).toContain(`import i1 from "./types";`);
-    expect(jsContents).toContain(`import * as i2 from "./types";`);
-    expect(jsContents).toContain('i0.ɵdirectiveInject(i1)');
-    expect(jsContents).toContain('i0.ɵdirectiveInject(i2.Other)');
-    expect(jsContents).toMatch(setClassMetadataRegExp('type: i1'));
-    expect(jsContents).toMatch(setClassMetadataRegExp('type: i2.Other'));
+    expect(jsContents).toContain(`import Default from './types';`);
+    expect(jsContents).toContain(`import * as i1 from "./types";`);
+    expect(jsContents).toContain('i0.ɵdirectiveInject(Default)');
+    expect(jsContents).toContain('i0.ɵdirectiveInject(i1.Other)');
+    expect(jsContents).toMatch(setClassMetadataRegExp('type: Default'));
+    expect(jsContents).toMatch(setClassMetadataRegExp('type: i1.Other'));
   });
 
   it('should use `undefined` in setClassMetadata if types can\'t be represented as values', () => {


### PR DESCRIPTION
This fixes an issue with commit b6f6b117. In this commit, default imports
processed in a type-to-value conversion were recorded as non-local imports
with a '*' name, and the ImportManager generated a new default import for
them. When transpiled to ES2015 modules, this resulted in the following
correct code:

import i3 from './module';

// somewhere in the file, a value reference of i3:
{type: i3}

However, when the AST with this synthetic import and reference was
transpiled to non-ES2015 modules (for example, to commonjs) an issue
appeared:

var module_1 = require('./module');
{type: i3}

TypeScript renames the imported identifier from i3 to module_1, but doesn't
substitute later references to i3. This is because the import and reference
are both synthetic, and never went through the TypeScript AST step of
"binding" which associates the reference to its import. This association is
important during emit when the identifiers might change.

Synthetic (transformer-added) imports will never be bound properly. The only
possible solution is to reuse the user's original import and the identifier
from it, which will be properly downleveled. The issue with this approach
(which prompted the fix in b6f6b117) is that if the import is only used in a
type position, TypeScript will mark it for deletion in the generated JS,
even though additional non-type usages are added in the transformer. This
again would leave a dangling import.

To work around this, it's necessary for the compiler to keep track of
identifiers that it emits which came from default imports, and tell TS not
to remove those imports during transpilation. A `DefaultImportTracker` class
is implemented to perform this tracking. It implements a
`DefaultImportRecorder` interface, which is used to record two significant
pieces of information:

* when a WrappedNodeExpr is generated which refers to a default imported
  value, the ts.Identifier is associated to the ts.ImportDeclaration via
  the recorder.
* when that WrappedNodeExpr is later emitted as part of the statement /
  expression translators, the fact that the ts.Identifier was used is
  also recorded.

Combined, this tracking gives the `DefaultImportTracker` enough information
to implement another TS transformer, which can recognize default imports
which were used in the output of the Ivy transform and can prevent them
from being elided. This is done by creating a new ts.ImportDeclaration for
the imports with the same ts.ImportClause. A test verifies that this works.
