### PR TITLE
ci: debug sandbox issue for circleci team

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,6 +463,7 @@ jobs:
     steps:
       - *attach_workspace
       - *init_environment
+      - run: uname -r
       # Runs the integration tests in parallel across multiple CircleCI container instances. The
       # amount of container nodes for this job is controlled by the "parallelism" option.
       - run: ./integration/run_tests.sh ${CIRCLE_NODE_INDEX} ${CIRCLE_NODE_TOTAL}


### PR DESCRIPTION
The CircleCI team needs to know what causes the Kernel
inconsistency that most likely causes our no usable sandbox
errors. Therefore we add "uname -r" temporarily.