### PR TITLE
fix(core): Deprecate TestBed.get(...):any

### DIFF
--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -13,6 +13,8 @@
 import {
   Component,
   Directive,
+  InjectFlags,
+  InjectionToken,
   Injector,
   NgModule,
   NgZone,
@@ -167,7 +169,14 @@ export class TestBedRender3 implements Injector, TestBed {
     return TestBedRender3 as any as TestBedStatic;
   }
 
-  static get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND): any {
+  static get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  /**
+   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   */
+  static get(token: any, notFoundValue?: any): any;
+  static get(
+      token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
+      flags: InjectFlags = InjectFlags.Default): any {
     return _getTestBedRender3().get(token, notFoundValue);
   }
 
@@ -254,12 +263,18 @@ export class TestBedRender3 implements Injector, TestBed {
 
   compileComponents(): Promise<any> { return this.compiler.compileComponents(); }
 
-  get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND): any {
+  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  /**
+   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   */
+  get(token: any, notFoundValue?: any): any;
+  get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
+      flags: InjectFlags = InjectFlags.Default): any {
     if (token === TestBedRender3) {
       return this;
     }
-    const result = this.testModuleRef.injector.get(token, UNDEFINED);
-    return result === UNDEFINED ? this.compiler.injector.get(token, notFoundValue) : result;
+    const result = this.testModuleRef.injector.get(token, UNDEFINED, flags);
+    return result === UNDEFINED ? this.compiler.injector.get(token, notFoundValue, flags) : result;
   }
 
   execute(tokens: any[], fn: Function, context?: any): any {
@@ -338,9 +353,11 @@ export class TestBedRender3 implements Injector, TestBed {
           `It looks like '${stringify(type)}' has not been IVY compiled - it has no 'ngComponentDef' field`);
     }
 
-    const noNgZone: boolean = this.get(ComponentFixtureNoNgZone, false);
-    const autoDetect: boolean = this.get(ComponentFixtureAutoDetect, false);
-    const ngZone: NgZone = noNgZone ? null : this.get(NgZone, null);
+    // TODO: Don't cast as `any`, proper type is boolean[]
+    const noNgZone = this.get(ComponentFixtureNoNgZone as any, false);
+    // TODO: Don't cast as `any`, proper type is boolean[]
+    const autoDetect: boolean = this.get(ComponentFixtureAutoDetect as any, false);
+    const ngZone: NgZone|null = noNgZone ? null : this.get(NgZone as Type<NgZone|null>, null);
     const componentFactory = new ComponentFactory(componentDef);
     const initComponent = () => {
       const componentRef =

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationInitStatus, CompilerOptions, Component, Directive, Injector, NgModule, NgModuleFactory, NgModuleRef, NgZone, Optional, Pipe, PlatformRef, Provider, SchemaMetadata, SkipSelf, StaticProvider, Type, ɵAPP_ROOT as APP_ROOT, ɵDepFlags as DepFlags, ɵInjectableDef as InjectableDef, ɵNodeFlags as NodeFlags, ɵclearOverrides as clearOverrides, ɵgetInjectableDef as getInjectableDef, ɵivyEnabled as ivyEnabled, ɵoverrideComponentView as overrideComponentView, ɵoverrideProvider as overrideProvider, ɵstringify as stringify} from '@angular/core';
+import {ApplicationInitStatus, CompilerOptions, Component, Directive, InjectFlags, InjectionToken, Injector, NgModule, NgModuleFactory, NgModuleRef, NgZone, Optional, Pipe, PlatformRef, Provider, SchemaMetadata, SkipSelf, StaticProvider, Type, ɵAPP_ROOT as APP_ROOT, ɵDepFlags as DepFlags, ɵInjectableDef as InjectableDef, ɵNodeFlags as NodeFlags, ɵclearOverrides as clearOverrides, ɵgetInjectableDef as getInjectableDef, ɵivyEnabled as ivyEnabled, ɵoverrideComponentView as overrideComponentView, ɵoverrideProvider as overrideProvider, ɵstringify as stringify} from '@angular/core';
 
 import {AsyncTestCompleter} from './async_test_completer';
 import {ComponentFixture} from './component_fixture';
@@ -56,6 +56,10 @@ export interface TestBed {
 
   compileComponents(): Promise<any>;
 
+  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  /**
+   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   */
   get(token: any, notFoundValue?: any): any;
 
   execute(tokens: any[], fn: Function, context?: any): any;
@@ -239,8 +243,16 @@ export class TestBedViewEngine implements Injector, TestBed {
     return TestBedViewEngine as any as TestBedStatic;
   }
 
-  static get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND) {
-    return _getTestBedViewEngine().get(token, notFoundValue);
+  static get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  /**
+   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   * @suppress {duplicate}
+   */
+  static get(token: any, notFoundValue?: any): any;
+  static get(
+      token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
+      flags: InjectFlags = InjectFlags.Default): any {
+    return _getTestBedViewEngine().get(token, notFoundValue, flags);
   }
 
   static createComponent<T>(component: Type<T>): ComponentFixture<T> {
@@ -469,15 +481,21 @@ export class TestBedViewEngine implements Injector, TestBed {
     }
   }
 
-  get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND): any {
+  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  /**
+   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   */
+  get(token: any, notFoundValue?: any): any;
+  get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
+      flags: InjectFlags = InjectFlags.Default): any {
     this._initIfNeeded();
     if (token === TestBed) {
       return this;
     }
     // Tests can inject things from the ng module and from the compiler,
     // but the ng module can't inject things from the compiler and vice versa.
-    const result = this._moduleRef.injector.get(token, UNDEFINED);
-    return result === UNDEFINED ? this._compiler.injector.get(token, notFoundValue) : result;
+    const result = this._moduleRef.injector.get(token, UNDEFINED, flags);
+    return result === UNDEFINED ? this._compiler.injector.get(token, notFoundValue, flags) : result;
   }
 
   execute(tokens: any[], fn: Function, context?: any): any {
@@ -599,9 +617,11 @@ export class TestBedViewEngine implements Injector, TestBed {
           `Cannot create the component ${stringify(component)} as it was not imported into the testing module!`);
     }
 
-    const noNgZone = this.get(ComponentFixtureNoNgZone, false);
-    const autoDetect: boolean = this.get(ComponentFixtureAutoDetect, false);
-    const ngZone: NgZone = noNgZone ? null : this.get(NgZone, null);
+    // TODO: Don't cast as `any`, proper type is boolean[]
+    const noNgZone = this.get(ComponentFixtureNoNgZone as any, false);
+    // TODO: Don't cast as `any`, proper type is boolean[]
+    const autoDetect: boolean = this.get(ComponentFixtureAutoDetect as any, false);
+    const ngZone: NgZone|null = noNgZone ? null : this.get(NgZone as Type<NgZone|null>, null);
     const testComponentRenderer: TestComponentRenderer = this.get(TestComponentRenderer);
     const rootElId = `root${_nextRootElementId++}`;
     testComponentRenderer.insertRootElement(rootElId);

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, InjectionToken, NgModule, Pipe, PlatformRef, SchemaMetadata, Type} from '@angular/core';
+import {Component, Directive, InjectFlags, InjectionToken, NgModule, Pipe, PlatformRef, SchemaMetadata, Type} from '@angular/core';
 
 import {ComponentFixture} from './component_fixture';
 import {MetadataOverride} from './metadata_override';
