### PR TITLE
feat(ivy): avoid unnecessary recompilations in TestBed

### DIFF
--- a/packages/core/src/di/interface/provider.ts
+++ b/packages/core/src/di/interface/provider.ts
@@ -365,3 +365,9 @@ export interface ClassProvider extends ClassSansProvider {
  */
 export type Provider = TypeProvider | ValueProvider | ClassProvider | ConstructorProvider |
     ExistingProvider | FactoryProvider | any[];
+
+/**
+ * Describes a function that is used to process provider list (for example in case of provider
+ * overrides).
+ */
+export type ProcessProvidersFunction = (providers: Provider[]) => Provider[];

--- a/packages/core/src/render3/features/providers_feature.ts
+++ b/packages/core/src/render3/features/providers_feature.ts
@@ -40,12 +40,11 @@ import {DirectiveDef} from '../interfaces/definition';
 export function ProvidersFeature<T>(providers: Provider[], viewProviders: Provider[] = []) {
   return (definition: DirectiveDef<T>) => {
     definition.providersResolver =
-        (def: DirectiveDef<T>, processProvidersFn?: ProcessProvidersFunction,
-         processViewProvidersFn?: ProcessProvidersFunction) => {
+        (def: DirectiveDef<T>, processProvidersFn?: ProcessProvidersFunction) => {
           return providersResolver(
-              def,  //
-              processProvidersFn ? processProvidersFn(providers) : providers,
-              processViewProvidersFn ? processViewProvidersFn(viewProviders) : viewProviders);
+              def,                                                             //
+              processProvidersFn ? processProvidersFn(providers) : providers,  //
+              viewProviders);
         };
   };
 }

--- a/packages/core/src/render3/features/providers_feature.ts
+++ b/packages/core/src/render3/features/providers_feature.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Provider} from '../../di/interface/provider';
+import {ProcessProvidersFunction, Provider} from '../../di/interface/provider';
 import {providersResolver} from '../di_setup';
 import {DirectiveDef} from '../interfaces/definition';
 
