### PR TITLE
refactor(core): fix misleading tslint schematic message

### DIFF
--- a/packages/core/schematics/migrations/static-queries/google3/explicitQueryTimingRule.ts
+++ b/packages/core/schematics/migrations/static-queries/google3/explicitQueryTimingRule.ts
@@ -14,7 +14,7 @@ import {NgQueryResolveVisitor} from '../angular/ng_query_visitor';
 import {QueryTiming} from '../angular/query-definition';
 import {getTransformedQueryCallExpr} from '../transform';
 
-const FAILURE_MESSAGE = 'Query does explicitly specify its timing. Read more here: ' +
+const FAILURE_MESSAGE = 'Query does not explicitly specify its timing. Read more here: ' +
     'https://github.com/angular/angular/pull/28810';
 
 /**
@@ -57,9 +57,8 @@ export class Rule extends Rules.TypedRule {
       // Replace the existing query decorator call expression with the
       // updated call expression node.
       const fix = new Replacement(queryExpr.getStart(), queryExpr.getWidth(), newText);
-      const timingStr = timing === QueryTiming.STATIC ? 'static' : 'dynamic';
       const failureMessage = `${FAILURE_MESSAGE}. Based on analysis of the query it can be ` +
-          `marked as "${timingStr}".`;
+          `marked as "{static: ${(timing === QueryTiming.STATIC).toString()}}".`;
 
       failures.push(new RuleFailure(
           sourceFile, queryExpr.getStart(), queryExpr.getWidth(), failureMessage, this.ruleName,

--- a/packages/core/schematics/test/google3/explicit_query_timing_rule_spec.ts
+++ b/packages/core/schematics/test/google3/explicit_query_timing_rule_spec.ts
@@ -109,7 +109,7 @@ describe('Google3 explicitQueryTiming TSLint rule', () => {
     const failures = linter.getResult().failures;
 
     expect(failures.length).toBe(1);
-    expect(failures[0].getFailure()).toMatch(/analysis of the query.*"static"/);
+    expect(failures[0].getFailure()).toMatch(/analysis of the query.*"{static: true}"/);
   });
 
   it('should report non-explicit dynamic query definitions', () => {
@@ -126,6 +126,6 @@ describe('Google3 explicitQueryTiming TSLint rule', () => {
     const failures = linter.getResult().failures;
 
     expect(failures.length).toBe(1);
-    expect(failures[0].getFailure()).toMatch(/analysis of the query.*"dynamic"/);
+    expect(failures[0].getFailure()).toMatch(/analysis of the query.*"{static: false}"/);
   });
 });


### PR DESCRIPTION
Fixes the incorrect failure message or the TSLint rule that
is used within Google. The TSLint rule is not part of the
public schematic code.

Additionally in order to make it easier to understand what
action the developer needs to take, we rather print out the
expected "static: true/false" statement instead of saying that
a query needs to be static or dynamic. Dynamic is ambiguous, as
there is no `dynamic: true` option.