### PR TITLE
build(bazel): update bazel managed yarn to 1.13.0 (same as CI version)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,7 +48,7 @@ node_repositories(
     node_version = "10.9.0",
     package_json = ["//:package.json"],
     preserve_symlinks = True,
-    yarn_version = "1.12.1",
+    yarn_version = "1.13.0",
 )
 
 yarn_install(

--- a/integration/bazel/WORKSPACE
+++ b/integration/bazel/WORKSPACE
@@ -37,7 +37,7 @@ Try running `yarn bazel` instead.
 # Setup the Node.js toolchain
 node_repositories(
     node_version = "10.9.0",
-    yarn_version = "1.12.1",
+    yarn_version = "1.13.0",
 )
 
 # Install our npm dependencies into @npm


### PR DESCRIPTION
This PR updates bazel managed yarn.

Note: we tried using `vendored_yarn` previously but this caused major issues on Windows: https://github.com/bazelbuild/rules_nodejs/issues/588

As a side note, CircleCI is currently on node 10.12 while Bazel is on node 10.9 which. We could update both to 10.13 at this point (node_repositories() has no definition for 10.12 and its not mirrored).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
