### PR TITLE
docs: remove configuration instructions at the top of the i18n guide

### DIFF
--- a/aio/content/guide/i18n.md
+++ b/aio/content/guide/i18n.md
@@ -49,18 +49,6 @@ locale id to find the correct corresponding locale data.
 
 By default, Angular uses the locale `en-US`, which is English as spoken in the United States of America.
 
-To set your app's locale to another value, use the CLI parameter `--configuration` with the value of the locale id that you want to use:
-
-<code-example language="sh" class="code-shell">
-  ng serve --configuration=fr
-</code-example>
-
-If you use JIT, you also need to define the `LOCALE_ID` provider in your main module:
-
-<code-example path="i18n/doc-files/app.module.ts" header="src/app/app.module.ts" linenums="false">
-</code-example>
-
-
 For more information about Unicode locale identifiers, see the
 [CLDR core spec](http://cldr.unicode.org/core-spec#Unicode_Language_and_Locale_Identifiers).
 


### PR DESCRIPTION
The instructions lead you to think you run this step before setting
up your locale. The command is mentioned further in the guide after
setup is complete.

Closes #26052

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
