### PR TITLE
fix(core): properly parse < inside interpolated expressions

### DIFF
--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -650,7 +650,8 @@ class _Tokenizer {
   }
 
   private _isTextEnd(): boolean {
-    if (this._cursor.peek() === chars.$LT || this._cursor.peek() === chars.$EOF) {
+    if ((this._cursor.peek() === chars.$LT && !this._inInterpolation) ||
+        this._cursor.peek() === chars.$EOF) {
       return true;
     }
 

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -7,7 +7,6 @@
  */
 
 import {getHtmlTagDefinition} from '../../src/ml_parser/html_tags';
-import {InterpolationConfig} from '../../src/ml_parser/interpolation_config';
 import * as lex from '../../src/ml_parser/lexer';
 import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_util';
 
@@ -254,6 +253,18 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
         ]);
       });
 
+      it('should parse valid start tag in attribute value', () => {
+        expect(tokenizeAndHumanizeParts('<div [if]="a<b">')).toEqual([
+          [lex.TokenType.TAG_OPEN_START, '', 'div'],
+          [lex.TokenType.ATTR_NAME, '', '[if]'],
+          [lex.TokenType.ATTR_QUOTE, '"'],
+          [lex.TokenType.ATTR_VALUE, 'a<b'],
+          [lex.TokenType.ATTR_QUOTE, '"'],
+          [lex.TokenType.TAG_OPEN_END],
+          [lex.TokenType.EOF],
+        ]);
+      });
+
       it('should parse attributes with prefix', () => {
         expect(tokenizeAndHumanizeParts('<t ns1:a>')).toEqual([
           [lex.TokenType.TAG_OPEN_START, '', 't'],
@@ -350,6 +361,18 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
           [lex.TokenType.ATTR_NAME, '', 'a'],
           [lex.TokenType.ATTR_QUOTE, '"'],
           [lex.TokenType.ATTR_VALUE, 'b && c &'],
+          [lex.TokenType.ATTR_QUOTE, '"'],
+          [lex.TokenType.TAG_OPEN_END],
+          [lex.TokenType.EOF],
+        ]);
+      });
+
+      it('should parse attributes with "=" in values', () => {
+        expect(tokenizeAndHumanizeParts('<div [if]="!(a = b)">')).toEqual([
+          [lex.TokenType.TAG_OPEN_START, '', 'div'],
+          [lex.TokenType.ATTR_NAME, '', '[if]'],
+          [lex.TokenType.ATTR_QUOTE, '"'],
+          [lex.TokenType.ATTR_VALUE, '!(a = b)'],
           [lex.TokenType.ATTR_QUOTE, '"'],
           [lex.TokenType.TAG_OPEN_END],
           [lex.TokenType.EOF],
@@ -542,12 +565,27 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
 
       it('should parse valid start tag in interpolation', () => {
         expect(tokenizeAndHumanizeParts('{{ a <b && c > d }}')).toEqual([
-          [lex.TokenType.TEXT, '{{ a '],
-          [lex.TokenType.TAG_OPEN_START, '', 'b'],
-          [lex.TokenType.ATTR_NAME, '', '&&'],
-          [lex.TokenType.ATTR_NAME, '', 'c'],
-          [lex.TokenType.TAG_OPEN_END],
-          [lex.TokenType.TEXT, ' d }}'],
+          [lex.TokenType.TEXT, '{{ a <b && c > d }}'],
+          [lex.TokenType.EOF],
+        ]);
+      });
+
+      it('should parse valid start tag in interpolation - no spaces between tag name and interpolation end',
+         () => {
+           expect(tokenizeAndHumanizeParts('{{a <b+5}}')).toEqual([
+             [lex.TokenType.TEXT, '{{a <b+5}}'],
+             [lex.TokenType.EOF],
+           ]);
+         });
+
+      it('should parse start tags with invalid attribute names as text', () => {
+        expect(tokenizeAndHumanizeParts('<t ">')).toEqual([
+          [lex.TokenType.TEXT, '<t ">'],
+          [lex.TokenType.EOF],
+        ]);
+
+        expect(tokenizeAndHumanizeParts('<t \'>')).toEqual([
+          [lex.TokenType.TEXT, '<t \'>'],
           [lex.TokenType.EOF],
         ]);
       });


### PR DESCRIPTION
This PR fixes the issue where interpolated text (ex.: `{{0 <one+5}}`) would not be parsed correctly (as we would try to interpret `<` as a HTML tag start). The fix consists of making sure that we are not trying to match `<` as tag start while inside interpolation. Other places where expressions could show up are inside attribute values (quoted string) and those cases are already handled correctly (added test to be sure).
