### PR TITLE
feat(core): Add "AbstractType<T>" interface

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -29,7 +29,7 @@ export * from './platform_core_providers';
 export {TRANSLATIONS, TRANSLATIONS_FORMAT, LOCALE_ID, MissingTranslationStrategy} from './i18n/tokens';
 export {ApplicationModule} from './application_module';
 export {wtfCreateScope, wtfLeave, wtfStartTimeRange, wtfEndTimeRange, WtfScopeFn} from './profile/profile';
-export {Type} from './interface/type';
+export {AbstractType, Type} from './interface/type';
 export {EventEmitter} from './event_emitter';
 export {ErrorHandler} from './error_handler';
 export * from './core_private_export';

--- a/packages/core/src/interface/type.ts
+++ b/packages/core/src/interface/type.ts
@@ -22,6 +22,16 @@ export function isType(v: any): v is Type<any> {
   return typeof v === 'function';
 }
 
+/**
+ * @description
+ *
+ * Represents an abstract class `T`, if applied to a concrete class it would stop being
+ * instantiatable.
+ *
+ * @publicApi
+ */
+export interface AbstractType<T> extends Function { prototype: T; }
+
 export interface Type<T> extends Function { new (...args: any[]): T; }
 
 export type Mutable<T extends{[x: string]: any}, K extends string> = {

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -1,3 +1,7 @@
+export interface AbstractType<T> extends Function {
+    prototype: T;
+}
+
 export interface AfterContentChecked {
     ngAfterContentChecked(): void;
 }


### PR DESCRIPTION
This new interface will match classes whether they are abstract or
concrete. Casting as `AbstractType<MyConcrete>` will return a type that
isn't newable. This type will be used to match abstract classes in the
`get()` functions of `Injector` and `TestBed`.
Type isn't used yet so this isn't a breaking change.

Issue #26491

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is no abstract type sugar syntax

Issue Number: #26491


## What is the new behavior?
There is now an interface that matches abstract classes just like `Type<T>` matches concrete classes.
This will be used in the future for `Injector.get` and `TestBed.get` to make the former more convenient and the latter more strict

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Added a bunch of TODOs on places I plan to update the `get` calls with a plan of how will they look like in the future (maybe Angular 9? :crossed_fingers:)