### PR TITLE
build: user bazelrc should be able to overwrite existing flags

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,3 @@
-# Load any settings specific to the current user
-try-import .bazelrc.user
 ################################
 # Settings for Angular team members only
 ################################
@@ -135,3 +133,7 @@ build:remote --remote_instance_name=projects/internal-200822/instances/default_i
 # Do not accept remote cache.
 # We need to understand the security risks of using prior build artifacts.
 build:remote --remote_accept_cached=false
+
+# Load any settings specific to the current user. Needs to be last statement in this
+# config, as the user configuration should be able to overwrite flags from this file.
+try-import .bazelrc.user


### PR DESCRIPTION
Currently the project `bazelrc` file imports a user bazelrc if present. This
has been added in order to allow user-specific Bazel configuration settings
when working within the Angular project. Since we currently import that
user configuration before setting the project-specific settings, it's not
possible for developers to overwrite given options (e.g. the `symlink_prefix`).

Moving the import to the end of the file solves that problem.