### PR TITLE
ci: run legacy saucelabs for every build [patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -541,6 +541,9 @@ workflows:
       - test_aio:
           requires:
           - setup
+      - legacy-unit-tests-saucelabs:
+          requires:
+          - setup
       - deploy_aio:
           requires:
             - test_aio
@@ -593,23 +596,8 @@ workflows:
             # Get the artifacts to publish from the build-packages-dist job
             # since the publishing script expects the legacy outputs layout.
             - build-npm-packages
+            - legacy-unit-tests-saucelabs
             - legacy-misc-tests
-
-  saucelabs_tests:
-    jobs:
-      - setup
-      - legacy-unit-tests-saucelabs:
-          requires:
-            - setup
-    triggers:
-      - schedule:
-          # Runs the Saucelabs legacy tests every hour. We still want to run Saucelabs
-          # frequently as the caretaker needs up-to-date results when merging PRs or creating
-          # a new release. Also we primarily moved the Saucelabs job into a cronjob that doesn't
-          # run for PRs, in order to ensure that PRs are not affected by Saucelabs flakiness or
-          # incidents. This is still guaranteed (even if we run the job every hour).
-          cron: "0 * * * *"
-          filters: *publish_branches_filter
 
   aio_monitoring:
     jobs:


### PR DESCRIPTION
Patch version of #29255 