### PR TITLE
fix(bazel): fix strict null checks compile error in packages/bazel/src/schematics/ng-add/index.ts

### DIFF
--- a/packages/bazel/src/schematics/ng-add/index.ts
+++ b/packages/bazel/src/schematics/ng-add/index.ts
@@ -81,7 +81,11 @@ function updateGitignore() {
     if (!host.exists(gitignore)) {
       return host;
     }
-    const gitIgnoreContent = host.read(gitignore).toString();
+    const gitIgnoreContentRaw = host.read(gitignore);
+    if (!gitIgnoreContentRaw) {
+      return host;
+    }
+    const gitIgnoreContent = gitIgnoreContentRaw.toString();
     if (gitIgnoreContent.includes('\n/bazel-out\n')) {
       return host;
     }
@@ -102,8 +106,11 @@ function updateAngularJsonToUseBazelBuilder(options: Schema): Rule {
     if (!workspacePath) {
       throw new Error('Could not find angular.json');
     }
-    const workspaceContent = host.read(workspacePath).toString();
-    const workspaceJsonAst = parseJsonAst(workspaceContent) as JsonAstObject;
+    const workspaceContent = host.read(workspacePath);
+    if (!workspaceContent) {
+      throw new Error('Failed to read angular.json content');
+    }
+    const workspaceJsonAst = parseJsonAst(workspaceContent.toString()) as JsonAstObject;
     const projects = findPropertyInAstObject(workspaceJsonAst, 'projects');
     if (!projects) {
       throw new SchematicsException('Expect projects in angular.json to be an Object');
@@ -220,7 +227,11 @@ function updateTsconfigJson(): Rule {
     if (!host.exists(tsconfigPath)) {
       return host;
     }
-    const content = host.read(tsconfigPath).toString();
+    const contentRaw = host.read(tsconfigPath).toString();
+    if (!contentRaw) {
+      return host;
+    }
+    const content = contentRaw.toString();
     const ast = parseJsonAst(content);
     if (!isJsonAstObject(ast)) {
       return host;
@@ -255,8 +266,11 @@ function upgradeRxjs() {
     if (!host.exists(packageJson)) {
       throw new Error(`Could not find ${packageJson}`);
     }
-    const content = host.read(packageJson).toString();
-    const jsonAst = parseJsonAst(content);
+    const content = host.read(packageJson);
+    if (!content) {
+      throw new Error('Failed to read package.json content');
+    }
+    const jsonAst = parseJsonAst(content.toString());
     if (!isJsonAstObject(jsonAst)) {
       throw new Error(`Failed to parse JSON for ${packageJson}`);
     }
@@ -300,8 +314,14 @@ function addPostinstallToGenerateNgSummaries() {
     if (!host.exists(packageJson)) {
       throw new Error(`Could not find ${packageJson}`);
     }
-    const content = host.read(packageJson).toString();
-    const jsonAst = parseJsonAst(content) as JsonAstObject;
+    const content = host.read(packageJson);
+    if (!content) {
+      throw new Error('Failed to read package.json content');
+    }
+    const jsonAst = parseJsonAst(content.toString());
+    if (!isJsonAstObject(jsonAst)) {
+      throw new Error(`Failed to parse JSON for ${packageJson}`);
+    }
     const scripts = findPropertyInAstObject(jsonAst, 'scripts') as JsonAstObject;
     const recorder = host.beginUpdate(packageJson);
     if (scripts) {


### PR DESCRIPTION
Noticed this failure:

```
ERROR: /home/circleci/ng/packages/bazel/src/schematics/ng-add/BUILD.bazel:5:1: Compiling TypeScript (devmode) //packages/bazel/src/schematics/ng-add:ng-add failed (Exit 1): tsc_wrapped__bin failed: error executing command 
  (cd /home/circleci/.cache/bazel/_bazel_circleci/9ce5c2144ecf75d11717c0aa41e45a8d/execroot/angular && \
  exec env - \
    BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 \
    PATH=/bin:/usr/bin \
  bazel-out/host/bin/external/npm/node_modules/@bazel/typescript/tsc_wrapped__bin @@bazel-out/k8-fastbuild/bin/packages/bazel/src/schematics/ng-add/ng-add_es5_tsconfig.json)
Execution platform: //tools:rbe_ubuntu1604-angular
packages/bazel/src/schematics/ng-add/index.ts:84:30 - error TS2531: Object is possibly 'null'.

84     const gitIgnoreContent = host.read(gitignore).toString();
                                ~~~~~~~~~~~~~~~~~~~~
packages/bazel/src/schematics/ng-add/index.ts:105:30 - error TS2531: Object is possibly 'null'.

105     const workspaceContent = host.read(workspacePath).toString();
                                 ~~~~~~~~~~~~~~~~~~~~~~~~
packages/bazel/src/schematics/ng-add/index.ts:223:21 - error TS2531: Object is possibly 'null'.

223     const content = host.read(tsconfigPath).toString();
                        ~~~~~~~~~~~~~~~~~~~~~~~
packages/bazel/src/schematics/ng-add/index.ts:258:21 - error TS2531: Object is possibly 'null'.

258     const content = host.read(packageJson).toString();
                        ~~~~~~~~~~~~~~~~~~~~~~
packages/bazel/src/schematics/ng-add/index.ts:303:21 - error TS2531: Object is possibly 'null'.

303     const content = host.read(packageJson).toString();
                        ~~~~~~~~~~~~~~~~~~~~~~
```

in test_ivy_aot in #29197. Not sure why the strict null checks failure showed up in that PR but it is correct in that `host.read()` may return null.

@alexeagle Any chance strict null checks are behaving differently on RBE than in a local worker?

