### PR TITLE
fix(ivy): ensure template styles/classes are applied before directives are instantiated

### DIFF
--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -619,10 +619,13 @@ export function elementStart(
   ngDevMode && ngDevMode.rendererCreateElement++;
 
   const native = elementCreate(name);
+  const renderer = lView[RENDERER];
 
   ngDevMode && assertDataInRange(lView, index - 1);
 
   const tNode = createNodeAtIndex(index, TNodeType.Element, native !, name, attrs || null);
+  let initialStylesIndex = 0;
+  let initialClassesIndex = 0;
 
   if (attrs) {
     const lastAttrIndex = setUpAttributes(native, attrs);
@@ -639,6 +642,14 @@ export function elementStart(
       if (stylingAttrsStartIndex >= 0) {
         tNode.stylingTemplate = initializeStaticStylingContext(attrs, stylingAttrsStartIndex);
       }
+    }
+
+    if (tNode.stylingTemplate) {
+      // the initial style/class values are rendered immediately after having been
+      // initialized into the context so the element styling is ready when directives
+      // are initialized (since they may read style/class values in their constructor)
+      initialStylesIndex = renderInitialStyles(native, tNode.stylingTemplate, renderer);
+      initialClassesIndex = renderInitialClasses(native, tNode.stylingTemplate, renderer);
     }
   }
 
@@ -667,11 +678,11 @@ export function elementStart(
     }
   }
 
-  // There is no point in rendering styles when a class directive is present since
-  // it will take that over for us (this will be removed once #FW-882 is in).
+  // we render the styling again below incase any directives have set any `style` and/or
+  // `class` host attribute values...
   if (tNode.stylingTemplate) {
-    renderInitialClasses(native, tNode.stylingTemplate, lView[RENDERER]);
-    renderInitialStyles(native, tNode.stylingTemplate, lView[RENDERER]);
+    renderInitialClasses(native, tNode.stylingTemplate, renderer, initialClassesIndex);
+    renderInitialStyles(native, tNode.stylingTemplate, renderer, initialStylesIndex);
   }
 
   const currentQueries = lView[QUERIES];

--- a/packages/core/src/render3/instructions.ts
+++ b/packages/core/src/render3/instructions.ts
@@ -678,7 +678,7 @@ export function elementStart(
     }
   }
 
-  // we render the styling again below incase any directives have set any `style` and/or
+  // we render the styling again below in case any directives have set any `style` and/or
   // `class` host attribute values...
   if (tNode.stylingTemplate) {
     renderInitialClasses(native, tNode.stylingTemplate, renderer, initialClassesIndex);

--- a/packages/core/src/render3/interfaces/styling.ts
+++ b/packages/core/src/render3/interfaces/styling.ts
@@ -471,6 +471,12 @@ export const enum InitialStylingValuesIndex {
   DirectiveOwnerOffset = 2,
 
   /**
+   * The first bit set aside to mark if the initial style was already rendere
+   */
+  AppliedFlagBitPosition = 0b0,
+  AppliedFlagBitLength = 1,
+
+  /**
    * The total size for each style/class entry (prop + value + directiveOwner)
    */
   Size = 3

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -600,13 +600,7 @@
     "name": "renderEmbeddedTemplate"
   },
   {
-    "name": "renderInitialClasses"
-  },
-  {
-    "name": "renderInitialStyles"
-  },
-  {
-    "name": "renderInitialStylingValues"
+    "name": "renderInitialStyling"
   },
   {
     "name": "renderStringify"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -600,7 +600,10 @@
     "name": "renderEmbeddedTemplate"
   },
   {
-    "name": "renderInitialStyling"
+    "name": "renderInitialClasses"
+  },
+  {
+    "name": "renderInitialStyles"
   },
   {
     "name": "renderStringify"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -420,7 +420,10 @@
     "name": "renderEmbeddedTemplate"
   },
   {
-    "name": "renderInitialStyling"
+    "name": "renderInitialClasses"
+  },
+  {
+    "name": "renderInitialStyles"
   },
   {
     "name": "renderStringify"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -420,13 +420,7 @@
     "name": "renderEmbeddedTemplate"
   },
   {
-    "name": "renderInitialClasses"
-  },
-  {
-    "name": "renderInitialStyles"
-  },
-  {
-    "name": "renderInitialStylingValues"
+    "name": "renderInitialStyling"
   },
   {
     "name": "renderStringify"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1173,7 +1173,10 @@
     "name": "renderEmbeddedTemplate"
   },
   {
-    "name": "renderInitialStyling"
+    "name": "renderInitialClasses"
+  },
+  {
+    "name": "renderInitialStyles"
   },
   {
     "name": "renderStringify"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1173,13 +1173,7 @@
     "name": "renderEmbeddedTemplate"
   },
   {
-    "name": "renderInitialClasses"
-  },
-  {
-    "name": "renderInitialStyles"
-  },
-  {
-    "name": "renderInitialStylingValues"
+    "name": "renderInitialStyling"
   },
   {
     "name": "renderStringify"

--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -43,7 +43,7 @@ window.testBlocklist = {
   },
   "MatSidenav should be fixed position when in fixed mode": {
     "error": "Error: Expected ng-tns-c22979-0 ng-trigger ng-trigger-transform mat-drawer mat-sidenav mat-drawer-over ng-star-inserted to contain 'mat-sidenav-fixed'.",
-    "notes": "FW-1132: Host class bindings don't work if super class has host class bindings"
+    "notes": "Unknown"
   },
   "MatSidenav should set fixed bottom and top when in fixed mode": {
     "error": "Error: Expected '' to be '20px'.",
@@ -104,14 +104,6 @@ window.testBlocklist = {
   "MatSnackBar with TemplateRef should be able to open a snack bar using a TemplateRef": {
     "error": "Error: Expected ' Fries Pizza  ' to contain 'Pasta'.",
     "notes": "Breaking change: Change detection follows insertion tree only, not declaration tree (MatSnackBarContainer is OnPush)"
-  },
-  "MatTooltip special cases should clear the `user-select` when a tooltip is set on a text field": {
-    "error": "Error: Expected 'none' to be falsy.",
-    "notes": "FW-1133: Inline styles are not applied before constructor is run"
-  },
-  "MatTooltip special cases should clear the `-webkit-user-drag` on draggable elements": {
-    "error": "Error: Expected 'none' to be falsy.",
-    "notes": "FW-1133: Inline styles are not applied before constructor is run"
   }
 };
 // clang-format on

--- a/tools/material-ci/angular_material_test_blocklist.js
+++ b/tools/material-ci/angular_material_test_blocklist.js
@@ -43,7 +43,7 @@ window.testBlocklist = {
   },
   "MatSidenav should be fixed position when in fixed mode": {
     "error": "Error: Expected ng-tns-c22979-0 ng-trigger ng-trigger-transform mat-drawer mat-sidenav mat-drawer-over ng-star-inserted to contain 'mat-sidenav-fixed'.",
-    "notes": "Unknown"
+    "notes": "FW-1132: Host class bindings don't work if super class has host class bindings"
   },
   "MatSidenav should set fixed bottom and top when in fixed mode": {
     "error": "Error: Expected '' to be '20px'.",


### PR DESCRIPTION
Angular Ivy interprets inline static style/class attribute values as instructions that
are processed whilst an element gets created. Because these inline style values are
referenced by style/class bindings, their inline style values are applied at a later
stage. Despite them being eventually applied, their values should be applied earlier
before any directives are instantiated so that directive code can rely on any inline
style/class changes.

This patch ensures that all static style/class attribute values are applied (rendered)
on the element before directives are instantiated.

Jira Issue: FW-1133