@@ -130,6 +130,10 @@ export interface TestBedStatic {
     deps?: any[],
   }): TestBedStatic;
 
+  get<T>(token: Type<T>|InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+  /**
+   * @deprecated from v8.0.0 use Type<T> or InjectionToken<T>
+   */
   get(token: any, notFoundValue?: any): any;
 
   createComponent<T>(component: Type<T>): ComponentFixture<T>;

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -62,15 +62,16 @@ export interface TestBed {
         useValue?: any;
         deps?: any[];
     }): void;
+    deprecatedOverrideProvider(token: any, provider: {
+        useValue: any;
+    }): void;
     /** @deprecated */ deprecatedOverrideProvider(token: any, provider: {
         useFactory: Function;
         deps: any[];
     }): void;
-    deprecatedOverrideProvider(token: any, provider: {
-        useValue: any;
-    }): void;
     execute(tokens: any[], fn: Function, context?: any): any;
-    get(token: any, notFoundValue?: any): any;
+    get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
+    /** @deprecated */ get(token: any, notFoundValue?: any): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): void;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): void;
     overrideDirective(directive: Type<any>, override: MetadataOverride<Directive>): void;
@@ -82,11 +83,11 @@ export interface TestBed {
         deps?: any[];
     }): void;
     overrideProvider(token: any, provider: {
-        useFactory: Function;
-        deps: any[];
+        useValue: any;
     }): void;
     overrideProvider(token: any, provider: {
-        useValue: any;
+        useFactory: Function;
+        deps: any[];
     }): void;
     overrideTemplateUsingTestingModule(component: Type<any>, template: string): void;
     resetTestEnvironment(): void;
@@ -116,7 +117,8 @@ export interface TestBedStatic {
         useFactory: Function;
         deps: any[];
     }): void;
-    get(token: any, notFoundValue?: any): any;
+    /** @deprecated */ get(token: any, notFoundValue?: any): any;
+    get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): TestBedStatic;
     overrideDirective(directive: Type<any>, override: MetadataOverride<Directive>): TestBedStatic;


### PR DESCRIPTION
Adds an overload to TestBed.get making parameters strongly typed and
deprecated previous signature that accepted types `any`. The function
still returns `any` to prevent build breakages, but eventually stronger
type checks will be added so a future Angular version will break builds
due to additional type checks.
See previous breaking change - #13785

Issue #26491

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
```ts
get(token: any, default?: any): any
```

Issue Number: #26491


## What is the new behavior?
"Same" signature as `Injector.get`:
```ts
get(token: InjetionToken<T>|Type<T>, default?: T, flags?: InjectorFlags): any
```
(Instead of returning `T`, it still returns `any`) to prevent breaking changes for 8.0, but this will hopefully break on 9.0

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Note that the return type is still `any`, this will change to be an actual breaking change similar to #13785 in a future major version

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