@@ -39,7 +39,13 @@ import {DirectiveDef} from '../interfaces/definition';
  */
 export function ProvidersFeature<T>(providers: Provider[], viewProviders: Provider[] = []) {
   return (definition: DirectiveDef<T>) => {
-    definition.providersResolver = (def: DirectiveDef<T>) =>
-        providersResolver(def, providers, viewProviders);
+    definition.providersResolver =
+        (def: DirectiveDef<T>, processProvidersFn?: ProcessProvidersFunction,
+         processViewProvidersFn?: ProcessProvidersFunction) => {
+          return providersResolver(
+              def,  //
+              processProvidersFn ? processProvidersFn(providers) : providers,
+              processViewProvidersFn ? processViewProvidersFn(viewProviders) : viewProviders);
+        };
   };
 }

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -140,9 +140,8 @@ export interface DirectiveDef<T> extends BaseDef<T> {
 
   /** Function that resolves providers and publishes them into the DI system. */
   providersResolver:
-      (<U extends T>(
-           def: DirectiveDef<U>, processProvidersFn?: ProcessProvidersFunction,
-           processViewProvidersFn?: ProcessProvidersFunction) => void)|null;
+      (<U extends T>(def: DirectiveDef<U>, processProvidersFn?: ProcessProvidersFunction) =>
+           void)|null;
 
   /** The selectors that will be used to match nodes to this directive. */
   readonly selectors: CssSelectorList;

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -7,6 +7,7 @@
  */
 
 import {SchemaMetadata, ViewEncapsulation} from '../../core';
+import {ProcessProvidersFunction} from '../../di/interface/provider';
 import {Type} from '../../interface/type';
 import {CssSelectorList} from './projection';
 
@@ -138,7 +139,10 @@ export interface DirectiveDef<T> extends BaseDef<T> {
   type: Type<T>;
 
   /** Function that resolves providers and publishes them into the DI system. */
-  providersResolver: (<U extends T>(def: DirectiveDef<U>) => void)|null;
+  providersResolver:
+      (<U extends T>(
+           def: DirectiveDef<U>, processProvidersFn?: ProcessProvidersFunction,
+           processViewProvidersFn?: ProcessProvidersFunction) => void)|null;
 
   /** The selectors that will be used to match nodes to this directive. */
   readonly selectors: CssSelectorList;

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -37,7 +37,7 @@ import {flushModuleScopingQueueAsMuchAsPossible, patchComponentDefWithScope, tra
 export function compileComponent(type: Type<any>, metadata: Component): void {
   let ngComponentDef: any = null;
   // Metadata may have resources which need to be resolved.
-  maybeQueueResolutionOfComponentResources(metadata);
+  maybeQueueResolutionOfComponentResources(type, metadata);
   Object.defineProperty(type, NG_COMPONENT_DEF, {
     get: () => {
       const compiler = getCompilerFacade();

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -357,6 +357,12 @@ export function patchComponentDefWithScope<C>(
   componentDef.pipeDefs = () =>
       Array.from(transitiveScopes.compilation.pipes).map(pipe => getPipeDef(pipe) !);
   componentDef.schemas = transitiveScopes.schemas;
+
+  // Since we avoid Components/Directives/Pipes recompiling in case there are no overrides, we
+  // may face a problem where previously compiled defs available to a given Component/Directive
+  // are cached in TView and may become stale (in case any of these defs gets recompiled). In
+  // order to avoid this problem, we force fresh TView to be created.
+  componentDef.template.ngPrivateData = undefined;
 }
 
 /**

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -136,6 +136,15 @@ function declareTests(config?: {useJit: boolean}) {
     }
 
     function createComp<T>(compType: Type<T>, moduleType: Type<any>): ComponentFixture<T> {
+      const componentDef = (compType as any).ngComponentDef;
+      if (componentDef) {
+        // Since we avoid Components/Directives/Pipes recompiling in case there are no overrides, we
+        // may face a problem where previously compiled defs available to a given
+        // Component/Directive are cached in TView and may become stale (in case any of these defs
+        // gets recompiled). In order to avoid this problem, we force fresh TView to be created.
+        componentDef.template.ngPrivateData = null;
+      }
+
       const ngModule = createModule(moduleType, injector);
 
       const cf = ngModule.componentFactoryResolver.resolveComponentFactory(compType) !;

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -294,8 +294,8 @@ describe('TestBed', () => {
           TestBed.resetTestingModule();
 
           const defAfterReset = (SomeComponent as any).ngComponentDef;
-          expect(defAfterReset.pipeDefs().length).toEqual(0);
-          expect(defAfterReset.directiveDefs().length).toEqual(1);  // component
+          expect(defAfterReset.pipeDefs).toBe(null);
+          expect(defAfterReset.directiveDefs).toBe(null);
         });
 
         it('should cleanup ng defs for classes with no ng annotations (in case of inheritance)',

--- a/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
+++ b/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
@@ -144,9 +144,7 @@ if (isBrowser) {
            });
          }),
          10000);  // Long timeout here because this test makes an actual ResourceLoader
-                  // request, and
-                  // is slow
-                  // on Edge.
+                  // request, and is slow on Edge.
     });
   });
 }

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -900,17 +900,24 @@ class CompWithUrlTemplate {
            () => {
              const itPromise = patchJasmineIt();
 
+             @Component({
+               selector: 'comp',
+               templateUrl: '/base/angular/packages/platform-browser/test/static_assets/test.html'
+             })
+             class InlineCompWithUrlTemplate {
+             }
+
              expect(
-                 () =>
-                     it('should fail', withModule(
-                                           {declarations: [CompWithUrlTemplate]},
-                                           () => TestBed.createComponent(CompWithUrlTemplate))))
+                 () => it(
+                     'should fail', withModule(
+                                        {declarations: [InlineCompWithUrlTemplate]},
+                                        () => TestBed.createComponent(InlineCompWithUrlTemplate))))
                  .toThrowError(
                      ivyEnabled ?
-                         `Component 'CompWithUrlTemplate' is not resolved:
+                         `Component 'InlineCompWithUrlTemplate' is not resolved:
  - templateUrl: /base/angular/packages/platform-browser/test/static_assets/test.html
 Did you run and wait for 'resolveComponentResources()'?` :
-                         `This test module uses the component ${stringify(CompWithUrlTemplate)} which is using a "templateUrl" or "styleUrls", but they were never compiled. ` +
+                         `This test module uses the component ${stringify(InlineCompWithUrlTemplate)} which is using a "templateUrl" or "styleUrls", but they were never compiled. ` +
                              `Please call "TestBed.compileComponents" before your test.`);
 
              restoreJasmineIt();


### PR DESCRIPTION
Prior to this change, we always recompile all Components/Directives/Pipes even if they were AOT-compiled and had no overrides. This is causing problems in case we try to recompile a Component with "templateUrl" or "styleUrls" (which were already resolved in case of AOT) and generally this unnecessary work that TestBed was doing is not required. This commit adds extra logic to check whether a Component/Directive/Pipe already have compiled NG def (like ngComponentDef) and whether there are no overrides present - in this case recompilation is skipped. Recopilation is also skipped in case a Component/Directive has only Provider overrides - in this situation providers resolver function is patched to reflect overrides. Provider overrides are very common in g3, thus this code path ensures no full recompilation.

This PR resolves FW-1103.

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No