### PR TITLE
docs: unify `comp: upgrade/{dynamic,static}` labels as `comp: upgrade`

### DIFF
--- a/docs/TRIAGE_AND_LABELS.md
+++ b/docs/TRIAGE_AND_LABELS.md
@@ -31,8 +31,7 @@ The components have a clear piece of source code associated with it within the `
 * `comp: server`
 * `comp: service-worker`
 * `comp: testing`
-* `comp: upgrade/dynamic`
-* `comp: upgrade/static`
+* `comp: upgrade`
 * `comp: web-worker`
 * `comp: zones`
 
@@ -126,7 +125,7 @@ Every triaged PR must have a `pr_action` label assigned to it:
 * `PR action: review` - work is complete and comment is needed from the reviewers.
 * `PR action: cleanup` - more work is needed from the author.
 * `PR action: discuss` - discussion is needed, to be led by the author.
-* `PR action: merge` - the PR author is ready for the changes to be merged by the caretaker as soon as the PR is green (or merge-assistance label is applied and caretaker has deemed it acceptable manually). In other words, this label indicates to "auto submit when ready". 
+* `PR action: merge` - the PR author is ready for the changes to be merged by the caretaker as soon as the PR is green (or merge-assistance label is applied and caretaker has deemed it acceptable manually). In other words, this label indicates to "auto submit when ready".
 
 
 In addition, PRs can have the following states:


### PR DESCRIPTION
The labels on GitHub have already been updated. This PR updates the docs to match the actual labels.