### PR TITLE
fix(bazel): Remove @angular/upgrade from dev dependencies

### DIFF
--- a/packages/bazel/src/schematics/ng-add/files/angular-metadata.tsconfig.json.template
+++ b/packages/bazel/src/schematics/ng-add/files/angular-metadata.tsconfig.json.template
@@ -16,6 +16,7 @@
   "exclude": [
     "node_modules/@angular/bazel/**",
     "node_modules/@angular/compiler-cli/**",
-    "node_modules/@angular/**/testing/**"
+    "node_modules/@angular/**/testing/**",
+    "node_modules/@angular/router/upgrade*"
   ]
 }

--- a/packages/bazel/src/schematics/ng-add/index.ts
+++ b/packages/bazel/src/schematics/ng-add/index.ts
@@ -43,7 +43,6 @@ function addDevDependenciesToPackageJson(options: Schema) {
 
     const devDependencies: {[k: string]: string} = {
       '@angular/bazel': angularCoreVersion,
-      '@angular/upgrade': angularCoreVersion,
       '@bazel/bazel': '^0.23.0',
       '@bazel/ibazel': '^0.9.0',
       '@bazel/karma': '^0.27.4',


### PR DESCRIPTION
@angular/upgrade is unnecessary, but it's required by router/upgrade.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
