### PR TITLE
fix(ivy): correctly remove placeholders inside of *ngFor with runtime i18n

### DIFF
--- a/packages/core/src/render3/i18n.ts
+++ b/packages/core/src/render3/i18n.ts
@@ -626,16 +626,6 @@ export function i18nEnd(): void {
   i18nEndFirstPass(tView);
 }
 
-function findLastNode(node: TNode): TNode {
-  while (node.next) {
-    node = node.next;
-  }
-  if (node.child) {
-    return findLastNode(node.child);
-  }
-  return node;
-}
-
 /**
  * See `i18nEnd` above.
  */
@@ -651,10 +641,8 @@ function i18nEndFirstPass(tView: TView) {
 
   // Find the last node that was added before `i18nEnd`
   let lastCreatedNode = getPreviousOrParentTNode();
-  if (lastCreatedNode.child) {
-    lastCreatedNode = findLastNode(lastCreatedNode.child);
-  }
 
+  // Read the instructions to insert/move/remove DOM elements
   const visitedNodes = readCreateOpCodes(rootIndex, tI18n.create, tI18n.icus, viewData);
 
   // Remove deleted nodes

--- a/packages/core/test/i18n_integration_spec.ts
+++ b/packages/core/test/i18n_integration_spec.ts
@@ -621,4 +621,20 @@ onlyInIvy('Ivy i18n logic').describe('i18n', function() {
     expect(fixture.nativeElement.innerHTML)
         .toBe('<div>Section 1</div><div>Section 2</div><div>Section 3</div>');
   });
+
+  it('should handle multiple i18n sections inside of *ngFor', () => {
+    const template = `
+    <ul *ngFor="let item of [1,2,3]">
+      <li i18n>Section 1</li>
+      <li i18n>Section 2</li>
+      <li i18n>Section 3</li>
+    </ul>
+  `;
+    const fixture = getFixtureWithOverrides({template});
+    const element = fixture.nativeElement;
+    for (let i = 0; i < element.children.length; i++) {
+      const child = element.children[i];
+      expect(child.innerHTML).toBe(`<li>Section 1</li><li>Section 2</li><li>Section 3</li>`);
+    }
+  });
 });


### PR DESCRIPTION
Following my previous change for placeholders removal, some special code that was used to find the last created node was no longer needed and had wrong interactions with the *ngFor directive.
Removing it fixed the issue.