### PR TITLE
build: re-add bazel symlink prefix in patch branch

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,7 +31,7 @@ test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test
 # eventually a surprising failure with auto-discovery of the C++ toolchain in
 # MacOS High Sierra.
 # See https://github.com/bazelbuild/bazel/issues/4603
-build --symlink_prefix=/
+build --symlink_prefix=dist/
 
 # Performance: avoid stat'ing input files
 build --watchfs


### PR DESCRIPTION
Recently the bazelrc configuration in the patch branch
has been accidentally overwritten. In order to keep
patch and master in sync, we need to revert that small
change in the patch branch.